### PR TITLE
[ui] Guard against partition set status error

### DIFF
--- a/js_modules/dagit/packages/core/src/partitions/DimensionRangeWizard.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/DimensionRangeWizard.tsx
@@ -16,7 +16,7 @@ import styled from 'styled-components/macro';
 
 import {AssetPartitionStatusDot} from '../assets/AssetPartitionList';
 import {partitionStatusAtIndex} from '../assets/usePartitionHealthData';
-import {PartitionDefinitionType} from '../graphql/types';
+import {PartitionDefinitionType, RunStatus} from '../graphql/types';
 import {RunStatusDot} from '../runs/RunStatusDots';
 import {testId} from '../testing/testId';
 import {RepoAddress} from '../workspace/types';
@@ -147,7 +147,10 @@ const OrdinalPartitionSelector: React.FC<{
         return <AssetPartitionStatusDot status={partitionStatusAtIndex(health.ranges, index)} />;
       } else {
         return (
-          <RunStatusDot size={10} status={health.runStatusForPartitionKey(partitionKey, index)} />
+          <RunStatusDot
+            size={10}
+            status={health.runStatusForPartitionKey(partitionKey, index) || RunStatus.NOT_STARTED}
+          />
         );
       }
     },

--- a/js_modules/dagit/packages/core/src/partitions/__fixtures__/OpJobPartitionsViewContent.fixtures.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/__fixtures__/OpJobPartitionsViewContent.fixtures.tsx
@@ -1,0 +1,22 @@
+import {
+  buildPartition,
+  buildPartitionSet,
+  buildPartitions,
+  buildPythonError,
+} from '../../graphql/types';
+import {OpJobPartitionSetFragment} from '../types/OpJobPartitionsView.types';
+
+export const buildOpJobPartitionSetFragmentWithError = (): OpJobPartitionSetFragment => {
+  return buildPartitionSet({
+    id: 'my-partition-set',
+    name: 'my-partition-set',
+    pipelineName: 'my-job',
+    partitionRuns: [],
+    partitionsOrError: buildPartitions({
+      results: [buildPartition({name: 'lorem'}), buildPartition({name: 'ipsum'})],
+    }),
+    partitionStatusesOrError: buildPythonError({
+      message: 'total fail',
+    }),
+  });
+};

--- a/js_modules/dagit/packages/core/src/partitions/__tests__/OpJobPartitionsViewContent.test.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/__tests__/OpJobPartitionsViewContent.test.tsx
@@ -1,0 +1,35 @@
+import {MockedProvider} from '@apollo/client/testing';
+import {render, screen} from '@testing-library/react';
+import * as React from 'react';
+
+import {buildRepoAddress} from '../../workspace/buildRepoAddress';
+import {OpJobPartitionsViewContent} from '../OpJobPartitionsView';
+import {buildOpJobPartitionSetFragmentWithError} from '../__fixtures__/OpJobPartitionsViewContent.fixtures';
+
+jest.mock('../usePartitionStepQuery', () => ({
+  usePartitionStepQuery: () => [],
+}));
+
+jest.mock('../JobBackfillsTable', () => ({
+  JobBackfillsTable: () => <div />,
+}));
+
+// This file must be mocked because Jest can't handle `import.meta.url`.
+jest.mock('../../graph/asyncGraphLayout', () => ({}));
+
+describe('OpJobPartitionsViewContent', () => {
+  it('does not error when partition statuses are in an error state', async () => {
+    const fragment = buildOpJobPartitionSetFragmentWithError();
+    render(
+      <MockedProvider>
+        <OpJobPartitionsViewContent
+          partitionNames={['lorem', 'ipsum']}
+          partitionSet={fragment}
+          repoAddress={buildRepoAddress('foo', 'bar')}
+        />
+      </MockedProvider>,
+    );
+
+    expect(await screen.findByTitle(/click to view per\-step status/i)).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary & Motivation

An error can occur on the op job partitions view when the partition status field returns with an error. We have no way to map the partitions back to the statuses, and an unreachable assert is hit because we try to evaulate a status string on `undefined`.

Work around this by allowing `undefined` to be treated as a "status", rendering as dark gray and using the label "Unknown". This should ideally not happen often, and seems better than erroring out the whole page because of the faulty error handling.

## How I Tested These Changes

Added a jest spec with a fragment matching the error state.

Raise an error from `resolve_partitionStatusesOrError` in Python and load an op job partitions view. Verify that the partition bar loads entirely dark gray, but that the page doesn't crash.

<img width="1296" alt="Screenshot 2023-05-25 at 8 58 45 PM" src="https://github.com/dagster-io/dagster/assets/2823852/9ab8593d-ad02-420a-907d-10e5832dd561">