### PR TITLE
[ui] Add filter button to Schedules and Sensors

### DIFF
--- a/js_modules/dagit/packages/core/src/overview/OverviewSchedulesRoot.tsx
+++ b/js_modules/dagit/packages/core/src/overview/OverviewSchedulesRoot.tsx
@@ -23,7 +23,6 @@ import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
 import {useSelectionReducer} from '../hooks/useSelectionReducer';
 import {INSTANCE_HEALTH_FRAGMENT} from '../instance/InstanceHealthFragment';
-import {RepoFilterButton} from '../instance/RepoFilterButton';
 import {INSTIGATION_STATE_FRAGMENT} from '../instigation/InstigationUtils';
 import {UnloadableSchedules} from '../instigation/Unloadable';
 import {filterPermissionedInstigationState} from '../instigation/filterPermissionedInstigationState';
@@ -31,6 +30,9 @@ import {ScheduleBulkActionMenu} from '../schedules/ScheduleBulkActionMenu';
 import {SchedulerInfo} from '../schedules/SchedulerInfo';
 import {makeScheduleKey} from '../schedules/makeScheduleKey';
 import {CheckAllBox} from '../ui/CheckAllBox';
+import {useFilters} from '../ui/Filters';
+import {useCodeLocationFilter} from '../ui/Filters/useCodeLocationFilter';
+import {useInstigationStatusFilter} from '../ui/Filters/useInstigationStatusFilter';
 import {WorkspaceContext} from '../workspace/WorkspaceContext';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
 import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
@@ -60,6 +62,15 @@ export const OverviewSchedulesRoot = () => {
     defaults: {search: ''},
   });
 
+  const codeLocationFilter = useCodeLocationFilter();
+  const runningStateFilter = useInstigationStatusFilter();
+
+  const filters = React.useMemo(() => [codeLocationFilter, runningStateFilter], [
+    codeLocationFilter,
+    runningStateFilter,
+  ]);
+  const {button: filterButton, activeFiltersJsx} = useFilters({filters});
+
   const queryResultOverview = useQuery<OverviewSchedulesQuery, OverviewSchedulesQueryVariables>(
     OVERVIEW_SCHEDULES_QUERY,
     {
@@ -78,18 +89,30 @@ export const OverviewSchedulesRoot = () => {
     );
   }, [data, visibleRepos]);
 
