### PR TITLE
[RFC] feat: deprecate `file_relative_path`

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -579,6 +579,11 @@ _DEPRECATED: Final[Mapping[str, TypingTuple[str, str, str]]] = {
     #     "1.1.0",  # breaking version
     #     "Use Bar instead.",
     # ),
+    "file_relative_path": (
+        "dagster._utils",
+        "1.4.0",
+        "Construct the relative path using `pathlib.Path(__file__)` instead.",
+    )
 }
 
 _DEPRECATED_RENAMED: Final[Mapping[str, TypingTuple[Callable, str]]] = {


### PR DESCRIPTION
## Summary & Motivation
This utility function is used in the `dagster-dbt` integration a lot, and I'm not too happy about this import.

- This is subsumed by https://docs.python.org/3/library/pathlib.html, which is in the standard library.
- Finding a relative path is not the purpose of the Dagster framework, and so this function shouldn't be in the public API.
- At its very best, this could stay as an internal utility function, but I don't really see how it's more clear than just constructing the `Path` directly.

## Deprecation Plan
1. Migrate examples away from `file_relative_path`.
2. [RFC] Migrate internal utilities away from `file_relative_path`. 
3. Remove the function from the public API in `1.4.0`

## How I Tested These Changes
N/A
