### PR TITLE
[telemetry] mark pythonic io managers as dagster maintained

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/fs_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/fs_io_manager.py
@@ -120,6 +120,11 @@ class FilesystemIOManager(ConfigurableIOManagerFactory["PickledObjectFilesystemI
 
     base_dir: Optional[str] = Field(default=None, description="Base directory for storing files.")
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def create_io_manager(self, context: InitResourceContext) -> "PickledObjectFilesystemIOManager":
         base_dir = self.base_dir or check.not_none(context.instance).storage_directory()
         return PickledObjectFilesystemIOManager(base_dir=base_dir)

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
@@ -130,6 +130,11 @@ class ConfigurablePickledObjectS3IOManager(ConfigurableIOManager):
         default="dagster", description="Prefix to use for the S3 bucket for this file manager."
     )
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @cached_method
     def inner_io_manager(self) -> PickledObjectS3IOManager:
         return PickledObjectS3IOManager(

--- a/python_modules/libraries/dagster-azure/dagster_azure/adls2/io_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/adls2/io_manager.py
@@ -178,6 +178,11 @@ class ConfigurablePickledObjectADLS2IOManager(ConfigurableIOManager):
         default="dagster", description="ADLS Gen2 file system prefix to write to."
     )
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @property
     @cached_method
     def _internal_io_manager(self) -> PickledObjectADLS2IOManager:

--- a/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas/duckdb_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas/duckdb_pandas_type_handler.py
@@ -191,6 +191,11 @@ class DuckDBPandasIOManager(DuckDBIOManager):
 
     """
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @staticmethod
     def type_handlers() -> Sequence[DbTypeHandler]:
         return [DuckDBPandasTypeHandler()]

--- a/python_modules/libraries/dagster-duckdb-polars/dagster_duckdb_polars/duckdb_polars_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-polars/dagster_duckdb_polars/duckdb_polars_type_handler.py
@@ -193,6 +193,11 @@ class DuckDBPolarsIOManager(DuckDBIOManager):
 
     """
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @staticmethod
     def type_handlers() -> Sequence[DbTypeHandler]:
         return [DuckDBPolarsTypeHandler()]

--- a/python_modules/libraries/dagster-duckdb-pyspark/dagster_duckdb_pyspark/duckdb_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pyspark/dagster_duckdb_pyspark/duckdb_pyspark_type_handler.py
@@ -200,6 +200,11 @@ class DuckDBPySparkIOManager(DuckDBIOManager):
 
     """
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @staticmethod
     def type_handlers() -> Sequence[DbTypeHandler]:
         return [DuckDBPySparkTypeHandler()]

--- a/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas/bigquery/bigquery_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas/bigquery/bigquery_pandas_type_handler.py
@@ -225,6 +225,11 @@ class BigQueryPandasIOManager(BigQueryIOManager):
 
     """
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @staticmethod
     def type_handlers() -> Sequence[DbTypeHandler]:
         return [BigQueryPandasTypeHandler()]

--- a/python_modules/libraries/dagster-gcp-pyspark/dagster_gcp_pyspark/bigquery/bigquery_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-gcp-pyspark/dagster_gcp_pyspark/bigquery/bigquery_pyspark_type_handler.py
@@ -232,6 +232,11 @@ class BigQueryPySparkIOManager(BigQueryIOManager):
 
     """
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @staticmethod
     def type_handlers() -> Sequence[DbTypeHandler]:
         return [BigQueryPySparkTypeHandler()]

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/io_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/io_manager.py
@@ -146,6 +146,11 @@ class ConfigurablePickledObjectGCSIOManager(ConfigurableIOManager):
     gcs_bucket: str = Field(description="GCS bucket to store files")
     gcs_prefix: str = Field(default="dagster", description="Prefix to add to all file paths")
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @property
     @cached_method
     def _internal_io_manager(self) -> PickledObjectGCSIOManager:

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
@@ -291,6 +291,11 @@ class SnowflakePandasIOManager(SnowflakeIOManager):
 
     """
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @staticmethod
     def type_handlers() -> Sequence[DbTypeHandler]:
         return [SnowflakePandasTypeHandler()]

--- a/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark/snowflake_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark/snowflake_pyspark_type_handler.py
@@ -236,6 +236,11 @@ class SnowflakePySparkIOManager(SnowflakeIOManager):
 
     """
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @staticmethod
     def type_handlers() -> Sequence[DbTypeHandler]:
         return [SnowflakePySparkTypeHandler()]

--- a/python_modules/libraries/dagstermill/dagstermill/io_managers.py
+++ b/python_modules/libraries/dagstermill/dagstermill/io_managers.py
@@ -100,6 +100,11 @@ class ConfigurableLocalOutputNotebookIOManager(ConfigurableIOManagerFactory):
         ),
     )
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def create_io_manager(self, context: InitResourceContext) -> "LocalOutputNotebookIOManager":
         return LocalOutputNotebookIOManager(
             base_dir=self.base_dir or check.not_none(context.instance).storage_directory(),


### PR DESCRIPTION
## Summary & Motivation
marks pythonic io managers with dagster maintained property for telemetry

## How I Tested These Changes
