### PR TITLE
change sqlalchemy engine/connection calls to handle autocommit, isolation levels

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/event_log/in_memory.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/in_memory.py
@@ -34,9 +34,13 @@ class InMemoryEventLogStorage(SqlEventLogStorage, ConfigurableClass):
         # hold one connection for life of instance, but vend new ones for specific calls
         self._held_conn = self._engine.connect()
 
-        SqlEventLogStorageMetadata.create_all(self._held_conn)
-        alembic_config = get_alembic_config(__file__, "sqlite/alembic/alembic.ini")
-        stamp_alembic_rev(alembic_config, self._held_conn)
+        with self._connect() as conn:
+            SqlEventLogStorageMetadata.create_all(conn)
+        with self._connect() as conn:
+            # need to do this as a separate connection since stamp_alembic_rev closes the current
+            # connection
+            alembic_config = get_alembic_config(__file__, "sqlite/alembic/alembic.ini")
+            stamp_alembic_rev(alembic_config, conn)
         self.reindex_events()
         self.reindex_assets()
 
@@ -46,18 +50,18 @@ class InMemoryEventLogStorage(SqlEventLogStorage, ConfigurableClass):
                     self.store_event(event)
 
     @contextmanager
-    def run_connection(self, run_id=None):
+    def _connect(self):
         with self._engine.connect() as conn:
-            conn.execute("PRAGMA journal_mode=WAL;")
-            conn.execute("PRAGMA foreign_keys=ON;")
-            yield conn
+            with conn.begin():
+                conn.execute("PRAGMA journal_mode=WAL;")
+                conn.execute("PRAGMA foreign_keys=ON;")
+                yield conn
 
-    @contextmanager
+    def run_connection(self, run_id=None):
+        return self._connect()
+
     def index_connection(self):
-        with self._engine.connect() as conn:
-            conn.execute("PRAGMA journal_mode=WAL;")
-            conn.execute("PRAGMA foreign_keys=ON;")
-            yield conn
+        return self._connect()
 
     def has_table(self, table_name: str) -> bool:
         with self._engine.connect() as conn:

--- a/python_modules/dagster/dagster/_core/storage/event_log/in_memory.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/in_memory.py
@@ -33,14 +33,11 @@ class InMemoryEventLogStorage(SqlEventLogStorage, ConfigurableClass):
 
         # hold one connection for life of instance, but vend new ones for specific calls
         self._held_conn = self._engine.connect()
-
-        with self._connect() as conn:
-            SqlEventLogStorageMetadata.create_all(conn)
-        with self._connect() as conn:
-            # need to do this as a separate connection since stamp_alembic_rev closes the current
-            # connection
+        with self._held_conn.begin():
+            SqlEventLogStorageMetadata.create_all(self._held_conn)
             alembic_config = get_alembic_config(__file__, "sqlite/alembic/alembic.ini")
-            stamp_alembic_rev(alembic_config, conn)
+            stamp_alembic_rev(alembic_config, self._held_conn)
+
         self.reindex_events()
         self.reindex_assets()
 

--- a/python_modules/dagster/dagster/_core/storage/event_log/migration.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/migration.py
@@ -5,6 +5,7 @@ from tqdm import tqdm
 
 from dagster._core.assets import AssetDetails
 from dagster._core.events.log import EventLogEntry
+from dagster._core.storage.sql import db_select
 from dagster._serdes.serdes import deserialize_value
 from dagster._utils import utc_datetime_from_timestamp
 
@@ -48,7 +49,7 @@ def migrate_asset_key_data(event_log_storage, print_fn=None):
         return
 
     query = (
-        db.select([SqlEventLogStorageTable.c.asset_key])
+        db_select([SqlEventLogStorageTable.c.asset_key])
         .where(SqlEventLogStorageTable.c.asset_key != None)  # noqa: E711
         .group_by(SqlEventLogStorageTable.c.asset_key)
     )
@@ -86,7 +87,7 @@ def migrate_asset_keys_index_columns(event_log_storage, print_fn=None):
         if print_fn:
             print_fn("Querying asset keys.")
         results = conn.execute(
-            db.select(
+            db_select(
                 [
                     AssetKeyTable.c.asset_key,
                     AssetKeyTable.c.asset_details,
@@ -118,7 +119,7 @@ def migrate_asset_keys_index_columns(event_log_storage, print_fn=None):
 
             if not event:
                 materialization_query = (
-                    db.select([SqlEventLogStorageTable.c.event])
+                    db_select([SqlEventLogStorageTable.c.event])
                     .where(
                         SqlEventLogStorageTable.c.asset_key == asset_key.to_string(),
                     )
@@ -164,7 +165,7 @@ def sql_asset_event_generator(conn, cursor=None, batch_size=1000):
     from .schema import SqlEventLogStorageTable
 
     while True:
-        query = db.select([SqlEventLogStorageTable.c.id, SqlEventLogStorageTable.c.event]).where(
+        query = db_select([SqlEventLogStorageTable.c.id, SqlEventLogStorageTable.c.event]).where(
             SqlEventLogStorageTable.c.asset_key != None  # noqa: E711
         )
         if cursor:

--- a/python_modules/dagster/dagster/_core/storage/event_log/sqlite/consolidated_sqlite_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sqlite/consolidated_sqlite_event_log.py
@@ -100,11 +100,9 @@ class ConsolidatedSqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
     @contextmanager
     def _connect(self):
         engine = create_engine(self._conn_string, poolclass=NullPool)
-        conn = engine.connect()
-        try:
-            yield conn
-        finally:
-            conn.close()
+        with engine.connect() as conn:
+            with conn.begin():
+                yield conn
 
     def run_connection(self, run_id: Optional[str]) -> SqlDbConnection:
         return self._connect()

--- a/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
@@ -212,13 +212,9 @@ class SqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
                 self._initdb(engine)
                 self._initialized_dbs.add(shard)
 
-            conn = engine.connect()
-
-            try:
-                yield conn
-            finally:
-                conn.close()
-            engine.dispose()
+            with engine.connect() as conn:
+                with conn.begin():
+                    yield conn
 
     def run_connection(self, run_id: Optional[str] = None) -> Any:
         return self._connect(run_id)  # type: ignore  # bad sig

--- a/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
@@ -9,7 +9,6 @@ from collections import defaultdict
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, ContextManager, Iterable, Iterator, Optional, Sequence
 
-import sqlalchemy as db
 import sqlalchemy.exc as db_exc
 from sqlalchemy.engine import Connection, Engine
 from sqlalchemy.pool import NullPool
@@ -32,6 +31,7 @@ from dagster._core.storage.sql import (
     AlembicVersion,
     check_alembic_revision,
     create_engine,
+    db_select,
     get_alembic_config,
     run_alembic_upgrade,
     stamp_alembic_rev,
@@ -288,7 +288,7 @@ class SqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
                 event_records_filter=event_records_filter, limit=limit, ascending=ascending
             )
 
-        query = db.select([SqlEventLogStorageTable.c.id, SqlEventLogStorageTable.c.event])
+        query = db_select([SqlEventLogStorageTable.c.id, SqlEventLogStorageTable.c.event])
         if event_records_filter.asset_key:
             asset_details = next(iter(self._get_assets_details([event_records_filter.asset_key])))
         else:

--- a/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
@@ -215,6 +215,7 @@ class SqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
             with engine.connect() as conn:
                 with conn.begin():
                     yield conn
+            engine.dispose()
 
     def run_connection(self, run_id: Optional[str] = None) -> Any:
         return self._connect(run_id)  # type: ignore  # bad sig

--- a/python_modules/dagster/dagster/_core/storage/runs/in_memory.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/in_memory.py
@@ -29,12 +29,19 @@ class InMemoryRunStorage(SqlRunStorage):
         # hold one connection for life of instance, but vend new ones for specific calls
         self._held_conn = self._engine.connect()
 
-        RunStorageSqlMetadata.create_all(self._held_conn)
-        alembic_config = get_alembic_config(__file__, "sqlite/alembic/alembic.ini")
-        stamp_alembic_rev(alembic_config, self._held_conn)
-        table_names = db.inspect(self._held_conn).get_table_names()
-        if "instance_info" not in table_names:
-            InstanceInfo.create(self._held_conn)
+        with self.connect() as conn:
+            RunStorageSqlMetadata.create_all(conn)
+
+        with self.connect() as conn:
+            # needs to do this as a separate connection since stamp_alembic_rev closes the current
+            # connection
+            alembic_config = get_alembic_config(__file__, "sqlite/alembic/alembic.ini")
+            stamp_alembic_rev(alembic_config, self._held_conn)
+
+        with self.connect() as conn:
+            table_names = db.inspect(conn).get_table_names()
+            if "instance_info" not in table_names:
+                InstanceInfo.create(conn)
         self.migrate()
         self.optimize()
 
@@ -49,10 +56,10 @@ class InMemoryRunStorage(SqlRunStorage):
     @contextmanager
     def connect(self) -> Iterator[Connection]:
         with self._engine.connect() as conn:
-            conn.execute("PRAGMA journal_mode=WAL;")
-            conn.execute("PRAGMA foreign_keys=ON;")
-
-            yield conn
+            with conn.begin():
+                conn.execute("PRAGMA journal_mode=WAL;")
+                conn.execute("PRAGMA foreign_keys=ON;")
+                yield conn
 
     def upgrade(self) -> None:
         pass

--- a/python_modules/dagster/dagster/_core/storage/runs/migration.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/migration.py
@@ -8,6 +8,7 @@ from tqdm import tqdm
 from typing_extensions import Final, TypeAlias
 
 import dagster._check as check
+from dagster._core.storage.sql import db_select
 from dagster._serdes import deserialize_value
 
 from ...execution.job_backfill import PartitionBackfill
@@ -165,12 +166,12 @@ def migrate_run_repo_tags(run_storage: RunStorage, print_fn: Optional[PrintFn] =
         print_fn("Querying run storage.")
 
     subquery = (
-        db.select([RunTagsTable.c.run_id.label("tags_run_id")])
+        db_select([RunTagsTable.c.run_id.label("tags_run_id")])
         .where(RunTagsTable.c.key == REPOSITORY_LABEL_TAG)
         .alias("tag_subquery")
     )
     base_query = (
-        db.select([RunsTable.c.run_body, RunsTable.c.id])
+        db_select([RunsTable.c.run_body, RunsTable.c.id])
         .select_from(
             RunsTable.join(subquery, RunsTable.c.run_id == subquery.c.tags_run_id, isouter=True)
         )
@@ -228,7 +229,7 @@ def migrate_bulk_actions(run_storage: RunStorage, print_fn: Optional[PrintFn] = 
         print_fn("Querying run storage.")
 
     base_query = (
-        db.select([BulkActionsTable.c.body, BulkActionsTable.c.id])
+        db_select([BulkActionsTable.c.body, BulkActionsTable.c.id])
         .where(BulkActionsTable.c.action_type.is_(None))
         .order_by(db.asc(BulkActionsTable.c.id))
         .limit(CHUNK_SIZE)

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -43,7 +43,7 @@ from dagster._core.snap import (
     create_execution_plan_snapshot_id,
     create_job_snapshot_id,
 )
-from dagster._core.storage.sql import SqlAlchemyQuery, SqlAlchemyRow
+from dagster._core.storage.sql import SqlAlchemyQuery, SqlAlchemyRow, db_select
 from dagster._core.storage.tags import (
     PARTITION_NAME_TAG,
     PARTITION_SET_TAG,
@@ -227,7 +227,7 @@ class SqlRunStorage(RunStorage):
     ) -> SqlAlchemyQuery:
         """Helper function to deal with cursor/limit pagination args."""
         if cursor:
-            cursor_query = db.select([RunsTable.c.id]).where(RunsTable.c.run_id == cursor)
+            cursor_query = db_select([RunsTable.c.id]).where(RunsTable.c.run_id == cursor)
             query = query.where(RunsTable.c.id < cursor_query)
 
         if limit:
@@ -274,7 +274,7 @@ class SqlRunStorage(RunStorage):
 
         if filters.tags and self.supports_intersect:
             intersections = [
-                db.select([RunTagsTable.c.run_id]).where(
+                db_select([RunTagsTable.c.run_id]).where(
                     db.and_(
                         RunTagsTable.c.key == key,
                         (
@@ -320,7 +320,7 @@ class SqlRunStorage(RunStorage):
         else:
             table = RunsTable
 
-        base_query = db.select([getattr(RunsTable.c, column) for column in columns]).select_from(
+        base_query = db_select([getattr(RunsTable.c, column) for column in columns]).select_from(
             table
         )
         base_query = self._add_filters_to_query(base_query, filters)
@@ -360,7 +360,7 @@ class SqlRunStorage(RunStorage):
                 table = self._apply_tags_table_joins(RunsTable, filters.tags)
             else:
                 table = RunsTable
-            base_query = db.select(query_columns).select_from(table)
+            base_query = db_select(query_columns).select_from(table)
             base_query = base_query.where(RunsTable.c.pipeline_name.in_(bucket_by.job_names))
             base_query = self._add_filters_to_query(base_query, filters)
 
@@ -381,15 +381,15 @@ class SqlRunStorage(RunStorage):
                     {bucket_by.tag_key: bucket_by.tag_values},
                 )
 
-            base_query = db.select(query_columns).select_from(table)
+            base_query = db_select(query_columns).select_from(table)
             base_query = self._add_filters_to_query(base_query, filters)
         else:
             # there are tag filters as well as tag buckets, so we have to apply the tag filters in
             # a separate join
             if self.supports_intersect:
-                filtered_query = db.select([RunsTable.c.run_id])
+                filtered_query = db_select([RunsTable.c.run_id])
             else:
-                filtered_query = db.select([RunsTable.c.run_id]).select_from(
+                filtered_query = db_select([RunsTable.c.run_id]).select_from(
                     self._apply_tags_table_joins(RunsTable, filters.tags)
                 )
 
@@ -409,7 +409,7 @@ class SqlRunStorage(RunStorage):
                     RunsTable, {bucket_by.tag_key: bucket_by.tag_values}
                 )
 
-            base_query = db.select(query_columns).select_from(
+            base_query = db_select(query_columns).select_from(
                 table.join(filtered_query, RunsTable.c.run_id == filtered_query.c.run_id)
             )
 
@@ -418,7 +418,7 @@ class SqlRunStorage(RunStorage):
         # select all the columns, but skip the bucket_rank column, which is only used for applying
         # the limit / order
         subquery_columns = [getattr(subquery.c, column) for column in columns]
-        query = db.select(subquery_columns).order_by(subquery.c.rank.asc())
+        query = db_select(subquery_columns).order_by(subquery.c.rank.asc())
         if bucket_by.bucket_limit:
             query = query.where(subquery.c.rank <= bucket_by.bucket_limit)
 
@@ -464,7 +464,7 @@ class SqlRunStorage(RunStorage):
         # aliased.
         subquery = subquery.alias("subquery")
 
-        query = db.select([db.func.count()]).select_from(subquery)
+        query = db_select([db.func.count()]).select_from(subquery)
         rows = self.fetchall(query)
         count = rows[0][0]
         return count
@@ -472,7 +472,7 @@ class SqlRunStorage(RunStorage):
     def _get_run_by_id(self, run_id: str) -> Optional[DagsterRun]:
         check.str_param(run_id, "run_id")
 
-        query = db.select([RunsTable.c.run_body, RunsTable.c.status]).where(
+        query = db_select([RunsTable.c.run_body, RunsTable.c.status]).where(
             RunsTable.c.run_id == run_id
         )
         rows = self.fetchall(query)
@@ -528,7 +528,7 @@ class SqlRunStorage(RunStorage):
     ) -> Sequence[Tuple[str, Set[str]]]:
         result = defaultdict(set)
         query = (
-            db.select([RunTagsTable.c.key, RunTagsTable.c.value])
+            db_select([RunTagsTable.c.key, RunTagsTable.c.value])
             .distinct(RunTagsTable.c.key, RunTagsTable.c.value)
             .order_by(RunTagsTable.c.key, RunTagsTable.c.value)
         )
@@ -545,7 +545,7 @@ class SqlRunStorage(RunStorage):
 
     def get_run_tag_keys(self) -> Sequence[str]:
         query = (
-            db.select([RunTagsTable.c.key])
+            db_select([RunTagsTable.c.key])
             .distinct(RunTagsTable.c.key)
             .order_by(RunTagsTable.c.key)
         )
@@ -622,7 +622,7 @@ class SqlRunStorage(RunStorage):
         # https://github.com/dagster-io/dagster/issues/2495
         # Note: we currently use tags to persist the run group info
         root_to_run = (
-            db.select(
+            db_select(
                 [RunTagsTable.c.value.label("root_run_id"), RunTagsTable.c.run_id.label("run_id")]
             )
             .where(
@@ -632,7 +632,7 @@ class SqlRunStorage(RunStorage):
         )
         # get run group
         run_group_query = (
-            db.select([RunsTable.c.run_body, RunsTable.c.status])
+            db_select([RunsTable.c.run_body, RunsTable.c.status])
             .select_from(
                 root_to_run.join(
                     RunsTable,
@@ -671,7 +671,7 @@ class SqlRunStorage(RunStorage):
         #   )
 
         all_descendant_runs = (
-            db.select([RunTagsTable])
+            db_select([RunTagsTable])
             .where(RunTagsTable.c.key == ROOT_RUN_ID_TAG)
             .alias("all_descendant_runs")
         )
@@ -691,7 +691,7 @@ class SqlRunStorage(RunStorage):
         #   )
 
         runs_augmented = (
-            db.select(
+            db_select(
                 [
                     runs.c.run_id.label("run_id"),
                     all_descendant_runs.c.value.label("root_run_id"),
@@ -720,7 +720,7 @@ class SqlRunStorage(RunStorage):
         #    )
 
         runs_and_root_runs = (
-            db.select([RunsTable.c.run_id.label("run_id")])
+            db_select([RunsTable.c.run_id.label("run_id")])
             .select_from(runs_augmented)
             .where(
                 db.or_(
@@ -748,7 +748,7 @@ class SqlRunStorage(RunStorage):
         #    order by child_counts desc
 
         runs_and_root_runs_with_descendant_counts = (
-            db.select(
+            db_select(
                 [
                     RunsTable.c.run_body,
                     RunsTable.c.status,
@@ -860,7 +860,7 @@ class SqlRunStorage(RunStorage):
             return snapshot_id
 
     def get_run_storage_id(self) -> str:
-        query = db.select([InstanceInfo.c.run_storage_id])
+        query = db_select([InstanceInfo.c.run_storage_id])
         row = self.fetchone(query)
         if not row:
             run_storage_id = str(uuid.uuid4())
@@ -871,7 +871,7 @@ class SqlRunStorage(RunStorage):
             return row[0]
 
     def _has_snapshot_id(self, snapshot_id: str) -> bool:
-        query = db.select([SnapshotsTable.c.snapshot_id]).where(
+        query = db_select([SnapshotsTable.c.snapshot_id]).where(
             SnapshotsTable.c.snapshot_id == snapshot_id
         )
 
@@ -880,7 +880,7 @@ class SqlRunStorage(RunStorage):
         return bool(row)
 
     def _get_snapshot(self, snapshot_id: str) -> Optional[JobSnapshot]:
-        query = db.select([SnapshotsTable.c.snapshot_body]).where(
+        query = db_select([SnapshotsTable.c.snapshot_body]).where(
             SnapshotsTable.c.snapshot_id == snapshot_id
         )
 
@@ -983,7 +983,7 @@ class SqlRunStorage(RunStorage):
 
     def has_built_index(self, migration_name: str) -> bool:
         query = (
-            db.select([1])
+            db_select([1])
             .where(SecondaryIndexMigrationTable.c.name == migration_name)
             .where(SecondaryIndexMigrationTable.c.migration_completed != None)  # noqa: E711
             .limit(1)
@@ -1049,7 +1049,7 @@ class SqlRunStorage(RunStorage):
 
     def get_daemon_heartbeats(self) -> Mapping[str, DaemonHeartbeat]:
         with self.connect() as conn:
-            rows = conn.execute(db.select([DaemonHeartbeatsTable.c.body]))
+            rows = conn.execute(db_select([DaemonHeartbeatsTable.c.body]))
             heartbeats = []
             for row in rows:
                 heartbeats.append(deserialize_value(row.body, DaemonHeartbeat))
@@ -1077,11 +1077,11 @@ class SqlRunStorage(RunStorage):
         limit: Optional[int] = None,
     ) -> Sequence[PartitionBackfill]:
         check.opt_inst_param(status, "status", BulkActionStatus)
-        query = db.select([BulkActionsTable.c.body])
+        query = db_select([BulkActionsTable.c.body])
         if status:
             query = query.where(BulkActionsTable.c.status == status.value)
         if cursor:
-            cursor_query = db.select([BulkActionsTable.c.id]).where(
+            cursor_query = db_select([BulkActionsTable.c.id]).where(
                 BulkActionsTable.c.key == cursor
             )
             query = query.where(BulkActionsTable.c.id < cursor_query)
@@ -1093,7 +1093,7 @@ class SqlRunStorage(RunStorage):
 
     def get_backfill(self, backfill_id: str) -> Optional[PartitionBackfill]:
         check.str_param(backfill_id, "backfill_id")
-        query = db.select([BulkActionsTable.c.body]).where(BulkActionsTable.c.key == backfill_id)
+        query = db_select([BulkActionsTable.c.body]).where(BulkActionsTable.c.key == backfill_id)
         row = self.fetchone(query)
         return deserialize_value(row[0], PartitionBackfill) if row else None
 
@@ -1135,7 +1135,7 @@ class SqlRunStorage(RunStorage):
 
         with self.connect() as conn:
             rows = conn.execute(
-                db.select([KeyValueStoreTable.c.key, KeyValueStoreTable.c.value]).where(
+                db_select([KeyValueStoreTable.c.key, KeyValueStoreTable.c.value]).where(
                     KeyValueStoreTable.c.key.in_(keys)
                 ),
             )

--- a/python_modules/dagster/dagster/_core/storage/runs/sqlite/sqlite_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sqlite/sqlite_run_storage.py
@@ -109,11 +109,9 @@ class SqliteRunStorage(SqlRunStorage, ConfigurableClass):
     @contextmanager
     def connect(self) -> Iterator[Connection]:
         engine = create_engine(self._conn_string, poolclass=NullPool)
-        conn = engine.connect()
-        try:
-            yield conn
-        finally:
-            conn.close()
+        with engine.connect() as conn:
+            with conn.begin():
+                yield conn
 
     def _alembic_upgrade(self, rev: str = "head") -> None:
         alembic_config = get_alembic_config(__file__)

--- a/python_modules/dagster/dagster/_core/storage/schedules/migration.py
+++ b/python_modules/dagster/dagster/_core/storage/schedules/migration.py
@@ -1,11 +1,11 @@
 from typing import Callable, Mapping, Optional
 
-import sqlalchemy as db
 import sqlalchemy.exc as db_exc
 from tqdm import tqdm
 
 from dagster._core.scheduler.instigation import InstigatorState
 from dagster._core.storage.schedules.base import ScheduleStorage
+from dagster._core.storage.sql import db_select
 from dagster._serdes import deserialize_value
 from dagster._utils import PrintFn
 
@@ -33,7 +33,7 @@ def add_selector_id_to_jobs_table(
 
     with storage.connect() as conn:  # type: ignore
         rows = conn.execute(
-            db.select(
+            db_select(
                 [
                     JobTable.c.id,
                     JobTable.c.job_body,

--- a/python_modules/dagster/dagster/_core/storage/schedules/sqlite/sqlite_schedule_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/schedules/sqlite/sqlite_schedule_storage.py
@@ -81,11 +81,9 @@ class SqliteScheduleStorage(SqlScheduleStorage, ConfigurableClass):
     @contextmanager
     def connect(self) -> Iterator[Connection]:
         engine = create_engine(self._conn_string, poolclass=NullPool)
-        conn = engine.connect()
-        try:
-            yield conn
-        finally:
-            conn.close()
+        with engine.connect() as conn:
+            with conn.begin():
+                yield conn
 
     @property
     def supports_batch_queries(self) -> bool:

--- a/python_modules/dagster/dagster/_core/storage/sql.py
+++ b/python_modules/dagster/dagster/_core/storage/sql.py
@@ -1,6 +1,6 @@
 import threading
 from functools import lru_cache
-from typing import Any, Optional, Tuple, Union
+from typing import Any, Iterable, Optional, Tuple, Union
 
 import sqlalchemy as db
 from alembic.command import downgrade, stamp, upgrade
@@ -211,3 +211,11 @@ def add_precision_to_mysql_FLOAT(_element, _compiler, **_kw) -> str:
 
 class MySQLCompatabilityTypes:
     UniqueText = db.String(512)
+
+
+def db_select(items: Iterable):
+    """Utility class that allows compatability between SqlAlchemy 1.3.x, 1.4.x, and 2.x."""
+    if db.__version__.startswith("2."):
+        return db.select(*items)
+
+    return db.select(items)

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -1,5 +1,4 @@
 # ruff: noqa: SLF001
-
 import datetime
 import json
 import os
@@ -37,6 +36,7 @@ from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus, Runs
 from dagster._core.storage.event_log.migration import migrate_event_log_data
 from dagster._core.storage.event_log.sql_event_log import SqlEventLogStorage
 from dagster._core.storage.migration.utils import upgrading_instance
+from dagster._core.storage.sql import db_select
 from dagster._core.storage.tags import REPOSITORY_LABEL_TAG
 from dagster._daemon.types import DaemonHeartbeat
 from dagster._serdes import create_snapshot_id
@@ -843,25 +843,25 @@ def test_jobs_selector_id_migration():
             assert instance.schedule_storage.has_built_index(SCHEDULE_JOBS_SELECTOR_ID)
             legacy_count = len(instance.all_instigator_state())
             migrated_instigator_count = instance.schedule_storage.execute(
-                db.select([db.func.count()]).select_from(InstigatorsTable)
+                db_select([db.func.count()]).select_from(InstigatorsTable)
             )[0][0]
             assert migrated_instigator_count == legacy_count
 
             migrated_job_count = instance.schedule_storage.execute(
-                db.select([db.func.count()])
+                db_select([db.func.count()])
                 .select_from(JobTable)
                 .where(JobTable.c.selector_id.isnot(None))
             )[0][0]
             assert migrated_job_count == legacy_count
 
             legacy_tick_count = instance.schedule_storage.execute(
-                db.select([db.func.count()]).select_from(JobTickTable)
+                db_select([db.func.count()]).select_from(JobTickTable)
             )[0][0]
             assert legacy_tick_count > 0
 
             # tick migrations are optional
             migrated_tick_count = instance.schedule_storage.execute(
-                db.select([db.func.count()])
+                db_select([db.func.count()])
                 .select_from(JobTickTable)
                 .where(JobTickTable.c.selector_id.isnot(None))
             )[0][0]
@@ -871,7 +871,7 @@ def test_jobs_selector_id_migration():
             instance.reindex()
 
             migrated_tick_count = instance.schedule_storage.execute(
-                db.select([db.func.count()])
+                db_select([db.func.count()])
                 .select_from(JobTickTable)
                 .where(JobTickTable.c.selector_id.isnot(None))
             )[0][0]
@@ -947,7 +947,7 @@ def test_add_bulk_actions_columns():
             # check data migration
             backfill_count = len(instance.get_backfills())
             migrated_row_count = instance._run_storage.fetchone(
-                db.select([db.func.count()])
+                db_select([db.func.count().label("count")])
                 .select_from(BulkActionsTable)
                 .where(BulkActionsTable.c.selector_id.isnot(None))
             )[0]
@@ -975,7 +975,7 @@ def test_add_bulk_actions_columns():
                 )
             )
             unmigrated_row_count = instance._run_storage.fetchone(
-                db.select([db.func.count()])
+                db_select([db.func.count().label("count")])
                 .select_from(BulkActionsTable)
                 .where(BulkActionsTable.c.selector_id.is_(None))
             )[0]
@@ -1098,7 +1098,7 @@ def test_add_dynamic_partitions_table():
 
 
 def _get_table_row_count(run_storage, table, with_non_null_id=False):
-    query = db.select([db.func.count()]).select_from(table)
+    query = db_select([db.func.count()]).select_from(table)
     if with_non_null_id:
         query = query.where(table.c.id.isnot(None))
     with run_storage.connect() as conn:

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/event_log/event_log.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/event_log/event_log.py
@@ -1,4 +1,4 @@
-from typing import ContextManager, Optional
+from typing import ContextManager, Optional, cast
 
 import dagster._check as check
 import sqlalchemy as db
@@ -30,6 +30,7 @@ from sqlalchemy.engine import Connection
 from ..utils import (
     create_mysql_connection,
     mysql_alembic_config,
+    mysql_isolation_level,
     mysql_url_from_config,
     parse_mysql_version,
     retry_mysql_connection_fn,
@@ -67,7 +68,7 @@ class MySQLEventLogStorage(SqlEventLogStorage, ConfigurableClass):
         # Default to not holding any connections open to prevent accumulating connections per DagsterInstance
         self._engine = create_engine(
             self.mysql_url,
-            isolation_level="AUTOCOMMIT",
+            isolation_level=mysql_isolation_level(),
             poolclass=db_pool.NullPool,
         )
         self._secondary_index_cache = {}
@@ -87,16 +88,15 @@ class MySQLEventLogStorage(SqlEventLogStorage, ConfigurableClass):
 
     def _init_db(self) -> None:
         with self._connect() as conn:
-            with conn.begin():
-                SqlEventLogStorageMetadata.create_all(conn)
-                stamp_alembic_rev(mysql_alembic_config(__file__), conn)
+            SqlEventLogStorageMetadata.create_all(conn)
+            stamp_alembic_rev(mysql_alembic_config(__file__), conn)
 
     def optimize_for_dagit(self, statement_timeout: int, pool_recycle: int) -> None:
         # When running in dagit, hold an open connection
         # https://github.com/dagster-io/dagster/issues/3719
         self._engine = create_engine(
             self.mysql_url,
-            isolation_level="AUTOCOMMIT",
+            isolation_level=mysql_isolation_level(),
             pool_size=1,
             pool_recycle=pool_recycle,
         )
@@ -124,7 +124,9 @@ class MySQLEventLogStorage(SqlEventLogStorage, ConfigurableClass):
 
     @staticmethod
     def wipe_storage(mysql_url: str) -> None:
-        engine = create_engine(mysql_url, isolation_level="AUTOCOMMIT", poolclass=db_pool.NullPool)
+        engine = create_engine(
+            mysql_url, isolation_level=mysql_isolation_level(), poolclass=db_pool.NullPool
+        )
         try:
             SqlEventLogStorageMetadata.drop_all(engine)
         finally:
@@ -137,14 +139,12 @@ class MySQLEventLogStorage(SqlEventLogStorage, ConfigurableClass):
 
     def get_server_version(self) -> Optional[str]:
         with self.index_connection() as conn:
-            result_proxy = conn.execute("select version()")
-            row = result_proxy.fetchone()
-            result_proxy.close()
+            row = conn.execute(db.text("select version()")).fetchone()
 
         if not row:
             return None
 
-        return row[0]  # type: ignore
+        return cast(str, row[0])
 
     def store_asset_event(self, event: EventLogEntry, event_id: int) -> None:
         # last_materialization_timestamp is updated upon observation, materialization, materialization_planned
@@ -185,7 +185,8 @@ class MySQLEventLogStorage(SqlEventLogStorage, ConfigurableClass):
         return self._connect()
 
     def has_table(self, table_name: str) -> bool:
-        return bool(self._engine.dialect.has_table(self._engine.connect(), table_name))
+        with self._connect() as conn:
+            return table_name in db.inspect(conn).get_table_names()
 
     def has_secondary_index(self, name: str) -> bool:
         if name not in self._secondary_index_cache:

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/run_storage/run_storage.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/run_storage/run_storage.py
@@ -1,4 +1,4 @@
-from typing import ContextManager, Mapping, Optional
+from typing import ContextManager, Mapping, Optional, cast
 
 import dagster._check as check
 import sqlalchemy as db
@@ -28,6 +28,7 @@ from sqlalchemy.engine import Connection
 from ..utils import (
     create_mysql_connection,
     mysql_alembic_config,
+    mysql_isolation_level,
     mysql_url_from_config,
     parse_mysql_version,
     retry_mysql_connection_fn,
@@ -63,7 +64,7 @@ class MySQLRunStorage(SqlRunStorage, ConfigurableClass):
         # Default to not holding any connections open to prevent accumulating connections per DagsterInstance
         self._engine = create_engine(
             self.mysql_url,
-            isolation_level="AUTOCOMMIT",
+            isolation_level=mysql_isolation_level(),
             poolclass=db_pool.NullPool,
         )
 
@@ -86,16 +87,15 @@ class MySQLRunStorage(SqlRunStorage, ConfigurableClass):
 
     def _init_db(self) -> None:
         with self.connect() as conn:
-            with conn.begin():
-                RunStorageSqlMetadata.create_all(conn)
-                stamp_alembic_rev(mysql_alembic_config(__file__), conn)
+            RunStorageSqlMetadata.create_all(conn)
+            stamp_alembic_rev(mysql_alembic_config(__file__), conn)
 
     def optimize_for_dagit(self, statement_timeout: int, pool_recycle: int) -> None:
         # When running in dagit, hold 1 open connection
         # https://github.com/dagster-io/dagster/issues/3719
         self._engine = create_engine(
             self.mysql_url,
-            isolation_level="AUTOCOMMIT",
+            isolation_level=mysql_isolation_level(),
             pool_size=1,
             pool_recycle=pool_recycle,
         )
@@ -109,11 +109,13 @@ class MySQLRunStorage(SqlRunStorage, ConfigurableClass):
         return mysql_config()
 
     def get_server_version(self) -> Optional[str]:
-        row = self.fetchone("select version()")
+        with self.connect() as conn:
+            row = conn.execute(db.text("select version()")).fetchone()
+
         if not row:
             return None
 
-        return row[0]
+        return cast(str, row[0])
 
     @classmethod
     def from_config_value(
@@ -123,7 +125,9 @@ class MySQLRunStorage(SqlRunStorage, ConfigurableClass):
 
     @staticmethod
     def wipe_storage(mysql_url: str) -> None:
-        engine = create_engine(mysql_url, isolation_level="AUTOCOMMIT", poolclass=db_pool.NullPool)
+        engine = create_engine(
+            mysql_url, isolation_level=mysql_isolation_level(), poolclass=db_pool.NullPool
+        )
         try:
             RunStorageSqlMetadata.drop_all(engine)
         finally:

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/utils.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/utils.py
@@ -178,6 +178,16 @@ def mysql_alembic_config(dunder_file: str) -> Config:
     return get_alembic_config(dunder_file, config_path="../alembic/alembic.ini")
 
 
+def mysql_isolation_level():
+    if db.__version__.startswith("2.") or db.__version__.startswith("1.4"):
+        # Starting with 1.4, the ability to emulate autocommit was deprecated, so we need to
+        # explicitly call commit on the connection for MySQL where the AUTOCOMMIT isolation
+        # level is not supported.  We should then set the isolation level to the MySQL default
+        return "REPEATABLE READ"
+
+    return "AUTOCOMMIT"
+
+
 @contextmanager
 def create_mysql_connection(
     engine: db.engine.Engine, dunder_file: str, storage_type_desc: Optional[str] = None
@@ -191,11 +201,7 @@ def create_mysql_connection(
     else:
         storage_type_desc = ""
 
-    conn = None
-    try:
-        # Retry connection to gracefully handle transient connection issues
-        conn = retry_mysql_connection_fn(engine.connect)
-        yield conn
-    finally:
-        if conn:
-            conn.close()
+    conn_cm = retry_mysql_connection_fn(engine.connect)
+    with conn_cm as conn:
+        with conn.begin():
+            yield conn

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
@@ -24,6 +24,7 @@ from dagster._core.storage.sql import (
     AlembicVersion,
     check_alembic_revision,
     create_engine,
+    db_select,
     run_alembic_upgrade,
     stamp_alembic_rev,
 )
@@ -312,7 +313,7 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
     def _gen_event_log_entry_from_cursor(self, cursor) -> EventLogEntry:
         with self._engine.connect() as conn:
             cursor_res = conn.execute(
-                db.select([SqlEventLogStorageTable.c.event]).where(
+                db_select([SqlEventLogStorageTable.c.event]).where(
                     SqlEventLogStorageTable.c.id == cursor
                 ),
             )

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
@@ -23,6 +23,7 @@ from dagster._core.errors import DagsterInvalidInvocationError
 from dagster._core.execution.api import execute_job
 from dagster._core.instance import DagsterInstance
 from dagster._core.storage.event_log.migration import ASSET_KEY_INDEX_COLS
+from dagster._core.storage.sql import db_select
 from dagster._core.storage.tags import PARTITION_NAME_TAG, PARTITION_SET_TAG
 from dagster._daemon.types import DaemonHeartbeat
 from dagster._utils import file_relative_path
@@ -556,25 +557,25 @@ def test_jobs_selector_id_migration(hostname, conn_string):
             assert instance.schedule_storage.has_built_index(SCHEDULE_JOBS_SELECTOR_ID)
             legacy_count = len(instance.all_instigator_state())
             migrated_instigator_count = instance.schedule_storage.execute(
-                db.select([db.func.count()]).select_from(InstigatorsTable)
+                db_select([db.func.count()]).select_from(InstigatorsTable)
             )[0][0]
             assert migrated_instigator_count == legacy_count
 
             migrated_job_count = instance.schedule_storage.execute(
-                db.select([db.func.count()])
+                db_select([db.func.count()])
                 .select_from(JobTable)
                 .where(JobTable.c.selector_id.isnot(None))
             )[0][0]
             assert migrated_job_count == legacy_count
 
             legacy_tick_count = instance.schedule_storage.execute(
-                db.select([db.func.count()]).select_from(JobTickTable)
+                db_select([db.func.count()]).select_from(JobTickTable)
             )[0][0]
             assert legacy_tick_count > 0
 
             # tick migrations are optional
             migrated_tick_count = instance.schedule_storage.execute(
-                db.select([db.func.count()])
+                db_select([db.func.count()])
                 .select_from(JobTickTable)
                 .where(JobTickTable.c.selector_id.isnot(None))
             )[0][0]
@@ -584,7 +585,7 @@ def test_jobs_selector_id_migration(hostname, conn_string):
             instance.reindex()
 
             migrated_tick_count = instance.schedule_storage.execute(
-                db.select([db.func.count()])
+                db_select([db.func.count()])
                 .select_from(JobTickTable)
                 .where(JobTickTable.c.selector_id.isnot(None))
             )[0][0]
@@ -809,7 +810,7 @@ def test_add_dynamic_partitions_table(hostname, conn_string):
 
 
 def _get_table_row_count(run_storage, table, with_non_null_id=False):
-    query = db.select([db.func.count()]).select_from(table)
+    query = db_select([db.func.count()]).select_from(table)
     if with_non_null_id:
         query = query.where(table.c.id.isnot(None))
     with run_storage.connect() as conn:


### PR DESCRIPTION
## Summary & Motivation
For sqlalchemy 2.0 compat

In sqlalchemy 2, autocommit at the library level is dropped, as is connection-less execution:

https://docs.sqlalchemy.org/en/20/changelog/migration_20.html#library-level-but-not-driver-level-autocommit-removed-from-both-core-and-orm
https://docs.sqlalchemy.org/en/20/changelog/migration_20.html#implicit-and-connectionless-execution-bound-metadata-removed

## How I Tested These Changes
Full stack of changes with a pin applied: https://github.com/dagster-io/dagster/pull/14263, https://buildkite.com/dagster/dagster/builds/59329