### PR TITLE
[snowflake] remove unused filter password function

### DIFF
--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
@@ -688,8 +688,3 @@ def snowflake_resource(context) -> SnowflakeConnection:
     return SnowflakeConnection(
         config=context, log=context.log, snowflake_connection_resource=snowflake_resource
     )
-
-
-def _filter_password(args):
-    """Remove password from connection args for logging."""
-    return {k: v for k, v in args.items() if k != "password"}


### PR DESCRIPTION
## Summary & Motivation
A while ago (like several years ago) we used to log the snowflake connection arguments, but we don't do that anymore. This `_filter_password` function is leftover from that logging, but never got removed

## How I Tested These Changes
