### PR TITLE
Add transient and run_worker_id flag to CheckRunHealthResult, set it in EcsRunLauncher

### DIFF
--- a/python_modules/dagster/dagster/_core/launcher/base.py
+++ b/python_modules/dagster/dagster/_core/launcher/base.py
@@ -46,6 +46,8 @@ class CheckRunHealthResult(NamedTuple):
 
     status: WorkerStatus
     msg: Optional[str] = None
+    transient: Optional[bool] = None
+    run_worker_id: Optional[str] = None  # Identifier for a particular run worker
 
     def __str__(self) -> str:
         return f"{self.status.value}: '{self.msg}'"

--- a/python_modules/dagster/dagster/_core/storage/tags.py
+++ b/python_modules/dagster/dagster/_core/storage/tags.py
@@ -68,6 +68,8 @@ USER_EDITABLE_SYSTEM_TAGS = [
     MAX_RUNTIME_SECONDS_TAG,
 ]
 
+RUN_WORKER_ID_TAG = f"{HIDDEN_TAG_PREFIX}run_worker"
+
 # In cloud, we tag runs with the email of the user who triggered the run
 # This is used to display the user in the UI
 USER_TAG = "user"


### PR DESCRIPTION
Summary:
Can be used to determine if a health check failure can be safely retried on startup or not.

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes
