### PR TITLE
Fix typo in using-environment-variables-and-secrets.mdx

### DIFF
--- a/docs/content/guides/dagster/using-environment-variables-and-secrets.mdx
+++ b/docs/content/guides/dagster/using-environment-variables-and-secrets.mdx
@@ -23,7 +23,7 @@ As of Dagster 1.1.0, Using `.env` files is supported for loading environment var
 
 DATABASE_NAME=staging
 DATABASE_SCHEMA=sales
-DATABSE_USERNAME=salesteam
+DATABASE_USERNAME=salesteam
 DATABASE_PASSWORD=supersecretstagingpassword
 ```
 


### PR DESCRIPTION
Fixes a typo.