### PR TITLE
feat(dbt-assets)[4/N]: add subsetting implementation

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
@@ -55,6 +55,10 @@ def dbt_assets(
             non_argument_deps=non_argument_deps,
             compute_kind="dbt",
             can_subset=True,
+            op_tags={
+                **({"dagster-dbt/select": select} if select else {}),
+                **({"dagster-dbt/exclude": exclude} if exclude else {}),
+            },
         )(fn)
 
         return asset_definition

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_decorator.py
@@ -110,3 +110,7 @@ def test_selections(
 
     expected_asset_keys = {AssetKey(key.split("/")) for key in expected_asset_names}
     assert my_dbt_assets.keys == expected_asset_keys
+
+    expected_select_tag = "fqn:*" if select is None else select
+    assert my_dbt_assets.op.tags.get("dagster-dbt/select") == expected_select_tag
+    assert my_dbt_assets.op.tags.get("dagster-dbt/exclude") == exclude


### PR DESCRIPTION
## Summary & Motivation
Within Dagster, one computation can model the materialization of multiple assets. However, there are instances where this computation is flexible enough that, when specified by the user, it can optionally materialize a subselection of its assets.

This behavior is called [Subsetting](https://docs.dagster.io/concepts/assets/multi-assets#subsetting-multi-assets).

Historically, because we constrained the compute function in our dbt integration to essentially be either `dbt run` or `dbt build`, it was easy for us to also implement subsetting on the user's behalf. That way, they could achieve this feature out of the box.

Now, we have decided to liberalize the compute function in the `dbt` integration, allowing the user to specify this compute function. Consequentially, the user will also need to implement subsetting in the body of their computation in order to achieve this feature.

Here, we provide a utility to accomplish this use case. When the user passes in the Dagster execution context to their dbt resource that controls CLI invocation, we can:
- Automatically construct the proper dbt selection arguments, and
- Pass the selection arguments into the CLI invocation on behalf of the user.

## How I Tested These Changes
pytest