### PR TITLE
Fix constraint error when the same snapshot ID is added twice

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -856,7 +856,12 @@ class SqlRunStorage(RunStorage):
                 snapshot_body=zlib.compress(serialize_value(snapshot_obj).encode("utf-8")),
                 snapshot_type=snapshot_type.value,
             )
-            conn.execute(snapshot_insert)
+            try:
+                conn.execute(snapshot_insert)
+            except db_exc.IntegrityError:
+                # on_conflict_do_nothing equivalent
+                pass
+
             return snapshot_id
 
     def get_run_storage_id(self) -> str:

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
@@ -948,6 +948,10 @@ class TestRunStorage:
 
         snapshot_id = storage.add_execution_plan_snapshot(ep_snapshot)
         fetched_ep_snapshot = storage.get_execution_plan_snapshot(snapshot_id)
+
+        # idempotent
+        assert storage.add_execution_plan_snapshot(ep_snapshot) == snapshot_id
+
         assert fetched_ep_snapshot
         assert serialize_pp(fetched_ep_snapshot) == serialize_pp(ep_snapshot)
         assert storage.has_execution_plan_snapshot(snapshot_id)


### PR DESCRIPTION
Summary:
Snapshot Id uniquely determines contents, so if two inserts happen at the same time, assume one of them succeeded rather than hitting a contraint error.

Test Plan: BK, new test case that was failing before

## Summary & Motivation

## How I Tested These Changes
