### PR TITLE
Add env vars in all our CLI entrypoints if there's a .env file in the local working directory

### DIFF
--- a/python_modules/dagit/dagit/app.py
+++ b/python_modules/dagit/dagit/app.py
@@ -1,14 +1,11 @@
 from dagster import (
-    DagsterInstance,
     _check as check,
 )
-from dagster._cli.workspace.cli_target import get_workspace_process_context_from_kwargs
 from dagster._core.execution.compute_logs import warn_if_compute_logs_disabled
 from dagster._core.telemetry import log_workspace_stats
 from dagster._core.workspace.context import IWorkspaceProcessContext
 from starlette.applications import Starlette
 
-from .version import __version__
 from .webserver import DagitWebserver
 
 
@@ -38,21 +35,3 @@ def create_app_from_workspace_process_context(
         workspace_process_context,
         path_prefix,
     ).create_asgi_app(**kwargs)
-
-
-def default_app(debug=False):
-    instance = DagsterInstance.get()
-    process_context = get_workspace_process_context_from_kwargs(
-        instance=instance,
-        version=__version__,
-        read_only=False,
-        kwargs={},
-    )
-
-    return DagitWebserver(
-        process_context,
-    ).create_asgi_app(debug=debug)
-
-
-def debug_app():
-    return default_app(debug=True)

--- a/python_modules/dagit/dagit/cli.py
+++ b/python_modules/dagit/dagit/cli.py
@@ -6,7 +6,7 @@ from typing import Optional
 import click
 import dagster._check as check
 import uvicorn
