### PR TITLE
Remove 'serverless is in early access' language from docs

### DIFF
--- a/docs/content/dagster-cloud/deployment.mdx
+++ b/docs/content/dagster-cloud/deployment.mdx
@@ -12,8 +12,6 @@ Dagster Cloud currently offers two deployment options to meet your needs: Server
 
 A Serverless deployment allows you to run Dagster jobs without spinning up any infrastructure. This fully-managed version of Dagster Cloud is the easiest way to get started with Dagster.
 
-**Note**: Serverless is currently in early access.
-
 [Learn more about Serverless deployments](/dagster-cloud/deployment/serverless).
 
 ---

--- a/docs/content/dagster-cloud/deployment/serverless.mdx
+++ b/docs/content/dagster-cloud/deployment/serverless.mdx
@@ -25,7 +25,7 @@ If any of the following are applicable, you should select [Hybrid deployment](/d
 
 ## Limitations
 
-Serverless is currently in early access and is subject to the following limitations:
+Serverless is subject to the following limitations:
 
 - Maximum of 100 GB of bandwidth per day
 - Maximum of 4500 step-minutes per day


### PR DESCRIPTION
Summary:
This was never removed despite serverless leaving early access.

Test Plan: View docs

## Summary & Motivation

## How I Tested These Changes
