### PR TITLE
[ui] Remove jest warnings about `act` in core

### DIFF
--- a/js_modules/dagit/packages/core/src/app/__tests__/CustomConfirmationProvider.test.tsx
+++ b/js_modules/dagit/packages/core/src/app/__tests__/CustomConfirmationProvider.test.tsx
@@ -42,9 +42,11 @@ describe('CustomConfirmationProvider', () => {
     );
 
     const button = screen.queryByRole('button', {name: /terminate/i}) as HTMLButtonElement;
-    await userEvent.click(button);
+    userEvent.click(button);
 
-    expect(screen.queryByText(/r u sure about this/i)).toBeVisible();
+    await waitFor(() => {
+      expect(screen.queryByText(/r u sure about this/i)).toBeVisible();
+    });
   });
 
   it('must perform confirmation correctly', async () => {
@@ -55,22 +57,22 @@ describe('CustomConfirmationProvider', () => {
     );
 
     const button = screen.queryByRole('button', {name: /terminate/i}) as HTMLButtonElement;
-    await userEvent.click(button);
+    userEvent.click(button);
 
-    const confirmationButton = screen.queryByRole('button', {
-      name: /confirm/i,
-    }) as HTMLButtonElement;
+    await waitFor(async () => {
+      const confirmationButton = await screen.findByRole('button', {name: /confirm/i});
+      userEvent.click(confirmationButton);
+    });
 
-    // Resolves the promise.
-    await userEvent.click(confirmationButton);
-
-    expect(screen.queryByText(/confirmed\? true/i)).toBeVisible();
+    await waitFor(() => {
+      expect(screen.queryByText(/confirmed\? true/i)).toBeVisible();
+    });
   });
 
   it('must remove the confirmation Dialog from the DOM afterward', async () => {
     jest.useFakeTimers();
 
-    await act(() => {
+    act(() => {
       render(
         <CustomConfirmationProvider>
           <Test />
@@ -79,7 +81,7 @@ describe('CustomConfirmationProvider', () => {
     });
 
     const button = screen.queryByRole('button', {name: /terminate/i}) as HTMLButtonElement;
-    await act(() => {
+    act(() => {
       button.click();
     });
 
@@ -88,7 +90,7 @@ describe('CustomConfirmationProvider', () => {
     }) as HTMLButtonElement;
 
     // Resolves the promise.
-    await act(() => {
+    act(() => {
       confirmationButton.click();
     });
 

--- a/js_modules/dagit/packages/core/src/assets/__tests__/AssetPartitions.test.tsx
+++ b/js_modules/dagit/packages/core/src/assets/__tests__/AssetPartitions.test.tsx
@@ -70,28 +70,26 @@ const SingleDimensionAssetPartitions: React.FC<{
 
 describe('AssetPartitions', () => {
   it('should support filtering a time-partitioned asset to a time range using the top bar', async () => {
-    await act(async () => {
-      render(<SingleDimensionAssetPartitions assetKey={{path: ['single_dimension_time']}} />);
-    });
+    render(<SingleDimensionAssetPartitions assetKey={{path: ['single_dimension_time']}} />);
 
     await waitFor(() => {
       expect(screen.getByTestId('partitions-selected')).toHaveTextContent('6,000 Partitions');
     });
 
-    const partitionInput = screen.getByTestId('dimension-range-input');
-    await userEvent.clear(partitionInput);
-    await userEvent.type(partitionInput, '{[}2022-11-28-20:00...2022-12-05-01:00{]}');
-    await userEvent.tab();
+    await act(async () => {
+      const partitionInput = screen.getByTestId('dimension-range-input');
+      await userEvent.clear(partitionInput);
+      await userEvent.type(partitionInput, '{[}2022-11-28-20:00...2022-12-05-01:00{]}');
+      await userEvent.tab();
+    });
 
-    await waitFor(() => {
+    await waitFor(async () => {
       // Verify that the counts update to reflect the subrange
       expect(screen.getByTestId('partitions-selected')).toHaveTextContent('150 Partitions');
-    });
-    await waitFor(() => {
+
       expect(screen.getByText('Missing (135)')).toBeVisible();
       expect(screen.getByText('Materialized (15)')).toBeVisible();
-    });
-    await waitFor(() => {
+
       // Verify that the items shown on the left update to reflect the subrange
       expect(screen.queryByText('2022-06-01-01:00')).toBeNull();
       expect(screen.queryByText('2022-11-28-20:00')).toBeVisible();
@@ -99,16 +97,16 @@ describe('AssetPartitions', () => {
   });
 
   it('should sync time range selection to the URL', async () => {
-    await act(async () => {
-      render(<SingleDimensionAssetPartitions assetKey={{path: ['single_dimension_time']}} />);
-    });
+    render(<SingleDimensionAssetPartitions assetKey={{path: ['single_dimension_time']}} />);
 
     const partitionInput = await waitFor(async () => {
       return screen.getByTestId('dimension-range-input');
     });
-    await userEvent.clear(partitionInput);
-    await userEvent.type(partitionInput, '{[}2022-11-28-20:00...2022-12-05-01:00{]}');
-    await userEvent.tab();
+    await act(async () => {
+      await userEvent.clear(partitionInput);
+      await userEvent.type(partitionInput, '{[}2022-11-28-20:00...2022-12-05-01:00{]}');
+      await userEvent.tab();
+    });
 
     await waitFor(() => {
       expect(screen.getByTestId('router-search')).toHaveTextContent(
@@ -118,9 +116,8 @@ describe('AssetPartitions', () => {
   });
 
   it('should support filtering by partition status and sync state to the URL', async () => {
-    await act(async () => {
-      render(<SingleDimensionAssetPartitions assetKey={{path: ['single_dimension_time']}} />);
-    });
+    render(<SingleDimensionAssetPartitions assetKey={{path: ['single_dimension_time']}} />);
+
     await waitFor(() => {
       expect(screen.getByTestId('partitions-selected')).toHaveTextContent('6,000 Partitions');
     });
@@ -128,29 +125,40 @@ describe('AssetPartitions', () => {
     const successCheck = screen.getByTestId(
       `partition-status-${AssetPartitionStatus.MATERIALIZED}-checkbox`,
     );
-    await userEvent.click(successCheck);
-    expect(screen.getByTestId('router-search')).toHaveTextContent(
-      `status=${AssetPartitionStatus.FAILED}%2C${AssetPartitionStatus.MATERIALIZING}%2C${AssetPartitionStatus.MISSING}`,
-    );
-    expect(screen.getByTestId('partitions-selected')).toHaveTextContent('5,310 Partitions');
+    userEvent.click(successCheck);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('router-search')).toHaveTextContent(
+        `status=${AssetPartitionStatus.FAILED}%2C${AssetPartitionStatus.MATERIALIZING}%2C${AssetPartitionStatus.MISSING}`,
+      );
+      expect(screen.getByTestId('partitions-selected')).toHaveTextContent('5,310 Partitions');
+    });
 
     const missingCheck = screen.getByTestId(
       `partition-status-${AssetPartitionStatus.MISSING}-checkbox`,
     );
-    await userEvent.click(missingCheck);
-    expect(screen.getByTestId('router-search')).toHaveTextContent(
-      `status=${AssetPartitionStatus.FAILED}`,
-    );
-    expect(screen.getByTestId('partitions-selected')).toHaveTextContent('22 Partitions Selected');
+    userEvent.click(missingCheck);
 
-    await userEvent.click(successCheck);
-    expect(screen.getByTestId('router-search')).toHaveTextContent(
-      `status=${AssetPartitionStatus.FAILED}%2C${AssetPartitionStatus.MATERIALIZED}`,
-    );
-    expect(screen.getByTestId('partitions-selected')).toHaveTextContent('712 Partitions Selected');
+    await waitFor(() => {
+      expect(screen.getByTestId('router-search')).toHaveTextContent(
+        `status=${AssetPartitionStatus.FAILED}`,
+      );
+      expect(screen.getByTestId('partitions-selected')).toHaveTextContent('22 Partitions Selected');
+    });
 
-    // verify that filtering by state updates the left sidebar
-    expect(screen.queryByText('2022-08-31-00:00')).toBeVisible();
+    userEvent.click(successCheck);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('router-search')).toHaveTextContent(
+        `status=${AssetPartitionStatus.FAILED}%2C${AssetPartitionStatus.MATERIALIZED}`,
+      );
+      expect(screen.getByTestId('partitions-selected')).toHaveTextContent(
+        '712 Partitions Selected',
+      );
+
+      // verify that filtering by state updates the left sidebar
+      expect(screen.queryByText('2022-08-31-00:00')).toBeVisible();
+    });
   });
 
   it('should support reverse sorting individual dimensions', async () => {
@@ -171,9 +179,7 @@ describe('AssetPartitions', () => {
         </MemoryRouter>
       );
     };
-    await act(async () => {
-      render(<Component />);
-    });
+    render(<Component />);
 
     await waitFor(() => {
       expect(screen.getByTestId('partitions-date')).toBeVisible();
@@ -192,7 +198,7 @@ describe('AssetPartitions', () => {
       ).toBeVisible();
     });
 
-    await userEvent.click(screen.getByTestId('sort-0'));
+    userEvent.click(screen.getByTestId('sort-0'));
 
     await waitFor(() => {
       expect(
@@ -206,7 +212,8 @@ describe('AssetPartitions', () => {
       ).toBeVisible();
     });
 
-    await userEvent.click(screen.getByTestId('sort-1'));
+    userEvent.click(screen.getByTestId('sort-1'));
+
     await waitFor(() => {
       expect(
         getByTestId(screen.getByTestId('partitions-zstate'), 'asset-partition-row-WV-index-0'),
@@ -215,9 +222,8 @@ describe('AssetPartitions', () => {
   });
 
   it('should set the focused partition when you click a list element', async () => {
-    await act(async () => {
-      render(<SingleDimensionAssetPartitions assetKey={{path: ['single_dimension_static']}} />);
-    });
+    render(<SingleDimensionAssetPartitions assetKey={{path: ['single_dimension_static']}} />);
+
     await waitFor(async () => {
       const listItem = screen.getByText('NC');
       await userEvent.click(listItem);
@@ -228,9 +234,8 @@ describe('AssetPartitions', () => {
   });
 
   it('should not render a top bar with a partition input for statically partitioned assets', async () => {
-    await act(async () => {
-      render(<SingleDimensionAssetPartitions assetKey={{path: ['single_dimension_static']}} />);
-    });
+    render(<SingleDimensionAssetPartitions assetKey={{path: ['single_dimension_static']}} />);
+
     await waitFor(() => {
       expect(screen.getByTestId('partitions-selected')).toHaveTextContent('11 Partitions Selected');
       expect(screen.queryByTestId('dimension-range-input')).toBeNull();

--- a/js_modules/dagit/packages/core/src/hooks/__tests__/useSelectionReducer.test.tsx
+++ b/js_modules/dagit/packages/core/src/hooks/__tests__/useSelectionReducer.test.tsx
@@ -1,4 +1,4 @@
-import {render, screen} from '@testing-library/react';
+import {render, screen, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as React from 'react';
 
@@ -41,10 +41,14 @@ describe('useSelectionReducer', () => {
     render(<Test ids={['a', 'b', 'c', 'd']} />);
     const checkA = screen.getByRole('checkbox', {name: /checkbox-a/i});
     expect(checkA).not.toBeChecked();
-    await userEvent.click(checkA);
-    expect(checkA).toBeChecked();
-    await userEvent.click(checkA);
-    expect(checkA).not.toBeChecked();
+    userEvent.click(checkA);
+    await waitFor(async () => {
+      expect(checkA).toBeChecked();
+    });
+    userEvent.click(checkA);
+    await waitFor(async () => {
+      expect(checkA).not.toBeChecked();
+    });
   });
 
   it('checks slices of items', async () => {
@@ -60,22 +64,28 @@ describe('useSelectionReducer', () => {
     expect(checkD).not.toBeChecked();
 
     const shiftClickUser = userEvent.setup();
-    await shiftClickUser.keyboard('[ShiftLeft>]');
+    shiftClickUser.keyboard('[ShiftLeft>]');
 
-    await userEvent.click(checkA);
-    expect(checkA).toBeChecked();
-    await shiftClickUser.click(checkC);
+    userEvent.click(checkA);
+    await waitFor(async () => {
+      expect(checkA).toBeChecked();
+    });
 
-    expect(checkA).toBeChecked();
-    expect(checkB).toBeChecked();
-    expect(checkC).toBeChecked();
-    expect(checkD).not.toBeChecked();
+    shiftClickUser.click(checkC);
+    await waitFor(async () => {
+      expect(checkA).toBeChecked();
+      expect(checkB).toBeChecked();
+      expect(checkC).toBeChecked();
+      expect(checkD).not.toBeChecked();
+    });
 
-    await shiftClickUser.click(checkB);
-    expect(checkA).toBeChecked();
-    expect(checkB).not.toBeChecked();
-    expect(checkC).not.toBeChecked();
-    expect(checkD).not.toBeChecked();
+    shiftClickUser.click(checkB);
+    await waitFor(async () => {
+      expect(checkA).toBeChecked();
+      expect(checkB).not.toBeChecked();
+      expect(checkC).not.toBeChecked();
+      expect(checkD).not.toBeChecked();
+    });
   });
 
   it('allows toggle-all', async () => {
@@ -91,18 +101,20 @@ describe('useSelectionReducer', () => {
     expect(checkC).not.toBeChecked();
     expect(checkD).not.toBeChecked();
 
-    await userEvent.click(checkAll);
+    userEvent.click(checkAll);
+    await waitFor(async () => {
+      expect(checkA).toBeChecked();
+      expect(checkB).toBeChecked();
+      expect(checkC).toBeChecked();
+      expect(checkD).toBeChecked();
+    });
 
-    expect(checkA).toBeChecked();
-    expect(checkB).toBeChecked();
-    expect(checkC).toBeChecked();
-    expect(checkD).toBeChecked();
-
-    await userEvent.click(checkAll);
-
-    expect(checkA).not.toBeChecked();
-    expect(checkB).not.toBeChecked();
-    expect(checkC).not.toBeChecked();
-    expect(checkD).not.toBeChecked();
+    userEvent.click(checkAll);
+    await waitFor(async () => {
+      expect(checkA).not.toBeChecked();
+      expect(checkB).not.toBeChecked();
+      expect(checkC).not.toBeChecked();
+      expect(checkD).not.toBeChecked();
+    });
   });
 });

--- a/js_modules/dagit/packages/core/src/instigation/__tests__/InstigationTick.test.tsx
+++ b/js_modules/dagit/packages/core/src/instigation/__tests__/InstigationTick.test.tsx
@@ -6,7 +6,7 @@ import {InstigationTickStatus} from '../../graphql/types';
 import {TickTag} from '../InstigationTick';
 import {TickTagFragment} from '../types/InstigationTick.types';
 
-describe('TickTag', () => {
+describe('InstigationTick', () => {
   const tick: TickTagFragment = {
     __typename: 'InstigationTick',
     id: 'foobar',
@@ -27,7 +27,7 @@ describe('TickTag', () => {
       const tag = screen.queryByText(/skipped/i);
       expect(tag).toBeVisible();
 
-      await userEvent.hover(tag as HTMLElement);
+      userEvent.hover(tag as HTMLElement);
       await waitFor(() => {
         expect(screen.queryByText('lol skipped')).toBeVisible();
       });
@@ -41,7 +41,7 @@ describe('TickTag', () => {
       const tag = screen.queryByText(/skipped/i);
       expect(tag).toBeVisible();
 
-      await userEvent.hover(tag as HTMLElement);
+      userEvent.hover(tag as HTMLElement);
       await waitFor(() => {
         expect(screen.queryByText(/2 runs requested, but skipped/i)).toBeVisible();
       });

--- a/js_modules/dagit/packages/core/src/nav/__tests__/InstanceWarningIcon.test.tsx
+++ b/js_modules/dagit/packages/core/src/nav/__tests__/InstanceWarningIcon.test.tsx
@@ -1,5 +1,5 @@
 import {waitFor} from '@testing-library/dom';
-import {render, screen} from '@testing-library/react';
+import {act, render, screen} from '@testing-library/react';
 import * as React from 'react';
 
 import {
@@ -28,7 +28,7 @@ describe('InstanceWarningIcon', () => {
       }),
     };
 
-    render(<Test mocks={[mocks]} />);
+    await act(() => render(<Test mocks={[mocks]} />));
     await waitFor(() => {
       expect(screen.queryByLabelText('warning')).toBeVisible();
     });
@@ -42,7 +42,7 @@ describe('InstanceWarningIcon', () => {
       }),
     };
 
-    render(<Test mocks={[mocks]} />);
+    await act(() => render(<Test mocks={[mocks]} />));
     await waitFor(() => {
       expect(screen.queryByLabelText('warning')).toBeNull();
     });
@@ -68,7 +68,7 @@ describe('InstanceWarningIcon', () => {
           }),
         };
 
-        render(<Test mocks={[daemonStoppedSchedulerMocks, repoMocks]} />);
+        await act(() => render(<Test mocks={[daemonStoppedSchedulerMocks, repoMocks]} />));
         await waitFor(() => {
           expect(screen.queryByLabelText('warning')).toBeNull();
         });
@@ -82,7 +82,7 @@ describe('InstanceWarningIcon', () => {
           }),
         };
 
-        render(<Test mocks={[daemonStoppedSchedulerMocks, repoMocks]} />);
+        await act(() => render(<Test mocks={[daemonStoppedSchedulerMocks, repoMocks]} />));
         await waitFor(() => {
           expect(screen.queryByLabelText('warning')).toBeNull();
         });
@@ -96,7 +96,7 @@ describe('InstanceWarningIcon', () => {
           }),
         };
 
-        render(<Test mocks={[daemonStoppedSchedulerMocks, repoMocks]} />);
+        await act(() => render(<Test mocks={[daemonStoppedSchedulerMocks, repoMocks]} />));
         await waitFor(() => {
           expect(screen.queryByLabelText('warning')).toBeVisible();
         });
@@ -122,7 +122,7 @@ describe('InstanceWarningIcon', () => {
           }),
         };
 
-        render(<Test mocks={[daemonStoppedSensorMocks, repoMocks]} />);
+        await act(() => render(<Test mocks={[daemonStoppedSensorMocks, repoMocks]} />));
         await waitFor(() => {
           expect(screen.queryByLabelText('warning')).toBeNull();
         });
@@ -136,7 +136,7 @@ describe('InstanceWarningIcon', () => {
           }),
         };
 
-        render(<Test mocks={[daemonStoppedSensorMocks, repoMocks]} />);
+        await act(() => render(<Test mocks={[daemonStoppedSensorMocks, repoMocks]} />));
         await waitFor(() => {
           expect(screen.queryByLabelText('warning')).toBeVisible();
         });
@@ -162,7 +162,7 @@ describe('InstanceWarningIcon', () => {
           }),
         };
 
-        render(<Test mocks={[daemonStoppedBothMocks, repoMocks]} />);
+        await act(() => render(<Test mocks={[daemonStoppedBothMocks, repoMocks]} />));
         await waitFor(() => {
           expect(screen.queryByLabelText('warning')).toBeNull();
         });
@@ -176,7 +176,7 @@ describe('InstanceWarningIcon', () => {
           }),
         };
 
-        render(<Test mocks={[daemonStoppedBothMocks, repoMocks]} />);
+        await act(() => render(<Test mocks={[daemonStoppedBothMocks, repoMocks]} />));
         await waitFor(() => {
           expect(screen.queryByLabelText('warning')).toBeVisible();
         });
@@ -190,7 +190,7 @@ describe('InstanceWarningIcon', () => {
           }),
         };
 
-        render(<Test mocks={[daemonStoppedBothMocks, repoMocks]} />);
+        await act(() => render(<Test mocks={[daemonStoppedBothMocks, repoMocks]} />));
         await waitFor(() => {
           expect(screen.queryByLabelText('warning')).toBeVisible();
         });
@@ -204,7 +204,7 @@ describe('InstanceWarningIcon', () => {
           }),
         };
 
-        render(<Test mocks={[daemonStoppedBothMocks, repoMocks]} />);
+        await act(() => render(<Test mocks={[daemonStoppedBothMocks, repoMocks]} />));
         await waitFor(() => {
           expect(screen.queryByLabelText('warning')).toBeVisible();
         });
@@ -230,9 +230,9 @@ describe('InstanceWarningIcon', () => {
           }),
         };
 
-        render(<Test mocks={[daemonStoppedOtherMocks, repoMocks]} />);
+        await act(() => render(<Test mocks={[daemonStoppedOtherMocks, repoMocks]} />));
         await waitFor(() => {
-          expect(screen.queryByLabelText('warning')).toBeNull();
+          expect(screen.queryByLabelText('warning')).toBeVisible();
         });
       });
     });

--- a/js_modules/dagit/packages/core/src/nav/__tests__/LeftNavRepositorySection.test.tsx
+++ b/js_modules/dagit/packages/core/src/nav/__tests__/LeftNavRepositorySection.test.tsx
@@ -1,4 +1,4 @@
-import {act, render, RenderResult, screen, waitFor} from '@testing-library/react';
+import {render, screen, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as React from 'react';
 
@@ -51,26 +51,20 @@ describe('Repository options', () => {
       }),
     };
 
-    await act(async () => {
-      render(
-        <TestProvider
-          apolloProps={{mocks: [defaultMocks, mocks]}}
-          routerProps={{initialEntries: ['/locations/foo@bar/etc']}}
-        >
-          <LeftNavRepositorySection />
-        </TestProvider>,
-      );
-    });
+    render(
+      <TestProvider
+        apolloProps={{mocks: [defaultMocks, mocks]}}
+        routerProps={{initialEntries: ['/locations/foo@bar/etc']}}
+      >
+        <LeftNavRepositorySection />
+      </TestProvider>,
+    );
 
-    const repoHeader = screen.getByRole('button', {name: /foo/i});
-    await userEvent.click(repoHeader);
+    const repoHeader = await screen.findByRole('button', {name: /foo/i});
+    userEvent.click(repoHeader);
 
     await waitFor(() => {
-      expect(
-        screen.getByRole('link', {
-          name: /my_pipeline/i,
-        }),
-      ).toBeVisible();
+      expect(screen.getByRole('link', {name: /my_pipeline/i})).toBeVisible();
     });
   });
 
@@ -120,19 +114,17 @@ describe('Repository options', () => {
     };
 
     it('initializes with first repo option, if one option and no localStorage', async () => {
-      await act(async () => {
-        render(
-          <TestProvider
-            apolloProps={{mocks: [defaultMocks, mocksWithOne]}}
-            routerProps={{initialEntries: ['/runs']}}
-          >
-            <LeftNavRepositorySection />
-          </TestProvider>,
-        );
-      });
+      render(
+        <TestProvider
+          apolloProps={{mocks: [defaultMocks, mocksWithOne]}}
+          routerProps={{initialEntries: ['/runs']}}
+        >
+          <LeftNavRepositorySection />
+        </TestProvider>,
+      );
 
-      const repoHeader = screen.getByRole('button', {name: /lorem/i});
-      await userEvent.click(repoHeader);
+      const repoHeader = await screen.findByRole('button', {name: /lorem/i});
+      userEvent.click(repoHeader);
 
       await waitFor(() => {
         // Three links. Two jobs, one repo name at the bottom.
@@ -142,19 +134,17 @@ describe('Repository options', () => {
 
     it(`initializes with one repo if it's the only one, even though it's hidden`, async () => {
       window.localStorage.setItem(HIDDEN_REPO_KEYS, `["${repoOne}:${locationOne}"]`);
-      await act(async () => {
-        render(
-          <TestProvider
-            apolloProps={{mocks: [defaultMocks, mocksWithOne]}}
-            routerProps={{initialEntries: ['/runs']}}
-          >
-            <LeftNavRepositorySection />
-          </TestProvider>,
-        );
-      });
+      render(
+        <TestProvider
+          apolloProps={{mocks: [defaultMocks, mocksWithOne]}}
+          routerProps={{initialEntries: ['/runs']}}
+        >
+          <LeftNavRepositorySection />
+        </TestProvider>,
+      );
 
-      const repoHeader = screen.getByRole('button', {name: /lorem/i});
-      await userEvent.click(repoHeader);
+      const repoHeader = await screen.findByRole('button', {name: /lorem/i});
+      userEvent.click(repoHeader);
 
       await waitFor(() => {
         // Three links. Two jobs, one repo name at the bottom.
@@ -163,27 +153,25 @@ describe('Repository options', () => {
     });
 
     it('initializes with all repos visible, if multiple options and no localStorage', async () => {
-      await act(async () => {
-        render(
-          <TestProvider
-            apolloProps={{mocks: [defaultMocks, mocksWithThree]}}
-            routerProps={{initialEntries: ['/runs']}}
-          >
-            <LeftNavRepositorySection />
-          </TestProvider>,
-        );
-      });
+      render(
+        <TestProvider
+          apolloProps={{mocks: [defaultMocks, mocksWithThree]}}
+          routerProps={{initialEntries: ['/runs']}}
+        >
+          <LeftNavRepositorySection />
+        </TestProvider>,
+      );
 
-      const loremHeader = screen.getByRole('button', {name: /lorem/i});
+      const loremHeader = await screen.findByRole('button', {name: /lorem/i});
       expect(loremHeader).toBeVisible();
-      const fooHeader = screen.getByRole('button', {name: /foo/i});
+      const fooHeader = await screen.findByRole('button', {name: /foo/i});
       expect(fooHeader).toBeVisible();
-      const dunderHeader = screen.getByRole('button', {name: /abc_location/i});
+      const dunderHeader = await screen.findByRole('button', {name: /abc_location/i});
       expect(dunderHeader).toBeVisible();
 
-      await userEvent.click(loremHeader);
-      await userEvent.click(fooHeader);
-      await userEvent.click(dunderHeader);
+      userEvent.click(loremHeader);
+      userEvent.click(fooHeader);
+      userEvent.click(dunderHeader);
 
       await waitFor(() => {
         // Twelve jobs total. No repo name link since multiple repos are visible.
@@ -196,19 +184,17 @@ describe('Repository options', () => {
         HIDDEN_REPO_KEYS,
         `["lorem:ipsum","${DUNDER_REPO_NAME}:abc_location"]`,
       );
-      await act(async () => {
-        render(
-          <TestProvider
-            apolloProps={{mocks: [defaultMocks, mocksWithThree]}}
-            routerProps={{initialEntries: ['/runs']}}
-          >
-            <LeftNavRepositorySection />
-          </TestProvider>,
-        );
-      });
+      render(
+        <TestProvider
+          apolloProps={{mocks: [defaultMocks, mocksWithThree]}}
+          routerProps={{initialEntries: ['/runs']}}
+        >
+          <LeftNavRepositorySection />
+        </TestProvider>,
+      );
 
-      const fooHeader = screen.getByRole('button', {name: /foo/i});
-      await userEvent.click(fooHeader);
+      const fooHeader = await screen.findByRole('button', {name: /foo/i});
+      userEvent.click(fooHeader);
 
       // `foo@bar` is visible, and has four jobs. Plus one for repo link at bottom.
       await waitFor(() => {
@@ -218,27 +204,25 @@ describe('Repository options', () => {
 
     it('initializes with all repo options, no matching `HIDDEN_REPO_KEYS` localStorage', async () => {
       window.localStorage.setItem(HIDDEN_REPO_KEYS, '["hello:world"]');
-      await act(async () => {
-        render(
-          <TestProvider
-            apolloProps={{mocks: [defaultMocks, mocksWithThree]}}
-            routerProps={{initialEntries: ['/runs']}}
-          >
-            <LeftNavRepositorySection />
-          </TestProvider>,
-        );
-      });
+      render(
+        <TestProvider
+          apolloProps={{mocks: [defaultMocks, mocksWithThree]}}
+          routerProps={{initialEntries: ['/runs']}}
+        >
+          <LeftNavRepositorySection />
+        </TestProvider>,
+      );
 
-      const loremHeader = screen.getByRole('button', {name: /lorem/i});
+      const loremHeader = await screen.findByRole('button', {name: /lorem/i});
       expect(loremHeader).toBeVisible();
-      const fooHeader = screen.getByRole('button', {name: /foo/i});
+      const fooHeader = await screen.findByRole('button', {name: /foo/i});
       expect(fooHeader).toBeVisible();
-      const dunderHeader = screen.getByRole('button', {name: /abc_location/i});
+      const dunderHeader = await screen.findByRole('button', {name: /abc_location/i});
       expect(dunderHeader).toBeVisible();
 
-      await userEvent.click(loremHeader);
-      await userEvent.click(fooHeader);
-      await userEvent.click(dunderHeader);
+      userEvent.click(loremHeader);
+      userEvent.click(fooHeader);
+      userEvent.click(dunderHeader);
 
       await waitFor(() => {
         // Twelve jobs total. No repo name link since multiple repos are visible.
@@ -251,16 +235,14 @@ describe('Repository options', () => {
         HIDDEN_REPO_KEYS,
         `["lorem:ipsum", "foo:bar", "${DUNDER_REPO_NAME}:abc_location"]`,
       );
-      await act(async () => {
-        render(
-          <TestProvider
-            apolloProps={{mocks: [defaultMocks, mocksWithThree]}}
-            routerProps={{initialEntries: ['/runs']}}
-          >
-            <LeftNavRepositorySection />
-          </TestProvider>,
-        );
-      });
+      render(
+        <TestProvider
+          apolloProps={{mocks: [defaultMocks, mocksWithThree]}}
+          routerProps={{initialEntries: ['/runs']}}
+        >
+          <LeftNavRepositorySection />
+        </TestProvider>,
+      );
 
       const loremHeader = screen.queryByRole('button', {name: /lorem/i});
       expect(loremHeader).toBeNull();
@@ -270,7 +252,9 @@ describe('Repository options', () => {
       expect(dunderHeader).toBeNull();
 
       // No linked jobs or repos. Everything is hidden.
-      expect(screen.queryAllByRole('link')).toHaveLength(0);
+      await waitFor(() => {
+        expect(screen.queryAllByRole('link')).toHaveLength(0);
+      });
     });
 
     it('initializes empty, then shows options when they are added', async () => {
@@ -281,44 +265,39 @@ describe('Repository options', () => {
         }),
       };
 
-      let rerender: RenderResult['rerender'];
-
-      await act(async () => {
-        const result = render(
-          <TestProvider
-            apolloProps={{mocks: [defaultMocks, initialMocks]}}
-            routerProps={{initialEntries: ['/runs']}}
-          >
-            <LeftNavRepositorySection />
-          </TestProvider>,
-        );
-        rerender = result.rerender;
-      });
+      const {rerender} = render(
+        <TestProvider
+          apolloProps={{mocks: [defaultMocks, initialMocks]}}
+          routerProps={{initialEntries: ['/runs']}}
+        >
+          <LeftNavRepositorySection />
+        </TestProvider>,
+      );
 
       // Zero repositories, so zero pipelines.
-      expect(screen.queryAllByRole('link')).toHaveLength(0);
-
-      await act(async () => {
-        rerender(
-          <TestProvider
-            apolloProps={{mocks: [defaultMocks, mocksWithThree]}}
-            routerProps={{initialEntries: ['/runs']}}
-          >
-            <LeftNavRepositorySection />
-          </TestProvider>,
-        );
+      await waitFor(() => {
+        expect(screen.queryAllByRole('link')).toHaveLength(0);
       });
 
-      const loremHeader = screen.getByRole('button', {name: /lorem/i});
+      rerender(
+        <TestProvider
+          apolloProps={{mocks: [defaultMocks, mocksWithThree]}}
+          routerProps={{initialEntries: ['/runs']}}
+        >
+          <LeftNavRepositorySection />
+        </TestProvider>,
+      );
+
+      const loremHeader = await screen.findByRole('button', {name: /lorem/i});
       expect(loremHeader).toBeVisible();
-      const fooHeader = screen.getByRole('button', {name: /foo/i});
+      const fooHeader = await screen.findByRole('button', {name: /foo/i});
       expect(fooHeader).toBeVisible();
-      const dunderHeader = screen.getByRole('button', {name: /abc_location/i});
+      const dunderHeader = await screen.findByRole('button', {name: /abc_location/i});
       expect(dunderHeader).toBeVisible();
 
-      await userEvent.click(loremHeader);
-      await userEvent.click(fooHeader);
-      await userEvent.click(dunderHeader);
+      userEvent.click(loremHeader);
+      userEvent.click(fooHeader);
+      userEvent.click(dunderHeader);
 
       // After repositories are added and expanded, all become visible.
       await waitFor(() => {
@@ -334,40 +313,37 @@ describe('Repository options', () => {
         }),
       };
 
-      let rerender: RenderResult['rerender'];
+      const {rerender} = render(
+        <TestProvider
+          apolloProps={{mocks: [defaultMocks, mocksWithOne]}}
+          routerProps={{initialEntries: ['/runs']}}
+        >
+          <LeftNavRepositorySection />
+        </TestProvider>,
+      );
 
-      await act(async () => {
-        const result = render(
-          <TestProvider
-            apolloProps={{mocks: [defaultMocks, mocksWithOne]}}
-            routerProps={{initialEntries: ['/runs']}}
-          >
-            <LeftNavRepositorySection />
-          </TestProvider>,
-        );
-        rerender = result.rerender;
-      });
-
-      const loremHeader = screen.getByRole('button', {name: /lorem/i});
+      const loremHeader = await screen.findByRole('button', {name: /lorem/i});
       expect(loremHeader).toBeVisible();
-      await userEvent.click(loremHeader);
+      userEvent.click(loremHeader);
 
       // Three links: two jobs, one repo link at bottom.
-      expect(screen.queryAllByRole('link')).toHaveLength(3);
-
-      await act(async () => {
-        rerender(
-          <TestProvider
-            apolloProps={{mocks: [defaultMocks, mocksAfterRemoval]}}
-            routerProps={{initialEntries: ['/runs']}}
-          >
-            <LeftNavRepositorySection />
-          </TestProvider>,
-        );
+      await waitFor(() => {
+        expect(screen.queryAllByRole('link')).toHaveLength(3);
       });
 
+      rerender(
+        <TestProvider
+          apolloProps={{mocks: [defaultMocks, mocksAfterRemoval]}}
+          routerProps={{initialEntries: ['/runs']}}
+        >
+          <LeftNavRepositorySection />
+        </TestProvider>,
+      );
+
       // After repositories are removed, there are none displayed.
-      expect(screen.queryAllByRole('link')).toHaveLength(0);
+      await waitFor(() => {
+        expect(screen.queryAllByRole('link')).toHaveLength(0);
+      });
     });
   });
 
@@ -399,31 +375,21 @@ describe('Repository options', () => {
     };
 
     it('renders asset groups alongside jobs', async () => {
-      await act(async () => {
-        render(
-          <TestProvider
-            apolloProps={{mocks: [defaultMocks, mocks]}}
-            routerProps={{initialEntries: ['/locations/foo@bar/etc']}}
-          >
-            <LeftNavRepositorySection />
-          </TestProvider>,
-        );
-      });
+      render(
+        <TestProvider
+          apolloProps={{mocks: [defaultMocks, mocks]}}
+          routerProps={{initialEntries: ['/locations/foo@bar/etc']}}
+        >
+          <LeftNavRepositorySection />
+        </TestProvider>,
+      );
 
-      const repoHeader = screen.getByRole('button', {name: /lorem/i});
-      await userEvent.click(repoHeader);
+      const repoHeader = await screen.findByRole('button', {name: /lorem/i});
+      userEvent.click(repoHeader);
 
       await waitFor(() => {
-        expect(
-          screen.getByRole('link', {
-            name: /my_pipeline/i,
-          }),
-        ).toBeVisible();
-        expect(
-          screen.getByRole('link', {
-            name: /my_asset_group/i,
-          }),
-        ).toBeVisible();
+        expect(screen.getByRole('link', {name: /my_pipeline/i})).toBeVisible();
+        expect(screen.getByRole('link', {name: /my_asset_group/i})).toBeVisible();
       });
     });
   });

--- a/js_modules/dagit/packages/core/src/nav/__tests__/WorkspaceStatus.test.tsx
+++ b/js_modules/dagit/packages/core/src/nav/__tests__/WorkspaceStatus.test.tsx
@@ -1,5 +1,5 @@
 import {waitFor} from '@testing-library/dom';
-import {render, screen} from '@testing-library/react';
+import {act, render, screen} from '@testing-library/react';
 import * as React from 'react';
 
 import {
@@ -21,7 +21,7 @@ describe('WorkspaceStatus', () => {
   };
 
   it('does not display if no errors', async () => {
-    render(<Test />);
+    await act(async () => render(<Test />));
     await waitFor(() => {
       expect(screen.queryByLabelText('warning')).toBeNull();
     });
@@ -34,7 +34,7 @@ describe('WorkspaceStatus', () => {
         message: () => 'Failure',
       }),
     };
-    render(<Test mocks={mocks} />);
+    await act(async () => render(<Test mocks={mocks} />));
     await waitFor(() => {
       expect(screen.queryByLabelText('warning')).toBeVisible();
     });

--- a/js_modules/dagit/packages/core/src/nav/__tests__/useRepositoryLocationReload.test.tsx
+++ b/js_modules/dagit/packages/core/src/nav/__tests__/useRepositoryLocationReload.test.tsx
@@ -7,7 +7,7 @@ import {
   useRepositoryLocationReload,
 } from '../useRepositoryLocationReload';
 
-describe('useRepositoryReloadLocation', () => {
+describe('useRepositoryLocationReload', () => {
   jest.useFakeTimers();
 
   const LOCATION = 'bar';
@@ -42,20 +42,20 @@ describe('useRepositoryReloadLocation', () => {
   };
 
   it('reloads successfully if there are no errors', async () => {
-    await act(() => {
+    await act(() =>
       render(
         <TestProvider apolloProps={{mocks: [defaultMocks]}}>
           <Test />
         </TestProvider>,
-      );
-    });
+      ),
+    );
 
     await waitFor(() => {
       expect(screen.queryByText(/Reloading: false/)).toBeVisible();
       expect(screen.queryByText(/Has error: false/)).toBeVisible();
     });
 
-    fireEvent.click(screen.getByText(/Try/));
+    await act(async () => await fireEvent.click(screen.getByText(/Try/)));
 
     await waitFor(() => {
       expect(screen.queryByText(/Reloading: true/)).toBeVisible();
@@ -78,10 +78,12 @@ describe('useRepositoryReloadLocation', () => {
       }),
     };
 
-    render(
-      <TestProvider apolloProps={{mocks: [defaultMocks, mocks]}}>
-        <Test />
-      </TestProvider>,
+    await act(async () =>
+      render(
+        <TestProvider apolloProps={{mocks: [defaultMocks, mocks]}}>
+          <Test />
+        </TestProvider>,
+      ),
     );
 
     await waitFor(() => {
@@ -112,10 +114,12 @@ describe('useRepositoryReloadLocation', () => {
       }),
     };
 
-    render(
-      <TestProvider apolloProps={{mocks: [defaultMocks, mocks]}}>
-        <Test />
-      </TestProvider>,
+    await act(() =>
+      render(
+        <TestProvider apolloProps={{mocks: [defaultMocks, mocks]}}>
+          <Test />
+        </TestProvider>,
+      ),
     );
 
     await waitFor(() => {
@@ -147,10 +151,12 @@ describe('useRepositoryReloadLocation', () => {
       }),
     };
 
-    const {rerender} = render(
-      <TestProvider apolloProps={{mocks: [defaultMocks, mocks]}}>
-        <Test />
-      </TestProvider>,
+    const {rerender} = await act(() =>
+      render(
+        <TestProvider apolloProps={{mocks: [defaultMocks, mocks]}}>
+          <Test />
+        </TestProvider>,
+      ),
     );
 
     fireEvent.click(screen.getByText(/Try/));
@@ -171,15 +177,13 @@ describe('useRepositoryReloadLocation', () => {
     });
 
     // Set the location entry to `LOADED`, which should terminate polling.
-    rerender(
-      <TestProvider apolloProps={{mocks: defaultMocks}}>
-        <Test />
-      </TestProvider>,
-    );
-
-    jest.runAllTicks();
-
     await waitFor(() => {
+      rerender(
+        <TestProvider apolloProps={{mocks: defaultMocks}}>
+          <Test />
+        </TestProvider>,
+      );
+      jest.runAllTicks();
       expect(screen.queryByText(/Reloading: false/)).toBeVisible();
       expect(screen.queryByText(/Has error: false/)).toBeVisible();
     });
@@ -194,10 +198,12 @@ describe('useRepositoryReloadLocation', () => {
       }),
     };
 
-    const {rerender} = render(
-      <TestProvider apolloProps={{mocks: [defaultMocks, mocks]}}>
-        <Test />
-      </TestProvider>,
+    const {rerender} = await act(() =>
+      render(
+        <TestProvider apolloProps={{mocks: [defaultMocks, mocks]}}>
+          <Test />
+        </TestProvider>,
+      ),
     );
 
     fireEvent.click(screen.getByText(/Try/));

--- a/js_modules/dagit/packages/core/src/partitions/__tests__/CreatePartitionDialog.test.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/__tests__/CreatePartitionDialog.test.tsx
@@ -53,8 +53,11 @@ describe('CreatePartitionDialog', () => {
       render(<Test mocks={[createFixture]} />);
     });
     const partitionInput = screen.getByTestId('partition-input');
-    await userEvent.type(partitionInput, 'testPartitionName');
-    await userEvent.click(screen.getByTestId('save-partition-button'));
+    userEvent.type(partitionInput, 'testPartitionName');
+    await waitFor(() => {
+      expect(partitionInput).toHaveValue('testPartitionName');
+    });
+    userEvent.click(screen.getByTestId('save-partition-button'));
     await waitFor(() => {
       expect(onCloseMock).toHaveBeenCalled();
       expect(onCreatedMock).toHaveBeenCalledWith('testPartitionName');
@@ -63,17 +66,27 @@ describe('CreatePartitionDialog', () => {
   });
 
   it('Shows error state', async () => {
-    await act(async () => {
-      render(<Test mocks={[]} />);
+    render(<Test mocks={[]} />);
+
+    const partitionInput = await screen.findByTestId('partition-input');
+    expect(screen.queryByTestId('warning-icon')).toBeNull();
+    userEvent.clear(partitionInput);
+    userEvent.type(partitionInput, 'invalidname\n\r\t');
+    await waitFor(() => {
+      expect(screen.getByTestId('warning-icon')).toBeVisible();
     });
-    const partitionInput = screen.getByTestId('partition-input');
-    expect(screen.queryByTestId('warning-icon')).toBeNull();
-    await userEvent.type(partitionInput, 'invalidname\n\r\t');
-    expect(screen.getByTestId('warning-icon')).toBeVisible();
-    await userEvent.clear(partitionInput);
-    expect(screen.queryByTestId('warning-icon')).toBeNull();
-    await userEvent.type(partitionInput, 'validname');
-    expect(screen.queryByTestId('warning-icon')).toBeNull();
+    await act(async () => {
+      userEvent.clear(partitionInput);
+    });
+    await waitFor(() => {
+      expect(screen.queryByTestId('warning-icon')).toBeNull();
+    });
+    await act(async () => {
+      await userEvent.type(partitionInput, 'validname');
+    });
+    await waitFor(() => {
+      expect(screen.queryByTestId('warning-icon')).toBeNull();
+    });
   });
 
   it('Shows error state when mutation fails', async () => {
@@ -90,12 +103,19 @@ describe('CreatePartitionDialog', () => {
         message: 'test message 123',
       }),
     });
-    await act(async () => {
-      render(<Test mocks={[createFixture]} />);
+    render(<Test mocks={[createFixture]} />);
+
+    const partitionInput = await screen.findByTestId('partition-input');
+    userEvent.clear(partitionInput);
+    await waitFor(() => {
+      expect(partitionInput).toHaveValue('');
     });
-    const partitionInput = screen.getByTestId('partition-input');
-    await userEvent.type(partitionInput, 'testPartitionName');
-    await userEvent.click(screen.getByTestId('save-partition-button'));
+    userEvent.type(partitionInput, 'testPartitionName');
+    await waitFor(() => {
+      expect(partitionInput).toHaveValue('testPartitionName');
+    });
+
+    userEvent.click(screen.getByTestId('save-partition-button'));
     await waitFor(() => {
       expect(createFixture.result).toHaveBeenCalled();
       expect(showCustomAlertSpy).toHaveBeenCalledWith({

--- a/js_modules/dagit/packages/core/src/runs/__tests__/ReexecutionDialog.test.tsx
+++ b/js_modules/dagit/packages/core/src/runs/__tests__/ReexecutionDialog.test.tsx
@@ -101,7 +101,7 @@ describe('ReexecutionDialog', () => {
     });
 
     const button = screen.getByText(/re\-execute 3 runs/i);
-    await userEvent.click(button);
+    userEvent.click(button);
 
     await waitFor(() => {
       expect(
@@ -123,7 +123,7 @@ describe('ReexecutionDialog', () => {
 
     await waitFor(async () => {
       const button = screen.getByText(/re\-execute 3 runs/i);
-      await userEvent.click(button);
+      userEvent.click(button);
     });
 
     await waitFor(() => {
@@ -145,7 +145,7 @@ describe('ReexecutionDialog', () => {
 
     await waitFor(async () => {
       const button = screen.getByText(/re\-execute 3 runs/i);
-      await userEvent.click(button);
+      userEvent.click(button);
     });
 
     await waitFor(() => {

--- a/js_modules/dagit/packages/core/src/runs/__tests__/RunActionsMenu.test.tsx
+++ b/js_modules/dagit/packages/core/src/runs/__tests__/RunActionsMenu.test.tsx
@@ -1,4 +1,4 @@
-import {act, render, screen} from '@testing-library/react';
+import {render, screen, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as React from 'react';
 
@@ -49,45 +49,45 @@ describe('RunActionsMenu', () => {
 
   describe('Permissions', () => {
     it('renders menu when open', async () => {
-      await act(async () => {
-        render(<Test run={runFragment} />);
-      });
+      render(<Test run={runFragment} />);
 
       const button = screen.queryByRole('button') as HTMLButtonElement;
       expect(button).toBeVisible();
 
-      await userEvent.click(button);
+      userEvent.click(button);
 
-      expect(screen.queryByRole('menuitem', {name: /view configuration/i})).toBeVisible();
-      expect(screen.queryByRole('link', {name: /open in launchpad/i})).toBeVisible();
-      expect(screen.queryByRole('menuitem', {name: /re\-execute/i})).toBeVisible();
-      expect(screen.queryByRole('menuitem', {name: /download debug file/i})).toBeVisible();
-      expect(screen.queryByRole('menuitem', {name: /delete/i})).toBeVisible();
+      await waitFor(() => {
+        expect(screen.queryByRole('menuitem', {name: /view configuration/i})).toBeVisible();
+        expect(screen.queryByRole('link', {name: /open in launchpad/i})).toBeVisible();
+        expect(screen.queryByRole('menuitem', {name: /re\-execute/i})).toBeVisible();
+        expect(screen.queryByRole('menuitem', {name: /download debug file/i})).toBeVisible();
+        expect(screen.queryByRole('menuitem', {name: /delete/i})).toBeVisible();
+      });
     });
 
     it('disables re-execution if no permission', async () => {
-      await act(async () => {
-        render(
-          <Test
-            run={runFragment}
-            permissionOverrides={{
-              launch_pipeline_reexecution: {enabled: false, disabledReason: 'lol nope'},
-            }}
-          />,
-        );
-      });
+      render(
+        <Test
+          run={runFragment}
+          permissionOverrides={{
+            launch_pipeline_reexecution: {enabled: false, disabledReason: 'lol nope'},
+          }}
+        />,
+      );
 
       const button = screen.queryByRole('button') as HTMLButtonElement;
       expect(button).toBeVisible();
 
-      await userEvent.click(button);
+      userEvent.click(button);
 
-      const reExecutionButton = screen.queryByRole('menuitem', {
-        name: /re\-execute/i,
-      }) as HTMLButtonElement;
+      await waitFor(() => {
+        const reExecutionButton = screen.queryByRole('menuitem', {
+          name: /re\-execute/i,
+        }) as HTMLButtonElement;
 
-      // Blueprint doesn't actually set `disabled` on the button element.
-      expect(reExecutionButton.classList.contains('bp4-disabled')).toBe(true);
+        // Blueprint doesn't actually set `disabled` on the button element.
+        expect(reExecutionButton.classList.contains('bp4-disabled')).toBe(true);
+      });
     });
   });
 });

--- a/js_modules/dagit/packages/core/src/runs/__tests__/RunFilterInput.test.tsx
+++ b/js_modules/dagit/packages/core/src/runs/__tests__/RunFilterInput.test.tsx
@@ -140,7 +140,7 @@ function TestRunsFilterInput({
 describe('<RunFilterInput  />', () => {
   // b. Test rendering with all enabledFilters
   // (Include tests for rendering with different combinations of enabledFilters)
-  it('should call onChange with updated tokens when created DATE filter is updated', () => {
+  it('should call onChange with updated tokens when created DATE filter is updated', async () => {
     const onChange = jest.fn();
     const tokens: RunFilterToken[] = [
       {token: 'created_date_before', value: '1609459200'}, // 1/1/2021
@@ -161,6 +161,7 @@ describe('<RunFilterInput  />', () => {
     fireEvent.click(getByText('Filter'));
     fireEvent.click(getByText('Created date'));
     fireEvent.click(getByText('Today'));
+    await waitFor(() => expect(getByText(/Timestamp is/)).toBeVisible());
 
     expect(onChange).toHaveBeenCalledWith([
       {
@@ -179,6 +180,11 @@ describe('<RunFilterInput  />', () => {
         onChange={onChange}
         enabledFilters={['job']}
         mocks={[
+          runTagKeysMock,
+          buildRunTagValuesQueryMockedResponse(DagsterTag.Partition, ['partition1', 'partition2']),
+          buildRunTagValuesQueryMockedResponse(DagsterTag.User, []),
+          buildRunTagValuesQueryMockedResponse(DagsterTag.SensorName, []),
+          buildRunTagValuesQueryMockedResponse(DagsterTag.ScheduleName, []),
           buildWorkspaceContextMockedResponse(
             buildWorkspace({
               locationEntries: [
@@ -204,17 +210,20 @@ describe('<RunFilterInput  />', () => {
         ]}
       />,
     );
-
     onChange.mockClear();
 
     fireEvent.click(getByText('Filter'));
+    await waitFor(() => expect(getByText('Job')).toBeVisible());
+
     fireEvent.click(getByText('Job'));
+    await waitFor(() => expect(getByText('some_job')).toBeVisible());
+
+    fireEvent.click(getByText('some_job'));
+    await waitFor(() => expect(getByText(/Job is/)).toBeVisible());
 
     await waitFor(() => {
-      fireEvent.click(getByText('some_job'));
+      expect(onChange).toHaveBeenCalledWith([{token: 'job', value: 'some_job'}]);
     });
-
-    expect(onChange).toHaveBeenCalledWith([{token: 'job', value: 'some_job'}]);
   });
 
   it('should call onChange with updated tokens when BACKFILL filter is updated', async () => {
@@ -251,6 +260,9 @@ describe('<RunFilterInput  />', () => {
         mocks={[
           runTagKeysMock,
           buildRunTagValuesQueryMockedResponse(DagsterTag.Partition, ['partition1', 'partition2']),
+          buildRunTagValuesQueryMockedResponse(DagsterTag.User, []),
+          buildRunTagValuesQueryMockedResponse(DagsterTag.ScheduleName, []),
+          buildRunTagValuesQueryMockedResponse(DagsterTag.SensorName, []),
         ]}
       />,
     );

--- a/js_modules/dagit/packages/core/src/schedules/__tests__/ScheduleBulkActionMenu.test.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/__tests__/ScheduleBulkActionMenu.test.tsx
@@ -1,4 +1,4 @@
-import {render, screen} from '@testing-library/react';
+import {render, screen, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as React from 'react';
 
@@ -35,12 +35,14 @@ describe('ScheduleBulkActionMenu', () => {
     expect(button).toBeVisible();
     expect(button).toBeEnabled();
 
-    await userEvent.click(button);
+    userEvent.click(button);
 
-    const startItem = screen.getByRole('menuitem', {name: /start 2 schedules/i});
-    expectAriaEnabled(startItem);
-    const stopItem = screen.getByRole('menuitem', {name: /stop 2 schedules/i});
-    expectAriaDisabled(stopItem);
+    await waitFor(async () => {
+      const startItem = screen.getByRole('menuitem', {name: /start 2 schedules/i});
+      expectAriaEnabled(startItem);
+      const stopItem = screen.getByRole('menuitem', {name: /stop 2 schedules/i});
+      expectAriaDisabled(stopItem);
+    });
   });
 
   it('renders button and menu items for running schedules', async () => {
@@ -55,12 +57,14 @@ describe('ScheduleBulkActionMenu', () => {
     expect(button).toBeVisible();
     expect(button).toBeEnabled();
 
-    await userEvent.click(button);
+    userEvent.click(button);
 
-    const startItem = screen.getByRole('menuitem', {name: /start 2 schedules/i});
-    expectAriaDisabled(startItem);
-    const stopItem = screen.getByRole('menuitem', {name: /stop 2 schedules/i});
-    expectAriaEnabled(stopItem);
+    await waitFor(async () => {
+      const startItem = screen.getByRole('menuitem', {name: /start 2 schedules/i});
+      expectAriaDisabled(startItem);
+      const stopItem = screen.getByRole('menuitem', {name: /stop 2 schedules/i});
+      expectAriaEnabled(stopItem);
+    });
   });
 
   it('renders button and menu items for mixture of statuses', async () => {
@@ -80,12 +84,14 @@ describe('ScheduleBulkActionMenu', () => {
     expect(button).toBeVisible();
     expect(button).toBeEnabled();
 
-    await userEvent.click(button);
+    userEvent.click(button);
 
     // Both options enabled
-    const startItem = screen.getByRole('menuitem', {name: /start 4 schedules/i});
-    expectAriaEnabled(startItem);
-    const stopItem = screen.getByRole('menuitem', {name: /stop 4 schedules/i});
-    expectAriaEnabled(stopItem);
+    await waitFor(async () => {
+      const startItem = screen.getByRole('menuitem', {name: /start 4 schedules/i});
+      expectAriaEnabled(startItem);
+      const stopItem = screen.getByRole('menuitem', {name: /stop 4 schedules/i});
+      expectAriaEnabled(stopItem);
+    });
   });
 });

--- a/js_modules/dagit/packages/core/src/schedules/__tests__/ScheduleStateChangeDialog.test.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/__tests__/ScheduleStateChangeDialog.test.tsx
@@ -116,7 +116,7 @@ describe('ScheduleStateChangeDialog', () => {
       );
 
       const confirmButton = screen.getByRole('button', {name: /start/i});
-      await userEvent.click(confirmButton);
+      userEvent.click(confirmButton);
 
       await waitFor(() => {
         const button = screen.getByRole('button', {name: /starting/i});
@@ -144,7 +144,7 @@ describe('ScheduleStateChangeDialog', () => {
       );
 
       const confirmButton = screen.getByRole('button', {name: /start/i});
-      await userEvent.click(confirmButton);
+      userEvent.click(confirmButton);
 
       await waitFor(() => {
         const button = screen.getByRole('button', {name: /starting/i});
@@ -180,7 +180,7 @@ describe('ScheduleStateChangeDialog', () => {
       );
 
       const confirmButton = screen.getByRole('button', {name: /stop/i});
-      await userEvent.click(confirmButton);
+      userEvent.click(confirmButton);
 
       await waitFor(() => {
         const button = screen.getByRole('button', {name: /stopping/i});
@@ -208,7 +208,7 @@ describe('ScheduleStateChangeDialog', () => {
       );
 
       const confirmButton = screen.getByRole('button', {name: /stop/i});
-      await userEvent.click(confirmButton);
+      userEvent.click(confirmButton);
 
       await waitFor(() => {
         const button = screen.getByRole('button', {name: /stopping/i});

--- a/js_modules/dagit/packages/core/src/sensors/__tests__/SensorStateChangeDialog.test.tsx
+++ b/js_modules/dagit/packages/core/src/sensors/__tests__/SensorStateChangeDialog.test.tsx
@@ -116,7 +116,7 @@ describe('SensorStateChangeDialog', () => {
       );
 
       const confirmButton = screen.getByRole('button', {name: /start/i});
-      await userEvent.click(confirmButton);
+      userEvent.click(confirmButton);
 
       await waitFor(() => {
         const button = screen.getByRole('button', {name: /starting/i});
@@ -144,7 +144,7 @@ describe('SensorStateChangeDialog', () => {
       );
 
       const confirmButton = screen.getByRole('button', {name: /start/i});
-      await userEvent.click(confirmButton);
+      userEvent.click(confirmButton);
 
       await waitFor(() => {
         const button = screen.getByRole('button', {name: /starting/i});
@@ -180,7 +180,7 @@ describe('SensorStateChangeDialog', () => {
       );
 
       const confirmButton = screen.getByRole('button', {name: /stop/i});
-      await userEvent.click(confirmButton);
+      userEvent.click(confirmButton);
 
       await waitFor(() => {
         const button = screen.getByRole('button', {name: /stopping/i});
@@ -208,7 +208,7 @@ describe('SensorStateChangeDialog', () => {
       );
 
       const confirmButton = screen.getByRole('button', {name: /stop/i});
-      await userEvent.click(confirmButton);
+      userEvent.click(confirmButton);
 
       await waitFor(() => {
         const button = screen.getByRole('button', {name: /stopping/i});

--- a/js_modules/dagit/packages/core/src/ticks/__tests__/EvaluateScheduleDialog.test.tsx
+++ b/js_modules/dagit/packages/core/src/ticks/__tests__/EvaluateScheduleDialog.test.tsx
@@ -1,6 +1,6 @@
 import {Resolvers} from '@apollo/client';
 import {MockedProvider, MockedResponse} from '@apollo/client/testing';
-import {act, render, screen, waitFor} from '@testing-library/react';
+import {render, screen, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as React from 'react';
 
@@ -38,39 +38,39 @@ function Test({mocks, resolvers}: {mocks?: MockedResponse[]; resolvers?: Resolve
   );
 }
 
-describe('EvaluateScheduleTest', () => {
+describe('EvaluateScheduleDialog', () => {
   it('submits evaluateSchedule mutation with cursor variable and renders successful result and persists cursor', async () => {
-    await act(async () => {
-      render(<Test mocks={[GetScheduleQueryMock, ScheduleDryRunMutationRunRequests]} />);
-    });
+    render(<Test mocks={[GetScheduleQueryMock, ScheduleDryRunMutationRunRequests]} />);
+
     await waitFor(async () => {
       const selectButton = screen.getByTestId('tick-selection');
       expect(selectButton).toBeVisible();
-      await userEvent.click(selectButton);
+      userEvent.click(selectButton);
     });
+
     await waitFor(() => {
       expect(screen.getByTestId('tick-5')).toBeVisible();
     });
-    await userEvent.click(screen.getByTestId('tick-5'));
-    await userEvent.click(screen.getByTestId('evaluate'));
+    userEvent.click(screen.getByTestId('tick-5'));
+    userEvent.click(screen.getByTestId('evaluate'));
+
     await waitFor(() => {
-      expect(screen.getByText(/1\s+run request/gi)).toBeVisible();
+      expect(screen.getByText(/1\s+run request/i)).toBeVisible();
     });
   });
 
   it('renders errors', async () => {
-    await act(async () => {
-      render(<Test mocks={[GetScheduleQueryMock, ScheduleDryRunMutationError]} />);
-    });
+    render(<Test mocks={[GetScheduleQueryMock, ScheduleDryRunMutationError]} />);
+
     await waitFor(async () => {
       expect(screen.getByTestId('tick-selection')).toBeVisible();
     });
-    await userEvent.click(screen.getByTestId('tick-selection'));
+    userEvent.click(screen.getByTestId('tick-selection'));
     await waitFor(() => {
       expect(screen.getByTestId('tick-5')).toBeVisible();
     });
-    await userEvent.click(screen.getByTestId('tick-5'));
-    await userEvent.click(screen.getByTestId('evaluate'));
+    userEvent.click(screen.getByTestId('tick-5'));
+    userEvent.click(screen.getByTestId('evaluate'));
     await waitFor(() => {
       expect(screen.getByText('Failed')).toBeVisible();
       expect(screen.queryByText('Skipped')).toBe(null);
@@ -78,19 +78,18 @@ describe('EvaluateScheduleTest', () => {
   });
 
   it('renders skip reason', async () => {
-    await act(async () => {
-      render(<Test mocks={[GetScheduleQueryMock, ScheduleDryRunMutationSkipped]} />);
-    });
+    render(<Test mocks={[GetScheduleQueryMock, ScheduleDryRunMutationSkipped]} />);
+
     await waitFor(async () => {
       const selectButton = screen.getByTestId('tick-selection');
       expect(selectButton).toBeVisible();
-      await userEvent.click(selectButton);
+      userEvent.click(selectButton);
     });
     await waitFor(() => {
       expect(screen.getByTestId('tick-5')).toBeVisible();
     });
-    await userEvent.click(screen.getByTestId('tick-5'));
-    await userEvent.click(screen.getByTestId('evaluate'));
+    userEvent.click(screen.getByTestId('tick-5'));
+    userEvent.click(screen.getByTestId('evaluate'));
     await waitFor(() => {
       expect(screen.getByText('Skipped')).toBeVisible();
     });

--- a/js_modules/dagit/packages/core/src/ticks/__tests__/SensorDryRunDialog.test.tsx
+++ b/js_modules/dagit/packages/core/src/ticks/__tests__/SensorDryRunDialog.test.tsx
@@ -1,6 +1,6 @@
 import {Resolvers} from '@apollo/client';
 import {MockedProvider, MockedResponse} from '@apollo/client/testing';
-import {act, render, screen, waitFor} from '@testing-library/react';
+import {render, screen, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as React from 'react';
 
@@ -36,33 +36,39 @@ function Test({mocks, resolvers}: {mocks?: MockedResponse[]; resolvers?: Resolve
 
 describe('SensorDryRunTest', () => {
   it('submits sensorDryRun mutation with cursor variable and renders successful result and persists cursor', async () => {
-    await act(async () => {
-      render(
-        <Test mocks={[Mocks.SensorDryRunMutationRunRequests, Mocks.PersistCursorValueMock]} />,
-      );
-    });
+    render(<Test mocks={[Mocks.SensorDryRunMutationRunRequests, Mocks.PersistCursorValueMock]} />);
+
     const cursorInput = screen.getByTestId('cursor-input');
-    await userEvent.type(cursorInput, 'testing123');
-    await userEvent.click(screen.getByTestId('evaluate'));
+    userEvent.type(cursorInput, 'testing123');
     await waitFor(() => {
-      expect(screen.getByText(/3\srun requests/g)).toBeVisible();
+      expect(cursorInput).toHaveValue('testCursortesting123');
+    });
+
+    userEvent.click(screen.getByTestId('evaluate'));
+    await waitFor(() => {
+      expect(screen.getByText(/3\srun requests/)).toBeVisible();
       expect(screen.queryByText('Skipped')).toBe(null);
       expect(screen.queryByText('Failed')).toBe(null);
     });
-    await userEvent.click(screen.getByTestId('persist-cursor'));
-    expect(screen.getByText('Persisting')).toBeVisible();
+    userEvent.click(screen.getByTestId('persist-cursor'));
+    await waitFor(() => {
+      expect(screen.getByText('Persisting')).toBeVisible();
+    });
     await waitFor(() => {
       expect(screen.getByText('Persisted')).toBeVisible();
     });
   });
 
   it('renders errors', async () => {
-    await act(async () => {
-      render(<Test mocks={[Mocks.SensorDryRunMutationError]} />);
-    });
+    render(<Test mocks={[Mocks.SensorDryRunMutationError]} />);
+
     const cursorInput = screen.getByTestId('cursor-input');
-    await userEvent.type(cursorInput, 'testing123');
-    await userEvent.click(screen.getByTestId('evaluate'));
+    userEvent.type(cursorInput, 'testing123');
+    await waitFor(() => {
+      expect(cursorInput).toHaveValue('testCursortesting123');
+    });
+
+    userEvent.click(screen.getByTestId('evaluate'));
     await waitFor(() => {
       expect(screen.getByText('Failed')).toBeVisible();
       expect(screen.queryByText('Skipped')).toBe(null);
@@ -70,29 +76,37 @@ describe('SensorDryRunTest', () => {
   });
 
   it('allows you to test again', async () => {
-    await act(async () => {
-      render(<Test mocks={[Mocks.SensorDryRunMutationError]} />);
-    });
+    render(<Test mocks={[Mocks.SensorDryRunMutationError]} />);
+
     const cursorInput = screen.getByTestId('cursor-input');
-    await userEvent.type(cursorInput, 'testing123');
-    await userEvent.click(screen.getByTestId('evaluate'));
+    userEvent.type(cursorInput, 'testing123');
+    await waitFor(() => {
+      expect(cursorInput).toHaveValue('testCursortesting123');
+    });
+
+    userEvent.click(screen.getByTestId('evaluate'));
     await waitFor(() => {
       expect(screen.getByText('Failed')).toBeVisible();
       expect(screen.queryByText('Skipped')).toBe(null);
     });
-    await userEvent.click(screen.getByTestId('test-again'));
-    expect(screen.queryByText('Failed')).toBe(null);
-    expect(screen.queryByText('Skipped')).toBe(null);
-    expect(screen.getByTestId('cursor-input')).toBeVisible();
+    userEvent.click(screen.getByTestId('test-again'));
+    await waitFor(() => {
+      expect(screen.queryByText('Failed')).toBe(null);
+      expect(screen.queryByText('Skipped')).toBe(null);
+      expect(screen.getByTestId('cursor-input')).toBeVisible();
+    });
   });
 
   it('renders skip reason', async () => {
-    await act(async () => {
-      render(<Test mocks={[Mocks.SensorDryRunMutationSkipped]} />);
-    });
+    render(<Test mocks={[Mocks.SensorDryRunMutationSkipped]} />);
+
     const cursorInput = screen.getByTestId('cursor-input');
-    await userEvent.type(cursorInput, 'testing123');
-    await userEvent.click(screen.getByTestId('evaluate'));
+    userEvent.type(cursorInput, 'testing123');
+    await waitFor(() => {
+      expect(cursorInput).toHaveValue('testCursortesting123');
+    });
+    userEvent.click(screen.getByTestId('evaluate'));
+
     await waitFor(() => {
       expect(screen.getByText('Skipped')).toBeVisible();
     });

--- a/js_modules/dagit/packages/core/src/ui/Filters/__tests__/FilterDropdown.test.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Filters/__tests__/FilterDropdown.test.tsx
@@ -47,7 +47,7 @@ describe('FilterDropdown', () => {
         setPortaledElements={jest.fn()}
       />,
     );
-    expect(screen.getByText(/Type/g)).toBeInTheDocument();
+    expect(screen.getByText(/Type/)).toBeInTheDocument();
     expect(screen.getByText('Status')).toBeInTheDocument();
   });
 
@@ -85,26 +85,26 @@ describe('FilterDropdownButton', () => {
   test('opens and closes the dropdown on click', async () => {
     render(<FilterDropdownButton filters={mockFilters} />);
     const button = screen.getByRole('button');
-    await userEvent.click(button);
+    userEvent.click(button);
     await waitFor(() => {
-      expect(screen.getByText(/Type/g)).toBeInTheDocument();
+      expect(screen.getByText(/Type/)).toBeInTheDocument();
     });
-    await userEvent.click(button);
+    userEvent.click(button);
     await waitFor(() => {
-      expect(screen.queryByText(/Type/g)).not.toBeInTheDocument();
+      expect(screen.queryByText(/Type/)).not.toBeInTheDocument();
     });
   });
 
   test('closes the dropdown when clicking outside', async () => {
     render(<FilterDropdownButton filters={mockFilters} />);
     const button = screen.getByRole('button');
-    await userEvent.click(button);
+    userEvent.click(button);
     await waitFor(() => {
-      expect(screen.getByText(/Type/g)).toBeInTheDocument();
+      expect(screen.getByText(/Type/)).toBeInTheDocument();
     });
-    await userEvent.click(document.body);
+    userEvent.click(document.body);
     await waitFor(() => {
-      expect(screen.queryByText(/Type/g)).not.toBeInTheDocument();
+      expect(screen.queryByText(/Type/)).not.toBeInTheDocument();
     });
   });
 });
@@ -113,8 +113,10 @@ describe('FilterDropdown Accessibility', () => {
   const testKeyboardNavigation = async (nextKey: any, prevKey: any, enterKey: any) => {
     render(<FilterDropdownButton filters={mockFilters} />);
 
-    await userEvent.click(screen.getByRole('button'));
-    expect(screen.getByRole('menu')).toBeInTheDocument();
+    userEvent.click(screen.getByRole('button'));
+    await waitFor(() => {
+      expect(screen.getByRole('menu')).toBeInTheDocument();
+    });
 
     const input = screen.getByLabelText('Search filters');
     expect(input).toHaveFocus();
@@ -190,9 +192,10 @@ describe('FilterDropdown Accessibility', () => {
   test('escape key behavior', async () => {
     render(<FilterDropdownButton filters={mockFilters} />);
 
-    await userEvent.click(screen.getByRole('button'));
-    expect(screen.getByRole('menu')).toBeVisible();
-
+    userEvent.click(screen.getByRole('button'));
+    await waitFor(() => {
+      expect(screen.getByRole('menu')).toBeVisible();
+    });
     const input = screen.getByLabelText('Search filters');
     expect(input).toHaveFocus();
 

--- a/js_modules/dagit/packages/core/src/ui/__tests__/useRepoExpansionState.test.tsx
+++ b/js_modules/dagit/packages/core/src/ui/__tests__/useRepoExpansionState.test.tsx
@@ -1,4 +1,4 @@
-import {act, render, screen} from '@testing-library/react';
+import {render, screen, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as React from 'react';
 
@@ -44,9 +44,7 @@ describe('useRepoExpansionState', () => {
 
   it('provides a list of expanded keys for the stored state', async () => {
     window.localStorage.setItem(buildStorageKey('', COLLAPSED_STORAGE_KEY), JSON.stringify([]));
-    await act(async () => {
-      render(<Test />);
-    });
+    render(<Test />);
 
     // Expect all keys to be expanded
     expect(screen.getByText('ipsum:lorem expanded')).toBeVisible();
@@ -59,9 +57,7 @@ describe('useRepoExpansionState', () => {
       buildStorageKey('', COLLAPSED_STORAGE_KEY),
       JSON.stringify(['ipsum:lorem']),
     );
-    await act(async () => {
-      render(<Test />);
-    });
+    render(<Test />);
 
     // Expect keys to have appropriate state. One collapsed!
     expect(screen.getByText('ipsum:lorem collapsed')).toBeVisible();
@@ -72,62 +68,61 @@ describe('useRepoExpansionState', () => {
   it('toggles a key to expanded', async () => {
     const fullCollapsedKey = buildStorageKey('', COLLAPSED_STORAGE_KEY);
     window.localStorage.setItem(fullCollapsedKey, JSON.stringify(['ipsum:lorem']));
-    await act(async () => {
-      render(<Test />);
-    });
+    render(<Test />);
 
     const button = screen.getByRole('button', {name: 'toggle ipsum:lorem'});
-    await userEvent.click(button);
-
-    expect(screen.getByText('ipsum:lorem expanded')).toBeVisible();
-    expect(window.localStorage.getItem(fullCollapsedKey)).toEqual('[]');
+    userEvent.click(button);
+    await waitFor(async () => {
+      expect(screen.getByText('ipsum:lorem expanded')).toBeVisible();
+      expect(window.localStorage.getItem(fullCollapsedKey)).toEqual('[]');
+    });
   });
 
   it('toggles a key to collapsed', async () => {
     const fullCollapsedKey = buildStorageKey('', COLLAPSED_STORAGE_KEY);
     window.localStorage.setItem(fullCollapsedKey, JSON.stringify([]));
-    await act(async () => {
-      render(<Test />);
-    });
+    render(<Test />);
 
     const button = screen.getByRole('button', {name: 'toggle ipsum:lorem'});
-    await userEvent.click(button);
+    userEvent.click(button);
 
-    expect(screen.getByText('ipsum:lorem collapsed')).toBeVisible();
-    expect(window.localStorage.getItem(fullCollapsedKey)).toEqual(JSON.stringify(['ipsum:lorem']));
+    await waitFor(async () => {
+      expect(screen.getByText('ipsum:lorem collapsed')).toBeVisible();
+      expect(window.localStorage.getItem(fullCollapsedKey)).toEqual(
+        JSON.stringify(['ipsum:lorem']),
+      );
+    });
   });
 
   it('toggles all to expanded', async () => {
     const fullCollapsedKey = buildStorageKey('', COLLAPSED_STORAGE_KEY);
     window.localStorage.setItem(fullCollapsedKey, JSON.stringify(['ipsum:lorem', 'amet:dolorsit']));
-    await act(async () => {
-      render(<Test />);
-    });
+    render(<Test />);
 
     const button = screen.getByRole('button', {name: 'expand all'});
-    await userEvent.click(button);
+    userEvent.click(button);
 
     // Everything expanded!
-    expect(screen.getByText('ipsum:lorem expanded')).toBeVisible();
-    expect(screen.getByText('amet:dolorsit expanded')).toBeVisible();
-    expect(screen.getByText('adipiscing:consectetur expanded')).toBeVisible();
+    await waitFor(async () => {
+      expect(screen.getByText('ipsum:lorem expanded')).toBeVisible();
+      expect(screen.getByText('amet:dolorsit expanded')).toBeVisible();
+      expect(screen.getByText('adipiscing:consectetur expanded')).toBeVisible();
+    });
   });
 
   it('toggles all to collapsed', async () => {
     const fullCollapsedKey = buildStorageKey('', COLLAPSED_STORAGE_KEY);
     window.localStorage.setItem(fullCollapsedKey, JSON.stringify(['ipsum:lorem']));
-    await act(async () => {
-      render(<Test />);
-    });
+    render(<Test />);
 
     const button = screen.getByRole('button', {name: 'collapse all'});
-    await act(async () => {
-      await userEvent.click(button);
-    });
+    userEvent.click(button);
 
     // Everything collapsed!
-    expect(screen.getByText('ipsum:lorem collapsed')).toBeVisible();
-    expect(screen.getByText('amet:dolorsit collapsed')).toBeVisible();
-    expect(screen.getByText('adipiscing:consectetur collapsed')).toBeVisible();
+    await waitFor(async () => {
+      expect(screen.getByText('ipsum:lorem collapsed')).toBeVisible();
+      expect(screen.getByText('amet:dolorsit collapsed')).toBeVisible();
+      expect(screen.getByText('adipiscing:consectetur collapsed')).toBeVisible();
+    });
   });
 });


### PR DESCRIPTION
## Summary & Motivation

This PR removes all occurrences of "change must be wrapped in act" from the `core` tests. Removing these mostly came down to:

- Do not `await` click commands, add a waitFor afterwards that waits for the impact to be visible.

- Do await `type` commands -- otherwise subsequent commands (like a click) will run before the typing is complete. You can achieve this by using `act` or by adding a `waitsFor value to be <what you just typed>`

- Do not `await` act if the body of the act function does not return a promise.

Fixing all these revealed some /actual/ warnings coming from the tests, and a few tests which were not actually testing things as intended because they were not awaiting the result properly! We may need some follow-ups to fix the real warnings.

## How I Tested These Changes

Getting these out of the tests was tricky because the log stack traces often don't reference the test that triggered the act warning because the trace is a bunch of async react stuff. To cause tests with act warnings to fail, I opened the react-testing node module and patched it to throw instead of warn. That made it easy to fix a test + re-run over and over again.