### PR TITLE
autoMaterializeAssetEvaluations make cursor not required

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -992,7 +992,7 @@ class GrapheneDagitQuery(graphene.ObjectType):
         graphene_info: ResolveInfo,
         assetKey: GrapheneAssetKeyInput,
         limit: int,
-        cursor: Optional[str],
+        cursor: Optional[str] = None,
     ):
         return fetch_auto_materialize_asset_evaluations(
             instance=graphene_info.context.instance, asset_key=assetKey, cursor=cursor, limit=limit


### PR DESCRIPTION
The gql type is optional but no default was provided to the resolver, so it could raise `TypeError: resolve_autoMaterializeAssetEvaluations() missing 1 required positional argument: 'cursor'\n"`