### PR TITLE
Fix resource binding when a job is only provided by a schedule/sensor and isn't included in the top-level list of jobs

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -142,6 +142,27 @@ def _attach_resources_to_jobs_and_instigator_jobs(
     schedules = schedules or []
     sensors = sensors or []
 
+    # Add jobs in schedules and sensors as well
+    jobs = [
+        *jobs,
+        *[
+            schedule.job
+            for schedule in schedules
+            if isinstance(schedule, ScheduleDefinition)
+            and schedule.has_loadable_target()
+            and isinstance(schedule.job, (JobDefinition, UnresolvedAssetJobDefinition))
+        ],
+        *[
+            job
+            for sensor in sensors
+            if sensor.has_loadable_targets()
+            for job in sensor.jobs
+            if isinstance(job, (JobDefinition, UnresolvedAssetJobDefinition))
+        ],
+    ]
+    # Dedupe
+    jobs = list({id(job): job for job in jobs}.values())
+
     # Find unsatisfied jobs
     unsatisfied_jobs = [
         job

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_binding.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_binding.py
@@ -239,7 +239,8 @@ def test_bind_resource_to_job_at_defn_time_override() -> None:
     assert out_txt == ["definitions says: hello, world!"]
 
 
-def test_bind_resource_to_instigator() -> None:
+@pytest.mark.parametrize("include_job_in_definitions", [True, False])
+def test_bind_resource_to_instigator(include_job_in_definitions) -> None:
     out_txt = []
 
     class WriterResource(ConfigurableResource):
@@ -266,7 +267,7 @@ def test_bind_resource_to_instigator() -> None:
 
     # Bind the resource to the job at definition time and validate that it works
     defs = Definitions(
-        jobs=[hello_world_job],
+        jobs=[hello_world_job] if include_job_in_definitions else [],
         schedules=[hello_world_schedule],
         sensors=[hello_world_sensor],
         resources={


### PR DESCRIPTION
Summary:
Test before was failing to map resources onto the job, now it is succeeding

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes
