### PR TITLE
Do not initialize instance in cases where schedules and sensors have no resources defined

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
@@ -378,6 +378,7 @@ def build_schedule_context(
     scheduled_execution_time: Optional[datetime] = None,
     resources: Optional[Mapping[str, object]] = None,
     repository_def: Optional["RepositoryDefinition"] = None,
+    instance_ref: Optional["InstanceRef"] = None,
 ) -> ScheduleEvaluationContext:
     """Builds schedule execution context using the provided parameters.
 
@@ -401,7 +402,11 @@ def build_schedule_context(
     check.opt_inst_param(instance, "instance", DagsterInstance)
 
     return ScheduleEvaluationContext(
-        instance_ref=instance.get_ref() if instance and instance.is_persistent else None,
+        instance_ref=instance_ref
+        if instance_ref
+        else instance.get_ref()
+        if instance and instance.is_persistent
+        else None,
         scheduled_execution_time=check.opt_inst_param(
             scheduled_execution_time, "scheduled_execution_time", datetime
         ),

--- a/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
@@ -243,9 +243,11 @@ class ScheduleEvaluationContext:
 
         if not self._resources:
             # Early exit if no resources are defined. This skips unnecessary initialization
-            # entirely. This also fixes an issue where a user had a deployment that depended
-            # on not setting environment variables necessary to access the instance, and then
-            # an upgrade broke them.
+            # entirely. This allows users to run user code servers in cases where they
+            # do not have access to the instance if they use a subset of features do
+            # that do not require instance access. In this case, if they do not use
+            # resources on schedules they do not require the instance, so we do not
+            # instantiate it
             if not self._resource_defs:
                 self._resources = ScopedResourcesBuilder.build_empty()
                 return self._resources

--- a/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
@@ -248,6 +248,8 @@ class ScheduleEvaluationContext:
             # that do not require instance access. In this case, if they do not use
             # resources on schedules they do not require the instance, so we do not
             # instantiate it
+            #
+            # Tracking at https://github.com/dagster-io/dagster/issues/14345
             if not self._resource_defs:
                 self._resources = ScopedResourcesBuilder.build_empty()
                 return self._resources

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -250,6 +250,8 @@ class SensorEvaluationContext:
             # that do not require instance access. In this case, if they do not use
             # resources on sensors they do not require the instance, so we do not
             # instantiate it
+            #
+            # Tracking at https://github.com/dagster-io/dagster/issues/14345
             if not self._resource_defs:
                 self._resources = ScopedResourcesBuilder.build_empty()
                 return self._resources

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -1000,6 +1000,7 @@ def build_sensor_context(
     sensor_name: Optional[str] = None,
     resources: Optional[Mapping[str, object]] = None,
     definitions: Optional["Definitions"] = None,
+    instance_ref: Optional["InstanceRef"] = None,
 ) -> SensorEvaluationContext:
     """Builds sensor execution context using the provided parameters.
 
