### PR TITLE
[dagster-dbt] enforce op_name

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
@@ -382,9 +382,10 @@ def _dbt_nodes_to_assets(
     )
 
     # prevent op name collisions between multiple dbt multi-assets
-    op_name = op_name or f"run_dbt_{project_id}"
-    if select != "fqn:*" or exclude:
-        op_name += "_" + hashlib.md5(select.encode() + exclude.encode()).hexdigest()[-5:]
+    if not op_name:
+        op_name = f"run_dbt_{project_id}"
+        if select != "fqn:*" or exclude:
+            op_name += "_" + hashlib.md5(select.encode() + exclude.encode()).hexdigest()[-5:]
 
     dbt_op = _get_dbt_op(
         op_name=op_name,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
@@ -666,7 +666,7 @@ def test_op_custom_name():
                     manifest_json=json.load(manifest_json),
                     key_prefix=[instance["target"], "duckdb", "test-schema"],
                     op_name=f"{instance['target']}_dbt_op",
-                    select="fqn:* tag:*",
+                    select="fqn:* fqn:*",  # just a non-default selection
                 )
             )
     op_names = [asset_group.op.name for asset_group in dbt_assets]

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
@@ -666,6 +666,7 @@ def test_op_custom_name():
                     manifest_json=json.load(manifest_json),
                     key_prefix=[instance["target"], "duckdb", "test-schema"],
                     op_name=f"{instance['target']}_dbt_op",
+                    select="fqn:* tag:*",
                 )
             )
     op_names = [asset_group.op.name for asset_group in dbt_assets]
@@ -674,6 +675,7 @@ def test_op_custom_name():
         f"dbt targets were: {instances}\n"
         f"op names generated were: {op_names}"
     )
+    assert set(op_names) == {"target_a_dbt_op", "target_b_dbt_op"}
 
 
 @pytest.mark.parametrize("load_from_manifest", [True, False])


### PR DESCRIPTION
## Summary & Motivation

If the user sets the op_name, that should be the op_name, regardless of any select strings etc.

## How I Tested These Changes

Updated test failed before the change, passes after.