### PR TITLE
Fix multi asset sensor unconsumed events caching

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
@@ -291,19 +291,19 @@ class MultiAssetSensorEvaluationContext(SensorEvaluationContext):
             return
 
         for asset_key in self._monitored_asset_keys:
-            event_records = self.instance.get_event_records(
-                EventRecordsFilter(
-                    event_type=DagsterEventType.ASSET_MATERIALIZATION,
-                    storage_ids=list(
-                        self._get_cursor(
-                            asset_key
-                        ).trailing_unconsumed_partitioned_event_ids.values()
-                    ),
+            unconsumed_event_ids = list(
+                self._get_cursor(asset_key).trailing_unconsumed_partitioned_event_ids.values()
+            )
+            if unconsumed_event_ids:
+                event_records = self.instance.get_event_records(
+                    EventRecordsFilter(
+                        event_type=DagsterEventType.ASSET_MATERIALIZATION,
+                        storage_ids=unconsumed_event_ids,
+                    )
                 )
-            )
-            self._initial_unconsumed_events_by_id.update(
-                {event_record.storage_id: event_record for event_record in event_records}
-            )
+                self._initial_unconsumed_events_by_id.update(
+                    {event_record.storage_id: event_record for event_record in event_records}
+                )
 
         self._fetched_initial_unconsumed_events = True
 

--- a/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
@@ -369,6 +369,7 @@ class MultiAssetSensorEvaluationContext(SensorEvaluationContext):
             self._cursor = new_cursor
             self._unpacked_cursor = MultiAssetSensorContextCursor(new_cursor, self)
             self._cursor_advance_state_mutation = MultiAssetSensorCursorAdvances()
+            self._fetched_initial_unconsumed_events = False
 
     @public
     def latest_materialization_records_by_key(

--- a/python_modules/dagster/dagster/_core/event_api.py
+++ b/python_modules/dagster/dagster/_core/event_api.py
@@ -125,6 +125,8 @@ class EventRecordsFilter(
                 "Can only filter by tags for asset materialization events"
             )
 
+        check.opt_sequence_param(storage_ids, "storage_ids", of_type=int)
+
         # type-ignores work around mypy type inference bug
         return super(EventRecordsFilter, cls).__new__(
             cls,
@@ -139,6 +141,6 @@ class EventRecordsFilter(
             ),
             after_timestamp=check.opt_float_param(after_timestamp, "after_timestamp"),
             before_timestamp=check.opt_float_param(before_timestamp, "before_timestamp"),
-            storage_ids=check.opt_sequence_param(storage_ids, "storage_ids", of_type=int),
+            storage_ids=storage_ids,
             tags=check.opt_mapping_param(tags, "tags", key_type=str),
         )

--- a/python_modules/dagster/dagster/_core/event_api.py
+++ b/python_modules/dagster/dagster/_core/event_api.py
@@ -125,8 +125,6 @@ class EventRecordsFilter(
                 "Can only filter by tags for asset materialization events"
             )
 
-        check.opt_sequence_param(storage_ids, "storage_ids", of_type=int)
-
         # type-ignores work around mypy type inference bug
         return super(EventRecordsFilter, cls).__new__(
             cls,
@@ -141,6 +139,6 @@ class EventRecordsFilter(
             ),
             after_timestamp=check.opt_float_param(after_timestamp, "after_timestamp"),
             before_timestamp=check.opt_float_param(before_timestamp, "before_timestamp"),
-            storage_ids=storage_ids,
+            storage_ids=check.opt_nullable_sequence_param(storage_ids, "storage_ids", of_type=int),
             tags=check.opt_mapping_param(tags, "tags", key_type=str),
         )

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -820,7 +820,7 @@ class SqlEventLogStorage(EventLogStorage):
                 > datetime.utcfromtimestamp(event_records_filter.after_timestamp)
             )
 
-        if event_records_filter.storage_ids:
+        if event_records_filter.storage_ids is not None:
             query = query.where(SqlEventLogStorageTable.c.id.in_(event_records_filter.storage_ids))
 
         if event_records_filter.tags and self.has_table(AssetEventTagsTable.name):

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -820,7 +820,7 @@ class SqlEventLogStorage(EventLogStorage):
                 > datetime.utcfromtimestamp(event_records_filter.after_timestamp)
             )
 
-        if event_records_filter.storage_ids is not None:
+        if event_records_filter.storage_ids:
             query = query.where(SqlEventLogStorageTable.c.id.in_(event_records_filter.storage_ids))
 
         if event_records_filter.tags and self.has_table(AssetEventTagsTable.name):

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
@@ -1165,6 +1165,22 @@ def test_multi_asset_sensor_update_cursor_no_overwrite():
         after_cursor_partitions_asset_sensor(ctx)
 
 
