### PR TITLE
AssetSelection.source_assets + key_prefixes bugfix

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py
@@ -124,7 +124,7 @@ def get_repo_with_root_assets_different_partitions() -> RepositoryDefinition:
 
 def test_launch_asset_backfill_read_only_context():
     repo = get_repo()
-    all_asset_keys = repo.asset_graph.all_asset_keys
+    all_asset_keys = repo.asset_graph.materializable_asset_keys
 
     with instance_for_test() as instance:
         # read-only context fails
@@ -184,7 +184,7 @@ def test_launch_asset_backfill_read_only_context():
 
 def test_launch_asset_backfill_all_partitions():
     repo = get_repo()
-    all_asset_keys = repo.asset_graph.all_asset_keys
+    all_asset_keys = repo.asset_graph.materializable_asset_keys
 
     with instance_for_test() as instance:
         with define_out_of_process_context(__file__, "get_repo", instance) as context:
@@ -246,7 +246,7 @@ def test_launch_asset_backfill_all_partitions_asset_selection():
 
 def test_launch_asset_backfill_all_partitions_root_assets_different_partitions():
     repo = get_repo_with_root_assets_different_partitions()
-    all_asset_keys = repo.asset_graph.all_asset_keys
+    all_asset_keys = repo.asset_graph.materializable_asset_keys
 
     with instance_for_test() as instance:
         with define_out_of_process_context(
@@ -282,7 +282,7 @@ def test_launch_asset_backfill_all_partitions_root_assets_different_partitions()
 
 def test_launch_asset_backfill():
     repo = get_repo()
-    all_asset_keys = repo.asset_graph.all_asset_keys
+    all_asset_keys = repo.asset_graph.materializable_asset_keys
 
     with instance_for_test() as instance:
         with define_out_of_process_context(__file__, "get_repo", instance) as context:
@@ -329,7 +329,7 @@ def test_launch_asset_backfill():
 
 def test_remove_partitions_defs_after_backfill():
     repo = get_repo()
-    all_asset_keys = repo.asset_graph.all_asset_keys
+    all_asset_keys = repo.asset_graph.materializable_asset_keys
 
     with instance_for_test() as instance:
         with define_out_of_process_context(__file__, "get_repo", instance) as context:
@@ -379,7 +379,7 @@ def test_remove_partitions_defs_after_backfill():
 
 def test_launch_asset_backfill_with_non_partitioned_asset():
     repo = get_repo_with_non_partitioned_asset()
-    all_asset_keys = repo.asset_graph.all_asset_keys
+    all_asset_keys = repo.asset_graph.materializable_asset_keys
 
     with instance_for_test() as instance:
         with define_out_of_process_context(
@@ -423,7 +423,7 @@ def get_daily_hourly_repo() -> RepositoryDefinition:
 
 def test_launch_asset_backfill_with_upstream_anchor_asset():
     repo = get_daily_hourly_repo()
-    all_asset_keys = repo.asset_graph.all_asset_keys
+    all_asset_keys = repo.asset_graph.materializable_asset_keys
 
     hourly_partitions = ["2020-01-02-23:00", "2020-01-02-22:00", "2020-01-03-00:00"]
 
@@ -490,7 +490,7 @@ def get_daily_two_hourly_repo() -> RepositoryDefinition:
 
 def test_launch_asset_backfill_with_two_anchor_assets():
     repo = get_daily_two_hourly_repo()
-    all_asset_keys = repo.asset_graph.all_asset_keys
+    all_asset_keys = repo.asset_graph.materializable_asset_keys
 
     hourly_partitions = ["2020-01-02-23:00", "2020-01-02-22:00", "2020-01-03-00:00"]
 
@@ -548,7 +548,7 @@ def get_daily_hourly_non_partitioned_repo() -> RepositoryDefinition:
 
 def test_launch_asset_backfill_with_upstream_anchor_asset_and_non_partitioned_asset():
     repo = get_daily_hourly_non_partitioned_repo()
-    all_asset_keys = repo.asset_graph.all_asset_keys
+    all_asset_keys = repo.asset_graph.materializable_asset_keys
 
     hourly_partitions = ["2020-01-02-23:00", "2020-01-02-22:00", "2020-01-03-00:00"]
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -102,7 +102,7 @@ class AssetGraph:
         """Non-source asset keys that have no non-source parents."""
         from .asset_selection import AssetSelection
 
-        return AssetSelection.keys(*self.non_source_asset_keys).roots().resolve(self)
+        return AssetSelection.keys(*self.materializable_asset_keys).roots().resolve(self)
 
     @property
     def freshness_policies_by_key(self) -> Mapping[AssetKey, Optional[FreshnessPolicy]]:
@@ -176,11 +176,12 @@ class AssetGraph:
 
     @property
     def all_asset_keys(self) -> AbstractSet[AssetKey]:
-        return self._asset_dep_graph["upstream"].keys()
+        return self.materializable_asset_keys | self.source_asset_keys
 
     @property
-    def non_source_asset_keys(self) -> AbstractSet[AssetKey]:
-        return self._asset_dep_graph["upstream"].keys() - self._source_asset_keys
+    def materializable_asset_keys(self) -> AbstractSet[AssetKey]:
+        # Source assets keys can sometimes appear in the upstream dict
+        return self._asset_dep_graph["upstream"].keys() - self.source_asset_keys
 
     def get_partitions_def(self, asset_key: AssetKey) -> Optional[PartitionsDefinition]:
         return self._partitions_defs_by_key.get(asset_key)
@@ -397,7 +398,9 @@ class AssetGraph:
         )
 
     def is_source(self, asset_key: AssetKey) -> bool:
-        return asset_key in self.source_asset_keys or asset_key not in self.all_asset_keys
+        return (
+            asset_key in self.source_asset_keys or asset_key not in self.materializable_asset_keys
+        )
 
     def has_non_source_parents(self, asset_key: AssetKey) -> bool:
         """Determines if an asset has any parents which are not source assets."""

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
@@ -235,7 +235,7 @@ class AssetGraphSubset:
         cls, asset_graph: AssetGraph, dynamic_partitions_store: DynamicPartitionsStore
     ) -> "AssetGraphSubset":
         return cls.from_asset_keys(
-            asset_graph.non_source_asset_keys, asset_graph, dynamic_partitions_store
+            asset_graph.materializable_asset_keys, asset_graph, dynamic_partitions_store
         )
 
     @classmethod

