### PR TITLE
[ui] Show an instructional tooltip about zoom modifier keys

### DIFF
--- a/js_modules/dagit/packages/core/src/graph/SVGViewport.tsx
+++ b/js_modules/dagit/packages/core/src/graph/SVGViewport.tsx
@@ -1,4 +1,4 @@
-import {Box, Colors, Icon, IconWrapper, Slider} from '@dagster-io/ui';
+import {Box, Colors, Icon, IconWrapper, Slider, Tag} from '@dagster-io/ui';
 import animate from 'amator';
 import * as React from 'react';
 import ReactDOM from 'react-dom';
@@ -152,6 +152,7 @@ const PanAndZoomInteractor: SVGViewportInteractor = {
   render(viewport: SVGViewport) {
     return (
       <ZoomSliderContainer id="zoom-slider-container">
+        <WheelInstructionTooltip />
         <Box margin={{bottom: 8}}>
           <IconButton
             onClick={() => {
@@ -595,4 +596,47 @@ const ZoomSliderContainer = styled.div`
   padding: 10px 8px;
   padding-bottom: 0;
   background: rgba(245, 248, 250, 0.4);
+`;
+
+const WheelInstructionTooltip: React.FC = () => {
+  const [usedMeta, setUsedMeta] = React.useState(false);
+  const [wheeling, setWheeling] = React.useState(false);
+  const timeout = React.useRef<NodeJS.Timeout>();
+
+  React.useEffect(() => {
+    const listener = (e: WheelEvent) => {
+      clearTimeout(timeout.current);
+      if (e.metaKey || e.shiftKey || e.ctrlKey) {
+        setUsedMeta(true);
+        setWheeling(false);
+        return;
+      }
+      setWheeling(true);
+      timeout.current = setTimeout(() => {
+        setWheeling(false);
+      }, 3000);
+    };
+    document.addEventListener('wheel', listener);
+    return () => {
+      document.removeEventListener('wheel', listener);
+      clearTimeout(timeout.current);
+    };
+  }, []);
+
+  const zoomKey = navigator.userAgent.includes('Mac') ? '⌘' : 'Ctrl';
+  const visible = wheeling && !usedMeta;
+
+  return (
+    <WheelInstructionTooltipContainer style={{opacity: visible ? 1 : 0}}>
+      <Tag>{`Hold ${zoomKey} to Zoom`}</Tag>
+    </WheelInstructionTooltipContainer>
+  );
+};
+
+const WheelInstructionTooltipContainer = styled.div`
+  position: absolute;
+  bottom: 40px;
+  right: 32px;
+  white-space: nowrap;
+  transition: opacity 300ms ease-in-out;
 `;

--- a/js_modules/dagit/packages/ui/src/components/Slider.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Slider.tsx
@@ -41,6 +41,10 @@ export const SliderStyles = css<{$fillColor: string}>`
       height: 8px;
     }
   }
+  &.bp4-vertical {
+    width: 20px;
+    min-width: 20px;
+  }
   &.bp4-vertical .bp4-slider-track,
   &.bp4-vertical .bp4-slider-track .bp4-slider-progress {
     height: initial;


### PR DESCRIPTION
## Summary & Motivation

This is a small tooltip that appears beside the zoom control when you start using the scroll wheel (to attempt to zoom) and disappears for the remainder of the time the component is mounted once you use a modifier key. Our goal here is to compensate for the lack of discoverability of the zoom functionality for users who do not have trackpads (pinch to zoom) and are not familiar with Figma, Photoshop, et. al.

https://www.loom.com/share/e206ec32d0724607ac45703ef0fc1d12


## How I Tested These Changes

I verified this manually in Chrome, Firefox, Edge and Safari. I used user-agent overrides in Chrome to verify that the key changes from "Cmd" to "Ctrl" for non-Mac users.