### PR TITLE
feat(dbt): automatically apply asset key replacements using the manifest

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
@@ -63,6 +63,9 @@ def dbt_assets(
             },
         )(fn)
 
-        return asset_definition
+        return asset_definition.with_attributes(
+            input_asset_key_replacements=manifest.asset_key_replacements,
+            output_asset_key_replacements=manifest.asset_key_replacements,
+        )
 
     return inner

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources_v2.py
@@ -75,7 +75,7 @@ class DbtManifest:
         return {output_name_fn(node): node for node in self.node_info_by_dbt_unique_id.values()}
 
     @property
-    def output_asset_key_replacements(self) -> Mapping[AssetKey, AssetKey]:
+    def asset_key_replacements(self) -> Mapping[AssetKey, AssetKey]:
         """A mapping of replacement asset keys for a dbt node to the node's dictionary representation in the manifest.
         """
         return {

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_decorator.py
@@ -1,4 +1,4 @@
-from typing import AbstractSet, Optional
+from typing import AbstractSet, Any, Mapping, Optional
 
 import pytest
 from dagster import AssetKey, DailyPartitionsDefinition, PartitionsDefinition, file_relative_path
@@ -125,3 +125,29 @@ def test_partitions_def(partitions_def: Optional[PartitionsDefinition]) -> None:
         ...
 
     assert my_dbt_assets.partitions_def == partitions_def
+
+
+@pytest.mark.parametrize(
+    "partitions_def", [None, DailyPartitionsDefinition(start_date="2023-01-01")]
+)
+def test_with_attributes(partitions_def: Optional[PartitionsDefinition]) -> None:
+    class CustomizedDbtManifest(DbtManifest):
+        @classmethod
+        def node_info_to_asset_key(cls, node_info: Mapping[str, Any]) -> AssetKey:
+            return AssetKey(["prefix", *super().node_info_to_asset_key(node_info).path])
+
+    manifest = CustomizedDbtManifest.read(path=manifest_path)
+
+    @dbt_assets(manifest=manifest, partitions_def=partitions_def)
+    def my_dbt_assets():
+        ...
+
+    assert my_dbt_assets.keys_by_input_name == {}
+    assert set(my_dbt_assets.keys_by_output_name.values()) == {
+        AssetKey(["prefix", "cereals"]),
+        AssetKey(["prefix", "cold_schema", "sort_cold_cereals_by_calories"]),
+        AssetKey(["prefix", "subdir_schema", "least_caloric"]),
+        AssetKey(["prefix", "orders_snapshot"]),
+        AssetKey(["prefix", "sort_hot_cereals_by_calories"]),
+        AssetKey(["prefix", "sort_by_calories"]),
+    }


### PR DESCRIPTION
## Summary & Motivation
Because we have access to the manifest, the source of truth of mappings, and the underlying `AssetsDefinition`, just apply the new mappings onto the created definition. We do not need to wait for the user to do it.

Originally, this was going to live in the `.with_attributes` decorator, but this seems more ergonomic.

## How I Tested These Changes
pytest