+  const {state: runningState} = runningStateFilter;
+  const filteredBuckets = React.useMemo(() => {
+    return repoBuckets.map(({schedules, ...rest}) => {
+      return {
+        ...rest,
+        schedules: runningState.size
+          ? schedules.filter(({scheduleState}) => runningState.has(scheduleState.status))
+          : schedules,
+      };
+    });
+  }, [repoBuckets, runningState]);
+
   const sanitizedSearch = searchValue.trim().toLocaleLowerCase();
   const anySearch = sanitizedSearch.length > 0;
 
   const filteredBySearch = React.useMemo(() => {
     const searchToLower = sanitizedSearch.toLocaleLowerCase();
-    return repoBuckets
+    return filteredBuckets
       .map(({repoAddress, schedules}) => ({
         repoAddress,
         schedules: schedules.filter(({name}) => name.toLocaleLowerCase().includes(searchToLower)),
       }))
       .filter(({schedules}) => schedules.length > 0);
-  }, [repoBuckets, sanitizedSearch]);
+  }, [filteredBuckets, sanitizedSearch]);
 
   const anySchedulesVisible = React.useMemo(
     () => filteredBySearch.some(({schedules}) => schedules.length > 0),
@@ -196,8 +219,8 @@ export const OverviewSchedulesRoot = () => {
             title="No schedules"
             description={
               anyReposHidden
-                ? 'No schedules were found in the selected code locations'
-                : 'No schedules were found in your definitions'
+                ? 'No matching schedules were found in the selected code locations'
+                : 'No matching schedules were found in your definitions'
             }
           />
         </Box>
@@ -233,7 +256,7 @@ export const OverviewSchedulesRoot = () => {
         flex={{direction: 'row', alignItems: 'center', justifyContent: 'space-between'}}
       >
         <Box flex={{direction: 'row', gap: 12}}>
-          {repoCount > 0 ? <RepoFilterButton /> : null}
+          {filterButton}
           <TextInput
             icon="search"
             value={searchValue}
@@ -257,6 +280,15 @@ export const OverviewSchedulesRoot = () => {
           />
         </Tooltip>
       </Box>
+      {activeFiltersJsx.length ? (
+        <Box
+          padding={{vertical: 8, horizontal: 24}}
+          border={{side: 'horizontal', width: 1, color: Colors.KeylineGray}}
+          flex={{direction: 'row', gap: 8}}
+        >
+          {activeFiltersJsx}
+        </Box>
+      ) : null}
       {loading && !repoCount ? (
         <Box padding={64}>
           <Spinner purpose="page" />

--- a/js_modules/dagit/packages/core/src/ui/Filters/FilterDropdown.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Filters/FilterDropdown.tsx
@@ -247,7 +247,14 @@ export const FilterDropdown = ({filters, setIsOpen, setPortaledElements}: Filter
               <Spinner purpose="section" />
             </Box>
           ) : allResultsJsx.length ? (
-            <Container ref={parentRef} style={{maxHeight: '500px', overflowY: 'auto'}}>
+            <Container
+              ref={parentRef}
+              style={{
+                maxHeight: '500px',
+                overflowY: 'auto',
+                width: selectedFilter?.menuWidth || 'auto',
+              }}
+            >
               <Inner $totalHeight={totalHeight}>
                 {items.map(({index, end, start}) => {
                   return (
@@ -332,7 +339,7 @@ export const FilterDropdownButton = React.memo(({filters}: FilterDropdownButtonP
         canEscapeKeyClose
         popoverClassName="filter-dropdown"
         isOpen={isOpen}
-        position="bottom"
+        placement="bottom-start"
         onClosing={() => {
           prevOpenRef.current = false;
         }}
@@ -427,7 +434,6 @@ const SlashShortcut = styled.div`
 
 const PopoverStyle = createGlobalStyle`
   .filter-dropdown.filter-dropdown.filter-dropdown.filter-dropdown {
-    margin-left: 16px !important;
     border-radius: 8px;
     max-width: 100%;
     overflow: hidden;

--- a/js_modules/dagit/packages/core/src/ui/Filters/useCodeLocationFilter.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Filters/useCodeLocationFilter.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+
+import {TruncatedTextWithFullTextOnHover} from '../../nav/getLeftNavItemsForOption';
+import {WorkspaceContext} from '../../workspace/WorkspaceContext';
+import {buildRepoAddress} from '../../workspace/buildRepoAddress';
+import {repoAddressAsHumanString} from '../../workspace/repoAddressAsString';
+import {RepoAddress} from '../../workspace/types';
+
+import {useStaticSetFilter} from './useStaticSetFilter';
+
+export const useCodeLocationFilter = () => {
+  const {allRepos, visibleRepos, setVisible, setHidden} = React.useContext(WorkspaceContext);
+
+  const allRepoAddresses = React.useMemo(() => {
+    return allRepos.map((repo) =>
+      buildRepoAddress(repo.repository.name, repo.repositoryLocation.name),
+    );
+  }, [allRepos]);
+
+  const visibleRepoAddresses = React.useMemo(() => {
+    return visibleRepos.length === allRepos.length
+      ? []
+      : visibleRepos.map((repo) =>
+          buildRepoAddress(repo.repository.name, repo.repositoryLocation.name),
+        );
+  }, [allRepos, visibleRepos]);
+
+  return useStaticSetFilter<RepoAddress>({
+    name: 'Code location',
+    icon: 'folder',
+    initialState: visibleRepoAddresses,
+    allValues: allRepoAddresses.map((repoAddress) => {
+      return {value: repoAddress, match: [repoAddressAsHumanString(repoAddress)]};
+    }),
+    getKey: (repoAddress) => repoAddressAsHumanString(repoAddress),
+    renderLabel: ({value}) => (
+      <TruncatedTextWithFullTextOnHover text={repoAddressAsHumanString(value)} />
+    ),
+    getStringValue: (value) => repoAddressAsHumanString(value),
+    onStateChanged: (state: Set<RepoAddress>) => {
+      if (state.size === 0) {
+        setVisible(allRepoAddresses);
+        return;
+      }
+
+      const hidden = allRepoAddresses.filter((repoAddress) => !state.has(repoAddress));
+      setHidden(hidden);
+      setVisible(Array.from(state));
+    },
+    menuWidth: '500px',
+  });
+};

--- a/js_modules/dagit/packages/core/src/ui/Filters/useFilter.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Filters/useFilter.tsx
@@ -18,6 +18,7 @@ export type FilterObject<T = any> = {
   }) => void;
   onUnselected?: () => void;
   isLoadingFilters?: boolean;
+  menuWidth?: number | string;
 };
 
 export const FilterTag = ({
@@ -29,7 +30,7 @@ export const FilterTag = ({
   iconName: IconName;
   onRemove: () => void;
 }) => (
-  <div style={{display: 'inline-block', height: '24px'}}>
+  <div>
     <BaseTag
       icon={<Icon name={iconName} color={Colors.Link} />}
       rightIcon={

--- a/js_modules/dagit/packages/core/src/ui/Filters/useInstigationStatusFilter.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Filters/useInstigationStatusFilter.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+
+import {InstigationStatus} from '../../graphql/types';
+
+import {useStaticSetFilter} from './useStaticSetFilter';
+
+export const useInstigationStatusFilter = () => {
+  return useStaticSetFilter<InstigationStatus>({
+    name: 'Running state',
+    icon: 'toggle_off',
+    allValues: [
+      {value: InstigationStatus.RUNNING, match: ['on', 'running']},
+      {value: InstigationStatus.STOPPED, match: ['off', 'stopped']},
+    ],
+    getKey: (value) => value,
+    renderLabel: ({value}) => (
+      <span>{value === InstigationStatus.RUNNING ? 'Running' : 'Stopped'}</span>
+    ),
+    getStringValue: (value) => value,
+  });
+};

--- a/js_modules/dagit/packages/core/src/ui/Filters/useStaticSetFilter.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Filters/useStaticSetFilter.tsx
@@ -21,6 +21,7 @@ type Args<TValue> = {
   onStateChanged?: (state: Set<TValue>) => void;
   allowMultipleSelections?: boolean;
   matchType?: 'any-of' | 'all-of';
+  menuWidth?: number | string;
 };
 
 export type StaticSetFilter<TValue> = FilterObject & {
@@ -38,10 +39,11 @@ export function useStaticSetFilter<TValue>({
   initialState,
   getStringValue,
   onStateChanged,
+  menuWidth,
   allowMultipleSelections = true,
   matchType = 'any-of',
 }: Args<TValue>): StaticSetFilter<TValue> {
-  const [state, setState] = React.useState(new Set(initialState || []));
+  const [state, setState] = React.useState(() => new Set(initialState || []));
 
   React.useEffect(() => {
     onStateChanged?.(state);
@@ -73,6 +75,7 @@ export function useStaticSetFilter<TValue>({
             value,
           }));
         }
+
         return allValues
           .filter(({match}) =>
             match.some((value) => value.toLowerCase().includes(query.toLowerCase())),
@@ -118,9 +121,20 @@ export function useStaticSetFilter<TValue>({
         />
       ),
       setState,
+      menuWidth,
     }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [name, icon, state, getStringValue, renderLabel, allValues, matchType, renderActiveStateLabel],
+    [
+      name,
+      icon,
+      state,
+      getStringValue,
+      renderLabel,
+      allValues,
+      matchType,
+      renderActiveStateLabel,
+      menuWidth,
+    ],
   );
   const filterObjRef = useUpdatingRef(filterObj);
   return filterObj;

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceContext.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceContext.tsx
@@ -34,6 +34,8 @@ export interface DagsterRepoOption {
   repository: Repository;
 }
 
+type SetVisibleOrHiddenFn = (repoAddresses: RepoAddress[]) => void;
+
 type WorkspaceState = {
   error: PythonErrorFragment | null;
   loading: boolean;
@@ -42,7 +44,9 @@ type WorkspaceState = {
   visibleRepos: DagsterRepoOption[];
 
   refetch: () => Promise<ApolloQueryResult<RootWorkspaceQuery>>;
-  toggleVisible: (repoAddresses: RepoAddress[]) => void;
+  toggleVisible: SetVisibleOrHiddenFn;
+  setVisible: SetVisibleOrHiddenFn;
+  setHidden: SetVisibleOrHiddenFn;
 };
 
 export const WorkspaceContext = React.createContext<WorkspaceState>(
@@ -212,7 +216,7 @@ const useWorkspaceState = (): WorkspaceState => {
     return {error: null, allRepos};
   }, [workspaceOrError]);
 
-  const [visibleRepos, toggleVisible] = useVisibleRepos(allRepos);
+  const {visibleRepos, toggleVisible, setVisible, setHidden} = useVisibleRepos(allRepos);
 
   return {
     refetch,
@@ -222,19 +226,26 @@ const useWorkspaceState = (): WorkspaceState => {
     allRepos,
     visibleRepos,
     toggleVisible,
+    setVisible,
+    setHidden,
   };
 };
 
 /**
- * useVisibleRepos vends `[reposForKeys, toggleVisible]` and internally mirrors the current
- * selection into localStorage so that the default selection in new browser windows
- * is the repo currently active in your session.
+ * useVisibleRepos returns `{reposForKeys, toggleVisible, setVisible, setHidden}` and internally
+ * mirrors the current selection into localStorage so that the default selection in new browser
+ * windows is the repo currently active in your session.
  */
 const validateHiddenKeys = (parsed: unknown) => (Array.isArray(parsed) ? parsed : []);
 
 const useVisibleRepos = (
   allRepos: DagsterRepoOption[],
-): [DagsterRepoOption[], WorkspaceState['toggleVisible']] => {
+): {
+  visibleRepos: DagsterRepoOption[];
+  toggleVisible: SetVisibleOrHiddenFn;
+  setVisible: SetVisibleOrHiddenFn;
+  setHidden: SetVisibleOrHiddenFn;
+} => {
   const {basePath} = React.useContext(AppContext);
 
   const [oldHiddenKeys, setOldHiddenKeys] = useStateWithStorage<string[]>(
@@ -245,6 +256,8 @@ const useVisibleRepos = (
     basePath + ':' + HIDDEN_REPO_KEYS,
     validateHiddenKeys,
   );
+
+  const hiddenKeysJSON = JSON.stringify([...hiddenKeys.sort()]);
 
   // TODO: Remove this logic eventually...
   const migratedOldHiddenKeys = React.useRef(false);
@@ -273,16 +286,41 @@ const useVisibleRepos = (
     [setHiddenKeys],
   );
 
-  const visibleOptions = React.useMemo(() => {
+  const setVisible = React.useCallback(
+    (repoAddresses: RepoAddress[]) => {
+      const keysToShow = new Set(
+        repoAddresses.map((repoAddress) => `${repoAddress.name}:${repoAddress.location}`),
+      );
+      setHiddenKeys((current) => {
+        return current?.filter((key) => !keysToShow.has(key));
+      });
+    },
+    [setHiddenKeys],
+  );
+
+  const setHidden = React.useCallback(
+    (repoAddresses: RepoAddress[]) => {
+      const keysToHide = new Set(
+        repoAddresses.map((repoAddress) => `${repoAddress.name}:${repoAddress.location}`),
+      );
+      setHiddenKeys((current) => {
+        const updatedSet = new Set([...(current || []), ...keysToHide]);
+        return Array.from(updatedSet);
+      });
+    },
+    [setHiddenKeys],
+  );
+
+  const visibleRepos = React.useMemo(() => {
     // If there's only one repo, skip the local storage check -- we have to show this one.
     if (allRepos.length === 1) {
       return allRepos;
-    } else {
-      return allRepos.filter((o) => !hiddenKeys.includes(getRepositoryOptionHash(o)));
     }
-  }, [allRepos, hiddenKeys]);
+    const hiddenKeys = new Set(JSON.parse(hiddenKeysJSON));
+    return allRepos.filter((o) => !hiddenKeys.has(getRepositoryOptionHash(o)));
+  }, [allRepos, hiddenKeysJSON]);
 
-  return [visibleOptions, toggleVisible];
+  return {visibleRepos, toggleVisible, setVisible, setHidden};
 };
 
 // Public


### PR DESCRIPTION
## Summary & Motivation

Use the new filter component to allow code location and running state filtering on the Overview schedules and sensors pages, as well as the code location schedules and sensors pages.

When no code locations are selected, all code locations are visible. Changing the selected code locations will also update the left nav, as it changes global-level code location filtering, as tracked in localStorage.

https://github.com/dagster-io/dagster/assets/2823852/88089699-9cae-4243-bdc8-de42449ffcde

## How I Tested These Changes

View Overview > Schedules, verify that the filter behavior is correct:

- Add/remove code locations in filter, verify that this updates the "hidden" code location state correctly, including the left nav.
- Add running/stopped in filter, verify that schedules are filtered correctly.

Repeat on Overview sensors and code location schedules/sensors.
