### PR TITLE
[ui] Fix “Materialize” button when >1 level deep in asset catalog

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetTable.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetTable.tsx
@@ -11,6 +11,7 @@ import {
   Checkbox,
   NonIdealState,
 } from '@dagster-io/ui';
+import groupBy from 'lodash/groupBy';
 import * as React from 'react';
 
 import {useUnscopedPermissions} from '../app/Permissions';
@@ -51,28 +52,17 @@ export const AssetTable: React.FC<Props> = ({
 }) => {
   const [toWipe, setToWipe] = React.useState<AssetKeyInput[] | undefined>();
 
-  const groupedByFirstComponent: {[pathComponent: string]: Asset[]} = {};
+  const groupedByDisplayKey = groupBy(assets, (a) => JSON.stringify(displayPathForAsset(a)));
+  const displayKeys = Object.keys(groupedByDisplayKey).sort();
 
-  assets.forEach((asset) => {
-    const displayPathKey = JSON.stringify(displayPathForAsset(asset));
-    groupedByFirstComponent[displayPathKey] = [
-      ...(groupedByFirstComponent[displayPathKey] || []),
-      asset,
-    ];
-  });
-
-  const [{checkedIds: checkedPaths}, {onToggleFactory, onToggleAll}] = useSelectionReducer(
-    Object.keys(groupedByFirstComponent),
+  const [{checkedIds: checkedDisplayKeys}, {onToggleFactory, onToggleAll}] = useSelectionReducer(
+    displayKeys,
   );
 
   const checkedAssets: Asset[] = [];
-  const checkedPathsOnscreen: string[] = [];
-
-  const pageDisplayPathKeys = Object.keys(groupedByFirstComponent).sort();
-  pageDisplayPathKeys.forEach((pathKey) => {
-    if (checkedPaths.has(pathKey)) {
-      checkedPathsOnscreen.push(pathKey);
-      checkedAssets.push(...(groupedByFirstComponent[pathKey] || []));
+  displayKeys.forEach((displayKey) => {
+    if (checkedDisplayKeys.has(displayKey)) {
+      checkedAssets.push(...(groupedByDisplayKey[displayKey] || []));
     }
   });
 
@@ -125,23 +115,19 @@ export const AssetTable: React.FC<Props> = ({
         headerCheckbox={
           <Checkbox
             indeterminate={
-              checkedPathsOnscreen.length > 0 &&
-              checkedPathsOnscreen.length !== pageDisplayPathKeys.length
+              checkedDisplayKeys.size > 0 && checkedDisplayKeys.size !== displayKeys.length
             }
-            checked={
-              checkedPathsOnscreen.length > 0 &&
-              checkedPathsOnscreen.length === pageDisplayPathKeys.length
-            }
+            checked={checkedDisplayKeys.size > 0 && checkedDisplayKeys.size === displayKeys.length}
             onChange={(e) => {
               if (e.target instanceof HTMLInputElement) {
-                onToggleAll(checkedPathsOnscreen.length !== pageDisplayPathKeys.length);
+                onToggleAll(checkedDisplayKeys.size !== displayKeys.length);
               }
             }}
           />
         }
         prefixPath={prefixPath}
-        groups={groupedByFirstComponent}
-        checkedPaths={checkedPaths}
+        groups={groupedByDisplayKey}
+        checkedDisplayKeys={checkedDisplayKeys}
         onToggleFactory={onToggleFactory}
         showRepoColumn
         view={view}

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedAssetTable.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedAssetTable.tsx
@@ -10,14 +10,14 @@ import {VirtualizedAssetCatalogHeader, VirtualizedAssetRow} from './VirtualizedA
 import {buildRepoAddress} from './buildRepoAddress';
 
 type Row =
-  | {type: 'asset'; path: string[]; asset: AssetTableFragment}
-  | {type: 'folder'; path: string[]; assets: AssetTableFragment[]};
+  | {type: 'asset'; path: string[]; displayKey: string; asset: AssetTableFragment}
+  | {type: 'folder'; path: string[]; displayKey: string; assets: AssetTableFragment[]};
 
 interface Props {
   headerCheckbox: React.ReactNode;
   prefixPath: string[];
-  groups: {[path: string]: AssetTableFragment[]};
-  checkedPaths: Set<string>;
+  groups: {[displayKey: string]: AssetTableFragment[]};
+  checkedDisplayKeys: Set<string>;
   onToggleFactory: (path: string) => (values: {checked: boolean; shiftKey: boolean}) => void;
   onWipe: (assets: AssetKeyInput[]) => void;
   showRepoColumn: boolean;
@@ -29,7 +29,7 @@ export const VirtualizedAssetTable: React.FC<Props> = (props) => {
     headerCheckbox,
     prefixPath,
     groups,
-    checkedPaths,
+    checkedDisplayKeys,
     onToggleFactory,
     onWipe,
     showRepoColumn,
@@ -49,11 +49,13 @@ export const VirtualizedAssetTable: React.FC<Props> = (props) => {
   const items = rowVirtualizer.getVirtualItems();
 
   const rows: Row[] = React.useMemo(() => {
-    return Object.keys(groups).map((key) => {
-      const path = [...prefixPath, ...JSON.parse(key)];
-      const assets = groups[key];
+    return Object.keys(groups).map((displayKey) => {
+      const path = [...prefixPath, ...JSON.parse(displayKey)];
+      const assets = groups[displayKey];
       const isFolder = assets.length > 1 || path.join('/') !== assets[0].key.path.join('/');
-      return isFolder ? {type: 'folder', path, assets} : {type: 'asset', path, asset: assets[0]};
+      return isFolder
+        ? {type: 'folder', path, displayKey, assets}
+        : {type: 'asset', path, displayKey, asset: assets[0]};
     });
   }, [prefixPath, groups]);
 
@@ -64,7 +66,6 @@ export const VirtualizedAssetTable: React.FC<Props> = (props) => {
         <Inner $totalHeight={totalHeight}>
           {items.map(({index, key, size, start}) => {
             const row: Row = rows[index];
-            const path = JSON.stringify(row.path);
             const rowType = () => {
               if (row.type === 'folder') {
                 return 'folder';
@@ -94,8 +95,8 @@ export const VirtualizedAssetTable: React.FC<Props> = (props) => {
                 showRepoColumn={showRepoColumn}
                 height={size}
                 start={start}
-                checked={checkedPaths.has(path)}
-                onToggleChecked={onToggleFactory(path)}
+                checked={checkedDisplayKeys.has(row.displayKey)}
+                onToggleChecked={onToggleFactory(row.displayKey)}
                 onWipe={() => onWipe(wipeableAssets.map((a) => a.key))}
               />
             );


### PR DESCRIPTION
## Summary & Motivation

Fixes https://github.com/dagster-io/dagster/issues/14408

I cleaned up this code a bit, but the core problem was that we were selecting rows with the current path prefix added (eg: `folder/asset`), but later comparing / filtering them without the path prefix added. 

## How I Tested These Changes

I tested this by creating assets 1, 2, and 3 layers deep, and verifying that I could launch them from all three layers (eg: selecting the folder containing them vs them individually), in both the "hierarchical" view and the "flat" view.

It turns out this also repro'd in our existing `Global Catalog With Prefix` Asset Table storybook example. We don't currently have unit tests for this component, but I will write one to cover this later this week.