@@ -1042,7 +1043,7 @@ def build_sensor_context(
     )
 
     return SensorEvaluationContext(
-        instance_ref=None,
+        instance_ref=instance_ref,
         last_completion_time=None,
         last_run_key=None,
         cursor=cursor,

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -245,9 +245,11 @@ class SensorEvaluationContext:
             """
 
             # Early exit if no resources are defined. This skips unnecessary initialization
-            # entirely. This also fixes an issue where a user had a deployment that depended
-            # on not setting environment variables necessary to access the instance, and then
-            # an upgrade broke them.
+            # entirely. This allows users to run user code servers in cases where they
+            # do not have access to the instance if they use a subset of features do
+            # that do not require instance access. In this case, if they do not use
+            # resources on sensors they do not require the instance, so we do not
+            # instantiate it
             if not self._resource_defs:
                 self._resources = ScopedResourcesBuilder.build_empty()
                 return self._resources

--- a/python_modules/dagster/dagster/_core/test_utils.py
+++ b/python_modules/dagster/dagster/_core/test_utils.py
@@ -302,6 +302,20 @@ def today_at_midnight(timezone_name="UTC") -> "DateTime":
     return create_pendulum_time(now.year, now.month, now.day, tz=now.timezone.name)
 
 
+from dagster._core.storage.runs import SqliteRunStorage
+
+
+class ExplodeOnInitRunStorage(SqliteRunStorage):
+    def __init__(self, inst_data: Optional[ConfigurableClassData] = None):
+        raise NotImplementedError("Init was called")
+
+    @classmethod
+    def from_config_value(
+        cls, inst_data: Optional[ConfigurableClassData], config_value
+    ) -> "SqliteRunStorage":
+        raise NotImplementedError("from_config_value was called")
+
+
 class ExplodingRunLauncher(RunLauncher, ConfigurableClass):
     def __init__(self, inst_data: Optional[ConfigurableClassData] = None):
         self._inst_data = inst_data

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_no_instance_with_no_resources_on_sensor.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_no_instance_with_no_resources_on_sensor.py
@@ -1,0 +1,70 @@
+import tempfile
+
+import pytest
+from dagster import ConfigurableResource, build_sensor_context, sensor
+from dagster._core.instance.ref import InstanceRef
+
+
+# these tests confirm the existing behavior where user code servers
+# do not load the instance to run sensors that do not require resources
+def test_sensor_instance_does_init_with_resource() -> None:
+    class MyResource(ConfigurableResource):
+        foo: str
+
+    @sensor(job_name="some_job")
+    def a_sensor(context, my_resource: MyResource):
+        raise Exception("should not execute")
+
+    with tempfile.TemporaryDirectory() as tempdir:
+        unloadable_instance_ref = InstanceRef.from_dir(
+            tempdir,
+            overrides={
+                "run_storage": {
+                    "module": "dagster._core.test_utils",
+                    "class": "ExplodeOnInitRunStorage",
+                    "config": {"base_dir": "UNUSED"},
+                },
+            },
+        )
+        with pytest.raises(NotImplementedError, match="from_config_value was called"):
+            a_sensor(
+                build_sensor_context(
+                    instance_ref=unloadable_instance_ref,
+                    resources={"my_resource": MyResource(foo="bar")},
+                )
+            )
+
+
+def test_sensor_instance_does_no_init_with_no_resources() -> None:
+    executed = {}
+
+    @sensor(job_name="some_job")
+    def a_sensor(context):
+        executed["yes"] = True
+
+    with tempfile.TemporaryDirectory() as tempdir:
+        unloadable_instance_ref = InstanceRef.from_dir(
+            tempdir,
+            overrides={
+                "run_storage": {
+                    "module": "dagster._core.test_utils",
+                    "class": "ExplodeOnInitRunStorage",
+                    "config": {"base_dir": "UNUSED"},
+                },
+            },
+        )
+
+    with tempfile.TemporaryDirectory() as tempdir:
+        unloadable_instance_ref = InstanceRef.from_dir(
+            tempdir,
+            overrides={
+                "run_storage": {
+                    "module": "dagster._core.test_utils",
+                    "class": "ExplodeOnInitRunStorage",
+                    "config": {"base_dir": "UNUSED"},
+                },
+            },
+        )
+        a_sensor(build_sensor_context(instance_ref=unloadable_instance_ref))
+
+    assert executed["yes"]

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_no_instance_with_no_resources_on_sensor.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_no_instance_with_no_resources_on_sensor.py
@@ -7,6 +7,7 @@ from dagster._core.instance.ref import InstanceRef
 
 # these tests confirm the existing behavior where user code servers
 # do not load the instance to run sensors that do not require resources
+# Tracking at https://github.com/dagster-io/dagster/issues/14345
 def test_sensor_instance_does_init_with_resource() -> None:
     class MyResource(ConfigurableResource):
         foo: str

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_no_instance_with_no_resources_on_schedule.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_no_instance_with_no_resources_on_schedule.py
@@ -7,6 +7,7 @@ from dagster._core.instance.ref import InstanceRef
 
 # these tests confirm the existing behavior where user code servers
 # do not load the instance to run sensors that do not require resources
+# Tracking at https://github.com/dagster-io/dagster/issues/14345
 def test_schedule_instance_does_init_with_resource() -> None:
     class MyResource(ConfigurableResource):
         foo: str

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_no_instance_with_no_resources_on_schedule.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_no_instance_with_no_resources_on_schedule.py
@@ -1,0 +1,62 @@
+import tempfile
+
+import pytest
+from dagster import ConfigurableResource, build_schedule_context, schedule
+from dagster._core.instance.ref import InstanceRef
+
+
+# these tests confirm the existing behavior where user code servers
+# do not load the instance to run sensors that do not require resources
+def test_schedule_instance_does_init_with_resource() -> None:
+    class MyResource(ConfigurableResource):
+        foo: str
+
+    @schedule(cron_schedule="@daily", job_name="some_job")
+    def a_schedule(context, my_resource: MyResource):
+        raise Exception("should not execute")
+
+    with tempfile.TemporaryDirectory() as tempdir:
+        unloadable_instance_ref = InstanceRef.from_dir(
+            tempdir,
+            overrides={
+                "run_storage": {
+                    "module": "dagster._core.test_utils",
+                    "class": "ExplodeOnInitRunStorage",
+                    "config": {"base_dir": "UNUSED"},
+                },
+            },
+        )
+        with pytest.raises(NotImplementedError, match="from_config_value was called"):
+            a_schedule(
+                build_schedule_context(
+                    instance_ref=unloadable_instance_ref,
+                    resources={"my_resource": MyResource(foo="bar")},
+                )
+            )
+
+
+def test_schedule_instance_does_no_init_with_no_resources() -> None:
+    executed = {}
+
+    @schedule(cron_schedule="@daily", job_name="some_job")
+    def a_schedule(context):
+        executed["yes"] = True
+
+    with tempfile.TemporaryDirectory() as tempdir:
+        unloadable_instance_ref = InstanceRef.from_dir(
+            tempdir,
+            overrides={
+                "run_storage": {
+                    "module": "dagster._core.test_utils",
+                    "class": "ExplodeOnInitRunStorage",
+                    "config": {"base_dir": "UNUSED"},
+                },
+            },
+        )
+        a_schedule(
+            build_schedule_context(
+                instance_ref=unloadable_instance_ref,
+            )
+        )
+
+    assert executed["yes"]


### PR DESCRIPTION
## Summary & Motivation

A user reported that during an upgrade from 1.1.9 to 1.3.4 they were required to access an environment variable they had not been required to access before. The issue is the change to support resources in schedules and sensors added a code path that unconditionally constructed the instance where it did not before. This PR reverts to the old behavior.

However I do not think this is the right fix. Allowing users to deploy code locations that do not have access to the instance is extremely fragile. Any access to `context.instance` can trigger a fatal, and if we add any feature at any time.

The core problem here is the wildly complicated state of all our initialization pathways, where everything is "Optional" when in fact they are not. It seems that these evolved this way to enable convenient test pathways, or just out of sheer laziness, but we are now left in a state where there is a combinatorial explosion of possible states in all of our context objects, and further more on top of that a combinatorial explosion of initialization codepaths, as we seem to lazily create things whenever it pleases us. This will result in a continual stream of difficult-to-predict bugs as it is super fragile, as this bug demonstrates.

## How I Tested These Changes

Included unit tests
