### PR TITLE
[Runs Page] More runs tweaks

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/RunActionsMenu.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunActionsMenu.tsx
@@ -17,7 +17,7 @@ import {
   Colors,
 } from '@dagster-io/ui';
 import * as React from 'react';
-import {useHistory} from 'react-router-dom';
+import {Link, useHistory} from 'react-router-dom';
 import styled from 'styled-components/macro';
 
 import {AppContext} from '../app/AppContext';
@@ -26,6 +26,7 @@ import {DEFAULT_DISABLED_REASON} from '../app/Permissions';
 import {useCopyToClipboard} from '../app/browser';
 import {ReexecutionStrategy} from '../graphql/types';
 import {NO_LAUNCH_PERMISSION_MESSAGE} from '../launchpad/LaunchRootExecutionButton';
+import {getPipelineSnapshotLink} from '../pipelines/PipelinePathUtils';
 import {AnchorButton} from '../ui/AnchorButton';
 import {MenuLink} from '../ui/MenuLink';
 import {isThisThingAJob} from '../workspace/WorkspaceContext';
@@ -144,7 +145,7 @@ export const RunActionsMenu: React.FC<{
                         alignItems: 'center',
                         display: 'inline-flex',
                       }}
-                      padding={{vertical: 4, horizontal: 8}}
+                      padding={{horizontal: 8}}
                     >
                       <SlashShortcut>t</SlashShortcut>
                     </Box>
