### PR TITLE
Prefer run config over config mapping when reconstructing Jobs

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -209,6 +209,7 @@ class JobDefinition(IHasInternalInit):
         self._partitioned_config = None
         self._run_config = None
         self._run_config_schema = None
+        self._original_config_argument = config
 
         if partitions_def:
             self._partitioned_config = PartitionedConfig.from_flexible_config(
@@ -918,13 +919,7 @@ class JobDefinition(IHasInternalInit):
             resource_defs=dict(self.resource_defs),
             executor_def=self._executor_def,
             logger_defs=self._loggers,
-            # One of the following is true:
-            #   _config_mapping is set, and _partitioned_config and _run_config are None
-            #   _partitioned_config is set, and _config_mapping and _run_config are None
-            #   _run_config is set and _config_mapping is built from it using _config_mapping_with_default_value (and _partitioned_config is None)
-            # In the last case, we want to copy the _run_config, not the _config_mapping, since a new _config_mapping will be built
-            # from the _run_config in the constructor
-            config=self._run_config or self._config_mapping or self._partitioned_config,
+            config=self._original_config_argument,
             name=self._name,
             description=self.description,
             tags=self.tags,

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -918,7 +918,7 @@ class JobDefinition(IHasInternalInit):
             resource_defs=dict(self.resource_defs),
             executor_def=self._executor_def,
             logger_defs=self._loggers,
-            config=self._config_mapping or self._partitioned_config or self._run_config,
+            config=self._run_config or self._config_mapping or self._partitioned_config,
             name=self._name,
             description=self.description,
             tags=self.tags,

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -918,6 +918,12 @@ class JobDefinition(IHasInternalInit):
             resource_defs=dict(self.resource_defs),
             executor_def=self._executor_def,
             logger_defs=self._loggers,
+            # One of the following is true:
+            #   _config_mapping is set, and _partitioned_config and _run_config are None
+            #   _partitioned_config is set, and _config_mapping and _run_config are None
+            #   _run_config is set and _config_mapping is built from it using _config_mapping_with_default_value (and _partitioned_config is None)
+            # In the last case, we want to copy the _run_config, not the _config_mapping, since a new _config_mapping will be built
+            # from the _run_config in the constructor
             config=self._run_config or self._config_mapping or self._partitioned_config,
             name=self._name,
             description=self.description,


### PR DESCRIPTION
## Summary

When a job is supplied a run config dict, we use `_config_mapping_with_default_value` to create a corresponding config mapping which produces this default config. This config mapping also bundles in information related to e.g. the executor.
The job object then has `_run_config` and `_config_mapping` set.

When copying a job (to attach a default executor, for example), we forward the config by passing `job._config_mapping or job._run_config`.

In the case where the original job object was passed a run config dict, it has `_run_config` and `_config_mapping` set. The or precedence means the copied job has `_config_mapping`, which does not take into account any changes in the copy (such as a new executor).

This PR reverses the `or` precedence so that `_run_config` is passed and a new config mapping is generated in this scenario.

Should resolve #14371

## Test Plan

Reproduced #14371 locally and ensured this fixed. Added a small test case (previously failing).



