### PR TITLE
Add 'dagster code-server start' support as an option to the Helm chart

### DIFF
--- a/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
@@ -41,7 +41,11 @@ spec:
           securityContext: {{ $deployment.securityContext | toYaml | nindent 12 }}
           imagePullPolicy: {{ $deployment.image.pullPolicy }}
           image: {{ include "dagster.dagsterImage.name" (list $ $deployment.image) | quote }}
+          {{- if $deployment.dagsterApiGrpcArgs }}
           args: ["dagster", "api", "grpc", "-h", "0.0.0.0", "-p", "{{ $deployment.port }}", "{{- join "\",\"" $deployment.dagsterApiGrpcArgs }}"]
+          {{- else if $deployment.codeServerArgs }}
+          args: ["dagster", "code-server", "start", "-h", "0.0.0.0", "-p", "{{ $deployment.port }}", "{{- join "\",\"" $deployment.codeServerArgs }}"]
+          {{- end }}
           env:
             - name: DAGSTER_CURRENT_IMAGE
               value: {{ include "dagster.dagsterImage.name" (list $ $deployment.image) | quote }}
@@ -52,10 +56,15 @@ spec:
                   key: postgresql-password
             {{- $includeConfigInLaunchedRuns := $deployment.includeConfigInLaunchedRuns | default (dict "enabled" true) }}
             {{- if $includeConfigInLaunchedRuns.enabled }}
+            {{- if $deployment.dagsterApiGrpcArgs }}
             # uses the auto_envvar_prefix of the dagster cli to set the --container-context arg
             # on 'dagster api grpc'
             - name: DAGSTER_CLI_API_GRPC_CONTAINER_CONTEXT
               value: {{ include "dagsterUserDeployments.k8sContainerContext" (list $ $deployment) | fromYaml | toJson | quote }}
+            {{- else }}
+            - name: DAGSTER_CONTAINER_CONTEXT
+              value: {{ include "dagsterUserDeployments.k8sContainerContext" (list $ $deployment) | fromYaml | toJson | quote }}
+            {{- end }}
             {{- end }}
             # If this is a map, we write it to a configmap. If it's a list, we include it here (can use more k8s spec like valueFrom).
             {{- if and ($deployment.env) (kindIs "slice" $deployment.env) }}

--- a/helm/dagster/charts/dagster-user-deployments/values.schema.json
+++ b/helm/dagster/charts/dagster-user-deployments/values.schema.json
@@ -216,6 +216,13 @@
                         "type": "string"
                     }
                 },
+                "codeServerArgs": {
+                    "title": "Codeserverargs",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "includeConfigInLaunchedRuns": {
                     "$ref": "#/definitions/UserDeploymentIncludeConfigInLaunchedRuns"
                 },
@@ -313,7 +320,6 @@
             "required": [
                 "name",
                 "image",
-                "dagsterApiGrpcArgs",
                 "port"
             ]
         },

--- a/helm/dagster/charts/dagster-user-deployments/values.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/values.yaml
@@ -39,6 +39,10 @@ deployments:
     #   - "dagster_test.test_project.test_jobs.repo"
     #   - "-a"
     #   - "define_demo_execution_repo"
+    # The `dagsterApiGrpcArgs` key can also be replaced with `codeServerArgs` to use a new
+    # experimental `dagster code-server start` command instead of `dagster api grpc`, which takes
+    # identical arguments but can reload its definitions from within the Dagster UI without
+    # needing to restart the user code deployment pod.
     dagsterApiGrpcArgs:
       - "-f"
       - "/example_project/example_repo/repo.py"

--- a/helm/dagster/schema/schema/charts/dagster_user_deployments/subschema/user_deployments.py
+++ b/helm/dagster/schema/schema/charts/dagster_user_deployments/subschema/user_deployments.py
@@ -12,7 +12,8 @@ class UserDeploymentIncludeConfigInLaunchedRuns(BaseModel):
 class UserDeployment(BaseModel):
     name: str
     image: kubernetes.Image
-    dagsterApiGrpcArgs: List[str]
+    dagsterApiGrpcArgs: Optional[List[str]]
+    codeServerArgs: Optional[List[str]]
     includeConfigInLaunchedRuns: Optional[UserDeploymentIncludeConfigInLaunchedRuns]
     port: int
     env: Optional[Union[Dict[str, str], List[kubernetes.EnvVar]]]

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -576,6 +576,13 @@
                         "type": "string"
                     }
                 },
+                "codeServerArgs": {
+                    "title": "Codeserverargs",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "includeConfigInLaunchedRuns": {
                     "$ref": "#/definitions/UserDeploymentIncludeConfigInLaunchedRuns"
                 },
@@ -673,7 +680,6 @@
             "required": [
                 "name",
                 "image",
-                "dagsterApiGrpcArgs",
                 "port"
             ]
         },

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -300,6 +300,11 @@ dagster-user-deployments:
       #   - "dagster_test.test_project.test_jobs.repo"
       #   - "-a"
       #   - "define_demo_execution_repo"
+      #
+      # The `dagsterApiGrpcArgs` key can also be replaced with `codeServerArgs` to use a new
+      # experimental `dagster code-server start` command instead of `dagster api grpc`, which takes
+      # identical arguments but can reload its definitions from within the Dagster UI without
+      # needing to restart the user code deployment pod.
       dagsterApiGrpcArgs:
         - "--python-file"
         - "/example_project/example_repo/repo.py"


### PR DESCRIPTION
Summary:
- make 'codeServerArgs' an option alongside 'dagsterApiGrpcArgs' that spins up the new entrypoint.

## Summary & Motivation

## How I Tested These Changes
