### PR TITLE
Add link to GraphQL examples in tests

### DIFF
--- a/docs/content/concepts/dagit/graphql.mdx
+++ b/docs/content/concepts/dagit/graphql.mdx
@@ -71,6 +71,8 @@ Dagster also provides a Python client to interface with Dagster's GraphQL API fr
 - [Launch a run](#launch-a-run)
 - [Terminate an in-progress run](#terminate-an-in-progress-run)
 
+You can find additional [examples in the dagster-graphql test suite](https://github.com/dagster-io/dagster/blob/master/python_modules/dagster-graphql/dagster_graphql_tests/graphql/).
+
 ### Get a list of Dagster runs
 
 <TabGroup>


### PR DESCRIPTION
There are a lot of useful GraphQL snippets in our test suite. Let's link to them from the documentation.