### PR TITLE
[Runs page] Fix cursor being reset when going to older

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/RunsFilterInput.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunsFilterInput.tsx
@@ -203,14 +203,20 @@ export interface RunsFilterInputProps {
 
 export const RunsFilterInput = (props: RunsFilterInputProps) => {
   const {flagRunsTableFiltering} = useFeatureFlags();
-  const {button, activeFiltersJsx} = useRunsFilterInputNew(props);
   return flagRunsTableFiltering ? (
+    <RunsFilterInputNew {...props} />
+  ) : (
+    <RunsFilterInputImpl {...props} />
+  );
+};
+
+const RunsFilterInputNew = (props: RunsFilterInputProps) => {
+  const {button, activeFiltersJsx} = useRunsFilterInputNew(props);
+  return (
     <div>
       {button}
       {activeFiltersJsx}
     </div>
-  ) : (
-    <RunsFilterInputImpl {...props} />
   );
 };
 


### PR DESCRIPTION
## Summary & Motivation

This is due to the hook for the news runs table being used even when the new runs table isn't being used. I moved the hook into a separate component. 

## How I Tested These Changes
Load the runs table and see the issue go away
👀 
