### PR TITLE
feat(dbt-assets): automatically apply description replacements using the manifest

### DIFF
--- a/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/customize_description.py
+++ b/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/customize_description.py
@@ -1,0 +1,31 @@
+from typing import Any, Mapping
+
+from dagster import OpExecutionContext
+from dagster_dbt.asset_decorator import dbt_assets
+from dagster_dbt.cli import DbtCli, DbtManifest
+
+from . import MANIFEST_PATH
+
+
+class CustomizedDbtManifest(DbtManifest):
+    @classmethod
+    def node_info_to_description(cls, node_info: Mapping[str, Any]) -> str:
+        description_sections = []
+
+        description = node_info.get("description", "")
+        if description:
+            description_sections.append(description)
+
+        compiled_code = node_info.get("compiled_code", "")
+        if compiled_code:
+            description_sections.append(f"#### Compiled SQL:\n```\n{compiled_code}\n```")
+
+        return "\n\n".join(description_sections)
+
+
+manifest = CustomizedDbtManifest.read(path=MANIFEST_PATH)
+
+
+@dbt_assets(manifest=manifest)
+def my_dbt_assets(context: OpExecutionContext, dbt: DbtCli):
+    yield from dbt.cli(["build"], manifest=manifest, context=context).stream()

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
@@ -73,6 +73,7 @@ def dbt_assets(
         return asset_definition.with_attributes(
             input_asset_key_replacements=manifest.asset_key_replacements,
             output_asset_key_replacements=manifest.asset_key_replacements,
+            descriptions_by_key=manifest.descriptions_by_asset_key,
         )
 
     return inner

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources_v2.py
@@ -20,7 +20,7 @@ from dbt.node_types import NodeType
 from pydantic import Field
 from typing_extensions import Literal
 
-from ..asset_utils import default_asset_key_fn, output_name_fn
+from ..asset_utils import default_asset_key_fn, default_description_fn, output_name_fn
 
 logger = get_dagster_logger()
 
@@ -61,6 +61,10 @@ class DbtManifest:
     def node_info_to_asset_key(cls, node_info: Mapping[str, Any]) -> AssetKey:
         return default_asset_key_fn(node_info)
 
+    @classmethod
+    def node_info_to_description(cls, node_info: Mapping[str, Any]) -> str:
+        return default_description_fn(node_info)
+
     @property
     def node_info_by_asset_key(self) -> Mapping[AssetKey, Mapping[str, Any]]:
         """A mapping of the default asset key for a dbt node to the node's dictionary representation in the manifest.
@@ -83,6 +87,15 @@ class DbtManifest:
         return {
             DbtManifest.node_info_to_asset_key(node_info): self.node_info_to_asset_key(node_info)
             for node_info in self.node_info_by_dbt_unique_id.values()
+        }
+
+    @property
+    def descriptions_by_asset_key(self) -> Mapping[AssetKey, str]:
+        """A mapping of the default asset key for a dbt node to the node's description in the manifest.
+        """
+        return {
+            self.node_info_to_asset_key(node): self.node_info_to_description(node)
+            for node in self.node_info_by_dbt_unique_id.values()
         }
 
     def get_node_info_by_output_name(self, output_name: str) -> Mapping[str, Any]:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_decorator.py
@@ -140,10 +140,7 @@ def test_io_manager_key(io_manager_key: Optional[str]) -> None:
         assert output_def.io_manager_key == expected_io_manager_key
 
 
-@pytest.mark.parametrize(
-    "partitions_def", [None, DailyPartitionsDefinition(start_date="2023-01-01")]
-)
-def test_with_attributes(partitions_def: Optional[PartitionsDefinition]) -> None:
+def test_with_asset_key_replacements() -> None:
     class CustomizedDbtManifest(DbtManifest):
         @classmethod
         def node_info_to_asset_key(cls, node_info: Mapping[str, Any]) -> AssetKey:
@@ -151,7 +148,7 @@ def test_with_attributes(partitions_def: Optional[PartitionsDefinition]) -> None
 
     manifest = CustomizedDbtManifest.read(path=manifest_path)
 
-    @dbt_assets(manifest=manifest, partitions_def=partitions_def)
+    @dbt_assets(manifest=manifest)
     def my_dbt_assets():
         ...
 
@@ -164,3 +161,21 @@ def test_with_attributes(partitions_def: Optional[PartitionsDefinition]) -> None
         AssetKey(["prefix", "sort_hot_cereals_by_calories"]),
         AssetKey(["prefix", "sort_by_calories"]),
     }
+
+
+def test_with_description_replacements() -> None:
+    expected_description = "customized description"
+
+    class CustomizedDbtManifest(DbtManifest):
+        @classmethod
+        def node_info_to_description(cls, node_info: Mapping[str, Any]) -> str:
+            return expected_description
+
+    manifest = CustomizedDbtManifest.read(path=manifest_path)
+
+    @dbt_assets(manifest=manifest)
+    def my_dbt_assets():
+        ...
+
+    for description in my_dbt_assets.descriptions_by_key.values():
+        assert description == expected_description


### PR DESCRIPTION
## Summary & Motivation
Some users want to modify the description of their dbt assets to include information like the dbt model's compiled code, which was supported previously using the `display_raw_sql` argument.

Add it back.

## How I Tested These Changes
pytest, local
