### PR TITLE
Fix missing `py.typed` in dagster-graphql

### DIFF
--- a/python_modules/dagster-graphql/setup.py
+++ b/python_modules/dagster-graphql/setup.py
@@ -33,6 +33,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_graphql_tests*"]),
+    include_package_data=True,
     install_requires=[
         f"dagster{pin}",
         "graphene>=3",


### PR DESCRIPTION
## Summary & Motivation

Currently the `py.typed` is not included in the installed package of `dagster_graphql`. To do so I added the `include_package_data=True` in the `setup.py`.

N.B: In many other libraries the `include_package_data=True` is not included, but it seems to work because the `MANIFEST.in` itself is fine to pick up non-empty files, and many of the `py.typed` are actually filled with `partial` inside. It is not the case for the `py.typed` within `dagster_graphql` which is empty and thus not copied to the installation location.
I'm fine doing it like that also but I'm not sure if adding the "partial" had a meaning for the dagster team.

## How I Tested These Changes
- Locally by performing an install and checking that the file is there