### PR TITLE
[ui] Limit useViewport ResizeObserver

### DIFF
--- a/js_modules/dagit/packages/ui/src/components/useViewport.tsx
+++ b/js_modules/dagit/packages/ui/src/components/useViewport.tsx
@@ -64,10 +64,13 @@ export const useViewport = (
     let resizeObserver: any;
     if (element instanceof HTMLElement) {
       if ('ResizeObserver' in window) {
-        resizeObserver = new window['ResizeObserver']((entries: any) => {
-          if (entries[0].target === element) {
-            onApplySize({width: element.clientWidth, height: element.clientHeight});
-          }
+        resizeObserver = new window['ResizeObserver']((entries: ResizeObserverEntry[]) => {
+          window.requestAnimationFrame(() => {
+            const target = entries[0]?.target;
+            if (target === element) {
+              onApplySize({width: element.clientWidth, height: element.clientHeight});
+            }
+          });
         });
         resizeObserver.observe(element);
       } else {


### PR DESCRIPTION
## Summary & Motivation

A "ResizeObserver loop limit exceeded" error keeps popping up on the run timeline in dev. Fix this by changing `useViewport`'s observer handler to use `requestAnimationFrame`.

## How I Tested These Changes

Load dev app on run timeline, verify that the loop error doesn't fire.
