### PR TITLE
Make default max_resume_run_attempts value 0, not 3

### DIFF
--- a/helm/dagster/schema/schema_tests/test_dagster_daemon.py
+++ b/helm/dagster/schema/schema_tests/test_dagster_daemon.py
@@ -247,6 +247,23 @@ def test_run_monitoring_disabled(
     assert "run_monitoring" not in instance
 
 
+def test_run_monitoring_enabled_default(
+    instance_template: HelmTemplate,
+):
+    helm_values = DagsterHelmValues.construct(
+        dagsterDaemon=Daemon.construct(runMonitoring={"enabled": True})
+    )
+
+    configmaps = instance_template.render(helm_values)
+
+    assert len(configmaps) == 1
+
+    instance = yaml.full_load(configmaps[0].data["dagster.yaml"])
+
+    assert "run_monitoring" in instance
+    assert instance["run_monitoring"]["max_resume_run_attempts"] == 0
+
+
 def test_run_monitoring_no_max_resume_run_attempts(
     instance_template: HelmTemplate,
 ):

--- a/integration_tests/test_suites/daemon-test-suite/monitoring_daemon_tests/test_monitoring.py
+++ b/integration_tests/test_suites/daemon-test-suite/monitoring_daemon_tests/test_monitoring.py
@@ -57,7 +57,11 @@ def test_monitoring():
     # with setup_instance() as instance:
     with instance_for_test(
         {
-            "run_monitoring": {"enabled": True, "poll_interval_seconds": 5},
+            "run_monitoring": {
+                "enabled": True,
+                "poll_interval_seconds": 5,
+                "max_resume_run_attempts": 3,
+            },
             "run_launcher": {
                 "class": "DockerRunLauncher",
                 "module": "dagster_docker",
@@ -104,7 +108,7 @@ def test_docker_monitoring():
 
     with docker_postgres_instance(
         {
-            "run_monitoring": {"enabled": True},
+            "run_monitoring": {"enabled": True, "max_resume_run_attempts": 3},
             "run_launcher": {
                 "class": "DockerRunLauncher",
                 "module": "dagster_docker",

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -813,10 +813,7 @@ class DagsterInstance(DynamicPartitionsStore):
 
     @property
     def run_monitoring_max_resume_run_attempts(self) -> int:
-        default_max_resume_run_attempts = 3 if self.run_launcher.supports_resume_run else 0
-        return self.run_monitoring_settings.get(
-            "max_resume_run_attempts", default_max_resume_run_attempts
-        )
+        return self.run_monitoring_settings.get("max_resume_run_attempts", 0)
 
     @property
     def run_monitoring_poll_interval_seconds(self) -> int:

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
@@ -463,7 +463,7 @@ def test_run_monitoring(capsys):
     ) as instance:
         assert instance.run_monitoring_enabled
         assert instance.run_monitoring_settings == settings
-        assert instance.run_monitoring_max_resume_run_attempts == 3
+        assert instance.run_monitoring_max_resume_run_attempts == 0
 
     settings = {"enabled": True, "max_resume_run_attempts": 5}
     with instance_for_test(

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_monitoring_daemon.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_monitoring_daemon.py
@@ -97,7 +97,7 @@ def instance():
                 "module": "dagster_tests.daemon_tests.test_monitoring_daemon",
                 "class": "TestRunLauncher",
             },
-            "run_monitoring": {"enabled": True},
+            "run_monitoring": {"enabled": True, "max_resume_run_attempts": 3},
         },
     ) as instance:
         yield instance

--- a/python_modules/dagster/dagster_tests/execution_tests/test_api_iterators.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_api_iterators.py
@@ -121,7 +121,7 @@ def test_execute_run_iterator():
                     "module": "dagster_tests.daemon_tests.test_monitoring_daemon",
                     "class": "TestRunLauncher",
                 },
-                "run_monitoring": {"enabled": True},
+                "run_monitoring": {"enabled": True, "max_resume_run_attempts": 3},
             }
         ) as run_monitoring_instance:
             dagster_run = instance.create_run_for_job(

--- a/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launcher_and_executor.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launcher_and_executor.py
@@ -218,7 +218,7 @@ def test_recovery(aws_env):
                 "module": "dagster_docker",
                 "config": launcher_config,
             },
-            "run_monitoring": {"enabled": True},
+            "run_monitoring": {"enabled": True, "max_resume_run_attempts": 3},
         }
     ) as instance:
         recon_job = get_test_project_recon_job("demo_slow_job_docker", docker_image)


### PR DESCRIPTION
Summary:
This should only come into play if the maxResumeRunAttempts value in the helm chart is explicitly set to None or nil somehow - but if it does, we should default to 0, not 3.

Test Plan: Bk

## Summary & Motivation

## How I Tested These Changes
