### PR TITLE
Update FileSource type name fix for issue  #14541

### DIFF
--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/managed/generated/sources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/managed/generated/sources.py
@@ -2791,7 +2791,7 @@ class FileSource(GeneratedAirbyteSource):
                 FileSource.LocalFilesystemLimited,
             ),
         )
-        super().__init__("File", name)
+        super().__init__("File (CSV, JSON, Excel, Feather, Parquet)", name)
 
 
 class GlassfrogSource(GeneratedAirbyteSource):


### PR DESCRIPTION
Airbyte changed type name from "File" to "File (CSV, JSON, Excel, Feather, Parquet)"

## Summary & Motivation

So faced this issue when creating FileSource connector. "dagster._check.CheckError: Expected non-None value: None"
Basically dagster was not able to create a FileSource because type name is hardcoded which got modified by Airbyte
https://github.com/dagster-io/dagster/issues/14541
Open

## How I Tested These Changes

Ran the code in local using dagster-airbyte cli and used check command to run before and after the changes.
