### PR TITLE
Pin around pydantic 1.10.7

### DIFF
--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -91,7 +91,7 @@ setup(
         "tabulate",
         "tomli",
         "tqdm",
-        "typing_extensions>=4.4.0,<4.6.0",
+        "typing_extensions>=4.4.0",
         "sqlalchemy>=1.0,<2.0.0",
         "toposort>=1.0",
         "watchdog>=0.8.3",
@@ -100,7 +100,8 @@ setup(
         'pywin32 != 226; platform_system=="Windows"',
         "docstring-parser",
         "universal_pathlib",
-        "pydantic",
+        # https://github.com/pydantic/pydantic/issues/5821
+        "pydantic != 1.10.7",
     ],
     extras_require={
         "docker": ["docker"],


### PR DESCRIPTION
This removes the pin introduced in:

https://github.com/dagster-io/dagster/pull/14407

Because pydantic has now fixed the underlying cause. Instead, we'll pin around the affected version of pydantic.