### PR TITLE
fix partitioned -> unpartitioned issue

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
@@ -921,7 +921,8 @@ def determine_asset_partitions_to_auto_materialize_for_freshness(
                 else current_time
             )
 
-            if key in target_asset_keys:
+            # currently, freshness logic has no effect on partitioned assets
+            if key in target_asset_keys and not asset_graph.is_partitioned(key):
                 # calculate the data times you would expect after all currently-executing runs
                 # were to successfully complete
                 in_progress_data_time = data_time_resolver.get_in_progress_data_time(

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/auto_materialize_policy_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/auto_materialize_policy_scenarios.py
@@ -14,7 +14,7 @@ from .asset_reconciliation_scenario import (
     run_request,
     single_asset_run,
 )
-from .freshness_policy_scenarios import overlapping_freshness_inf
+from .freshness_policy_scenarios import daily_to_unpartitioned, overlapping_freshness_inf
 from .partition_scenarios import (
     hourly_partitions_def,
     hourly_to_daily_partitions,
@@ -132,5 +132,14 @@ auto_materialize_policy_scenarios = {
         ],
         # no need to rematerialize as this is a lazy policy
         expected_run_requests=[],
+    ),
+    "auto_materialize_policy_daily_to_unpartitioned_freshness": AssetReconciliationScenario(
+        assets=with_auto_materialize_policy(
+            daily_to_unpartitioned,
+            AutoMaterializePolicy.eager(),
+        ),
+        unevaluated_runs=[],
+        current_time=create_pendulum_time(year=2020, month=2, day=7, hour=4),
+        expected_run_requests=[run_request(asset_keys=["daily"], partition_key="2020-02-06")],
     ),
 }


### PR DESCRIPTION
## Summary & Motivation

The added test failed before this change with an error, as we were erroneously adding AutoMaterializeConditions to the dictionary under the `AssetKeyPartitionKey(key, None)` for partitioned assets. This would cause errors when trying to build the AutoMaterializeEvaluation objects

The freshness logic is not intended to impact partitioned assets

## How I Tested These Changes