@@ -153,6 +154,19 @@ export const RunActionsMenu: React.FC<{
                 icon="tag"
                 onClick={() => setVisibleDialog('tags')}
               />
+
+              {run.pipelineSnapshotId ? (
+                <LinkNoUnderline
+                  to={getPipelineSnapshotLink(run.pipelineName, run.pipelineSnapshotId)}
+                >
+                  <MenuItem
+                    tagName="button"
+                    icon="job"
+                    text="View snapshot"
+                    onClick={() => setVisibleDialog('tags')}
+                  />
+                </LinkNoUnderline>
+              ) : null}
               <MenuDivider />
               <>
                 <Tooltip
@@ -507,4 +521,8 @@ const SlashShortcut = styled.div`
   padding: 0px 6px;
   background: ${Colors.Gray100};
   color: ${Colors.Gray500};
+`;
+
+const LinkNoUnderline = styled(Link)`
+  text-decoration: none !important;
 `;

--- a/js_modules/dagit/packages/core/src/runs/RunCreatedByCell.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunCreatedByCell.tsx
@@ -1,4 +1,4 @@
-import {Box, Tag} from '@dagster-io/ui';
+import {Box, Tag, Tooltip} from '@dagster-io/ui';
 import React from 'react';
 import styled from 'styled-components/macro';
 
@@ -37,30 +37,6 @@ export function RunCreatedByCell(props: Props) {
 
   if (user) {
     creator = <UserDisplay email={user.value} />;
-  } else if (backfillTag) {
-    const link = props.run.assetSelection?.length
-      ? `/overview/backfills/${backfillTag.value}`
-      : runsPathWithFilters([
-          {
-            token: 'tag',
-            value: `dagster/backfill=${backfillTag.value}`,
-          },
-        ]);
-    creator = (
-      <RunTagsWrapper>
-        <RunTags
-          tags={[
-            {
-              key: DagsterTag.Backfill,
-              value: backfillTag.value,
-              link,
-            },
-          ]}
-          mode={null}
-          onAddTag={props.onAddTag}
-        />
-      </RunTagsWrapper>
-    );
   } else if (scheduleTag) {
     creator = (
       <Tag icon="schedule" key="schedule">
@@ -80,7 +56,11 @@ export function RunCreatedByCell(props: Props) {
       </Tag>
     );
   } else {
-    creator = <Tag icon="account_circle">Launchpad</Tag>;
+    creator = (
+      <Tooltip content="No 'user' tag specified. You can add one by specifying the `dagster/user` tag">
+        <Tag icon="account_circle">Manually launched</Tag>
+      </Tooltip>
+    );
   }
 
   return (

--- a/js_modules/dagit/packages/core/src/runs/RunCreatedByCell.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunCreatedByCell.tsx
@@ -5,8 +5,6 @@ import styled from 'styled-components/macro';
 import {useLaunchPadHooks} from '../launchpad/LaunchpadHooksContext';
 
 import {DagsterTag} from './RunTag';
-import {RunTags} from './RunTags';
-import {runsPathWithFilters} from './RunsFilterInput';
 import {RunFilterToken} from './RunsFilterInputNew';
 import {RunTableRunFragment} from './types/RunTable.types';
 
@@ -18,7 +16,6 @@ type Props = {
 export function RunCreatedByCell(props: Props) {
   const tags = props.run.tags || [];
 
-  const backfillTag = tags.find((tag) => tag.key === DagsterTag.Backfill);
   const scheduleTag = tags.find((tag) => tag.key === DagsterTag.ScheduleName);
   const sensorTag = tags.find((tag) => tag.key === DagsterTag.SensorName);
   const user = tags.find((tag) => tag.key === DagsterTag.User);
@@ -67,9 +64,3 @@ export function RunCreatedByCell(props: Props) {
     <Box flex={{direction: 'column', alignItems: 'flex-start'}}>{creator || createdBy?.value}</Box>
   );
 }
-const RunTagsWrapper = styled.div`
-  display: contents;
-  > * {
-    display: contents;
-  }
-`;

--- a/js_modules/dagit/packages/core/src/runs/RunCreatedByCell.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunCreatedByCell.tsx
@@ -57,7 +57,7 @@ export function RunCreatedByCell(props: Props) {
     );
   } else {
     creator = (
-      <Tooltip content="No 'user' tag specified. You can add one by specifying the `dagster/user` tag">
+      <Tooltip content="No user specified. Add a `dagster/user` tag to specify one">
         <Tag icon="account_circle">Manually launched</Tag>
       </Tooltip>
     );

--- a/js_modules/dagit/packages/core/src/runs/RunCreatedByCell.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunCreatedByCell.tsx
@@ -1,6 +1,5 @@
 import {Box, Tag, Tooltip} from '@dagster-io/ui';
 import React from 'react';
-import styled from 'styled-components/macro';
 
 import {useLaunchPadHooks} from '../launchpad/LaunchpadHooksContext';
 

--- a/js_modules/dagit/packages/core/src/runs/RunsFilterInputNew.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunsFilterInputNew.tsx
@@ -399,7 +399,7 @@ export const useRunsFilterInput = ({tokens, onChange, enabledFilters}: RunsFilte
     filters: [
       !enabledFilters || enabledFilters?.includes('status') ? statusFilter : null,
       useStaticSetFilter({
-        name: 'Created By',
+        name: 'Launched By',
         icon: 'add_circle',
         allValues: createdByValues,
         renderLabel: ({value}) => {

--- a/js_modules/dagit/packages/core/src/runs/RunsFilterInputNew.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunsFilterInputNew.tsx
@@ -399,7 +399,7 @@ export const useRunsFilterInput = ({tokens, onChange, enabledFilters}: RunsFilte
     filters: [
       !enabledFilters || enabledFilters?.includes('status') ? statusFilter : null,
       useStaticSetFilter({
-        name: 'Launched By',
+        name: 'Launched by',
         icon: 'add_circle',
         allValues: createdByValues,
         renderLabel: ({value}) => {


### PR DESCRIPTION
## Summary & Motivation

- Change “Created by” to “Launched by”
    - Change the table column header and the filter key
- In OSS, if no user is specified, lets change the tag label from “Launchpad” to “Manually launched”
    - I think it would be cool to add a tooltip on the “Manually launched” tag that says “No ‘user’ tag specified” … that will give users an indication of how to populate this tag in the future.
- Remove the “Snapshot” tag from the Target column since everyone agreed it’s not that useful.
- For backfill runs:
    - Let’s show the user that triggered the backfill in the “Launched by column”
    - Lets move the backfill tag to the “Target” column
    - It looks like for single run backfills we append two extra tags. asset_partition_range_start and asset_partition_range_end. I think we should just show those two tags in the “Target” column so it’s easy to see the range of targeted partitions. 

## How I Tested These Changes
<img width="2041" alt="Screen Shot 2023-05-22 at 10 41 22 AM" src="https://github.com/dagster-io/dagster/assets/2286579/7a111622-6af5-40ab-accb-9b4836993b0e">
<img width="2056" alt="Screen Shot 2023-05-22 at 10 40 05 AM" src="https://github.com/dagster-io/dagster/assets/2286579/5b941b2d-e212-40b6-8b31-cf5545e88e64">
<img width="2056" alt="Screen Shot 2023-05-22 at 10 39 16 AM" src="https://github.com/dagster-io/dagster/assets/2286579/7214c394-5ac9-4de5-ab36-af15451206ab">

