### PR TITLE
[Auto-materialize Page] Actually use maximum lag minutes

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AssetAutomaterializePolicyPage.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AssetAutomaterializePolicyPage.tsx
@@ -315,10 +315,14 @@ const RightPanel = ({
           )}
           {data.assetNodeOrError.freshnessPolicy ? (
             <RightPanelSection title="Freshness policy">
-              <RightPanelDetail title="Maximum lag minutes" tooltip="test" value={2} />
+              <RightPanelDetail
+                title="Maximum lag minutes"
+                value={data.assetNodeOrError.freshnessPolicy.maximumLagMinutes}
+              />
               <Box flex={{direction: 'column', gap: 8}}>
-                This asset will be considered late if it is not materialized within 2 minutes of
-                it’s upstream dependencies.
+                This asset will be considered late if it is not materialized within{' '}
+                {data.assetNodeOrError.freshnessPolicy.maximumLagMinutes} minutes of it’s upstream
+                dependencies.
                 <Link
                   to={assetDetailsPathForKey(assetKey, {view: 'lineage', lineageScope: 'upstream'})}
                 >


### PR DESCRIPTION
## Summary & Motivation
This was hardcoded when it shouldn't be.

The test tooltip was also there from when this was using mock data.

## How I Tested These Changes

I loaded an asset with a freshness policy

<img width="1725" alt="Screen Shot 2023-06-01 at 5 01 13 PM" src="https://github.com/dagster-io/dagster/assets/2286579/e4795d8b-2aee-4a2c-a81d-a497ed1a8242">
