### PR TITLE
Add a 'transient' flag to CheckRunHealthResult

### DIFF
--- a/python_modules/dagster/dagster/_core/launcher/base.py
+++ b/python_modules/dagster/dagster/_core/launcher/base.py
@@ -46,6 +46,7 @@ class CheckRunHealthResult(NamedTuple):
 
     status: WorkerStatus
     msg: Optional[str] = None
+    transient: bool = False  # If the health check is a failure, will it potentially pass on retry?
 
     def __str__(self) -> str:
         return f"{self.status.value}: '{self.msg}'"


### PR DESCRIPTION
Summary:
Lets a run worker return whether it believes that a retry may help if there's a failure.

## Summary & Motivation

## How I Tested These Changes
