### PR TITLE
Expose 'raw instance config' as a helm chart field

### DIFF
--- a/helm/dagster/schema/schema/charts/dagster/values.py
+++ b/helm/dagster/schema/schema/charts/dagster/values.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Any, List, Mapping, Optional
 
 from pydantic import BaseModel, Field
 
@@ -31,3 +31,4 @@ class DagsterHelmValues(BaseModel):
     serviceAccount: subschema.ServiceAccount
     global_: subschema.Global = Field(..., alias="global")
     retention: subschema.Retention
+    additionalInstanceConfig: Optional[Mapping[str, Any]]

--- a/helm/dagster/templates/configmap-instance.yaml
+++ b/helm/dagster/templates/configmap-instance.yaml
@@ -146,3 +146,7 @@ data:
         purge_after_days: {{ .Values.retention.schedule.purgeAfterDays | toYaml | nindent 12 }}
       {{- end }}
     {{- end }}
+
+    {{- if .Values.additionalInstanceConfig }}
+    {{- .Values.additionalInstanceConfig | toYaml | nindent 4}}
+    {{- end }}

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -71,6 +71,10 @@
         },
         "retention": {
             "$ref": "#/definitions/Retention"
+        },
+        "additionalInstanceConfig": {
+            "title": "Additionalinstanceconfig",
+            "type": "object"
         }
     },
     "required": [

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -1317,3 +1317,14 @@ retention:
       skipped: 7
       started: -1
       success: -1
+####################################################################################################
+# Additional fields on the instance to configure that aren't already determined by a key above.
+# See https://docs.dagster.io/deployment/dagster-instance for the full set of available fields.
+####################################################################################################
+# Example:
+#
+# additionalInstanceConfig:
+#   auto_materialize: # See: https://docs.dagster.io/deployment/dagster-instance#auto-materialize
+#     run_tags:
+#       key: value
+additionalInstanceConfig: {}

--- a/python_modules/dagster/dagster/_core/instance/config.py
+++ b/python_modules/dagster/dagster/_core/instance/config.py
@@ -348,6 +348,7 @@ def dagster_instance_config_schema() -> Mapping[str, Field]:
         "code_servers": Field(
             {
                 "local_startup_timeout": Field(int, is_required=False),
+                "reload_timeout": Field(int, is_required=False),
                 "wait_for_local_processes_on_shutdown": Field(bool, is_required=False),
             },
             is_required=False,


### PR DESCRIPTION
Summary:
Right now every time we add a new instance config field, we require it to also be added to the helm chart schema. This causes two problems:
- It's a pain for Dagster engineers to add every feature in the Helm chart. It's easy to forget fields, and users invariably want to use them. (for example, 'auto_materialize', 'local_artifact_storage', and 'code_servers' could all plausibly be asked for by users (the last two have) and we have to scramble to get out a helm PR).
- The docs are no longer useful if you are using the helm chart, since the helm chart is in camelCase and doesn't include all fields.

It makes sense to stub in things that are actually determined by other properties of the helm chart, like storage and potentially the run launcher - but for the long tail of instance configuration fields that we offer, I think this translation layer does more harm than good. (THe main good that we're losing is the Helm-level schema validation - if you enter a key that doesn't exist here, it will fail at deploy time rather than violate a schema)

This PR addresses this problem by adding a new field that stubs in raw instance yaml and is included in the dagster.yaml.

## Summary & Motivation

## How I Tested These Changes
