### PR TITLE
wrap all sql string queries with db.text

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/event_log/in_memory.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/in_memory.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 from contextlib import contextmanager
 from typing import Callable, Optional
 
+import sqlalchemy as db
 from sqlalchemy.pool import NullPool
 
 from dagster._core.storage.event_log.base import EventLogCursor
@@ -50,8 +51,8 @@ class InMemoryEventLogStorage(SqlEventLogStorage, ConfigurableClass):
     def _connect(self):
         with self._engine.connect() as conn:
             with conn.begin():
-                conn.execute("PRAGMA journal_mode=WAL;")
-                conn.execute("PRAGMA foreign_keys=ON;")
+                conn.execute(db.text("PRAGMA journal_mode=WAL;"))
+                conn.execute(db.text("PRAGMA foreign_keys=ON;"))
                 yield conn
 
     def run_connection(self, run_id=None):

--- a/python_modules/dagster/dagster/_core/storage/event_log/migration.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/migration.py
@@ -5,7 +5,7 @@ from tqdm import tqdm
 
 from dagster._core.assets import AssetDetails
 from dagster._core.events.log import EventLogEntry
-from dagster._core.storage.sql import db_select
+from dagster._core.storage.sqlalchemy_compat import db_select
 from dagster._serdes.serdes import deserialize_value
 from dagster._utils import utc_datetime_from_timestamp
 

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -38,7 +38,7 @@ from dagster._core.event_api import RunShardedEventsCursor
 from dagster._core.events import ASSET_EVENTS, MARKER_EVENTS, DagsterEventType
 from dagster._core.execution.stats import RunStepKeyStatsSnapshot, build_run_step_stats_from_events
 from dagster._core.storage.sql import SqlAlchemyQuery, SqlAlchemyRow
-from dagster._core.storage.sqlalchemy_compat import db_select, db_subquery
+from dagster._core.storage.sqlalchemy_compat import db_fetch_mappings, db_select, db_subquery
 from dagster._serdes import (
     deserialize_value,
     serialize_value,
@@ -1028,16 +1028,16 @@ class SqlEventLogStorage(EventLogStorage):
     ) -> AssetRecord:
         from dagster._core.storage.partition_status_cache import AssetStatusCacheValue
 
-        asset_key = AssetKey.from_db_string(row[1])
+        asset_key = AssetKey.from_db_string(row["asset_key"])
         if asset_key:
             return AssetRecord(
-                storage_id=row[0],
+                storage_id=row["id"],
                 asset_entry=AssetEntry(
                     asset_key=asset_key,
                     last_materialization_record=last_materialization_record,
-                    last_run_id=row[3],
-                    asset_details=AssetDetails.from_db_string(row[4]),
-                    cached_status=AssetStatusCacheValue.from_db_string(row[5])
+                    last_run_id=row["last_run_id"],
+                    asset_details=AssetDetails.from_db_string(row["asset_details"]),
+                    cached_status=AssetStatusCacheValue.from_db_string(row["cached_status_data"])
                     if can_cache_asset_status_data
                     else None,
                 ),
@@ -1054,10 +1054,14 @@ class SqlEventLogStorage(EventLogStorage):
         to_backcompat_fetch = set()
         results: Dict[AssetKey, Optional[EventLogRecord]] = {}
         for row in raw_asset_rows:
-            asset_key = AssetKey.from_db_string(row[1])
+            asset_key = AssetKey.from_db_string(row["asset_key"])
             if not asset_key:
                 continue
-            event_or_materialization = deserialize_value(row[2], NamedTuple) if row[2] else None
+            event_or_materialization = (
+                deserialize_value(row["last_materialization"], NamedTuple)
+                if row["last_materialization"]
+                else None
+            )
             if isinstance(event_or_materialization, EventLogRecord):
                 results[asset_key] = event_or_materialization
             else:
@@ -1098,14 +1102,14 @@ class SqlEventLogStorage(EventLogStorage):
             )
         )
         with self.index_connection() as conn:
-            event_rows = conn.execute(backcompat_query).fetchall()
+            event_rows = db_fetch_mappings(conn, backcompat_query)
 
         for row in event_rows:
-            asset_key = AssetKey.from_db_string(cast(Optional[str], row[0]))
+            asset_key = AssetKey.from_db_string(cast(Optional[str], row["asset_key"]))
             if asset_key:
                 results[asset_key] = EventLogRecord(
-                    storage_id=cast(int, row[1]),
-                    event_log_entry=deserialize_value(cast(str, row[2]), EventLogEntry),
+                    storage_id=cast(int, row["id"]),
+                    event_log_entry=deserialize_value(cast(str, row["event"]), EventLogEntry),
                 )
         return results
 
@@ -1133,7 +1137,7 @@ class SqlEventLogStorage(EventLogStorage):
 
         asset_records: List[AssetRecord] = []
         for row in rows:
