### PR TITLE
[pythonic resources][rfc] Adjust EnvVar behavior to explicitly disallow direct usage

### DIFF
--- a/python_modules/dagster/dagster/_config/errors.py
+++ b/python_modules/dagster/dagster/_config/errors.py
@@ -2,6 +2,7 @@ from enum import Enum
 from typing import Mapping, NamedTuple, Sequence, Union
 
 import dagster._check as check
+from dagster._config.field_utils import EnvVar, IntEnvVar
 from dagster._utils.error import SerializableErrorInfo
 
 from .config_type import ConfigTypeKind
@@ -378,19 +379,23 @@ def create_scalar_error(context: ContextData, config_value: object) -> Evaluatio
     )
 
 
-def create_pydantic_env_var_error(context: ContextData, config_value: object) -> EvaluationError:
-    correct_env_var = str({"env": config_value})
+def create_pydantic_env_var_error(
+    context: ContextData, config_value: Union[EnvVar, IntEnvVar]
+) -> EvaluationError:
+    env_var_name = config_value.env_var_name
+
+    correct_env_var = str({"env": env_var_name})
     return EvaluationError(
         stack=context.stack,
         reason=DagsterEvaluationErrorReason.RUNTIME_TYPE_MISMATCH,
         message=(
-            f'Invalid use of environment variable wrapper. Value "{config_value}" is wrapped with'
+            f'Invalid use of environment variable wrapper. Value "{env_var_name}" is wrapped with'
             " EnvVar(), which is reserved for passing to structured pydantic config objects only."
             " To provide an environment variable to a run config dictionary, replace"
-            f' EnvVar("{config_value}") with {correct_env_var}, or pass a structured RunConfig'
+            f' EnvVar("{env_var_name}") with {correct_env_var}, or pass a structured RunConfig'
             " object."
         ),
-        error_data=RuntimeMismatchErrorData(context.config_type_snap, repr(config_value)),
+        error_data=RuntimeMismatchErrorData(context.config_type_snap, repr(env_var_name)),
     )
 
 

--- a/python_modules/dagster/dagster/_config/field_utils.py
+++ b/python_modules/dagster/dagster/_config/field_utils.py
@@ -500,3 +500,12 @@ class EnvVar(str):
     @classmethod
     def int(cls, name: str) -> "IntEnvVar":
         return IntEnvVar.create(name=name)
+
+    def __str__(self) -> str:
+        raise RuntimeError(
+            f'Attempted to directly retrieve environment variable EnvVar("{self.env_var_name()}").'
+            " EnvVar should only be used as input to Dagster config or resources."
+        )
+
+    def env_var_name(self) -> str:
+        return repr(self)[1:-1]

--- a/python_modules/dagster/dagster/_config/field_utils.py
+++ b/python_modules/dagster/dagster/_config/field_utils.py
@@ -490,6 +490,30 @@ class IntEnvVar(int):
         var.name = name
         return var
 
+    def __int__(self) -> int:
+        """Raises an exception of the EnvVar value is directly accessed. Users should instead use
+        the `get_value` method, or use the EnvVar as an input to Dagster config or resources.
+        """
+        raise RuntimeError(
+            f'Attempted to directly retrieve environment variable IntEnvVar("{self.name}").'
+            " IntEnvVar should only be used as input to Dagster config or resources."
+        )
+
+    def __str__(self) -> str:
+        return str(int(self))
+
+    def get_value(self, default: Optional[int] = None) -> Optional[int]:
+        """Returns the value of the environment variable, or the default value if the
+        environment variable is not set. If no default is provided, None will be returned.
+        """
+        value = os.getenv(self.name, default=default)
+        return int(value) if value else None
+
+    @property
+    def env_var_name(self) -> str:
+        """Returns the name of the environment variable."""
+        return self.name
+
 
 class EnvVar(str):
     """Class used to represent an environment variable in the Dagster config system.
@@ -510,10 +534,11 @@ class EnvVar(str):
         the `get_value` method, or use the EnvVar as an input to Dagster config or resources.
         """
         raise RuntimeError(
-            f'Attempted to directly retrieve environment variable EnvVar("{self.env_var_name()}").'
+            f'Attempted to directly retrieve environment variable EnvVar("{self.env_var_name}").'
             " EnvVar should only be used as input to Dagster config or resources."
         )
 
+    @property
     def env_var_name(self) -> str:
         """Returns the name of the environment variable."""
         return super().__str__()
@@ -522,4 +547,4 @@ class EnvVar(str):
         """Returns the value of the environment variable, or the default value if the
         environment variable is not set. If no default is provided, None will be returned.
         """
-        return os.getenv(self.env_var_name(), default=default)
+        return os.getenv(self.env_var_name, default=default)

