### PR TITLE
fix incorrect case in ECS docs

### DIFF
--- a/docs/content/deployment/guides/aws.mdx
+++ b/docs/content/deployment/guides/aws.mdx
@@ -103,7 +103,7 @@ def my_op(context):
   tags = {
     "ecs/cpu": "256",
     "ecs/memory": "512",
-    "ecs/ephemeralStorage": "40",
+    "ecs/ephemeral_storage": "40",
   }
 )
 def my_job():


### PR DESCRIPTION
Summary:
Docs were listing the wrong case.

Test Plan: View docs

## Summary & Motivation

## How I Tested These Changes
