### PR TITLE
Change AutoMaterializeAssetEvaluation to store serialized subsets

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
@@ -66,14 +66,14 @@ class AutoMaterializeAssetEvaluation(NamedTuple):
         asset_key (AssetKey): The asset key that was evaluated.
         conditions: The conditions that impact if the asset should be materialized, skipped, or
             discarded. If the asset is partitioned, this will be a list of tuples, where the first
-            element is the condition and the second element is the set of partitions that the
+            element is the condition and the second element is the serialized subset of partitions that the
             condition applies to.
     """
 
     asset_key: AssetKey
     conditions: Union[
         Sequence[AutoMaterializeCondition],
-        Sequence[Tuple[AutoMaterializeCondition, PartitionsSubset]],
+        Sequence[Tuple[AutoMaterializeCondition, str]],
     ]
     num_requested: int
     num_skipped: int
@@ -122,7 +122,12 @@ class AutoMaterializeAssetEvaluation(NamedTuple):
             return AutoMaterializeAssetEvaluation(
                 asset_key=asset_key,
                 conditions=[
-                    (condition, partitions_def.empty_subset().with_partition_keys(partition_keys))
+                    (
+                        condition,
+                        partitions_def.empty_subset()
+                        .with_partition_keys(partition_keys)
+                        .serialize(),
+                    )
                     for condition, partition_keys in partition_keys_by_condition.items()
                 ],
                 num_requested=num_requested,

--- a/python_modules/dagster/dagster/_utils/test/schedule_storage.py
+++ b/python_modules/dagster/dagster/_utils/test/schedule_storage.py
@@ -4,6 +4,7 @@ import time
 import pendulum
 import pytest
 
+from dagster import StaticPartitionsDefinition
 from dagster._core.definitions.asset_reconciliation_sensor import (
     AutoMaterializeAssetEvaluation,
 )
@@ -749,3 +750,34 @@ class TestScheduleStorage:
         )
         assert len(res) == 1
         assert res[0].evaluation_id == 10
+
+    def test_auto_materialize_asset_evaluations_with_partitions(self, storage):
+        if not self.can_store_auto_materialize_asset_evaluations():
+            pytest.skip("Storage cannot store auto materialize asset evaluations")
+
+        partitions_def = StaticPartitionsDefinition(["a", "b"])
+        subset = partitions_def.empty_subset().with_partition_keys(["a"])
+
+        storage.add_auto_materialize_asset_evaluations(
+            evaluation_id=10,
+            asset_evaluations=[
+                AutoMaterializeAssetEvaluation(
+                    asset_key=AssetKey("asset_two"),
+                    conditions=[(MissingAutoMaterializeCondition(), subset.serialize())],
+                    num_requested=1,
+                    num_skipped=0,
+                    num_discarded=0,
+                ),
+            ],
+        )
+
+        res = storage.get_auto_materialize_asset_evaluations(
+            asset_key=AssetKey("asset_two"), limit=100
+        )
+        assert len(res) == 1
+        assert res[0].evaluation.asset_key == AssetKey("asset_two")
+        assert res[0].evaluation_id == 10
+        assert res[0].evaluation.num_requested == 1
+
+        assert res[0].evaluation.conditions[0][0] == MissingAutoMaterializeCondition()
+        assert partitions_def.deserialize_subset(res[0].evaluation.conditions[0][1]) == subset


### PR DESCRIPTION
Silly that I didn't test this but it doesn't impact the storage diffs:

partition subsets don't use the regular serdes since they need the partition def to deserialize. This adds the pattern we use elsewhere of having a string field in the namedtuple.