### PR TITLE
[fix][dagster-dbt] Fix initialization of DBT cloud Pythonic resource when loading from instance

### DIFF
--- a/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
@@ -26,6 +26,7 @@ from dagster import (
     Enum as DagsterEnum,
     Field as DagsterField,
 )
+from dagster._annotations import deprecated
 from dagster._config.config_type import (
     Array,
     ConfigFloatInstance,
@@ -915,7 +916,13 @@ class ConfigurableResourceFactory(
             to_update = {**resources_to_update, **partial_resources_to_update}
             yield self._with_updated_values(to_update)
 
+    @deprecated
     def with_resource_context(
+        self, resource_context: InitResourceContext
+    ) -> "ConfigurableResourceFactory[TResValue]":
+        return self.with_replaced_resource_context(resource_context)
+
+    def with_replaced_resource_context(
         self, resource_context: InitResourceContext
     ) -> "ConfigurableResourceFactory[TResValue]":
         """Returns a new instance of the resource with the given resource init context bound."""
@@ -929,7 +936,7 @@ class ConfigurableResourceFactory(
 
     def _initialize_and_run(self, context: InitResourceContext) -> TResValue:
         with self._resolve_and_update_nested_resources(context) as has_nested_resource:
-            updated_resource = has_nested_resource.with_resource_context(  # noqa: SLF001
+            updated_resource = has_nested_resource.with_replaced_resource_context(  # noqa: SLF001
                 context
             )._with_updated_values(context.resource_config)
 
@@ -941,7 +948,7 @@ class ConfigurableResourceFactory(
         self, context: InitResourceContext
     ) -> Generator[TResValue, None, None]:
         with self._resolve_and_update_nested_resources(context) as has_nested_resource:
-            updated_resource = has_nested_resource.with_resource_context(  # noqa: SLF001
+            updated_resource = has_nested_resource.with_replaced_resource_context(  # noqa: SLF001
                 context
             )._with_updated_values(context.resource_config)
 
@@ -985,7 +992,7 @@ class ConfigurableResourceFactory(
             additional_message="Attempted to get context before resource was initialized.",
         )
 
-    def _process_config_and_initialize(self) -> TResValue:
+    def process_config_and_initialize(self) -> TResValue:
         """Initializes this resource, fully processing its config and returning the prepared
         resource value.
         """

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_general_pythonic_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_general_pythonic_resources.py
@@ -1389,7 +1389,9 @@ def test_context_on_resource_basic() -> None:
         ContextUsingResource().access_context()
 
     # Can access context after binding one
-    ContextUsingResource().with_resource_context(build_init_resource_context()).access_context()
+    ContextUsingResource().with_replaced_resource_context(
+        build_init_resource_context()
+    ).access_context()
 
     @asset
     def my_test_asset(context_using: ContextUsingResource) -> None:
@@ -1432,7 +1434,7 @@ def test_context_on_resource_use_instance() -> None:
         with DagsterInstance.ephemeral() as instance:
             assert (
                 OutputDirResource(output_dir=None)
-                .with_resource_context(build_init_resource_context(instance=instance))
+                .with_replaced_resource_context(build_init_resource_context(instance=instance))
                 .get_effective_output_dir()
                 == "/tmp"
             )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/asset_defs.py
@@ -75,10 +75,9 @@ class DbtCloudCacheableAssetsDefinition(CacheableAssetsDefinition):
             if isinstance(dbt_cloud_resource_def, DbtCloudClientResource)
             else dbt_cloud_resource_def
         )
+
         self._dbt_cloud: DbtCloudClient = (
-            dbt_cloud_resource_def.from_resource_context(
-                build_init_resource_context()
-            ).get_dbt_client()  # type: ignore
+            dbt_cloud_resource_def._process_config_and_initialize().get_dbt_client()  # noqa: SLF001
             if isinstance(dbt_cloud_resource_def, DbtCloudClientResource)
             else dbt_cloud_resource_def(build_init_resource_context())
         )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/asset_defs.py
@@ -76,7 +76,7 @@ class DbtCloudCacheableAssetsDefinition(CacheableAssetsDefinition):
             else dbt_cloud_resource_def
         )
         self._dbt_cloud: DbtCloudClient = (
-            dbt_cloud_resource_def.with_resource_context(
+            dbt_cloud_resource_def.from_resource_context(
                 build_init_resource_context()
             ).get_dbt_client()  # type: ignore
             if isinstance(dbt_cloud_resource_def, DbtCloudClientResource)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/asset_defs.py
@@ -77,7 +77,7 @@ class DbtCloudCacheableAssetsDefinition(CacheableAssetsDefinition):
         )
 
         self._dbt_cloud: DbtCloudClient = (
-            dbt_cloud_resource_def._process_config_and_initialize().get_dbt_client()  # noqa: SLF001
+            dbt_cloud_resource_def.process_config_and_initialize().get_dbt_client()
             if isinstance(dbt_cloud_resource_def, DbtCloudClientResource)
             else dbt_cloud_resource_def(build_init_resource_context())
         )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_asset_defs.py
@@ -68,7 +68,7 @@ def dbt_cloud_service_fixture(resource_type) -> Any:
     if resource_type == "pythonic":
         yield DbtCloudClientResource(
             auth_token=DBT_CLOUD_API_TOKEN, account_id=DBT_CLOUD_ACCOUNT_ID
-        ).with_resource_context(
+        ).with_replaced_resource_context(
             build_init_resource_context()
         ).get_dbt_client()  # type: ignore
     else:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_resources.py
@@ -32,7 +32,7 @@ def get_dbt_cloud_resource_fixture(request) -> Any:
             lambda **kwargs: DbtCloudClientResource(
                 auth_token="some_auth_token", account_id=SAMPLE_ACCOUNT_ID, **kwargs
             )
-            .with_resource_context(build_init_resource_context())
+            .with_replaced_resource_context(build_init_resource_context())
             .get_dbt_client()  # type: ignore
         )
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
@@ -146,7 +146,7 @@ def test_fail_immediately(
     ).execute_in_process()
 
     if isinstance(good_dbt, DbtCliClientResource):
-        assert good_dbt.with_resource_context(build_init_resource_context()).get_dbt_client().get_run_results_json()  # type: ignore
+        assert good_dbt.with_replaced_resource_context(build_init_resource_context()).get_dbt_client().get_run_results_json()  # type: ignore
     else:
         assert good_dbt(build_init_resource_context()).get_run_results_json()
 


### PR DESCRIPTION
## Summary

Fixes an unfortunate invocation of `with_resource_context` (which attaches a resource init context to a Pythonic resource) instead of `from_resource_context` (which initializes the resource using that context). This meant that, when using the Pythonic DBT Cloud resource to load assets from the DBT Cloud instance, we weren't fully resolving the config. This meant that things like env vars were not getting resolved properly.

Because of the changes in #14306, Pythonic resources now expect fully processed config when initialized. Accordingly, introduces a new helper method `_process_config_and_initialize` which processes the Pythonic resource's config (resolving env vars, etc) and then initializes it.

## Test Plan

Unit test using env vars and `load_assets_from_dbt_cloud_job`