### PR TITLE
Asset job metadata

### DIFF
--- a/python_modules/dagster-test/dagster_test/toys/basic_assets.py
+++ b/python_modules/dagster-test/dagster_test/toys/basic_assets.py
@@ -1,4 +1,4 @@
-from dagster import AssetSelection, asset, define_asset_job, MetadataValue
+from dagster import AssetSelection, MetadataValue, asset, define_asset_job
 
 
 @asset(group_name="basic_assets")
@@ -24,8 +24,5 @@ def basic_asset_4(basic_asset_2, basic_asset_3):
 basic_assets_job = define_asset_job(
     "basic_assets_job",
     selection=AssetSelection.groups("basic_assets"),
-    metadata={
-        "owner": "data team",
-        "link": MetadataValue.url(url="https://dagster.io"),
-    },
+    metadata={"owner": "data team", "link": MetadataValue.url(url="https://dagster.io")},
 )

--- a/python_modules/dagster-test/dagster_test/toys/basic_assets.py
+++ b/python_modules/dagster-test/dagster_test/toys/basic_assets.py
@@ -1,4 +1,4 @@
-from dagster import AssetSelection, asset, define_asset_job
+from dagster import AssetSelection, asset, define_asset_job, MetadataValue
 
 
 @asset(group_name="basic_assets")
@@ -22,5 +22,10 @@ def basic_asset_4(basic_asset_2, basic_asset_3):
 
 
 basic_assets_job = define_asset_job(
-    "basic_assets_job", selection=AssetSelection.groups("basic_assets")
+    "basic_assets_job",
+    selection=AssetSelection.groups("basic_assets"),
+    metadata={
+        "owner": "data team",
+        "link": MetadataValue.url(url="https://dagster.io"),
+    },
 )

