### PR TITLE
[telemetry] mark functional resources as dagster maintained

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -54,7 +54,11 @@ from dagster._core.selector.subset_selector import (
     AssetSelectionData,
     OpSelectionData,
 )
-from dagster._core.storage.io_manager import IOManagerDefinition, io_manager
+from dagster._core.storage.io_manager import (
+    IOManagerDefinition,
+    dagster_maintained_io_manager,
+    io_manager,
+)
 from dagster._core.storage.tags import MEMOIZED_RUN_TAG
 from dagster._core.types.dagster_type import DagsterType
 from dagster._core.utils import str_format_set
@@ -988,6 +992,7 @@ def _swap_default_io_man(resources: Mapping[str, ResourceDefinition], job: JobDe
     return resources
 
 
+@dagster_maintained_io_manager
 @io_manager(
     description="Built-in filesystem IO manager that stores and retrieves values using pickling."
 )
@@ -1028,6 +1033,7 @@ def default_job_io_manager(init_context: "InitResourceContext"):
     return PickledObjectFilesystemIOManager(base_dir=instance.storage_directory())
 
 
+@dagster_maintained_io_manager
 @io_manager(
     description="Built-in filesystem IO manager that stores and retrieves values using pickling.",
     config_schema={"base_dir": Field(StringSource, is_required=False)},

--- a/python_modules/dagster/dagster/_core/definitions/no_step_launcher.py
+++ b/python_modules/dagster/dagster/_core/definitions/no_step_launcher.py
@@ -1,6 +1,8 @@
 from dagster import resource
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 
 
+@dagster_maintained_resource
 @resource
 def no_step_launcher(_):
     return None

--- a/python_modules/dagster/dagster/_core/execution/plan/external_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/external_step.py
@@ -9,7 +9,7 @@ import dagster._check as check
 from dagster._config import Field, StringSource
 from dagster._core.code_pointer import FileCodePointer, ModuleCodePointer
 from dagster._core.definitions.reconstruct import ReconstructableJob, ReconstructableRepository
-from dagster._core.definitions.resource_definition import resource
+from dagster._core.definitions.resource_definition import dagster_maintained_resource, resource
 from dagster._core.definitions.step_launcher import StepLauncher, StepRunRef
 from dagster._core.errors import raise_execution_interrupts
 from dagster._core.events import DagsterEvent
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
     from dagster._core.execution.plan.step import ExecutionStep
 
 
+@dagster_maintained_resource
 @resource(
     config_schema={
         "scratch_dir": Field(

--- a/python_modules/dagster/dagster/_core/storage/file_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/file_manager.py
@@ -11,7 +11,7 @@ from typing_extensions import TypeAlias
 import dagster._check as check
 from dagster._annotations import public
 from dagster._config import Field, StringSource
-from dagster._core.definitions.resource_definition import resource
+from dagster._core.definitions.resource_definition import dagster_maintained_resource, resource
 from dagster._core.execution.context.init import InitResourceContext
 from dagster._core.instance import DagsterInstance
 from dagster._utils import mkdir_p
@@ -167,6 +167,7 @@ class FileManager(ABC):
         raise NotImplementedError()
 
 
+@dagster_maintained_resource
 @resource(config_schema={"base_dir": Field(StringSource, is_required=False)})
 def local_file_manager(init_context: InitResourceContext) -> "LocalFileManager":
     """FileManager that provides abstract access to a local filesystem.

--- a/python_modules/dagster/dagster/_core/storage/fs_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/fs_io_manager.py
@@ -18,7 +18,7 @@ from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.execution.context.init import InitResourceContext
 from dagster._core.execution.context.input import InputContext
 from dagster._core.execution.context.output import OutputContext
-from dagster._core.storage.io_manager import IOManager, io_manager
+from dagster._core.storage.io_manager import IOManager, dagster_maintained_io_manager, io_manager
 from dagster._core.storage.upath_io_manager import UPathIOManager
 from dagster._utils import PICKLE_PROTOCOL, mkdir_p
 
@@ -120,11 +120,17 @@ class FilesystemIOManager(ConfigurableIOManagerFactory["PickledObjectFilesystemI
 
     base_dir: Optional[str] = Field(default=None, description="Base directory for storing files.")
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def create_io_manager(self, context: InitResourceContext) -> "PickledObjectFilesystemIOManager":
         base_dir = self.base_dir or check.not_none(context.instance).storage_directory()
         return PickledObjectFilesystemIOManager(base_dir=base_dir)
 
 
+@dagster_maintained_io_manager
 @io_manager(
     config_schema=FilesystemIOManager.to_config_schema(),
     description="Built-in filesystem IO manager that stores and retrieves values using pickling.",
@@ -327,6 +333,7 @@ class CustomPathPickledObjectFilesystemIOManager(IOManager):
             return pickle.load(read_obj)
 
 
+@dagster_maintained_io_manager
 @io_manager(config_schema={"base_dir": DagsterField(StringSource, is_required=True)})
 @experimental
 def custom_path_fs_io_manager(

--- a/python_modules/dagster/dagster/_core/storage/mem_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/mem_io_manager.py
@@ -2,7 +2,7 @@ from typing import Dict, Tuple
 
 from dagster._core.execution.context.input import InputContext
 from dagster._core.execution.context.output import OutputContext
-from dagster._core.storage.io_manager import IOManager, io_manager
+from dagster._core.storage.io_manager import IOManager, dagster_maintained_io_manager, io_manager
 
 
 class InMemoryIOManager(IOManager):
@@ -18,6 +18,7 @@ class InMemoryIOManager(IOManager):
         return self.values[keys]
 
 
+@dagster_maintained_io_manager
 @io_manager(description="Built-in IO manager that stores and retrieves values in memory.")
 def mem_io_manager(_) -> InMemoryIOManager:
     """Built-in IO manager that stores and retrieves values in memory."""

--- a/python_modules/dagster/dagster/_core/storage/memoizable_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/memoizable_io_manager.py
@@ -9,7 +9,7 @@ from dagster._config import Field, StringSource
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.execution.context.input import InputContext
 from dagster._core.execution.context.output import OutputContext
-from dagster._core.storage.io_manager import IOManager, io_manager
+from dagster._core.storage.io_manager import IOManager, dagster_maintained_io_manager, io_manager
 from dagster._utils import PICKLE_PROTOCOL, mkdir_p
 
 
@@ -92,6 +92,7 @@ class VersionedPickledObjectFilesystemIOManager(MemoizableIOManager):
         return os.path.exists(filepath) and not os.path.isdir(filepath)
 
 
+@dagster_maintained_io_manager
 @io_manager(config_schema={"base_dir": Field(StringSource, is_required=False)})
 @experimental
 def versioned_filesystem_io_manager(init_context):

--- a/python_modules/dagster/dagster/_core/storage/temp_file_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/temp_file_manager.py
@@ -3,7 +3,7 @@ import os
 import shutil
 import tempfile
 
-from dagster._core.definitions.resource_definition import resource
+from dagster._core.definitions.resource_definition import dagster_maintained_resource, resource
 
 
 class TempfileManager:
@@ -42,6 +42,7 @@ def _tempfile_manager():
         manager.close()
 
 
+@dagster_maintained_resource
 @resource
 def tempfile_resource(_init_context):
     with _tempfile_manager() as manager:

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
@@ -70,6 +70,11 @@ class BaseAirbyteResource(ConfigurableResource):
         ),
     )
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @property
     @cached_method
     def _log(self) -> logging.Logger:

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
@@ -16,6 +16,7 @@ from dagster import (
     resource,
 )
 from dagster._config.pythonic_config import infer_schema_from_config_class
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._utils.cached_method import cached_method
 from dagster._utils.merger import deep_merge_dicts
 from pydantic import Field
@@ -660,6 +661,7 @@ class AirbyteResource(BaseAirbyteResource):
         return AirbyteOutput(job_details=job_details, connection_details=connection_details)
 
 
+@dagster_maintained_resource
 @resource(config_schema=AirbyteResource.to_config_schema())
 def airbyte_resource(context) -> AirbyteResource:
     """This resource allows users to programatically interface with the Airbyte REST API to launch
@@ -697,6 +699,7 @@ def airbyte_resource(context) -> AirbyteResource:
     return AirbyteResource.from_resource_context(context)
 
 
+@dagster_maintained_resource
 @resource(config_schema=infer_schema_from_config_class(AirbyteCloudResource))
 def airbyte_cloud_resource(context) -> AirbyteCloudResource:
     """This resource allows users to programatically interface with the Airbyte Cloud REST API to launch

--- a/python_modules/libraries/dagster-aws/dagster_aws/athena/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/athena/resources.py
@@ -14,6 +14,7 @@ from dagster import (
     resource,
 )
 from dagster._annotations import deprecated
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._core.execution.context.init import InitResourceContext
 from pydantic import Field
 
@@ -279,6 +280,7 @@ class AthenaClientResource(ResourceWithAthenaConfig):
         )
 
 
+@dagster_maintained_resource
 @resource(
     config_schema=ResourceWithAthenaConfig.to_config_schema(),
     description="Resource for connecting to AWS Athena",
@@ -303,6 +305,7 @@ def athena_resource(context: InitResourceContext) -> AthenaClient:
     return AthenaClientResource.from_resource_context(context).get_client()
 
 
+@dagster_maintained_resource
 @resource(
     config_schema=ResourceWithAthenaConfig.to_config_schema(),
     description="Fake resource for connecting to AWS Athena",

--- a/python_modules/libraries/dagster-aws/dagster_aws/athena/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/athena/resources.py
@@ -265,6 +265,11 @@ class AthenaClientResource(ResourceWithAthenaConfig):
 
     """
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def get_client(self) -> AthenaClient:
         """Returns an Athena client object."""
         client = boto3.client(

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecr/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecr/resources.py
@@ -3,6 +3,7 @@ import datetime
 import boto3
 from botocore.stub import Stubber
 from dagster import ConfigurableResource, resource
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 
 
 class ECRPublicClient:
@@ -51,6 +52,7 @@ class FakeECRPublicResource(ConfigurableResource):
         return FakeECRPublicClient()
 
 
+@dagster_maintained_resource
 @resource(
     description=(
         "This resource enables connecting to AWS Public and getting a login password from it."
@@ -61,6 +63,7 @@ def ecr_public_resource(context) -> ECRPublicClient:
     return ECRPublicResource.from_resource_context(context).get_client()
 
 
+@dagster_maintained_resource
 @resource(
     description=(
         "This resource behaves like ecr_public_resource except it stubs out the real AWS API"

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecr/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecr/resources.py
@@ -39,6 +39,11 @@ class ECRPublicResource(ConfigurableResource):
     Similar to the AWS CLI's `aws ecr-public get-login-password` command.
     """
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def get_client(self) -> ECRPublicClient:
         return ECRPublicClient()
 
@@ -47,6 +52,11 @@ class FakeECRPublicResource(ConfigurableResource):
     """This resource behaves like ecr_public_resource except it stubs out the real AWS API
     requests and always returns `'token'` as its login password.
     """
+
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
 
     def get_client(self) -> FakeECRPublicClient:
         return FakeECRPublicClient()

--- a/python_modules/libraries/dagster-aws/dagster_aws/emr/pyspark_step_launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/emr/pyspark_step_launcher.py
@@ -12,6 +12,7 @@ from dagster import (
     _check as check,
     resource,
 )
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._core.definitions.step_launcher import StepLauncher
 from dagster._core.errors import DagsterInvariantViolationError, raise_execution_interrupts
 from dagster._core.execution.plan.external_step import (
@@ -31,6 +32,7 @@ EMR_SPARK_HOME = "/usr/lib/spark/"
 CODE_ZIP_NAME = "code.zip"
 
 
+@dagster_maintained_resource
 @resource(
     {
         "spark_config": get_spark_config(),

--- a/python_modules/libraries/dagster-aws/dagster_aws/redshift/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/redshift/resources.py
@@ -335,6 +335,11 @@ class RedshiftClientResource(ConfigurableResource):
         ),
     )
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def get_client(self) -> RedshiftClient:
         conn_args = {
             k: getattr(self, k, None)

--- a/python_modules/libraries/dagster-aws/dagster_aws/redshift/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/redshift/resources.py
@@ -12,6 +12,7 @@ from dagster import (
     resource,
 )
 from dagster._annotations import deprecated
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from pydantic import Field
 
 
@@ -357,6 +358,7 @@ class FakeRedshiftClientResource(RedshiftClientResource):
         return FakeRedshiftClient(get_dagster_logger())
 
 
+@dagster_maintained_resource
 @resource(
     config_schema=RedshiftClientResource.to_config_schema(),
     description="Resource for connecting to the Redshift data warehouse",
@@ -389,6 +391,7 @@ def redshift_resource(context) -> RedshiftClient:
     return RedshiftClientResource.from_resource_context(context).get_client()
 
 
+@dagster_maintained_resource
 @resource(
     config_schema=FakeRedshiftClientResource.to_config_schema(),
     description=(

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
@@ -11,6 +11,7 @@ from dagster import (
     _check as check,
     io_manager,
 )
+from dagster._core.storage.io_manager import dagster_maintained_io_manager
 from dagster._core.storage.upath_io_manager import UPathIOManager
 from dagster._utils import PICKLE_PROTOCOL
 from dagster._utils.cached_method import cached_method
@@ -129,6 +130,11 @@ class ConfigurablePickledObjectS3IOManager(ConfigurableIOManager):
         default="dagster", description="Prefix to use for the S3 bucket for this file manager."
     )
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @cached_method
     def inner_io_manager(self) -> PickledObjectS3IOManager:
         return PickledObjectS3IOManager(
@@ -144,6 +150,7 @@ class ConfigurablePickledObjectS3IOManager(ConfigurableIOManager):
         return self.inner_io_manager().handle_output(context, obj)
 
 
+@dagster_maintained_io_manager
 @io_manager(
     config_schema=ConfigurablePickledObjectS3IOManager.to_config_schema(),
     required_resource_keys={"s3"},

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/resources.py
@@ -83,6 +83,11 @@ class S3Resource(ResourceWithS3Configuration, IAttachDifferentObjectToOpContext)
 
     """
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def get_client(self) -> Any:
         return construct_s3_client(
             max_attempts=self.max_attempts,

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/resources.py
@@ -1,6 +1,7 @@
 from typing import Any, Optional, TypeVar
 
 from dagster import ConfigurableResource, IAttachDifferentObjectToOpContext, resource
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from pydantic import Field
 
 from .file_manager import S3FileManager
@@ -100,6 +101,7 @@ class S3Resource(ResourceWithS3Configuration, IAttachDifferentObjectToOpContext)
         return self.get_client()
 
 
+@dagster_maintained_resource
 @resource(config_schema=S3Resource.to_config_schema())
 def s3_resource(context) -> Any:
     """Resource that gives access to S3.
@@ -201,6 +203,7 @@ class S3FileManagerResource(ResourceWithS3Configuration, IAttachDifferentObjectT
         return self.get_client()
 
 
+@dagster_maintained_resource
 @resource(
     config_schema=S3FileManagerResource.to_config_schema(),
 )

--- a/python_modules/libraries/dagster-aws/dagster_aws/secretsmanager/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/secretsmanager/resources.py
@@ -50,6 +50,11 @@ class SecretsManagerResource(ResourceWithBoto3Configuration):
             )
     """
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def get_client(self) -> "botocore.client.SecretsManager":
         return construct_secretsmanager_client(
             max_attempts=self.max_attempts,
@@ -160,6 +165,11 @@ class SecretsManagerSecretsResource(ResourceWithBoto3Configuration):
         default=None,
         description="AWS Secrets Manager secrets with this tag will be fetched and made available.",
     )
+
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
 
     @contextmanager
     def secrets_in_environment(

--- a/python_modules/libraries/dagster-aws/dagster_aws/secretsmanager/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/secretsmanager/resources.py
@@ -7,6 +7,7 @@ from dagster import (
     resource,
 )
 from dagster._config.field_utils import Shape
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._core.test_utils import environ
 from dagster._utils.merger import merge_dicts
 from pydantic import Field
@@ -57,6 +58,7 @@ class SecretsManagerResource(ResourceWithBoto3Configuration):
         )
 
 
+@dagster_maintained_resource
 @resource(SecretsManagerResource.to_config_schema())
 def secretsmanager_resource(context) -> "botocore.client.SecretsManager":
     """Resource that gives access to AWS SecretsManager.
@@ -228,6 +230,7 @@ LEGACY_SECRETSMANAGER_SECRETS_SCHEMA = {
 }
 
 
+@dagster_maintained_resource
 @resource(config_schema=LEGACY_SECRETSMANAGER_SECRETS_SCHEMA)
 @contextmanager
 def secretsmanager_secrets_resource(context):

--- a/python_modules/libraries/dagster-aws/dagster_aws/ssm/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ssm/resources.py
@@ -57,6 +57,11 @@ class SSMResource(ResourceWithBoto3Configuration):
             )
     """
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def get_client(self) -> "botocore.client.ssm":
         return construct_ssm_client(
             max_attempts=self.max_attempts,
@@ -183,6 +188,11 @@ class ParameterStoreResource(ResourceWithBoto3Configuration):
             " String or StringList"
         ),
     )
+
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
 
     @contextmanager
     def parameters_in_environment(

--- a/python_modules/libraries/dagster-aws/dagster_aws/ssm/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ssm/resources.py
@@ -8,6 +8,7 @@ from dagster import (
     resource,
 )
 from dagster._config.field_utils import Shape
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._core.test_utils import environ
 from dagster._utils.merger import merge_dicts
 from pydantic import Field
@@ -64,6 +65,7 @@ class SSMResource(ResourceWithBoto3Configuration):
         )
 
 
+@dagster_maintained_resource
 @resource(config_schema=SSMResource.to_config_schema())
 def ssm_resource(context) -> "botocore.client.ssm":
     """Resource that gives access to AWS Systems Manager Parameter Store.
@@ -276,6 +278,7 @@ LEGACY_PARAMETERSTORE_SCHEMA = {
 }
 
 
+@dagster_maintained_resource
 @resource(config_schema=LEGACY_PARAMETERSTORE_SCHEMA)
 @contextmanager
 def parameter_store_resource(context) -> Any:

--- a/python_modules/libraries/dagster-azure/dagster_azure/adls2/fake_adls2_resource.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/adls2/fake_adls2_resource.py
@@ -28,6 +28,11 @@ class FakeADLS2Resource(ConfigurableResource):
     account_name: str
     storage_account: Optional[str] = None
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @property
     @cached_method
     def adls2_client(self) -> "FakeADLS2ServiceClient":

--- a/python_modules/libraries/dagster-azure/dagster_azure/adls2/fake_adls2_resource.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/adls2/fake_adls2_resource.py
@@ -5,6 +5,7 @@ from unittest import mock
 
 from dagster import resource
 from dagster._config.pythonic_config import ConfigurableResource
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._utils.cached_method import cached_method
 
 from dagster_azure.blob import FakeBlobServiceClient
@@ -12,6 +13,7 @@ from dagster_azure.blob import FakeBlobServiceClient
 from .utils import ResourceNotFoundError
 
 
+@dagster_maintained_resource
 @resource({"account_name": str})
 def fake_adls2_resource(context):
     return FakeADLS2Resource(account_name=context.resource_config["account_name"])

--- a/python_modules/libraries/dagster-azure/dagster_azure/adls2/io_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/adls2/io_manager.py
@@ -10,6 +10,7 @@ from dagster import (
     io_manager,
 )
 from dagster._config.pythonic_config import ConfigurableIOManager
+from dagster._core.storage.io_manager import dagster_maintained_io_manager
 from dagster._core.storage.upath_io_manager import UPathIOManager
 from dagster._utils import PICKLE_PROTOCOL
 from dagster._utils.cached_method import cached_method
@@ -177,6 +178,11 @@ class ConfigurablePickledObjectADLS2IOManager(ConfigurableIOManager):
         default="dagster", description="ADLS Gen2 file system prefix to write to."
     )
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @property
     @cached_method
     def _internal_io_manager(self) -> PickledObjectADLS2IOManager:
@@ -195,6 +201,7 @@ class ConfigurablePickledObjectADLS2IOManager(ConfigurableIOManager):
         self._internal_io_manager.handle_output(context, obj)
 
 
+@dagster_maintained_io_manager
 @io_manager(
     config_schema=ConfigurablePickledObjectADLS2IOManager.to_config_schema(),
     required_resource_keys={"adls2"},

--- a/python_modules/libraries/dagster-azure/dagster_azure/adls2/resources.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/adls2/resources.py
@@ -11,6 +11,7 @@ from dagster import (
     StringSource,
     resource,
 )
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._utils.cached_method import cached_method
 from dagster._utils.merger import merge_dicts
 from pydantic import Field
@@ -100,6 +101,7 @@ class ADLS2Resource(ADLS2BaseResource):
 # Due to a limitation of the discriminated union type, we can't directly mirror these old
 # config fields in the new resource config. Instead, we'll just use the old config fields
 # to construct the new config and then use that to construct the resource.
+@dagster_maintained_resource
 @resource(ADLS2_CLIENT_CONFIG)
 def adls2_resource(context):
     """Resource that gives ops access to Azure Data Lake Storage Gen2.
@@ -153,6 +155,7 @@ def adls2_resource(context):
     return _adls2_resource_from_config(context.resource_config)
 
 
+@dagster_maintained_resource
 @resource(
     merge_dicts(
         ADLS2_CLIENT_CONFIG,

--- a/python_modules/libraries/dagster-azure/dagster_azure/adls2/resources.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/adls2/resources.py
@@ -73,6 +73,11 @@ class ADLS2Resource(ADLS2BaseResource):
     of each.
     """
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @property
     @cached_method
     def _raw_credential(self) -> Any:

--- a/python_modules/libraries/dagster-census/dagster_census/resources.py
+++ b/python_modules/libraries/dagster-census/dagster_census/resources.py
@@ -6,6 +6,7 @@ from typing import Any, Mapping, Optional
 
 import requests
 from dagster import Failure, Field, StringSource, __version__, get_dagster_logger, resource
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from requests.auth import HTTPBasicAuth
 from requests.exceptions import RequestException
 
@@ -238,6 +239,7 @@ class CensusResource:
         )
 
 
+@dagster_maintained_resource
 @resource(
     config_schema={
         "api_key": Field(

--- a/python_modules/libraries/dagster-dask/dagster_dask/resources.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/resources.py
@@ -1,4 +1,5 @@
 from dagster import Bool, Field, Int, Permissive, Selector, Shape, String, resource
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dask.distributed import Client
 
 DaskClusterTypes = {
@@ -65,6 +66,7 @@ class DaskResource:
         self._client, self._cluster = None, None
 
 
+@dagster_maintained_resource
 @resource(
     description="Dask Client resource.",
     config_schema=Shape(

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
@@ -15,6 +15,7 @@ from dagster import (
     _check as check,
     resource,
 )
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._core.definitions.step_launcher import StepLauncher
 from dagster._core.errors import raise_execution_interrupts
 from dagster._core.execution.plan.external_step import (
@@ -59,6 +60,7 @@ DAGSTER_SYSTEM_ENV_VARS = {
 }
 
 
+@dagster_maintained_resource
 @resource(
     {
         "run_config": define_databricks_submit_run_config(),

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/resources.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/resources.py
@@ -5,6 +5,7 @@ from dagster import (
     IAttachDifferentObjectToOpContext,
     resource,
 )
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from pydantic import Field
 
 from .databricks import DatabricksClient
@@ -37,6 +38,7 @@ class DatabricksClientResource(ConfigurableResource, IAttachDifferentObjectToOpC
         return self.get_client()
 
 
+@dagster_maintained_resource
 @resource(config_schema=DatabricksClientResource.to_config_schema())
 def databricks_client(init_context) -> DatabricksClient:
     return DatabricksClientResource.from_resource_context(init_context).get_client()

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/resources.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/resources.py
@@ -27,6 +27,11 @@ class DatabricksClientResource(ConfigurableResource, IAttachDifferentObjectToOpC
         ),
     )
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def get_client(self) -> DatabricksClient:
         return DatabricksClient(
             host=self.host,

--- a/python_modules/libraries/dagster-datadog/dagster_datadog/resources.py
+++ b/python_modules/libraries/dagster-datadog/dagster_datadog/resources.py
@@ -1,4 +1,5 @@
 from dagster import ConfigurableResource, resource
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from datadog import DogStatsd, initialize, statsd
 from pydantic import Field
 
@@ -89,6 +90,7 @@ class DatadogResource(ConfigurableResource):
         return DatadogClient(self.api_key, self.app_key)
 
 
+@dagster_maintained_resource
 @resource(
     config_schema=DatadogResource.to_config_schema(),
     description="This resource is for publishing to DataDog",

--- a/python_modules/libraries/dagster-datadog/dagster_datadog/resources.py
+++ b/python_modules/libraries/dagster-datadog/dagster_datadog/resources.py
@@ -86,6 +86,11 @@ class DatadogResource(ConfigurableResource):
         )
     )
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def get_client(self) -> DatadogClient:
         return DatadogClient(self.api_key, self.app_key)
 

--- a/python_modules/libraries/dagster-datahub/dagster_datahub/resources.py
+++ b/python_modules/libraries/dagster-datahub/dagster_datahub/resources.py
@@ -28,6 +28,11 @@ class DatahubRESTEmitterResource(ConfigurableResource):
     server_telemetry_id: Optional[str] = None
     disable_ssl_verification: bool = False
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def get_emitter(self) -> DatahubRestEmitter:
         return DatahubRestEmitter(
             gms_server=self.connection,
@@ -82,6 +87,11 @@ class DatahubKafkaEmitterResource(ConfigurableResource):
             MCP_KEY: DEFAULT_MCP_KAFKA_TOPIC,
         }
     )
+
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
 
     def get_emitter(self) -> DatahubKafkaEmitter:
         return DatahubKafkaEmitter(

--- a/python_modules/libraries/dagster-datahub/dagster_datahub/resources.py
+++ b/python_modules/libraries/dagster-datahub/dagster_datahub/resources.py
@@ -2,6 +2,7 @@ from typing import Any, Dict, List, Optional
 
 from dagster import InitResourceContext, resource
 from dagster._config.pythonic_config import Config, ConfigurableResource
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from datahub.emitter.kafka_emitter import (
     DEFAULT_MCE_KAFKA_TOPIC,
     DEFAULT_MCP_KAFKA_TOPIC,
@@ -43,6 +44,7 @@ class DatahubRESTEmitterResource(ConfigurableResource):
         )
 
 
+@dagster_maintained_resource
 @resource(config_schema=DatahubRESTEmitterResource.to_config_schema())
 def datahub_rest_emitter(init_context: InitResourceContext) -> DatahubRestEmitter:
     emitter = DatahubRestEmitter(
@@ -87,6 +89,7 @@ class DatahubKafkaEmitterResource(ConfigurableResource):
         )
 
 
+@dagster_maintained_resource
 @resource(config_schema=DatahubKafkaEmitterResource.to_config_schema())
 def datahub_kafka_emitter(init_context: InitResourceContext) -> DatahubKafkaEmitter:
     return DatahubKafkaEmitter(KafkaEmitterConfig.parse_obj(init_context.resource_config))

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources.py
@@ -478,6 +478,11 @@ class DbtCliClientResource(ConfigurableResourceWithCliFlags, IAttachDifferentObj
     class Config:
         extra = "allow"
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def get_dbt_client(self) -> DbtCliClient:
         context = self.get_resource_context()
         default_flags = {

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources.py
@@ -4,6 +4,7 @@ import dagster._check as check
 from dagster import resource
 from dagster._annotations import public
 from dagster._config.pythonic_config import ConfigurableResource, IAttachDifferentObjectToOpContext
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._utils.merger import merge_dicts
 from pydantic import Field
 
@@ -502,6 +503,7 @@ class DbtCliClientResource(ConfigurableResourceWithCliFlags, IAttachDifferentObj
         return self.get_dbt_client()
 
 
+@dagster_maintained_resource
 @resource(config_schema=DbtCliClientResource.to_config_schema())
 def dbt_cli_resource(context) -> DbtCliClient:
     """This resource issues dbt CLI commands against a configured dbt project."""

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/resources.py
@@ -639,6 +639,11 @@ class DbtCloudClientResource(ConfigurableResource, IAttachDifferentObjectToOpCon
         ),
     )
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def get_dbt_client(self) -> DbtCloudClient:
         context = self.get_resource_context()
         assert context.log

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/resources.py
@@ -17,6 +17,7 @@ from dagster import (
     get_dagster_logger,
     resource,
 )
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._utils.merger import deep_merge_dicts
 from pydantic import Field
 from requests.exceptions import RequestException
@@ -656,6 +657,7 @@ class DbtCloudClientResource(ConfigurableResource, IAttachDifferentObjectToOpCon
         return self.get_dbt_client()
 
 
+@dagster_maintained_resource
 @resource(
     config_schema=DbtCloudClientResource.to_config_schema(),
     description="This resource helps interact with dbt Cloud connectors",

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/rpc/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/rpc/resources.py
@@ -18,7 +18,10 @@ from dagster import (
     _check as check,
     resource,
 )
-from dagster._core.definitions.resource_definition import ResourceDefinition
+from dagster._core.definitions.resource_definition import (
+    ResourceDefinition,
+    dagster_maintained_resource,
+)
 from dagster._core.utils import coerce_valid_log_level
 
 from ..dbt_resource import DbtResource
@@ -577,6 +580,7 @@ class DbtRpcSyncResource(DbtRpcResource):
         return out
 
 
+@dagster_maintained_resource
 @resource(
     description="A resource representing a dbt RPC client.",
     config_schema={
@@ -606,6 +610,7 @@ def dbt_rpc_resource(context) -> DbtRpcResource:
     )
 
 
+@dagster_maintained_resource
 @resource(
     description="A resource representing a synchronous dbt RPC client.",
     config_schema={

--- a/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas/duckdb_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas/duckdb_pandas_type_handler.py
@@ -191,6 +191,11 @@ class DuckDBPandasIOManager(DuckDBIOManager):
 
     """
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @staticmethod
     def type_handlers() -> Sequence[DbTypeHandler]:
         return [DuckDBPandasTypeHandler()]

--- a/python_modules/libraries/dagster-duckdb-polars/dagster_duckdb_polars/duckdb_polars_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-polars/dagster_duckdb_polars/duckdb_polars_type_handler.py
@@ -193,6 +193,11 @@ class DuckDBPolarsIOManager(DuckDBIOManager):
 
     """
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @staticmethod
     def type_handlers() -> Sequence[DbTypeHandler]:
         return [DuckDBPolarsTypeHandler()]

--- a/python_modules/libraries/dagster-duckdb-pyspark/dagster_duckdb_pyspark/duckdb_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pyspark/dagster_duckdb_pyspark/duckdb_pyspark_type_handler.py
@@ -200,6 +200,11 @@ class DuckDBPySparkIOManager(DuckDBIOManager):
 
     """
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @staticmethod
     def type_handlers() -> Sequence[DbTypeHandler]:
         return [DuckDBPySparkTypeHandler()]

--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
@@ -15,6 +15,7 @@ from dagster._core.storage.db_io_manager import (
     TablePartitionDimension,
     TableSlice,
 )
+from dagster._core.storage.io_manager import dagster_maintained_io_manager
 from dagster._utils.backoff import backoff
 from pydantic import Field
 
@@ -83,6 +84,7 @@ def build_duckdb_io_manager(
 
     """
 
+    @dagster_maintained_io_manager
     @io_manager(config_schema=DuckDBIOManager.to_config_schema())
     def duckdb_io_manager(init_context):
         """IO Manager for storing outputs in a DuckDB database.

--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb/resource.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb/resource.py
@@ -34,6 +34,11 @@ class DuckDBResource(ConfigurableResource):
         )
     )
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @contextmanager
     def get_connection(self):
         conn = backoff(

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
@@ -16,6 +16,7 @@ from dagster import (
     resource,
 )
 from dagster._config.pythonic_config import ConfigurableResource
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._utils.cached_method import cached_method
 from dateutil import parser
 from pydantic import Field
@@ -391,6 +392,7 @@ class FivetranResource(ConfigurableResource):
         return FivetranOutput(connector_details=final_details, schema_config=schema_config)
 
 
+@dagster_maintained_resource
 @resource(config_schema=FivetranResource.to_config_schema())
 def fivetran_resource(context: InitResourceContext) -> FivetranResource:
     """This resource allows users to programatically interface with the Fivetran REST API to launch

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
@@ -58,6 +58,11 @@ class FivetranResource(ConfigurableResource):
         description="Time (in seconds) to wait between each request retry.",
     )
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @property
     def _auth(self) -> HTTPBasicAuth:
         return HTTPBasicAuth(self.api_key, self.api_secret)

--- a/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas/bigquery/bigquery_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas/bigquery/bigquery_pandas_type_handler.py
@@ -225,6 +225,11 @@ class BigQueryPandasIOManager(BigQueryIOManager):
 
     """
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @staticmethod
     def type_handlers() -> Sequence[DbTypeHandler]:
         return [BigQueryPandasTypeHandler()]

--- a/python_modules/libraries/dagster-gcp-pyspark/dagster_gcp_pyspark/bigquery/bigquery_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-gcp-pyspark/dagster_gcp_pyspark/bigquery/bigquery_pyspark_type_handler.py
@@ -232,6 +232,11 @@ class BigQueryPySparkIOManager(BigQueryIOManager):
 
     """
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @staticmethod
     def type_handlers() -> Sequence[DbTypeHandler]:
         return [BigQueryPySparkTypeHandler()]

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/io_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/io_manager.py
@@ -15,6 +15,7 @@ from dagster._core.storage.db_io_manager import (
     TableSlice,
     TimeWindow,
 )
+from dagster._core.storage.io_manager import dagster_maintained_io_manager
 from google.api_core.exceptions import NotFound
 from google.cloud import bigquery
 from pydantic import Field
@@ -101,6 +102,7 @@ def build_bigquery_io_manager(
         the base64 encoded with this shell command: cat $GOOGLE_APPLICATION_CREDENTIALS | base64
     """
 
+    @dagster_maintained_io_manager
     @io_manager(config_schema=BigQueryIOManager.to_config_schema())
     def bigquery_io_manager(init_context):
         """I/O Manager for storing outputs in a BigQuery database.

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/resources.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/resources.py
@@ -82,6 +82,7 @@ class BigQueryResource(ConfigurableResource, IAttachDifferentObjectToOpContext):
             yield client
 
 
+@dagster_maintained_resource
 @resource(
     config_schema=BigQueryResource.to_config_schema(),
     description="Dagster resource for connecting to BigQuery",

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/resources.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/resources.py
@@ -56,6 +56,11 @@ class BigQueryResource(ConfigurableResource, IAttachDifferentObjectToOpContext):
         ),
     )
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @contextmanager
     def get_client(self) -> Iterator[bigquery.Client]:
         """Context manager to create a BigQuery Client.

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/resources.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/resources.py
@@ -2,6 +2,7 @@ from contextlib import contextmanager
 from typing import Any, Iterator, Optional
 
 from dagster import ConfigurableResource, IAttachDifferentObjectToOpContext, resource
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from google.cloud import bigquery
 from pydantic import Field
 

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/dataproc/resources.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/dataproc/resources.py
@@ -199,6 +199,11 @@ class DataprocResource(ConfigurableResource, IAttachDifferentObjectToOpContext):
         ),
     )
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def _read_yaml_config(self, path: str) -> Mapping[str, Any]:
         with open(path, "r", encoding="utf8") as f:
             return yaml.safe_load(f)

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/dataproc/resources.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/dataproc/resources.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, Mapping, Optional
 import dagster._check as check
 import yaml
 from dagster import ConfigurableResource, IAttachDifferentObjectToOpContext, resource
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from googleapiclient.discovery import build
 from oauth2client.client import GoogleCredentials
 from pydantic import Field
@@ -248,6 +249,7 @@ class DataprocResource(ConfigurableResource, IAttachDifferentObjectToOpContext):
         return self.get_client()
 
 
+@dagster_maintained_resource
 @resource(
     config_schema=define_dataproc_create_cluster_config(),
     description="Manage a Dataproc cluster resource",

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/io_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/io_manager.py
@@ -9,6 +9,7 @@ from dagster import (
     _check as check,
     io_manager,
 )
+from dagster._core.storage.io_manager import dagster_maintained_io_manager
 from dagster._core.storage.upath_io_manager import UPathIOManager
 from dagster._utils import PICKLE_PROTOCOL
 from dagster._utils.backoff import backoff
@@ -145,6 +146,11 @@ class ConfigurablePickledObjectGCSIOManager(ConfigurableIOManager):
     gcs_bucket: str = Field(description="GCS bucket to store files")
     gcs_prefix: str = Field(default="dagster", description="Prefix to add to all file paths")
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @property
     @cached_method
     def _internal_io_manager(self) -> PickledObjectGCSIOManager:
@@ -159,6 +165,7 @@ class ConfigurablePickledObjectGCSIOManager(ConfigurableIOManager):
         self._internal_io_manager.handle_output(context, obj)
 
 
+@dagster_maintained_io_manager
 @io_manager(
     config_schema=ConfigurablePickledObjectGCSIOManager.to_config_schema(),
     required_resource_keys={"gcs"},

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/resources.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/resources.py
@@ -1,6 +1,7 @@
 from typing import Any, Optional
 
 from dagster import ConfigurableResource, IAttachDifferentObjectToOpContext, resource
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from google.cloud import storage
 from pydantic import Field
 
@@ -17,6 +18,7 @@ class GCSResource(ConfigurableResource, IAttachDifferentObjectToOpContext):
         return self.get_client()
 
 
+@dagster_maintained_resource
 @resource(
     config_schema=GCSResource.to_config_schema(),
     description="This resource provides a GCS client",
@@ -42,6 +44,7 @@ class GCSFileManagerResource(ConfigurableResource, IAttachDifferentObjectToOpCon
         return self.get_client()
 
 
+@dagster_maintained_resource
 @resource(config_schema=GCSFileManagerResource.to_config_schema())
 def gcs_file_manager(context):
     """FileManager that provides abstract access to GCS.

--- a/python_modules/libraries/dagster-ge/dagster_ge/factory.py
+++ b/python_modules/libraries/dagster-ge/dagster_ge/factory.py
@@ -15,6 +15,7 @@ from dagster import (
     op,
     resource,
 )
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster_pandas import DataFrame
 from great_expectations.render.renderer import ValidationResultsPageRenderer
 from great_expectations.render.view import DefaultMarkdownPageView
@@ -43,6 +44,7 @@ class GEContextResource(ConfigurableResource, IAttachDifferentObjectToOpContext)
         return self.get_data_context()
 
 
+@dagster_maintained_resource
 @resource(config_schema=GEContextResource.to_config_schema())
 def ge_data_context(context):
     return GEContextResource.from_resource_context(context).get_data_context()

--- a/python_modules/libraries/dagster-github/dagster_github/resources.py
+++ b/python_modules/libraries/dagster-github/dagster_github/resources.py
@@ -5,6 +5,7 @@ from typing import Optional
 import jwt
 import requests
 from dagster import ConfigurableResource, resource
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from pydantic import Field
 
 
@@ -190,6 +191,7 @@ class GithubResource(ConfigurableResource):
         )
 
 
+@dagster_maintained_resource
 @resource(
     config_schema=GithubResource.to_config_schema(),
     description="This resource is for connecting to Github",

--- a/python_modules/libraries/dagster-github/dagster_github/resources.py
+++ b/python_modules/libraries/dagster-github/dagster_github/resources.py
@@ -181,6 +181,11 @@ class GithubResource(ConfigurableResource):
         ),
     )
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def get_client(self) -> GithubClient:
         return GithubClient(
             client=requests.Session(),

--- a/python_modules/libraries/dagster-mlflow/dagster_mlflow/resources.py
+++ b/python_modules/libraries/dagster-mlflow/dagster_mlflow/resources.py
@@ -10,6 +10,7 @@ from typing import Any, Optional
 
 import mlflow
 from dagster import Field, Noneable, Permissive, StringSource, resource
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from mlflow.entities.run_status import RunStatus
 
 CONFIG_SCHEMA = {
@@ -218,6 +219,7 @@ class MlFlow(metaclass=MlflowMeta):
             yield {k: params[k] for k in islice(it, size)}
 
 
+@dagster_maintained_resource
 @resource(config_schema=CONFIG_SCHEMA)
 def mlflow_tracking(context):
     """This resource initializes an MLflow run that's used for all steps within a Dagster run.

--- a/python_modules/libraries/dagster-msteams/dagster_msteams/resources.py
+++ b/python_modules/libraries/dagster-msteams/dagster_msteams/resources.py
@@ -1,4 +1,5 @@
 from dagster import ConfigurableResource, resource
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from pydantic import Field
 
 from dagster_msteams.client import TeamsClient
@@ -70,6 +71,7 @@ class MSTeamsResource(ConfigurableResource):
         )
 
 
+@dagster_maintained_resource
 @resource(
     config_schema=MSTeamsResource.to_config_schema(),
     description="This resource is for connecting to MS Teams",

--- a/python_modules/libraries/dagster-msteams/dagster_msteams/resources.py
+++ b/python_modules/libraries/dagster-msteams/dagster_msteams/resources.py
@@ -61,6 +61,11 @@ class MSTeamsResource(ConfigurableResource):
         default=True, description="Whether to verify SSL certificates, defaults to True"
     )
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def get_client(self) -> TeamsClient:
         return TeamsClient(
             hook_url=self.hook_url,

--- a/python_modules/libraries/dagster-pagerduty/dagster_pagerduty/resources.py
+++ b/python_modules/libraries/dagster-pagerduty/dagster_pagerduty/resources.py
@@ -4,6 +4,7 @@ import pypd
 from dagster import ConfigurableResource, resource
 from dagster._annotations import quiet_experimental_warnings
 from dagster._config.pythonic_config import infer_schema_from_config_class
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from pydantic import Field as PyField
 
 
@@ -160,6 +161,7 @@ class PagerDutyService(ConfigurableResource):
         return pypd.EventV2.create(data=data)
 
 
+@dagster_maintained_resource
 @resource(
     config_schema=infer_schema_from_config_class(PagerDutyService),
     description="""This resource is for posting events to PagerDuty.""",

--- a/python_modules/libraries/dagster-pagerduty/dagster_pagerduty/resources.py
+++ b/python_modules/libraries/dagster-pagerduty/dagster_pagerduty/resources.py
@@ -31,6 +31,11 @@ class PagerDutyService(ConfigurableResource):
         ),
     )
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def EventV2_create(
         self,
         summary: str,

--- a/python_modules/libraries/dagster-prometheus/dagster_prometheus/resources.py
+++ b/python_modules/libraries/dagster-prometheus/dagster_prometheus/resources.py
@@ -3,8 +3,8 @@ from dagster import (
     ConfigurableResource,
     resource,
 )
-from dagster._core.execution.context.init import InitResourceContext
 from dagster._core.definitions.resource_definition import dagster_maintained_resource
+from dagster._core.execution.context.init import InitResourceContext
 from prometheus_client.exposition import default_handler
 from pydantic import Field, PrivateAttr
 

--- a/python_modules/libraries/dagster-prometheus/dagster_prometheus/resources.py
+++ b/python_modules/libraries/dagster-prometheus/dagster_prometheus/resources.py
@@ -51,6 +51,11 @@ class PrometheusResource(ConfigurableResource):
     )
     _registry: prometheus_client.CollectorRegistry = PrivateAttr(default=None)
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def setup_for_execution(self, context: InitResourceContext) -> None:
         self._registry = prometheus_client.CollectorRegistry()
 

--- a/python_modules/libraries/dagster-prometheus/dagster_prometheus/resources.py
+++ b/python_modules/libraries/dagster-prometheus/dagster_prometheus/resources.py
@@ -4,6 +4,7 @@ from dagster import (
     resource,
 )
 from dagster._core.execution.context.init import InitResourceContext
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from prometheus_client.exposition import default_handler
 from pydantic import Field, PrivateAttr
 
@@ -145,6 +146,7 @@ class PrometheusResource(ConfigurableResource):
         )
 
 
+@dagster_maintained_resource
 @resource(
     config_schema=PrometheusResource.to_config_schema(),
     description="""This resource is for sending metrics to a Prometheus Pushgateway.""",

--- a/python_modules/libraries/dagster-pyspark/dagster_pyspark/resources.py
+++ b/python_modules/libraries/dagster-pyspark/dagster_pyspark/resources.py
@@ -3,6 +3,7 @@ from typing import Any, Dict
 import dagster._check as check
 from dagster import ConfigurableResource, resource
 from dagster._core.execution.context.init import InitResourceContext
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster_spark.configs_spark import spark_config
 from dagster_spark.utils import flatten_dict
 from pydantic import PrivateAttr
@@ -59,6 +60,7 @@ class PySparkResource(ConfigurableResource):
         return self.spark_session.sparkContext
 
 
+@dagster_maintained_resource
 @resource({"spark_conf": spark_config()})
 def pyspark_resource(init_context) -> PySparkResource:
     """This resource provides access to a PySpark SparkSession for executing PySpark code within Dagster.
@@ -130,6 +132,7 @@ class LazyPySparkResource(ConfigurableResource):
         return self._spark_session.sparkContext
 
 
+@dagster_maintained_resource
 @resource({"spark_conf": spark_config()})
 def lazy_pyspark_resource(init_context: InitResourceContext) -> LazyPySparkResource:
     """This resource provides access to a lazily-created  PySpark SparkSession for executing PySpark

--- a/python_modules/libraries/dagster-pyspark/dagster_pyspark/resources.py
+++ b/python_modules/libraries/dagster-pyspark/dagster_pyspark/resources.py
@@ -2,8 +2,8 @@ from typing import Any, Dict
 
 import dagster._check as check
 from dagster import ConfigurableResource, resource
-from dagster._core.execution.context.init import InitResourceContext
 from dagster._core.definitions.resource_definition import dagster_maintained_resource
+from dagster._core.execution.context.init import InitResourceContext
 from dagster_spark.configs_spark import spark_config
 from dagster_spark.utils import flatten_dict
 from pydantic import PrivateAttr

--- a/python_modules/libraries/dagster-pyspark/dagster_pyspark/resources.py
+++ b/python_modules/libraries/dagster-pyspark/dagster_pyspark/resources.py
@@ -48,6 +48,11 @@ class PySparkResource(ConfigurableResource):
     spark_config: Dict[str, Any]
     _spark_session = PrivateAttr(default=None)
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def setup_for_execution(self, context: InitResourceContext) -> None:
         self._spark_session = spark_session_from_config(self.spark_config)
 
@@ -116,6 +121,11 @@ class LazyPySparkResource(ConfigurableResource):
 
     spark_config: Dict[str, Any]
     _spark_session = PrivateAttr(default=None)
+
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
 
     def _init_session(self) -> None:
         if self._spark_session is None:

--- a/python_modules/libraries/dagster-slack/dagster_slack/resources.py
+++ b/python_modules/libraries/dagster-slack/dagster_slack/resources.py
@@ -44,6 +44,11 @@ class SlackResource(ConfigurableResource):
         ),
     )
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def get_client(self) -> WebClient:
         """Returns a ``slack_sdk.WebClient`` for interacting with the Slack API."""
         return WebClient(self.token)

--- a/python_modules/libraries/dagster-slack/dagster_slack/resources.py
+++ b/python_modules/libraries/dagster-slack/dagster_slack/resources.py
@@ -1,4 +1,5 @@
 from dagster import ConfigurableResource, resource
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from pydantic import Field
 from slack_sdk.web.client import WebClient
 
@@ -48,6 +49,7 @@ class SlackResource(ConfigurableResource):
         return WebClient(self.token)
 
 
+@dagster_maintained_resource
 @resource(
     config_schema=SlackResource.to_config_schema(),
 )

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
@@ -291,6 +291,11 @@ class SnowflakePandasIOManager(SnowflakeIOManager):
 
     """
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @staticmethod
     def type_handlers() -> Sequence[DbTypeHandler]:
         return [SnowflakePandasTypeHandler()]

--- a/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark/snowflake_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark/snowflake_pyspark_type_handler.py
@@ -236,6 +236,11 @@ class SnowflakePySparkIOManager(SnowflakeIOManager):
 
     """
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @staticmethod
     def type_handlers() -> Sequence[DbTypeHandler]:
         return [SnowflakePySparkTypeHandler()]

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
@@ -288,6 +288,11 @@ class SnowflakeResource(ConfigurableResource, IAttachDifferentObjectToOpContext)
 
         return values
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @property
     @cached_method
     def _connection_args(self) -> Mapping[str, Any]:

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
@@ -14,6 +14,7 @@ from dagster import (
     resource,
 )
 from dagster._annotations import public
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._core.storage.event_log.sql_event_log import SqlDbConnection
 from dagster._utils.cached_method import cached_method
 from pydantic import Field, root_validator, validator
@@ -643,6 +644,7 @@ class SnowflakeConnection:
         self.execute_queries(sql_queries)
 
 
+@dagster_maintained_resource
 @resource(
     config_schema=SnowflakeResource.to_config_schema(),
     description="This resource is for connecting to the Snowflake data warehouse",

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
@@ -14,6 +14,7 @@ from dagster._core.storage.db_io_manager import (
     TablePartitionDimension,
     TableSlice,
 )
+from dagster._core.storage.io_manager import dagster_maintained_io_manager
 from pydantic import Field
 from sqlalchemy.exc import ProgrammingError
 
@@ -91,6 +92,7 @@ def build_snowflake_io_manager(
 
     """
 
+    @dagster_maintained_io_manager
     @io_manager(config_schema=SnowflakeIOManager.to_config_schema())
     def snowflake_io_manager(init_context):
         return DbIOManager(

--- a/python_modules/libraries/dagster-spark/dagster_spark/resources.py
+++ b/python_modules/libraries/dagster-spark/dagster_spark/resources.py
@@ -3,6 +3,7 @@ import subprocess
 
 import dagster._check as check
 from dagster import resource
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._core.log_manager import DagsterLogManager
 
 from .types import SparkOpError
@@ -60,6 +61,7 @@ class SparkResource:
             raise SparkOpError("Spark job failed. Please consult your logs.")
 
 
+@dagster_maintained_resource
 @resource
 def spark_resource(context):
     return SparkResource(context.log)

--- a/python_modules/libraries/dagster-ssh/dagster_ssh/resources.py
+++ b/python_modules/libraries/dagster-ssh/dagster_ssh/resources.py
@@ -11,6 +11,7 @@ from dagster import (
     _check as check,
     resource,
 )
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._utils import mkdir_p
 from dagster._utils.merger import merge_dicts
 from paramiko.config import SSH_PORT
@@ -212,6 +213,7 @@ class SSHResource:
         return local_filepath
 
 
+@dagster_maintained_resource
 @resource(
     config_schema={
         "remote_host": Field(

--- a/python_modules/libraries/dagster-twilio/dagster_twilio/resources.py
+++ b/python_modules/libraries/dagster-twilio/dagster_twilio/resources.py
@@ -22,6 +22,11 @@ class TwilioResource(ConfigurableResource):
         ),
     )
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def create_client(self) -> Client:
         return Client(self.account_sid, self.auth_token)
 

--- a/python_modules/libraries/dagster-twilio/dagster_twilio/resources.py
+++ b/python_modules/libraries/dagster-twilio/dagster_twilio/resources.py
@@ -1,4 +1,5 @@
 from dagster import ConfigurableResource, resource
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._core.execution.context.init import InitResourceContext
 from pydantic import Field
 from twilio.rest import Client
@@ -25,6 +26,7 @@ class TwilioResource(ConfigurableResource):
         return Client(self.account_sid, self.auth_token)
 
 
+@dagster_maintained_resource
 @resource(
     config_schema=TwilioResource.to_config_schema(),
     description="This resource is for connecting to Twilio",

--- a/python_modules/libraries/dagster-wandb/dagster_wandb/io_manager.py
+++ b/python_modules/libraries/dagster-wandb/dagster_wandb/io_manager.py
@@ -19,6 +19,7 @@ from dagster import (
     String,
     io_manager,
 )
+from dagster._core.storage.io_manager import dagster_maintained_io_manager
 from wandb.sdk.data_types.base_types.wb_value import WBValue
 from wandb.sdk.wandb_artifacts import Artifact
 
@@ -580,6 +581,7 @@ class ArtifactsIOManager(IOManager):
             raise WandbArtifactsIOManagerError() from exception
 
 
+@dagster_maintained_io_manager
 @io_manager(
     required_resource_keys={"wandb_resource", "wandb_config"},
     description="IO manager to read and write W&B Artifacts",

--- a/python_modules/libraries/dagster-wandb/dagster_wandb/resources.py
+++ b/python_modules/libraries/dagster-wandb/dagster_wandb/resources.py
@@ -2,11 +2,13 @@ from typing import Any, Dict
 
 import wandb
 from dagster import Field, InitResourceContext, String, StringSource, resource
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from wandb.sdk.internal.internal_api import Api
 
 WANDB_CLOUD_HOST: str = "https://api.wandb.ai"
 
 
+@dagster_maintained_resource
 @resource(
     config_schema={
         "api_key": Field(

--- a/python_modules/libraries/dagstermill/dagstermill/io_managers.py
+++ b/python_modules/libraries/dagstermill/dagstermill/io_managers.py
@@ -13,7 +13,7 @@ from dagster import (
 from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.execution.context.input import InputContext
 from dagster._core.execution.context.output import OutputContext
-from dagster._core.storage.io_manager import io_manager
+from dagster._core.storage.io_manager import dagster_maintained_io_manager, io_manager
 from dagster._utils import mkdir_p
 from pydantic import Field
 
@@ -100,6 +100,11 @@ class ConfigurableLocalOutputNotebookIOManager(ConfigurableIOManagerFactory):
         ),
     )
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def create_io_manager(self, context: InitResourceContext) -> "LocalOutputNotebookIOManager":
         return LocalOutputNotebookIOManager(
             base_dir=self.base_dir or check.not_none(context.instance).storage_directory(),
@@ -107,6 +112,7 @@ class ConfigurableLocalOutputNotebookIOManager(ConfigurableIOManagerFactory):
         )
 
 
+@dagster_maintained_io_manager
 @io_manager(config_schema=ConfigurableLocalOutputNotebookIOManager.to_config_schema())
 def local_output_notebook_io_manager(init_context) -> LocalOutputNotebookIOManager:
     """Built-in IO Manager that handles output notebooks."""


### PR DESCRIPTION
## Summary & Motivation
marks all function resources with `dagster_maintained_resource` decorator for telemetry
## How I Tested These Changes
