### PR TITLE
[pythonic resources][rfc] Adjust EnvVar behavior to allow for direct usage

### DIFF
--- a/python_modules/dagster/dagster/_config/field_utils.py
+++ b/python_modules/dagster/dagster/_config/field_utils.py
@@ -1,5 +1,6 @@
 # encoding: utf-8
 import hashlib
+import os
 from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Mapping, Sequence
 
 import dagster._check as check
@@ -499,3 +500,14 @@ class EnvVar(str):
     @classmethod
     def int(cls, name: str) -> "IntEnvVar":
         return IntEnvVar.create(name=name)
+
+    def __str__(self) -> str:
+        if self not in os.environ:
+            raise ValueError(
+                f'Attempted to retrieve environment variable EnvVar("{self.env_var_name()}"), which'
+                " is not set in the environment"
+            )
+        return str(os.getenv(self))
+
+    def env_var_name(self) -> str:
+        return repr(self)[1:-1]

--- a/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
@@ -314,7 +314,7 @@ def _config_value_to_dict_representation(field: Optional[ModelField], value: Any
     elif isinstance(value, list):
         return [_config_value_to_dict_representation(None, v) for v in value]
     elif isinstance(value, EnvVar):
-        return {"env": str(value)}
+        return {"env": value.env_var_name()}
     elif isinstance(value, IntEnvVar):
         return {"env": value.name}
     if isinstance(value, Config):

--- a/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_env_vars.py
+++ b/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_env_vars.py
@@ -1,8 +1,30 @@
+import os
+
 import pytest
 from dagster import Definitions, EnvVar, RunConfig, asset
 from dagster._config.pythonic_config import Config
 from dagster._core.errors import DagsterInvalidConfigError
 from dagster._core.test_utils import environ
+
+
+def test_direct_use_env_var() -> None:
+    # Users can directly stringify an EnvVar to resolve it to its value
+    with environ({"A_STR": "foo"}):
+        my_env_var = EnvVar("A_STR")
+
+        assert str(my_env_var) == "foo"
+
+    if "NOT_EXISTING_ENV_VAR" in os.environ:
+        del os.environ["NOT_EXISTING_ENV_VAR"]
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            'Attempted to retrieve environment variable EnvVar\\("NOT_EXISTING_ENV_VAR"\\), which'
+            " is not set in the environment"
+        ),
+    ):
+        str(EnvVar("NOT_EXISTING_ENV_VAR"))
 
 
 def test_str_env_var() -> None:


### PR DESCRIPTION
## Summary

Small RFC in response to #14452. Keeps `EnvVar` as a direct subclass of `str` but implements a custom override of `__str__` to fetch the value from the environment in the case that the user attempts to use the `EnvVar` anywhere.

In the case that it's passed into a resource or config, the resolution will still happen in a lazy manner.

A potentially compelling alternative could be to error on `__str__` to explicitly prevent users from using `EnvVar` outside of resource/config contexts. Right now we're sort of in the worst of both worlds where a user can use an `EnvVar` in inapproporiate places and they get an odd result (see user comment in the above issue). (See #14490 for an example of this)

## Test Plan

Small unit test, existing unit tests. Will expand suite if this is a direction we want to go.

