### PR TITLE
[telemetry] mark functional io managers as dagster maintained

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -54,7 +54,11 @@ from dagster._core.selector.subset_selector import (
     AssetSelectionData,
     OpSelectionData,
 )
-from dagster._core.storage.io_manager import IOManagerDefinition, io_manager
+from dagster._core.storage.io_manager import (
+    IOManagerDefinition,
+    dagster_maintained_io_manager,
+    io_manager,
+)
 from dagster._core.storage.tags import MEMOIZED_RUN_TAG
 from dagster._core.types.dagster_type import DagsterType
 from dagster._core.utils import str_format_set
@@ -988,6 +992,7 @@ def _swap_default_io_man(resources: Mapping[str, ResourceDefinition], job: JobDe
     return resources
 
 
+@dagster_maintained_io_manager
 @io_manager(
     description="Built-in filesystem IO manager that stores and retrieves values using pickling."
 )
@@ -1028,6 +1033,7 @@ def default_job_io_manager(init_context: "InitResourceContext"):
     return PickledObjectFilesystemIOManager(base_dir=instance.storage_directory())
 
 
+@dagster_maintained_io_manager
 @io_manager(
     description="Built-in filesystem IO manager that stores and retrieves values using pickling.",
     config_schema={"base_dir": Field(StringSource, is_required=False)},

--- a/python_modules/dagster/dagster/_core/storage/fs_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/fs_io_manager.py
@@ -120,6 +120,11 @@ class FilesystemIOManager(ConfigurableIOManagerFactory["PickledObjectFilesystemI
 
     base_dir: Optional[str] = Field(default=None, description="Base directory for storing files.")
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def create_io_manager(self, context: InitResourceContext) -> "PickledObjectFilesystemIOManager":
         base_dir = self.base_dir or check.not_none(context.instance).storage_directory()
         return PickledObjectFilesystemIOManager(base_dir=base_dir)

--- a/python_modules/dagster/dagster/_core/storage/fs_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/fs_io_manager.py
@@ -18,7 +18,7 @@ from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.execution.context.init import InitResourceContext
 from dagster._core.execution.context.input import InputContext
 from dagster._core.execution.context.output import OutputContext
-from dagster._core.storage.io_manager import IOManager, io_manager
+from dagster._core.storage.io_manager import IOManager, dagster_maintained_io_manager, io_manager
 from dagster._core.storage.upath_io_manager import UPathIOManager
 from dagster._utils import PICKLE_PROTOCOL, mkdir_p
 
@@ -125,6 +125,7 @@ class FilesystemIOManager(ConfigurableIOManagerFactory["PickledObjectFilesystemI
         return PickledObjectFilesystemIOManager(base_dir=base_dir)
 
 
+@dagster_maintained_io_manager
 @io_manager(
     config_schema=FilesystemIOManager.to_config_schema(),
     description="Built-in filesystem IO manager that stores and retrieves values using pickling.",
@@ -327,6 +328,7 @@ class CustomPathPickledObjectFilesystemIOManager(IOManager):
             return pickle.load(read_obj)
 
 
+@dagster_maintained_io_manager
 @io_manager(config_schema={"base_dir": DagsterField(StringSource, is_required=True)})
 @experimental
 def custom_path_fs_io_manager(

--- a/python_modules/dagster/dagster/_core/storage/mem_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/mem_io_manager.py
@@ -2,7 +2,7 @@ from typing import Dict, Tuple
 
 from dagster._core.execution.context.input import InputContext
 from dagster._core.execution.context.output import OutputContext
-from dagster._core.storage.io_manager import IOManager, io_manager
+from dagster._core.storage.io_manager import IOManager, dagster_maintained_io_manager, io_manager
 
 
 class InMemoryIOManager(IOManager):
@@ -18,6 +18,7 @@ class InMemoryIOManager(IOManager):
         return self.values[keys]
 
 
+@dagster_maintained_io_manager
 @io_manager(description="Built-in IO manager that stores and retrieves values in memory.")
 def mem_io_manager(_) -> InMemoryIOManager:
     """Built-in IO manager that stores and retrieves values in memory."""

--- a/python_modules/dagster/dagster/_core/storage/memoizable_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/memoizable_io_manager.py
@@ -9,7 +9,7 @@ from dagster._config import Field, StringSource
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.execution.context.input import InputContext
 from dagster._core.execution.context.output import OutputContext
-from dagster._core.storage.io_manager import IOManager, io_manager
+from dagster._core.storage.io_manager import IOManager, dagster_maintained_io_manager, io_manager
 from dagster._utils import PICKLE_PROTOCOL, mkdir_p
 
 
@@ -92,6 +92,7 @@ class VersionedPickledObjectFilesystemIOManager(MemoizableIOManager):
         return os.path.exists(filepath) and not os.path.isdir(filepath)
 
 
+@dagster_maintained_io_manager
 @io_manager(config_schema={"base_dir": Field(StringSource, is_required=False)})
 @experimental
 def versioned_filesystem_io_manager(init_context):

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
@@ -70,6 +70,11 @@ class BaseAirbyteResource(ConfigurableResource):
         ),
     )
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @property
     @cached_method
     def _log(self) -> logging.Logger:

--- a/python_modules/libraries/dagster-aws/dagster_aws/athena/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/athena/resources.py
@@ -265,6 +265,11 @@ class AthenaClientResource(ResourceWithAthenaConfig):
 
     """
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def get_client(self) -> AthenaClient:
         """Returns an Athena client object."""
         client = boto3.client(

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecr/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecr/resources.py
@@ -39,6 +39,11 @@ class ECRPublicResource(ConfigurableResource):
     Similar to the AWS CLI's `aws ecr-public get-login-password` command.
     """
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def get_client(self) -> ECRPublicClient:
         return ECRPublicClient()
 
@@ -47,6 +52,11 @@ class FakeECRPublicResource(ConfigurableResource):
     """This resource behaves like ecr_public_resource except it stubs out the real AWS API
     requests and always returns `'token'` as its login password.
     """
+
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
 
     def get_client(self) -> FakeECRPublicClient:
         return FakeECRPublicClient()

--- a/python_modules/libraries/dagster-aws/dagster_aws/redshift/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/redshift/resources.py
@@ -335,6 +335,11 @@ class RedshiftClientResource(ConfigurableResource):
         ),
     )
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def get_client(self) -> RedshiftClient:
         conn_args = {
             k: getattr(self, k, None)

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
@@ -130,6 +130,11 @@ class ConfigurablePickledObjectS3IOManager(ConfigurableIOManager):
         default="dagster", description="Prefix to use for the S3 bucket for this file manager."
     )
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @cached_method
     def inner_io_manager(self) -> PickledObjectS3IOManager:
         return PickledObjectS3IOManager(

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
@@ -11,6 +11,7 @@ from dagster import (
     _check as check,
     io_manager,
 )
+from dagster._core.storage.io_manager import dagster_maintained_io_manager
 from dagster._core.storage.upath_io_manager import UPathIOManager
 from dagster._utils import PICKLE_PROTOCOL
 from dagster._utils.cached_method import cached_method
@@ -144,6 +145,7 @@ class ConfigurablePickledObjectS3IOManager(ConfigurableIOManager):
         return self.inner_io_manager().handle_output(context, obj)
 
 
+@dagster_maintained_io_manager
 @io_manager(
     config_schema=ConfigurablePickledObjectS3IOManager.to_config_schema(),
     required_resource_keys={"s3"},

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/resources.py
@@ -83,6 +83,11 @@ class S3Resource(ResourceWithS3Configuration, IAttachDifferentObjectToOpContext)
 
     """
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def get_client(self) -> Any:
         return construct_s3_client(
             max_attempts=self.max_attempts,

--- a/python_modules/libraries/dagster-aws/dagster_aws/secretsmanager/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/secretsmanager/resources.py
@@ -50,6 +50,11 @@ class SecretsManagerResource(ResourceWithBoto3Configuration):
             )
     """
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def get_client(self) -> "botocore.client.SecretsManager":
         return construct_secretsmanager_client(
             max_attempts=self.max_attempts,
@@ -160,6 +165,11 @@ class SecretsManagerSecretsResource(ResourceWithBoto3Configuration):
         default=None,
         description="AWS Secrets Manager secrets with this tag will be fetched and made available.",
     )
+
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
 
     @contextmanager
     def secrets_in_environment(

--- a/python_modules/libraries/dagster-aws/dagster_aws/ssm/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ssm/resources.py
@@ -57,6 +57,11 @@ class SSMResource(ResourceWithBoto3Configuration):
             )
     """
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def get_client(self) -> "botocore.client.ssm":
         return construct_ssm_client(
             max_attempts=self.max_attempts,
@@ -183,6 +188,11 @@ class ParameterStoreResource(ResourceWithBoto3Configuration):
             " String or StringList"
         ),
     )
+
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
 
     @contextmanager
     def parameters_in_environment(

--- a/python_modules/libraries/dagster-azure/dagster_azure/adls2/fake_adls2_resource.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/adls2/fake_adls2_resource.py
@@ -28,6 +28,11 @@ class FakeADLS2Resource(ConfigurableResource):
     account_name: str
     storage_account: Optional[str] = None
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @property
     @cached_method
     def adls2_client(self) -> "FakeADLS2ServiceClient":

--- a/python_modules/libraries/dagster-azure/dagster_azure/adls2/io_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/adls2/io_manager.py
@@ -10,6 +10,7 @@ from dagster import (
     io_manager,
 )
 from dagster._config.pythonic_config import ConfigurableIOManager
+from dagster._core.storage.io_manager import dagster_maintained_io_manager
 from dagster._core.storage.upath_io_manager import UPathIOManager
 from dagster._utils import PICKLE_PROTOCOL
 from dagster._utils.cached_method import cached_method
@@ -195,6 +196,7 @@ class ConfigurablePickledObjectADLS2IOManager(ConfigurableIOManager):
         self._internal_io_manager.handle_output(context, obj)
 
 
+@dagster_maintained_io_manager
 @io_manager(
     config_schema=ConfigurablePickledObjectADLS2IOManager.to_config_schema(),
     required_resource_keys={"adls2"},

--- a/python_modules/libraries/dagster-azure/dagster_azure/adls2/io_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/adls2/io_manager.py
@@ -178,6 +178,11 @@ class ConfigurablePickledObjectADLS2IOManager(ConfigurableIOManager):
         default="dagster", description="ADLS Gen2 file system prefix to write to."
     )
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @property
     @cached_method
     def _internal_io_manager(self) -> PickledObjectADLS2IOManager:

--- a/python_modules/libraries/dagster-azure/dagster_azure/adls2/resources.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/adls2/resources.py
@@ -73,6 +73,11 @@ class ADLS2Resource(ADLS2BaseResource):
     of each.
     """
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @property
     @cached_method
     def _raw_credential(self) -> Any:

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/resources.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/resources.py
@@ -27,6 +27,11 @@ class DatabricksClientResource(ConfigurableResource, IAttachDifferentObjectToOpC
         ),
     )
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def get_client(self) -> DatabricksClient:
         return DatabricksClient(
             host=self.host,

--- a/python_modules/libraries/dagster-datadog/dagster_datadog/resources.py
+++ b/python_modules/libraries/dagster-datadog/dagster_datadog/resources.py
@@ -86,6 +86,11 @@ class DatadogResource(ConfigurableResource):
         )
     )
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def get_client(self) -> DatadogClient:
         return DatadogClient(self.api_key, self.app_key)
 

--- a/python_modules/libraries/dagster-datahub/dagster_datahub/resources.py
+++ b/python_modules/libraries/dagster-datahub/dagster_datahub/resources.py
@@ -28,6 +28,11 @@ class DatahubRESTEmitterResource(ConfigurableResource):
     server_telemetry_id: Optional[str] = None
     disable_ssl_verification: bool = False
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def get_emitter(self) -> DatahubRestEmitter:
         return DatahubRestEmitter(
             gms_server=self.connection,
@@ -82,6 +87,11 @@ class DatahubKafkaEmitterResource(ConfigurableResource):
             MCP_KEY: DEFAULT_MCP_KAFKA_TOPIC,
         }
     )
+
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
 
     def get_emitter(self) -> DatahubKafkaEmitter:
         return DatahubKafkaEmitter(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources.py
@@ -478,6 +478,11 @@ class DbtCliClientResource(ConfigurableResourceWithCliFlags, IAttachDifferentObj
     class Config:
         extra = "allow"
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def get_dbt_client(self) -> DbtCliClient:
         context = self.get_resource_context()
         default_flags = {

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/resources.py
@@ -639,6 +639,11 @@ class DbtCloudClientResource(ConfigurableResource, IAttachDifferentObjectToOpCon
         ),
     )
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def get_dbt_client(self) -> DbtCloudClient:
         context = self.get_resource_context()
         assert context.log

--- a/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas/duckdb_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas/duckdb_pandas_type_handler.py
@@ -191,6 +191,11 @@ class DuckDBPandasIOManager(DuckDBIOManager):
 
     """
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @staticmethod
     def type_handlers() -> Sequence[DbTypeHandler]:
         return [DuckDBPandasTypeHandler()]

--- a/python_modules/libraries/dagster-duckdb-polars/dagster_duckdb_polars/duckdb_polars_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-polars/dagster_duckdb_polars/duckdb_polars_type_handler.py
@@ -193,6 +193,11 @@ class DuckDBPolarsIOManager(DuckDBIOManager):
 
     """
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @staticmethod
     def type_handlers() -> Sequence[DbTypeHandler]:
         return [DuckDBPolarsTypeHandler()]

--- a/python_modules/libraries/dagster-duckdb-pyspark/dagster_duckdb_pyspark/duckdb_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pyspark/dagster_duckdb_pyspark/duckdb_pyspark_type_handler.py
@@ -200,6 +200,11 @@ class DuckDBPySparkIOManager(DuckDBIOManager):
 
     """
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @staticmethod
     def type_handlers() -> Sequence[DbTypeHandler]:
         return [DuckDBPySparkTypeHandler()]

--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
@@ -15,6 +15,7 @@ from dagster._core.storage.db_io_manager import (
     TablePartitionDimension,
     TableSlice,
 )
+from dagster._core.storage.io_manager import dagster_maintained_io_manager
 from dagster._utils.backoff import backoff
 from pydantic import Field
 
@@ -83,6 +84,7 @@ def build_duckdb_io_manager(
 
     """
 
+    @dagster_maintained_io_manager
     @io_manager(config_schema=DuckDBIOManager.to_config_schema())
     def duckdb_io_manager(init_context):
         """IO Manager for storing outputs in a DuckDB database.

--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb/resource.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb/resource.py
@@ -34,6 +34,11 @@ class DuckDBResource(ConfigurableResource):
         )
     )
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @contextmanager
     def get_connection(self):
         conn = backoff(

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
@@ -58,6 +58,11 @@ class FivetranResource(ConfigurableResource):
         description="Time (in seconds) to wait between each request retry.",
     )
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @property
     def _auth(self) -> HTTPBasicAuth:
         return HTTPBasicAuth(self.api_key, self.api_secret)

--- a/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas/bigquery/bigquery_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas/bigquery/bigquery_pandas_type_handler.py
@@ -225,6 +225,11 @@ class BigQueryPandasIOManager(BigQueryIOManager):
 
     """
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @staticmethod
     def type_handlers() -> Sequence[DbTypeHandler]:
         return [BigQueryPandasTypeHandler()]

--- a/python_modules/libraries/dagster-gcp-pyspark/dagster_gcp_pyspark/bigquery/bigquery_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-gcp-pyspark/dagster_gcp_pyspark/bigquery/bigquery_pyspark_type_handler.py
@@ -232,6 +232,11 @@ class BigQueryPySparkIOManager(BigQueryIOManager):
 
     """
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @staticmethod
     def type_handlers() -> Sequence[DbTypeHandler]:
         return [BigQueryPySparkTypeHandler()]

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/io_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/io_manager.py
@@ -15,6 +15,7 @@ from dagster._core.storage.db_io_manager import (
     TableSlice,
     TimeWindow,
 )
+from dagster._core.storage.io_manager import dagster_maintained_io_manager
 from google.api_core.exceptions import NotFound
 from google.cloud import bigquery
 from pydantic import Field
@@ -101,6 +102,7 @@ def build_bigquery_io_manager(
         the base64 encoded with this shell command: cat $GOOGLE_APPLICATION_CREDENTIALS | base64
     """
 
+    @dagster_maintained_io_manager
     @io_manager(config_schema=BigQueryIOManager.to_config_schema())
     def bigquery_io_manager(init_context):
         """I/O Manager for storing outputs in a BigQuery database.

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/resources.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/resources.py
@@ -56,6 +56,11 @@ class BigQueryResource(ConfigurableResource, IAttachDifferentObjectToOpContext):
         ),
     )
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @contextmanager
     def get_client(self) -> Iterator[bigquery.Client]:
         """Context manager to create a BigQuery Client.

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/dataproc/resources.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/dataproc/resources.py
@@ -199,6 +199,11 @@ class DataprocResource(ConfigurableResource, IAttachDifferentObjectToOpContext):
         ),
     )
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def _read_yaml_config(self, path: str) -> Mapping[str, Any]:
         with open(path, "r", encoding="utf8") as f:
             return yaml.safe_load(f)

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/io_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/io_manager.py
@@ -146,6 +146,11 @@ class ConfigurablePickledObjectGCSIOManager(ConfigurableIOManager):
     gcs_bucket: str = Field(description="GCS bucket to store files")
     gcs_prefix: str = Field(default="dagster", description="Prefix to add to all file paths")
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @property
     @cached_method
     def _internal_io_manager(self) -> PickledObjectGCSIOManager:

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/io_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/io_manager.py
@@ -9,6 +9,7 @@ from dagster import (
     _check as check,
     io_manager,
 )
+from dagster._core.storage.io_manager import dagster_maintained_io_manager
 from dagster._core.storage.upath_io_manager import UPathIOManager
 from dagster._utils import PICKLE_PROTOCOL
 from dagster._utils.backoff import backoff
@@ -159,6 +160,7 @@ class ConfigurablePickledObjectGCSIOManager(ConfigurableIOManager):
         self._internal_io_manager.handle_output(context, obj)
 
 
+@dagster_maintained_io_manager
 @io_manager(
     config_schema=ConfigurablePickledObjectGCSIOManager.to_config_schema(),
     required_resource_keys={"gcs"},

--- a/python_modules/libraries/dagster-github/dagster_github/resources.py
+++ b/python_modules/libraries/dagster-github/dagster_github/resources.py
@@ -181,6 +181,11 @@ class GithubResource(ConfigurableResource):
         ),
     )
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def get_client(self) -> GithubClient:
         return GithubClient(
             client=requests.Session(),

--- a/python_modules/libraries/dagster-msteams/dagster_msteams/resources.py
+++ b/python_modules/libraries/dagster-msteams/dagster_msteams/resources.py
@@ -61,6 +61,11 @@ class MSTeamsResource(ConfigurableResource):
         default=True, description="Whether to verify SSL certificates, defaults to True"
     )
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def get_client(self) -> TeamsClient:
         return TeamsClient(
             hook_url=self.hook_url,

--- a/python_modules/libraries/dagster-pagerduty/dagster_pagerduty/resources.py
+++ b/python_modules/libraries/dagster-pagerduty/dagster_pagerduty/resources.py
@@ -31,6 +31,11 @@ class PagerDutyService(ConfigurableResource):
         ),
     )
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def EventV2_create(
         self,
         summary: str,

--- a/python_modules/libraries/dagster-prometheus/dagster_prometheus/resources.py
+++ b/python_modules/libraries/dagster-prometheus/dagster_prometheus/resources.py
@@ -51,6 +51,11 @@ class PrometheusResource(ConfigurableResource):
     )
     _registry: prometheus_client.CollectorRegistry = PrivateAttr(default=None)
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def setup_for_execution(self, context: InitResourceContext) -> None:
         self._registry = prometheus_client.CollectorRegistry()
 

--- a/python_modules/libraries/dagster-pyspark/dagster_pyspark/resources.py
+++ b/python_modules/libraries/dagster-pyspark/dagster_pyspark/resources.py
@@ -48,6 +48,11 @@ class PySparkResource(ConfigurableResource):
     spark_config: Dict[str, Any]
     _spark_session = PrivateAttr(default=None)
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def setup_for_execution(self, context: InitResourceContext) -> None:
         self._spark_session = spark_session_from_config(self.spark_config)
 
@@ -116,6 +121,11 @@ class LazyPySparkResource(ConfigurableResource):
 
     spark_config: Dict[str, Any]
     _spark_session = PrivateAttr(default=None)
+
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
 
     def _init_session(self) -> None:
         if self._spark_session is None:

--- a/python_modules/libraries/dagster-slack/dagster_slack/resources.py
+++ b/python_modules/libraries/dagster-slack/dagster_slack/resources.py
@@ -44,6 +44,11 @@ class SlackResource(ConfigurableResource):
         ),
     )
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def get_client(self) -> WebClient:
         """Returns a ``slack_sdk.WebClient`` for interacting with the Slack API."""
         return WebClient(self.token)

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
@@ -291,6 +291,11 @@ class SnowflakePandasIOManager(SnowflakeIOManager):
 
     """
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @staticmethod
     def type_handlers() -> Sequence[DbTypeHandler]:
         return [SnowflakePandasTypeHandler()]

--- a/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark/snowflake_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark/snowflake_pyspark_type_handler.py
@@ -236,6 +236,11 @@ class SnowflakePySparkIOManager(SnowflakeIOManager):
 
     """
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @staticmethod
     def type_handlers() -> Sequence[DbTypeHandler]:
         return [SnowflakePySparkTypeHandler()]

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
@@ -288,6 +288,11 @@ class SnowflakeResource(ConfigurableResource, IAttachDifferentObjectToOpContext)
 
         return values
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @property
     @cached_method
     def _connection_args(self) -> Mapping[str, Any]:

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
@@ -14,6 +14,7 @@ from dagster._core.storage.db_io_manager import (
     TablePartitionDimension,
     TableSlice,
 )