--- a/python_modules/dagster/dagster/_config/field_utils.py
+++ b/python_modules/dagster/dagster/_config/field_utils.py
@@ -496,7 +496,10 @@ class IntEnvVar(int):
         """
         raise RuntimeError(
             f'Attempted to directly retrieve environment variable IntEnvVar("{self.name}").'
-            " IntEnvVar should only be used as input to Dagster config or resources."
+            " IntEnvVar defers resolution of the env var value until run time, and should only be"
+            " used as input to Dagster config or resources.\n\n"
+            "To access the environment variable value, call `get_value` on the IntEnvVar, or use"
+            " os.getenv directly."
         )
 
     def __str__(self) -> str:
@@ -535,7 +538,10 @@ class EnvVar(str):
         """
         raise RuntimeError(
             f'Attempted to directly retrieve environment variable EnvVar("{self.env_var_name}").'
-            " EnvVar should only be used as input to Dagster config or resources."
+            " EnvVar defers resolution of the env var value until run time, and should only be"
+            " used as input to Dagster config or resources.\n\n"
+            "To access the environment variable value, call `get_value` on the EnvVar, or use"
+            " os.getenv directly."
         )
 
     @property

--- a/python_modules/dagster/dagster/_config/pythonic_config/config.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/config.py
@@ -263,7 +263,7 @@ def _config_value_to_dict_representation(field: Optional[ModelField], value: Any
     elif isinstance(value, list):
         return [_config_value_to_dict_representation(None, v) for v in value]
     elif isinstance(value, EnvVar):
-        return {"env": str(value)}
+        return {"env": value.env_var_name()}
     elif isinstance(value, IntEnvVar):
         return {"env": value.name}
     if isinstance(value, Config):

--- a/python_modules/dagster/dagster/_config/pythonic_config/config.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/config.py
@@ -263,7 +263,7 @@ def _config_value_to_dict_representation(field: Optional[ModelField], value: Any
     elif isinstance(value, list):
         return [_config_value_to_dict_representation(None, v) for v in value]
     elif isinstance(value, EnvVar):
-        return {"env": value.env_var_name()}
+        return {"env": value.env_var_name}
     elif isinstance(value, IntEnvVar):
         return {"env": value.name}
     if isinstance(value, Config):

--- a/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_env_vars.py
+++ b/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_env_vars.py
@@ -35,9 +35,9 @@ def test_direct_use_env_var_err() -> None:
     with pytest.raises(
         RuntimeError,
         match=(
-            "Attempted to directly retrieve environment variable"
-            ' EnvVar\\("A_STR"\\). EnvVar should only be used as input to Dagster'
-            " config or resources."
+            'Attempted to directly retrieve environment variable EnvVar\\("A_STR"\\). EnvVar defers'
+            " resolution of the env var value until run time, and should only be used as input to"
+            " Dagster config or resources.\n\n"
         ),
     ):
         str(EnvVar("A_STR"))
@@ -45,9 +45,9 @@ def test_direct_use_env_var_err() -> None:
     with pytest.raises(
         RuntimeError,
         match=(
-            "Attempted to directly retrieve environment variable"
-            ' EnvVar\\("A_STR"\\). EnvVar should only be used as input to Dagster'
-            " config or resources."
+            'Attempted to directly retrieve environment variable EnvVar\\("A_STR"\\). EnvVar defers'
+            " resolution of the env var value until run time, and should only be used as input to"
+            " Dagster config or resources.\n\n"
         ),
     ):
         print(EnvVar("A_STR"))  # noqa: T201
@@ -57,9 +57,9 @@ def test_direct_use_int_env_var_err() -> None:
     with pytest.raises(
         RuntimeError,
         match=(
-            "Attempted to directly retrieve environment variable"
-            ' IntEnvVar\\("AN_INT"\\). IntEnvVar should only be used as input to Dagster'
-            " config or resources."
+            'Attempted to directly retrieve environment variable IntEnvVar\\("AN_INT"\\). IntEnvVar'
+            " defers resolution of the env var value until run time, and should only be used as"
+            " input to Dagster config or resources."
         ),
     ):
         int(EnvVar.int("AN_INT"))
@@ -67,9 +67,9 @@ def test_direct_use_int_env_var_err() -> None:
     with pytest.raises(
         RuntimeError,
         match=(
-            "Attempted to directly retrieve environment variable"
-            ' IntEnvVar\\("AN_INT"\\). IntEnvVar should only be used as input to Dagster'
-            " config or resources."
+            'Attempted to directly retrieve environment variable IntEnvVar\\("AN_INT"\\). IntEnvVar'
+            " defers resolution of the env var value until run time, and should only be used as"
+            " input to Dagster config or resources."
         ),
     ):
         print(EnvVar.int("AN_INT"))  # noqa: T201

--- a/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_env_vars.py
+++ b/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_env_vars.py
@@ -5,6 +5,18 @@ from dagster._core.errors import DagsterInvalidConfigError
 from dagster._core.test_utils import environ
 
 
+def test_direct_use_env_var() -> None:
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            "Attempted to directly retrieve environment variable"
+            ' EnvVar\\("A_STR"\\). EnvVar should only be used as input to Dagster'
+            " config or resources."
+        ),
+    ):
+        str(EnvVar("A_STR"))
+
+
 def test_str_env_var() -> None:
     executed = {}
 

