### PR TITLE
Document that env vars need to be set on both code servers and runs in order to work when used in resources

### DIFF
--- a/docs/content/deployment/guides/aws.mdx
+++ b/docs/content/deployment/guides/aws.mdx
@@ -50,7 +50,7 @@ The Deploying on ECS example on GitHub demonstrates how to configure the [Docker
 - A Dagit container for loading and launching jobs
 - A `dagster-daemon` container for managing a run queue and submitting runs from schedules and sensors
 - A Postgres container for persistent storage
-- A container with user job code
+- A code server container that provides information about your code to Dagit and the daemon.
 
 The [Dagster instance](/deployment/dagster-instance) uses the <PyObject module="dagster_aws.ecs" object="EcsRunLauncher" /> to launch each run in its own ECS task.
 
@@ -199,6 +199,8 @@ run_launcher:
 ```
 
 In this example, any secret tagged with `dagster` will be included in the environment. `MY_API_TOKEN` and `MY_PASSWORD` will also be included in the environment.
+
+Note that these secrets may also need to be included in your code server task definition if they are checked when your code is imported or referenced as <PyObject object="EnvVar" />s in your job configuration.
 
 ---
 

--- a/docs/content/deployment/guides/docker.mdx
+++ b/docs/content/deployment/guides/docker.mdx
@@ -162,6 +162,8 @@ This launcher will start each run in a new container, using whatever image set i
 
 Any container that launches runs - usually the `dagster-daemon` container if you're maintaining a [run queue](/guides/customizing-run-queue-priority) or launching runs from schedules or sensors - must have permissions to create Docker containers in order to use this run launcher. Mounting `/var/run/docker.sock` as a volume is one way to give it these permissions.
 
+Note that any environment variables listed in the run launcher may also need to be included in your code server container if they are checked when your code is imported or referenced as <PyObject object="EnvVar" />s in your job configuration.
+
 ---
 
 ## Mounting volumes

--- a/docs/content/guides/dagster/using-environment-variables-and-secrets.mdx
+++ b/docs/content/guides/dagster/using-environment-variables-and-secrets.mdx
@@ -296,8 +296,8 @@ Using this info, we can write code that executes differently when in a Branch De
       </td>
       <td>
         Surfacing when a run is launched in Dagit, this error means that an
-        environment variable set using <PyObject object="StringSource" /> could
-        not be found in the executing environment.
+        environment variable set using <PyObject object="EnvVar" /> could not be
+        found in the executing environment.
         <br></br>
         <br></br>
         Verify that the environment variable is named correctly and accessible in
@@ -307,6 +307,19 @@ Using this info, we can write code that executes differently when in a Branch De
             If developing locally and using a <code>.env</code> file, try
             re-loading the workspace in Dagit. The workspace must be re-loaded
             any time this file is modified for Dagit to be aware of the changes.
+          </li>
+          <li>
+            If deploying Dagster in an environment where there are separately
+            deployed code servers (for example, in Docker, Kubernetes, or Amazon
+            ECS), make sure that the environment variable is set in the code
+            server as well as the run launcher. In Kubernetes, you can{" "}
+            <a href="/deployment/guides/kubernetes/deploying-with-helm#step-61-configure-the-deployment">
+              configure your code server
+            </a>{" "}
+            so that environment variables are automatically included in both code servers and
+            runs. In other deployment scenarios, you may need to configure the
+            environment variable twice, once in the code server and once in the
+            run launcher in your `dagster.yaml` file.
           </li>
           <li>
             If using Dagster Cloud:


### PR DESCRIPTION
Summary:
Document a rough edge in the troubleshooting guide that often trips people up when deploying OSS.

## Summary & Motivation

## How I Tested These Changes
