### PR TITLE
Add `hooks` argument to `define_asset_job`

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -18,6 +18,7 @@ from typing import (
 )
 
 import dagster._check as check
+from dagster._core.definitions.hook_definition import HookDefinition
 from dagster._core.definitions.metadata import (
     ArbitraryMetadataMapping,
     RawMetadataValue,
@@ -745,6 +746,7 @@ def build_asset_selection_job(
     metadata: Optional[Mapping[str, RawMetadataValue]] = None,
     asset_selection: Optional[AbstractSet[AssetKey]] = None,
     asset_selection_data: Optional[AssetSelectionData] = None,
+    hooks: Optional[AbstractSet[HookDefinition]] = None,
 ) -> "JobDefinition":
     from dagster._core.definitions.assets_job import (
         build_assets_job,
@@ -783,6 +785,7 @@ def build_asset_selection_job(
             description=description,
             tags=tags,
             metadata=metadata,
+            hooks=hooks,
             _asset_selection_data=asset_selection_data,
         )
     else:
@@ -795,6 +798,7 @@ def build_asset_selection_job(
             partitions_def=partitions_def,
             description=description,
             tags=tags,
+            hooks=hooks,
             _asset_selection_data=asset_selection_data,
         )
 

--- a/python_modules/dagster/dagster/_core/definitions/assets_job.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets_job.py
@@ -252,6 +252,7 @@ def build_source_asset_observation_job(
     tags: Optional[Mapping[str, str]] = None,
     executor_def: Optional[ExecutorDefinition] = None,
     partitions_def: Optional[PartitionsDefinition] = None,
+    hooks: Optional[AbstractSet[HookDefinition]] = None,
     _asset_selection_data: Optional[AssetSelectionData] = None,
 ) -> JobDefinition:
     """Builds a job that observes the given source assets.
@@ -338,6 +339,7 @@ def build_source_asset_observation_job(
         executor_def=executor_def,
         partitions_def=partitions_def,
         asset_layer=asset_layer,
+        hooks=hooks,
         _asset_selection_data=_asset_selection_data,
     )
 

--- a/python_modules/dagster/dagster/_core/definitions/assets_job.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets_job.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 from typing import (
     TYPE_CHECKING,
+    AbstractSet,
     Any,
     Dict,
     Iterable,
@@ -16,6 +17,7 @@ from typing import (
 from toposort import CircularDependencyError, toposort
 
 import dagster._check as check
+from dagster._core.definitions.hook_definition import HookDefinition
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.selector.subset_selector import AssetSelectionData
 from dagster._utils.merger import merge_dicts
@@ -120,6 +122,7 @@ def build_assets_job(
     metadata: Optional[Mapping[str, RawMetadataValue]] = None,
     executor_def: Optional[ExecutorDefinition] = None,
     partitions_def: Optional[PartitionsDefinition] = None,
+    hooks: Optional[AbstractSet[HookDefinition]] = None,
     _asset_selection_data: Optional[AssetSelectionData] = None,
 ) -> JobDefinition:
     """Builds a job that materializes the given assets.
@@ -235,6 +238,7 @@ def build_assets_job(
         executor_def=executor_def,
         partitions_def=partitions_def,
         asset_layer=asset_layer,
+        hooks=hooks,
         _asset_selection_data=_asset_selection_data,
     )
 


### PR DESCRIPTION
## Summary & Motivation

Resolves: https://github.com/dagster-io/dagster/issues/14419

While this resolves the immediate issue, it still does not enable users to set the `hooks` parameter when using the `@asset` decorator (or similar). This is because currently `AssetsDefinition` expects an `OpDefinition`, but once you apply hooks to an op, it gets turned into a `PendingNodeInvocation` object. This gets a little trickier to resolve so I've left it out of this PR.

## How I Tested These Changes