-from dagster._cli.utils import get_possibly_ephemeral_instance_for_cli
+from dagster._cli.utils import get_possibly_temporary_instance_for_cli
 from dagster._cli.workspace import (
     get_workspace_process_context_from_kwargs,
     workspace_target_argument,
@@ -158,7 +158,7 @@ def dagit(
     configure_loggers()
     logger = logging.getLogger("dagit")
 
-    with get_possibly_ephemeral_instance_for_cli(
+    with get_possibly_temporary_instance_for_cli(
         cli_command="dagit",
         instance_ref=deserialize_value(instance_ref, InstanceRef) if instance_ref else None,
         logger=logger,

--- a/python_modules/dagit/dagit/cli.py
+++ b/python_modules/dagit/dagit/cli.py
@@ -6,7 +6,7 @@ from typing import Optional
 import click
 import dagster._check as check
 import uvicorn
-from dagster._cli.utils import get_instance_for_service
+from dagster._cli.utils import get_possibly_ephemeral_instance_for_cli
 from dagster._cli.workspace import (
     get_workspace_process_context_from_kwargs,
     workspace_target_argument,
@@ -158,10 +158,10 @@ def dagit(
     configure_loggers()
     logger = logging.getLogger("dagit")
 
-    with get_instance_for_service(
-        "dagit",
+    with get_possibly_ephemeral_instance_for_cli(
+        cli_command="dagit",
         instance_ref=deserialize_value(instance_ref, InstanceRef) if instance_ref else None,
-        logger_fn=logger.info,
+        logger=logger,
     ) as instance:
         # Allow the instance components to change behavior in the context of a long running server process
         instance.optimize_for_dagit(db_statement_timeout, db_pool_recycle)

--- a/python_modules/dagster-graphql/dagster_graphql/cli.py
+++ b/python_modules/dagster-graphql/dagster_graphql/cli.py
@@ -5,12 +5,12 @@ import click
 import dagster._check as check
 import dagster._seven as seven
 import requests
+from dagster._cli.utils import get_possibly_ephemeral_instance_for_cli
 from dagster._cli.workspace import workspace_target_argument
 from dagster._cli.workspace.cli_target import (
     WORKSPACE_TARGET_WARNING,
     get_workspace_process_context_from_kwargs,
 )
-from dagster._core.instance import DagsterInstance
 from dagster._core.workspace.context import WorkspaceProcessContext
 from dagster._utils import DEFAULT_WORKSPACE_YAML_FILENAME
 from dagster._utils.log import get_stack_trace_array
@@ -196,9 +196,7 @@ def ui(text, file, predefined, variables, remote, output, ephemeral_instance, **
         res = execute_query_against_remote(remote, query, variables)
         print(res)  # noqa: T201
     else:
-        with (
-            DagsterInstance.local_temp() if ephemeral_instance else DagsterInstance.get()
-        ) as instance:
+        with get_possibly_ephemeral_instance_for_cli() as instance:
             with get_workspace_process_context_from_kwargs(
                 instance, version=__version__, read_only=False, kwargs=kwargs
             ) as workspace_process_context:

--- a/python_modules/dagster-graphql/dagster_graphql/cli.py
+++ b/python_modules/dagster-graphql/dagster_graphql/cli.py
@@ -5,7 +5,7 @@ import click
 import dagster._check as check
 import dagster._seven as seven
 import requests
-from dagster._cli.utils import get_possibly_ephemeral_instance_for_cli
+from dagster._cli.utils import get_instance_for_cli, get_temporary_instance_for_cli
 from dagster._cli.workspace import workspace_target_argument
 from dagster._cli.workspace.cli_target import (
     WORKSPACE_TARGET_WARNING,
@@ -196,7 +196,9 @@ def ui(text, file, predefined, variables, remote, output, ephemeral_instance, **
         res = execute_query_against_remote(remote, query, variables)
         print(res)  # noqa: T201
     else:
-        with get_possibly_ephemeral_instance_for_cli() as instance:
+        with (
+            get_temporary_instance_for_cli() if ephemeral_instance else get_instance_for_cli()
+        ) as instance:
             with get_workspace_process_context_from_kwargs(
                 instance, version=__version__, read_only=False, kwargs=kwargs
             ) as workspace_process_context:

--- a/python_modules/dagster/dagster/_cli/api.py
+++ b/python_modules/dagster/dagster/_cli/api.py
@@ -40,6 +40,8 @@ from dagster._utils.hosted_user_process import recon_job_from_origin
 from dagster._utils.interrupts import capture_interrupts, setup_interrupt_handlers
 from dagster._utils.log import configure_loggers
 
+from .utils import get_instance_for_cli
+
 
 @click.group(name="api", hidden=True)
 def api_cli():
@@ -60,11 +62,7 @@ def execute_run_command(input_json):
     with capture_interrupts():
         args = deserialize_value(input_json, ExecuteRunArgs)
 
-        with (
-            DagsterInstance.from_ref(args.instance_ref)
-            if args.instance_ref
-            else DagsterInstance.get()
-        ) as instance:
+        with get_instance_for_cli(instance_ref=args.instance_ref) as instance:
             buffer = []
 
             def send_to_buffer(event):
@@ -165,11 +163,7 @@ def resume_run_command(input_json):
     with capture_interrupts():
         args = deserialize_value(input_json, ResumeRunArgs)
 
-        with (
-            DagsterInstance.from_ref(args.instance_ref)
-            if args.instance_ref
-            else DagsterInstance.get()
-        ) as instance:
+        with get_instance_for_cli(instance_ref=args.instance_ref) as instance:
             buffer = []
 
             def send_to_buffer(event):
@@ -341,11 +335,7 @@ def execute_step_command(input_json, compressed_input_json):
 
         args = deserialize_value(input_json, ExecuteStepArgs)
 
-        with (
-            DagsterInstance.from_ref(args.instance_ref)
-            if args.instance_ref
-            else DagsterInstance.get()
-        ) as instance:
+        with get_instance_for_cli(instance_ref=args.instance_ref) as instance:
             dagster_run = instance.get_run_by_id(args.run_id)
 
             buff = []

--- a/python_modules/dagster/dagster/_cli/asset.py
+++ b/python_modules/dagster/dagster/_cli/asset.py
@@ -20,7 +20,7 @@ from dagster._utils.hosted_user_process import (
 )
 from dagster._utils.interrupts import capture_interrupts
 
-from .utils import get_instance_for_service
+from .utils import get_instance_for_cli, get_possibly_ephemeral_instance_for_cli
 
 
 @click.group(name="asset")
@@ -34,7 +34,9 @@ def asset_cli():
 @click.option("--partition", help="Asset partition to target", required=False)
 def asset_materialize_command(**kwargs):
     with capture_interrupts():
-        with get_instance_for_service("``dagster asset materialize``") as instance:
+        with get_possibly_ephemeral_instance_for_cli(
+            "``dagster asset materialize``",
+        ) as instance:
             execute_materialize_command(instance, kwargs)
 
 
@@ -133,7 +135,7 @@ def asset_wipe_command(key, **cli_args):
 
     noprompt = cli_args.get("noprompt")
 
-    with DagsterInstance.get() as instance:
+    with get_instance_for_cli() as instance:
         if len(key) > 0:
             asset_keys = [AssetKey.from_db_string(key_string) for key_string in key]
             prompt = (
@@ -185,7 +187,7 @@ def asset_wipe_cache_command(key, **cli_args):
 
     noprompt = cli_args.get("noprompt")
 
-    with DagsterInstance.get() as instance:
+    with get_instance_for_cli() as instance:
         if instance.can_cache_asset_status_data() is False:
             raise click.UsageError(
                 "Error, the instance does not support caching asset status. Wiping the cache is not"

--- a/python_modules/dagster/dagster/_cli/asset.py
+++ b/python_modules/dagster/dagster/_cli/asset.py
@@ -20,7 +20,7 @@ from dagster._utils.hosted_user_process import (
 )
 from dagster._utils.interrupts import capture_interrupts
 
-from .utils import get_instance_for_cli, get_possibly_ephemeral_instance_for_cli
+from .utils import get_instance_for_cli, get_possibly_temporary_instance_for_cli
 
 
 @click.group(name="asset")
@@ -34,7 +34,7 @@ def asset_cli():
 @click.option("--partition", help="Asset partition to target", required=False)
 def asset_materialize_command(**kwargs):
     with capture_interrupts():
-        with get_possibly_ephemeral_instance_for_cli(
+        with get_possibly_temporary_instance_for_cli(
             "``dagster asset materialize``",
         ) as instance:
             execute_materialize_command(instance, kwargs)

--- a/python_modules/dagster/dagster/_cli/debug.py
+++ b/python_modules/dagster/dagster/_cli/debug.py
@@ -4,10 +4,11 @@ from typing import List, Tuple
 import click
 from tqdm import tqdm
 
-from dagster import DagsterInstance
 from dagster._core.debug import DebugRunPayload
 from dagster._core.storage.dagster_run import DagsterRunStatus, RunsFilter
 from dagster._serdes import deserialize_value
+
+from .utils import get_instance_for_cli
 
 
 def _recent_failed_runs_text(instance):
@@ -49,7 +50,7 @@ def debug_cli():
 @click.argument("run_id", type=str)
 @click.argument("output_file", type=click.Path())
 def export_command(run_id, output_file):
-    with DagsterInstance.get() as instance:
+    with get_instance_for_cli() as instance:
         run = instance.get_run_by_id(run_id)
         if run is None:
             raise click.UsageError(
@@ -73,7 +74,7 @@ def import_command(input_files: Tuple[str, ...]):
             debug_payload = deserialize_value(blob, DebugRunPayload)
             debug_payloads.append(debug_payload)
 
-    with DagsterInstance.get() as instance:
+    with get_instance_for_cli() as instance:
         for debug_payload in debug_payloads:
             run = debug_payload.dagster_run
             click.echo(f"Importing run {run.run_id} (Dagster: {debug_payload.version})")

--- a/python_modules/dagster/dagster/_cli/dev.py
+++ b/python_modules/dagster/dagster/_cli/dev.py
@@ -14,7 +14,7 @@ from dagster._serdes.ipc import interrupt_ipc_subprocess, open_ipc_subprocess
 from dagster._utils.log import configure_loggers
 
 from .job import apply_click_params
-from .utils import get_instance_for_service
+from .utils import get_possibly_ephemeral_instance_for_cli
 from .workspace.cli_target import (
     ClickArgValue,
     get_workspace_load_target,
@@ -95,7 +95,7 @@ def dev_command(
                 " unless it is placed in the same folder as DAGSTER_HOME."
             )
 
-    with get_instance_for_service("dagster dev", logger_fn=logger.info) as instance:
+    with get_possibly_ephemeral_instance_for_cli("dagster dev", logger=logger) as instance:
         logger.info("Launching Dagster services...")
 
         args = [

--- a/python_modules/dagster/dagster/_cli/dev.py
+++ b/python_modules/dagster/dagster/_cli/dev.py
@@ -14,7 +14,7 @@ from dagster._serdes.ipc import interrupt_ipc_subprocess, open_ipc_subprocess
 from dagster._utils.log import configure_loggers
 
 from .job import apply_click_params
-from .utils import get_possibly_ephemeral_instance_for_cli
+from .utils import get_possibly_temporary_instance_for_cli
 from .workspace.cli_target import (
     ClickArgValue,
     get_workspace_load_target,
@@ -95,7 +95,7 @@ def dev_command(
                 " unless it is placed in the same folder as DAGSTER_HOME."
             )
 
-    with get_possibly_ephemeral_instance_for_cli("dagster dev", logger=logger) as instance:
+    with get_possibly_temporary_instance_for_cli("dagster dev", logger=logger) as instance:
         logger.info("Launching Dagster services...")
 
         args = [

--- a/python_modules/dagster/dagster/_cli/instance.py
+++ b/python_modules/dagster/dagster/_cli/instance.py
@@ -3,7 +3,8 @@ import os
 import click
 
 import dagster._check as check
-from dagster._core.instance import DagsterInstance
+
+from .utils import get_instance_for_cli
 
 
 @click.group(name="instance")
@@ -13,7 +14,7 @@ def instance_cli():
 
 @instance_cli.command(name="info", help="List the information about the current instance.")
 def info_command():
-    with DagsterInstance.get() as instance:
+    with get_instance_for_cli() as instance:
         home = os.environ.get("DAGSTER_HOME")
 
         if instance.is_ephemeral:
@@ -39,13 +40,14 @@ def info_command():
 
 @instance_cli.command(name="migrate", help="Automatically migrate an out of date instance.")
 def migrate_command():
-    home = os.environ.get("DAGSTER_HOME")
-    if not home:
-        click.echo("$DAGSTER_HOME is not set; ephemeral instances do not need to be migrated.")
+    with get_instance_for_cli() as instance:
+        home = os.environ.get("DAGSTER_HOME")
+        if not home:
+            click.echo("$DAGSTER_HOME is not set; ephemeral instances do not need to be migrated.")
+            return
 
-    click.echo(f"$DAGSTER_HOME: {home}\n")
+        click.echo(f"$DAGSTER_HOME: {home}\n")
 
-    with DagsterInstance.get() as instance:
         instance.upgrade(click.echo)
 
         click.echo(instance.info_str())
@@ -53,7 +55,7 @@ def migrate_command():
 
 @instance_cli.command(name="reindex", help="Rebuild index over historical runs for performance.")
 def reindex_command():
-    with DagsterInstance.get() as instance:
+    with get_instance_for_cli() as instance:
         home = os.environ.get("DAGSTER_HOME")
 
         if instance.is_ephemeral:

--- a/python_modules/dagster/dagster/_cli/job.py
+++ b/python_modules/dagster/dagster/_cli/job.py
@@ -63,7 +63,7 @@ from dagster._utils.merger import merge_dicts
 from dagster._utils.yaml_utils import dump_run_config_yaml, load_yaml_from_glob_list
 
 from .config_scaffolder import scaffold_job_config
-from .utils import get_instance_for_service
+from .utils import get_instance_for_cli, get_possibly_ephemeral_instance_for_cli
 
 T = TypeVar("T")
 T_Callable = TypeVar("T_Callable", bound=Callable[..., Any])
@@ -90,7 +90,7 @@ def job_list_command(**kwargs):
 
 
 def execute_list_command(cli_args, print_fn):
-    with get_instance_for_service("``dagster job list``") as instance:
+    with get_possibly_ephemeral_instance_for_cli("``dagster job list``") as instance:
         with get_external_repository_from_kwargs(
             instance, version=dagster_version, kwargs=cli_args
         ) as external_repository:
@@ -143,7 +143,7 @@ def get_job_instructions(command_name):
 @click.option("--verbose", is_flag=True)
 @job_target_argument
 def job_print_command(verbose, **cli_args):
-    with get_instance_for_service("``dagster job print``") as instance:
+    with get_possibly_ephemeral_instance_for_cli("``dagster job print``") as instance:
         return execute_print_command(instance, verbose, cli_args, click.echo)
 
 
@@ -247,7 +247,7 @@ def print_op(
 @python_job_target_argument
 @python_job_config_argument("list_versions")
 def job_list_versions_command(**kwargs):
-    with DagsterInstance.get() as instance:
+    with get_instance_for_cli() as instance:
         execute_list_versions_command(instance, kwargs)
 
 
@@ -311,7 +311,7 @@ def add_step_to_table(memoized_plan):
 @click.option("--tags", type=click.STRING, help="JSON string of tags to use for this job run")
 def job_execute_command(**kwargs: ClickArgValue):
     with capture_interrupts():
-        with get_instance_for_service("``dagster job execute``") as instance:
+        with get_possibly_ephemeral_instance_for_cli("``dagster job execute``") as instance:
             execute_execute_command(instance, kwargs)
 
 
@@ -428,7 +428,7 @@ def do_execute_command(
 @click.option("--tags", type=click.STRING, help="JSON string of tags to use for this job run")
 @click.option("--run-id", type=click.STRING, help="The ID to give to the launched job run")
 def job_launch_command(**kwargs) -> DagsterRun:
-    with DagsterInstance.get() as instance:
+    with get_instance_for_cli() as instance:
         return execute_launch_command(instance, kwargs)
 
 
@@ -636,7 +636,7 @@ def do_scaffold_command(
 @click.option("--tags", type=click.STRING, help="JSON string of tags to use for this job run")
 @click.option("--noprompt", is_flag=True)
 def job_backfill_command(**kwargs):
-    with DagsterInstance.get() as instance:
+    with get_instance_for_cli() as instance:
         execute_backfill_command(kwargs, click.echo, instance)
 
 

--- a/python_modules/dagster/dagster/_cli/job.py
+++ b/python_modules/dagster/dagster/_cli/job.py
@@ -63,7 +63,7 @@ from dagster._utils.merger import merge_dicts
 from dagster._utils.yaml_utils import dump_run_config_yaml, load_yaml_from_glob_list
 
 from .config_scaffolder import scaffold_job_config
-from .utils import get_instance_for_cli, get_possibly_ephemeral_instance_for_cli
+from .utils import get_instance_for_cli, get_possibly_temporary_instance_for_cli
 
 T = TypeVar("T")
 T_Callable = TypeVar("T_Callable", bound=Callable[..., Any])
@@ -90,7 +90,7 @@ def job_list_command(**kwargs):
 
 
 def execute_list_command(cli_args, print_fn):
-    with get_possibly_ephemeral_instance_for_cli("``dagster job list``") as instance:
+    with get_possibly_temporary_instance_for_cli("``dagster job list``") as instance:
         with get_external_repository_from_kwargs(
             instance, version=dagster_version, kwargs=cli_args
         ) as external_repository:
@@ -143,7 +143,7 @@ def get_job_instructions(command_name):
 @click.option("--verbose", is_flag=True)
 @job_target_argument
 def job_print_command(verbose, **cli_args):
-    with get_possibly_ephemeral_instance_for_cli("``dagster job print``") as instance:
+    with get_possibly_temporary_instance_for_cli("``dagster job print``") as instance:
         return execute_print_command(instance, verbose, cli_args, click.echo)
 
 
@@ -311,7 +311,7 @@ def add_step_to_table(memoized_plan):
 @click.option("--tags", type=click.STRING, help="JSON string of tags to use for this job run")
 def job_execute_command(**kwargs: ClickArgValue):
     with capture_interrupts():
-        with get_possibly_ephemeral_instance_for_cli("``dagster job execute``") as instance:
+        with get_possibly_temporary_instance_for_cli("``dagster job execute``") as instance:
             execute_execute_command(instance, kwargs)
 
 

--- a/python_modules/dagster/dagster/_cli/run.py
+++ b/python_modules/dagster/dagster/_cli/run.py
@@ -3,7 +3,8 @@ from tqdm import tqdm
 
 from dagster import __version__ as dagster_version
 from dagster._cli.workspace.cli_target import get_external_job_from_kwargs, job_target_argument
-from dagster._core.instance import DagsterInstance
+
+from .utils import get_instance_for_cli
 
 
 @click.group(name="run")
@@ -14,7 +15,7 @@ def run_cli():
 @run_cli.command(name="list", help="List the runs in the current Dagster instance.")
 @click.option("--limit", help="Only list a specified number of runs", default=None, type=int)
 def run_list_command(limit):
-    with DagsterInstance.get() as instance:
+    with get_instance_for_cli() as instance:
         for run in instance.get_runs(limit=limit):
             click.echo(f"Run: {run.run_id}")
             click.echo(f"     Job: {run.job_name}")
@@ -27,7 +28,7 @@ def run_list_command(limit):
 @click.option("--force", "-f", is_flag=True, default=False, help="Skip prompt to delete run.")
 @click.argument("run_id")
 def run_delete_command(run_id, force):
-    with DagsterInstance.get() as instance:
+    with get_instance_for_cli() as instance:
         if not instance.has_run(run_id):
             raise click.ClickException(f"No run found with id {run_id}.")
 
@@ -66,7 +67,7 @@ def run_wipe_command(force):
         should_delete_run = confirmation == "DELETE"
 
     if should_delete_run:
-        with DagsterInstance.get() as instance:
+        with get_instance_for_cli() as instance:
             instance.wipe()
         click.echo("Deleted all run history and event logs.")
     else:
@@ -97,7 +98,7 @@ def run_migrate_command(from_label, **kwargs):
             "`--from` argument must be of the format: <repository_name>@<location_name>"
         )
 
-    with DagsterInstance.get() as instance:
+    with get_instance_for_cli() as instance:
         with get_external_job_from_kwargs(
             instance, version=dagster_version, kwargs=kwargs
         ) as external_job:

--- a/python_modules/dagster/dagster/_cli/schedule.py
+++ b/python_modules/dagster/dagster/_cli/schedule.py
@@ -19,6 +19,8 @@ from dagster._core.instance import DagsterInstance
 from dagster._core.scheduler.instigation import InstigatorStatus
 from dagster._core.scheduler.scheduler import DagsterDaemonScheduler
 
+from .utils import get_instance_for_cli
+
 
 @click.group(name="schedule")
 def schedule_cli():
@@ -146,7 +148,7 @@ def schedule_preview_command(**kwargs):
 
 
 def execute_preview_command(cli_args, print_fn):
-    with DagsterInstance.get() as instance:
+    with get_instance_for_cli() as instance:
         with get_external_repository_from_kwargs(
             instance, version=dagster_version, kwargs=cli_args
         ) as external_repo:
@@ -168,7 +170,7 @@ def schedule_list_command(running, stopped, name, **kwargs):
 
 
 def execute_list_command(running_filter, stopped_filter, name_filter, cli_args, print_fn):
-    with DagsterInstance.get() as instance:
+    with get_instance_for_cli() as instance:
         with get_external_repository_from_kwargs(
             instance, version=dagster_version, kwargs=cli_args
         ) as external_repo:
@@ -247,7 +249,7 @@ def schedule_start_command(schedule_name, start_all, **kwargs):
 
 
 def execute_start_command(schedule_name, all_flag, cli_args, print_fn):
-    with DagsterInstance.get() as instance:
+    with get_instance_for_cli() as instance:
         with get_external_repository_from_kwargs(
             instance, version=dagster_version, kwargs=cli_args
         ) as external_repo:
@@ -285,7 +287,7 @@ def schedule_stop_command(schedule_name, **kwargs):
 
 
 def execute_stop_command(schedule_name, cli_args, print_fn, instance=None):
-    with DagsterInstance.get() as instance:
+    with get_instance_for_cli() as instance:
         with get_external_repository_from_kwargs(
             instance, version=dagster_version, kwargs=cli_args
         ) as external_repo:
@@ -319,7 +321,7 @@ def schedule_logs_command(schedule_name, **kwargs):
 
 
 def execute_logs_command(schedule_name, cli_args, print_fn, instance=None):
-    with DagsterInstance.get() as instance:
+    with get_instance_for_cli() as instance:
         with get_external_repository_from_kwargs(
             instance, version=dagster_version, kwargs=cli_args
         ) as external_repo:
@@ -385,7 +387,7 @@ def schedule_restart_command(schedule_name, restart_all_running, **kwargs):
 
 
 def execute_restart_command(schedule_name, all_running_flag, cli_args, print_fn):
-    with DagsterInstance.get() as instance:
+    with get_instance_for_cli() as instance:
         with get_external_repository_from_kwargs(
             instance, version=dagster_version, kwargs=cli_args
         ) as external_repo:
@@ -450,7 +452,7 @@ def schedule_wipe_command():
 
 
 def execute_wipe_command(print_fn):
-    with DagsterInstance.get() as instance:
+    with get_instance_for_cli() as instance:
         confirmation = click.prompt(
             "Are you sure you want to turn off all schedules and delete all schedule history? Type"
             " DELETE"
@@ -468,7 +470,7 @@ def schedule_debug_command():
 
 
 def execute_debug_command(print_fn):
-    with DagsterInstance.get() as instance:
+    with get_instance_for_cli() as instance:
         debug_info = instance.scheduler_debug_info()
 
         output = ""

--- a/python_modules/dagster/dagster/_cli/sensor.py
+++ b/python_modules/dagster/dagster/_cli/sensor.py
@@ -25,6 +25,8 @@ from dagster._core.scheduler.instigation import (
 from dagster._utils.error import serializable_error_info_from_exc_info
 from dagster._utils.yaml_utils import dump_run_config_yaml
 
+from .utils import get_instance_for_cli
+
 
 @click.group(name="sensor")
 def sensor_cli():
@@ -127,7 +129,7 @@ def sensor_list_command(running, stopped, name, **kwargs):
 
 
 def execute_list_command(running_filter, stopped_filter, name_filter, cli_args, print_fn):
-    with DagsterInstance.get() as instance:
+    with get_instance_for_cli() as instance:
         with get_external_repository_from_kwargs(
             instance, version=dagster_version, kwargs=cli_args
         ) as external_repo:
@@ -186,7 +188,7 @@ def sensor_start_command(sensor_name, start_all, **kwargs):
 
 
 def execute_start_command(sensor_name, all_flag, cli_args, print_fn):
-    with DagsterInstance.get() as instance:
+    with get_instance_for_cli() as instance:
         with get_external_repository_from_kwargs(
             instance, version=dagster_version, kwargs=cli_args
         ) as external_repo:
@@ -223,7 +225,7 @@ def sensor_stop_command(sensor_name, **kwargs):
 
 
 def execute_stop_command(sensor_name, cli_args, print_fn):
-    with DagsterInstance.get() as instance:
+    with get_instance_for_cli() as instance:
         with get_external_repository_from_kwargs(
             instance, version=dagster_version, kwargs=cli_args
         ) as external_repo:
@@ -269,7 +271,7 @@ def sensor_preview_command(sensor_name, since, last_run_key, cursor, **kwargs):
 def execute_preview_command(
     sensor_name, since, last_run_key, cursor, cli_args, print_fn, instance=None
 ):
-    with DagsterInstance.get() as instance:
+    with get_instance_for_cli() as instance:
         with get_code_location_from_kwargs(
             instance,
             version=dagster_version,
@@ -347,7 +349,7 @@ def sensor_cursor_command(sensor_name, **kwargs):
 
 
 def execute_cursor_command(sensor_name, cli_args, print_fn):
-    with DagsterInstance.get() as instance:
+    with get_instance_for_cli() as instance:
         with get_code_location_from_kwargs(
             instance, version=dagster_version, kwargs=cli_args
         ) as code_location:

--- a/python_modules/dagster/dagster/_core/instance/ref.py
+++ b/python_modules/dagster/dagster/_core/instance/ref.py
@@ -556,8 +556,7 @@ class InstanceRef(
         )
 
     @property
-    def secrets_loader(self) -> "SecretsLoader":
-        from dagster._core.secrets.env_file import EnvFileLoader
+    def secrets_loader(self) -> Optional["SecretsLoader"]:
         from dagster._core.secrets.loader import SecretsLoader
 
         # Defining a default here rather than in stored config to avoid
@@ -566,11 +565,7 @@ class InstanceRef(
         return (
             self.secrets_loader_data.rehydrate(as_type=SecretsLoader)
             if self.secrets_loader_data
-            else ConfigurableClassData(
-                "dagster._core.secrets.env_file",
-                "EnvFileLoader",
-                yaml.dump({}),
-            ).rehydrate(as_type=EnvFileLoader)
+            else None
         )
 
     @property

--- a/python_modules/dagster/dagster/_core/instance_for_test.py
+++ b/python_modules/dagster/dagster/_core/instance_for_test.py
@@ -8,31 +8,9 @@ import yaml
 
 from dagster._utils.error import serializable_error_info_from_exc_info
 
+from .._utils.env import environ
 from .._utils.merger import merge_dicts
 from .instance import DagsterInstance
-
-
-@contextmanager
-def environ(env: Mapping[str, str]) -> Iterator[None]:
-    """Temporarily set environment variables inside the context manager and
-    fully restore previous environment afterwards.
-    """
-    previous_values = {key: os.getenv(key) for key in env}
-    for key, value in env.items():
-        if value is None:
-            if key in os.environ:
-                del os.environ[key]
-        else:
-            os.environ[key] = value
-    try:
-        yield
-    finally:
-        for key, value in previous_values.items():
-            if value is None:
-                if key in os.environ:
-                    del os.environ[key]
-            else:
-                os.environ[key] = value
 
 
 @contextmanager

--- a/python_modules/dagster/dagster/_daemon/cli/__init__.py
+++ b/python_modules/dagster/dagster/_daemon/cli/__init__.py
@@ -5,6 +5,7 @@ from typing import Optional
 import click
 
 from dagster import __version__ as dagster_version
+from dagster._cli.utils import get_instance_for_cli
 from dagster._cli.workspace.cli_target import (
     ClickArgMapping,
     ClickArgValue,
@@ -58,9 +59,9 @@ def run_command(
 ) -> None:
     try:
         with capture_interrupts():
-            with DagsterInstance.from_ref(
-                deserialize_value(instance_ref, InstanceRef)
-            ) if instance_ref else DagsterInstance.get() as instance:
+            with get_instance_for_cli(
+                instance_ref=deserialize_value(instance_ref, InstanceRef) if instance_ref else None
+            ) as instance:
                 _daemon_run_command(instance, code_server_log_level, kwargs)
     except KeyboardInterrupt:
         return  # Exit cleanly on interrupt
@@ -86,7 +87,7 @@ def _daemon_run_command(
     help="Check for recent heartbeats from the daemon.",
 )
 def liveness_check_command() -> None:
-    with DagsterInstance.get() as instance:
+    with get_instance_for_cli() as instance:
         if all_daemons_live(instance, heartbeat_tolerance_seconds=_get_heartbeat_tolerance()):
             click.echo("Daemon live")
         else:
@@ -99,7 +100,7 @@ def liveness_check_command() -> None:
     help="Wipe all heartbeats from storage.",
 )
 def wipe_command() -> None:
-    with DagsterInstance.get() as instance:
+    with get_instance_for_cli() as instance:
         instance.wipe_daemon_heartbeats()
         click.echo("Daemon heartbeats wiped")
 
@@ -109,7 +110,7 @@ def wipe_command() -> None:
     help="Read and write a heartbeat",
 )
 def debug_heartbeat_command() -> None:
-    with DagsterInstance.get() as instance:
+    with get_instance_for_cli() as instance:
         debug_daemon_heartbeats(instance)
 
 
@@ -118,7 +119,7 @@ def debug_heartbeat_command() -> None:
     help="Log all heartbeat statuses",
 )
 def debug_heartbeat_dump_command() -> None:
-    with DagsterInstance.get() as instance:
+    with get_instance_for_cli() as instance:
         for daemon_status in get_daemon_statuses(instance, instance.get_required_daemon_types()):
             click.echo(daemon_status)
 

--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -264,11 +264,11 @@ class DagsterApiServer(DagsterApiServicer):
 
         try:
             if inject_env_vars_from_instance:
+                from dagster._cli.utils import get_instance_for_cli
+
                 # If arguments indicate it wants to load env vars, use the passed-in instance
                 # ref (or the dagster.yaml on the filesystem if no instance ref is provided)
-                with DagsterInstance.from_ref(
-                    instance_ref
-                ) if instance_ref else DagsterInstance.get() as instance:
+                with get_instance_for_cli(instance_ref=instance_ref) as instance:
                     instance.inject_env_vars(location_name)
 
             self._loaded_repositories: Optional[LoadedRepositories] = LoadedRepositories(

--- a/python_modules/dagster/dagster/_utils/env.py
+++ b/python_modules/dagster/dagster/_utils/env.py
@@ -1,0 +1,29 @@
+import os
+from contextlib import contextmanager
+from typing import (
+    Iterator,
+    Mapping,
+)
+
+
+@contextmanager
+def environ(env: Mapping[str, str]) -> Iterator[None]:
+    """Temporarily set environment variables inside the context manager and
+    fully restore previous environment afterwards.
+    """
+    previous_values = {key: os.getenv(key) for key in env}
+    for key, value in env.items():
+        if value is None:
+            if key in os.environ:
+                del os.environ[key]
+        else:
+            os.environ[key] = value
+    try:
+        yield
+    finally:
+        for key, value in previous_values.items():
+            if value is None:
+                if key in os.environ:
+                    del os.environ[key]
+            else:
+                os.environ[key] = value

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
@@ -1,4 +1,6 @@
+import os
 import re
+import tempfile
 from typing import Any, Mapping, Optional
 
 import pytest
@@ -13,6 +15,7 @@ from dagster import (
     reconstructable,
 )
 from dagster._check import CheckError
+from dagster._cli.utils import get_instance_for_cli
 from dagster._config import Field
 from dagster._core.definitions import build_assets_job
 from dagster._core.errors import (
@@ -25,7 +28,6 @@ from dagster._core.instance import DagsterInstance, InstanceRef
 from dagster._core.instance.config import DEFAULT_LOCAL_CODE_SERVER_STARTUP_TIMEOUT
 from dagster._core.launcher import LaunchRunContext, RunLauncher
 from dagster._core.run_coordinator.queued_run_coordinator import QueuedRunCoordinator
-from dagster._core.secrets.env_file import EnvFileLoader
 from dagster._core.snap import (
     create_execution_plan_snapshot_id,
     create_job_snapshot_id,
@@ -45,6 +47,7 @@ from dagster._core.test_utils import (
     create_run_for_test,
     environ,
     instance_for_test,
+    new_cwd,
 )
 from dagster._daemon.asset_daemon import AssetDaemon
 from dagster._serdes import ConfigurableClass
@@ -139,7 +142,7 @@ def test_unified_storage_env_var(tmpdir):
 
 def test_custom_secrets_manager():
     with instance_for_test() as instance:
-        assert isinstance(instance._secrets_loader, EnvFileLoader)  # noqa: SLF001
+        assert instance._secrets_loader is None  # noqa: SLF001
 
     with instance_for_test(
         overrides={
@@ -567,6 +570,43 @@ def test_dagster_home_not_dir():
             match=re.escape(f'$DAGSTER_HOME "{dirname}" is not a directory or does not exist.'),
         ):
             DagsterInstance.get()
+
+
+def test_dagster_env_vars_from_dotenv_file():
+    with tempfile.TemporaryDirectory() as working_dir, tempfile.TemporaryDirectory() as dagster_home:
+        # Create a dagster.yaml file in the dagster_home folder that requires SQLITE_STORAGE_BASE_DIR to be set
+        # (and DAGSTER_HOME to be set in order to find the dagster.yaml file)
+        with open(os.path.join(dagster_home, "dagster.yaml"), "w", encoding="utf8") as fd:
+            yaml.dump(
+                {
+                    "storage": {
+                        "sqlite": {
+                            "base_dir": {"env": "SQLITE_STORAGE_BASE_DIR"},
+                        }
+                    }
+                },
+                fd,
+                default_flow_style=False,
+            )
+
+        with new_cwd(working_dir):
+            with environ({"DAGSTER_HOME": None}):
+                # without .env file with a DAGSTER_HOME, loading fails
+                with pytest.raises(DagsterHomeNotSetError):
+                    with get_instance_for_cli():
+                        pass
+
+                storage_dir = os.path.join(dagster_home, "my_storage")
+                # with DAGSTER_HOME and SQLITE_STORAGE_BASE_DIR set in a .env file, DagsterInstacne succeeds
+                with open(os.path.join(working_dir, ".env"), "w", encoding="utf8") as fd:
+                    fd.write(f"DAGSTER_HOME={dagster_home}\n")
+                    fd.write(f"SQLITE_STORAGE_BASE_DIR={storage_dir}\n")
+
+                with get_instance_for_cli() as instance:
+                    assert (
+                        _runs_directory(str(storage_dir))
+                        in instance.run_storage._conn_string  # noqa: SLF001
+                    )
 
 
 class TestInstanceSubclass(DagsterInstance):


### PR DESCRIPTION
Summary:
This PR intends to address a point of user confusion that comes up frequently in support - we tell users in our docs to put env vars in a .env file and they'll be automatically injected into the environment, but it doesn't apply to our own dagster env vars, just the ones that are used in their code. So users still hit the same friction / confusion that the .env file is intended to address.

So instead of using a pluggable component and defaulting it to a SecretLoader that pulls from a local .env file but is only called in certain CLIs, make it called in every CLI / Dagster entrypoint.

I thought about putting this directly in DagsterInstance.get() but it seemed bad to add a permanent side effect there that wasn't there before, and there are many places where we create a DagsterInstance outside of a process entrypoint that wouldn't need to inject the env vars.

Will add testing after any initial thoughts on this direction.

## Summary & Motivation

## How I Tested These Changes
