### PR TITLE
feat(dbt-assets)[6/N]: add examples for `@dbt_assets`

### DIFF
--- a/examples/tutorial_dbt_dagster_v2/README.md
+++ b/examples/tutorial_dbt_dagster_v2/README.md
@@ -1,0 +1,28 @@
+# (Experimental) dbt with software-defined assets tutorial example
+
+This example demonstrates how to integrate dbt with Dagster using dbt's example [jaffle shop project](https://github.com/dbt-labs/jaffle_shop), the [dagster-dbt library](/\_apidocs/libraries/dagster-dbt), and a [DuckDB database](https://duckdb.org/).
+
+In this example, we use the new `dagster-dbt` APIs that require the usage of `dbt-core>=1.4.0`.
+
+---
+
+## Getting started
+
+To download this example, run:
+
+```shell
+dagster project from-example --name my-dagster-project --example tutorial_dbt_dagster_v2
+```
+
+To install this example and its dependencies, run:
+
+```shell
+cd my-dagster-project
+pip install -e ".[dev]"
+```
+
+At this point, you can view the **completed** project in the Dagster UI by running:
+
+```shell
+dagster dev
+```

--- a/examples/tutorial_dbt_dagster_v2/jaffle_shop/models/staging/stg_orders.sql
+++ b/examples/tutorial_dbt_dagster_v2/jaffle_shop/models/staging/stg_orders.sql
@@ -1,3 +1,5 @@
+{{ config(alias='staging_orders') }}
+
 with source as (
 
     {#-

--- a/examples/tutorial_dbt_dagster_v2/pyproject.toml
+++ b/examples/tutorial_dbt_dagster_v2/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "tutorial_dbt_dagster_v2"
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[tool.dagster]
+module_name = "tutorial_dbt_dagster_v2"

--- a/examples/tutorial_dbt_dagster_v2/setup.py
+++ b/examples/tutorial_dbt_dagster_v2/setup.py
@@ -1,0 +1,12 @@
+from setuptools import find_packages, setup
+
+setup(
+    name="tutorial_dbt_dagster_v2",
+    packages=find_packages(),
+    install_requires=[
+        "dagster",
+        "dagster-dbt",
+        "dbt-duckdb",
+    ],
+    extras_require={"dev": ["dagit"]},
+)

--- a/examples/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/__init__.py
+++ b/examples/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/__init__.py
@@ -1,0 +1,12 @@
+from dagster import Definitions
+from dagster_dbt.cli import DbtCli
+
+from tutorial_dbt_dagster_v2.assets import DBT_PROJECT_DIR
+from tutorial_dbt_dagster_v2.assets.build import my_dbt_assets
+
+defs = Definitions(
+    assets=[my_dbt_assets],
+    resources={
+        "dbt": DbtCli(project_dir=DBT_PROJECT_DIR, global_config=["--no-use-colors"]),
+    },
+)

--- a/examples/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/__init__.py
+++ b/examples/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/__init__.py
@@ -1,0 +1,11 @@
+import json
+
+from dagster import file_relative_path
+from dagster_dbt.cli import DbtManifest
+
+DBT_PROJECT_DIR = file_relative_path(__file__, "../../jaffle_shop")
+MANIFEST_PATH = file_relative_path(__file__, "../../jaffle_shop/target/manifest.json")
+
+with open(MANIFEST_PATH) as f:
+    raw_manifest: dict = json.load(f)
+    manifest = DbtManifest(raw_manifest=raw_manifest)

--- a/examples/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/build.py
+++ b/examples/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/build.py
@@ -1,0 +1,10 @@
+from dagster import OpExecutionContext
+from dagster_dbt.asset_decorator import dbt_assets
+from dagster_dbt.cli import DbtCli
+
+from tutorial_dbt_dagster_v2.assets import manifest
+
+
+@dbt_assets(manifest=manifest)
+def my_dbt_assets(context: OpExecutionContext, dbt: DbtCli):
+    yield from dbt.cli(["build"], manifest=manifest, context=context).stream()

--- a/examples/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/customize_asset_keys.py
+++ b/examples/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/customize_asset_keys.py
@@ -1,0 +1,21 @@
+from typing import Any, Mapping
+
+from dagster import AssetKey, OpExecutionContext
+from dagster_dbt.asset_decorator import dbt_assets
+from dagster_dbt.cli import DbtCli, DbtManifest
+
+from tutorial_dbt_dagster_v2.assets import raw_manifest
+
+
+class CustomizedDbtManifest(DbtManifest):
+    @classmethod
+    def node_info_to_asset_key(cls, node_info: Mapping[str, Any]) -> AssetKey:
+        return AssetKey(["prefix", node_info["alias"]])
+
+
+manifest = CustomizedDbtManifest(raw_manifest=raw_manifest)
+
+
+@dbt_assets(manifest=manifest)
+def my_dbt_assets(context: OpExecutionContext, dbt: DbtCli):
+    yield from dbt.cli(["build"], manifest=manifest, context=context).stream()

--- a/examples/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/partitions.py
+++ b/examples/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/partitions.py
@@ -1,0 +1,26 @@
+import json
+
+from dagster import DailyPartitionsDefinition, OpExecutionContext
+from dagster_dbt.asset_decorator import dbt_assets
+from dagster_dbt.cli import DbtCli
+
+from tutorial_dbt_dagster_v2.assets import manifest
+
+DBT_SELECT_SEED = "resource_type:seed"
+
+
+@dbt_assets(manifest=manifest, select=DBT_SELECT_SEED)
+def dbt_seed_assets(context: OpExecutionContext, dbt: DbtCli):
+    yield from dbt.cli(["seed"], manifest=manifest, context=context).stream()
+
+
+@dbt_assets(
+    manifest=manifest,
+    exclude=DBT_SELECT_SEED,
+    partitions_def=DailyPartitionsDefinition(start_date="2023-05-01"),
+)
+def dbt_daily_assets(context: OpExecutionContext, dbt: DbtCli):
+    dbt_vars = {"date": context.partition_key}
+    dbt_args = ["run", "--vars", json.dumps(dbt_vars)]
+
+    yield from dbt.cli(dbt_args, manifest=manifest, context=context).stream()

--- a/examples/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/runtime_metadata.py
+++ b/examples/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/runtime_metadata.py
@@ -1,0 +1,30 @@
+from dagster import OpExecutionContext, Output
+from dagster_dbt.asset_decorator import dbt_assets
+from dagster_dbt.cli import DbtCli
+from dateutil import parser
+
+from tutorial_dbt_dagster_v2.assets import manifest
+
+
+@dbt_assets(manifest=manifest)
+def my_dbt_assets(context: OpExecutionContext, dbt: DbtCli):
+    for event in dbt.cli(["build"], manifest=manifest, context=context).stream_raw_events():
+        for dagster_event in event.to_default_asset_events(manifest=manifest):
+            if isinstance(dagster_event, Output):
+                event_node_info = event.event["data"]["node_info"]
+
+                started_at = parser.isoparse(event_node_info["node_started_at"])
+                completed_at = parser.isoparse(event_node_info["node_finished_at"])
+
+                metadata = {
+                    "Execution Started At": started_at.isoformat(timespec="seconds"),
+                    "Execution Completed At": completed_at.isoformat(timespec="seconds"),
+                    "Execution Duration": (completed_at - started_at).total_seconds(),
+                }
+
+                context.add_output_metadata(
+                    metadata=metadata,
+                    output_name=dagster_event.output_name,
+                )
+
+            yield dagster_event

--- a/examples/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/seed_run_test.py
+++ b/examples/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/seed_run_test.py
@@ -1,0 +1,17 @@
+from dagster import OpExecutionContext
+from dagster_dbt.asset_decorator import dbt_assets
+from dagster_dbt.cli import DbtCli
+
+from tutorial_dbt_dagster_v2.assets import manifest
+
+
+@dbt_assets(manifest=manifest)
+def my_dbt_assets(context: OpExecutionContext, dbt: DbtCli):
+    dbt_commands = [
+        ["seed"],
+        ["run"],
+        ["test"],
+    ]
+
+    for dbt_command in dbt_commands:
+        yield from dbt.cli(dbt_command, manifest=manifest, context=context).stream()

--- a/examples/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/separate_asset_defs.py
+++ b/examples/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/separate_asset_defs.py
@@ -1,0 +1,35 @@
+from dagster import OpExecutionContext
+from dagster_dbt.asset_decorator import dbt_assets
+from dagster_dbt.cli import DbtCli
+
+from tutorial_dbt_dagster_v2.assets import manifest
+
+STAGING_SELECT = "fqn:staging.*"
+MATERIALIZE_SELECT = "fqn:customers fqn:orders"
+
+
+@dbt_assets(manifest=manifest, select="resource_type:seed")
+def dbt_seed_assets(context: OpExecutionContext, dbt: DbtCli):
+    yield from dbt.cli(["seed"], manifest=manifest, context=context).stream()
+
+
+@dbt_assets(manifest=manifest, select=STAGING_SELECT)
+def dbt_staging_assets(context: OpExecutionContext, dbt: DbtCli):
+    dbt_commands = [
+        ["run"],
+        ["test"],
+    ]
+
+    for dbt_command in dbt_commands:
+        yield from dbt.cli(dbt_command, manifest=manifest, context=context).stream()
+
+
+@dbt_assets(manifest=manifest, select=MATERIALIZE_SELECT)
+def my_dbt_assets(context: OpExecutionContext, dbt: DbtCli):
+    dbt_commands = [
+        ["run"],
+        ["test"],
+    ]
+
+    for dbt_command in dbt_commands:
+        yield from dbt.cli(dbt_command, manifest=manifest, context=context).stream()

--- a/examples/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/use_artifacts.py
+++ b/examples/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/use_artifacts.py
@@ -1,0 +1,17 @@
+import pprint
+import sys
+
+from dagster import OpExecutionContext
+from dagster_dbt.asset_decorator import dbt_assets
+from dagster_dbt.cli import DbtCli
+
+from tutorial_dbt_dagster_v2.assets import manifest
+
+
+@dbt_assets(manifest=manifest)
+def my_dbt_assets(context: OpExecutionContext, dbt: DbtCli):
+    dbt_build = dbt.cli(["build"], manifest=manifest, context=context)
+
+    yield from dbt_build.stream()
+
+    sys.stdout.write(pprint.pformat(dbt_build.get_artifact("run_results.json")))


### PR DESCRIPTION
## Summary & Motivation
We add examples to show off the new APIs for interfacing with dbt within Dagster. This will be presented in an associated GitHub discussion.

Some use cases for your dbt project in Dagster:
- Running `dbt build`
- Customizing the corresponding Dagster asset keys for your dbt resources
- Running your dbt project with Dagster partitions
- Adding customized metadata to your Dagster events
- Manipulating dbt artifacts after running a dbt command

## How I Tested These Changes
local