### PR TITLE
feat(dbt-assets): allow configuration of io managers

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
@@ -14,6 +14,7 @@ def dbt_assets(
     manifest: DbtManifest,
     select: str = "fqn:*",
     exclude: Optional[str] = None,
+    io_manager_key: Optional[str] = None,
     partitions_def: Optional[PartitionsDefinition] = None,
 ) -> Callable[..., AssetsDefinition]:
     """Create a definition for how to compute a set of dbt resources, described by a manifest.json.
@@ -24,6 +25,11 @@ def dbt_assets(
             to include. Defaults to "*".
         exclude (Optional[str]): A dbt selection string for the models in a project that you want
             to exclude. Defaults to "".
+        io_manager_key (Optional[str]): The IO manager key that will be set on each of the returned
+            assets. When other ops are downstream of the loaded assets, the IOManager specified
+            here determines how the inputs to those ops are loaded. Defaults to "io_manager".
+        partitions_def (Optional[PartitionsDefinition]): Defines the set of partition keys that
+            compose the dbt assets.
 
     Examples:
         .. code-block:: python
@@ -47,6 +53,7 @@ def dbt_assets(
     ) = get_dbt_multi_asset_args(
         dbt_nodes=manifest.node_info_by_dbt_unique_id,
         deps=deps,
+        io_manager_key=io_manager_key,
     )
 
     def inner(fn) -> AssetsDefinition:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -176,6 +176,7 @@ def get_deps(
 def get_dbt_multi_asset_args(
     dbt_nodes: Mapping[str, Any],
     deps: Mapping[str, FrozenSet[str]],
+    io_manager_key: Optional[str] = None,
 ) -> Tuple[Set[AssetKey], Dict[str, AssetOut], Dict[str, Set[AssetKey]],]:
     """Use the standard defaults for dbt to construct the arguments for a dbt multi asset."""
     non_argument_deps: Set[AssetKey] = set()
@@ -191,6 +192,7 @@ def get_dbt_multi_asset_args(
         outs[output_name] = AssetOut(
             key=asset_key,
             dagster_type=Nothing,
+            io_manager_key=io_manager_key,
             description=default_description_fn(node_info, display_raw_sql=False),
             is_required=False,
             metadata=default_metadata_fn(node_info),

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_decorator.py
@@ -2,6 +2,7 @@ from typing import AbstractSet, Any, Mapping, Optional
 
 import pytest
 from dagster import AssetKey, DailyPartitionsDefinition, PartitionsDefinition, file_relative_path
+from dagster._core.definitions.utils import DEFAULT_IO_MANAGER_KEY
 from dagster_dbt.asset_decorator import dbt_assets
 from dagster_dbt.cli import DbtManifest
 
@@ -125,6 +126,18 @@ def test_partitions_def(partitions_def: Optional[PartitionsDefinition]) -> None:
         ...
 
     assert my_dbt_assets.partitions_def == partitions_def
+
+
+@pytest.mark.parametrize("io_manager_key", [None, "my_io_manager_key"])
+def test_io_manager_key(io_manager_key: Optional[str]) -> None:
+    @dbt_assets(manifest=manifest, io_manager_key=io_manager_key)
+    def my_dbt_assets():
+        ...
+
+    expected_io_manager_key = DEFAULT_IO_MANAGER_KEY if io_manager_key is None else io_manager_key
+
+    for output_def in my_dbt_assets.node_def.output_defs:
+        assert output_def.io_manager_key == expected_io_manager_key
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary & Motivation
Allow dbt assets to specify how they should be loaded downstream, using the io manager abstraction.

## How I Tested These Changes
pytest
