### PR TITLE
makes the schedule execution independent from tick history

### DIFF
--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
@@ -2390,12 +2390,10 @@ def test_repository_namespacing(instance: DagsterInstance, executor):
             evaluate_schedules(full_workspace_context, executor, pendulum.now("UTC"))
             assert instance.get_runs_count() == 4  # still 4
             ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
-            assert len(ticks) == 1
-            assert ticks[0].status == TickStatus.SUCCESS
+            assert len(ticks) == 0
 
             ticks = instance.get_ticks(other_origin.get_id(), other_schedule.selector_id)
-            assert len(ticks) == 1
-            assert ticks[0].status == TickStatus.SUCCESS
+            assert len(ticks) == 0
 
 
 @pytest.mark.parametrize("executor", get_schedule_executors())


### PR DESCRIPTION
## Summary & Motivation
With the monthly schedules and a 30-day purge window, we can run into an issue where schedules will repeatedly try to kick off duplicate runs because they are trying to read from the tick history.

This diff adds the last tick into the schedule state, to prevent from this dependency on the tick history being maintained.

(keeping a sensible tick history for observability on these sparse schedules is a separate issue to be tackled in a different PR).

## How I Tested These Changes
BK