-            asset_key = AssetKey.from_db_string(row[1])
+            asset_key = AssetKey.from_db_string(row["asset_key"])
             if asset_key:
                 asset_records.append(
                     self._construct_asset_record_from_row(
@@ -1152,7 +1156,10 @@ class SqlEventLogStorage(EventLogStorage):
 
     def all_asset_keys(self):
         rows = self._fetch_asset_rows()
-        asset_keys = [AssetKey.from_db_string(row[1]) for row in sorted(rows, key=lambda x: x[1])]
+        asset_keys = [
+            AssetKey.from_db_string(row["asset_key"])
+            for row in sorted(rows, key=lambda x: x["asset_key"])
+        ]
         return [asset_key for asset_key in asset_keys if asset_key]
 
     def get_asset_keys(
@@ -1162,7 +1169,10 @@ class SqlEventLogStorage(EventLogStorage):
         cursor: Optional[str] = None,
     ) -> Sequence[AssetKey]:
         rows = self._fetch_asset_rows(prefix=prefix, limit=limit, cursor=cursor)
-        asset_keys = [AssetKey.from_db_string(row[1]) for row in sorted(rows, key=lambda x: x[1])]
+        asset_keys = [
+            AssetKey.from_db_string(row["asset_key"])
+            for row in sorted(rows, key=lambda x: x["asset_key"])
+        ]
         return [asset_key for asset_key in asset_keys if asset_key]
 
     def get_latest_materialization_events(
@@ -1259,26 +1269,28 @@ class SqlEventLogStorage(EventLogStorage):
                 )
             )
             with self.index_connection() as conn:
-                rows = conn.execute(query).fetchall()
+                rows = db_fetch_mappings(conn, query)
 
             return rows, False, None
 
         with self.index_connection() as conn:
-            rows = conn.execute(query).fetchall()
+            rows = db_fetch_mappings(conn, query)
 
         wiped_timestamps_by_asset_key: Dict[AssetKey, float] = {}
         row_by_asset_key: Dict[AssetKey, SqlAlchemyRow] = OrderedDict()
 
         for row in rows:
-            asset_key = AssetKey.from_db_string(cast(str, row[1]))
+            asset_key = AssetKey.from_db_string(cast(str, row["asset_key"]))
             if not asset_key:
                 continue
-            asset_details = AssetDetails.from_db_string(row[4])
+            asset_details = AssetDetails.from_db_string(row["asset_details"])
             if not asset_details or not asset_details.last_wipe_timestamp:
                 row_by_asset_key[asset_key] = row
                 continue
             materialization_or_event_or_record = (
-                deserialize_value(cast(str, row[2]), NamedTuple) if row[2] else None
+                deserialize_value(cast(str, row["last_materialization"]), NamedTuple)
+                if row["last_materialization"]
+                else None
             )
             if isinstance(materialization_or_event_or_record, (EventLogRecord, EventLogEntry)):
                 if isinstance(materialization_or_event_or_record, EventLogRecord):
@@ -1309,7 +1321,7 @@ class SqlEventLogStorage(EventLogStorage):
                     row_by_asset_key.pop(asset_key)
 
         has_more = limit and len(rows) == limit
-        new_cursor = rows[-1][0] if rows else None
+        new_cursor = rows[-1]["id"] if rows else None
 
         return row_by_asset_key.values(), has_more, new_cursor  # type: ignore
 
@@ -1335,7 +1347,7 @@ class SqlEventLogStorage(EventLogStorage):
             db_select(
                 [
                     SqlEventLogStorageTable.c.asset_key,
-                    db.func.max(SqlEventLogStorageTable.c.timestamp),
+                    db.func.max(SqlEventLogStorageTable.c.timestamp).label("timestamp"),
                 ]
             )
             .where(
@@ -1347,8 +1359,8 @@ class SqlEventLogStorage(EventLogStorage):
             .order_by(db.func.max(SqlEventLogStorageTable.c.timestamp).asc())
         )
         with self.index_connection() as conn:
-            backcompat_rows = conn.execute(backcompat_query).fetchall()
-        return {AssetKey.from_db_string(row[0]): row[1] for row in backcompat_rows}  # type: ignore
+            backcompat_rows = db_fetch_mappings(conn, backcompat_query)
+        return {AssetKey.from_db_string(row["asset_key"]): row["timestamp"] for row in backcompat_rows}  # type: ignore
 
     def _can_mark_assets_as_migrated(self, rows):
         if not self.has_asset_key_index_cols():
@@ -1397,17 +1409,20 @@ class SqlEventLogStorage(EventLogStorage):
         check.sequence_param(asset_keys, "asset_key", AssetKey)
         rows = None
         with self.index_connection() as conn:
-            rows = conn.execute(
+            rows = db_fetch_mappings(
+                conn,
                 db_select([AssetKeyTable.c.asset_key, AssetKeyTable.c.asset_details]).where(
                     AssetKeyTable.c.asset_key.in_(
                         [asset_key.to_string() for asset_key in asset_keys]
                     ),
-                )
-            ).fetchall()
+                ),
+            )
 
             asset_key_to_details = {
-                cast(str, row[0]): (
-                    deserialize_value(cast(str, row[1]), AssetDetails) if row[1] else None
+                cast(str, row["asset_key"]): (
+                    deserialize_value(cast(str, row["asset_details"]), AssetDetails)
+                    if row["asset_details"]
+                    else None
                 )
                 for row in rows
             }
@@ -1761,8 +1776,8 @@ class SqlEventLogStorage(EventLogStorage):
         )
 
         with self.index_connection() as conn:
