### PR TITLE
Store evaluations from asset daemon

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/schedules/base.py
+++ b/python_modules/dagster/dagster/_core/storage/schedules/base.py
@@ -137,6 +137,10 @@ class ScheduleStorage(abc.ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
             tick_statuses (Optional[List[TickStatus]]): The tick statuses to wipe
         """
 
+    @property
+    def supports_auto_materialize_asset_evaluations(self) -> bool:
+        return True
+
     @abc.abstractmethod
     def add_auto_materialize_asset_evaluations(
         self,

--- a/python_modules/dagster/dagster/_core/storage/schedules/sql_schedule_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/schedules/sql_schedule_storage.py
@@ -459,6 +459,11 @@ class SqlScheduleStorage(ScheduleStorage):
         with self.connect() as conn:
             conn.execute(query)
 
+    @property
+    def supports_auto_materialize_asset_evaluations(self) -> bool:
+        with self.connect() as conn:
+            return self._has_asset_daemon_asset_evaluations_table(conn)
+
     def add_auto_materialize_asset_evaluations(
         self,
         evaluation_id: int,

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -53,6 +53,12 @@ class AssetDaemon(IntervalDaemon):
             "Auto materialization requires schedule storage to be configured",
         )
 
+        if not schedule_storage.supports_auto_materialize_asset_evaluations:
+            self._logger.warning(
+                "Auto materialize evaluations are not getting logged. Run `dagster instance"
+                " migrate` to enable."
+            )
+
         workspace = workspace_process_context.create_request_context()
         asset_graph = ExternalAssetGraph.from_workspace(workspace)
         target_asset_keys = {
@@ -83,9 +89,10 @@ class AssetDaemon(IntervalDaemon):
             run_tags=None,
         )
 
-        schedule_storage.add_auto_materialize_asset_evaluations(
-            check.not_none(new_cursor.evaluation_id), evaluations
-        )
+        if schedule_storage.supports_auto_materialize_asset_evaluations:
+            schedule_storage.add_auto_materialize_asset_evaluations(
+                check.not_none(new_cursor.evaluation_id), evaluations
+            )
 
         for run_request in run_requests:
             yield

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_daemon.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_daemon.py
@@ -42,9 +42,6 @@ daemon_scenarios = {**auto_materialize_policy_scenarios, **multi_code_location_s
 
 @pytest.fixture
 def daemon_not_paused_instance():
-    # instance = DagsterInstance.ephemeral()
-    # set_auto_materialize_paused(instance, False)
-    # yield instance
     with instance_for_test(
         overrides={
             "run_launcher": {

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_daemon.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_daemon.py
@@ -1,5 +1,6 @@
 import pytest
 from dagster import DagsterInstance
+from dagster._core.instance_for_test import instance_for_test
 from dagster._core.storage.dagster_run import DagsterRunStatus
 from dagster._core.storage.tags import PARTITION_NAME_TAG
 from dagster._daemon.asset_daemon import set_auto_materialize_paused
@@ -41,9 +42,19 @@ daemon_scenarios = {**auto_materialize_policy_scenarios, **multi_code_location_s
 
 @pytest.fixture
 def daemon_not_paused_instance():
-    instance = DagsterInstance.ephemeral()
-    set_auto_materialize_paused(instance, False)
-    yield instance
+    # instance = DagsterInstance.ephemeral()
+    # set_auto_materialize_paused(instance, False)
+    # yield instance
+    with instance_for_test(
+        overrides={
+            "run_launcher": {
+                "module": "dagster._core.launcher.sync_in_memory_run_launcher",
+                "class": "SyncInMemoryRunLauncher",
+            }
+        }
+    ) as instance:
+        set_auto_materialize_paused(instance, False)
+        yield instance
 
 
 @pytest.mark.parametrize(
@@ -86,62 +97,76 @@ def test_daemon_run_tags():
     scenario_name = "auto_materialize_policy_eager_with_freshness_policies"
     scenario = auto_materialize_policy_scenarios[scenario_name]
 
-    instance = DagsterInstance.ephemeral(
-        settings={"auto_materialize": {"run_tags": {"foo": "bar"}}}
-    )
-    set_auto_materialize_paused(instance, False)
-    scenario.do_daemon_scenario(instance, scenario_name=scenario_name)
+    with instance_for_test(
+        overrides={
+            "run_launcher": {
+                "module": "dagster._core.launcher.sync_in_memory_run_launcher",
+                "class": "SyncInMemoryRunLauncher",
+            },
+            "auto_materialize": {"run_tags": {"foo": "bar"}},
+        }
+    ) as instance:
+        set_auto_materialize_paused(instance, False)
 
-    runs = instance.get_runs()
+        scenario.do_daemon_scenario(instance, scenario_name=scenario_name)
 
-    assert len(runs) == len(
-        scenario.expected_run_requests
-        + scenario.unevaluated_runs
-        + (scenario.cursor_from.unevaluated_runs if scenario.cursor_from else [])
-    )
+        runs = instance.get_runs()
 
-    for run in runs:
-        assert run.status == DagsterRunStatus.SUCCESS
+        assert len(runs) == len(
+            scenario.expected_run_requests
+            + scenario.unevaluated_runs
+            + (scenario.cursor_from.unevaluated_runs if scenario.cursor_from else [])
+        )
 
-    def sort_run_request_key_fn(run_request):
-        return (min(run_request.asset_selection), run_request.partition_key)
+        for run in runs:
+            assert run.status == DagsterRunStatus.SUCCESS
 
-    def sort_run_key_fn(run):
-        return (min(run.asset_selection), run.tags.get(PARTITION_NAME_TAG))
+        def sort_run_request_key_fn(run_request):
+            return (min(run_request.asset_selection), run_request.partition_key)
 
-    sorted_runs = sorted(runs[: len(scenario.expected_run_requests)], key=sort_run_key_fn)
-    sorted_expected_run_requests = sorted(
-        scenario.expected_run_requests, key=sort_run_request_key_fn
-    )
-    for run, expected_run_request in zip(sorted_runs, sorted_expected_run_requests):
-        assert run.asset_selection is not None
-        assert set(run.asset_selection) == set(expected_run_request.asset_selection)
-        assert run.tags.get(PARTITION_NAME_TAG) == expected_run_request.partition_key
-        assert run.tags["foo"] == "bar"
+        def sort_run_key_fn(run):
+            return (min(run.asset_selection), run.tags.get(PARTITION_NAME_TAG))
+
+        sorted_runs = sorted(runs[: len(scenario.expected_run_requests)], key=sort_run_key_fn)
+        sorted_expected_run_requests = sorted(
+            scenario.expected_run_requests, key=sort_run_request_key_fn
+        )
+        for run, expected_run_request in zip(sorted_runs, sorted_expected_run_requests):
+            assert run.asset_selection is not None
+            assert set(run.asset_selection) == set(expected_run_request.asset_selection)
+            assert run.tags.get(PARTITION_NAME_TAG) == expected_run_request.partition_key
+            assert run.tags["foo"] == "bar"
 
 
 def test_daemon_paused():
     scenario_name = "auto_materialize_policy_eager_with_freshness_policies"
     scenario = auto_materialize_policy_scenarios[scenario_name]
 
-    instance = DagsterInstance.ephemeral()
-    scenario.do_daemon_scenario(instance, scenario_name=scenario_name)
+    with instance_for_test(
+        overrides={
+            "run_launcher": {
+                "module": "dagster._core.launcher.sync_in_memory_run_launcher",
+                "class": "SyncInMemoryRunLauncher",
+            },
+        }
+    ) as instance:
+        scenario.do_daemon_scenario(instance, scenario_name=scenario_name)
 
-    runs = instance.get_runs()
+        runs = instance.get_runs()
 
-    # daemon is paused by default , so no new runs should have been created
-    assert len(runs) == len(
-        scenario.unevaluated_runs
-        + (scenario.cursor_from.unevaluated_runs if scenario.cursor_from else [])
-    )
+        # daemon is paused by default , so no new runs should have been created
+        assert len(runs) == len(
+            scenario.unevaluated_runs
+            + (scenario.cursor_from.unevaluated_runs if scenario.cursor_from else [])
+        )
 
-    instance.wipe()
-    set_auto_materialize_paused(instance, False)
-    scenario.do_daemon_scenario(instance, scenario_name=scenario_name)
-    runs = instance.get_runs()
+        instance.wipe()
+        set_auto_materialize_paused(instance, False)
+        scenario.do_daemon_scenario(instance, scenario_name=scenario_name)
+        runs = instance.get_runs()
 
-    assert len(runs) == len(
-        scenario.expected_run_requests
-        + scenario.unevaluated_runs
-        + (scenario.cursor_from.unevaluated_runs if scenario.cursor_from else [])
-    )
+        assert len(runs) == len(
+            scenario.expected_run_requests
+            + scenario.unevaluated_runs
+            + (scenario.cursor_from.unevaluated_runs if scenario.cursor_from else [])
+        )

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_daemon_cursor.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_daemon_cursor.py
@@ -1,0 +1,36 @@
+from dagster import AssetKey, StaticPartitionsDefinition, asset
+from dagster._core.definitions.asset_graph import AssetGraph
+from dagster._core.definitions.asset_reconciliation_sensor import (
+    AssetReconciliationCursor,
+)
+
+partitions = StaticPartitionsDefinition(partition_keys=["a", "b", "c"])
+
+
+@asset(partitions_def=partitions)
+def my_asset(_):
+    pass
+
+
+def test_asset_reconciliation_cursor_evaluation_id():
+    backcompat_serialized = (
+        """[20, ["a"], {"my_asset": "{\\"version\\": 1, \\"subset\\": [\\"a\\"]}"}]"""
+    )
+
+    asset_graph = AssetGraph.from_assets([my_asset])
+    c = AssetReconciliationCursor.from_serialized(backcompat_serialized, asset_graph)
+
+    assert c == AssetReconciliationCursor(
+        20,
+        {AssetKey("a")},
+        {AssetKey("my_asset"): partitions.empty_subset().with_partition_keys(["a"])},
+        None,
+    )
+
+    c2 = c.with_updates(
+        21, [], {AssetKey("my_asset")}, {AssetKey("my_asset"): {"a"}}, 1, asset_graph
+    )
+
+    serdes_c2 = AssetReconciliationCursor.from_serialized(c2.serialize(), asset_graph)
+    assert serdes_c2 == c2
+    assert serdes_c2.evaluation_id == 1


### PR DESCRIPTION
Keep an evaluation id in the cursor, and write asset evaluations on each iteration

Added a backcompat test for cursors without an evaluation id

Added a check that the new table exists so that people can upgrade and the daemon won't crash