### PR TITLE
Remove unused timezone mocking code

### DIFF
--- a/python_modules/dagster/dagster/_core/test_utils.py
+++ b/python_modules/dagster/dagster/_core/test_utils.py
@@ -54,7 +54,7 @@ from dagster._core.workspace.context import WorkspaceProcessContext, WorkspaceRe
 from dagster._core.workspace.load_target import WorkspaceLoadTarget
 from dagster._serdes import ConfigurableClass
 from dagster._serdes.config_class import ConfigurableClassData
-from dagster._seven.compat.pendulum import create_pendulum_time, mock_pendulum_timezone
+from dagster._seven.compat.pendulum import create_pendulum_time
 from dagster._utils import Counter, get_terminate_signal, traced, traced_counter
 from dagster._utils.log import configure_loggers
 
@@ -465,20 +465,6 @@ def get_crash_signals() -> Sequence[Signals]:
 
 
 _mocked_system_timezone: Dict[str, Optional[str]] = {"timezone": None}
-
-
-@contextmanager
-def mock_system_timezone(override_timezone: str) -> Iterator[None]:
-    with mock_pendulum_timezone(override_timezone):
-        try:
-            _mocked_system_timezone["timezone"] = override_timezone
-            yield
-        finally:
-            _mocked_system_timezone["timezone"] = None
-
-
-def get_mocked_system_timezone() -> Optional[str]:
-    return _mocked_system_timezone["timezone"]
 
 
 # Test utility for creating a test workspace for a function

--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -1066,10 +1066,6 @@ def open_server_process(
     check.opt_inst_param(loadable_target_origin, "loadable_target_origin", LoadableTargetOrigin)
     check.opt_int_param(max_workers, "max_workers")
 
-    from dagster._core.test_utils import get_mocked_system_timezone
-
-    mocked_system_timezone = get_mocked_system_timezone()
-
     executable_path = loadable_target_origin.executable_path if loadable_target_origin else None
 
     subprocess_args = [
@@ -1082,7 +1078,6 @@ def open_server_process(
         *(["--heartbeat"] if heartbeat else []),
         *(["--heartbeat-timeout", str(heartbeat_timeout)] if heartbeat_timeout else []),
         *(["--fixed-server-id", fixed_server_id] if fixed_server_id else []),
-        *(["--override-system-timezone", mocked_system_timezone] if mocked_system_timezone else []),
         *(["--log-level", log_level]),
         # only use the Python environment if it has been explicitly set in the workspace,
         *(["--use-python-environment-entry-point"] if executable_path else []),

--- a/python_modules/dagster/dagster/_utils/log.py
+++ b/python_modules/dagster/dagster/_utils/log.py
@@ -6,7 +6,6 @@ from contextlib import contextmanager
 from typing import Mapping, NamedTuple, Optional
 
 import coloredlogs
-import pendulum
 
 import dagster._check as check
 import dagster._seven as seven
@@ -206,13 +205,6 @@ def get_stack_trace_array(exception):
     return traceback.format_tb(tb)
 
 
-def _mockable_formatTime(record, datefmt=None):
-    """Uses pendulum.now to determine the logging time, causing pendulum
-    mocking to affect the logger timestamp in tests.
-    """
-    return pendulum.now().strftime(datefmt if datefmt else default_date_format_string())
-
-
 def default_format_string():
     return "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 
@@ -273,10 +265,6 @@ def configure_loggers(handler="default", log_level="INFO"):
     }
 
     logging.config.dictConfig(LOGGING_CONFIG)
-
-    if handler == "default":
-        for name in ["dagster", "dagit"]:
-            logging.getLogger(name).handlers[0].formatter.formatTime = _mockable_formatTime
 
 
 def create_console_logger(name, level):


### PR DESCRIPTION
this code is not used, and raises an exception if your process doesn't have a timezone set. Remove it.
