### PR TITLE
feat(dbt): add argument to modify partitions def on dbt_assets

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
@@ -1,6 +1,6 @@
 from typing import Callable, Optional
 
-from dagster import AssetsDefinition, multi_asset
+from dagster import AssetsDefinition, PartitionsDefinition, multi_asset
 from dagster._annotations import experimental
 
 from .asset_utils import get_dbt_multi_asset_args, get_deps
@@ -14,6 +14,7 @@ def dbt_assets(
     manifest: DbtManifest,
     select: str = "fqn:*",
     exclude: Optional[str] = None,
+    partitions_def: Optional[PartitionsDefinition] = None,
 ) -> Callable[..., AssetsDefinition]:
     """Create a definition for how to compute a set of dbt resources, described by a manifest.json.
 
@@ -54,6 +55,7 @@ def dbt_assets(
             internal_asset_deps=internal_asset_deps,
             non_argument_deps=non_argument_deps,
             compute_kind="dbt",
+            partitions_def=partitions_def,
             can_subset=True,
             op_tags={
                 **({"dagster-dbt/select": select} if select else {}),

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_decorator.py
@@ -1,7 +1,7 @@
 from typing import AbstractSet, Optional
 
 import pytest
-from dagster import AssetKey, file_relative_path
+from dagster import AssetKey, DailyPartitionsDefinition, PartitionsDefinition, file_relative_path
 from dagster_dbt.asset_decorator import dbt_assets
 from dagster_dbt.cli import DbtManifest
 
@@ -114,3 +114,14 @@ def test_selections(
     expected_select_tag = "fqn:*" if select is None else select
     assert my_dbt_assets.op.tags.get("dagster-dbt/select") == expected_select_tag
     assert my_dbt_assets.op.tags.get("dagster-dbt/exclude") == exclude
+
+
+@pytest.mark.parametrize(
+    "partitions_def", [None, DailyPartitionsDefinition(start_date="2023-01-01")]
+)
+def test_partitions_def(partitions_def: Optional[PartitionsDefinition]) -> None:
+    @dbt_assets(manifest=manifest, partitions_def=partitions_def)
+    def my_dbt_assets():
+        ...
+
+    assert my_dbt_assets.partitions_def == partitions_def


### PR DESCRIPTION
## Summary & Motivation
Ideally, this should be on the `.with_attributes` decorator (https://github.com/dagster-io/dagster/pull/14349). But for now, at least give a hook into defining this setting in one place, rather than mutating the `AssetsDefinition` after the fact using the `.with_attributes` method.

## How I Tested These Changes
local, pytest