--- a/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
@@ -341,7 +341,7 @@ class AssetReconciliationCursor(NamedTuple):
             serialized_subset,
         ) in serialized_materialized_or_requested_root_partitions_by_asset_key.items():
             key = AssetKey.from_user_string(key_str)
-            if key not in asset_graph.non_source_asset_keys:
+            if key not in asset_graph.materializable_asset_keys:
                 continue
 
             partitions_def = asset_graph.get_partitions_def(key)

--- a/python_modules/dagster/dagster/_core/definitions/external_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/external_asset_graph.py
@@ -215,7 +215,7 @@ class ExternalAssetGraph(AssetGraph):
         """Returns asset keys that are targeted for materialization in the given job."""
         return [
             k
-            for k in self.non_source_asset_keys
+            for k in self.materializable_asset_keys
             if job_name in self.get_materialization_job_names(k)
         ]
 

--- a/python_modules/dagster/dagster/_core/definitions/freshness_based_auto_materialize.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_based_auto_materialize.py
@@ -121,7 +121,7 @@ def determine_asset_partitions_to_auto_materialize_for_freshness(
         for key in level:
             if (
                 key not in target_asset_keys_and_parents
-                or key not in asset_graph.non_source_asset_keys
+                or key not in asset_graph.materializable_asset_keys
                 or not asset_graph.get_downstream_freshness_policies(asset_key=key)
             ):
                 continue

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -84,7 +84,7 @@ class AssetDaemon(IntervalDaemon):
         asset_graph = ExternalAssetGraph.from_workspace(workspace)
         target_asset_keys = {
             target_key
-            for target_key in asset_graph.non_source_asset_keys
+            for target_key in asset_graph.materializable_asset_keys
             if asset_graph.get_auto_materialize_policy(target_key) is not None
         }
 

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
@@ -165,7 +165,7 @@ def test_from_asset_partitions_target_subset(
     backfill_data = AssetBackfillData.from_asset_partitions(
         partition_names=partition_keys,
         asset_graph=asset_graph,
-        asset_selection=list(asset_graph.all_asset_keys),
+        asset_selection=list(asset_graph.materializable_asset_keys),
         dynamic_partitions_store=MagicMock(),
         all_partitions=False,
         backfill_start_time=scenarios[scenario_name].evaluation_time,

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/asset_reconciliation_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/asset_reconciliation_scenario.py
@@ -243,7 +243,7 @@ class AssetReconciliationScenario(NamedTuple):
             target_asset_keys = (
                 self.asset_selection.resolve(asset_graph)
                 if self.asset_selection
-                else asset_graph.non_source_asset_keys
+                else asset_graph.materializable_asset_keys
             )
 
             run_requests, cursor, evaluations = reconcile(


### PR DESCRIPTION
## Summary & Motivation

Internal companion PR: https://github.com/dagster-io/internal/pull/5722

- Add `AssetSelection.upstream_source_assets` method to allow selecting source assets upstream of the current selection. There is no current way to do this. See: https://elementl-workspace.slack.com/archives/C03C3E81TNE/p1683647912931259
- Add optional `include_sources` flag to `AssetSelection.key_prefixes` and `.groups` that toggles inclusion of source assets.
- Update docstrings of several `AssetSelection` methods to clarify that they _do not_ select source assets.
- Rename `AssetSelection.non_source_assets` to `materializable_assets`.
- Fix `AssetGraph.all_assets` (used in selection resolution) so that it returns _all assets_, including source assets. It was not intended that it did not, since there was also `_non_source_assets`, which returned the same thing with a different implementation. Update existing use of `all_asset_keys` that depend on _not_ selecting source assets to instead call `materializable_assets` (new name for `non_source_assets`)

## How I Tested These Changes

- New unit test for `AssetSelection.source_assets`
- Add to unit test for `AssetSelection.key_prefixes`
- Add to unit test for `AssetSelection.groups`