### PR TITLE
Fix subsetting bug

### DIFF
--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
@@ -2607,7 +2607,7 @@ def test_subset_cycle_resolution_embed_assets_in_complex_graph():
     result = job.execute_in_process()
 
     assert _all_asset_keys(result) == {AssetKey(x) for x in "a,b,c,d,e,f,g,h,x,y".split(",")}
-    assert result.output_for_node("foo_subset_53118", "h") == 12
+    assert result.output_for_node("foo_3", "h") == 12
 
 
 def test_subset_cycle_resolution_complex():

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
@@ -428,9 +428,14 @@ def test_inter_op_dependency():
     def assets(in1, in2):
         pass
 
-    assets_job = build_assets_job("assets_job", [in1, in2, assets, downstream])
+    subset_job = define_asset_job("subset_job", selection="mixed").resolve(
+        [in1, in2, assets, downstream], []
+    )
+    all_assets_job = build_assets_job("assets_job", [in1, in2, assets, downstream])
 
-    external_asset_nodes = external_asset_graph_from_defs([assets_job], source_assets_by_key={})
+    external_asset_nodes = external_asset_graph_from_defs(
+        [subset_job, all_assets_job], source_assets_by_key={}
+    )
     # sort so that test is deterministic
     sorted_nodes = sorted(
         [
@@ -508,7 +513,7 @@ def test_inter_op_dependency():
             graph_name=None,
             op_names=["assets"],
             op_description=None,
-            job_names=["assets_job"],
+            job_names=["assets_job", "subset_job"],
             output_name="mixed",
             group_name=DEFAULT_GROUP_NAME,
         ),

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
@@ -428,13 +428,13 @@ def test_inter_op_dependency():
     def assets(in1, in2):
         pass
 
+    all_assets_job = build_assets_job("assets_job", [in1, in2, assets, downstream])
     subset_job = define_asset_job("subset_job", selection="mixed").resolve(
         [in1, in2, assets, downstream], []
     )
-    all_assets_job = build_assets_job("assets_job", [in1, in2, assets, downstream])
 
     external_asset_nodes = external_asset_graph_from_defs(
-        [subset_job, all_assets_job], source_assets_by_key={}
+        [all_assets_job, subset_job], source_assets_by_key={}
     )
     # sort so that test is deterministic
     sorted_nodes = sorted(

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
@@ -428,13 +428,13 @@ def test_inter_op_dependency():
     def assets(in1, in2):
         pass
 
-    all_assets_job = build_assets_job("assets_job", [in1, in2, assets, downstream])
     subset_job = define_asset_job("subset_job", selection="mixed").resolve(
         [in1, in2, assets, downstream], []
     )
+    all_assets_job = build_assets_job("assets_job", [in1, in2, assets, downstream])
 
     external_asset_nodes = external_asset_graph_from_defs(
-        [all_assets_job, subset_job], source_assets_by_key={}
+        [subset_job, all_assets_job], source_assets_by_key={}
     )
     # sort so that test is deterministic
     sorted_nodes = sorted(
@@ -513,7 +513,7 @@ def test_inter_op_dependency():
             graph_name=None,
             op_names=["assets"],
             op_description=None,
-            job_names=["assets_job", "subset_job"],
+            job_names=["subset_job", "assets_job"],
             output_name="mixed",
             group_name=DEFAULT_GROUP_NAME,
         ),


### PR DESCRIPTION
## Summary & Motivation

We have some special handling in place for the rare case that you have a subsettable multi asset which has some nodes upstream of another asset (`A`) and other nodes downstream of `A`.

In these cases, we need to separate out the asset into two separate op invocations in order for it to be possible to execute (as otherwise the op for the multi-asset would need to execute both before and after the op for `A`).

In some cases, this requires just invoking the original op two separate times, but in other cases, we actually need to generate a new op. See: https://github.com/dagster-io/dagster/pull/13830 for more context.

However, we were overly zealous in the original PR, generating new ops in situations where it was not actually necessary (as the broader job would not actually need to plug in any output into the new input we created).

This PR fixes this, meaning we will only create the new input in cases where it will actually be used. 

Further work should be done to investigate if there are other similar issues that are caused by this behavior, but this PR should quarantine the impact to the rare situation described in the above PR.

## How I Tested These Changes

Modified test failed before this change, passes now.