### PR TITLE
[ui] Clean up loading and error states on op job partitions view

### DIFF
--- a/js_modules/dagit/packages/core/src/partitions/types/OpJobPartitionsView.types.ts
+++ b/js_modules/dagit/packages/core/src/partitions/types/OpJobPartitionsView.types.ts
@@ -17,7 +17,16 @@ export type PartitionsStatusQuery = {
         pipelineName: string;
         partitionsOrError:
           | {__typename: 'Partitions'; results: Array<{__typename: 'Partition'; name: string}>}
-          | {__typename: 'PythonError'};
+          | {
+              __typename: 'PythonError';
+              message: string;
+              stack: Array<string>;
+              errorChain: Array<{
+                __typename: 'ErrorChainLink';
+                isExplicitLink: boolean;
+                error: {__typename: 'PythonError'; message: string; stack: Array<string>};
+              }>;
+            };
         partitionStatusesOrError:
           | {
               __typename: 'PartitionStatuses';
@@ -40,8 +49,17 @@ export type PartitionsStatusQuery = {
               }>;
             };
       }
-    | {__typename: 'PartitionSetNotFoundError'}
-    | {__typename: 'PythonError'};
+    | {__typename: 'PartitionSetNotFoundError'; message: string}
+    | {
+        __typename: 'PythonError';
+        message: string;
+        stack: Array<string>;
+        errorChain: Array<{
+          __typename: 'ErrorChainLink';
+          isExplicitLink: boolean;
+          error: {__typename: 'PythonError'; message: string; stack: Array<string>};
+        }>;
+      };
 };
 
 export type OpJobPartitionSetFragment = {
@@ -51,7 +69,16 @@ export type OpJobPartitionSetFragment = {
   pipelineName: string;
   partitionsOrError:
     | {__typename: 'Partitions'; results: Array<{__typename: 'Partition'; name: string}>}
-    | {__typename: 'PythonError'};
+    | {
+        __typename: 'PythonError';
+        message: string;
+        stack: Array<string>;
+        errorChain: Array<{
+          __typename: 'ErrorChainLink';
+          isExplicitLink: boolean;
+          error: {__typename: 'PythonError'; message: string; stack: Array<string>};
+        }>;
+      };
   partitionStatusesOrError:
     | {
         __typename: 'PartitionStatuses';


### PR DESCRIPTION
## Summary & Motivation

We're currently showing `null` on the op job partitions view when the query response has errors, which doesn't give the user much information about what's going on.

Instead, surface a few error states, including Python errors. I'm also removing the `<Loading>` component usage here, because I think we need to rethink that component.

I don't think this will help us track down the weird JS error spotted in Cloud this morning, but it should at least give the user a bit more context about what's going on on the page.

## How I Tested These Changes

View a partition tab in a case where Python errors are being returned in the response, verify correct loading state, and verify that the red box appears on the page post-response.

View partition tabs on successful pages, verify that they render correctly.
