### PR TITLE
Add a `dagster code-server start` CLI entrypoint with the ability to reload code without restarting the process

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -380,6 +380,7 @@ LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
             "sqlite_instance_multi_location",
             "sqlite_instance_managed_grpc_env",
             "sqlite_instance_deployed_grpc_env",
+            "sqlite_instance_code_server_cli_grpc_env",
             "graphql_python_client",
             "postgres-graphql_context_variants",
             "postgres-instance_multi_location",
@@ -396,6 +397,7 @@ LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
                         # due to https://github.com/grpc/grpc/issues/31885
                         "sqlite_instance_managed_grpc_env",
                         "sqlite_instance_deployed_grpc_env",
+                        "sqlite_instance_code_server_cli_grpc_env",
                         "sqlite_instance_multi_location",
                         "postgres-instance_multi_location",
                         "postgres-instance_managed_grpc_env",

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/repositories_workspaces_tests/test_workspace.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/repositories_workspaces_tests/test_workspace.py
@@ -1,4 +1,7 @@
+import pytest
+
 from dagster import DagsterInstance
+from dagster._core.instance_for_test import instance_for_test
 from dagster._core.workspace.load import load_workspace_process_context_from_yaml_paths
 from dagster._utils import file_relative_path
 from docs_snippets.concepts.repositories_workspaces.hello_world_repository import (
@@ -17,9 +20,15 @@ def test_hello_world_repository():
     assert len(hello_world_repository.get_all_jobs()) == 1
 
 
-def test_workspace_yamls():
+@pytest.fixture
+def instance():
+    with instance_for_test() as my_instance:
+        yield my_instance
+
+
+def test_workspace_yamls(instance):
     with load_workspace_process_context_from_yaml_paths(
-        DagsterInstance.ephemeral(),
+        instance,
         [
             file_relative_path(
                 __file__,
@@ -30,7 +39,7 @@ def test_workspace_yamls():
         assert workspace_process_context.code_locations_count == 1
 
     with load_workspace_process_context_from_yaml_paths(
-        DagsterInstance.ephemeral(),
+        instance,
         [
             file_relative_path(
                 __file__,
@@ -41,7 +50,7 @@ def test_workspace_yamls():
         assert workspace_process_context.code_locations_count == 1
 
     with load_workspace_process_context_from_yaml_paths(
-        DagsterInstance.ephemeral(),
+        instance,
         [
             file_relative_path(
                 __file__,
@@ -52,7 +61,7 @@ def test_workspace_yamls():
         assert workspace_process_context.code_locations_count == 1
 
     with load_workspace_process_context_from_yaml_paths(
-        DagsterInstance.ephemeral(),
+        instance,
         [
             file_relative_path(
                 __file__,
@@ -63,7 +72,7 @@ def test_workspace_yamls():
         assert workspace_process_context.code_locations_count == 1
 
     with load_workspace_process_context_from_yaml_paths(
-        DagsterInstance.ephemeral(),
+        instance,
         [
             file_relative_path(
                 __file__,

--- a/python_modules/dagit/dagit/app.py
+++ b/python_modules/dagit/dagit/app.py
@@ -5,7 +5,7 @@ from dagster import (
 from dagster._cli.workspace.cli_target import get_workspace_process_context_from_kwargs
 from dagster._core.execution.compute_logs import warn_if_compute_logs_disabled
 from dagster._core.telemetry import log_workspace_stats
-from dagster._core.workspace.context import WorkspaceProcessContext
+from dagster._core.workspace.context import IWorkspaceProcessContext
 from starlette.applications import Starlette
 
 from .version import __version__
@@ -13,12 +13,12 @@ from .webserver import DagitWebserver
 
 
 def create_app_from_workspace_process_context(
-    workspace_process_context: WorkspaceProcessContext,
+    workspace_process_context: IWorkspaceProcessContext,
     path_prefix: str = "",
     **kwargs,
 ) -> Starlette:
     check.inst_param(
-        workspace_process_context, "workspace_process_context", WorkspaceProcessContext
+        workspace_process_context, "workspace_process_context", IWorkspaceProcessContext
     )
     check.str_param(path_prefix, "path_prefix")
 

--- a/python_modules/dagit/dagit/cli.py
+++ b/python_modules/dagit/dagit/cli.py
@@ -15,7 +15,9 @@ from dagster._cli.workspace.cli_target import WORKSPACE_TARGET_WARNING, ClickArg
 from dagster._core.instance import InstanceRef
 from dagster._core.telemetry import START_DAGIT_WEBSERVER, log_action
 from dagster._core.telemetry_upload import uploading_logging_thread
-from dagster._core.workspace.context import WorkspaceProcessContext
+from dagster._core.workspace.context import (
+    IWorkspaceProcessContext,
+)
 from dagster._serdes import deserialize_value
 from dagster._utils import DEFAULT_WORKSPACE_YAML_FILENAME, find_free_port, is_port_in_use
 from dagster._utils.log import configure_loggers
@@ -187,14 +189,14 @@ async def _lifespan(app):
 
 
 def host_dagit_ui_with_workspace_process_context(
-    workspace_process_context: WorkspaceProcessContext,
+    workspace_process_context: IWorkspaceProcessContext,
     host: Optional[str],
     port: Optional[int],
     path_prefix: str,
     log_level: str,
 ):
     check.inst_param(
-        workspace_process_context, "workspace_process_context", WorkspaceProcessContext
+        workspace_process_context, "workspace_process_context", IWorkspaceProcessContext
     )
     host = check.opt_str_param(host, "host", "127.0.0.1")
     check.opt_int_param(port, "port")

--- a/python_modules/dagit/dagit/debug.py
+++ b/python_modules/dagit/dagit/debug.py
@@ -1,11 +1,16 @@
 from gzip import GzipFile
+from typing import Any, Optional
 
 import click
 from dagster import (
     DagsterInstance,
 )
 from dagster._core.debug import DebugRunPayload
-from dagster._core.workspace.context import WorkspaceProcessContext
+from dagster._core.workspace.context import (
+    BaseWorkspaceRequestContext,
+    IWorkspaceProcessContext,
+    WorkspaceRequestContext,
+)
 from dagster._serdes.serdes import deserialize_value
 
 from .cli import (
@@ -14,6 +19,41 @@ from .cli import (
     host_dagit_ui_with_workspace_process_context,
 )
 from .version import __version__
+
+
+class DagitDebugWorkspaceProcessContext(IWorkspaceProcessContext):
+    def __init__(
+        self,
+        instance: DagsterInstance,
+    ):
+        self._instance = instance
+
+    def create_request_context(self, source: Optional[Any] = None) -> BaseWorkspaceRequestContext:
+        return WorkspaceRequestContext(
+            instance=self._instance,
+            workspace_snapshot={},
+            process_context=self,
+            version=__version__,
+            source=source,
+            read_only=False,
+        )
+
+    @property
+    def version(self) -> str:
+        return __version__
+
+    def refresh_code_location(self, name: str) -> None:
+        raise NotImplementedError
+
+    def reload_code_location(self, name: str) -> None:
+        raise NotImplementedError
+
+    def reload_workspace(self) -> None:
+        pass
+
+    @property
+    def instance(self) -> DagsterInstance:
+        return self._instance
 
 
 @click.command(
@@ -44,7 +84,7 @@ def dagit_debug_command(input_files, port):
             debug_payloads.append(debug_payload)
 
     instance = DagsterInstance.ephemeral(preload=debug_payloads)
-    with WorkspaceProcessContext(instance, None, version=__version__) as workspace_process_context:
+    with DagitDebugWorkspaceProcessContext(instance) as workspace_process_context:
         host_dagit_ui_with_workspace_process_context(
             workspace_process_context=workspace_process_context,
             port=port,

--- a/python_modules/dagit/dagit/debug.py
+++ b/python_modules/dagit/dagit/debug.py
@@ -22,6 +22,11 @@ from .version import __version__
 
 
 class DagitDebugWorkspaceProcessContext(IWorkspaceProcessContext):
+    """IWorkspaceProcessContext that works with an ephemeral instance, which is needed
+    for dagit-debug to work (a regular WorkspaceProcessContext will fail when it tries
+    to call .get_ref() on the instance when spinning up a code server).
+    """
+
     def __init__(
         self,
         instance: DagsterInstance,

--- a/python_modules/dagit/dagit_tests/test_app.py
+++ b/python_modules/dagit/dagit_tests/test_app.py
@@ -15,17 +15,23 @@ from dagster._utils import file_relative_path
 from starlette.testclient import TestClient
 
 
-def test_create_app_with_workspace():
+@pytest.fixture
+def instance():
+    with instance_for_test() as the_instance:
+        yield the_instance
+
+
+def test_create_app_with_workspace(instance):
     with load_workspace_process_context_from_yaml_paths(
-        DagsterInstance.ephemeral(),
+        instance,
         [file_relative_path(__file__, "./workspace.yaml")],
     ) as workspace_process_context:
         assert create_app_from_workspace_process_context(workspace_process_context)
 
 
-def test_create_app_with_multiple_workspace_files():
+def test_create_app_with_multiple_workspace_files(instance):
     with load_workspace_process_context_from_yaml_paths(
-        DagsterInstance.ephemeral(),
+        instance,
         [
             file_relative_path(__file__, "./workspace.yaml"),
             file_relative_path(__file__, "./override.yaml"),
@@ -71,9 +77,9 @@ def test_notebook_view():
             assert b"6cac0c38-2c97-49ca-887c-4ac43f141213" in res.content
 
 
-def test_index_view():
+def test_index_view(instance):
     with load_workspace_process_context_from_yaml_paths(
-        DagsterInstance.ephemeral(), [file_relative_path(__file__, "./workspace.yaml")]
+        instance, [file_relative_path(__file__, "./workspace.yaml")]
     ) as workspace_process_context:
         client = TestClient(create_app_from_workspace_process_context(workspace_process_context))
         res = client.get("/")
@@ -82,9 +88,9 @@ def test_index_view():
         assert b"You need to enable JavaScript to run this app" in res.content
 
 
-def test_index_view_at_path_prefix():
+def test_index_view_at_path_prefix(instance):
     with load_workspace_process_context_from_yaml_paths(
-        DagsterInstance.ephemeral(), [file_relative_path(__file__, "./workspace.yaml")]
+        instance, [file_relative_path(__file__, "./workspace.yaml")]
     ) as workspace_process_context:
         client = TestClient(
             create_app_from_workspace_process_context(workspace_process_context, "/dagster-path"),
@@ -101,9 +107,9 @@ def test_index_view_at_path_prefix():
         assert b'{"pathPrefix": "/dagster-path"' in res.content
 
 
-def test_graphql_view():
+def test_graphql_view(instance):
     with load_workspace_process_context_from_yaml_paths(
-        DagsterInstance.ephemeral(), [file_relative_path(__file__, "./workspace.yaml")]
+        instance, [file_relative_path(__file__, "./workspace.yaml")]
     ) as workspace_process_context:
         client = TestClient(
             create_app_from_workspace_process_context(
@@ -114,9 +120,9 @@ def test_graphql_view():
         assert b"No GraphQL query found in the request" in res.content
 
 
-def test_graphql_view_at_path_prefix():
+def test_graphql_view_at_path_prefix(instance):
     with load_workspace_process_context_from_yaml_paths(
-        DagsterInstance.ephemeral(), [file_relative_path(__file__, "./workspace.yaml")]
+        instance, [file_relative_path(__file__, "./workspace.yaml")]
     ) as workspace_process_context:
         client = TestClient(
             create_app_from_workspace_process_context(workspace_process_context, "/dagster-path"),

--- a/python_modules/dagster-graphql/dagster_graphql/cli.py
+++ b/python_modules/dagster-graphql/dagster_graphql/cli.py
@@ -196,16 +196,18 @@ def ui(text, file, predefined, variables, remote, output, ephemeral_instance, **
         res = execute_query_against_remote(remote, query, variables)
         print(res)  # noqa: T201
     else:
-        instance = DagsterInstance.ephemeral() if ephemeral_instance else DagsterInstance.get()
-        with get_workspace_process_context_from_kwargs(
-            instance, version=__version__, read_only=False, kwargs=kwargs
-        ) as workspace_process_context:
-            execute_query_from_cli(
-                workspace_process_context,
-                query,
-                variables,
-                output,
-            )
+        with (
+            DagsterInstance.local_temp() if ephemeral_instance else DagsterInstance.get()
+        ) as instance:
+            with get_workspace_process_context_from_kwargs(
+                instance, version=__version__, read_only=False, kwargs=kwargs
+            ) as workspace_process_context:
+                execute_query_from_cli(
+                    workspace_process_context,
+                    query,
+                    variables,
+                    output,
+                )
 
 
 cli = create_dagster_graphql_cli()

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/graphql_context_test_suite.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/graphql_context_test_suite.py
@@ -278,7 +278,7 @@ class EnvironmentManagers:
     def managed_grpc(target=None, location_name="test"):
         @contextmanager
         def _mgr_fn(instance, read_only):
-            """Goes out of process via grpc."""
+            """Relies on Dagit to load the code location in a subprocess and manage its lifecyle."""
             loadable_target_origin = (
                 target if target is not None else get_main_loadable_target_origin()
             )
@@ -308,6 +308,8 @@ class EnvironmentManagers:
 
     @staticmethod
     def deployed_grpc(target=None, location_name="test"):
+        """Launches a code server in a "dagster api grpc" subprocess."""
+
         @contextmanager
         def _mgr_fn(instance, read_only):
             with GrpcServerProcess(
@@ -336,6 +338,10 @@ class EnvironmentManagers:
 
     @staticmethod
     def code_server_cli_grpc(target=None, location_name="test"):
+        """Launches a code server in a "dagster code-server start" subprocess (which will
+        in turn open up a `dagster api grpc` subprocess that actually loads the code location).
+        """
+
         @contextmanager
         def _mgr_fn(instance, read_only):
             loadable_target_origin = target or get_main_loadable_target_origin()
@@ -419,7 +425,7 @@ class Marks:
     queued_run_coordinator = pytest.mark.queued_run_coordinator
     non_launchable = pytest.mark.non_launchable
 
-    # Repository Location marks
+    # Code location marks
     multi_location = pytest.mark.multi_location
     managed_grpc_env = pytest.mark.managed_grpc_env
     deployed_grpc_env = pytest.mark.deployed_grpc_env

--- a/python_modules/dagster-graphql/pytest.ini
+++ b/python_modules/dagster-graphql/pytest.ini
@@ -10,7 +10,8 @@ markers =
     non_launchable: The instance does has neither a run launcher nor an execution manager configured
     multi_location: Workspace has multiple repository locations
     managed_grpc_env: Dagster creates a gRPC server to run user code
-    deployed_grpc_env: User is running their own gRPC server
+    deployed_grpc_env: User is running their own gRPC server via `dagster api grpc`
+    code_server_cli_grpc_env: User is running their own gRPC server via `dagster code-server start`
     graphql_context_test_suite: Uses graphql_context_test_suite infrastructure.
     asset_aware_instance:
     python_client_test_suite: Tests for the GraphQL Python client

--- a/python_modules/dagster-graphql/tox.ini
+++ b/python_modules/dagster-graphql/tox.ini
@@ -23,6 +23,7 @@ commands =
   sqlite_instance_multi_location: pytest -c ../../pyproject.toml -m "graphql_context_test_suite and sqlite_instance and multi_location" -vv {posargs}
   sqlite_instance_managed_grpc_env: pytest -c ../../pyproject.toml -m "graphql_context_test_suite and sqlite_instance and managed_grpc_env" -vv {posargs}
   sqlite_instance_deployed_grpc_env: pytest -c ../../pyproject.toml -m "graphql_context_test_suite and sqlite_instance and deployed_grpc_env" -vv {posargs}
+  sqlite_instance_code_server_cli_grpc_env: pytest -c ../../pyproject.toml -m "graphql_context_test_suite and sqlite_instance and code_server_cli_grpc_env" -vv {posargs}
   graphql_python_client: pytest -c ../../pyproject.toml -m "python_client_test_suite" -vv {posargs}
   postgres-graphql_context_variants: pytest -c ../../pyproject.toml -m "not graphql_context_test_suite and graphql_context_variants" -vv {posargs}
   postgres-instance_multi_location: pytest -c ../../pyproject.toml -m "graphql_context_test_suite and postgres_instance and multi_location" -vv {posargs}

--- a/python_modules/dagster/dagster/_cli/__init__.py
+++ b/python_modules/dagster/dagster/_cli/__init__.py
@@ -3,6 +3,7 @@ import click
 from ..version import __version__
 from .api import api_cli
 from .asset import asset_cli
+from .code_server import code_server_cli
 from .debug import debug_cli
 from .dev import dev_command
 from .instance import instance_cli
@@ -25,6 +26,7 @@ def create_dagster_cli():
         "debug": debug_cli,
         "project": project_cli,
         "dev": dev_command,
+        "code-server": code_server_cli,
     }
 
     @click.group(

--- a/python_modules/dagster/dagster/_cli/api.py
+++ b/python_modules/dagster/dagster/_cli/api.py
@@ -30,7 +30,6 @@ from dagster._core.origin import (
 )
 from dagster._core.storage.dagster_run import DagsterRun
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
-from dagster._core.utils import coerce_valid_log_level
 from dagster._grpc import DagsterGrpcClient, DagsterGrpcServer
 from dagster._grpc.impl import core_execute_run
 from dagster._grpc.server import DagsterApiServer
@@ -571,10 +570,11 @@ def _execute_step_command_body(
 )
 @click.option(
     "--log-level",
-    type=click.STRING,
+    type=click.Choice(["critical", "error", "warning", "info", "debug"], case_sensitive=False),
+    show_default=True,
     required=False,
-    default="INFO",
-    help="Level at which to log output from the gRPC server process",
+    default="info",
+    help="Level at which to log output from the code server process",
 )
 @click.option(
     "--container-image",
@@ -653,8 +653,8 @@ def grpc_command(
     if not (port or socket and not (port and socket)):
         raise click.UsageError("You must pass one and only one of --port/-p or --socket/-s.")
 
-    configure_loggers(log_level=coerce_valid_log_level(log_level))
-    logger = logging.getLogger("dagster")
+    configure_loggers(log_level=log_level.upper())
+    logger = logging.getLogger("dagster.code_server")
 
     container_image = container_image or os.getenv("DAGSTER_CURRENT_IMAGE")
 

--- a/python_modules/dagster/dagster/_cli/api.py
+++ b/python_modules/dagster/dagster/_cli/api.py
@@ -37,7 +37,7 @@ from dagster._grpc.types import ExecuteRunArgs, ExecuteStepArgs, ResumeRunArgs
 from dagster._serdes import deserialize_value, serialize_value
 from dagster._utils.error import serializable_error_info_from_exc_info
 from dagster._utils.hosted_user_process import recon_job_from_origin
-from dagster._utils.interrupts import capture_interrupts
+from dagster._utils.interrupts import capture_interrupts, setup_interrupt_handlers
 from dagster._utils.log import configure_loggers
 
 
@@ -653,6 +653,8 @@ def grpc_command(
     if not (port or socket and not (port and socket)):
         raise click.UsageError("You must pass one and only one of --port/-p or --socket/-s.")
 
+    setup_interrupt_handlers()
+
     configure_loggers(log_level=log_level.upper())
     logger = logging.getLogger("dagster.code_server")
 
@@ -694,6 +696,7 @@ def grpc_command(
         server_termination_event = threading.Event()
         api_servicer = DagsterApiServer(
             server_termination_event=server_termination_event,
+            logger=logger,
             loadable_target_origin=loadable_target_origin,
             heartbeat=heartbeat,
             heartbeat_timeout=heartbeat_timeout,

--- a/python_modules/dagster/dagster/_cli/code_server.py
+++ b/python_modules/dagster/dagster/_cli/code_server.py
@@ -1,0 +1,234 @@
+import json
+import logging
+import os
+import sys
+import threading
+from typing import Optional
+
+import click
+
+import dagster._check as check
+import dagster._seven as seven
+from dagster._cli.workspace.cli_target import (
+    get_working_directory_from_kwargs,
+    python_origin_target_argument,
+)
+from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
+from dagster._utils.log import configure_loggers
+
+
+@click.group(name="code-server")
+def code_server_cli():
+    """Commands for working with Dagster code servers."""
+
+
+@code_server_cli.command(
+    name="start",
+    help="Start a code server that can serve metadata about a code location and launch runs.",
+)
+@click.option(
+    "--port",
+    "-p",
+    type=click.INT,
+    required=False,
+    help="Port over which to serve. You must pass one and only one of --port/-p or --socket/-s.",
+    envvar="DAGSTER_CODE_SERVER_PORT",
+)
+@click.option(
+    "--socket",
+    "-s",
+    type=click.Path(),
+    required=False,
+    help="Serve over a UDS socket. You must pass one and only one of --port/-p or --socket/-s.",
+    envvar="DAGSTER_CODE_SERVER_SOCKET",
+)
+@click.option(
+    "--host",
+    "-h",
+    type=click.STRING,
+    required=False,
+    default="localhost",
+    help="Hostname at which to serve. Default is localhost.",
+    envvar="DAGSTER_CODE_SERVER_HOST",
+)
+@click.option(
+    "--max-workers",
+    "-n",
+    type=click.INT,
+    required=False,
+    default=None,
+    help="Maximum number of (threaded) workers to use in the code server",
+)
+@click.option(
+    "--lazy-load-user-code",
+    is_flag=True,
+    required=False,
+    default=True,
+    help=(
+        "Surface errors in the Dagster UI when there's an error while importing the code, instead "
+        "of exiting the process on startup wit han error code."
+    ),
+    envvar="DAGSTER_LAZY_LOAD_USER_CODE",
+)
+@python_origin_target_argument
+@click.option(
+    "--use-python-environment-entry-point",
+    is_flag=True,
+    required=False,
+    default=False,
+    help=(
+        "If this flag is set, the server will signal to clients that they should launch "
+        "dagster commands using `<this server's python executable> -m dagster`, instead of the "
+        "default `dagster` entry point. This is useful when there are multiple Python environments "
+        "running in the same machine, so a single `dagster` entry point is not enough to uniquely "
+        "determine the environment."
+    ),
+    envvar="DAGSTER_USE_PYTHON_ENVIRONMENT_ENTRY_POINT",
+)
+@click.option(
+    "--fixed-server-id",
+    type=click.STRING,
+    required=False,
+    help=(
+        "[INTERNAL] This option should generally not be used by users. Internal param used by "
+        "dagster to spawn a server with the specified server id."
+    ),
+)
+@click.option(
+    "--log-level",
+    type=click.Choice(["critical", "error", "warning", "info", "debug"], case_sensitive=False),
+    show_default=True,
+    required=False,
+    default="info",
+    help="Level at which to log output from the code server process",
+)
+@click.option(
+    "--container-image",
+    type=click.STRING,
+    required=False,
+    help="Container image to use to run code from this server.",
+    envvar="DAGSTER_CONTAINER_IMAGE",
+)
+@click.option(
+    "--container-context",
+    type=click.STRING,
+    required=False,
+    help=(
+        "Serialized JSON with configuration for any containers created to run the "
+        "code from this server."
+    ),
+    envvar="DAGSTER_CONTAINER_CONTEXT",
+)
+@click.option(
+    "--inject-env-vars-from-instance",
+    is_flag=True,
+    required=False,
+    default=False,
+    help="Whether to load env vars from the instance and inject them into the environment.",
+    envvar="DAGSTER_INJECT_ENV_VARS_FROM_INSTANCE",
+)
+@click.option(
+    "--location-name",
+    type=click.STRING,
+    required=False,
+    help="Name of the code location this server corresponds to.",
+    envvar="DAGSTER_LOCATION_NAME",
+)
+@click.option(
+    "--startup-timeout",
+    type=click.INT,
+    required=False,
+    default=180,
+    help="How long to wait for code to load or reload before timing out. Defaults to no timeout.",
+    envvar="DAGSTER_CODE_SERVER_STARTUP_TIMEOUT",
+)
+def start_command(
+    port: Optional[int] = None,
+    socket: Optional[str] = None,
+    host: str = "localhost",
+    max_workers: Optional[int] = None,
+    lazy_load_user_code: bool = True,
+    fixed_server_id: Optional[str] = None,
+    log_level: str = "INFO",
+    use_python_environment_entry_point: bool = False,
+    container_image: Optional[str] = None,
+    container_context: Optional[str] = None,
+    location_name: Optional[str] = None,
+    inject_env_vars_from_instance: bool = False,
+    startup_timeout: int = 0,
+    **kwargs,
+):
+    from dagster._grpc import DagsterGrpcServer
+    from dagster._grpc.proxy_server import DagsterProxyApiServer
+
+    if seven.IS_WINDOWS and port is None:
+        raise click.UsageError(
+            "You must pass a valid --port/-p on Windows: --socket/-s not supported."
+        )
+    if not (port or socket and not (port and socket)):
+        raise click.UsageError("You must pass one and only one of --port/-p or --socket/-s.")
+
+    configure_loggers(log_level=log_level.upper())
+    logger = logging.getLogger("dagster.code_server")
+
+    container_image = container_image or os.getenv("DAGSTER_CURRENT_IMAGE")
+
+    # in the gRPC api CLI we never load more than one module or python file at a time
+    module_name = check.opt_str_elem(kwargs, "module_name")
+    python_file = check.opt_str_elem(kwargs, "python_file")
+
+    loadable_target_origin = LoadableTargetOrigin(
+        executable_path=sys.executable if use_python_environment_entry_point else None,
+        attribute=kwargs["attribute"],
+        working_directory=get_working_directory_from_kwargs(kwargs),
+        module_name=module_name,
+        python_file=python_file,
+        package_name=kwargs["package_name"],
+    )
+    server_termination_event = threading.Event()
+
+    with DagsterProxyApiServer(
+        loadable_target_origin=loadable_target_origin,
+        lazy_load_user_code=lazy_load_user_code,
+        fixed_server_id=fixed_server_id,
+        container_image=container_image,
+        container_context=(
+            json.loads(container_context) if container_context is not None else None
+        ),
+        inject_env_vars_from_instance=inject_env_vars_from_instance,
+        location_name=location_name,
+        log_level=log_level,
+        startup_timeout=startup_timeout,
+    ) as api_servicer:
+        server = DagsterGrpcServer(
+            server_termination_event=server_termination_event,
+            dagster_api_servicer=api_servicer,
+            port=port,
+            socket=socket,
+            host=host,
+            max_workers=max_workers,
+        )
+
+        code_desc = " "
+        if loadable_target_origin.python_file:
+            code_desc = f" for file {loadable_target_origin.python_file} "
+        elif loadable_target_origin.package_name:
+            code_desc = f" for package {loadable_target_origin.package_name} "
+        elif loadable_target_origin.module_name:
+            code_desc = f" for module {loadable_target_origin.module_name} "
+
+        server_desc = (
+            f"Dagster code proxy server{code_desc}on port {port} in process {os.getpid()}"
+            if port
+            else f"Dagster code proxy server{code_desc}in process {os.getpid()}"
+        )
+
+        logger.info("Started %s", server_desc)
+
+        try:
+            server.serve()
+        except KeyboardInterrupt:
+            # Terminate cleanly on interrupt
+            logger.info("Code proxy server was interrupted")
+        finally:
+            logger.info("Shutting down %s", server_desc)

--- a/python_modules/dagster/dagster/_cli/code_server.py
+++ b/python_modules/dagster/dagster/_cli/code_server.py
@@ -158,7 +158,7 @@ def start_command(
     **kwargs,
 ):
     from dagster._grpc import DagsterGrpcServer
-    from dagster._grpc.proxy_server import DagsterProxyApiServer
+    from dagster._grpc.proxy_server import DagsterProxyApiServicer
 
     if seven.IS_WINDOWS and port is None:
         raise click.UsageError(
@@ -188,7 +188,7 @@ def start_command(
     )
     server_termination_event = threading.Event()
 
-    api_servicer = DagsterProxyApiServer(
+    api_servicer = DagsterProxyApiServicer(
         loadable_target_origin=loadable_target_origin,
         fixed_server_id=fixed_server_id,
         container_image=container_image,

--- a/python_modules/dagster/dagster/_core/host_representation/grpc_server_registry.py
+++ b/python_modules/dagster/dagster/_core/host_representation/grpc_server_registry.py
@@ -290,7 +290,7 @@ class GrpcServerRegistry(AbstractContextManager):
         for process in self._all_processes:
             process.shutdown_server()
 
-    def have_all_servers_shut_down(self) -> bool:
+    def are_all_servers_shut_down(self) -> bool:
         for process in self._all_processes:
             try:
                 process.create_client().ping("")

--- a/python_modules/dagster/dagster/_core/host_representation/grpc_server_registry.py
+++ b/python_modules/dagster/dagster/_core/host_representation/grpc_server_registry.py
@@ -6,6 +6,7 @@ import uuid
 from contextlib import AbstractContextManager
 from typing import (
     TYPE_CHECKING,
+    Any,
     Dict,
     List,
     NamedTuple,
@@ -23,7 +24,7 @@ from dagster._core.host_representation.origin import (
     CodeLocationOrigin,
     ManagedGrpcPythonEnvCodeLocationOrigin,
 )
-from dagster._core.instance import DagsterInstance
+from dagster._core.instance import InstanceRef
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._grpc.server import GrpcServerProcess
 from dagster._utils.error import SerializableErrorInfo, serializable_error_info_from_exc_info
@@ -76,7 +77,7 @@ class ErrorRegistryEntry(NamedTuple):
 class GrpcServerRegistry(AbstractContextManager):
     def __init__(
         self,
-        instance: DagsterInstance,
+        instance_ref: Optional[InstanceRef],
         # How long each process should run before a new process should be created the next
         # time a given origin is requested (which will pick up any changes that have been
         # made to the code)
@@ -89,9 +90,14 @@ class GrpcServerRegistry(AbstractContextManager):
         heartbeat_ttl: int,
         # How long to wait for the server to start up and receive connections before timing out
         startup_timeout: int,
+        wait_for_processes_on_shutdown: bool,
         log_level: str = "INFO",
+        lazy_load_user_code: bool = True,
+        inject_env_vars_from_instance: bool = True,
+        container_image: Optional[str] = None,
+        container_context: Optional[Dict[str, Any]] = None,
     ):
-        self.instance = instance
+        self.instance_ref = instance_ref
 
         # map of servers being currently returned, keyed by origin ID
         self._active_entries: Dict[str, Union[ServerRegistryEntry, ErrorRegistryEntry]] = {}
@@ -118,17 +124,22 @@ class GrpcServerRegistry(AbstractContextManager):
         self._cleanup_thread: Optional[threading.Thread] = None
 
         self._log_level = check.str_param(log_level, "log_level")
+        self._lazy_load_user_code = lazy_load_user_code
+        self._inject_env_vars_from_instance = inject_env_vars_from_instance
+        self._container_image = container_image
+        self._container_context = container_context
 
-        if self._reload_interval > 0:
-            self._cleanup_thread_shutdown_event = threading.Event()
+        self._wait_for_processes_on_shutdown = wait_for_processes_on_shutdown
 
-            self._cleanup_thread = threading.Thread(
-                target=self._clear_old_processes,
-                name="grpc-server-registry-cleanup",
-                args=(self._cleanup_thread_shutdown_event, self._reload_interval),
-            )
-            self._cleanup_thread.daemon = True
-            self._cleanup_thread.start()
+        self._cleanup_thread_shutdown_event = threading.Event()
+
+        self._cleanup_thread = threading.Thread(
+            target=self._clear_old_processes,
+            name="grpc-server-registry-cleanup",
+            args=(self._cleanup_thread_shutdown_event, self._reload_interval),
+        )
+        self._cleanup_thread.daemon = True
+        self._cleanup_thread.start()
 
     def supports_origin(
         self, code_location_origin: CodeLocationOrigin
@@ -192,7 +203,7 @@ class GrpcServerRegistry(AbstractContextManager):
             try:
                 new_server_id = str(uuid.uuid4())
                 server_process = GrpcServerProcess(
-                    instance_ref=self.instance.get_ref(),
+                    instance_ref=self.instance_ref,
                     location_name=code_location_origin.location_name,
                     loadable_target_origin=loadable_target_origin,
                     heartbeat=True,
@@ -200,6 +211,10 @@ class GrpcServerRegistry(AbstractContextManager):
                     fixed_server_id=new_server_id,
                     startup_timeout=self._startup_timeout,
                     log_level=self._log_level,
+                    lazy_load_user_code=self._lazy_load_user_code,
+                    inject_env_vars_from_instance=self._inject_env_vars_from_instance,
+                    container_image=self._container_image,
+                    container_context=self._container_context,
                 )
                 self._all_processes.append(server_process)
                 self._active_entries[origin_id] = ServerRegistryEntry(
@@ -245,7 +260,8 @@ class GrpcServerRegistry(AbstractContextManager):
 
                 for origin_id, entry in self._active_entries.items():
                     if (
-                        current_time - entry.creation_timestamp > reload_interval
+                        reload_interval > 0
+                        and current_time - entry.creation_timestamp > reload_interval
                     ):  # Use a different threshold for errors so they aren't cached as long?
                         origin_ids_to_clear.append(origin_id)
 
@@ -271,7 +287,7 @@ class GrpcServerRegistry(AbstractContextManager):
         for process in self._all_processes:
             process.shutdown_server()
 
-        if self.instance.code_server_settings.get("wait_for_local_processes_on_shutdown", False):
+        if self._wait_for_processes_on_shutdown:
             self.wait_for_processes()
 
     def wait_for_processes(self) -> None:

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -812,6 +812,16 @@ class DagsterInstance(DynamicPartitionsStore):
         )
 
     @property
+    def code_server_reload_timeout(self) -> int:
+        return self.code_server_settings.get(
+            "reload_timeout", DEFAULT_LOCAL_CODE_SERVER_STARTUP_TIMEOUT
+        )
+
+    @property
+    def wait_for_local_code_server_processes_on_shutdown(self) -> bool:
+        return self.code_server_settings.get("wait_for_local_processes_on_shutdown", False)
+
+    @property
     def run_monitoring_max_resume_run_attempts(self) -> int:
         return self.run_monitoring_settings.get("max_resume_run_attempts", 0)
 

--- a/python_modules/dagster/dagster/_core/workspace/context.py
+++ b/python_modules/dagster/dagster/_core/workspace/context.py
@@ -33,7 +33,10 @@ from dagster._core.host_representation.grpc_server_state_subscriber import (
     LocationStateChangeEventType,
     LocationStateSubscriber,
 )
-from dagster._core.host_representation.origin import GrpcServerCodeLocationOrigin
+from dagster._core.host_representation.origin import (
+    GrpcServerCodeLocationOrigin,
+    ManagedGrpcPythonEnvCodeLocationOrigin,
+)
 from dagster._core.instance import DagsterInstance
 from dagster._utils.error import SerializableErrorInfo, serializable_error_info_from_exc_info
 
@@ -192,9 +195,15 @@ class BaseWorkspaceRequestContext(IWorkspace):
         entry = self.get_location_entry(name)
         return entry.origin.is_shutdown_supported if entry else False
 
+    def refresh_code_location(self, name: str) -> "BaseWorkspaceRequestContext":
+        # This method reloads Dagit's copy of the code from the remote gRPC server without
+        # restarting it, and returns a new request context created from the updated process context
+        self.process_context.refresh_code_location(name)
+        return self.process_context.create_request_context()
+
     def reload_code_location(self, name: str) -> "BaseWorkspaceRequestContext":
-        # This method reloads the location on the process context, and returns a new
-        # request context created from the updated process context
+        # This method signals to the remote gRPC server that it should reload its
+        # code, and returns a new request context created from the updated process context
         self.process_context.reload_code_location(name)
         return self.process_context.create_request_context()
 
@@ -397,6 +406,10 @@ class IWorkspaceProcessContext(ABC):
         pass
 
     @abstractmethod
+    def refresh_code_location(self, name: str) -> None:
+        pass
+
+    @abstractmethod
     def reload_code_location(self, name: str) -> None:
         pass
 
@@ -453,10 +466,8 @@ class WorkspaceProcessContext(IWorkspaceProcessContext):
 
         self._version = version
 
-        # Guards changes to _location_dict, _location_error_dict, and _location_origin_dict
+        # Guards changes to _location_entry_dict, _watch_thread_shutdown_events and _watch_threads
         self._lock = threading.Lock()
-
-        # Only ever set up by main thread
         self._watch_thread_shutdown_events: Dict[str, threading.Event] = {}
         self._watch_threads: Dict[str, threading.Thread] = {}
 
@@ -471,17 +482,21 @@ class WorkspaceProcessContext(IWorkspaceProcessContext):
         else:
             self._grpc_server_registry = self._stack.enter_context(
                 GrpcServerRegistry(
-                    instance=self._instance,
+                    instance_ref=self._instance.get_ref(),
                     reload_interval=0,
                     heartbeat_ttl=DAGIT_GRPC_SERVER_HEARTBEAT_TTL,
                     startup_timeout=instance.code_server_process_startup_timeout,
                     log_level=code_server_log_level,
+                    wait_for_processes_on_shutdown=instance.wait_for_local_code_server_processes_on_shutdown,
                 )
             )
 
         self._location_entry_dict: Dict[str, CodeLocationEntry] = {}
         self._update_workspace(
-            {origin.location_name: self._load_location(origin) for origin in self._origins}
+            {
+                origin.location_name: self._load_location(origin, reload=False)
+                for origin in self._origins
+            }
         )
 
     @property
@@ -500,27 +515,6 @@ class WorkspaceProcessContext(IWorkspaceProcessContext):
     def rm_state_subscriber(self, token: int) -> None:
         if token in self._state_subscribers:
             del self._state_subscribers[token]
-
-    def _create_location_from_origin(self, origin: CodeLocationOrigin) -> Optional[CodeLocation]:
-        if not self._grpc_server_registry.supports_origin(origin):
-            return origin.create_location()
-        else:
-            endpoint = (
-                self._grpc_server_registry.reload_grpc_endpoint(origin)
-                if self._grpc_server_registry.supports_reload
-                else self._grpc_server_registry.get_grpc_endpoint(origin)
-            )
-
-            return GrpcServerCodeLocation(
-                origin=origin,
-                server_id=endpoint.server_id,
-                port=endpoint.port,
-                socket=endpoint.socket,
-                host=endpoint.host,
-                heartbeat=True,
-                watch_server=False,
-                grpc_server_registry=self._grpc_server_registry,
-            )
 
     @property
     def instance(self) -> DagsterInstance:
@@ -578,12 +572,32 @@ class WorkspaceProcessContext(IWorkspaceProcessContext):
         self._watch_threads[location_name] = watch_thread
         watch_thread.start()
 
-    def _load_location(self, origin: CodeLocationOrigin) -> CodeLocationEntry:
+    def _load_location(self, origin: CodeLocationOrigin, reload: bool) -> CodeLocationEntry:
         location_name = origin.location_name
         location = None
         error = None
         try:
-            location = self._create_location_from_origin(origin)
+            if isinstance(origin, ManagedGrpcPythonEnvCodeLocationOrigin):
+                endpoint = (
+                    self._grpc_server_registry.reload_grpc_endpoint(origin)
+                    if reload
+                    else self._grpc_server_registry.get_grpc_endpoint(origin)
+                )
+                location = GrpcServerCodeLocation(
+                    origin=origin,
+                    server_id=endpoint.server_id,
+                    port=endpoint.port,
+                    socket=endpoint.socket,
+                    host=endpoint.host,
+                    heartbeat=True,
+                    watch_server=False,
+                    grpc_server_registry=self._grpc_server_registry,
+                )
+            else:
+                location = (
+                    origin.reload_location(self.instance) if reload else origin.create_location()
+                )
+
         except Exception:
             error = serializable_error_info_from_exc_info(sys.exc_info())
             warnings.warn(
@@ -634,9 +648,15 @@ class WorkspaceProcessContext(IWorkspaceProcessContext):
                 and self._location_entry_dict[location_name].load_error is not None
             )
 
+    def refresh_code_location(self, name: str) -> None:
+        new = self._load_location(self._location_entry_dict[name].origin, reload=False)
+        with self._lock:
+            # Relying on GC to clean up the old location once nothing else
+            # is referencing it
+            self._location_entry_dict[name] = new
+
     def reload_code_location(self, name: str) -> None:
-        # Can be called from a background thread
-        new = self._load_location(self._location_entry_dict[name].origin)
+        new = self._load_location(self._location_entry_dict[name].origin, reload=True)
         with self._lock:
             # Relying on GC to clean up the old location once nothing else
             # is referencing it
@@ -648,7 +668,8 @@ class WorkspaceProcessContext(IWorkspaceProcessContext):
 
     def reload_workspace(self) -> None:
         updated_locations = {
-            origin.location_name: self._load_location(origin) for origin in self._origins
+            origin.location_name: self._load_location(origin, reload=True)
+            for origin in self._origins
         }
         self._update_workspace(updated_locations)
 
@@ -701,7 +722,8 @@ class WorkspaceProcessContext(IWorkspaceProcessContext):
             # re-attach a subscriber
             # In case of a location error, just reload the handle in order to update the workspace
             # with the correct error messages
-            self.reload_code_location(event.location_name)
+
+            self.refresh_code_location(event.location_name)
 
     def __enter__(self):
         return self

--- a/python_modules/dagster/dagster/_daemon/controller.py
+++ b/python_modules/dagster/dagster/_daemon/controller.py
@@ -67,11 +67,12 @@ def create_daemon_grpc_server_registry(
     instance: DagsterInstance, code_server_log_level: str = "INFO"
 ) -> GrpcServerRegistry:
     return GrpcServerRegistry(
-        instance=instance,
+        instance_ref=instance.get_ref(),
         reload_interval=DAEMON_GRPC_SERVER_RELOAD_INTERVAL,
         heartbeat_ttl=DAEMON_GRPC_SERVER_HEARTBEAT_TTL,
         startup_timeout=instance.code_server_process_startup_timeout,
         log_level=code_server_log_level,
+        wait_for_processes_on_shutdown=instance.wait_for_local_code_server_processes_on_shutdown,
     )
 
 

--- a/python_modules/dagster/dagster/_grpc/__generated__/api_pb2.py
+++ b/python_modules/dagster/dagster/_grpc/__generated__/api_pb2.py
@@ -65,9 +65,10 @@ DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
     b" \x01(\t\x12\x10\n\x08job_name\x18\x02"
     b' \x01(\t"I\n\x10\x45xternalJobReply\x12\x1b\n\x13serialized_job_data\x18\x01'
     b" \x01(\t\x12\x18\n\x10serialized_error\x18\x02"
-    b' \x01(\t2\xd3\x0e\n\nDagsterApi\x12*\n\x04Ping\x12\x10.api.PingRequest\x1a\x0e.api.PingReply"\x00\x12/\n\tHeartbeat\x12\x10.api.PingRequest\x1a\x0e.api.PingReply"\x00\x12G\n\rStreamingPing\x12\x19.api.StreamingPingRequest\x1a\x17.api.StreamingPingEvent"\x00\x30\x01\x12\x32\n\x0bGetServerId\x12\n.api.Empty\x1a\x15.api.GetServerIdReply"\x00\x12]\n\x15\x45xecutionPlanSnapshot\x12!.api.ExecutionPlanSnapshotRequest\x1a\x1f.api.ExecutionPlanSnapshotReply"\x00\x12N\n\x10ListRepositories\x12\x1c.api.ListRepositoriesRequest\x1a\x1a.api.ListRepositoriesReply"\x00\x12`\n\x16\x45xternalPartitionNames\x12".api.ExternalPartitionNamesRequest\x1a'
+    b' \x01(\t"\x13\n\x11ReloadCodeRequest"+\n\x0fReloadCodeReply\x12\x18\n\x10serialized_error\x18\x02'
+    b' \x01(\t2\x91\x0f\n\nDagsterApi\x12*\n\x04Ping\x12\x10.api.PingRequest\x1a\x0e.api.PingReply"\x00\x12/\n\tHeartbeat\x12\x10.api.PingRequest\x1a\x0e.api.PingReply"\x00\x12G\n\rStreamingPing\x12\x19.api.StreamingPingRequest\x1a\x17.api.StreamingPingEvent"\x00\x30\x01\x12\x32\n\x0bGetServerId\x12\n.api.Empty\x1a\x15.api.GetServerIdReply"\x00\x12]\n\x15\x45xecutionPlanSnapshot\x12!.api.ExecutionPlanSnapshotRequest\x1a\x1f.api.ExecutionPlanSnapshotReply"\x00\x12N\n\x10ListRepositories\x12\x1c.api.ListRepositoriesRequest\x1a\x1a.api.ListRepositoriesReply"\x00\x12`\n\x16\x45xternalPartitionNames\x12".api.ExternalPartitionNamesRequest\x1a'
     b' .api.ExternalPartitionNamesReply"\x00\x12Z\n\x14\x45xternalNotebookData\x12'
-    b' .api.ExternalNotebookDataRequest\x1a\x1e.api.ExternalNotebookDataReply"\x00\x12\x63\n\x17\x45xternalPartitionConfig\x12#.api.ExternalPartitionConfigRequest\x1a!.api.ExternalPartitionConfigReply"\x00\x12]\n\x15\x45xternalPartitionTags\x12!.api.ExternalPartitionTagsRequest\x1a\x1f.api.ExternalPartitionTagsReply"\x00\x12t\n#ExternalPartitionSetExecutionParams\x12/.api.ExternalPartitionSetExecutionParamsRequest\x1a\x18.api.StreamingChunkEvent"\x00\x30\x01\x12x\n\x1e\x45xternalPipelineSubsetSnapshot\x12*.api.ExternalPipelineSubsetSnapshotRequest\x1a(.api.ExternalPipelineSubsetSnapshotReply"\x00\x12T\n\x12\x45xternalRepository\x12\x1e.api.ExternalRepositoryRequest\x1a\x1c.api.ExternalRepositoryReply"\x00\x12?\n\x0b\x45xternalJob\x12\x17.api.ExternalJobRequest\x1a\x15.api.ExternalJobReply"\x00\x12h\n\x1bStreamingExternalRepository\x12\x1e.api.ExternalRepositoryRequest\x1a%.api.StreamingExternalRepositoryEvent"\x00\x30\x01\x12`\n\x19\x45xternalScheduleExecution\x12%.api.ExternalScheduleExecutionRequest\x1a\x18.api.StreamingChunkEvent"\x00\x30\x01\x12\\\n\x17\x45xternalSensorExecution\x12#.api.ExternalSensorExecutionRequest\x1a\x18.api.StreamingChunkEvent"\x00\x30\x01\x12\x38\n\x0eShutdownServer\x12\n.api.Empty\x1a\x18.api.ShutdownServerReply"\x00\x12K\n\x0f\x43\x61ncelExecution\x12\x1b.api.CancelExecutionRequest\x1a\x19.api.CancelExecutionReply"\x00\x12T\n\x12\x43\x61nCancelExecution\x12\x1e.api.CanCancelExecutionRequest\x1a\x1c.api.CanCancelExecutionReply"\x00\x12\x36\n\x08StartRun\x12\x14.api.StartRunRequest\x1a\x12.api.StartRunReply"\x00\x12:\n\x0fGetCurrentImage\x12\n.api.Empty\x1a\x19.api.GetCurrentImageReply"\x00\x12\x38\n\x0eGetCurrentRuns\x12\n.api.Empty\x1a\x18.api.GetCurrentRunsReply"\x00\x62\x06proto3'
+    b' .api.ExternalNotebookDataRequest\x1a\x1e.api.ExternalNotebookDataReply"\x00\x12\x63\n\x17\x45xternalPartitionConfig\x12#.api.ExternalPartitionConfigRequest\x1a!.api.ExternalPartitionConfigReply"\x00\x12]\n\x15\x45xternalPartitionTags\x12!.api.ExternalPartitionTagsRequest\x1a\x1f.api.ExternalPartitionTagsReply"\x00\x12t\n#ExternalPartitionSetExecutionParams\x12/.api.ExternalPartitionSetExecutionParamsRequest\x1a\x18.api.StreamingChunkEvent"\x00\x30\x01\x12x\n\x1e\x45xternalPipelineSubsetSnapshot\x12*.api.ExternalPipelineSubsetSnapshotRequest\x1a(.api.ExternalPipelineSubsetSnapshotReply"\x00\x12T\n\x12\x45xternalRepository\x12\x1e.api.ExternalRepositoryRequest\x1a\x1c.api.ExternalRepositoryReply"\x00\x12?\n\x0b\x45xternalJob\x12\x17.api.ExternalJobRequest\x1a\x15.api.ExternalJobReply"\x00\x12h\n\x1bStreamingExternalRepository\x12\x1e.api.ExternalRepositoryRequest\x1a%.api.StreamingExternalRepositoryEvent"\x00\x30\x01\x12`\n\x19\x45xternalScheduleExecution\x12%.api.ExternalScheduleExecutionRequest\x1a\x18.api.StreamingChunkEvent"\x00\x30\x01\x12\\\n\x17\x45xternalSensorExecution\x12#.api.ExternalSensorExecutionRequest\x1a\x18.api.StreamingChunkEvent"\x00\x30\x01\x12\x38\n\x0eShutdownServer\x12\n.api.Empty\x1a\x18.api.ShutdownServerReply"\x00\x12K\n\x0f\x43\x61ncelExecution\x12\x1b.api.CancelExecutionRequest\x1a\x19.api.CancelExecutionReply"\x00\x12T\n\x12\x43\x61nCancelExecution\x12\x1e.api.CanCancelExecutionRequest\x1a\x1c.api.CanCancelExecutionReply"\x00\x12\x36\n\x08StartRun\x12\x14.api.StartRunRequest\x1a\x12.api.StartRunReply"\x00\x12:\n\x0fGetCurrentImage\x12\n.api.Empty\x1a\x19.api.GetCurrentImageReply"\x00\x12\x38\n\x0eGetCurrentRuns\x12\n.api.Empty\x1a\x18.api.GetCurrentRunsReply"\x00\x12<\n\nReloadCode\x12\x16.api.ReloadCodeRequest\x1a\x14.api.ReloadCodeReply"\x00\x62\x06proto3'
 )
 
 
@@ -119,6 +120,8 @@ _GETCURRENTIMAGEREPLY = DESCRIPTOR.message_types_by_name["GetCurrentImageReply"]
 _GETCURRENTRUNSREPLY = DESCRIPTOR.message_types_by_name["GetCurrentRunsReply"]
 _EXTERNALJOBREQUEST = DESCRIPTOR.message_types_by_name["ExternalJobRequest"]
 _EXTERNALJOBREPLY = DESCRIPTOR.message_types_by_name["ExternalJobReply"]
+_RELOADCODEREQUEST = DESCRIPTOR.message_types_by_name["ReloadCodeRequest"]
+_RELOADCODEREPLY = DESCRIPTOR.message_types_by_name["ReloadCodeReply"]
 Empty = _reflection.GeneratedProtocolMessageType(
     "Empty",
     (_message.Message,),
@@ -537,6 +540,28 @@ ExternalJobReply = _reflection.GeneratedProtocolMessageType(
 )
 _sym_db.RegisterMessage(ExternalJobReply)
 
+ReloadCodeRequest = _reflection.GeneratedProtocolMessageType(
+    "ReloadCodeRequest",
+    (_message.Message,),
+    {
+        "DESCRIPTOR": _RELOADCODEREQUEST,
+        "__module__": "api_pb2"
+        # @@protoc_insertion_point(class_scope:api.ReloadCodeRequest)
+    },
+)
+_sym_db.RegisterMessage(ReloadCodeRequest)
+
+ReloadCodeReply = _reflection.GeneratedProtocolMessageType(
+    "ReloadCodeReply",
+    (_message.Message,),
+    {
+        "DESCRIPTOR": _RELOADCODEREPLY,
+        "__module__": "api_pb2"
+        # @@protoc_insertion_point(class_scope:api.ReloadCodeReply)
+    },
+)
+_sym_db.RegisterMessage(ReloadCodeReply)
+
 _DAGSTERAPI = DESCRIPTOR.services_by_name["DagsterApi"]
 if _descriptor._USE_C_DESCRIPTORS == False:
     DESCRIPTOR._options = None
@@ -616,6 +641,10 @@ if _descriptor._USE_C_DESCRIPTORS == False:
     _EXTERNALJOBREQUEST._serialized_end = 2628
     _EXTERNALJOBREPLY._serialized_start = 2630
     _EXTERNALJOBREPLY._serialized_end = 2703
-    _DAGSTERAPI._serialized_start = 2706
-    _DAGSTERAPI._serialized_end = 4581
+    _RELOADCODEREQUEST._serialized_start = 2705
+    _RELOADCODEREQUEST._serialized_end = 2724
+    _RELOADCODEREPLY._serialized_start = 2726
+    _RELOADCODEREPLY._serialized_end = 2769
+    _DAGSTERAPI._serialized_start = 2772
+    _DAGSTERAPI._serialized_end = 4709
 # @@protoc_insertion_point(module_scope)

--- a/python_modules/dagster/dagster/_grpc/__generated__/api_pb2_grpc.py
+++ b/python_modules/dagster/dagster/_grpc/__generated__/api_pb2_grpc.py
@@ -135,6 +135,11 @@ class DagsterApiStub(object):
             request_serializer=api__pb2.Empty.SerializeToString,
             response_deserializer=api__pb2.GetCurrentRunsReply.FromString,
         )
+        self.ReloadCode = channel.unary_unary(
+            "/api.DagsterApi/ReloadCode",
+            request_serializer=api__pb2.ReloadCodeRequest.SerializeToString,
+            response_deserializer=api__pb2.ReloadCodeReply.FromString,
+        )
 
 
 class DagsterApiServicer(object):
@@ -278,6 +283,12 @@ class DagsterApiServicer(object):
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
+    def ReloadCode(self, request, context):
+        """Missing associated documentation comment in .proto file."""
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details("Method not implemented!")
+        raise NotImplementedError("Method not implemented!")
+
 
 def add_DagsterApiServicer_to_server(servicer, server):
     rpc_method_handlers = {
@@ -395,6 +406,11 @@ def add_DagsterApiServicer_to_server(servicer, server):
             servicer.GetCurrentRuns,
             request_deserializer=api__pb2.Empty.FromString,
             response_serializer=api__pb2.GetCurrentRunsReply.SerializeToString,
+        ),
+        "ReloadCode": grpc.unary_unary_rpc_method_handler(
+            servicer.ReloadCode,
+            request_deserializer=api__pb2.ReloadCodeRequest.FromString,
+            response_serializer=api__pb2.ReloadCodeReply.SerializeToString,
         ),
     }
     generic_handler = grpc.method_handlers_generic_handler("api.DagsterApi", rpc_method_handlers)
@@ -1062,6 +1078,35 @@ class DagsterApi(object):
             "/api.DagsterApi/GetCurrentRuns",
             api__pb2.Empty.SerializeToString,
             api__pb2.GetCurrentRunsReply.FromString,
+            options,
+            channel_credentials,
+            insecure,
+            call_credentials,
+            compression,
+            wait_for_ready,
+            timeout,
+            metadata,
+        )
+
+    @staticmethod
+    def ReloadCode(
+        request,
+        target,
+        options=(),
+        channel_credentials=None,
+        call_credentials=None,
+        insecure=False,
+        compression=None,
+        wait_for_ready=None,
+        timeout=None,
+        metadata=None,
+    ):
+        return grpc.experimental.unary_unary(
+            request,
+            target,
+            "/api.DagsterApi/ReloadCode",
+            api__pb2.ReloadCodeRequest.SerializeToString,
+            api__pb2.ReloadCodeReply.FromString,
             options,
             channel_credentials,
             insecure,

--- a/python_modules/dagster/dagster/_grpc/client.py
+++ b/python_modules/dagster/dagster/_grpc/client.py
@@ -296,6 +296,9 @@ class DagsterGrpcClient:
 
         return res.serialized_external_pipeline_subset_result
 
+    def reload_code(self, timeout: int):
+        return self._query("ReloadCode", api_pb2.ReloadCodeRequest, timeout=timeout)
+
     def external_repository(
         self,
         external_repository_origin: ExternalRepositoryOrigin,

--- a/python_modules/dagster/dagster/_grpc/protos/api.proto
+++ b/python_modules/dagster/dagster/_grpc/protos/api.proto
@@ -28,6 +28,7 @@ service DagsterApi {
   rpc StartRun (StartRunRequest) returns (StartRunReply) {}
   rpc GetCurrentImage (Empty) returns (GetCurrentImageReply) {}
   rpc GetCurrentRuns (Empty) returns (GetCurrentRunsReply) {}
+  rpc ReloadCode (ReloadCodeRequest) returns (ReloadCodeReply) {}
 }
 
 message Empty {}
@@ -183,5 +184,12 @@ message ExternalJobRequest {
 
 message ExternalJobReply {
   string serialized_job_data = 1;
+  string serialized_error = 2;
+}
+
+message ReloadCodeRequest {
+}
+
+message ReloadCodeReply {
   string serialized_error = 2;
 }

--- a/python_modules/dagster/dagster/_grpc/proxy_server.py
+++ b/python_modules/dagster/dagster/_grpc/proxy_server.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+import sys
+import threading
+from contextlib import ExitStack
+from typing import Dict, Optional
+
+from dagster._core.host_representation.grpc_server_registry import GrpcServerRegistry
+from dagster._core.host_representation.origin import (
+    ManagedGrpcPythonEnvCodeLocationOrigin,
+)
+from dagster._core.instance import InstanceRef
+from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
+from dagster._grpc.client import DagsterGrpcClient
+from dagster._serdes import deserialize_value, serialize_value
+from dagster._utils.error import serializable_error_info_from_exc_info
+
+from .__generated__ import api_pb2
+from .__generated__.api_pb2_grpc import DagsterApiServicer
+from .types import (
+    CancelExecutionRequest,
+    CancelExecutionResult,
+    ExecuteExternalJobArgs,
+)
+
+
+class DagsterProxyApiServer(DagsterApiServicer):
+    def __init__(
+        self,
+        loadable_target_origin: LoadableTargetOrigin,
+        lazy_load_user_code: bool,
+        fixed_server_id: Optional[str],
+        container_image: Optional[str],
+        container_context: Optional[dict],
+        inject_env_vars_from_instance: bool,
+        location_name: Optional[str],
+        log_level: str,
+        startup_timeout: int,
+        instance_ref: Optional[InstanceRef] = None,
+    ):
+        super(DagsterProxyApiServer, self).__init__()
+
+        self._loadable_target_origin = loadable_target_origin
+        self._lazy_load_user_code = lazy_load_user_code
+        self._fixed_server_id = fixed_server_id
+        self._container_image = container_image
+        self._container_context = container_context
+        self._inject_env_vars_from_instance = inject_env_vars_from_instance
+        self._instance_ref = instance_ref
+        self._location_name = location_name
+        self._log_level = log_level
+
+        self._exit_stack = ExitStack()
+
+        self._reload_lock = threading.Lock()
+
+        self._grpc_server_registry = self._exit_stack.enter_context(
+            GrpcServerRegistry(
+                instance_ref=self._instance_ref,
+                reload_interval=0,
+                heartbeat_ttl=30,
+                startup_timeout=startup_timeout,
+                log_level=self._log_level,
+                lazy_load_user_code=self._lazy_load_user_code,
+                inject_env_vars_from_instance=self._inject_env_vars_from_instance,
+                container_image=self._container_image,
+                container_context=self._container_context,
+                wait_for_processes_on_shutdown=True,
+            )
+        )
+        self._origin = ManagedGrpcPythonEnvCodeLocationOrigin(
+            loadable_target_origin=self._loadable_target_origin, location_name=location_name
+        )
+
+        self._run_clients: Dict[str, DagsterGrpcClient] = {}
+
+        self._reload_location()
+
+    def _reload_location(self):
+        from dagster._grpc.client import client_heartbeat_thread
+
+        endpoint = self._grpc_server_registry.reload_grpc_endpoint(self._origin)
+        self._client = endpoint.create_client()
+
+        self._heartbeat_shutdown_event = threading.Event()
+        self._heartbeat_thread = threading.Thread(
+            target=client_heartbeat_thread,
+            args=(
+                self._client,
+                self._heartbeat_shutdown_event,
+            ),
+            name="grpc-client-heartbeat",
+        )
+        self._heartbeat_thread.daemon = True
+        self._heartbeat_thread.start()
+
+    def ReloadCode(self, request, context):
+        with self._reload_lock:  # can only call this method once at a time
+            old_heartbeat_shutdown_event = self._heartbeat_shutdown_event
+            old_heartbeat_thread = self._heartbeat_thread
+
+            self._reload_location()  # Creates and starts a new heartbeat thread
+
+        old_heartbeat_shutdown_event.set()
+        old_heartbeat_thread.join()
+
+        return api_pb2.ReloadCodeReply()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, _exception_type, _exception_value, _traceback):
+        if self._heartbeat_shutdown_event:
+            self._heartbeat_shutdown_event.set()
+            self._heartbeat_shutdown_event = None
+
+        if self._heartbeat_thread:
+            self._heartbeat_thread.join()
+            self._heartbeat_thread = None
+
+        self._exit_stack.close()
+
+    def _get_grpc_client(self):
+        return self._client
+
+    def _query(self, api_name: str, request, _context):
+        return self._client._get_response(api_name, request)  # noqa
+
+    def _streaming_query(self, api_name: str, request, _context):
+        return self._client._get_streaming_response(api_name, request)  # noqa
+
+    def ExecutionPlanSnapshot(self, request, context):
+        return self._query("ExecutionPlanSnapshot", request, context)
+
+    def ListRepositories(self, request, context):
+        return self._query("ListRepositories", request, context)
+
+    def Ping(self, request, context):
+        return self._query("Ping", request, context)
+
+    def GetServerId(self, request, context):
+        return self._fixed_server_id or self._query("GetServerId", request, context)
+
+    def GetCurrentImage(self, request, context):
+        return self._query("GetCurrentImage", request, context)
+
+    def StreamingExternalRepository(self, request, context):
+        return self._streaming_query("StreamingExternalRepository", request, context)
+
+    def Heartbeat(self, request, context):
+        return self._query("Heartbeat", request, context)
+
+    def StreamingPing(self, request, context):
+        return self._streaming_query("StreamingPing", request, context)
+
+    def ExternalPartitionNames(self, request, context):
+        return self._query("ExternalPartitionNames", request, context)
+
+    def ExternalNotebookData(self, request, context):
+        return self._query("ExternalNotebookData", request, context)
+
+    def ExternalPartitionConfig(self, request, context):
+        return self._query("ExternalPartitionConfig", request, context)
+
+    def ExternalPartitionTags(self, request, context):
+        return self._query("ExternalPartitionTags", request, context)
+
+    def ExternalPartitionSetExecutionParams(self, request, context):
+        return self._streaming_query("ExternalPartitionSetExecutionParams", request, context)
+
+    def ExternalPipelineSubsetSnapshot(self, request, context):
+        return self._query("ExternalPipelineSubsetSnapshot", request, context)
+
+    def ExternalRepository(self, request, context):
+        return self._query("ExternalRepository", request, context)
+
+    def ExternalJob(self, request, context):
+        return self._query("ExternalJob", request, context)
+
+    def ExternalScheduleExecution(self, request, context):
+        return self._streaming_query("ExternalScheduleExecution", request, context)
+
+    def ExternalSensorExecution(self, request, context):
+        return self._streaming_query("ExternalSensorExecution", request, context)
+
+    def ShutdownServer(self, request, context):
+        return self._query("ShutdownServer", request, context)
+
+    def CancelExecution(self, request, context):
+        try:
+            cancel_execution_request = deserialize_value(
+                request.serialized_cancel_execution_request,
+                CancelExecutionRequest,
+            )
+
+            run_id = cancel_execution_request.run_id
+
+            client = self._run_clients.get(run_id)
+            if not client:
+                raise Exception(f"Could not find a server for run {run_id}")
+
+            return client._get_response("CancelExecution", request, context)  # noqa
+        except:
+            serializable_error_info = serializable_error_info_from_exc_info(sys.exc_info())
+
+            return api_pb2.CancelExecutionReply(
+                serialized_cancel_execution_result=serialize_value(
+                    CancelExecutionResult(
+                        success=False,
+                        message=None,
+                        serializable_error_info=serializable_error_info,
+                    )
+                )
+            )
+
+    def CanCancelExecution(self, request, context):
+        return self._query("CanCancelExecution", request, context)
+
+    def StartRun(self, request, context):
+        execute_external_job_args = deserialize_value(
+            request.serialized_execute_run_args,
+            ExecuteExternalJobArgs,
+        )
+
+        run_id = execute_external_job_args.run_id
+
+        client = self._client
+
+        self._run_clients[run_id] = client
+        return client._get_response("StartRun", request)  # noqa

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_daemon.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_daemon.py
@@ -1,5 +1,4 @@
 import pytest
-from dagster import DagsterInstance
 from dagster._core.instance_for_test import instance_for_test
 from dagster._core.storage.dagster_run import DagsterRunStatus
 from dagster._core.storage.tags import PARTITION_NAME_TAG
@@ -10,14 +9,19 @@ from .multi_code_location_scenarios import multi_code_location_scenarios
 from .scenarios import ASSET_RECONCILIATION_SCENARIOS
 
 
+@pytest.fixture
+def instance():
+    with instance_for_test() as the_instance:
+        yield the_instance
+
+
 @pytest.mark.parametrize(
     "scenario_item",
     list(ASSET_RECONCILIATION_SCENARIOS.items()),
     ids=list(ASSET_RECONCILIATION_SCENARIOS.keys()),
 )
-def test_reconcile_with_external_asset_graph(scenario_item):
+def test_reconcile_with_external_asset_graph(scenario_item, instance):
     scenario_name, scenario = scenario_item
-    instance = DagsterInstance.ephemeral()
     run_requests, _, _ = scenario.do_sensor_scenario(
         instance, scenario_name=scenario_name, with_external_asset_graph=True
     )

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_grpc_server_registry.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_grpc_server_registry.py
@@ -62,10 +62,11 @@ def test_error_repo_in_registry(instance):
         ),
     )
     with GrpcServerRegistry(
-        instance=instance,
+        instance_ref=instance.get_ref(),
         reload_interval=5,
         heartbeat_ttl=10,
         startup_timeout=5,
+        wait_for_processes_on_shutdown=True,
     ) as registry:
         # Repository with a loading error does not raise an exception
         endpoint = registry.get_grpc_endpoint(error_origin)
@@ -105,10 +106,11 @@ def test_server_registry(instance):
     )
 
     with GrpcServerRegistry(
-        instance=instance,
+        instance_ref=instance.get_ref(),
         reload_interval=5,
         heartbeat_ttl=10,
         startup_timeout=5,
+        wait_for_processes_on_shutdown=True,
     ) as registry:
         endpoint_one = registry.get_grpc_endpoint(origin)
         endpoint_two = registry.get_grpc_endpoint(origin)
@@ -172,10 +174,11 @@ def test_registry_multithreading(instance):
     )
 
     with GrpcServerRegistry(
-        instance=instance,
+        instance_ref=instance.get_ref(),
         reload_interval=300,
         heartbeat_ttl=600,
         startup_timeout=30,
+        wait_for_processes_on_shutdown=True,
     ) as registry:
         endpoint = registry.get_grpc_endpoint(origin)
 
@@ -205,7 +208,11 @@ class TestMockProcessGrpcServerRegistry(GrpcServerRegistry):
     def __init__(self, instance):
         self.mocked_loadable_target_origin = None
         super(TestMockProcessGrpcServerRegistry, self).__init__(
-            instance=instance, reload_interval=300, heartbeat_ttl=600, startup_timeout=30
+            instance_ref=instance.get_ref(),
+            reload_interval=300,
+            heartbeat_ttl=600,
+            startup_timeout=30,
+            wait_for_processes_on_shutdown=True,
         )
 
     def supports_origin(self, code_location_origin):


### PR DESCRIPTION
## Summary & Motivation
A new entry point that adds a layer of indirection between the entrypoint process, and a subprocess that actually runs user code. The main benefit this gives is the ability to reload code without restarting the process (or re-deploying the k8s pod / task / etc.) - resolving https://github.com/dagster-io/dagster/issues/12581.

The main entry point implements the same gRPC api, but then redirects requests to a subprocess that it spins up.

The parent process uses a GrpcServerRegistry under the hood, which handles things like cleaning up subprocesses after they die and are no longer running any executions.

Unfortunately since gRPC servers still don't always have access to the instance, had to make the instance argument to GrpcServerRegistry optional (and add a few more config toggles since they get passed through).

Also added a new graphql test suite which should exercise the actual underlying gRPC api pretty comprehensively, and added a test that verifies that reloading works the way you would expect.

This is a large PR, I could potentially split it into two - one that adds the entrypoint, the other that implements the reload logic in dagster-graphql.