--- a/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_env_vars.py
+++ b/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_env_vars.py
@@ -36,8 +36,8 @@ def test_direct_use_env_var_err() -> None:
         RuntimeError,
         match=(
             'Attempted to directly retrieve environment variable EnvVar\\("A_STR"\\). EnvVar defers'
-            " resolution of the env var value until run time, and should only be used as input to"
-            " Dagster config or resources.\n\n"
+            " resolution of the environment variable value until run time, and should only be used"
+            " as input to Dagster config or resources.\n\n"
         ),
     ):
         str(EnvVar("A_STR"))
@@ -46,8 +46,8 @@ def test_direct_use_env_var_err() -> None:
         RuntimeError,
         match=(
             'Attempted to directly retrieve environment variable EnvVar\\("A_STR"\\). EnvVar defers'
-            " resolution of the env var value until run time, and should only be used as input to"
-            " Dagster config or resources.\n\n"
+            " resolution of the environment variable value until run time, and should only be used"
+            " as input to Dagster config or resources.\n\n"
         ),
     ):
         print(EnvVar("A_STR"))  # noqa: T201
@@ -58,8 +58,8 @@ def test_direct_use_int_env_var_err() -> None:
         RuntimeError,
         match=(
             'Attempted to directly retrieve environment variable IntEnvVar\\("AN_INT"\\). IntEnvVar'
-            " defers resolution of the env var value until run time, and should only be used as"
-            " input to Dagster config or resources."
+            " defers resolution of the environment variable value until run time, and should only"
+            " be used as input to Dagster config or resources."
         ),
     ):
         int(EnvVar.int("AN_INT"))
@@ -68,8 +68,8 @@ def test_direct_use_int_env_var_err() -> None:
         RuntimeError,
         match=(
             'Attempted to directly retrieve environment variable IntEnvVar\\("AN_INT"\\). IntEnvVar'
-            " defers resolution of the env var value until run time, and should only be used as"
-            " input to Dagster config or resources."
+            " defers resolution of the environment variable value until run time, and should only"
+            " be used as input to Dagster config or resources."
         ),
     ):
         print(EnvVar.int("AN_INT"))  # noqa: T201

--- a/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_env_vars.py
+++ b/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_env_vars.py
@@ -19,6 +19,18 @@ def test_direct_use_env_var_ok() -> None:
     assert EnvVar("A_NON_EXISTENT_VAR").get_value(default="bar") == "bar"
 
 
+def test_direct_use_int_env_var_ok() -> None:
+    with environ({"AN_INT": "55"}):
+        assert EnvVar.int("AN_INT").get_value() == 55
+        assert EnvVar.int("AN_INT").get_value(default=10) == 55
+
+    if "A_NON_EXISTENT_VAR" in os.environ:
+        del os.environ["A_NON_EXISTENT_VAR"]
+
+    assert EnvVar.int("A_NON_EXISTENT_VAR").get_value() is None
+    assert EnvVar.int("A_NON_EXISTENT_VAR").get_value(default=100) == 100
+
+
 def test_direct_use_env_var_err() -> None:
     with pytest.raises(
         RuntimeError,
@@ -39,6 +51,28 @@ def test_direct_use_env_var_err() -> None:
         ),
     ):
         print(EnvVar("A_STR"))  # noqa: T201
+
+
+def test_direct_use_int_env_var_err() -> None:
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            "Attempted to directly retrieve environment variable"
+            ' IntEnvVar\\("AN_INT"\\). IntEnvVar should only be used as input to Dagster'
+            " config or resources."
+        ),
+    ):
+        int(EnvVar.int("AN_INT"))
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            "Attempted to directly retrieve environment variable"
+            ' IntEnvVar\\("AN_INT"\\). IntEnvVar should only be used as input to Dagster'
+            " config or resources."
+        ),
+    ):
+        print(EnvVar.int("AN_INT"))  # noqa: T201
 
 
 def test_str_env_var() -> None:


### PR DESCRIPTION
## Summary

Alternative RFC to #14488. Keeps `EnvVar` as a direct subclass of `str` but errors on resolving the value via `__str__` to explicitly prevent users from using `EnvVar` outside of resource/config contexts. Right now we're sort of in the worst of both worlds where a user can use an `EnvVar` in inapproporiate places and they get an odd result.

1. Users who try to use an `EnvVar` value as a string will hit an error:

```python
my_env_var = EnvVar("MY_ENV_VAR")

# errors!
print(f"Hello, {my_env_var}!")
```

2. Users can directly access the `EnvVar` name or value:

```python
my_env_var = EnvVar("MY_ENV_VAR")

print(f"Env var {my_env_var.env_var_name} has value {my_env_var.get_value()}")
```

## Test Plan

Set of unit tests, existing unit tests.

