### PR TITLE
Purge asset daemon evaluations

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -698,8 +698,8 @@ class LegacyScheduleStorage(ScheduleStorage, ConfigurableClass):
             asset_key, limit, cursor
         )
 
-    def purge_evaluations(self, before: float):
-        return self._storage.schedule_storage.purge_evaluations(before)
+    def purge_asset_evaluations(self, before: float):
+        return self._storage.schedule_storage.purge_asset_evaluations(before)
 
     def upgrade(self) -> None:
         return self._storage.schedule_storage.upgrade()

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -698,6 +698,9 @@ class LegacyScheduleStorage(ScheduleStorage, ConfigurableClass):
             asset_key, limit, cursor
         )
 
+    def purge_evaluations(self, before: float):
+        return self._storage.schedule_storage.purge_evaluations(before)
+
     def upgrade(self) -> None:
         return self._storage.schedule_storage.upgrade()
 

--- a/python_modules/dagster/dagster/_core/storage/schedules/base.py
+++ b/python_modules/dagster/dagster/_core/storage/schedules/base.py
@@ -162,6 +162,14 @@ class ScheduleStorage(abc.ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         """
 
     @abc.abstractmethod
+    def purge_evaluations(self, before: float) -> None:
+        """Wipe evaluations before a certain timestamp.
+
+        Args:
+            before (datetime): All evaluations before this datetime will get purged
+        """
+
+    @abc.abstractmethod
     def upgrade(self) -> None:
         """Perform any needed migrations."""
 

--- a/python_modules/dagster/dagster/_core/storage/schedules/base.py
+++ b/python_modules/dagster/dagster/_core/storage/schedules/base.py
@@ -162,7 +162,7 @@ class ScheduleStorage(abc.ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         """
 
     @abc.abstractmethod
-    def purge_evaluations(self, before: float) -> None:
+    def purge_asset_evaluations(self, before: float) -> None:
         """Wipe evaluations before a certain timestamp.
 
         Args:

--- a/python_modules/dagster/dagster/_core/storage/schedules/sql_schedule_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/schedules/sql_schedule_storage.py
@@ -511,7 +511,7 @@ class SqlScheduleStorage(ScheduleStorage):
             rows = db_fetch_mappings(conn, query)
             return [AutoMaterializeAssetEvaluationRecord.from_db_row(row) for row in rows]
 
-    def purge_evaluations(self, before: float):
+    def purge_asset_evaluations(self, before: float):
         check.float_param(before, "before")
 
         utc_before = utc_datetime_from_timestamp(before)

--- a/python_modules/dagster/dagster/_core/storage/schedules/sql_schedule_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/schedules/sql_schedule_storage.py
@@ -511,6 +511,17 @@ class SqlScheduleStorage(ScheduleStorage):
             rows = db_fetch_mappings(conn, query)
             return [AutoMaterializeAssetEvaluationRecord.from_db_row(row) for row in rows]
 
+    def purge_evaluations(self, before: float):
+        check.float_param(before, "before")
+
+        utc_before = utc_datetime_from_timestamp(before)
+        query = AssetDaemonAssetEvaluationsTable.delete().where(
+            AssetDaemonAssetEvaluationsTable.c.create_timestamp < utc_before
+        )
+
+        with self.connect() as conn:
+            conn.execute(query)
+
     def wipe(self) -> None:
         """Clears the schedule storage."""
         with self.connect() as conn:

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -1,5 +1,7 @@
 from typing import Optional
 
+import pendulum
+
 import dagster._check as check
 from dagster._core.definitions.asset_reconciliation_sensor import (
     AssetReconciliationCursor,
@@ -15,6 +17,8 @@ from dagster._daemon.daemon import DaemonIterator, IntervalDaemon
 
 CURSOR_KEY = "ASSET_DAEMON_CURSOR"
 ASSET_DAEMON_PAUSED_KEY = "ASSET_DAEMON_PAUSED"
+
+EVALUATIONS_TTL_DAYS = 7
 
 
 def get_auto_materialize_paused(instance: DagsterInstance) -> bool:
@@ -169,5 +173,8 @@ class AssetDaemon(IntervalDaemon):
         # so that if the daemon crashes and doesn't update the cursor we don't try to write duplicates.
         if schedule_storage.supports_auto_materialize_asset_evaluations:
             schedule_storage.add_auto_materialize_asset_evaluations(
-                check.not_none(new_cursor.evaluation_id), evaluations
+                new_cursor.evaluation_id, evaluations
+            )
+            schedule_storage.purge_evaluations(
+                before=pendulum.now("UTC").subtract(days=EVALUATIONS_TTL_DAYS).timestamp(),
             )

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -175,6 +175,6 @@ class AssetDaemon(IntervalDaemon):
             schedule_storage.add_auto_materialize_asset_evaluations(
                 new_cursor.evaluation_id, evaluations
             )
-            schedule_storage.purge_evaluations(
+            schedule_storage.purge_asset_evaluations(
                 before=pendulum.now("UTC").subtract(days=EVALUATIONS_TTL_DAYS).timestamp(),
             )

--- a/python_modules/dagster/dagster/_utils/test/schedule_storage.py
+++ b/python_modules/dagster/dagster/_utils/test/schedule_storage.py
@@ -799,7 +799,7 @@ class TestScheduleStorage:
             == subset
         )
 
-    def test_purge_evaluations(self, storage):
+    def test_purge_asset_evaluations(self, storage):
         if not self.can_purge():
             pytest.skip("Storage cannot purge")
 
@@ -816,14 +816,14 @@ class TestScheduleStorage:
             ],
         )
 
-        storage.purge_evaluations(before=pendulum.now().subtract(hours=10).timestamp())
+        storage.purge_asset_evaluations(before=pendulum.now().subtract(hours=10).timestamp())
 
         res = storage.get_auto_materialize_asset_evaluations(
             asset_key=AssetKey("asset_one"), limit=100
         )
         assert len(res) == 1
 
-        storage.purge_evaluations(before=pendulum.now().add(minutes=10).timestamp())
+        storage.purge_asset_evaluations(before=pendulum.now().add(minutes=10).timestamp())
 
         res = storage.get_auto_materialize_asset_evaluations(
             asset_key=AssetKey("asset_one"), limit=100

--- a/python_modules/dagster/dagster/_utils/test/schedule_storage.py
+++ b/python_modules/dagster/dagster/_utils/test/schedule_storage.py
@@ -798,3 +798,34 @@ class TestScheduleStorage:
             )
             == subset
         )
+
+    def test_purge_evaluations(self, storage):
+        if not self.can_purge():
+            pytest.skip("Storage cannot purge")
+
+        storage.add_auto_materialize_asset_evaluations(
+            evaluation_id=11,
+            asset_evaluations=[
+                AutoMaterializeAssetEvaluation(
+                    asset_key=AssetKey("asset_one"),
+                    partition_subsets_by_condition=[],
+                    num_requested=0,
+                    num_skipped=0,
+                    num_discarded=0,
+                ),
+            ],
+        )
+
+        storage.purge_evaluations(before=pendulum.now().subtract(hours=10).timestamp())
+
+        res = storage.get_auto_materialize_asset_evaluations(
+            asset_key=AssetKey("asset_one"), limit=100
+        )
+        assert len(res) == 1
+
+        storage.purge_evaluations(before=pendulum.now().add(minutes=10).timestamp())
+
+        res = storage.get_auto_materialize_asset_evaluations(
+            asset_key=AssetKey("asset_one"), limit=100
+        )
+        assert len(res) == 0


### PR DESCRIPTION
Purge evaluations like ticks after 1 week. Maybe we'll make this configurable in the future but I don't think that's necessary off the bat