### PR TITLE
[ui] Repair path-prefix

### DIFF
--- a/js_modules/dagit/packages/app/src/publicPath.ts
+++ b/js_modules/dagit/packages/app/src/publicPath.ts
@@ -10,7 +10,7 @@ const extracted = extractInitializationData();
 // Set the webpack path prefix based on DOM value. This will be used
 // for dynamically loaded bundles.
 if (typeof extracted.pathPrefix === 'string') {
-  (window as any).__webpack_public_path__ = `${extracted.pathPrefix}/`;
+  __webpack_public_path__ = `${extracted.pathPrefix}/`;
 }
 
 export {};

--- a/js_modules/dagit/packages/app/src/typings.d.ts
+++ b/js_modules/dagit/packages/app/src/typings.d.ts
@@ -8,6 +8,8 @@ declare module '@vx/responsive';
 
 declare module 'amator';
 
+declare let __webpack_public_path__: string;
+
 // Type declarations for Clipboard API
 // https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API
 interface Clipboard {


### PR DESCRIPTION
## Summary & Motivation

With the upgrade to Storybook, `@types/webpack` was eliminated, which removed the global type declaration for `__webpack_public_path__`. In an effort to repair the resulting type error, I added a `(window as any)` to the variable in `publicPath.ts`. It appears that this is what led to the breakage of path prefixing.

By manually adding a type declaration for this Webpack global in our own typedef file, I can remove the `(window as any)` annotation, and the variable goes back to working properly.

## How I Tested These Changes

`yarn build`, load dagit with a path-prefix. Verify that the app loads, and that all JS assets are retrieved properly.
