### PR TITLE
Partition stale status resolution

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -581,10 +581,12 @@ class GrapheneAssetNode(graphene.ObjectType):
         causes = self.stale_status_loader.get_stale_root_causes(self._external_asset_node.asset_key)
         return [
             GrapheneAssetStaleCause(
-                GrapheneAssetKey(path=cause.key.path),
+                GrapheneAssetKey(path=cause.asset_key.path),
                 cause.category,
                 cause.reason,
-                GrapheneAssetKey(path=cause.dependency.path) if cause.dependency else None,
+                GrapheneAssetKey(path=cause.dependency.asset_key.path)
+                if cause.dependency
+                else None,
             )
             for cause in causes
         ]

--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -630,11 +630,18 @@ class AssetLayer:
     def asset_key_for_input(self, node_handle: NodeHandle, input_name: str) -> Optional[AssetKey]:
         return self._asset_keys_by_node_input_handle.get(NodeInputHandle(node_handle, input_name))
 
+    def input_for_asset_key(self, node_handle: NodeHandle, key: AssetKey) -> Optional[str]:
+        return next(
+            (
+                input_handle.input_name
+                for input_handle, k in self._asset_keys_by_node_input_handle.items()
+                if k == key
+            ),
+            None,
+        )
+
     def io_manager_key_for_asset(self, asset_key: AssetKey) -> str:
         return self._io_manager_keys_by_asset_key.get(asset_key, "io_manager")
