### PR TITLE
[ui] Restore hover tooltip on run tags

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/RunTag.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTag.tsx
@@ -93,8 +93,15 @@ export const RunTag = ({tag, actions}: IRunTagProps) => {
   const ValueWrapper = ({children}: {children: React.ReactNode}) =>
     tag.link ? <Link to={tag.link}>{children}</Link> : <>{children}</>;
 
+  const tooltipValue = displayedKey ? `${displayedKey}: ${displayValue}` : displayValue;
+
   const tagElement = (
-    <Tag intent={isDagsterTag ? 'none' : 'primary'} interactive icon={icon || undefined}>
+    <Tag
+      intent={isDagsterTag ? 'none' : 'primary'}
+      interactive
+      icon={icon || undefined}
+      tooltipText={tooltipValue}
+    >
       {displayedKey ? (
         <span>
           {displayedKey}: <ValueWrapper>{displayValue}</ValueWrapper>

--- a/js_modules/dagit/packages/ui/src/components/BaseTag.tsx
+++ b/js_modules/dagit/packages/ui/src/components/BaseTag.tsx
@@ -12,6 +12,7 @@ interface Props {
   interactive?: boolean;
   rightIcon?: React.ReactNode;
   label?: React.ReactNode;
+  tooltipText?: string;
 }
 
 const BaseTagTooltipStyle: React.CSSProperties = {
@@ -23,7 +24,7 @@ const BaseTagTooltipStyle: React.CSSProperties = {
   pointerEvents: 'none',
   borderRadius: 8,
   border: 'none',
-  top: -10,
+  top: -9,
   left: -13,
 };
 
@@ -35,13 +36,14 @@ export const BaseTag = (props: Props) => {
     interactive = false,
     rightIcon,
     label,
+    tooltipText,
   } = props;
   return (
     <StyledTag $fillColor={fillColor} $interactive={interactive} $textColor={textColor}>
       {icon || null}
       {label !== undefined && label !== null ? (
         <span
-          data-tooltip={typeof label === 'string' ? label : undefined}
+          data-tooltip={typeof label === 'string' ? label : tooltipText}
           data-tooltip-style={JSON.stringify({
             ...BaseTagTooltipStyle,
             backgroundColor: fillColor,

--- a/js_modules/dagit/packages/ui/src/components/Tag.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Tag.tsx
@@ -59,6 +59,7 @@ interface Props extends Omit<React.ComponentProps<typeof BlueprintTag>, 'icon' |
   children?: React.ReactNode;
   icon?: IconName | 'spinner';
   rightIcon?: IconName | 'spinner';
+  tooltipText?: string;
 }
 
 const IconOrSpinner: React.FC<{icon: IconName | 'spinner' | null; color: string}> = React.memo(


### PR DESCRIPTION
## Summary & Motivation

Resolves #14355.

A recent change to `RunTag` led to the `data-tooltip` overlay no longer working. Restore this by adding an optional `tooltipText` that allows setting a tooltipable value when the tag child is not a string.

## How I Tested These Changes

Create a run with a long tag, verify that the tag renders correctly when truncated and when hovered.

Default:

<img width="544" alt="Screenshot 2023-05-30 at 1 40 29 PM" src="https://github.com/dagster-io/dagster/assets/2823852/f426171a-c9bb-49c8-acb8-bc51b8b03d50">

Hovered, with tooltip:

<img width="606" alt="Screenshot 2023-05-30 at 1 40 24 PM" src="https://github.com/dagster-io/dagster/assets/2823852/15d0de34-4630-4241-8a71-65f3b4c04399">
