### PR TITLE
Don't prompt to use '-h' for 'dagster dev' help since its already in use

### DIFF
--- a/python_modules/dagster/dagster/_cli/dev.py
+++ b/python_modules/dagster/dagster/_cli/dev.py
@@ -44,6 +44,10 @@ def dev_command_options(f):
         "Start a local deployment of Dagster, including dagit running on localhost and the"
         " dagster-daemon running in the background"
     ),
+    context_settings=dict(
+        max_content_width=120,
+        help_option_names=["--help"],  # Don't show '-h' since that's the dagit host
+    ),
 )
 @dev_command_options
 @click.option(


### PR DESCRIPTION
Summary:
Override the default help names for this command specifically since -h means something else for `dagster dev`.

Test Plan
Run `dagster dev` locally, help message changed

## Summary & Motivation

## How I Tested These Changes
