### PR TITLE
[auto-materialize] Auto Observe Bug

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_policy.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_policy.py
@@ -63,7 +63,7 @@ class AutoMaterializePolicy(
         on_new_parent_data: bool,
         for_freshness: bool,
         time_window_partition_scope_minutes: Optional[float],
-        max_materializations_per_minute: Optional[int],
+        max_materializations_per_minute: Optional[int] = 1,
     ):
         check.invariant(
             on_new_parent_data or for_freshness,

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -338,24 +338,29 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
         # no records found with a new data version
         return None
 
-    def new_version_exists(
+    def new_version_storage_id(
         self,
         observable_source_asset_key: AssetKey,
         after_cursor: Optional[int] = None,
-    ) -> bool:
-        """Returns True if there is an asset observation of the given observable source asset key
-        after the specified cursor.
+    ) -> Optional[int]:
+        """Returns the storage id of the latest asset observation of the given observable source
+        asset key after the specified cursor, or None if no such observation exists.
 
         Args:
             observable_source_asset_key (AssetKeyPartitionKey): The observable source asset to query.
             after_cursor (Optional[int]): Filter parameter such that only records with a storage_id
                 greater than this value will be considered.
         """
-        previous_version_record = self.get_observation_record(
-            asset_key=observable_source_asset_key,
-            # we're looking for if a new version exists after `after_cursor`, so we need to know
-            # what the version was before `after_cursor`
-            before_cursor=after_cursor,
+        previous_version_record = (
+            self.get_observation_record(
+                asset_key=observable_source_asset_key,
+                # we're looking for if a new version exists after `after_cursor`, so we need to know
+                # what the version was before `after_cursor`
+                before_cursor=after_cursor,
+            )
+            # if the after_cursor is None, then no previous version can exist
+            if after_cursor is not None
+            else None
         )
         previous_version = (
             extract_data_version_from_entry(previous_version_record.event_log_entry)
@@ -368,7 +373,7 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
             after_cursor=after_cursor,
             data_version=previous_version,
         )
-        return next_version_record is not None
+        return next_version_record.storage_id if next_version_record else None
 
     def _new_version_of_source_exists_after_asset_partition(
         self,

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/observable_source_asset_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/observable_source_asset_scenarios.py
@@ -33,6 +33,13 @@ downstream_of_multiple_observable_source_assets = [
 ]
 
 observable_source_asset_scenarios = {
+    "observable_to_unpartitioned0": AssetReconciliationScenario(
+        assets=unpartitioned_downstream_of_observable_source,
+        unevaluated_runs=[
+            run(["source_asset"], is_observation=True),
+        ],
+        expected_run_requests=[run_request(["asset1"])],
+    ),
     "observable_to_unpartitioned1": AssetReconciliationScenario(
         assets=unpartitioned_downstream_of_observable_source,
         unevaluated_runs=[
@@ -49,6 +56,21 @@ observable_source_asset_scenarios = {
             run(["source_asset"], is_observation=True),
         ],
         expected_run_requests=[run_request(["asset1"])],
+    ),
+    "observable_to_unpartitioned_with_failure": AssetReconciliationScenario(
+        assets=unpartitioned_downstream_of_observable_source,
+        cursor_from=AssetReconciliationScenario(
+            assets=unpartitioned_downstream_of_observable_source,
+            unevaluated_runs=[
+                run(["source_asset"], is_observation=True),
+            ],
+            expected_run_requests=[run_request(["asset1"])],
+        ),
+        unevaluated_runs=[
+            run(["asset1"], failed_asset_keys=["asset1"]),
+        ],
+        # should not request again
+        expected_run_requests=[],
     ),
     "observable_to_partitioned": AssetReconciliationScenario(
         assets=partitioned_downstream_of_observable_source,


### PR DESCRIPTION
## Summary & Motivation

Previously, we weren't advancing the daemon's cursor unless there were new materialization events. So if there was a new observation, then a run was launched to respond to that observation, but it did not materialize any assets before the next tick, then the daemon would not realize that it had already processed that observation.

This fixes that issue.

## How I Tested These Changes