+from dagster._core.storage.io_manager import dagster_maintained_io_manager
 from pydantic import Field
 from sqlalchemy.exc import ProgrammingError
 
@@ -91,6 +92,7 @@ def build_snowflake_io_manager(
 
     """
 
+    @dagster_maintained_io_manager
     @io_manager(config_schema=SnowflakeIOManager.to_config_schema())
     def snowflake_io_manager(init_context):
         return DbIOManager(

--- a/python_modules/libraries/dagster-twilio/dagster_twilio/resources.py
+++ b/python_modules/libraries/dagster-twilio/dagster_twilio/resources.py
@@ -22,6 +22,11 @@ class TwilioResource(ConfigurableResource):
         ),
     )
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def create_client(self) -> Client:
         return Client(self.account_sid, self.auth_token)
 

--- a/python_modules/libraries/dagster-wandb/dagster_wandb/io_manager.py
+++ b/python_modules/libraries/dagster-wandb/dagster_wandb/io_manager.py
@@ -19,6 +19,7 @@ from dagster import (
     String,
     io_manager,
 )
+from dagster._core.storage.io_manager import dagster_maintained_io_manager
 from wandb.sdk.data_types.base_types.wb_value import WBValue
 from wandb.sdk.wandb_artifacts import Artifact
 
@@ -580,6 +581,7 @@ class ArtifactsIOManager(IOManager):
             raise WandbArtifactsIOManagerError() from exception
 
 
+@dagster_maintained_io_manager
 @io_manager(
     required_resource_keys={"wandb_resource", "wandb_config"},
     description="IO manager to read and write W&B Artifacts",

--- a/python_modules/libraries/dagstermill/dagstermill/io_managers.py
+++ b/python_modules/libraries/dagstermill/dagstermill/io_managers.py
@@ -100,6 +100,11 @@ class ConfigurableLocalOutputNotebookIOManager(ConfigurableIOManagerFactory):
         ),
     )
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def create_io_manager(self, context: InitResourceContext) -> "LocalOutputNotebookIOManager":
         return LocalOutputNotebookIOManager(
             base_dir=self.base_dir or check.not_none(context.instance).storage_directory(),

--- a/python_modules/libraries/dagstermill/dagstermill/io_managers.py
+++ b/python_modules/libraries/dagstermill/dagstermill/io_managers.py
@@ -13,7 +13,7 @@ from dagster import (
 from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.execution.context.input import InputContext
 from dagster._core.execution.context.output import OutputContext
-from dagster._core.storage.io_manager import io_manager
+from dagster._core.storage.io_manager import dagster_maintained_io_manager, io_manager
 from dagster._utils import mkdir_p
 from pydantic import Field
 
@@ -107,6 +107,7 @@ class ConfigurableLocalOutputNotebookIOManager(ConfigurableIOManagerFactory):
         )
 
 
+@dagster_maintained_io_manager
 @io_manager(config_schema=ConfigurableLocalOutputNotebookIOManager.to_config_schema())
 def local_output_notebook_io_manager(init_context) -> LocalOutputNotebookIOManager:
     """Built-in IO Manager that handles output notebooks."""


### PR DESCRIPTION
## Summary & Motivation
Marks all function IO managers with `dagster_maintained_io_manager` for telemetry
## How I Tested These Changes
