### PR TITLE
PythonErrorInfo -  Add Button on hover to copy errors to clipboard

### DIFF
--- a/js_modules/dagit/packages/core/src/app/PythonErrorInfo.tsx
+++ b/js_modules/dagit/packages/core/src/app/PythonErrorInfo.tsx
@@ -109,7 +109,7 @@ export const CopyErrorButton = ({copy}: {copy: () => void | string}) => {
           });
         }}
       >
-        <Icon name="copy_to_clipboard" color={Colors.Red700} />
+        <Icon name="content_copy" /> Copy
       </CopyErrorButtonWrapper>
     </div>
   );
@@ -117,6 +117,9 @@ export const CopyErrorButton = ({copy}: {copy: () => void | string}) => {
 
 const CopyErrorButtonWrapper = styled.button`
   position: absolute;
+  display: flex;
+  flex-direction: row;
+  gap: 8px;
   top: 0px;
   right: -8px;
   border: 1px solid ${Colors.KeylineGray};
@@ -165,7 +168,7 @@ export const ErrorWrapper = styled.div`
     display: none;
   }
   &:hover ${CopyErrorButtonWrapper} {
-    display: block;
+    display: flex;
   }
 `;
 

--- a/js_modules/dagit/packages/core/src/app/PythonErrorInfo.tsx
+++ b/js_modules/dagit/packages/core/src/app/PythonErrorInfo.tsx
@@ -97,7 +97,7 @@ export const UNAUTHORIZED_ERROR_FRAGMENT = gql`
   }
 `;
 
-export const CopyErrorButton = ({copy}: {copy: () => void}) => {
+export const CopyErrorButton = ({copy}: {copy: () => void | string}) => {
   return (
     <div style={{position: 'relative'}}>
       <CopyErrorButtonWrapper

--- a/js_modules/dagit/packages/core/src/app/PythonErrorInfo.tsx
+++ b/js_modules/dagit/packages/core/src/app/PythonErrorInfo.tsx
@@ -49,7 +49,6 @@ export const PythonErrorInfo: React.FC<IPythonErrorInfoProps> = (props) => {
         <CopyErrorButton
           copy={() => {
             const text = wrapperRef.current?.innerText || '';
-            console.log({text});
             copy(text);
           }}
         />

--- a/js_modules/dagit/packages/core/src/app/__stories__/PythonErrorInfo.stories.tsx
+++ b/js_modules/dagit/packages/core/src/app/__stories__/PythonErrorInfo.stories.tsx
@@ -1,0 +1,40 @@
+// eslint-disable-next-line no-restricted-imports
+import {Meta} from '@storybook/react';
+import * as React from 'react';
+
+import {buildPythonError, buildErrorChainLink} from '../../graphql/types';
+import {PythonErrorInfo} from '../PythonErrorInfo';
+
+// eslint-disable-next-line import/no-default-export
+export default {
+  title: 'PythonErrorInfo',
+} as Meta;
+
+const error = buildPythonError({
+  message:
+    'dagster._core.errors.SensorExecutionError: Error occurred during the execution of evaluation_fn for sensor toy_file_sensor\n',
+  stack: [
+    '  File "/Users/marcosalazar/code/dagster/python_modules/dagster/dagster/_grpc/impl.py", line 328, in get_external_sensor_execution\n    return sensor_def.evaluate_tick(sensor_context)\n',
+    '  File "/Users/marcosalazar/.pyenv/versions/3.9.9/lib/python3.9/contextlib.py", line 137, in __exit__\n    self.gen.throw(typ, value, traceback)\n',
+    '  File "/Users/marcosalazar/code/dagster/python_modules/dagster/dagster/_core/errors.py", line 213, in user_code_error_boundary\n    raise error_cls(\n',
+  ],
+  errorChain: [
+    buildErrorChainLink({
+      isExplicitLink: true,
+      error: buildPythonError({
+        message: 'Exception: testing\n',
+        stack: [
+          '  File "/Users/marcosalazar/code/dagster/python_modules/dagster/dagster/_core/errors.py", line 206, in user_code_error_boundary\n    yield\n',
+          '  File "/Users/marcosalazar/code/dagster/python_modules/dagster/dagster/_grpc/impl.py", line 328, in get_external_sensor_execution\n    return sensor_def.evaluate_tick(sensor_context)\n',
+          '  File "/Users/marcosalazar/code/dagster/python_modules/dagster/dagster/_core/definitions/sensor_definition.py", line 428, in evaluate_tick\n    result = list(self._evaluation_fn(context))\n',
+          '  File "/Users/marcosalazar/code/dagster/python_modules/dagster/dagster/_core/definitions/sensor_definition.py", line 598, in _wrapped_fn\n    for item in result:\n',
+          '  File "/Users/marcosalazar/code/dagster/python_modules/dagster-test/dagster_test/toys/sensors.py", line 76, in toy_file_sensor\n',
+        ],
+      }),
+    }),
+  ],
+});
+
+export const Error = () => {
+  return <PythonErrorInfo error={error} />;
+};

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AssetAutomaterializePolicyPage.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AssetAutomaterializePolicyPage.tsx
@@ -10,7 +10,6 @@ import {
   Spinner,
   Mono,
   Subheading,
-  Tooltip,
   Tag,
 } from '@dagster-io/ui';
 import dayjs from 'dayjs';
@@ -380,7 +379,6 @@ const RightPanelSection = ({
 
 const RightPanelDetail = ({
   title,
-  tooltip,
   value,
 }: {
   title: React.ReactNode;


### PR DESCRIPTION
## Summary & Motivation

closes https://github.com/dagster-io/dagster/issues/14303

## How I Tested These Changes

storybook: https://dagit-core-storybook-7xjynyc7p-elementl.vercel.app/?path=/docs/pythonerrorinfo--docs


![image](https://github.com/dagster-io/dagster/assets/2286579/299f991b-e43f-42be-8082-ecc5ae1c0dc7)

