### PR TITLE
increase failure threshold on readiness probe for user code deployments

### DIFF
--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -395,7 +395,7 @@ dagster-user-deployments:
         periodSeconds: 20
         timeoutSeconds: 3
         successThreshold: 1
-        failureThreshold: 3
+        failureThreshold: 15  # Allow roughly 300 seconds to start up by default
 
       # As of 0.14.0, liveness probes are disabled by default. If you want to enable them, it's recommended to also
       # enable startup probes.


### PR DESCRIPTION
The default here is about 60 seconds which is less than we allow code to startup elsewhere, increase it.