### PR TITLE
[ui] Handle network error on repository location reload

### DIFF
--- a/js_modules/dagit/packages/core/src/nav/useRepositoryLocationReload.tsx
+++ b/js_modules/dagit/packages/core/src/nav/useRepositoryLocationReload.tsx
@@ -1,4 +1,4 @@
-import {ApolloClient, gql, useApolloClient, useQuery} from '@apollo/client';
+import {ApolloClient, ApolloError, gql, useApolloClient, useQuery} from '@apollo/client';
 // eslint-disable-next-line no-restricted-imports
 import {Intent} from '@blueprintjs/core';
 import * as React from 'react';
@@ -310,13 +310,24 @@ const RELOAD_WORKSPACE_MUTATION = gql`
 
 export const buildReloadFnForLocation = (location: string) => {
   return async (client: ApolloClient<any>): Promise<Action> => {
-    const {data} = await client.mutate<
-      ReloadRepositoryLocationMutation,
-      ReloadRepositoryLocationMutationVariables
-    >({
-      mutation: RELOAD_REPOSITORY_LOCATION_MUTATION,
-      variables: {location},
-    });
+    let data;
+    try {
+      const result = await client.mutate<
+        ReloadRepositoryLocationMutation,
+        ReloadRepositoryLocationMutationVariables
+      >({
+        mutation: RELOAD_REPOSITORY_LOCATION_MUTATION,
+        variables: {location},
+      });
+      data = result.data;
+    } catch (e) {
+      // The `mutate` Promise has rejected due to an error, probably an http error.
+      return {
+        type: 'error',
+        error: {message: e instanceof ApolloError ? e.message : 'An unexpected error occurred'},
+        errorLocationId: location,
+      };
+    }
 
     if (data?.reloadRepositoryLocation.__typename === 'WorkspaceLocationEntry') {
       // If the mutation occurs successfully, begin polling.


### PR DESCRIPTION
## Summary & Motivation

When reloading a code location, a network error on the mutation will be ignored by the UI and the button remains disabled and spinning.

Resolve this by catching the rejected promise on the `client.mutate` call, which is how the network error is surfaced in direct Apollo API access like this. (We use `client.mutate` here to avoid needing to use a React hook to set up the mutation.)

Currently, the rejected promise just falls through and the UI is none the wiser. By catching the rejection and returning an error payload to the caller, the UI can handle it and update state accordingly.

## How I Tested These Changes

Add an error to the reload mutation in `schema/roots/mutation.py`, try to reload the code location. Verify that an error dialog appears with information about the 500 error.

Repeat with the error removed, verify that reloading the code location is successful.

<img width="1203" alt="Screenshot 2023-06-01 at 10 18 47 AM" src="https://github.com/dagster-io/dagster/assets/2823852/2abf4d9c-c756-4734-9a29-ed953fad46d4">
