### PR TITLE
Fix rendering MetadataEntryTable when their are `nulls` in the table.

### DIFF
--- a/js_modules/dagit/packages/core/src/metadata/MetadataEntry.tsx
+++ b/js_modules/dagit/packages/core/src/metadata/MetadataEntry.tsx
@@ -362,7 +362,9 @@ const TableMetadataEntryComponent: React.FC<{entry: TableMetadataEntry}> = ({ent
           {records.map((record, idx) => (
             <tr key={idx}>
               {schema.columns.map((column) => (
-                <td key={column.name}>{record[column.name].toString()}</td>
+                <td key={column.name}>
+                  {record[column.name] ? record[column.name].toString() : null}
+                </td>
               ))}
             </tr>
           ))}

--- a/js_modules/dagit/packages/core/src/metadata/MetadataEntry.tsx
+++ b/js_modules/dagit/packages/core/src/metadata/MetadataEntry.tsx
@@ -362,9 +362,7 @@ const TableMetadataEntryComponent: React.FC<{entry: TableMetadataEntry}> = ({ent
           {records.map((record, idx) => (
             <tr key={idx}>
               {schema.columns.map((column) => (
-                <td key={column.name}>
-                  {record[column.name] ? record[column.name].toString() : null}
-                </td>
+                <td key={column.name}>{record[column.name]?.toString()}</td>
               ))}
             </tr>
           ))}


### PR DESCRIPTION
## Summary & Motivation

We're trying to call `toString` on `null`, use optional chaining to call `toString` instead to avoid calling it on `null`.

## How I Tested These Changes

👀 