-
-    def is_source_for_asset(self, asset_key: AssetKey) -> bool:
-        return asset_key in self.source_assets_by_key
 
     def is_observable_for_asset(self, asset_key: AssetKey) -> bool:
         return (

--- a/python_modules/dagster/dagster/_core/definitions/data_version.py
+++ b/python_modules/dagster/dagster/_core/definitions/data_version.py
@@ -23,7 +23,12 @@ from dagster._utils.cached_method import cached_method
 
 if TYPE_CHECKING:
     from dagster._core.definitions.asset_graph import AssetGraph
-    from dagster._core.definitions.events import AssetKey, AssetMaterialization, AssetObservation
+    from dagster._core.definitions.events import (
+        AssetKey,
+        AssetKeyPartitionKey,
+        AssetMaterialization,
+        AssetObservation,
+    )
     from dagster._core.event_api import EventLogRecord
     from dagster._core.events.log import EventLogEntry
     from dagster._core.instance import DagsterInstance
@@ -32,10 +37,6 @@ if TYPE_CHECKING:
 
 class UnknownValue:
     pass
-
-
-def foo(x):
-    return False
 
 
 UNKNOWN_VALUE: Final[UnknownValue] = UnknownValue()
@@ -91,6 +92,7 @@ class DataVersionsByPartition(
 DEFAULT_DATA_VERSION: Final[DataVersion] = DataVersion("INITIAL")
 NULL_DATA_VERSION: Final[DataVersion] = DataVersion("NULL")
 UNKNOWN_DATA_VERSION: Final[DataVersion] = DataVersion("UNKNOWN")
+NULL_EVENT_POINTER: Final[str] = "NULL"
 
 
 class DataProvenance(
@@ -99,6 +101,7 @@ class DataProvenance(
         [
             ("code_version", str),
             ("input_data_versions", Mapping["AssetKey", DataVersion]),
+            ("input_storage_ids", Mapping["AssetKey", Optional[int]]),
             ("is_user_provided", bool),
         ],
     )
@@ -117,6 +120,7 @@ class DataProvenance(
         cls,
         code_version: str,
         input_data_versions: Mapping["AssetKey", DataVersion],
+        input_storage_ids: Mapping["AssetKey", Optional[int]],
         is_user_provided: bool,
     ):
         from dagster._core.definitions.events import AssetKey
@@ -130,30 +134,46 @@ class DataProvenance(
                 key_type=AssetKey,
                 value_type=DataVersion,
             ),
+            input_storage_ids=check.mapping_param(
+                input_storage_ids,
+                "input_storage_ids",
+                key_type=AssetKey,
+            ),
             is_user_provided=check.bool_param(is_user_provided, "is_user_provided"),
         )
 
     @staticmethod
     def from_tags(tags: Mapping[str, str]) -> Optional["DataProvenance"]:
-        from dagster._core.definitions.events import AssetKey
-
         code_version = tags.get(CODE_VERSION_TAG)
         if code_version is None:
             return None
         input_data_versions = {
-            # Everything after the 2nd slash is the asset key
-            AssetKey.from_user_string(k.split("/", maxsplit=2)[-1]): DataVersion(tags[k])
+            _asset_key_from_tag(k): DataVersion(v)
             for k, v in tags.items()
             if k.startswith(INPUT_DATA_VERSION_TAG_PREFIX)
             or k.startswith(_OLD_INPUT_DATA_VERSION_TAG_PREFIX)
         }
+        input_storage_ids = {
+            _asset_key_from_tag(k): int(v) if v != NULL_EVENT_POINTER else None
+            for k, v in tags.items()
+            if k.startswith(INPUT_EVENT_POINTER_TAG_PREFIX)
+        }
         is_user_provided = tags.get(DATA_VERSION_IS_USER_PROVIDED_TAG) == "true"
-        return DataProvenance(code_version, input_data_versions, is_user_provided)
+        return DataProvenance(
+            code_version, input_data_versions, input_storage_ids, is_user_provided
+        )
 
     @property
     @deprecated(breaking_version="2.0", additional_warn_text="Use `input_data_versions` instead.")
     def input_logical_versions(self) -> Mapping["AssetKey", DataVersion]:
         return self.input_data_versions
+
+
+def _asset_key_from_tag(tag: str) -> "AssetKey":
+    from dagster._core.definitions.events import AssetKey
+
+    # Everything after the 2nd slash is the asset key
+    return AssetKey.from_user_string(tag.split("/", maxsplit=2)[-1])
 
 
 # ########################
@@ -267,12 +287,65 @@ class StaleCauseCategory(Enum):
         return NotImplemented
 
 
-class StaleCause(NamedTuple):
-    key: "AssetKey"
-    category: StaleCauseCategory
-    reason: str
-    dependency: Optional["AssetKey"] = None
-    children: Optional[Sequence["StaleCause"]] = None
+class StaleCause(
+    NamedTuple(
+        "_StaleCause",
+        [
+            ("key", "AssetKeyPartitionKey"),
+            ("category", StaleCauseCategory),
+            ("reason", str),
+            ("dependency", Optional["AssetKeyPartitionKey"]),
+            ("children", Optional[Sequence["StaleCause"]]),
+        ],
+    )
+):
+    def __new__(
+        cls,
+        key: Union["AssetKey", "AssetKeyPartitionKey"],
+        category: StaleCauseCategory,
+        reason: str,
+        dependency: Optional[Union["AssetKey", "AssetKeyPartitionKey"]] = None,
+        children: Optional[Sequence["StaleCause"]] = None,
+    ):
+        from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
+
+        return super().__new__(
+            cls,
+            AssetKeyPartitionKey(key) if isinstance(key, AssetKey) else key,
+            category,
+            reason,
+            AssetKeyPartitionKey(dependency) if isinstance(dependency, AssetKey) else dependency,
+            children,
+        )
+
+    @property
+    def asset_key(self) -> "AssetKey":
+        return self.key.asset_key
+
+    @property
+    def partition_key(self) -> Optional[str]:
+        return self.key.partition_key
+
+    @property
+    def dependency_asset_key(self) -> Optional["AssetKey"]:
+        return self.dependency.asset_key if self.dependency else None
+
+    @property
+    def dependency_partition_key(self) -> Optional[str]:
+        return self.dependency.partition_key if self.dependency else None
+
+    @property
+    def sort_key(self) -> str:
+        if not hasattr(self, "_sort_key"):
+            self._sort_key = f"{self.key}/{self.dependency}" if self.dependency else str(self.key)
+        return self._sort_key
+
+
+# If a partition has greater than this number of dependencies, we don't check
+# this edge for updated data or propagate other stale causes through this edge.
+# This constraint can be removed when we have thoroughly tested performance for
+# large upstream partition counts.
+SKIP_PARTITION_DATA_VERSION_DEPENDENCY_THRESHOLD = 100
 
 
 class CachingStaleStatusResolver:
@@ -302,45 +375,89 @@ class CachingStaleStatusResolver:
             self._asset_graph = None
             self._asset_graph_load_fn = asset_graph
 
-    def get_status(self, key: "AssetKey") -> StaleStatus:
-        return self._get_status(key=key)
+    def get_status(self, key: "AssetKey", partition_key: Optional[str] = None) -> StaleStatus:
+        from dagster._core.definitions.events import AssetKeyPartitionKey
 
-    def get_stale_causes(self, key: "AssetKey") -> Sequence[StaleCause]:
-        return self._get_stale_causes(key=key)
+        return self._get_status(key=AssetKeyPartitionKey(key, partition_key))
 
-    def get_stale_root_causes(self, key: "AssetKey") -> Sequence[StaleCause]:
-        return self._get_stale_root_causes(key=key)
+    def get_stale_causes(
+        self, key: "AssetKey", partition_key: Optional[str] = None
+    ) -> Sequence[StaleCause]:
+        from dagster._core.definitions.events import AssetKeyPartitionKey
 
-    def get_current_data_version(self, key: "AssetKey") -> DataVersion:
-        return self._get_current_data_version(key=key)
+        return self._get_stale_causes(key=AssetKeyPartitionKey(key, partition_key))
+
+    def get_stale_root_causes(
+        self, key: "AssetKey", partition_key: Optional[str] = None
+    ) -> Sequence[StaleCause]:
+        from dagster._core.definitions.events import AssetKeyPartitionKey
+
+        return self._get_stale_root_causes(key=AssetKeyPartitionKey(key, partition_key))
+
+    def get_current_data_version(
+        self, key: "AssetKey", partition_key: Optional[str] = None
+    ) -> DataVersion:
+        from dagster._core.definitions.events import AssetKeyPartitionKey
+
+        return self._get_current_data_version(key=AssetKeyPartitionKey(key, partition_key))
 
     @cached_method
-    def _get_status(self, key: "AssetKey") -> StaleStatus:
+    def _get_status(self, key: "AssetKeyPartitionKey") -> StaleStatus:
         current_version = self._get_current_data_version(key=key)
         if current_version == NULL_DATA_VERSION:
             return StaleStatus.MISSING
-        elif self.asset_graph.is_source(key) or self._is_partitioned_or_downstream(key=key):
+        elif self.asset_graph.is_source(key.asset_key):
             return StaleStatus.FRESH
         else:
             causes = self._get_stale_causes(key=key)
             return StaleStatus.FRESH if len(causes) == 0 else StaleStatus.STALE
 
     @cached_method
-    def _get_stale_causes(self, key: "AssetKey") -> Sequence[StaleCause]:
+    def _get_stale_causes(self, key: "AssetKeyPartitionKey") -> Sequence[StaleCause]:
         current_version = self._get_current_data_version(key=key)
-        if (
-            current_version == NULL_DATA_VERSION
-            or self.asset_graph.is_source(key)
-            or self._is_partitioned_or_downstream(key=key)
-        ):
+        if current_version == NULL_DATA_VERSION or self.asset_graph.is_source(key.asset_key):
             return []
         else:
-            return list(self._get_stale_causes_materialized(key))
+            return sorted(
+                self._get_stale_causes_materialized(key=key), key=lambda cause: cause.sort_key
+            )
 
-    def _get_stale_causes_materialized(self, key: "AssetKey") -> Iterator[StaleCause]:
-        code_version = self.asset_graph.get_code_version(key)
+    def _is_dep_updated(self, provenance: DataProvenance, dep_key: "AssetKeyPartitionKey") -> bool:
+        if dep_key.partition_key is None:
+            current_data_version = self._get_current_data_version(key=dep_key)
+            return provenance.input_data_versions[dep_key.asset_key] != current_data_version
+        else:
+            cursor = provenance.input_storage_ids[dep_key.asset_key]
+            updated_record = self._instance.get_latest_data_version_record(
+                dep_key.asset_key,
+                self.asset_graph.is_source(dep_key.asset_key),
+                dep_key.partition_key,
+                after_cursor=cursor,
+            )
+            if updated_record:
+                previous_record = self._instance.get_latest_data_version_record(
+                    dep_key.asset_key,
+                    self.asset_graph.is_source(dep_key.asset_key),
+                    dep_key.partition_key,
+                    before_cursor=cursor + 1 if cursor else None,
+                )
+                previous_version = (
+                    extract_data_version_from_entry(previous_record.event_log_entry)
+                    if previous_record
+                    else None
+                )
+                updated_version = extract_data_version_from_entry(updated_record.event_log_entry)
+                return previous_version != updated_version
+            else:
+                return False
+
+    def _get_stale_causes_materialized(self, key: "AssetKeyPartitionKey") -> Iterator[StaleCause]:
+        from dagster._core.definitions.events import AssetKeyPartitionKey
+
+        code_version = self.asset_graph.get_code_version(key.asset_key)
         provenance = self._get_current_data_provenance(key=key)
-        dependency_keys = self.asset_graph.get_parents(key)
+
+        asset_deps = self.asset_graph.get_parents(key.asset_key)
 
         # only used if no provenance available
         materialization = check.not_none(self._get_latest_data_version_record(key=key))
@@ -350,16 +467,21 @@ class CachingStaleStatusResolver:
             if code_version and code_version != provenance.code_version:
                 yield StaleCause(key, StaleCauseCategory.CODE, "has a new code version")
 
-            removed_deps = set(provenance.input_data_versions.keys()) - set(dependency_keys)
+            removed_deps = set(provenance.input_data_versions.keys()) - set(asset_deps)
             for dep_key in removed_deps:
                 yield StaleCause(
                     key,
                     StaleCauseCategory.DEPENDENCIES,
                     f"removed dependency on {dep_key.to_user_string()}",
-                    dep_key,
+                    AssetKeyPartitionKey(dep_key, None),
                 )
 
-        for dep_key in sorted(dependency_keys):
+        # If a partition has greater than or equal to SKIP_PARTITION_DATA_VERSION_DEPENDENCY_THRESHOLD of
+        # dependencies, it is not included in partition_deps. This is for performance reasons. This
+        # constraint can be removed when we have thoroughly tested performance for large upstream
+        # partition counts.
+        partition_deps = self._get_partition_dependencies(key=key)
+        for dep_key in sorted(partition_deps):
             if self._get_status(key=dep_key) == StaleStatus.STALE:
                 yield StaleCause(
                     key,
@@ -369,18 +491,18 @@ class CachingStaleStatusResolver:
                     self._get_stale_causes(key=dep_key),
                 )
             elif provenance:
-                if dep_key not in provenance.input_data_versions:
+                if dep_key.asset_key not in provenance.input_data_versions:
                     yield StaleCause(
                         key,
                         StaleCauseCategory.DEPENDENCIES,
-                        f"has a new dependency on {dep_key.to_user_string()}",
+                        f"has a new dependency on {dep_key.asset_key.to_user_string()}",
                         dep_key,
                     )
-                elif provenance.input_data_versions[dep_key] != self._get_current_data_version(
-                    key=dep_key
-                ):
+                # Currently we exclude assets downstream of AllPartitionMappings from stale
+                # status logic due to potentially huge numbers of dependencies.
+                elif self._is_dep_updated(provenance, dep_key):
                     report_data_version = self.asset_graph.get_code_version(
-                        dep_key
+                        dep_key.asset_key
                     ) is not None or self._is_current_data_version_user_provided(key=dep_key)
                     yield StaleCause(
                         key,
@@ -406,7 +528,7 @@ class CachingStaleStatusResolver:
             # timestamps instead of versions this should be removable eventually since
             # provenance is on all newer materializations. If dep is a source, then we'll never
             # provide a stale reason here.
-            elif not self.asset_graph.is_source(dep_key):
+            elif not self.asset_graph.is_source(dep_key.asset_key):
                 dep_materialization = self._get_latest_data_version_record(key=dep_key)
                 if dep_materialization is None:
                     # The input must be new if it has no materialization
@@ -427,7 +549,7 @@ class CachingStaleStatusResolver:
                     )
 
     @cached_method
-    def _get_stale_root_causes(self, key: "AssetKey") -> Sequence[StaleCause]:
+    def _get_stale_root_causes(self, key: "AssetKeyPartitionKey") -> Sequence[StaleCause]:
         causes = self._get_stale_causes(key=key)
         root_pairs = sorted([pair for cause in causes for pair in self._gather_leaves(cause)])
         # After sorting the pairs, we can drop the level and de-dup using an
@@ -463,11 +585,11 @@ class CachingStaleStatusResolver:
         return self._instance_queryer
 
     @cached_method
-    def _get_current_data_version(self, *, key: "AssetKey") -> DataVersion:
+    def _get_current_data_version(self, *, key: "AssetKeyPartitionKey") -> DataVersion:
         # Currently we can only use asset records, which are fetched in one shot, for non-source
         # assets. This is because the most recent AssetObservation is not stored on the AssetRecord.
         record = self._get_latest_data_version_record(key=key)
-        if self.asset_graph.is_source(key) and record is None:
+        if self.asset_graph.is_source(key.asset_key) and record is None:
             return DEFAULT_DATA_VERSION
         elif record is None:
             return NULL_DATA_VERSION
@@ -476,32 +598,22 @@ class CachingStaleStatusResolver:
             return data_version or DEFAULT_DATA_VERSION
 
     @cached_method
-    def _is_current_data_version_user_provided(self, *, key: "AssetKey") -> bool:
-        if self.asset_graph.is_source(key):
+    def _is_current_data_version_user_provided(self, *, key: "AssetKeyPartitionKey") -> bool:
+        if self.asset_graph.is_source(key.asset_key):
             return True
         else:
             provenance = self._get_current_data_provenance(key=key)
             return provenance is not None and provenance.is_user_provided
 
     @cached_method
-    def _get_current_data_provenance(self, *, key: "AssetKey") -> Optional[DataProvenance]:
+    def _get_current_data_provenance(
+        self, *, key: "AssetKeyPartitionKey"
+    ) -> Optional[DataProvenance]:
         record = self._get_latest_data_version_record(key=key)
         if record is None:
             return None
         else:
             return extract_data_provenance_from_entry(record.event_log_entry)
-
-    @cached_method
-    def _is_partitioned_or_downstream(self, *, key: "AssetKey") -> bool:
-        if self.asset_graph.get_partitions_def(key):
-            return True
-        elif self.asset_graph.is_source(key):
-            return False
-        else:
-            return any(
-                self._is_partitioned_or_downstream(key=dep_key)
-                for dep_key in self.asset_graph.get_parents(key)
-            )
 
     # Volatility means that an asset is assumed to be constantly changing. We assume that observable
     # source assets are non-volatile, since the primary purpose of the observation function is to
@@ -517,7 +629,7 @@ class CachingStaleStatusResolver:
 
     @cached_method
     def _get_latest_data_version_event(
-        self, *, key: "AssetKey"
+        self, *, key: "AssetKeyPartitionKey"
     ) -> Optional[Union["AssetMaterialization", "AssetObservation"]]:
         record = self._get_latest_data_version_record(key=key)
         if record:
@@ -527,15 +639,55 @@ class CachingStaleStatusResolver:
             return None
 
     @cached_method
-    def _get_latest_data_version_record(self, key: "AssetKey") -> Optional["EventLogRecord"]:
-        from dagster._core.definitions.events import AssetKeyPartitionKey
-
+    def _get_latest_data_version_record(
+        self, key: "AssetKeyPartitionKey"
+    ) -> Optional["EventLogRecord"]:
         # If an asset record is cached, all of its ancestors have already been cached.
-        if not self.asset_graph.is_source(
-            key
-        ) and not self.instance_queryer.has_cached_asset_record(key):
-            ancestors = self.asset_graph.get_ancestors(key, include_self=True)
+        if (
+            key.partition_key is None
+            and not self.asset_graph.is_source(key.asset_key)
+            and not self.instance_queryer.has_cached_asset_record(key.asset_key)
+        ):
+            ancestors = self.asset_graph.get_ancestors(key.asset_key, include_self=True)
             self.instance_queryer.prefetch_asset_records(ancestors)
         return self.instance_queryer.get_latest_materialization_or_observation_record(
-            asset_partition=AssetKeyPartitionKey(key)
+            asset_partition=key
         )
+
+    # If a partition has greater than or equal to SKIP_PARTITION_DATA_VERSION_DEPENDENCY_THRESHOLD
+    # of dependencies, it is not included in partition_deps. This is for performance reasons. This
+    # constraint can be removed when we have thoroughly tested performance for large upstream
+    # partition counts. At that time, the body of this method can just be replaced with a call to
+    # `asset_graph.get_parents_partitions`, which the logic here largely replicates.
+    @cached_method
+    def _get_partition_dependencies(
+        self, *, key: "AssetKeyPartitionKey"
+    ) -> Sequence["AssetKeyPartitionKey"]:
+        from dagster._core.definitions.events import (
+            AssetKeyPartitionKey,
+        )
+
+        asset_deps = self.asset_graph.get_parents(key.asset_key)
+
+        deps = []
+        for dep_asset_key in asset_deps:
+            if not self.asset_graph.is_partitioned(dep_asset_key):
+                deps.append(AssetKeyPartitionKey(dep_asset_key, None))
+            else:
+                upstream_partition_keys = list(
+                    self.asset_graph.get_parent_partition_keys_for_child(
+                        key.partition_key,
+                        dep_asset_key,
+                        key.asset_key,
+                        dynamic_partitions_store=self._instance,
+                        current_time=self.instance_queryer.evaluation_time,
+                    ).partitions_subset.get_partition_keys()
+                )
+                if len(upstream_partition_keys) < SKIP_PARTITION_DATA_VERSION_DEPENDENCY_THRESHOLD:
+                    deps.extend(
+                        [
+                            AssetKeyPartitionKey(dep_asset_key, partition_key)
+                            for partition_key in upstream_partition_keys
+                        ]
+                    )
+        return deps

--- a/python_modules/dagster/dagster/_core/execution/context/system.py
+++ b/python_modules/dagster/dagster/_core/execution/context/system.py
@@ -4,6 +4,8 @@ so we have a different layer of objects that encode the explicit public API
 in the user_context module.
 """
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from hashlib import sha256
 from typing import (
     TYPE_CHECKING,
     AbstractSet,
@@ -14,6 +16,7 @@ from typing import (
     Mapping,
     NamedTuple,
     Optional,
+    Sequence,
     Set,
     Union,
     cast,
@@ -21,6 +24,10 @@ from typing import (
 
 import dagster._check as check
 from dagster._annotations import public
+from dagster._core.definitions.data_version import (
+    DATA_VERSION_TAG,
+    SKIP_PARTITION_DATA_VERSION_DEPENDENCY_THRESHOLD,
+)
 from dagster._core.definitions.dependency import OpNode
 from dagster._core.definitions.events import AssetKey, AssetLineageInfo
 from dagster._core.definitions.hook_definition import HookDefinition
@@ -30,7 +37,10 @@ from dagster._core.definitions.multi_dimensional_partitions import MultiPartitio
 from dagster._core.definitions.op_definition import OpDefinition
 from dagster._core.definitions.partition import PartitionsDefinition, PartitionsSubset
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
-from dagster._core.definitions.partition_mapping import infer_partition_mapping
+from dagster._core.definitions.partition_mapping import (
+    PartitionMapping,
+    infer_partition_mapping,
+)
 from dagster._core.definitions.policy import RetryPolicy
 from dagster._core.definitions.reconstruct import ReconstructableJob
 from dagster._core.definitions.resource_definition import ScopedResourcesBuilder
@@ -458,6 +468,18 @@ class PlanExecutionContext(IPlanContext):
         )
 
 
+@dataclass
+class InputAssetVersionInfo:
+    # This is the storage id of the last materialization of any partition of an asset. Thus it is
+    # computed the same way for both partitioned and non-partitioned assets.
+    storage_id: int
+
+    # If the input asset is partitioned, this is a hash of the sorted data versions of each dependency
+    # partition. If the input asset is not partitioned, this is the data version of the asset. It
+    # can be none if we are sourcing a materialization from before data versions.
+    data_version: Optional["DataVersion"]
+
+
 class StepExecutionContext(PlanExecutionContext, IStepContext):
     """Context for the execution of a step. Users should not instantiate this class directly.
 
@@ -522,8 +544,8 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
         self._output_metadata: Dict[str, Any] = {}
         self._seen_outputs: Dict[str, Union[str, Set[str]]] = {}
 
-        self._input_asset_records: Dict[AssetKey, Optional["EventLogRecord"]] = {}
-        self._is_external_input_asset_records_loaded = False
+        self._input_asset_version_info: Dict[AssetKey, Optional["InputAssetVersionInfo"]] = {}
+        self._is_external_input_asset_version_info_loaded = False
         self._data_version_cache: Dict[AssetKey, "DataVersion"] = {}
 
     @property
@@ -856,21 +878,22 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
         return self._data_version_cache[asset_key]
 
     @property
-    def input_asset_records(self) -> Optional[Mapping[AssetKey, Optional["EventLogRecord"]]]:
-        return self._input_asset_records
+    def input_asset_records(self) -> Optional[Mapping[AssetKey, Optional["InputAssetVersionInfo"]]]:
+        return self._input_asset_version_info
 
     @property
-    def is_external_input_asset_records_loaded(self) -> bool:
-        return self._is_external_input_asset_records_loaded
+    def is_external_input_asset_version_info_loaded(self) -> bool:
+        return self._is_external_input_asset_version_info_loaded
 
-    def get_input_asset_record(self, key: AssetKey) -> Optional["EventLogRecord"]:
-        if key not in self._input_asset_records:
-            self._fetch_input_asset_record(key)
-        return self._input_asset_records[key]
+    def get_input_asset_version_info(self, key: AssetKey) -> Optional["InputAssetVersionInfo"]:
+        if key not in self._input_asset_version_info:
+            self._fetch_input_asset_version_info(key)
+        return self._input_asset_version_info[key]
 
     # "external" refers to records for inputs generated outside of this step
-    def fetch_external_input_asset_records(self) -> None:
+    def fetch_external_input_asset_version_info(self) -> None:
         output_keys = self.get_output_asset_keys()
+
         all_dep_keys: List[AssetKey] = []
         for output_key in output_keys:
             if output_key not in self.job_def.asset_layer._asset_deps:  # noqa: SLF001
@@ -880,35 +903,117 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
                 if key not in all_dep_keys and key not in output_keys:
                     all_dep_keys.append(key)
 
-        self._input_asset_records = {}
+        self._input_asset_version_info = {}
         for key in all_dep_keys:
-            self._fetch_input_asset_record(key)
-        self._is_external_input_asset_records_loaded = True
+            self._fetch_input_asset_version_info(key)
+        self._is_external_input_asset_version_info_loaded = True
 
-    def _fetch_input_asset_record(self, key: AssetKey, retries: int = 0) -> None:
+    def _fetch_input_asset_version_info(self, key: AssetKey) -> None:
         from dagster._core.definitions.data_version import (
             extract_data_version_from_entry,
         )
 
-        event = self.instance.get_latest_data_version_record(key)
-        if key in self._data_version_cache and retries <= 5:
-            event_data_version = (
-                None if event is None else extract_data_version_from_entry(event.event_log_entry)
-            )
-            if event_data_version == self._data_version_cache[key]:
-                self._input_asset_records[key] = event
-            else:
-                self._fetch_input_asset_record(key, retries + 1)
+        event = self._get_input_asset_event(key)
+        if event is None:
+            self._input_asset_version_info[key] = None
         else:
-            self._input_asset_records[key] = event
+            storage_id = event.storage_id
+            # Input name will be none if this is an internal dep
+            input_name = self.job_def.asset_layer.input_for_asset_key(self.node_handle, key)
+            # Exclude AllPartitionMapping for now to avoid huge queries
+            if input_name and self.has_asset_partitions_for_input(input_name):
+                subset = self.asset_partitions_subset_for_input(
+                    input_name, require_valid_partitions=False
+                )
+                input_keys = list(subset.get_partition_keys())
+
+                # This check represents a temporary constraint that prevents huge query results for upstream
+                # partition data versions from timing out runs. If a partitioned dependency (a) uses an
+                # AllPartitionMapping; and (b) has greater than or equal to
+                # SKIP_PARTITION_DATA_VERSION_DEPENDENCY_THRESHOLD dependency partitions, then we
+                # process it as a non-partitioned dependency (note that this was the behavior for
+                # all partition dependencies prior to 2023-08).  This means that stale status
+                # results cannot be accurately computed for the dependency, and there is thus
+                # corresponding logic in the CachingStaleStatusResolver to account for this. This
+                # constraint should be removed when we have thoroughly examined the performance of
+                # the data version retrieval query and can guarantee decent performance.
+                if len(input_keys) < SKIP_PARTITION_DATA_VERSION_DEPENDENCY_THRESHOLD:
+                    data_version = self._get_partitions_data_version_from_keys(key, input_keys)
+                else:
+                    data_version = extract_data_version_from_entry(event.event_log_entry)
+            else:
+                data_version = extract_data_version_from_entry(event.event_log_entry)
+            self._input_asset_version_info[key] = InputAssetVersionInfo(storage_id, data_version)
+
+    def partition_mapping_for_input(self, input_name: str) -> Optional[PartitionMapping]:
+        asset_layer = self.job_def.asset_layer
+        upstream_asset_key = asset_layer.asset_key_for_input(self.node_handle, input_name)
+        if upstream_asset_key:
+            upstream_asset_partitions_def = asset_layer.partitions_def_for_asset(upstream_asset_key)
+            assets_def = asset_layer.assets_def_for_node(self.node_handle)
+            partitions_def = assets_def.partitions_def if assets_def else None
+            explicit_partition_mapping = self.job_def.asset_layer.partition_mapping_for_node_input(
+                self.node_handle, upstream_asset_key
+            )
+            return infer_partition_mapping(
+                explicit_partition_mapping,
+                partitions_def,
+                upstream_asset_partitions_def,
+            )
+        else:
+            return None
+
+    def _get_input_asset_event(self, key: AssetKey, retries: int = 0) -> Optional["EventLogRecord"]:
+        from dagster._core.definitions.data_version import (
+            extract_data_version_from_entry,
+        )
+
+        is_step_internal_input = key in self._data_version_cache
+        event = self.instance.get_latest_data_version_record(key)
+        if event is None and is_step_internal_input and retries <= 5:
+            return self._get_input_asset_event(key, retries + 1)
+        elif event is None:
+            return None
+        else:
+            # The cache gets populated for inputs generated during the current step. We need to keep
+            # reloading the latest event until the data version matches the one in the cache to ensure
+            # the storage id reflects the input actually used.
+            data_version = extract_data_version_from_entry(event.event_log_entry)
+            if is_step_internal_input and data_version != self._data_version_cache[key]:
+                return self._get_input_asset_event(key, retries + 1)
+            else:
+                return event
+
+    def _get_partitions_data_version_from_keys(
+        self, key: AssetKey, partition_keys: Sequence[str]
+    ) -> "DataVersion":
+        from dagster._core.definitions.data_version import (
+            DataVersion,
+        )
+        from dagster._core.events import DagsterEventType
+
+        # TODO: this needs to account for observations also
+        event_type = DagsterEventType.ASSET_MATERIALIZATION
+        tags_by_partition = (
+            self.instance._event_storage.get_latest_tags_by_partition(  # noqa: SLF001
+                key, event_type, [DATA_VERSION_TAG], asset_partitions=list(partition_keys)
+            )
+        )
+        partition_data_versions = [
+            pair[1][DATA_VERSION_TAG]
+            for pair in sorted(tags_by_partition.items(), key=lambda x: x[0])
+        ]
+        hash_sig = sha256()
+        hash_sig.update(bytearray("".join(partition_data_versions), "utf8"))
+        return DataVersion(hash_sig.hexdigest())
 
     # Call this to clear the cache for an input asset record. This is necessary when an old
     # materialization for an asset was loaded during `fetch_external_input_asset_records` because an
     # intrastep asset is not required, but then that asset is materialized during the step. If we
     # don't clear the cache for this asset, then we won't use the most up-to-date asset record.
-    def wipe_input_asset_record(self, key: AssetKey) -> None:
-        if key in self._input_asset_records:
-            del self._input_asset_records[key]
+    def wipe_input_asset_version_info(self, key: AssetKey) -> None:
+        if key in self._input_asset_version_info:
+            del self._input_asset_version_info[key]
 
     def get_output_asset_keys(self) -> AbstractSet[AssetKey]:
         output_keys: Set[AssetKey] = set()
@@ -946,7 +1051,9 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
 
         return partition_key_ranges[0]
 
-    def asset_partitions_subset_for_input(self, input_name: str) -> PartitionsSubset:
+    def asset_partitions_subset_for_input(
+        self, input_name: str, *, require_valid_partitions: bool = True
+    ) -> PartitionsSubset:
         asset_layer = self.job_def.asset_layer
         assets_def = asset_layer.assets_def_for_node(self.node_handle)
         upstream_asset_key = asset_layer.asset_key_for_input(self.node_handle, input_name)
@@ -978,7 +1085,10 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
                     )
                 )
 