--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -20,7 +20,7 @@ from typing import (
 import dagster._check as check
 from dagster._core.definitions.metadata import (
     ArbitraryMetadataMapping,
-    MetadataValue,
+    RawMetadataValue,
 )
 from dagster._core.selector.subset_selector import AssetSelectionData
 
@@ -742,7 +742,7 @@ def build_asset_selection_job(
     resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
     description: Optional[str] = None,
     tags: Optional[Mapping[str, Any]] = None,
-    metadata: Optional[Mapping[str, MetadataValue]] = None,
+    metadata: Optional[Mapping[str, RawMetadataValue]] = None,
     asset_selection: Optional[AbstractSet[AssetKey]] = None,
     asset_selection_data: Optional[AssetSelectionData] = None,
 ) -> "JobDefinition":
@@ -795,7 +795,6 @@ def build_asset_selection_job(
             partitions_def=partitions_def,
             description=description,
             tags=tags,
-            metadata=metadata,
             _asset_selection_data=asset_selection_data,
         )
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -20,6 +20,7 @@ from typing import (
 import dagster._check as check
 from dagster._core.definitions.metadata import (
     ArbitraryMetadataMapping,
+    MetadataValue,
 )
 from dagster._core.selector.subset_selector import AssetSelectionData
 
@@ -741,6 +742,7 @@ def build_asset_selection_job(
     resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
     description: Optional[str] = None,
     tags: Optional[Mapping[str, Any]] = None,
+    metadata: Optional[Mapping[str, MetadataValue]] = None,
     asset_selection: Optional[AbstractSet[AssetKey]] = None,
     asset_selection_data: Optional[AssetSelectionData] = None,
 ) -> "JobDefinition":
@@ -780,6 +782,7 @@ def build_asset_selection_job(
             partitions_def=partitions_def,
             description=description,
             tags=tags,
+            metadata=metadata,
             _asset_selection_data=asset_selection_data,
         )
     else:
@@ -792,6 +795,7 @@ def build_asset_selection_job(
             partitions_def=partitions_def,
             description=description,
             tags=tags,
+            metadata=metadata,
             _asset_selection_data=asset_selection_data,
         )
 

--- a/python_modules/dagster/dagster/_core/definitions/assets_job.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets_job.py
@@ -34,6 +34,7 @@ from .events import AssetKey
 from .executor_definition import ExecutorDefinition
 from .graph_definition import GraphDefinition
 from .job_definition import JobDefinition, default_job_io_manager
+from .metadata import MetadataValue
 from .partition import PartitionedConfig, PartitionsDefinition
 from .resolved_asset_deps import ResolvedAssetDependencies
 from .resource_definition import ResourceDefinition
@@ -116,6 +117,7 @@ def build_assets_job(
         Union[ConfigMapping, Mapping[str, object], PartitionedConfig, "RunConfig"]
     ] = None,
     tags: Optional[Mapping[str, str]] = None,
+    metadata: Optional[Mapping[str, MetadataValue]] = None,
     executor_def: Optional[ExecutorDefinition] = None,
     partitions_def: Optional[PartitionsDefinition] = None,
     _asset_selection_data: Optional[AssetSelectionData] = None,
@@ -229,6 +231,7 @@ def build_assets_job(
         resource_defs=all_resource_defs,
         config=config,
         tags=tags,
+        metadata=metadata,
         executor_def=executor_def,
         partitions_def=partitions_def,
         asset_layer=asset_layer,

--- a/python_modules/dagster/dagster/_core/definitions/assets_job.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets_job.py
@@ -34,7 +34,7 @@ from .events import AssetKey
 from .executor_definition import ExecutorDefinition
 from .graph_definition import GraphDefinition
 from .job_definition import JobDefinition, default_job_io_manager
-from .metadata import MetadataValue
+from .metadata import RawMetadataValue
 from .partition import PartitionedConfig, PartitionsDefinition
 from .resolved_asset_deps import ResolvedAssetDependencies
 from .resource_definition import ResourceDefinition
@@ -117,7 +117,7 @@ def build_assets_job(
         Union[ConfigMapping, Mapping[str, object], PartitionedConfig, "RunConfig"]
     ] = None,
     tags: Optional[Mapping[str, str]] = None,
-    metadata: Optional[Mapping[str, MetadataValue]] = None,
+    metadata: Optional[Mapping[str, RawMetadataValue]] = None,
     executor_def: Optional[ExecutorDefinition] = None,
     partitions_def: Optional[PartitionsDefinition] = None,
     _asset_selection_data: Optional[AssetSelectionData] = None,

--- a/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
@@ -10,7 +10,7 @@ from dagster._utils.backcompat import deprecation_warning
 
 from .asset_layer import build_asset_selection_job
 from .config import ConfigMapping
-from .metadata import MetadataValue
+from .metadata import RawMetadataValue
 
 if TYPE_CHECKING:
     from dagster._core.definitions import (
@@ -39,7 +39,7 @@ class UnresolvedAssetJobDefinition(
             ),
             ("description", Optional[str]),
             ("tags", Optional[Mapping[str, Any]]),
-            ("metadata", Optional[Mapping[str, MetadataValue]]),
+            ("metadata", Optional[Mapping[str, RawMetadataValue]]),
             ("partitions_def", Optional["PartitionsDefinition"]),
             ("executor_def", Optional["ExecutorDefinition"]),
         ],
@@ -54,7 +54,7 @@ class UnresolvedAssetJobDefinition(
         ] = None,
         description: Optional[str] = None,
         tags: Optional[Mapping[str, Any]] = None,
-        metadata: Optional[Mapping[str, MetadataValue]] = None,
+        metadata: Optional[Mapping[str, RawMetadataValue]] = None,
         partitions_def: Optional["PartitionsDefinition"] = None,
         executor_def: Optional["ExecutorDefinition"] = None,
     ):
@@ -249,7 +249,7 @@ def define_asset_job(
     ] = None,
     description: Optional[str] = None,
     tags: Optional[Mapping[str, Any]] = None,
-    metadata: Optional[Mapping[str, MetadataValue]] = None,
+    metadata: Optional[Mapping[str, RawMetadataValue]] = None,
     partitions_def: Optional["PartitionsDefinition"] = None,
     executor_def: Optional["ExecutorDefinition"] = None,
 ) -> UnresolvedAssetJobDefinition:
@@ -295,7 +295,7 @@ def define_asset_job(
             Values that are not strings will be json encoded and must meet the criteria that
             `json.loads(json.dumps(value)) == value`.  These tag values may be overwritten by tag
             values provided at invocation time.
-        metadata (Optional[Mapping[str, MetadataValue]]):
+        metadata (Optional[Mapping[str, RawMetadataValue]]):
 
         description (Optional[str]):
             A description for the Job.

--- a/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
@@ -10,6 +10,7 @@ from dagster._utils.backcompat import deprecation_warning
 
 from .asset_layer import build_asset_selection_job
 from .config import ConfigMapping
+from .metadata import MetadataValue
 
 if TYPE_CHECKING:
     from dagster._core.definitions import (
@@ -38,6 +39,7 @@ class UnresolvedAssetJobDefinition(
             ),
             ("description", Optional[str]),
             ("tags", Optional[Mapping[str, Any]]),
+            ("metadata", Optional[Mapping[str, MetadataValue]]),
             ("partitions_def", Optional["PartitionsDefinition"]),
             ("executor_def", Optional["ExecutorDefinition"]),
         ],
@@ -52,6 +54,7 @@ class UnresolvedAssetJobDefinition(
         ] = None,
         description: Optional[str] = None,
         tags: Optional[Mapping[str, Any]] = None,
+        metadata: Optional[Mapping[str, MetadataValue]] = None,
         partitions_def: Optional["PartitionsDefinition"] = None,
         executor_def: Optional["ExecutorDefinition"] = None,
     ):
@@ -69,6 +72,7 @@ class UnresolvedAssetJobDefinition(
             config=convert_config_input(config),
             description=check.opt_str_param(description, "description"),
             tags=check.opt_mapping_param(tags, "tags"),
+            metadata=check.opt_mapping_param(metadata, "metadata"),
             partitions_def=check.opt_inst_param(
                 partitions_def, "partitions_def", PartitionsDefinition
             ),
@@ -230,6 +234,7 @@ class UnresolvedAssetJobDefinition(
             source_assets=source_assets,
             description=self.description,
             tags=self.tags,
+            metadata=self.metadata,
             asset_selection=selected_asset_keys,
             partitions_def=self.partitions_def if self.partitions_def else inferred_partitions_def,
             executor_def=self.executor_def or default_executor_def,
@@ -244,6 +249,7 @@ def define_asset_job(
     ] = None,
     description: Optional[str] = None,
     tags: Optional[Mapping[str, Any]] = None,
+    metadata: Optional[Mapping[str, MetadataValue]] = None,
     partitions_def: Optional["PartitionsDefinition"] = None,
     executor_def: Optional["ExecutorDefinition"] = None,
 ) -> UnresolvedAssetJobDefinition:
@@ -289,6 +295,8 @@ def define_asset_job(
             Values that are not strings will be json encoded and must meet the criteria that
             `json.loads(json.dumps(value)) == value`.  These tag values may be overwritten by tag
             values provided at invocation time.
+        metadata (Optional[Mapping[str, MetadataValue]]):
+
         description (Optional[str]):
             A description for the Job.
         partitions_def (Optional[PartitionsDefinition]):
@@ -369,6 +377,7 @@ def define_asset_job(
         config=config,
         description=description,
         tags=tags,
+        metadata=metadata,
         partitions_def=partitions_def,
         executor_def=executor_def,
     )


### PR DESCRIPTION
## Summary & Motivation
Job metadata can be added when defining jobs using the `@asset` decorator ([docs](https://docs.dagster.io/concepts/ops-jobs-graphs/metadata-tags#specifying-metadata)). However, they cannot currently be added when using the `define_asset_job` function. I would like to be to do this, so we can specify job owners, links to external documentation, and other metadata for asset jobs.

This would resolve issue #10639.
## How I Tested These Changes
I added two metadata fields to the `basic_assets_job` in the `basic_assets_repository` and verified that the metadata section is populated with these fields:
![image](https://github.com/dagster-io/dagster/assets/49532242/5d4c0c04-4ec0-4b8a-877f-099f00fd63fa)

## Caveats
- I was not able to get pyright running, so I would appreciate if someone could run type checking on this.