### PR TITLE
[fix][dagster-census] CensusResource poll_sync_run new 'preparing' st…

### DIFF
--- a/python_modules/libraries/dagster-census/dagster_census/resources.py
+++ b/python_modules/libraries/dagster-census/dagster_census/resources.py
@@ -159,7 +159,7 @@ class CensusResource:
 
             sync_id = response_dict["data"]["sync_id"]
 
-            if response_dict["data"]["status"] == "working":
+            if response_dict["data"]["status"] in {"preparing", "working"}:
                 self._log.debug(
                     f"Sync {sync_id} still running after {datetime.datetime.now() - poll_start}."
                 )


### PR DESCRIPTION
…atus

## Summary & Motivation

Fixes [this issue](https://github.com/dagster-io/dagster/issues/14542) where any op that runs a Census sync prematurely breaks the `while` loop in the `CensusResource` class's `poll_sync_run` method.

## How I Tested These Changes

I have the Census integration in prod work pipelines and have been using a locally patched package with this small PR change. With this change, the `poll_sync_run` method behaves as expected, meaning it successfully polls a Census sync during both its `"preparing"` and `"working"` statuses until the sync is finished. 