### PR TITLE
Add optional threadpool for enqueueing/launching sensor ticks in parallel

### DIFF
--- a/docs/content/deployment/dagster-instance.mdx
+++ b/docs/content/deployment/dagster-instance.mdx
@@ -765,7 +765,7 @@ The `purge_after_days` key accepts either:
 
 ### Sensor evaluation
 
-The `sensors` key allows you to configure how sensors are evaluated. To asynchronously evaluate sensors, set the `use_threads` and `num_workers` keys:
+The `sensors` key allows you to configure how sensors are evaluated. To evaluate multiple sensors in parallel simultaneously, set the `use_threads` and `num_workers` keys:
 
 ```yaml file=/deploying/dagster_instance/dagster.yaml startafter=start_marker_sensors endbefore=end_marker_sensors
 sensors:
@@ -773,17 +773,21 @@ sensors:
   num_workers: 8
 ```
 
+You can also set the optional `num_submit_workers` key to evaluate multiple run requests from the same sensor tick in parallel, which can help decrease latency when a single sensor tick returns many run requests.
+
 ### Schedule evaluation
 
-The `schedules` key allows you to configure how schedules are evaluated. By default, Dagster evaluates schedules synchronously.
+The `schedules` key allows you to configure how schedules are evaluated. By default, Dagster evaluates schedules one at a time.
 
-To asynchronously evaluate schedules, set the `use_threads` and `num_workers` keys:
+To evaluate multiple schedules in parallel simultaneously, set the `use_threads` and `num_workers` keys:
 
 ```yaml file=/deploying/dagster_instance/dagster.yaml startafter=start_marker_schedules endbefore=end_marker_schedules
 schedules:
   use_threads: true
   num_workers: 8
 ```
+
+You can also set the optional `num_submit_workers` key to evaluate multiple run requests from the same schedule tick in parallel, which can help decrease latency when a single schedule tick returns many run requests.
 
 ### Auto-materialize
 

--- a/helm/dagster/schema/schema/charts/dagster/subschema/daemon.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/daemon.py
@@ -65,11 +65,13 @@ class RunCoordinator(BaseModel):
 class Sensors(BaseModel):
     useThreads: bool
     numWorkers: Optional[int]
+    numSubmitWorkers: Optional[int]
 
 
 class Schedules(BaseModel):
     useThreads: bool
     numWorkers: Optional[int]
+    numSubmitWorkers: Optional[int]
 
 
 class Daemon(BaseModel):

--- a/helm/dagster/schema/schema_tests/test_dagster_daemon.py
+++ b/helm/dagster/schema/schema_tests/test_dagster_daemon.py
@@ -469,9 +469,28 @@ def test_sensor_threading(instance_template: HelmTemplate):
     assert len(configmaps) == 1
     instance = yaml.full_load(configmaps[0].data["dagster.yaml"])
     sensors_config = instance["sensors"]
+    assert instance["sensors"]["use_threads"] is True
+    assert instance["sensors"]["num_workers"] == 4
+    assert "num_submit_workers" not in instance["sensors"]
+
+    helm_values = DagsterHelmValues.construct(
+        dagsterDaemon=Daemon.construct(
+            sensors=Sensors.construct(
+                useThreads=True,
+                numWorkers=4,
+                numSubmitWorkers=8,
+            )
+        )
+    )
+
+    configmaps = instance_template.render(helm_values)
+    assert len(configmaps) == 1
+    instance = yaml.full_load(configmaps[0].data["dagster.yaml"])
+    sensors_config = instance["sensors"]
     assert sensors_config.keys() == sensors_daemon_config().config_type.fields.keys()
     assert instance["sensors"]["use_threads"] is True
     assert instance["sensors"]["num_workers"] == 4
+    assert instance["sensors"]["num_submit_workers"] == 8
 
 
 def test_scheduler_threading(instance_template: HelmTemplate):