+def test_multi_asset_sensor_no_unconsumed_events():
+    @multi_asset_sensor(monitored_assets=[july_asset.key, july_asset_2.key])
+    def my_sensor(context):
+        context.latest_materialization_records_by_partition_and_asset()
+        assert context._initial_unconsumed_events_by_id == {}  # noqa: SLF001
+
+    with instance_for_test() as instance:
+        materialize([july_asset], partition_key="2022-08-04", instance=instance)
+        ctx = build_multi_asset_sensor_context(
+            monitored_assets=[july_asset.key, july_asset_2.key],
+            instance=instance,
+            repository_def=my_repo,
+        )
+        my_sensor(ctx)
+
+
 def test_multi_asset_sensor_latest_materialization_records_by_partition_and_asset():
     @multi_asset_sensor(monitored_assets=[july_asset.key, july_asset_2.key])
     def my_sensor(context):

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
@@ -1168,7 +1168,10 @@ def test_multi_asset_sensor_update_cursor_no_overwrite():
 def test_multi_asset_sensor_no_unconsumed_events():
     @multi_asset_sensor(monitored_assets=[july_asset.key, july_asset_2.key])
     def my_sensor(context):
+        # This call reads unconsumed event IDs from the cursor, fetches them via get_event_records,
+        # and caches them in memory
         context.latest_materialization_records_by_partition_and_asset()
+        # Assert that when no unconsumed events exist in the cursor, no events are cached
         assert context._initial_unconsumed_events_by_id == {}  # noqa: SLF001
 
     with instance_for_test() as instance:

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -2407,6 +2407,7 @@ class TestEventLogStorage:
             assert len(records) == 1
             assert records[0].storage_id == storage_id
 
+            # Assert that not providing storage IDs to filter on will still fetch events
             assert (
                 len(
                     storage.get_event_records(
@@ -2415,7 +2416,7 @@ class TestEventLogStorage:
                         )
                     )
                 )
-                > 0
+                == 1
             )
 
     def test_get_asset_records(self, storage, instance):

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -2407,13 +2407,6 @@ class TestEventLogStorage:
             assert len(records) == 1
             assert records[0].storage_id == storage_id
 
-            records = storage.get_event_records(
-                EventRecordsFilter(
-                    event_type=DagsterEventType.ASSET_MATERIALIZATION, storage_ids=[]
-                )
-            )
-            assert len(records) == 0
-
             assert (
                 len(
                     storage.get_event_records(

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -2372,6 +2372,59 @@ class TestEventLogStorage:
 
                     assert [key] == storage.all_asset_keys()
 
+    def test_filter_on_storage_ids(self, storage, instance, test_run_id):
+        a = AssetKey(["key_a"])
+
+        @op
+        def gen_op():
+            yield AssetMaterialization(asset_key=a, metadata={"foo": "bar"})
+            yield Output(1)
+
+        with instance_for_test() as instance:
+            if not storage.has_instance:
+                storage.register_instance(instance)
+
+            events_one, _ = _synthesize_events(
+                lambda: gen_op(), instance=instance, run_id=test_run_id
+            )
+            for event in events_one:
+                storage.store_event(event)
+
+            records = storage.get_event_records(
+                EventRecordsFilter(
+                    event_type=DagsterEventType.ASSET_MATERIALIZATION,
+                    asset_key=a,
+                )
+            )
+            assert len(records) == 1
+            storage_id = records[0].storage_id
+
+            records = storage.get_event_records(
+                EventRecordsFilter(
+                    event_type=DagsterEventType.ASSET_MATERIALIZATION, storage_ids=[storage_id]
+                )
+            )
+            assert len(records) == 1
+            assert records[0].storage_id == storage_id
+
+            records = storage.get_event_records(
+                EventRecordsFilter(
+                    event_type=DagsterEventType.ASSET_MATERIALIZATION, storage_ids=[]
+                )
+            )
+            assert len(records) == 0
+
+            assert (
+                len(
+                    storage.get_event_records(
+                        EventRecordsFilter(
+                            event_type=DagsterEventType.ASSET_MATERIALIZATION,
+                        )
+                    )
+                )
+                > 0
+            )
+
     def test_get_asset_records(self, storage, instance):
         @asset
         def my_asset():


### PR DESCRIPTION
Cloud user reported that a multi asset sensor that used `context.latest_materialization_records_by_partition_and_asset` was timing out.

The reason that this occurred was because we implemented filtering event log records by storage IDs in OSS in order to cache unconsumed events: https://github.com/dagster-io/dagster/blob/dbad48a80318130305cc0d197c3ef38251b639f5/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py#L294-L303
But this functionality was not mirrored in cloud, so in cloud we just did not do any filtering which cause the `get_event_records` method to fetch an unbounded number of records.

This PR accompanies the cloud fix https://github.com/dagster-io/internal/pull/5707 and adds tests for this functionality.

**Test Plan**
- Adds tests to the multi asset sensor context to assert that only unconsumed events are cached
- Adds tests to event log storage to assert that filtering by storage ID will occur if a non-empty list of storage IDs is provided