### PR TITLE
added sys.stdout.write(stdout)

### DIFF
--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
@@ -2,6 +2,7 @@ import gzip
 import io
 import os.path
 import pickle
+import sys
 import tempfile
 import time
 import zlib
@@ -272,6 +273,7 @@ class DatabricksPySparkStepLauncher(StepLauncher):
             ).decode()
             log.info(f"Captured stdout for step {step_key}:")
             log.info(stdout)
+            sys.stdout.write(stdout)
         except Exception as e:
             log.error(
                 f"Encountered exception {e} when attempting to load stdout logs for step"

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
@@ -285,6 +285,7 @@ class DatabricksPySparkStepLauncher(StepLauncher):
             ).decode()
             log.info(f"Captured stderr for step {step_key}:")
             log.info(stderr)
+            sys.stderr.write(stderr)
         except Exception as e:
             log.error(
                 f"Encountered exception {e} when attempting to load stderr logs for step"


### PR DESCRIPTION
## Summary & Motivation
Details are described in issue #14519.
Added call sys.stdout.write(stdout) in dagster_databricks/databricks_pyspark_step_launcher.py in order to write stdout collected from Databricks cluster into local stdout, so that it will be stored in Azure.

## How I Tested These Changes
Not yet tested, please suggest a way for proper testing.