@@ -488,9 +507,24 @@ def test_scheduler_threading(instance_template: HelmTemplate):
     assert len(configmaps) == 1
     instance = yaml.full_load(configmaps[0].data["dagster.yaml"])
     schedules_config = instance["schedules"]
+    assert instance["schedules"]["use_threads"] is True
+    assert instance["schedules"]["num_workers"] == 4
+    assert "num_submit_workers" not in instance["schedules"]
+
+    helm_values = DagsterHelmValues.construct(
+        dagsterDaemon=Daemon.construct(
+            schedules=Schedules.construct(useThreads=True, numWorkers=4, numSubmitWorkers=8)
+        )
+    )
+
+    configmaps = instance_template.render(helm_values)
+    assert len(configmaps) == 1
+    instance = yaml.full_load(configmaps[0].data["dagster.yaml"])
+    schedules_config = instance["schedules"]
     assert schedules_config.keys() == schedules_daemon_config().config_type.fields.keys()
     assert instance["schedules"]["use_threads"] is True
     assert instance["schedules"]["num_workers"] == 4
+    assert instance["schedules"]["num_submit_workers"] == 8
 
 
 def test_scheduler_name(template: HelmTemplate):

--- a/helm/dagster/templates/configmap-instance.yaml
+++ b/helm/dagster/templates/configmap-instance.yaml
@@ -115,6 +115,9 @@ data:
       {{- if $sensors.numWorkers }}
       num_workers: {{ $sensors.numWorkers }}
       {{- end }}
+      {{- if $sensors.numSubmitWorkers }}
+      num_submit_workers: {{ $sensors.numSubmitWorkers }}
+      {{- end }}
     {{- end }}
 
     {{- $schedules := .Values.dagsterDaemon.schedules }}
@@ -123,6 +126,9 @@ data:
       use_threads: {{ $schedules.useThreads }}
       {{- if $schedules.numWorkers }}
       num_workers: {{ $schedules.numWorkers }}
+      {{- end }}
+      {{- if $schedules.numSubmitWorkers }}
+      num_submit_workers: {{ $schedules.numSubmitWorkers }}
       {{- end }}
     {{- end }}
 

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -2608,6 +2608,17 @@
                             "type": "null"
                         }
                     ]
