### PR TITLE
[Automaterialize page] Actually pass down selectedEvaluationID 

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AssetAutomaterializePolicyPage.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AssetAutomaterializePolicyPage.tsx
@@ -644,6 +644,7 @@ const CenterAlignedRow = React.forwardRef((props: React.ComponentProps<typeof Bo
 export const GET_EVALUATIONS_QUERY = gql`
   query GetEvaluationsQuery($assetKey: AssetKeyInput!, $limit: Int!, $cursor: String) {
     autoMaterializeAssetEvaluations(assetKey: $assetKey, limit: $limit, cursor: $cursor) {
+      id
       evaluationId
       numRequested
       numSkipped

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AssetAutomaterializePolicyPage.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AssetAutomaterializePolicyPage.tsx
@@ -82,8 +82,6 @@ export const AssetAutomaterializePolicyPage = ({assetKey}: {assetKey: AssetKey})
     },
   });
 
-  console.log({selectedEvaluationId});
-
   const selectedEvaluation: EvaluationType | undefined = React.useMemo(() => {
     if (selectedEvaluationId) {
       return evaluations.find((evaluation) => evaluation.evaluationId === selectedEvaluationId);

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AssetAutomaterializePolicyPage.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AssetAutomaterializePolicyPage.tsx
@@ -69,7 +69,7 @@ export const AssetAutomaterializePolicyPage = ({assetKey}: {assetKey: AssetKey})
     return queryResult.data?.autoMaterializeAssetEvaluations || [];
   }, [queryResult.data?.autoMaterializeAssetEvaluations]);
 
-  const [selectedEvaluationId, setSelectedEvaluationId] = useQueryPersistedState({
+  const [selectedEvaluationId, setSelectedEvaluationId] = useQueryPersistedState<string>({
     queryKey: 'evaluation',
   });
 
@@ -111,7 +111,7 @@ export const AssetAutomaterializePolicyPage = ({assetKey}: {assetKey: AssetKey})
               queryResult={queryResult}
               paginationProps={paginationProps}
               onSelectEvaluation={(evaluation) => {
-                setSelectedEvaluationId(evaluation.evaluationId);
+                setSelectedEvaluationId(evaluation.evaluationId.toString());
               }}
               selectedEvaluation={selectedEvaluation}
             />
@@ -121,6 +121,7 @@ export const AssetAutomaterializePolicyPage = ({assetKey}: {assetKey: AssetKey})
               assetKey={assetKey}
               key={selectedEvaluation?.evaluationId || ''}
               maxMaterializationsPerMinute={maxMaterializationsPerMinute}
+              selectedEvaluationId={selectedEvaluationId?.toString()}
             />
           </Box>
         </Box>
@@ -171,19 +172,21 @@ function LeftPanel({
               ) : evaluation.numSkipped ? (
                 <div
                   style={{
+                    margin: '7px',
                     borderRadius: '50%',
                     height: '10px',
                     width: '10px',
-                    color: Colors.Yellow500,
+                    background: Colors.Yellow500,
                   }}
                 />
               ) : (
                 <div
                   style={{
+                    margin: '7px',
                     borderRadius: '50%',
                     height: '10px',
                     width: '10px',
-                    color: Colors.Yellow50,
+                    background: Colors.Yellow50,
                   }}
                 />
               )}
@@ -384,10 +387,12 @@ const MiddlePanel = ({
       variables: {
         assetKey,
         cursor: selectedEvaluationId,
-        limit: 1,
+        limit: 2,
       },
     },
   );
+
+  console.log({selectedEvaluationId, data});
 
   const evaluationData = React.useMemo(() => {
     return data?.autoMaterializeAssetEvaluations[0];

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AssetAutomaterializePolicyPage.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AssetAutomaterializePolicyPage.tsx
@@ -69,15 +69,24 @@ export const AssetAutomaterializePolicyPage = ({assetKey}: {assetKey: AssetKey})
     return queryResult.data?.autoMaterializeAssetEvaluations || [];
   }, [queryResult.data?.autoMaterializeAssetEvaluations]);
 
-  const [selectedEvaluationId, setSelectedEvaluationId] = useQueryPersistedState<string>({
+  const [selectedEvaluationId, setSelectedEvaluationId] = useQueryPersistedState<
+    number | undefined
+  >({
     queryKey: 'evaluation',
+    decode: (raw) => {
+      try {
+        return raw.evaluation ? parseInt(raw.evaluation) : undefined;
+      } catch (e) {
+        return undefined;
+      }
+    },
   });
+
+  console.log({selectedEvaluationId});
 
   const selectedEvaluation: EvaluationType | undefined = React.useMemo(() => {
     if (selectedEvaluationId) {
-      return evaluations.find(
-        (evaluation) => evaluation.evaluationId.toString() === selectedEvaluationId,
-      );
+      return evaluations.find((evaluation) => evaluation.evaluationId === selectedEvaluationId);
     }
     return evaluations[0];
   }, [selectedEvaluationId, evaluations]);
@@ -121,7 +130,7 @@ export const AssetAutomaterializePolicyPage = ({assetKey}: {assetKey: AssetKey})
               assetKey={assetKey}
               key={selectedEvaluation?.evaluationId || ''}
               maxMaterializationsPerMinute={maxMaterializationsPerMinute}
-              selectedEvaluationId={selectedEvaluationId?.toString()}
+              selectedEvaluationId={selectedEvaluationId}
             />
           </Box>
         </Box>
@@ -378,7 +387,7 @@ const MiddlePanel = ({
   maxMaterializationsPerMinute,
 }: {
   assetKey: Omit<AssetKey, '__typename'>;
-  selectedEvaluationId?: string;
+  selectedEvaluationId?: number;
   maxMaterializationsPerMinute: number;
 }) => {
   const {data, loading, error} = useQuery<GetEvaluationsQuery, GetEvaluationsQueryVariables>(
@@ -386,13 +395,11 @@ const MiddlePanel = ({
     {
       variables: {
         assetKey,
-        cursor: selectedEvaluationId,
+        cursor: selectedEvaluationId ? (selectedEvaluationId + 1).toString() : undefined,
         limit: 2,
       },
     },
   );
-
-  console.log({selectedEvaluationId, data});
 
   const evaluationData = React.useMemo(() => {
     return data?.autoMaterializeAssetEvaluations[0];

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AssetAutomaterializePolicyPage.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AssetAutomaterializePolicyPage.tsx
@@ -74,11 +74,8 @@ export const AssetAutomaterializePolicyPage = ({assetKey}: {assetKey: AssetKey})
   >({
     queryKey: 'evaluation',
     decode: (raw) => {
-      try {
-        return raw.evaluation ? parseInt(raw.evaluation) : undefined;
-      } catch (e) {
-        return undefined;
-      }
+      const value = parseInt(raw.evaluation);
+      return isNaN(value) ? undefined : value;
     },
   });
 

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AssetAutomaterializePolicyPage.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AssetAutomaterializePolicyPage.tsx
@@ -115,7 +115,7 @@ export const AssetAutomaterializePolicyPage = ({assetKey}: {assetKey: AssetKey})
               queryResult={queryResult}
               paginationProps={paginationProps}
               onSelectEvaluation={(evaluation) => {
-                setSelectedEvaluationId(evaluation.evaluationId.toString());
+                setSelectedEvaluationId(evaluation.evaluationId);
               }}
               selectedEvaluation={selectedEvaluation}
             />

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AssetAutomaterializePolicyPage.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AssetAutomaterializePolicyPage.tsx
@@ -553,7 +553,7 @@ const MiddlePanel = ({
             met={!!conditionResults.waitingOnUpstreamData}
           />
           <Condition
-            text={`Exceeds ${maxMaterializationsPerMinute} materializations per hour`}
+            text={`Exceeds ${maxMaterializationsPerMinute} materializations per minute`}
             met={!!conditionResults.exceedsXMaterializationsPerHour}
           />
         </Box>

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/types/AssetAutomaterializePolicyPage.types.ts
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/types/AssetAutomaterializePolicyPage.types.ts
@@ -12,6 +12,7 @@ export type GetEvaluationsQuery = {
   __typename: 'DagitQuery';
   autoMaterializeAssetEvaluations: Array<{
     __typename: 'AutoMaterializeAssetEvaluationRecord';
+    id: string;
     evaluationId: number;
     numRequested: number;
     numSkipped: number;


### PR DESCRIPTION
## Summary & Motivation

Actually pass down selectedEvaluationID + fix rendering the skipped icon.

<img width="873" alt="Screen Shot 2023-05-26 at 3 14 53 PM" src="https://github.com/dagster-io/dagster/assets/2286579/299e4cfe-f6f8-4a3a-9b54-d5407fa16b99">


Note that the screenshot shows the wrong content in the middle due to a backend bug
https://elementl-workspace.slack.com/archives/C04UD72HHQX/p1685128308432409?thread_ts=1685126824.627239&cid=C04UD72HHQX

## How I Tested These Changes

I tested this with `eager_downstream2` from the toys repo. Unfortunately the storybook is kind of busted because `useQueryPersistedState` doesn't seem to work in storybook (probably due to the iframe sandboxing) so I couldnt fully test this in storybook.
