### PR TITLE
[ui] Only implement our own shift scroll when OS does not natively implement it

### DIFF
--- a/js_modules/dagit/packages/core/src/graph/SVGViewport.tsx
+++ b/js_modules/dagit/packages/core/src/graph/SVGViewport.tsx
@@ -152,8 +152,8 @@ const PanAndZoomInteractor: SVGViewportInteractor = {
       const scale = Math.max(viewport.getMinZoom(), Math.min(viewport.getMaxZoom(), targetScale));
 
       viewport.adjustZoomRelativeToScreenPoint(scale, cursorPosition);
-    } else if (event.shiftKey) {
-      viewport.shiftXY(event.deltaX * panSpeed, event.deltaY * panSpeed);
+    } else if (event.shiftKey && !event.deltaX) {
+      viewport.shiftXY(event.deltaY * panSpeed, 0);
     } else {
       viewport.shiftXY(-event.deltaX * panSpeed, -event.deltaY * panSpeed);
     }


### PR DESCRIPTION
## Summary & Motivation

I am testing our new graph interactions on Linux. It turns out that our "shift scroll" case really wasn't doing anything -- it was still mapping x to x and y to y. It actually worked as-is because the operating system on mac + windows natively implement shift-scrolling and convert the Wheel events for us.

However linux does not do this -- to get shift-scrolling, we actually have to take the passed Y value and use it as an X offset.

## How I Tested These Changes

I have Ubuntu 22 and Firefox 113 running in a VM. I also tested these changes on Mac Chrome, Firefox, and Safari.