+                },
+                "numSubmitWorkers": {
+                    "title": "Numsubmitworkers",
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
                 }
             },
             "required": [
@@ -2624,6 +2635,17 @@
                 },
                 "numWorkers": {
                     "title": "Numworkers",
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "numSubmitWorkers": {
+                    "title": "Numsubmitworkers",
                     "anyOf": [
                         {
                             "type": "integer"

--- a/python_modules/dagster/dagster/_core/instance/config.py
+++ b/python_modules/dagster/dagster/_core/instance/config.py
@@ -251,6 +251,7 @@ def sensors_daemon_config() -> Field:
         {
             "use_threads": Field(Bool, is_required=False, default_value=False),
             "num_workers": Field(int, is_required=False),
+            "num_enqueue_workers": Field(int, is_required=False),
         },
         is_required=False,
     )

--- a/python_modules/dagster/dagster/_core/instance/config.py
+++ b/python_modules/dagster/dagster/_core/instance/config.py
@@ -250,8 +250,22 @@ def sensors_daemon_config() -> Field:
     return Field(
         {
             "use_threads": Field(Bool, is_required=False, default_value=False),
-            "num_workers": Field(int, is_required=False),
-            "num_enqueue_workers": Field(int, is_required=False),
+            "num_workers": Field(
+                int,
+                is_required=False,
+                description=(
+                    "How many threads to use to process ticks from multiple sensors in parallel"
+                ),
+            ),
+            "num_submit_workers": Field(
+                int,
+                is_required=False,
+                description=(
+                    "How many threads to use to submit runs from sensor ticks. Can be used to"
+                    " decrease latency when a sensor emits multiple run requests within a single"
+                    " tick."
+                ),
+            ),
         },
         is_required=False,
     )
@@ -261,7 +275,22 @@ def schedules_daemon_config() -> Field:
     return Field(
         {
             "use_threads": Field(Bool, is_required=False, default_value=False),
-            "num_workers": Field(int, is_required=False),
+            "num_workers": Field(
+                int,
+                is_required=False,
+                description=(
+                    "How many threads to use to process ticks from multiple schedules in parallel"
+                ),
+            ),
+            "num_submit_workers": Field(
+                int,
+                is_required=False,
+                description=(
+                    "How many threads to use to submit runs from schedule ticks. Can be used to"
+                    " decrease latency when a schedule emits multiple run requests within a single"
+                    " tick."
+                ),
+            ),
         },
         is_required=False,
     )

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -255,6 +255,8 @@ def execute_sensor_iteration_loop(
     """
     sensor_state_lock = threading.Lock()
     sensor_tick_futures: Dict[str, Future] = {}
+    enqueue_threadpool_executor = None
+    threadpool_executor = None
     with ExitStack() as stack:
         settings = workspace_process_context.instance.get_settings("sensors")
         if settings.get("use_threads"):
@@ -264,8 +266,14 @@ def execute_sensor_iteration_loop(
                     thread_name_prefix="sensor_daemon_worker",
                 )
             )
-        else:
-            threadpool_executor = None
+            num_enqueue_workers = settings.get("num_enqueue_workers")
+            if num_enqueue_workers:
+                enqueue_threadpool_executor = stack.enter_context(
+                    ThreadPoolExecutor(
+                        max_workers=settings.get("num_enqueue_workers"),
+                        thread_name_prefix="sensor_daemon_worker",
+                    )
+                )
 
         last_verbose_time = None
         while True:
@@ -282,6 +290,7 @@ def execute_sensor_iteration_loop(
                 workspace_process_context,
                 logger,
                 threadpool_executor=threadpool_executor,
+                enqueue_threadpool_executor=enqueue_threadpool_executor,
                 sensor_tick_futures=sensor_tick_futures,
                 sensor_state_lock=sensor_state_lock,
                 log_verbose_checks=verbose_logs_iteration,
@@ -306,6 +315,7 @@ def execute_sensor_iteration(
     workspace_process_context: IWorkspaceProcessContext,
     logger: logging.Logger,
     threadpool_executor: Optional[ThreadPoolExecutor] = None,
+    enqueue_threadpool_executor: Optional[ThreadPoolExecutor] = None,
     sensor_tick_futures: Optional[Dict[str, Future]] = None,
     sensor_state_lock: Optional[threading.Lock] = None,
     log_verbose_checks: bool = True,
@@ -430,6 +440,7 @@ def execute_sensor_iteration(
                 sensor_state_lock,
                 sensor_debug_crash_flags,
                 tick_retention_settings,
+                enqueue_threadpool_executor,
             )
             sensor_tick_futures[external_sensor.selector_id] = future
             yield
@@ -445,6 +456,7 @@ def execute_sensor_iteration(
                 sensor_state_lock,
                 sensor_debug_crash_flags,
                 tick_retention_settings,
+                enqueue_threadpool_executor=None,
             )
 
 
@@ -456,10 +468,11 @@ def _process_tick(
     sensor_state_lock: threading.Lock,
     sensor_debug_crash_flags: Optional[SingleInstigatorDebugCrashFlags],
     tick_retention_settings,
+    enqueue_threadpool_executor: Optional[ThreadPoolExecutor],
 ):
     # evaluate the tick immediately, but from within a thread.  The main thread should be able to
     # heartbeat to keep the daemon alive
-    list(
+    return list(
         _process_tick_generator(
             workspace_process_context,
             logger,
@@ -468,6 +481,7 @@ def _process_tick(
             sensor_state_lock,
             sensor_debug_crash_flags,
             tick_retention_settings,
+            enqueue_threadpool_executor,
         )
     )
 
@@ -480,6 +494,7 @@ def _process_tick_generator(
     sensor_state_lock: threading.Lock,
     sensor_debug_crash_flags: Optional[SingleInstigatorDebugCrashFlags],
     tick_retention_settings,
+    enqueue_threadpool_executor: Optional[ThreadPoolExecutor],
 ):
     instance = workspace_process_context.instance
     error_info = None
@@ -522,6 +537,7 @@ def _process_tick_generator(
                 tick_context,
                 external_sensor,
                 sensor_state,
+                enqueue_threadpool_executor,
                 sensor_debug_crash_flags,
             )
 
@@ -562,11 +578,77 @@ def _mark_sensor_state_for_tick(
     )
 
 
+class SubmitRunRequestResult(NamedTuple):
+    run_key: Optional[str]
+    error_info: Optional[SerializableErrorInfo]
+    run: Union[SkippedSensorRun, DagsterRun]
+
+
+def _submit_run_request(
+    run_request: RunRequest,
+    workspace_process_context: IWorkspaceProcessContext,
+    external_sensor: ExternalSensor,
+    code_location: CodeLocation,
+    existing_runs_by_key,
+    logger,
+    sensor_debug_crash_flags,
+) -> SubmitRunRequestResult:
+    instance = workspace_process_context.instance
+    sensor_origin = external_sensor.get_external_origin()
+
+    target_data: ExternalTargetData = check.not_none(
+        external_sensor.get_target_data(run_request.job_name)
+    )
+
+    job_subset_selector = JobSubsetSelector(
+        location_name=code_location.name,
+        repository_name=sensor_origin.external_repository_origin.repository_name,
+        job_name=target_data.job_name,
+        op_selection=target_data.op_selection,
+        asset_selection=run_request.asset_selection,
+    )
+    external_job = code_location.get_external_job(job_subset_selector)
+    run = _get_or_create_sensor_run(
+        logger,
+        instance,
+        code_location,
+        external_sensor,
+        external_job,
+        run_request,
+        target_data,
+        existing_runs_by_key,
+    )
+
+    if isinstance(run, SkippedSensorRun):
+        return SubmitRunRequestResult(run_key=run_request.run_key, error_info=None, run=run)
+
+    _check_for_debug_crash(sensor_debug_crash_flags, "RUN_CREATED")
+
+    error_info = None
+    try:
+        logger.info(f"Launching run for {external_sensor.name}")
+        instance.submit_run(run.run_id, workspace_process_context.create_request_context())
+        logger.info(
+            "Completed launch of run {run_id} for {sensor_name}".format(
+                run_id=run.run_id, sensor_name=external_sensor.name
+            )
+        )
+    except Exception:
+        error_info = serializable_error_info_from_exc_info(sys.exc_info())
+        logger.error(
+            f"Run {run.run_id} created successfully but failed to launch: {str(error_info)}"
+        )
+
+    _check_for_debug_crash(sensor_debug_crash_flags, "RUN_LAUNCHED")
+    return SubmitRunRequestResult(run_key=run_request.run_key, error_info=error_info, run=run)
+
+
 def _evaluate_sensor(
     workspace_process_context: IWorkspaceProcessContext,
     context: SensorLaunchContext,
     external_sensor: ExternalSensor,
     state: InstigatorState,
+    enqueue_threadpool_executor: Optional[ThreadPoolExecutor],
     sensor_debug_crash_flags: Optional[SingleInstigatorDebugCrashFlags] = None,
 ):
     instance = workspace_process_context.instance
@@ -723,6 +805,8 @@ def _evaluate_sensor(
         instance, external_sensor, sensor_runtime_data.run_requests
     )
 
+    run_requests = []
+
     for raw_run_request in sensor_runtime_data.run_requests:
         if raw_run_request.stale_assets_only:
             stale_assets = resolve_stale_or_missing_assets(workspace_process_context, raw_run_request, external_sensor)  # type: ignore
@@ -736,56 +820,33 @@ def _evaluate_sensor(
         else:
             run_request = raw_run_request
 
-        target_data: ExternalTargetData = check.not_none(
-            external_sensor.get_target_data(run_request.job_name)
-        )
+        run_requests.append(run_request)
 
-        job_subset_selector = JobSubsetSelector(
-            location_name=code_location.name,
-            repository_name=sensor_origin.external_repository_origin.repository_name,
-            job_name=target_data.job_name,
-            op_selection=target_data.op_selection,
-            asset_selection=run_request.asset_selection,
-        )
-        external_job = code_location.get_external_job(job_subset_selector)
-        run = _get_or_create_sensor_run(
-            context,
-            instance,
-            code_location,
-            external_sensor,
-            external_job,
-            run_request,
-            target_data,
-            existing_runs_by_key,
-        )
+    submit_run_request = lambda run_request: _submit_run_request(
+        run_request,
+        workspace_process_context,
+        external_sensor,
+        code_location,
+        existing_runs_by_key,
+        context.logger,
+        sensor_debug_crash_flags,
+    )
+
+    if enqueue_threadpool_executor:
+        gen_run_request_results = enqueue_threadpool_executor.map(submit_run_request, run_requests)
+    else:
+        gen_run_request_results = map(submit_run_request, run_requests)
+
+    for run_request_result in gen_run_request_results:
+        yield run_request_result.error_info
+
+        run = run_request_result.run
 
         if isinstance(run, SkippedSensorRun):
             skipped_runs.append(run)
-            context.add_run_info(run_id=None, run_key=run_request.run_key)
-            yield
-            continue
-
-        _check_for_debug_crash(sensor_debug_crash_flags, "RUN_CREATED")
-
-        error_info = None
-        try:
-            context.logger.info(f"Launching run for {external_sensor.name}")
-            instance.submit_run(run.run_id, workspace_process_context.create_request_context())
-            context.logger.info(
-                "Completed launch of run {run_id} for {sensor_name}".format(
-                    run_id=run.run_id, sensor_name=external_sensor.name
-                )
-            )
-        except Exception:
-            error_info = serializable_error_info_from_exc_info(sys.exc_info())
-            context.logger.error(
-                f"Run {run.run_id} created successfully but failed to launch: {str(error_info)}"
-            )
-        yield error_info
-
-        _check_for_debug_crash(sensor_debug_crash_flags, "RUN_LAUNCHED")
-
-        context.add_run_info(run_id=run.run_id, run_key=run_request.run_key)
+            context.add_run_info(run_id=None, run_key=run_request_result.run_key)
+        else:
+            context.add_run_info(run_id=run.run_id, run_key=run_request_result.run_key)
 
     if skipped_runs:
         run_keys = [skipped.run_key for skipped in skipped_runs]
@@ -863,7 +924,7 @@ def _fetch_existing_runs(
 
 
 def _get_or_create_sensor_run(
-    context: SensorLaunchContext,
+    logger: logging.Logger,
     instance: DagsterInstance,
     code_location: CodeLocation,
     external_sensor: ExternalSensor,
@@ -885,13 +946,13 @@ def _get_or_create_sensor_run(
             # crashed before the tick could be updated
             return SkippedSensorRun(run_key=run_request.run_key, existing_run=run)
         else:
-            context.logger.info(
+            logger.info(
                 f"Run {run.run_id} already created with the run key "
                 f"`{run_request.run_key}` for {external_sensor.name}"
             )
             return run
 
-    context.logger.info(f"Creating new run for {external_sensor.name}")
+    logger.info(f"Creating new run for {external_sensor.name}")
 
     return _create_sensor_run(
         instance, code_location, external_sensor, external_job, run_request, target_data

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/conftest.py
@@ -25,7 +25,7 @@ def executor(request):
 
 
 @pytest.fixture(params=["synchronous", "threadpool"])
-def enqueue_executor(request):
+def submit_executor(request):
     if request.param == "synchronous":
         yield None
     elif request.param == "threadpool":

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/conftest.py
@@ -24,6 +24,15 @@ def executor(request):
             yield executor
 
 
+@pytest.fixture(params=["synchronous", "threadpool"])
+def enqueue_executor(request):
+    if request.param == "synchronous":
+        yield None
+    elif request.param == "threadpool":
+        with SingleThreadPoolExecutor() as executor:
+            yield executor
+
+
 @pytest.fixture(name="instance_module_scoped", scope="module")
 def instance_module_scoped_fixture() -> Iterator[DagsterInstance]:
     with instance_for_test(

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -929,7 +929,7 @@ def asset_sensor_repo():
     ]
 
 
-def evaluate_sensors(workspace_context, executor, enqueue_executor=None, timeout=75):
+def evaluate_sensors(workspace_context, executor, submit_executor=None, timeout=75):
     logger = get_default_daemon_logger("SensorDaemon")
     futures = {}
     list(
@@ -938,7 +938,7 @@ def evaluate_sensors(workspace_context, executor, enqueue_executor=None, timeout
             logger,
             threadpool_executor=executor,
             sensor_tick_futures=futures,
-            enqueue_threadpool_executor=enqueue_executor,
+            submit_threadpool_executor=submit_executor,
         )
     )
 
@@ -1776,9 +1776,7 @@ def test_large_sensor(executor, instance, workspace_context, external_repo):
         )
 
 
-def test_many_request_sensor(
-    executor, enqueue_executor, instance, workspace_context, external_repo
-):
+def test_many_request_sensor(executor, submit_executor, instance, workspace_context, external_repo):
     freeze_datetime = to_timezone(
         create_pendulum_time(year=2019, month=2, day=27, tz="UTC"),
         "US/Central",
@@ -1786,7 +1784,7 @@ def test_many_request_sensor(
     with pendulum.test(freeze_datetime):
         external_sensor = external_repo.get_external_sensor("many_request_sensor")
         instance.start_sensor(external_sensor)
-        evaluate_sensors(workspace_context, executor, enqueue_executor=enqueue_executor)
+        evaluate_sensors(workspace_context, executor, submit_executor=submit_executor)
         ticks = instance.get_ticks(
             external_sensor.get_external_origin_id(), external_sensor.selector_id
         )

--- a/python_modules/dagster/dagster_tests/scheduler_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/conftest.py
@@ -5,10 +5,23 @@ from typing import Iterator, Optional
 import pytest
 from dagster._core.host_representation.external import ExternalRepository
 from dagster._core.instance import DagsterInstance
-from dagster._core.test_utils import create_test_daemon_workspace_context, instance_for_test
+from dagster._core.test_utils import (
+    SingleThreadPoolExecutor,
+    create_test_daemon_workspace_context,
+    instance_for_test,
+)
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._core.workspace.context import WorkspaceProcessContext
 from dagster._core.workspace.load_target import ModuleTarget
+
+
+@pytest.fixture(params=["synchronous", "threadpool"])
+def submit_executor(request):
+    if request.param == "synchronous":
+        yield None
+    elif request.param == "threadpool":
+        with SingleThreadPoolExecutor() as executor:
+            yield executor
 
 
 @pytest.fixture(name="instance_session_scoped", scope="session")


### PR DESCRIPTION
Summary:
Added another separate threadpool for enqueueing and/or launching runs simultaneously. Keeping the two threadpools separate ensures that they can't starve each other out and can be tuned separately.

Test Plan:
New BK test case
Manually: Run a sensor that creates 20 ticks locally, benchmark the difference in execution times - ticks go by much faster with threads enabled.