-            materialization_planned_rows = conn.execute(materialization_planned_events).fetchall()
-            materialization_rows = conn.execute(materialization_events).fetchall()
+            materialization_planned_rows = db_fetch_mappings(conn, materialization_planned_events)
+            materialization_rows = db_fetch_mappings(conn, materialization_events)
 
         materialization_planned_rows_by_partition = {
             cast(str, row["partition"]): (cast(str, row["run_id"]), cast(int, row["id"]))
@@ -1858,6 +1873,6 @@ def _get_from_row(row: SqlAlchemyRow, column: str) -> object:
     """Utility function for extracting a column from a sqlalchemy row proxy, since '_asdict' is not
     supported in sqlalchemy 1.3.
     """
-    if not row.has_key(column):
+    if column not in row.keys():
         return None
     return row[column]

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -37,7 +37,8 @@ from dagster._core.errors import (
 from dagster._core.event_api import RunShardedEventsCursor
 from dagster._core.events import ASSET_EVENTS, MARKER_EVENTS, DagsterEventType
 from dagster._core.execution.stats import RunStepKeyStatsSnapshot, build_run_step_stats_from_events
-from dagster._core.storage.sql import SqlAlchemyQuery, SqlAlchemyRow, db_select
+from dagster._core.storage.sql import SqlAlchemyQuery, SqlAlchemyRow
+from dagster._core.storage.sqlalchemy_compat import db_select, db_subquery
 from dagster._serdes import (
     deserialize_value,
     serialize_value,
@@ -856,8 +857,12 @@ class SqlEventLogStorage(EventLogStorage):
         asset_key: Optional[AssetKey],
     ) -> db.Table:
         event_id_col = table.c.id if table == SqlEventLogStorageTable else table.c.event_id
+        i = 0
         for key, value in tags.items():
-            tags_table = AssetEventTagsTable.alias()
+            i += 1
+            tags_table = db_subquery(
+                db_select([AssetEventTagsTable]), f"asset_event_tags_subquery_{i}"
+            )
             table = table.join(
                 tags_table,
                 db.and_(
@@ -1058,7 +1063,7 @@ class SqlEventLogStorage(EventLogStorage):
             else:
                 to_backcompat_fetch.add(asset_key)
 
-        latest_event_subquery = (
+        latest_event_subquery = db_subquery(
             db_select(
                 [
                     SqlEventLogStorageTable.c.asset_key,
@@ -1074,8 +1079,8 @@ class SqlEventLogStorage(EventLogStorage):
                     == DagsterEventType.ASSET_MATERIALIZATION.value,
                 )
             )
-            .group_by(SqlEventLogStorageTable.c.asset_key)
-            .alias("latest_materializations")
+            .group_by(SqlEventLogStorageTable.c.asset_key),
+            "latest_event_subquery",
         )
         backcompat_query = db_select(
             [
@@ -1708,11 +1713,14 @@ class SqlEventLogStorage(EventLogStorage):
         )
 
         assets_details = self._get_assets_details([asset_key])
-        latest_event_ids_subquery = self._add_assets_wipe_filter_to_query(
-            latest_event_ids_subquery, assets_details, [asset_key]
-        ).alias("latest_materialization_event_ids")
+        latest_event_ids_subquery = db_subquery(
+            self._add_assets_wipe_filter_to_query(
+                latest_event_ids_subquery, assets_details, [asset_key]
+            ),
+            "latest_event_ids_subquery",
+        )
 
-        latest_events_subquery = (
+        latest_events_subquery = db_subquery(
             db_select(
                 [
                     SqlEventLogStorageTable.c.dagster_event_type,
@@ -1720,45 +1728,36 @@ class SqlEventLogStorage(EventLogStorage):
                     SqlEventLogStorageTable.c.run_id,
                     SqlEventLogStorageTable.c.id,
                 ]
-            )
-            .select_from(
+            ).select_from(
                 latest_event_ids_subquery.join(
                     SqlEventLogStorageTable,
                     SqlEventLogStorageTable.c.id == latest_event_ids_subquery.c.id,
                 ),
-            )
-            .alias("latest_materialization_events")
+            ),
+            "latest_events_subquery",
         )
 
-        materialization_planned_events = (
-            db_select(
-                [
-                    latest_events_subquery.c.dagster_event_type,
-                    latest_events_subquery.c.partition,
-                    latest_events_subquery.c.run_id,
-                    latest_events_subquery.c.id,
-                ]
-            )
-            .where(
-                latest_events_subquery.c.dagster_event_type
-                == DagsterEventType.ASSET_MATERIALIZATION_PLANNED.value
-            )
-            .alias("materialization_planned_events")
+        materialization_planned_events = db_select(
+            [
+                latest_events_subquery.c.dagster_event_type,
+                latest_events_subquery.c.partition,
+                latest_events_subquery.c.run_id,
+                latest_events_subquery.c.id,
+            ]
+        ).where(
+            latest_events_subquery.c.dagster_event_type
+            == DagsterEventType.ASSET_MATERIALIZATION_PLANNED.value
         )
 
-        materialization_events = (
-            db_select(
-                [
-                    latest_events_subquery.c.dagster_event_type,
-                    latest_events_subquery.c.partition,
-                    latest_events_subquery.c.run_id,
-                ]
-            )
-            .where(
-                latest_events_subquery.c.dagster_event_type
-                == DagsterEventType.ASSET_MATERIALIZATION.value
-            )
-            .alias("materialization_events")
+        materialization_events = db_select(
+            [
+                latest_events_subquery.c.dagster_event_type,
+                latest_events_subquery.c.partition,
+                latest_events_subquery.c.run_id,
+            ]
+        ).where(
+            latest_events_subquery.c.dagster_event_type
+            == DagsterEventType.ASSET_MATERIALIZATION.value
         )
 
         with self.index_connection() as conn:

--- a/python_modules/dagster/dagster/_core/storage/event_log/sqlite/consolidated_sqlite_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sqlite/consolidated_sqlite_event_log.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 from contextlib import contextmanager
 from typing import Any, Mapping, Optional
 
+import sqlalchemy as db
 from sqlalchemy.pool import NullPool
 from typing_extensions import Self
 from watchdog.events import PatternMatchingEventHandler
@@ -88,7 +89,7 @@ class ConsolidatedSqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
             db_revision, head_revision = check_alembic_revision(alembic_config, connection)
             if not (db_revision and head_revision):
                 SqlEventLogStorageMetadata.create_all(engine)
-                engine.execute("PRAGMA journal_mode=WAL;")
+                connection.execute(db.text("PRAGMA journal_mode=WAL;"))
                 stamp_alembic_rev(alembic_config, connection)
                 should_mark_indexes = True
 

--- a/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
@@ -9,6 +9,7 @@ from collections import defaultdict
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, ContextManager, Iterable, Iterator, Optional, Sequence
 
+import sqlalchemy as db
 import sqlalchemy.exc as db_exc
 from sqlalchemy.engine import Connection, Engine
 from sqlalchemy.pool import NullPool
@@ -168,7 +169,7 @@ class SqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
 
                     if not (db_revision and head_revision):
                         SqlEventLogStorageMetadata.create_all(engine)
-                        connection.execute("PRAGMA journal_mode=WAL;")
+                        connection.execute(db.text("PRAGMA journal_mode=WAL;"))
                         stamp_alembic_rev(alembic_config, connection)
 
                 break

--- a/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
@@ -31,11 +31,11 @@ from dagster._core.storage.sql import (
     AlembicVersion,
     check_alembic_revision,
     create_engine,
-    db_select,
     get_alembic_config,
     run_alembic_upgrade,
     stamp_alembic_rev,
 )
+from dagster._core.storage.sqlalchemy_compat import db_select
 from dagster._core.storage.sqlite import create_db_conn_string
 from dagster._serdes import (
     ConfigurableClass,

--- a/python_modules/dagster/dagster/_core/storage/runs/in_memory.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/in_memory.py
@@ -54,8 +54,8 @@ class InMemoryRunStorage(SqlRunStorage):
     def connect(self) -> Iterator[Connection]:
         with self._engine.connect() as conn:
             with conn.begin():
-                conn.execute("PRAGMA journal_mode=WAL;")
-                conn.execute("PRAGMA foreign_keys=ON;")
+                conn.execute(db.text("PRAGMA journal_mode=WAL;"))
+                conn.execute(db.text("PRAGMA foreign_keys=ON;"))
                 yield conn
 
     def upgrade(self) -> None:

--- a/python_modules/dagster/dagster/_core/storage/runs/migration.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/migration.py
@@ -8,7 +8,7 @@ from tqdm import tqdm
 from typing_extensions import Final, TypeAlias
 
 import dagster._check as check
-from dagster._core.storage.sql import db_select
+from dagster._core.storage.sqlalchemy_compat import db_select
 from dagster._serdes import deserialize_value
 
 from ...execution.job_backfill import PartitionBackfill

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -43,8 +43,8 @@ from dagster._core.snap import (
     create_execution_plan_snapshot_id,
     create_job_snapshot_id,
 )
-from dagster._core.storage.sql import SqlAlchemyQuery, SqlAlchemyRow
-from dagster._core.storage.sqlalchemy_compat import db_select, db_subquery
+from dagster._core.storage.sql import SqlAlchemyQuery
+from dagster._core.storage.sqlalchemy_compat import db_fetch_mappings, db_select, db_subquery
 from dagster._core.storage.tags import (
     PARTITION_NAME_TAG,
     PARTITION_SET_TAG,
@@ -108,19 +108,14 @@ class SqlRunStorage(RunStorage):
 
     def fetchall(self, query: SqlAlchemyQuery) -> Sequence[Any]:
         with self.connect() as conn:
-            result_proxy = conn.execute(query)
-            res = result_proxy.fetchall()
-            result_proxy.close()
-
-        return res
+            return db_fetch_mappings(conn, query)
 
     def fetchone(self, query: SqlAlchemyQuery) -> Optional[Any]:
         with self.connect() as conn:
-            result_proxy = conn.execute(query)
-            row = result_proxy.fetchone()
-            result_proxy.close()
-
-        return row
+            if db.__version__.startswith("2."):
+                return conn.execute(query).mappings().first()
+            else:
+                return conn.execute(query).fetchone()
 
     def add_run(self, dagster_run: DagsterRun) -> DagsterRun:
         check.inst_param(dagster_run, "dagster_run", DagsterRun)
@@ -207,7 +202,7 @@ class SqlRunStorage(RunStorage):
                 )
             )
 
-    def _row_to_run(self, row: SqlAlchemyRow) -> DagsterRun:
+    def _row_to_run(self, row: Dict) -> DagsterRun:
         run = deserialize_value(row["run_body"], DagsterRun)
         status = DagsterRunStatus(row["status"])
         # NOTE: the status column is more trustworthy than the status in the run body, since concurrent
@@ -215,7 +210,7 @@ class SqlRunStorage(RunStorage):
         # overriden with an old value.
         return run.with_status(status)
 
-    def _rows_to_runs(self, rows: Iterable[SqlAlchemyRow]) -> Sequence[DagsterRun]:
+    def _rows_to_runs(self, rows: Iterable[Dict]) -> Sequence[DagsterRun]:
         return list(map(self._row_to_run, rows))
 
     def _add_cursor_limit_to_query(
@@ -543,13 +538,13 @@ class SqlRunStorage(RunStorage):
             query = query.limit(limit)
         rows = self.fetchall(query)
         for r in rows:
-            result[r[0]].add(r[1])
+            result[r["key"]].add(r["value"])
         return sorted(list([(k, v) for k, v in result.items()]), key=lambda x: x[0])
 
     def get_run_tag_keys(self) -> Sequence[str]:
         query = db_select([RunTagsTable.c.key]).distinct().order_by(RunTagsTable.c.key)
         rows = self.fetchall(query)
-        return sorted([r[0] for r in rows])
+        return sorted([r["key"] for r in rows])
 
     def add_run_tags(self, run_id: str, new_tags: Mapping[str, str]) -> None:
         check.str_param(run_id, "run_id")
@@ -637,9 +632,8 @@ class SqlRunStorage(RunStorage):
             )
         )
 
-        with self.connect() as conn:
-            res = conn.execute(run_group_query)
-            run_group = self._rows_to_runs(res)
+        res = self.fetchall(run_group_query)
+        run_group = self._rows_to_runs(res)
 
         return (root_run_id, [root_run, *run_group])
 
@@ -767,8 +761,7 @@ class SqlRunStorage(RunStorage):
             .order_by(db.desc(db.column("child_counts")))
         )
 
-        with self.connect() as conn:
-            res = conn.execute(runs_and_root_runs_with_descendant_counts).fetchall()
+        res = self.fetchall(runs_and_root_runs_with_descendant_counts)
 
         # Postprocess: descendant runs get aggregated with their roots
         root_run_id_to_group: Dict[str, List[DagsterRun]] = defaultdict(list)
@@ -872,7 +865,7 @@ class SqlRunStorage(RunStorage):
                 conn.execute(InstanceInfo.insert().values(run_storage_id=run_storage_id))
             return run_storage_id
         else:
-            return row[0]
+            return row["run_storage_id"]
 
     def _has_snapshot_id(self, snapshot_id: str) -> bool:
         query = db_select([SnapshotsTable.c.snapshot_id]).where(
@@ -890,7 +883,7 @@ class SqlRunStorage(RunStorage):
 
         row = self.fetchone(query)
 
-        return defensively_unpack_execution_plan_snapshot_query(logging, row) if row else None  # type: ignore
+        return defensively_unpack_execution_plan_snapshot_query(logging, [row["snapshot_body"]]) if row else None  # type: ignore
 
     def get_run_partition_data(self, runs_filter: RunsFilter) -> Sequence[RunPartitionData]:
         if self.has_built_index(RUN_PARTITIONS) and self.has_run_stats_index_cols():
@@ -992,8 +985,7 @@ class SqlRunStorage(RunStorage):
             .where(SecondaryIndexMigrationTable.c.migration_completed != None)  # noqa: E711
             .limit(1)
         )
-        with self.connect() as conn:
-            results = conn.execute(query).fetchall()
+        results = self.fetchall(query)
 
         return len(results) > 0
 
@@ -1052,12 +1044,11 @@ class SqlRunStorage(RunStorage):
                 )
 
     def get_daemon_heartbeats(self) -> Mapping[str, DaemonHeartbeat]:
-        with self.connect() as conn:
-            rows = conn.execute(db_select([DaemonHeartbeatsTable.c.body]))
-            heartbeats = []
-            for row in rows:
-                heartbeats.append(deserialize_value(row.body, DaemonHeartbeat))
-            return {heartbeat.daemon_type: heartbeat for heartbeat in heartbeats}
+        rows = self.fetchall(db_select([DaemonHeartbeatsTable.c.body]))
+        heartbeats = []
+        for row in rows:
+            heartbeats.append(deserialize_value(row["body"], DaemonHeartbeat))
+        return {heartbeat.daemon_type: heartbeat for heartbeat in heartbeats}
 
     def wipe(self) -> None:
         """Clears the run storage."""
@@ -1093,13 +1084,13 @@ class SqlRunStorage(RunStorage):
             query = query.limit(limit)
         query = query.order_by(BulkActionsTable.c.id.desc())
         rows = self.fetchall(query)
-        return [deserialize_value(row[0], PartitionBackfill) for row in rows]
+        return [deserialize_value(row["body"], PartitionBackfill) for row in rows]
 
     def get_backfill(self, backfill_id: str) -> Optional[PartitionBackfill]:
         check.str_param(backfill_id, "backfill_id")
         query = db_select([BulkActionsTable.c.body]).where(BulkActionsTable.c.key == backfill_id)
         row = self.fetchone(query)
-        return deserialize_value(row[0], PartitionBackfill) if row else None
+        return deserialize_value(row["body"], PartitionBackfill) if row else None
 
     def add_backfill(self, partition_backfill: PartitionBackfill) -> None:
         check.inst_param(partition_backfill, "partition_backfill", PartitionBackfill)
@@ -1137,13 +1128,12 @@ class SqlRunStorage(RunStorage):
     def get_cursor_values(self, keys: Set[str]) -> Mapping[str, str]:
         check.set_param(keys, "keys", of_type=str)
 
-        with self.connect() as conn:
-            rows = conn.execute(
-                db_select([KeyValueStoreTable.c.key, KeyValueStoreTable.c.value]).where(
-                    KeyValueStoreTable.c.key.in_(keys)
-                ),
-            )
-            return {row.key: row.value for row in rows}
+        rows = self.fetchall(
+            db_select([KeyValueStoreTable.c.key, KeyValueStoreTable.c.value]).where(
+                KeyValueStoreTable.c.key.in_(keys)
+            ),
+        )
+        return {row["key"]: row["value"] for row in rows}
 
     def set_cursor_values(self, pairs: Mapping[str, str]) -> None:
         check.mapping_param(pairs, "pairs", key_type=str, value_type=str)
@@ -1182,11 +1172,10 @@ GET_PIPELINE_SNAPSHOT_QUERY_ID = "get-pipeline-snapshot"
 
 
 def defensively_unpack_execution_plan_snapshot_query(
-    logger: logging.Logger, row: SqlAlchemyRow
+    logger: logging.Logger, row: Sequence[Any]
 ) -> Optional[Union[ExecutionPlanSnapshot, JobSnapshot]]:
-    # no checking here because sqlalchemy returns a special
-    # row proxy and don't want to instance check on an internal
-    # implementation detail
+    # minimal checking here because sqlalchemy returns a different type based on what version of
+    # SqlAlchemy you are using
 
     def _warn(msg: str) -> None:
         logger.warning(f"get-pipeline-snapshot: {msg}")

--- a/python_modules/dagster/dagster/_core/storage/runs/sqlite/sqlite_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sqlite/sqlite_run_storage.py
@@ -90,7 +90,7 @@ class SqliteRunStorage(SqlRunStorage, ConfigurableClass):
             db_revision, head_revision = check_alembic_revision(alembic_config, connection)
             if not (db_revision and head_revision):
                 RunStorageSqlMetadata.create_all(engine)
-                connection.execute("PRAGMA journal_mode=WAL;")
+                connection.execute(db.text("PRAGMA journal_mode=WAL;"))
                 stamp_alembic_rev(alembic_config, connection)
                 should_mark_indexes = True
 

--- a/python_modules/dagster/dagster/_core/storage/schedules/migration.py
+++ b/python_modules/dagster/dagster/_core/storage/schedules/migration.py
@@ -5,7 +5,7 @@ from tqdm import tqdm
 
 from dagster._core.scheduler.instigation import InstigatorState
 from dagster._core.storage.schedules.base import ScheduleStorage
-from dagster._core.storage.sql import db_select
+from dagster._core.storage.sqlalchemy_compat import db_select
 from dagster._serdes import deserialize_value
 from dagster._utils import PrintFn
 

--- a/python_modules/dagster/dagster/_core/storage/schedules/sql_schedule_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/schedules/sql_schedule_storage.py
@@ -33,7 +33,7 @@ from dagster._core.scheduler.instigation import (
     TickStatus,
 )
 from dagster._core.storage.sql import SqlAlchemyQuery, SqlAlchemyRow
-from dagster._core.storage.sqlalchemy_compat import db_select, db_subquery
+from dagster._core.storage.sqlalchemy_compat import db_fetch_mappings, db_select, db_subquery
 from dagster._serdes import serialize_value
 from dagster._serdes.serdes import deserialize_value
 from dagster._utils import PrintFn, utc_datetime_from_timestamp
@@ -508,7 +508,7 @@ class SqlScheduleStorage(ScheduleStorage):
             if cursor:
                 query = query.where(AssetDaemonAssetEvaluationsTable.c.evaluation_id < cursor)
 
-            rows = conn.execute(query)
+            rows = db_fetch_mappings(conn, query)
             return [AutoMaterializeAssetEvaluationRecord.from_db_row(row) for row in rows]
 
     def wipe(self) -> None:

--- a/python_modules/dagster/dagster/_core/storage/schedules/sql_schedule_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/schedules/sql_schedule_storage.py
@@ -32,7 +32,8 @@ from dagster._core.scheduler.instigation import (
     TickData,
     TickStatus,
 )
-from dagster._core.storage.sql import SqlAlchemyQuery, SqlAlchemyRow, db_select
+from dagster._core.storage.sql import SqlAlchemyQuery, SqlAlchemyRow
+from dagster._core.storage.sqlalchemy_compat import db_select, db_subquery
 from dagster._serdes import serialize_value
 from dagster._serdes.serdes import deserialize_value
 from dagster._utils import PrintFn, utc_datetime_from_timestamp
@@ -307,7 +308,7 @@ class SqlScheduleStorage(ScheduleStorage):
             )
             .label("rank")
         )
-        subquery = (
+        subquery = db_subquery(
             db_select(
                 [
                     JobTickTable.c.id,
@@ -318,7 +319,6 @@ class SqlScheduleStorage(ScheduleStorage):
             )
             .select_from(JobTickTable)
             .where(JobTickTable.c.selector_id.in_(selector_ids))
-            .alias("subquery")
         )
         if statuses:
             subquery = subquery.where(

--- a/python_modules/dagster/dagster/_core/storage/schedules/sqlite/sqlite_schedule_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/schedules/sqlite/sqlite_schedule_storage.py
@@ -1,6 +1,7 @@
 from contextlib import contextmanager
 from typing import Iterator, Optional
 
+import sqlalchemy as db
 from packaging.version import parse
 from sqlalchemy.engine import Connection
 from sqlalchemy.pool import NullPool
@@ -67,7 +68,7 @@ class SqliteScheduleStorage(SqlScheduleStorage, ConfigurableClass):
             db_revision, head_revision = check_alembic_revision(alembic_config, connection)
             if not (db_revision and head_revision):
                 ScheduleStorageSqlMetadata.create_all(engine)
-                connection.execute("PRAGMA journal_mode=WAL;")
+                connection.execute(db.text("PRAGMA journal_mode=WAL;"))
                 stamp_alembic_rev(alembic_config, connection)
                 should_migrate_data = True
 

--- a/python_modules/dagster/dagster/_core/storage/sql.py
+++ b/python_modules/dagster/dagster/_core/storage/sql.py
@@ -1,6 +1,6 @@
 import threading
 from functools import lru_cache
-from typing import Any, Iterable, Optional, Tuple, Union
+from typing import Any, Optional, Tuple, Union
 
 import sqlalchemy as db
 from alembic.command import downgrade, stamp, upgrade
@@ -211,11 +211,3 @@ def add_precision_to_mysql_FLOAT(_element, _compiler, **_kw) -> str:
 
 class MySQLCompatabilityTypes:
     UniqueText = db.String(512)
-
-
-def db_select(items: Iterable):
-    """Utility class that allows compatability between SqlAlchemy 1.3.x, 1.4.x, and 2.x."""
-    if db.__version__.startswith("2."):
-        return db.select(*items)
-
-    return db.select(items)

--- a/python_modules/dagster/dagster/_core/storage/sql.py
+++ b/python_modules/dagster/dagster/_core/storage/sql.py
@@ -133,26 +133,25 @@ def run_migrations_online(
     """
     from sqlite3 import DatabaseError
 
-    connectable = config.attributes.get("connection", None)
+    connection = config.attributes.get("connection", None)
 
-    if connectable is None:
+    if connection is None:
         raise Exception(
             "No connection set in alembic config. If you are trying to run this script from the "
             "command line, STOP and read the README."
         )
 
-    with connectable.connect() as connection:
-        try:
-            context.configure(connection=connection, target_metadata=target_metadata)
+    try:
+        context.configure(connection=connection, target_metadata=target_metadata)
 
-            with context.begin_transaction():
-                context.run_migrations()
+        with context.begin_transaction():
+            context.run_migrations()
 
-        except DatabaseError as exc:
-            # This is to deal with concurrent execution -- if this table already exists thanks to a
-            # race with another process, we are fine and can continue.
-            if "table alembic_version already exists" not in str(exc):
-                raise
+    except DatabaseError as exc:
+        # This is to deal with concurrent execution -- if this table already exists thanks to a
+        # race with another process, we are fine and can continue.
+        if "table alembic_version already exists" not in str(exc):
+            raise
 
 
 # SQLAlchemy types, compiler directives, etc. to avoid pre-0.11.0 migrations

--- a/python_modules/dagster/dagster/_core/storage/sqlalchemy_compat.py
+++ b/python_modules/dagster/dagster/_core/storage/sqlalchemy_compat.py
@@ -1,4 +1,4 @@
-from typing import Iterable
+from typing import Any, Iterable, Sequence
 
 import sqlalchemy as db
 
@@ -19,3 +19,11 @@ def db_subquery(query, name: str = "subquery"):
         return query.subquery(name)
 
     return query.alias(name)
+
+
+def db_fetch_mappings(conn, query: Any) -> Sequence[Any]:
+    """Utility class that allows compatibility between SqlAlchemy 1.3.x, 1.4.x, and 2.x."""
+    if not IS_SQLALCHEMY_VERSION_1:
+        return conn.execute(query).mappings().all()
+
+    return conn.execute(query).fetchall()

--- a/python_modules/dagster/dagster/_core/storage/sqlalchemy_compat.py
+++ b/python_modules/dagster/dagster/_core/storage/sqlalchemy_compat.py
@@ -1,0 +1,21 @@
+from typing import Iterable
+
+import sqlalchemy as db
+
+IS_SQLALCHEMY_VERSION_1 = db.__version__.startswith("1.")
+
+
+def db_select(items: Iterable):
+    """Utility class that allows compatability between SqlAlchemy 1.3.x, 1.4.x, and 2.x."""
+    if not IS_SQLALCHEMY_VERSION_1:
+        return db.select(*items)
+
+    return db.select(items)
+
+
+def db_subquery(query, name: str = "subquery"):
+    """Utility class that allows compatibility between SqlAlchemy 1.3.x, 1.4.x, and 2.x."""
+    if not IS_SQLALCHEMY_VERSION_1:
+        return query.subquery(name)
+
+    return query.alias(name)

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -950,7 +950,7 @@ def test_add_bulk_actions_columns():
                 db_select([db.func.count().label("count")])
                 .select_from(BulkActionsTable)
                 .where(BulkActionsTable.c.selector_id.isnot(None))
-            )[0]
+            )["count"]
             assert migrated_row_count > 0
             assert backfill_count == migrated_row_count
 
@@ -978,7 +978,7 @@ def test_add_bulk_actions_columns():
                 db_select([db.func.count().label("count")])
                 .select_from(BulkActionsTable)
                 .where(BulkActionsTable.c.selector_id.is_(None))
-            )[0]
+            )["count"]
             assert unmigrated_row_count == 0
 
             # test downgrade

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -36,7 +36,7 @@ from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus, Runs
 from dagster._core.storage.event_log.migration import migrate_event_log_data
 from dagster._core.storage.event_log.sql_event_log import SqlEventLogStorage
 from dagster._core.storage.migration.utils import upgrading_instance
-from dagster._core.storage.sql import db_select
+from dagster._core.storage.sqlalchemy_compat import db_select
 from dagster._core.storage.tags import REPOSITORY_LABEL_TAG
 from dagster._daemon.types import DaemonHeartbeat
 from dagster._serdes import create_snapshot_id

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -9,6 +9,7 @@ from typing import List, Optional, Sequence, Tuple, cast
 import mock
 import pendulum
 import pytest
+import sqlalchemy as db
 from dagster import (
     AssetKey,
     AssetMaterialization,
@@ -267,7 +268,7 @@ def _synthesize_events(
 
 def _fetch_all_events(configured_storage, run_id=None):
     with configured_storage.run_connection(run_id=run_id) as conn:
-        res = conn.execute("SELECT event from event_logs")
+        res = conn.execute(db.text("SELECT event from event_logs"))
         return res.fetchall()
 
 

--- a/python_modules/libraries/dagster-mysql/dagster_mysql_tests/compat_tests/test_back_compat.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql_tests/compat_tests/test_back_compat.py
@@ -20,7 +20,7 @@ from dagster import (
 from dagster._core.errors import DagsterInvalidInvocationError
 from dagster._core.instance import DagsterInstance
 from dagster._core.storage.event_log.migration import ASSET_KEY_INDEX_COLS
-from dagster._core.storage.sql import db_select
+from dagster._core.storage.sqlalchemy_compat import db_select
 from dagster._daemon.types import DaemonHeartbeat
 from dagster._utils import file_relative_path
 

--- a/python_modules/libraries/dagster-mysql/dagster_mysql_tests/test_instance.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql_tests/test_instance.py
@@ -140,12 +140,12 @@ def test_statement_timeouts(conn_string):
 
         with pytest.raises(db.exc.OperationalError, match="QueryCanceled"):
             with instance._run_storage.connect() as conn:  # noqa: SLF001
-                conn.execute("select pg_sleep(1)").fetchone()
+                conn.execute(db.text("select sleep(1)")).fetchone()
 
         with pytest.raises(db.exc.OperationalError, match="QueryCanceled"):
             with instance._event_storage.connect() as conn:  # noqa: SLF001
-                conn.execute("select pg_sleep(1)").fetchone()
+                conn.execute(db.text("select sleep(1)")).fetchone()
 
         with pytest.raises(db.exc.OperationalError, match="QueryCanceled"):
             with instance._schedule_storage.connect() as conn:  # noqa: SLF001
-                conn.execute("select pg_sleep(1)").fetchone()
+                conn.execute(db.text("select sleep(1)")).fetchone()

--- a/python_modules/libraries/dagster-mysql/dagster_mysql_tests/test_wait_timeout.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql_tests/test_wait_timeout.py
@@ -1,8 +1,8 @@
 import time
 
 import pytest
+import sqlalchemy as db
 from dagster_mysql.run_storage import MySQLRunStorage
-from sqlalchemy import exc
 
 
 def retry_connect(conn_string: str, num_retries: int = 5, pool_recycle=-1):
@@ -10,18 +10,18 @@ def retry_connect(conn_string: str, num_retries: int = 5, pool_recycle=-1):
     storage.optimize_for_dagit(-1, pool_recycle=pool_recycle)
 
     with storage.connect() as conn:
-        conn.execute("SET SESSION wait_timeout = 2;")
+        conn.execute(db.text("SET SESSION wait_timeout = 2;"))
 
     for _ in range(num_retries):
         time.sleep(3)
         with storage.connect() as conn:
-            conn.execute("SELECT 1;")
+            conn.execute(db.text("SELECT 1;"))
 
     return storage.get_runs()
 
 
 def test_pool_recycle_greater_than_wait_timeout(conn_string):
-    with pytest.raises(exc.OperationalError):
+    with pytest.raises(db.exc.OperationalError):
         retry_connect(conn_string)
 
 

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
@@ -184,8 +184,8 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
 
             # LISTEN/NOTIFY no longer used for pg event watch - preserved here to support version skew
             conn.execute(
-                f"""NOTIFY {CHANNEL_NAME}, %s; """,
-                (res[0] + "_" + str(res[1]),),  # type: ignore
+                db.text(f"""NOTIFY {CHANNEL_NAME}, :notify_id; """),
+                {"notify_id": res[0] + "_" + str(res[1])},  # type: ignore
             )
             event_id = int(res[1])  # type: ignore
 

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
@@ -24,10 +24,10 @@ from dagster._core.storage.sql import (
     AlembicVersion,
     check_alembic_revision,
     create_engine,
-    db_select,
     run_alembic_upgrade,
     stamp_alembic_rev,
 )
+from dagster._core.storage.sqlalchemy_compat import db_select
 from dagster._serdes import ConfigurableClass, ConfigurableClassData, deserialize_value
 from sqlalchemy.engine import Connection
 

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
@@ -23,7 +23,7 @@ from dagster._core.errors import DagsterInvalidInvocationError
 from dagster._core.execution.api import execute_job
 from dagster._core.instance import DagsterInstance
 from dagster._core.storage.event_log.migration import ASSET_KEY_INDEX_COLS
-from dagster._core.storage.sql import db_select
+from dagster._core.storage.sqlalchemy_compat import db_select
 from dagster._core.storage.tags import PARTITION_NAME_TAG, PARTITION_SET_TAG
 from dagster._daemon.types import DaemonHeartbeat
 from dagster._utils import file_relative_path

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_instance.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_instance.py
@@ -210,15 +210,15 @@ def test_statement_timeouts(hostname):
 
         with pytest.raises(db.exc.OperationalError, match="QueryCanceled"):
             with instance._run_storage.connect() as conn:  # noqa: SLF001
-                conn.execute("select pg_sleep(1)").fetchone()
+                conn.execute(db.text("select pg_sleep(1)")).fetchone()
 
         with pytest.raises(db.exc.OperationalError, match="QueryCanceled"):
             with instance._event_storage._connect() as conn:  # noqa: SLF001
-                conn.execute("select pg_sleep(1)").fetchone()
+                conn.execute(db.text("select pg_sleep(1)")).fetchone()
 
         with pytest.raises(db.exc.OperationalError, match="QueryCanceled"):
             with instance._schedule_storage.connect() as conn:  # noqa: SLF001
-                conn.execute("select pg_sleep(1)").fetchone()
+                conn.execute(db.text("select pg_sleep(1)")).fetchone()
 
 
 def test_skip_autocreate(hostname, conn_string):
@@ -306,7 +306,8 @@ def test_configured_other_schema(hostname):
             hostname=hostname,
         )
     ).connect() as conn:
-        conn.execute("create schema other_schema;")
+        with conn.begin():
+            conn.execute(db.text("create schema other_schema;"))
 
     with instance_for_test(
         overrides=yaml.safe_load(schema_specified_pg_config(hostname))


### PR DESCRIPTION
## Summary & Motivation
SqlAlchemy 2.0 compat

The `execute` args are stricter now and only take sql expression objects (not strings).  All raw sql strings need to be wrapped with `db.text`.

https://docs.sqlalchemy.org/en/20/changelog/migration_20.html#execute-method-more-strict-execution-options-are-more-prominent

## How I Tested These Changes
Full stack of changes with a pin applied: https://github.com/dagster-io/dagster/pull/14263, https://buildkite.com/dagster/dagster/builds/59329

