### PR TITLE
Use a different task definition family for each job in a code location

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -40,7 +40,7 @@ from .tasks import (
     get_task_definition_dict_from_current_task,
     get_task_kwargs_from_current_task,
 )
-from .utils import get_task_logs, sanitize_family, task_definitions_match
+from .utils import get_task_definition_family, get_task_logs, task_definitions_match
 
 Tags = namedtuple("Tags", ["arn", "cluster", "cpu", "memory"])
 
@@ -530,9 +530,7 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
         return self._current_task
 
     def _get_run_task_definition_family(self, run: DagsterRun) -> str:
-        return sanitize_family(
-            run.external_job_origin.external_repository_origin.code_location_origin.location_name  # type: ignore  # (possible none)
-        )
+        return get_task_definition_family("run", check.not_none(run.external_job_origin))
 
     def _get_container_name(self, container_context) -> str:
         return container_context.container_name or self.container_name

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
@@ -20,6 +20,7 @@ from dagster_aws.ecs.launcher import (
     STOPPED_STATUSES,
 )
 from dagster_aws.ecs.tasks import DagsterEcsTaskDefinitionConfig
+from dagster_aws.ecs.utils import get_task_definition_family
 
 
 @pytest.mark.parametrize("task_long_arn_format", ["enabled", "disabled"])
@@ -51,9 +52,7 @@ def test_default_launcher(
     assert instance.run_launcher.check_run_worker_health(run).status == WorkerStatus.RUNNING
 
     # It has a new family, name, and image
-    # We get the family name from the location name. With the InProcessExecutor that we use in tests,
-    # the location name is always <<in_process>>. And we sanitize it so it's compatible with the ECS API.
-    assert task_definition["family"] == "in_process"
+    assert task_definition["family"] == get_task_definition_family("run", run.external_job_origin)
     assert len(task_definition["containerDefinitions"]) == 1
     container_definition = task_definition["containerDefinitions"][0]
     assert container_definition["name"] == "run"
@@ -222,9 +221,7 @@ def test_launcher_dont_use_current_task(
     assert instance.run_launcher.check_run_worker_health(run).status == WorkerStatus.RUNNING
 
     # It has a new family, name, and image
-    # We get the family name from the location name. With the InProcessExecutor that we use in tests,
-    # the location name is always <<in_process>>. And we sanitize it so it's compatible with the ECS API.
-    assert task_definition["family"] == "in_process"
+    assert task_definition["family"] == get_task_definition_family("run", run.external_job_origin)
     assert len(task_definition["containerDefinitions"]) == 1
     container_definition = task_definition["containerDefinitions"][0]
     assert container_definition["name"] == "run"

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_utils.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_utils.py
@@ -1,4 +1,9 @@
-from dagster_aws.ecs.utils import sanitize_family
+from dagster._core.host_representation.origin import (
+    ExternalJobOrigin,
+    ExternalRepositoryOrigin,
+    RegisteredCodeLocationOrigin,
+)
+from dagster_aws.ecs.utils import get_task_definition_family, sanitize_family
 
 
 def test_sanitize_family():
@@ -8,3 +13,37 @@ def test_sanitize_family():
     assert sanitize_family("abc_123") == "abc_123"
     assert sanitize_family("abc 123") == "abc123"
     assert sanitize_family("abc~123") == "abc123"
+
+
+def test_get_task_definition_family():
+    external_job_origin = ExternalJobOrigin(
+        external_repository_origin=ExternalRepositoryOrigin(
+            repository_name="the_repo",
+            code_location_origin=RegisteredCodeLocationOrigin(location_name="the_location"),
+        ),
+        job_name="the_job",
+    )
+
+    assert (
+        get_task_definition_family("foo", external_job_origin)
+        == "foo_the_location_66c360f2_the_repo_b9c5532e_the_job_38cc9a96"
+    )
+
+
+def test_long_names():
+    long_job_name = "a" * 512
+    long_repo_name = "b" * 512
+    long_location_name = "c" * 512
+
+    external_job_origin = ExternalJobOrigin(
+        external_repository_origin=ExternalRepositoryOrigin(
+            repository_name=long_repo_name,
+            code_location_origin=RegisteredCodeLocationOrigin(location_name=long_location_name),
+        ),
+        job_name=long_job_name,
+    )
+
+    assert (
+        get_task_definition_family("foo", external_job_origin)
+        == f"foo_{'c'*55}_d9023790_{'b'*55}_3956139d_{'a'*55}_164557fa"
+    )


### PR DESCRIPTION
Summary:
Since we set a different env var for each job, the current behavior causes lots of thrash if you are launching multiple jobs in the same code location in sequence. Use a separate one for each job instead.

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes
