### PR TITLE
use with_suffix in UPathIOManager

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
@@ -78,7 +78,7 @@ class UPathIOManager(MemoizableIOManager):
         return self.path_exists(self._get_path(context))
 
     def _with_extension(self, path: "UPath") -> "UPath":
-        return UPath(f"{path}{self.extension}") if self.extension else path
+        return path.with_suffix(path.suffix + self.extension) if self.extension else path
 
     def _get_path_without_extension(self, context: Union[InputContext, OutputContext]) -> "UPath":
         if context.has_asset_key:

--- a/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
@@ -78,8 +78,6 @@ class UPathIOManager(MemoizableIOManager):
         return self.path_exists(self._get_path(context))
 
     def _with_extension(self, path: "UPath") -> "UPath":
-        from upath import UPath
-
         return UPath(f"{path}{self.extension}") if self.extension else path
 
     def _get_path_without_extension(self, context: Union[InputContext, OutputContext]) -> "UPath":


### PR DESCRIPTION
## Summary & Motivation

resolves: https://github.com/dagster-io/dagster/issues/14492

UPath.with_suffix _replaces_ the existing suffix. So, if you have a file named `foo.bar.0`, and want to give it the extension `.txt`, directly calling UPath.with_suffix(".txt") would result in `foo.bar.txt`. This code adds the existing suffix (if any) to the extension, giving us the desired `foo.bar.0.txt`.

## How I Tested These Changes
