### PR TITLE
Enable different start/end partitions defs in TimeWindowPartitionMapping

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -298,17 +298,6 @@ class TimeWindowPartitionsDefinition(
             )
         return partition_def_str
 
-    def __eq__(self, other):
-        return (
-            isinstance(other, TimeWindowPartitionsDefinition)
-            and pendulum.instance(self.start, tz=self.timezone).timestamp()
-            == pendulum.instance(other.start, tz=other.timezone).timestamp()
-            and self.timezone == other.timezone
-            and self.fmt == other.fmt
-            and self.end_offset == other.end_offset
-            and self.cron_schedule == other.cron_schedule
-        )
-
     def __repr__(self):
         # Between python 3.8 and 3.9 the repr of a datetime object changed.
         # Replaces start time with timestamp as a workaround to make sure the repr is consistent across versions.

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_time_window_partition_mapping.py
@@ -526,7 +526,7 @@ def test_different_start_time_partitions_defs():
         ).get_partition_keys()
 
     assert (
-        TimeWindowPartitionMapping(raise_error_on_nonexistent_upstream_partition=False)
+        TimeWindowPartitionMapping(allow_nonexistent_upstream_partitions=True)
         .get_upstream_partitions_for_partitions(
             downstream_partitions_subset=subset_with_keys(jan_start, ["2023-01-15"]),
             upstream_partitions_def=feb_start,
@@ -562,7 +562,7 @@ def test_different_end_time_partitions_defs():
         ).get_partition_keys()
 
     assert (
-        TimeWindowPartitionMapping(raise_error_on_nonexistent_upstream_partition=False)
+        TimeWindowPartitionMapping(allow_nonexistent_upstream_partitions=True)
         .get_upstream_partitions_for_partitions(
             downstream_partitions_subset=subset_with_keys(jan_feb_partitions_def, ["2023-02-15"]),
             upstream_partitions_def=jan_partitions_def,

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
@@ -683,7 +683,7 @@ def test_error_on_nonexistent_upstream_partition():
         return upstream_asset + 1
 
     with pendulum.test(create_pendulum_time(2020, 1, 2, 10, 0)):
-        with pytest.raises(DagsterInvalidInvocationError, match="invalid time window"):
+        with pytest.raises(DagsterInvalidInvocationError, match="nonexistent time windows"):
             materialize(
                 [downstream_asset, upstream_asset.to_source_asset()],
                 partition_key="2020-01-02-05:00",

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
@@ -683,7 +683,7 @@ def test_error_on_nonexistent_upstream_partition():
         return upstream_asset + 1
 
     with pendulum.test(create_pendulum_time(2020, 1, 2, 10, 0)):
-        with pytest.raises(DagsterInvalidInvocationError, match="invalid time windows"):
+        with pytest.raises(DagsterInvalidInvocationError, match="invalid time window"):
             materialize(
                 [downstream_asset, upstream_asset.to_source_asset()],
                 partition_key="2020-01-02-05:00",


### PR DESCRIPTION
Requested by a user: https://dagster.slack.com/archives/C01U954MEER/p1682972599494859

Sometimes, a downstream time-partitioned asset Z might be dependent on an upstream time-partitioned asset Y that starts later than B. For example:
- Assets Z and X are partitioned daily, starting 2022-01-01
- Logic was changed recently to make Z dependent on X _and_ Y, but Y only exists starting on 2022-06-01
- Z should be able to execute on partitions before 2022-06-01, with Y being passed in as a null value

Selecting one of these partitions with a nonexistent upstream errors within a call to `get_upstream_partitions_for_partitions`.


This PR enables this behavior by adding an additional `raise_error_on_nonexistent_upstream_partition` arg to `TimeWindowPartitionsDefinition`, which when set to True (the default) raises an error when upstream partitions fall outside of the start-end time range of their partitions def. 

For the users above in this special case, they can set this bool to False. In this case, no error will be raised and the method will just filter for existent partitions. There are no changes to behavior for when `get_downstream_partitions_for_partitions` is called.