### PR TITLE
Pin alembic <= 1.11.0

### DIFF
--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -72,7 +72,7 @@ setup(
         "PyYAML>=5.1",
         # core (not explicitly expressed atm)
         # pin around issues in specific versions of alembic that broke our migrations
-        "alembic>=1.2.1,!=1.6.3,!=1.7.0",
+        "alembic>=1.2.1,!=1.6.3,!=1.7.0,<1.11.0",
         "croniter>=0.3.34",
         # grpcio 1.44.0 is the min version compatible with both protobuf 3 and 4
         # Also pinned <1.48.0 until the resolution of https://github.com/grpc/grpc/issues/31885


### PR DESCRIPTION
The latest alembic release broke a bunch of historical migrations. Let's pin around it for now.
