### PR TITLE
[telemetry] do not merge - example telemetry

### DIFF
--- a/examples/project_fully_featured/project_fully_featured/resources/__init__.py
+++ b/examples/project_fully_featured/project_fully_featured/resources/__init__.py
@@ -4,9 +4,11 @@ from dagster._utils import file_relative_path
 from dagster_aws.s3 import S3Resource
 from dagster_aws.s3.io_manager import ConfigurablePickledObjectS3IOManager
 from dagster_dbt import DbtCliClientResource
+from dagster_gcp import bigquery_resource, BigQueryResource
 from dagster_pyspark import pyspark_resource
 from dagster_snowflake import SnowflakeResource, snowflake_resource
 from dagster_snowflake_pandas import SnowflakePandasIOManager, snowflake_pandas_io_manager
+from dagster_duckdb_pandas import duckdb_pandas_io_manager, DuckDBPandasIOManager
 
 from .duckdb_parquet_io_manager import DuckDBPartitionedParquetIOManager
 from .hn_resource import HNAPIClient, HNAPISubsampleClient
@@ -98,15 +100,18 @@ RESOURCES_LOCAL = {
     "dbt": dbt_local_resource,
     "old_style_io": snowflake_pandas_io_manager,
     "old_style_resource": snowflake_resource,
-    "old_style_resource_configured": snowflake_resource.configured({"account": "bar"}),
-    "old_style_io_configured": snowflake_pandas_io_manager.configured({"account": "bar"}),
+    "old_style_resource_configured": bigquery_resource.configured({"project": "bar"}),
+    "old_style_io_configured": duckdb_pandas_io_manager.configured({"database": "bar"}),
     "new_style_io_configured": SnowflakePandasIOManager(
         database="foo", account="foo", password="foo", user="foo"
     ),
     "new_style_resource_configured": SnowflakeResource(
         database="foo", account="foo", password="foo", user="foo"
     ),
-    "new_style_io": SnowflakePandasIOManager.configure_at_launch(),
-    "new_style_resource": SnowflakeResource.configure_at_launch(),
+    "new_style_io": DuckDBPandasIOManager.configure_at_launch(),
+    "new_style_resource": BigQueryResource.configure_at_launch(),
     "custom_configure_at_launch": DuckDBPartitionedParquetIOManager.configure_at_launch(),
+    "duplicate_resource": SnowflakeResource(
+        database="foo", account="foo", password="foo", user="foo"
+    ),
 }

--- a/examples/project_fully_featured/project_fully_featured/resources/__init__.py
+++ b/examples/project_fully_featured/project_fully_featured/resources/__init__.py
@@ -5,6 +5,8 @@ from dagster_aws.s3 import S3Resource
 from dagster_aws.s3.io_manager import ConfigurablePickledObjectS3IOManager
 from dagster_dbt import DbtCliClientResource
 from dagster_pyspark import pyspark_resource
+from dagster_snowflake import SnowflakeResource, snowflake_resource
+from dagster_snowflake_pandas import SnowflakePandasIOManager, snowflake_pandas_io_manager
 
 from .duckdb_parquet_io_manager import DuckDBPartitionedParquetIOManager
 from .hn_resource import HNAPIClient, HNAPISubsampleClient
@@ -94,4 +96,16 @@ RESOURCES_LOCAL = {
     ),
     "hn_client": HNAPIClient(),
     "dbt": dbt_local_resource,
+    "old_style_io": snowflake_pandas_io_manager,
+    "old_style_resource": snowflake_resource,
+    "old_style_resource_configured": snowflake_resource.configured({"account": "bar"}),
+    "old_style_io_configured": snowflake_pandas_io_manager.configured({"account": "bar"}),
+    "new_style_io_configured": SnowflakePandasIOManager(
+        database="foo", account="foo", password="foo", user="foo"
+    ),
+    "new_style_resource_configured": SnowflakeResource(
+        database="foo", account="foo", password="foo", user="foo"
+    ),
+    "new_style_io": SnowflakePandasIOManager.configure_at_launch(),
+    "new_style_resource": SnowflakeResource.configure_at_launch(),
 }

--- a/examples/project_fully_featured/project_fully_featured/resources/__init__.py
+++ b/examples/project_fully_featured/project_fully_featured/resources/__init__.py
@@ -108,4 +108,5 @@ RESOURCES_LOCAL = {
     ),
     "new_style_io": SnowflakePandasIOManager.configure_at_launch(),
     "new_style_resource": SnowflakeResource.configure_at_launch(),
+    "custom_configure_at_launch": DuckDBPartitionedParquetIOManager.configure_at_launch(),
 }


### PR DESCRIPTION
## Summary & Motivation
Adds a bunch of types of resources and io managers to Project Fully Featured to show how telemetry is collected. Will not actually merge this PR it is just a proof of concept for the other PRs in the stack 

The  relevant telemetry received is 

``` python
{"dagster_resources": "[
  {'module_name': 'dagster_dbt', 'class_name': 'DbtCliClientResource'}, 
  {'module_name': 'dagster_snowflake', 'class_name': 'SnowflakeResource'}, 
  {'module_name': 'dagster_duckdb_pandas', 'class_name': 'DuckDBPandasIOManager'}, 
  {'module_name': 'dagster_snowflake_pandas', 'class_name': 'SnowflakePandasIOManager'}, 
  {'module_name': 'dagster_snowflake', 'class_name': 'SnowflakeResource'}, 
  {'module_name': 'dagster_snowflake', 'class_name': 'snowflake_io_manager'}, 
  {'module_name': 'dagster_duckdb', 'class_name': 'duckdb_io_manager'}, 
  {'module_name': 'dagster_snowflake', 'class_name': 'snowflake_resource'}, 
  {'module_name': 'dagster_gcp', 'class_name': 'bigquery_resource'}
]", 
"has_custom_resources": "True",
}

```

## How I Tested These Changes
