### PR TITLE
Store asset daemon evaluations after cursor

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
@@ -235,7 +235,7 @@ class AssetReconciliationCursor(NamedTuple):
     latest_storage_id: Optional[int]
     materialized_or_requested_root_asset_keys: AbstractSet[AssetKey]
     materialized_or_requested_root_partitions_by_asset_key: Mapping[AssetKey, PartitionsSubset]
-    evaluation_id: Optional[int]
+    evaluation_id: int
 
     def was_previously_materialized_or_requested(self, asset_key: AssetKey) -> bool:
         return asset_key in self.materialized_or_requested_root_asset_keys
@@ -284,7 +284,7 @@ class AssetReconciliationCursor(NamedTuple):
         run_requests: Sequence[RunRequest],
         newly_materialized_root_asset_keys: AbstractSet[AssetKey],
         newly_materialized_root_partitions_by_asset_key: Mapping[AssetKey, AbstractSet[str]],
-        evaluation_id: Optional[int],
+        evaluation_id: int,
         asset_graph: AssetGraph,
     ) -> "AssetReconciliationCursor":
         """Returns a cursor that represents this cursor plus the updates that have happened within the
@@ -365,7 +365,7 @@ class AssetReconciliationCursor(NamedTuple):
             serialized_materialized_or_requested_root_partitions_by_asset_key,
         ) = data[:3]
 
-        evaluation_id = data[3] if len(data) == 4 else None
+        evaluation_id = data[3] if len(data) == 4 else 0
 
         materialized_or_requested_root_partitions_by_asset_key = {}
         for (
@@ -1121,7 +1121,7 @@ def reconcile(
             asset_graph=asset_graph,
             newly_materialized_root_asset_keys=newly_materialized_root_asset_keys,
             newly_materialized_root_partitions_by_asset_key=newly_materialized_root_partitions_by_asset_key,
-            evaluation_id=cursor.evaluation_id + 1 if cursor.evaluation_id is not None else 0,
+            evaluation_id=cursor.evaluation_id + 1,
         ),
         build_auto_materialize_asset_evaluations(
             asset_graph, conditions_by_asset_partition, dynamic_partitions_store=instance_queryer

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_daemon_cursor.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_daemon_cursor.py
@@ -24,7 +24,7 @@ def test_asset_reconciliation_cursor_evaluation_id():
         20,
         {AssetKey("a")},
         {AssetKey("my_asset"): partitions.empty_subset().with_partition_keys(["a"])},
-        None,
+        0,
     )
 
     c2 = c.with_updates(


### PR DESCRIPTION
I'm trying to figure out causes of https://elementl-workspace.slack.com/archives/C04UD72HHQX/p1685543991696809. One potential cause is that if the daemon crashes before it stores the cursor, then it will keep trying the previous evaluation_id.

I'm suspicious that this isn't the only cause bc it seems unlikely that multiple org's daemons would crash there, but good to squash it anyway