### PR TITLE
Update generation of artificial input names

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -961,7 +961,7 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
                 # of the underlying op.
                 op_valid = False
                 # create a new input for this key
-                input_name = f"input_{input_index}"
+                input_name = f"artificial_input_{input_index}"
                 input_index += 1
                 ins[input_name] = In(Nothing)
                 input_names_by_key[input_key] = input_name

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -946,8 +946,8 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
         ins = {}
 
         input_names_by_key = {v: k for k, v in self.keys_by_input_name.items()}
-        output_names_by_key = {v: k for k, v in self.keys_by_output_name.items()}
         op_valid = True
+        input_index = 0
         for input_key in input_keys:
             input_name = input_names_by_key.get(input_key)
             if input_name is not None:
@@ -960,9 +960,11 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
                 # a new input such that the dependency would be respected, and therefore a new copy
                 # of the underlying op.
                 op_valid = False
-                output_name = output_names_by_key[input_key]
-                ins[output_name] = In(Nothing)
-                input_names_by_key[input_key] = output_name
+                # create a new input for this key
+                input_name = f"input_{input_index}"
+                input_index += 1
+                ins[input_name] = In(Nothing)
+                input_names_by_key[input_key] = input_name
 
         # must create a new copy of the op
         if op_valid:


### PR DESCRIPTION
## Summary & Motivation

We sometimes need to create artificial op inputs out of existing op outputs to make our automatic-subsetting approach work. When this happens, we were previously generating a name for this input based on the original output name. 

In some rare cases, this automatic subsetting process will happen multiple times on a single node, which results in us losing track of what output a key was originally associated with. We could probably fix this, but instead we can just ignore that original mapping and just create an arbitrary input name of "artificial_input_N" so that we don't have to deal with that situation.

## How I Tested These Changes
