### PR TITLE
fix(dbt): default capture_logs to True

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources.py
@@ -109,7 +109,7 @@ class ConfigurableResourceWithCliFlags(ConfigurableResource):
         ),
     )
     capture_logs: bool = Field(
-        default=False,
+        default=True,
         description=(
             "When True, dbt will invoked with the `--capture-output` flag, allowing "
             "Dagster to capture the logs and emit them to the event log."


### PR DESCRIPTION
## Summary & Motivation
Resolves https://github.com/dagster-io/dagster/issues/14374.

In https://github.com/dagster-io/dagster/pull/13816, the default value for this configuration was changed to be `False`. Revert that.

## How I Tested These Changes
local
