### PR TITLE
Fix cleanup issue with OpExecutionContext

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -120,13 +120,12 @@ class UnboundOpExecutionContext(OpExecutionContext):
 
     def __exit__(self, *exc):
         self._resources_cm.__exit__(*exc)
-        if self._instance_provided:
-            self._instance_cm.__exit__(*exc)
+        self._instance_cm.__exit__(*exc)
 
     def __del__(self):
         if self._resources_contain_cm and not self._cm_scope_entered:
             self._resources_cm.__exit__(None, None, None)
-        if self._instance_provided and not self._cm_scope_entered:
+        if not self._cm_scope_entered:
             self._instance_cm.__exit__(None, None, None)
 
     @property

--- a/python_modules/dagster/dagster_tests/core_tests/test_op_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_op_invocation.py
@@ -85,6 +85,18 @@ def test_op_invocation_none_arg():
     assert result == 5
 
 
+def test_op_invocation_lifecycle():
+    @op
+    def basic_op(context):
+        return 5
+
+    with build_op_context() as context:
+        pass
+
+    # Verify dispose was called on the instance
+    assert context.instance.run_storage._held_conn.closed  # noqa
+
+
 def test_op_invocation_context_arg():
     @op
     def basic_op(context):


### PR DESCRIPTION
Summary:
We were always entering this contextmanager but not always leaving it, causing surprising error spew even when you use the op context as a contextmanager. Fix that.

Test Plan:

BK, and

The following script:
```
@asset
def my_asset(context):
    pass

def test_asset() -> None:
    with build_op_context() as context:
        actual = my_asset(context)

    assert False
```

No longer produces weird error spew.

## Summary & Motivation

## How I Tested These Changes
