### PR TITLE
Don't log evaluations in asset daemon

### DIFF
--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -48,17 +48,6 @@ class AssetDaemon(IntervalDaemon):
             yield
             return
 
-        schedule_storage = check.not_none(
-            instance.schedule_storage,
-            "Auto materialization requires schedule storage to be configured",
-        )
-
-        if not schedule_storage.supports_auto_materialize_asset_evaluations:
-            self._logger.warning(
-                "Auto materialize evaluations are not getting logged. Run `dagster instance"
-                " migrate` to enable."
-            )
-
         workspace = workspace_process_context.create_request_context()
         asset_graph = ExternalAssetGraph.from_workspace(workspace)
         target_asset_keys = {
@@ -88,11 +77,6 @@ class AssetDaemon(IntervalDaemon):
             cursor=cursor,
             run_tags=None,
         )
-
-        if schedule_storage.supports_auto_materialize_asset_evaluations:
-            schedule_storage.add_auto_materialize_asset_evaluations(
-                check.not_none(new_cursor.evaluation_id), evaluations
-            )
 
         for run_request in run_requests:
             yield


### PR DESCRIPTION
Since we didn't manage to ship the UI for evaluations in this release, I think we should consider not turning on storing anything. We've had a couple late changes to what we want to store, and this would give us another week for any more changes.

We also haven't added cleaning up old ticks