-                if mapped_partitions_result.required_but_nonexistent_partition_keys:
+                if (
+                    require_valid_partitions
+                    and mapped_partitions_result.required_but_nonexistent_partition_keys
+                ):
                     raise DagsterInvariantViolationError(
                         f"Partition key range {self.asset_partition_key_range} in"
                         f" {self.node_handle.name} depends on invalid partition keys"

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -2723,6 +2723,9 @@ class DagsterInstance(DynamicPartitionsStore):
         self,
         key: AssetKey,
         is_source: Optional[bool] = None,
+        partition_key: Optional[str] = None,
+        before_cursor: Optional[int] = None,
+        after_cursor: Optional[int] = None,
     ) -> Optional["EventLogRecord"]:
         from dagster._core.event_api import EventRecordsFilter
         from dagster._core.events import DagsterEventType
@@ -2737,6 +2740,9 @@ class DagsterInstance(DynamicPartitionsStore):
                 EventRecordsFilter(
                     event_type=DagsterEventType.ASSET_OBSERVATION,
                     asset_key=key,
+                    asset_partitions=[partition_key] if partition_key else None,
+                    before_cursor=before_cursor,
+                    after_cursor=after_cursor,
                 ),
                 limit=1,
             )
@@ -2748,6 +2754,9 @@ class DagsterInstance(DynamicPartitionsStore):
                 EventRecordsFilter(
                     event_type=DagsterEventType.ASSET_MATERIALIZATION,
                     asset_key=key,
+                    asset_partitions=[partition_key] if partition_key else None,
+                    before_cursor=before_cursor,
+                    after_cursor=after_cursor,
                 ),
                 limit=1,
             )

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance_data_versions.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance_data_versions.py
@@ -65,6 +65,10 @@ def test_extract_data_version_and_provenance_from_materialization_entry():
     assert extract_data_version_from_entry(entry) == DataVersion("1")
     assert extract_data_provenance_from_entry(entry) == DataProvenance(
         code_version="3",
+        input_storage_ids={
+            AssetKey(["assetgroup", "bar"]): 10,
+            AssetKey(["baz"]): 11,
+        },
         input_data_versions={
             AssetKey(["assetgroup", "bar"]): DataVersion("2"),
             AssetKey(["baz"]): DataVersion("3"),

--- a/python_modules/dagster/dagster_tests/execution_tests/test_data_versions.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_data_versions.py
@@ -1,3 +1,4 @@
+from random import randint
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, Union, cast, overload
 from unittest import mock
 
@@ -6,6 +7,7 @@ from dagster import (
     AssetsDefinition,
     DagsterInstance,
     IOManager,
+    RunConfig,
     SourceAsset,
     asset,
     io_manager,
@@ -13,12 +15,14 @@ from dagster import (
     observable_source_asset,
 )
 from dagster._config.field import Field
+from dagster._config.pythonic_config import Config
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_out import AssetOut
 from dagster._core.definitions.data_version import (
     CODE_VERSION_TAG,
     DATA_VERSION_TAG,
     INPUT_DATA_VERSION_TAG_PREFIX,
+    SKIP_PARTITION_DATA_VERSION_DEPENDENCY_THRESHOLD,
     CachingStaleStatusResolver,
     DataProvenance,
     DataVersion,
@@ -30,13 +34,17 @@ from dagster._core.definitions.data_version import (
     extract_data_version_from_entry,
 )
 from dagster._core.definitions.decorators.asset_decorator import multi_asset
-from dagster._core.definitions.events import AssetKey, Output
+from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey, Output
 from dagster._core.definitions.observe import observe
 from dagster._core.definitions.partition import StaticPartitionsDefinition
 from dagster._core.events import DagsterEventType
 from dagster._core.execution.context.compute import AssetExecutionContext
 from dagster._core.execution.execute_in_process_result import ExecuteInProcessResult
 from dagster._core.instance_for_test import instance_for_test
+from dagster._core.storage.tags import (
+    ASSET_PARTITION_RANGE_END_TAG,
+    ASSET_PARTITION_RANGE_START_TAG,
+)
 from typing_extensions import Literal
 
 from dagster_tests.core_tests.instance_tests.test_instance_data_versions import (
@@ -153,7 +161,7 @@ def materialize_asset(
     *,
     is_multi: Literal[True],
     partition_key: Optional[str] = None,
-    run_config: Optional[Mapping[str, Any]] = None,
+    run_config: Optional[Union[RunConfig, Mapping[str, Any]]] = None,
 ) -> MaterializationTable:
     ...
 
@@ -166,7 +174,7 @@ def materialize_asset(
     *,
     is_multi: Literal[False] = ...,
     partition_key: Optional[str] = None,
-    run_config: Optional[Mapping[str, Any]] = None,
+    run_config: Optional[Union[RunConfig, Mapping[str, Any]]] = None,
 ) -> AssetMaterialization:
     ...
 
@@ -179,7 +187,8 @@ def materialize_asset(
     *,
     is_multi: bool = False,
     partition_key: Optional[str] = None,
-    run_config: Optional[Mapping[str, Any]] = None,
+    run_config: Optional[Union[RunConfig, Mapping[str, Any]]] = None,
+    tags: Optional[Mapping[str, str]] = None,
 ) -> Union[AssetMaterialization, MaterializationTable]:
     assets: List[Union[AssetsDefinition, SourceAsset]] = []
     for asset_def in all_assets:
@@ -198,6 +207,7 @@ def materialize_asset(
         resources={"io_manager": mock_io_manager},
         partition_key=partition_key,
         run_config=run_config,
+        tags=tags,
     )
     if is_multi:
         return get_mats_from_result(result, [asset_to_materialize])
@@ -211,6 +221,7 @@ def materialize_assets(
     instance: DagsterInstance,
     partition_key: Optional[str] = None,
     run_config: Optional[Mapping[str, Any]] = None,
+    tags: Optional[Mapping[str, str]] = None,
 ) -> MaterializationTable:
     result = materialize(
         assets,
@@ -218,6 +229,7 @@ def materialize_assets(
         resources={"io_manager": mock_io_manager},
         partition_key=partition_key,
         run_config=run_config,
+        tags=tags,
     )
     return get_mats_from_result(result, assets)
 
@@ -232,7 +244,10 @@ def materialize_twice(
     return mat1, mat2
 
 
-def get_stale_status_resolver(instance, assets) -> CachingStaleStatusResolver:
+def get_stale_status_resolver(
+    instance: DagsterInstance,
+    assets: Sequence[Union[AssetsDefinition, SourceAsset]],
+) -> CachingStaleStatusResolver:
     return CachingStaleStatusResolver(
         instance=instance,
         asset_graph=AssetGraph.from_assets(assets),
@@ -628,12 +643,96 @@ def test_stale_status_redundant_upstream_materialization() -> None:
         assert status_resolver.get_status(asset2.key) == StaleStatus.FRESH
 
 
-def test_stale_status_partitioned() -> None:
-    partitions_def = StaticPartitionsDefinition(["foo"])
+def test_stale_status_dependency_partitions_count_over_threshold() -> None:
+    partitions_def = StaticPartitionsDefinition(
+        [str(x) for x in range(SKIP_PARTITION_DATA_VERSION_DEPENDENCY_THRESHOLD)]
+    )
 
     @asset(partitions_def=partitions_def)
+    def asset1(context):
+        keys = partitions_def.get_partition_keys_in_range(context.asset_partition_key_range)
+        return {key: randint(0, 100) for key in keys}
+
+    @asset
+    def asset2(asset1):
+        ...
+
+    @asset
+    def asset3(asset1):
+        ...
+
+    all_assets = [asset1, asset2, asset3]
+    with instance_for_test() as instance:
+        status_resolver = get_stale_status_resolver(instance, all_assets)
+        assert status_resolver.get_status(asset1.key, "0") == StaleStatus.MISSING
+        assert status_resolver.get_status(asset2.key) == StaleStatus.MISSING
+        assert status_resolver.get_status(asset3.key) == StaleStatus.MISSING
+
+        materialize_assets(
+            [asset1, asset2],
+            tags={
+                ASSET_PARTITION_RANGE_START_TAG: "0",
+                ASSET_PARTITION_RANGE_END_TAG: str(
+                    SKIP_PARTITION_DATA_VERSION_DEPENDENCY_THRESHOLD - 1
+                ),
+            },
+            instance=instance,
+        )
+        status_resolver = get_stale_status_resolver(instance, all_assets)
+        assert status_resolver.get_status(asset1.key, "0") == StaleStatus.FRESH
+        assert status_resolver.get_status(asset2.key) == StaleStatus.FRESH
+        assert status_resolver.get_status(asset3.key) == StaleStatus.MISSING
+
+        materialize_asset(all_assets, asset3, instance)
+        status_resolver = get_stale_status_resolver(instance, all_assets)
+        assert status_resolver.get_status(asset3.key) == StaleStatus.FRESH
+
+        # Downstream values are not stale even after upstream changed because we are over threshold
+        materialize_asset(all_assets, asset1, instance, partition_key="0")
+        status_resolver = get_stale_status_resolver(instance, all_assets)
+        assert status_resolver.get_status(asset1.key, "0") == StaleStatus.FRESH
+        assert status_resolver.get_status(asset2.key) == StaleStatus.FRESH
+        assert status_resolver.get_status(asset3.key) == StaleStatus.FRESH
+
+
+def test_stale_status_partitions_disabled_code_versions() -> None:
+    partitions_def = StaticPartitionsDefinition(["foo"])
+
+    @asset(code_version="1", partitions_def=partitions_def)
     def asset1():
         ...
+
+    @asset(code_version="1", partitions_def=partitions_def)
+    def asset2(asset1):
+        ...
+
+    all_assets = [asset1, asset2]
+    with instance_for_test() as instance:
+        materialize_assets([asset1, asset2], partition_key="foo", instance=instance)
+
+        status_resolver = get_stale_status_resolver(instance, all_assets)
+        assert status_resolver.get_status(asset1.key, "foo") == StaleStatus.FRESH
+        assert status_resolver.get_status(asset2.key, "foo") == StaleStatus.FRESH
+
+        @asset(code_version="2", partitions_def=partitions_def)
+        def asset1():
+            ...
+
+        all_assets = [asset1, asset2]
+        status_resolver = get_stale_status_resolver(instance, all_assets)
+        assert status_resolver.get_status(asset1.key, "foo") == StaleStatus.STALE
+        assert status_resolver.get_status(asset2.key, "foo") == StaleStatus.STALE
+
+
+def test_stale_status_partitions_enabled() -> None:
+    partitions_def = StaticPartitionsDefinition(["foo"])
+
+    class AssetConfig(Config):
+        value: int = 1
+
+    @asset(partitions_def=partitions_def)
+    def asset1(config: AssetConfig):
+        return Output(config.value, data_version=DataVersion(str(config.value)))
 
     @asset(partitions_def=partitions_def)
     def asset2(asset1):
@@ -646,26 +745,152 @@ def test_stale_status_partitioned() -> None:
     all_assets = [asset1, asset2, asset3]
     with instance_for_test() as instance:
         status_resolver = get_stale_status_resolver(instance, all_assets)
-        assert status_resolver.get_status(asset1.key) == StaleStatus.MISSING
-        assert status_resolver.get_status(asset2.key) == StaleStatus.MISSING
+        assert status_resolver.get_status(asset1.key, "foo") == StaleStatus.MISSING
+        assert status_resolver.get_status(asset2.key, "foo") == StaleStatus.MISSING
         assert status_resolver.get_status(asset3.key) == StaleStatus.MISSING
 
         materialize_assets([asset1, asset2], partition_key="foo", instance=instance)
         status_resolver = get_stale_status_resolver(instance, all_assets)
-        assert status_resolver.get_status(asset1.key) == StaleStatus.FRESH
-        assert status_resolver.get_status(asset2.key) == StaleStatus.FRESH
+        assert status_resolver.get_status(asset1.key, "foo") == StaleStatus.FRESH
+        assert status_resolver.get_status(asset2.key, "foo") == StaleStatus.FRESH
         assert status_resolver.get_status(asset3.key) == StaleStatus.MISSING
 
         materialize_asset(all_assets, asset3, instance)
         status_resolver = get_stale_status_resolver(instance, all_assets)
         assert status_resolver.get_status(asset3.key) == StaleStatus.FRESH
 
-        # Downstream values are not stale even after upstream changed
-        materialize_asset(all_assets, asset1, instance, partition_key="foo")
+        # Downstream values are not stale after upstream rematerialized with same version
+        materialize_asset(
+            all_assets,
+            asset1,
+            instance,
+            partition_key="foo",
+            run_config=RunConfig({"asset1": AssetConfig(value=1)}),
+        )
         status_resolver = get_stale_status_resolver(instance, all_assets)
-        assert status_resolver.get_status(asset1.key) == StaleStatus.FRESH
-        assert status_resolver.get_status(asset2.key) == StaleStatus.FRESH
+        assert status_resolver.get_status(asset1.key, "foo") == StaleStatus.FRESH
+        assert status_resolver.get_status(asset2.key, "foo") == StaleStatus.FRESH
         assert status_resolver.get_status(asset3.key) == StaleStatus.FRESH
+
+        # Downstream values are not stale after upstream rematerialized with same version
+        materialize_asset(
+            all_assets,
+            asset1,
+            instance,
+            partition_key="foo",
+            run_config=RunConfig({"asset1": AssetConfig(value=2)}),
+        )
+        status_resolver = get_stale_status_resolver(instance, all_assets)
+        assert status_resolver.get_status(asset1.key, "foo") == StaleStatus.FRESH
+        assert status_resolver.get_status(asset2.key, "foo") == StaleStatus.STALE
+        assert status_resolver.get_status(asset3.key) == StaleStatus.STALE
+
+
+def test_stale_status_many_to_one_partitions() -> None:
+    partitions_def = StaticPartitionsDefinition(["alpha", "beta"])
+
+    class AssetConfig(Config):
+        value: int = 1
+
+    @asset(partitions_def=partitions_def, code_version="1")
+    def asset1(config: AssetConfig):
+        return Output(1, data_version=DataVersion(str(config.value)))
+
+    @asset(code_version="1")
+    def asset2(asset1):
+        ...
+
+    @asset(partitions_def=partitions_def, code_version="1")
+    def asset3(asset2):
+        return 1
+
+    a1_foo_key = AssetKeyPartitionKey(asset1.key, "alpha")
+    a1_bar_key = AssetKeyPartitionKey(asset1.key, "beta")
+
+    all_assets = [asset1, asset2, asset3]
+    with instance_for_test() as instance:
+        for key in partitions_def.get_partition_keys():
+            materialize_asset(
+                all_assets,
+                asset1,
+                instance,
+                partition_key=key,
+            )
+        materialize_asset(all_assets, asset2, instance)
+
+        status_resolver = get_stale_status_resolver(instance, all_assets)
+        assert status_resolver.get_status(asset1.key, "alpha") == StaleStatus.FRESH
+        assert status_resolver.get_status(asset1.key, "beta") == StaleStatus.FRESH
+        assert status_resolver.get_status(asset2.key) == StaleStatus.FRESH
+        assert status_resolver.get_status(asset3.key, "alpha") == StaleStatus.MISSING
+
+        for key in partitions_def.get_partition_keys():
+            materialize_asset(
+                all_assets,
+                asset3,
+                instance,
+                partition_key=key,
+            )
+        status_resolver = get_stale_status_resolver(instance, all_assets)
+        assert status_resolver.get_status(asset3.key, "alpha") == StaleStatus.FRESH
+        assert status_resolver.get_status(asset3.key, "beta") == StaleStatus.FRESH
+
+        materialize_asset(
+            all_assets,
+            asset1,
+            instance,
+            partition_key="alpha",
+            run_config=RunConfig({"asset1": AssetConfig(value=2)}),
+        )
+        status_resolver = get_stale_status_resolver(instance, all_assets)
+        assert status_resolver.get_status(asset1.key, "alpha") == StaleStatus.FRESH
+        assert status_resolver.get_status(asset1.key, "beta") == StaleStatus.FRESH
+        assert status_resolver.get_status(asset2.key) == StaleStatus.STALE
+        assert status_resolver.get_status(asset3.key, "alpha") == StaleStatus.STALE
+        assert status_resolver.get_status(asset3.key, "beta") == StaleStatus.STALE
+        assert status_resolver.get_stale_causes(asset2.key) == [
+            StaleCause(
+                asset2.key,
+                StaleCauseCategory.DATA,
+                "has a new dependency data version",
+                a1_foo_key,
+                [
+                    StaleCause(a1_foo_key, StaleCauseCategory.DATA, "has a new data version"),
+                ],
+            )
+        ]
+
+        # Now both partitions should show up in stale reasons
+        materialize_asset(
+            all_assets,
+            asset1,
+            instance,
+            partition_key="beta",
+            run_config=RunConfig({"asset1": AssetConfig(value=2)}),
+        )
+        status_resolver = get_stale_status_resolver(instance, all_assets)
+        assert status_resolver.get_stale_causes(asset2.key) == [
+            StaleCause(
+                asset2.key,
+                StaleCauseCategory.DATA,
+                "has a new dependency data version",
+                dep_key,
+                [
+                    StaleCause(dep_key, StaleCauseCategory.DATA, "has a new data version"),
+                ],
+            )
+            for dep_key in [a1_foo_key, a1_bar_key]
+        ]
+        assert status_resolver.get_stale_root_causes(asset3.key, "alpha") == [
+            StaleCause(dep_key, StaleCauseCategory.DATA, "has a new data version")
+            for dep_key in [a1_foo_key, a1_bar_key]
+        ]
+
+        materialize_asset(all_assets, asset2, instance)
+        status_resolver = get_stale_status_resolver(instance, all_assets)
+        assert status_resolver.get_status(asset2.key) == StaleStatus.FRESH
+        assert status_resolver.get_status(asset3.key, "alpha") == StaleStatus.STALE
+        assert status_resolver.get_status(asset3.key, "beta") == StaleStatus.STALE
 
 
 def test_stale_status_manually_versioned() -> None:
@@ -931,6 +1156,7 @@ def test_legacy_data_version_tags():
         assert extract_data_provenance_from_entry(record.event_log_entry) == DataProvenance(
             code_version="1",
             input_data_versions={AssetKey(["foo"]): DataVersion("alpha")},
+            input_storage_ids={AssetKey(["foo"]): 3},
             is_user_provided=True,
         )
 


### PR DESCRIPTION
## Summary & Motivation

Add stale status and cause resolution at partition granularity. The implementation here is somewhat complicated:

- change the identifier used in the `CachingStaleStatusResolver` to `AssetKeyPartitionKey` instead of the plain `AssetKey`
- update `DataProvenance` to contain input storage ids (already stored on `AssetMaterialization` events) in addition to data versions
- given assets A -> B, with A partitioned, the `DataVersion` for A stored in the provenance tags of a B materialization now uses _the combined hash of all partitions of A on which B depends_. This is also used when auto-computing the `DataVersion` of B. This change allows us to avoid an explosion of tags stored on B materializations in the event that are many dependency partitions of A.
- Exception to above: If A has > `SKIP_PARTITION_DATA_VERSION_DEPENDENCY_THRESHOLD` (set to 100 in this PR) partition dependencies of B, then we revert to old behavior (opt out of accurate data version computation and stale status reporting for the A->B edge). This is a temporary limitation that eventually we should remove.

Given A -> B, with A partitioned, when resolving stale status of B we use the storage ID of A stored on the last materialization of B as a cursor:

- check if _any_ new data version record (materialization or observation) for A has been created after the cursor
    - if no, then the dependency hasn't changed, there is no new upstream data from A, since any dependency partition that was newly materialized would have to exist post-cursor
    - if yes, then for each dependency partition, retrieve two records (1) the most recent materialization; (2) the most recent materialization before the cursor. Record (2) corresponds to the materialization last used as input for B. Compare data versions on these two records-- if they are the same for at least one dependency partition, then B is stale (i.e. has new upstream data from A).

Current issues:

- This _does not work_ for observable source assets, since the optimized method used to fetch the data version tag for a large set of partitions requires filtering by a single event type (so we can't look for both `AssetObservation` and `AssetMaterialization` at once).
- The `CachingStaleStatusResolver` currently performs an optimized batch fetch of the most recent materialization/observation for regular asset keys, but it implements no such optimization for `AssetKeyPartitionKey`
- We should probably change the provenance tag used for the data version of a partitioned dependency-- currently the `DATA_VERSION_TAG` is used, but this is misleading since we are now storing a hash of the data versions of all dependency assets rather than an actual data version.
- There is no record on the materialization of exactly which upstream partitions are used to calculate the "combined data version"-- this is determined at runtime by applying the partition mapping. We might want to store this information.

## How I Tested These Changes

- New unit tests
- Profiling done with this script: https://github.com/dagster-io/dagster/pull/15610

Profiling gives a rough estimate of the effect of the dependency limit. In the benchmark script, resolving stale status for ~2000 partitions took approximately 8 seconds with no limit and 4 seconds with a limit (see full results below). This benchmark tests a dead simple scenario for resolving partition status, and more varied scenarios need to be explored to better understand performance characteristics here.

```
Experiment settings
┏━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━┓
┃                      Key ┃ Value ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━┩
│           num_partitions │  2000 │
│ override_partition_limit │  True │
└──────────────────────────┴───────┘

Execution times
┏━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┓
┃ Index ┃                                      Step ┃    Time ┃
┡━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━┩
│     0 │         Resolve StaleStatus of all assets │  0.0443 │
│     1 │ Materialize all 2000 partitions of `root` │ 75.1230 │
│     2 │                 Materialize `downstream1` │  0.1839 │
│     3 │         Resolve StaleStatus of all assets │  7.7065 │
│     4 │                 Materialize `downstream2` │  0.1750 │
│     5 │         Resolve StaleStatus of all assets │  7.5177 │
│     6 │    Materialize single partition of `root` │  0.1642 │
│     7 │         Resolve StaleStatus of all assets │  7.5286 │
└───────┴───────────────────────────────────────────┴─────────┘

Experiment settings
┏━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━┓
┃                      Key ┃ Value ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━┩
│           num_partitions │  2000 │
│ override_partition_limit │ False │
└──────────────────────────┴───────┘

Execution times
┏━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┓
┃ Index ┃                                      Step ┃    Time ┃
┡━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━┩
│     0 │         Resolve StaleStatus of all assets │  0.0440 │
│     1 │ Materialize all 2000 partitions of `root` │ 74.4319 │
│     2 │                 Materialize `downstream1` │  0.2226 │
│     3 │         Resolve StaleStatus of all assets │  4.0985 │
│     4 │                 Materialize `downstream2` │  0.1963 │
│     5 │         Resolve StaleStatus of all assets │  4.1553 │
│     6 │    Materialize single partition of `root` │  0.1618 │
│     7 │         Resolve StaleStatus of all assets │  4.2651 │
└───────┴───────────────────────────────────────────┴─────────┘
```
