### PR TITLE
Revert "resources and io manager telemetry"

### DIFF
--- a/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
@@ -620,7 +620,6 @@ class ConfigurableResourceFactoryResourceDefinition(ResourceDefinition, AllowDel
         description: Optional[str],
         resolve_resource_keys: Callable[[Mapping[int, str]], AbstractSet[str]],
         nested_resources: Mapping[str, CoercibleToResource],
-        dagster_maintained: bool = False,
     ):
         super().__init__(
             resource_fn=resource_fn,
@@ -630,7 +629,6 @@ class ConfigurableResourceFactoryResourceDefinition(ResourceDefinition, AllowDel
         self._configurable_resource_cls = configurable_resource_cls
         self._resolve_resource_keys = resolve_resource_keys
         self._nested_resources = nested_resources
-        self._dagster_maintained = dagster_maintained
 
     @property
     def configurable_resource_cls(self) -> Type:
@@ -659,7 +657,6 @@ class ConfigurableIOManagerFactoryResourceDefinition(IOManagerDefinition, AllowD
         nested_resources: Mapping[str, CoercibleToResource],
         input_config_schema: Optional[Union[CoercableToConfigSchema, Type[Config]]] = None,
         output_config_schema: Optional[Union[CoercableToConfigSchema, Type[Config]]] = None,
-        dagster_maintained: bool = False,
     ):
         input_config_schema_resolved: CoercableToConfigSchema = (
             cast(Type[Config], input_config_schema).to_config_schema()
@@ -681,7 +678,6 @@ class ConfigurableIOManagerFactoryResourceDefinition(IOManagerDefinition, AllowD
         self._resolve_resource_keys = resolve_resource_keys
         self._nested_resources = nested_resources
         self._configurable_resource_cls = configurable_resource_cls
-        self._dagster_maintained = dagster_maintained
 
     @property
     def configurable_resource_cls(self) -> Type:
@@ -815,13 +811,6 @@ class ConfigurableResourceFactory(
         return self._state__internal__.resolved_config_dict
 
     @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
-        """This property should be overridden to return True by all dagster maintained resources and IO managers.
-        """
-        return False
-
-    @classmethod
     def _is_cm_resource_cls(cls: Type["ConfigurableResourceFactory"]) -> bool:
         return (
             cls.yield_for_execution != ConfigurableResourceFactory.yield_for_execution
@@ -844,7 +833,6 @@ class ConfigurableResourceFactory(
             description=self.__doc__,
             resolve_resource_keys=self._resolve_required_resource_keys,
             nested_resources=self.nested_resources,
-            dagster_maintained=self._dagster_maintained,
         )
 
     @abstractmethod
@@ -1167,13 +1155,12 @@ class PartialResource(Generic[TResValue], AllowDelayedDependencies, MakeConfigCa
     @cached_method
     def get_resource_definition(self) -> ConfigurableResourceFactoryResourceDefinition:
         return ConfigurableResourceFactoryResourceDefinition(
-            self.resource_cls,
+            self.__class__,
             resource_fn=self._state__internal__.resource_fn,
             config_schema=self._state__internal__.config_schema,
             description=self._state__internal__.description,
             resolve_resource_keys=self._resolve_required_resource_keys,
             nested_resources=self.nested_resources,
-            dagster_maintained=self.resource_cls._dagster_maintained,  # noqa: SLF001
         )
 
 
@@ -1243,7 +1230,6 @@ class ConfigurableLegacyResourceAdapter(ConfigurableResource, ABC):
             description=self.__doc__,
             resolve_resource_keys=self._resolve_required_resource_keys,
             nested_resources=self.nested_resources,
-            dagster_maintained=self._dagster_maintained,
         )
 
     def __call__(self, *args, **kwargs):
@@ -1324,7 +1310,6 @@ class ConfigurableIOManagerFactory(ConfigurableResourceFactory[TIOManagerValue])
             nested_resources=self.nested_resources,
             input_config_schema=self.__class__.input_config_schema(),
             output_config_schema=self.__class__.output_config_schema(),
-            dagster_maintained=self._dagster_maintained,
         )
 
     @classmethod
@@ -1360,7 +1345,7 @@ class PartialIOManager(Generic[TResValue], PartialResource[TResValue]):
             output_config_schema = factory_cls.output_config_schema()
 
         return ConfigurableIOManagerFactoryResourceDefinition(
-            self.resource_cls,
+            self.__class__,
             resource_fn=self._state__internal__.resource_fn,
             config_schema=self._state__internal__.config_schema,
             description=self._state__internal__.description,
@@ -1368,7 +1353,6 @@ class PartialIOManager(Generic[TResValue], PartialResource[TResValue]):
             nested_resources=self._state__internal__.nested_resources,
             input_config_schema=input_config_schema,
             output_config_schema=output_config_schema,
-            dagster_maintained=self.resource_cls._dagster_maintained,  # noqa: SLF001
         )
 
 
@@ -1624,7 +1608,6 @@ class ConfigurableLegacyIOManagerAdapter(ConfigurableIOManagerFactory):
             description=self.__doc__,
             resolve_resource_keys=self._resolve_required_resource_keys,
             nested_resources=self.nested_resources,
-            dagster_maintained=self._dagster_maintained,
         )
 
 

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -54,11 +54,7 @@ from dagster._core.selector.subset_selector import (
     AssetSelectionData,
     OpSelectionData,
 )
-from dagster._core.storage.io_manager import (
-    IOManagerDefinition,
-    dagster_maintained_io_manager,
-    io_manager,
-)
+from dagster._core.storage.io_manager import IOManagerDefinition, io_manager
 from dagster._core.storage.tags import MEMOIZED_RUN_TAG
 from dagster._core.types.dagster_type import DagsterType
 from dagster._core.utils import str_format_set
@@ -992,7 +988,6 @@ def _swap_default_io_man(resources: Mapping[str, ResourceDefinition], job: JobDe
     return resources
 
 
-@dagster_maintained_io_manager
 @io_manager(
     description="Built-in filesystem IO manager that stores and retrieves values using pickling."
 )
@@ -1033,7 +1028,6 @@ def default_job_io_manager(init_context: "InitResourceContext"):
     return PickledObjectFilesystemIOManager(base_dir=instance.storage_directory())
 
 
-@dagster_maintained_io_manager
 @io_manager(
     description="Built-in filesystem IO manager that stores and retrieves values using pickling.",
     config_schema={"base_dir": Field(StringSource, is_required=False)},

--- a/python_modules/dagster/dagster/_core/definitions/no_step_launcher.py
+++ b/python_modules/dagster/dagster/_core/definitions/no_step_launcher.py
@@ -1,8 +1,6 @@
 from dagster import resource
-from dagster._core.definitions.resource_definition import dagster_maintained_resource
 
 
-@dagster_maintained_resource
 @resource
 def no_step_launcher(_):
     return None

--- a/python_modules/dagster/dagster/_core/execution/plan/external_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/external_step.py
@@ -9,7 +9,7 @@ import dagster._check as check
 from dagster._config import Field, StringSource
 from dagster._core.code_pointer import FileCodePointer, ModuleCodePointer
 from dagster._core.definitions.reconstruct import ReconstructableJob, ReconstructableRepository
-from dagster._core.definitions.resource_definition import dagster_maintained_resource, resource
+from dagster._core.definitions.resource_definition import resource
 from dagster._core.definitions.step_launcher import StepLauncher, StepRunRef
 from dagster._core.errors import raise_execution_interrupts
 from dagster._core.events import DagsterEvent
@@ -30,7 +30,6 @@ if TYPE_CHECKING:
     from dagster._core.execution.plan.step import ExecutionStep
 
 
-@dagster_maintained_resource
 @resource(
     config_schema={
         "scratch_dir": Field(

--- a/python_modules/dagster/dagster/_core/host_representation/external.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external.py
@@ -585,10 +585,6 @@ class ExternalResource:
     def job_ops_using(self) -> List[ResourceJobUsageEntry]:
         return self._external_resource_data.job_ops_using
 
-    @property
-    def is_dagster_maintained(self) -> bool:
-        return self._external_resource_data.dagster_maintained
-
 
 class ExternalSchedule:
     def __init__(self, external_schedule_data: ExternalScheduleData, handle: RepositoryHandle):

--- a/python_modules/dagster/dagster/_core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external_data.py
@@ -36,7 +36,11 @@ from dagster._config.pythonic_config import (
     ConfigurableResourceFactoryResourceDefinition,
     ResourceWithKeyMapping,
 )
-from dagster._config.snap import ConfigFieldSnap, ConfigSchemaSnapshot, snap_from_config_type
+from dagster._config.snap import (
+    ConfigFieldSnap,
+    ConfigSchemaSnapshot,
+    snap_from_config_type,
+)
 from dagster._core.definitions import (
     JobDefinition,
     PartitionsDefinition,
@@ -66,7 +70,10 @@ from dagster._core.definitions.metadata import (
 )
 from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionsDefinition
 from dagster._core.definitions.op_definition import OpDefinition
-from dagster._core.definitions.partition import DynamicPartitionsDefinition, ScheduleType
+from dagster._core.definitions.partition import (
+    DynamicPartitionsDefinition,
+    ScheduleType,
+)
 from dagster._core.definitions.partition_mapping import (
     PartitionMapping,
     get_builtin_partition_mapping_types,
@@ -967,7 +974,6 @@ class ExternalResourceData(
             ("is_top_level", bool),
             ("asset_keys_using", List[AssetKey]),
             ("job_ops_using", List[ResourceJobUsageEntry]),
-            ("dagster_maintained", bool),
         ],
     )
 ):
@@ -989,7 +995,6 @@ class ExternalResourceData(
         is_top_level: bool = True,
         asset_keys_using: Optional[Sequence[AssetKey]] = None,
         job_ops_using: Optional[Sequence[ResourceJobUsageEntry]] = None,
-        dagster_maintained: bool = False,
     ):
         return super(ExternalResourceData, cls).__new__(
             cls,
@@ -1035,7 +1040,6 @@ class ExternalResourceData(
                 )
             )
             or [],
-            dagster_maintained=dagster_maintained,
         )
 
 
@@ -1632,18 +1636,6 @@ def external_resource_data_from_def(
     else:
         resource_type = _get_class_name(type(resource_type_def))
 
-    dagster_maintained = (
-        resource_type_def._dagster_maintained  # noqa: SLF001
-        if type(resource_type_def)
-        in (
-            ResourceDefinition,
-            IOManagerDefinition,
-            ConfigurableResourceFactoryResourceDefinition,
-            ConfigurableIOManagerFactoryResourceDefinition,
-        )
-        else False
-    )
-
     return ExternalResourceData(
         name=name,
         resource_snapshot=build_resource_def_snap(name, resource_def),
@@ -1656,7 +1648,6 @@ def external_resource_data_from_def(
         asset_keys_using=resource_asset_usage_map.get(name, []),
         job_ops_using=resource_job_usage_map.get(name, []),
         resource_type=resource_type,
-        dagster_maintained=dagster_maintained,
     )
 
 

--- a/python_modules/dagster/dagster/_core/storage/file_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/file_manager.py
@@ -11,7 +11,7 @@ from typing_extensions import TypeAlias
 import dagster._check as check
 from dagster._annotations import public
 from dagster._config import Field, StringSource
-from dagster._core.definitions.resource_definition import dagster_maintained_resource, resource
+from dagster._core.definitions.resource_definition import resource
 from dagster._core.execution.context.init import InitResourceContext
 from dagster._core.instance import DagsterInstance
 from dagster._utils import mkdir_p
@@ -167,7 +167,6 @@ class FileManager(ABC):
         raise NotImplementedError()
 
 
-@dagster_maintained_resource
 @resource(config_schema={"base_dir": Field(StringSource, is_required=False)})
 def local_file_manager(init_context: InitResourceContext) -> "LocalFileManager":
     """FileManager that provides abstract access to a local filesystem.

--- a/python_modules/dagster/dagster/_core/storage/fs_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/fs_io_manager.py
@@ -18,7 +18,7 @@ from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.execution.context.init import InitResourceContext
 from dagster._core.execution.context.input import InputContext
 from dagster._core.execution.context.output import OutputContext
-from dagster._core.storage.io_manager import IOManager, dagster_maintained_io_manager, io_manager
+from dagster._core.storage.io_manager import IOManager, io_manager
 from dagster._core.storage.upath_io_manager import UPathIOManager
 from dagster._utils import PICKLE_PROTOCOL, mkdir_p
 
@@ -120,17 +120,11 @@ class FilesystemIOManager(ConfigurableIOManagerFactory["PickledObjectFilesystemI
 
     base_dir: Optional[str] = Field(default=None, description="Base directory for storing files.")
 
-    @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
-        return True
-
     def create_io_manager(self, context: InitResourceContext) -> "PickledObjectFilesystemIOManager":
         base_dir = self.base_dir or check.not_none(context.instance).storage_directory()
         return PickledObjectFilesystemIOManager(base_dir=base_dir)
 
 
-@dagster_maintained_io_manager
 @io_manager(
     config_schema=FilesystemIOManager.to_config_schema(),
     description="Built-in filesystem IO manager that stores and retrieves values using pickling.",
@@ -333,7 +327,6 @@ class CustomPathPickledObjectFilesystemIOManager(IOManager):
             return pickle.load(read_obj)
 
 
-@dagster_maintained_io_manager
 @io_manager(config_schema={"base_dir": DagsterField(StringSource, is_required=True)})
 @experimental
 def custom_path_fs_io_manager(

--- a/python_modules/dagster/dagster/_core/storage/io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/io_manager.py
@@ -92,7 +92,7 @@ class IOManagerDefinition(ResourceDefinition, IInputManagerDefinition, IOutputMa
         description: Optional[str],
         config_schema: CoercableToConfigSchema,
     ) -> "IOManagerDefinition":
-        io_def = IOManagerDefinition(
+        return IOManagerDefinition(
             config_schema=config_schema,
             description=description or self.description,
             resource_fn=self.resource_fn,
@@ -100,10 +100,6 @@ class IOManagerDefinition(ResourceDefinition, IInputManagerDefinition, IOutputMa
             input_config_schema=self.input_config_schema,
             output_config_schema=self.output_config_schema,
         )
-
-        io_def._dagster_maintained = self.dagster_maintained  # noqa: SLF001
-
-        return io_def
 
     @public
     @staticmethod
@@ -242,11 +238,6 @@ def io_manager(
         )(resource_fn)
 
     return _wrap
-
-
-def dagster_maintained_io_manager(io_manager_def: IOManagerDefinition) -> IOManagerDefinition:
-    io_manager_def._dagster_maintained = True  # noqa: SLF001
-    return io_manager_def
 
 
 class _IOManagerDecoratorCallable:

--- a/python_modules/dagster/dagster/_core/storage/mem_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/mem_io_manager.py
@@ -2,7 +2,7 @@ from typing import Dict, Tuple
 
 from dagster._core.execution.context.input import InputContext
 from dagster._core.execution.context.output import OutputContext
-from dagster._core.storage.io_manager import IOManager, dagster_maintained_io_manager, io_manager
+from dagster._core.storage.io_manager import IOManager, io_manager
 
 
 class InMemoryIOManager(IOManager):
@@ -18,7 +18,6 @@ class InMemoryIOManager(IOManager):
         return self.values[keys]
 
 
-@dagster_maintained_io_manager
 @io_manager(description="Built-in IO manager that stores and retrieves values in memory.")
 def mem_io_manager(_) -> InMemoryIOManager:
     """Built-in IO manager that stores and retrieves values in memory."""

--- a/python_modules/dagster/dagster/_core/storage/memoizable_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/memoizable_io_manager.py
@@ -9,7 +9,7 @@ from dagster._config import Field, StringSource
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.execution.context.input import InputContext
 from dagster._core.execution.context.output import OutputContext
-from dagster._core.storage.io_manager import IOManager, dagster_maintained_io_manager, io_manager
+from dagster._core.storage.io_manager import IOManager, io_manager
 from dagster._utils import PICKLE_PROTOCOL, mkdir_p
 
 
@@ -92,7 +92,6 @@ class VersionedPickledObjectFilesystemIOManager(MemoizableIOManager):
         return os.path.exists(filepath) and not os.path.isdir(filepath)
 
 
-@dagster_maintained_io_manager
 @io_manager(config_schema={"base_dir": Field(StringSource, is_required=False)})
 @experimental
 def versioned_filesystem_io_manager(init_context):

--- a/python_modules/dagster/dagster/_core/storage/temp_file_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/temp_file_manager.py
@@ -3,7 +3,7 @@ import os
 import shutil
 import tempfile
 
-from dagster._core.definitions.resource_definition import dagster_maintained_resource, resource
+from dagster._core.definitions.resource_definition import resource
 
 
 class TempfileManager:
@@ -42,7 +42,6 @@ def _tempfile_manager():
         manager.close()
 
 
-@dagster_maintained_resource
 @resource
 def tempfile_resource(_init_context):
     with _tempfile_manager() as manager:

--- a/python_modules/dagster/dagster/_core/telemetry.py
+++ b/python_modules/dagster/dagster/_core/telemetry.py
@@ -54,11 +54,7 @@ from dagster._utils.merger import merge_dicts
 from dagster.version import __version__ as dagster_module_version
 
 if TYPE_CHECKING:
-    from dagster._core.host_representation.external import (
-        ExternalJob,
-        ExternalRepository,
-        ExternalResource,
-    )
+    from dagster._core.host_representation.external import ExternalJob, ExternalRepository
     from dagster._core.workspace.context import IWorkspaceProcessContext
 
 TELEMETRY_STR = ".telemetry"
@@ -469,7 +465,6 @@ def get_stats_from_external_repo(external_repo: "ExternalRepository") -> Mapping
     num_sensors_in_repo = len(external_repo.get_external_sensors())
     external_asset_nodes = external_repo.get_external_asset_nodes()
     num_assets_in_repo = len(external_asset_nodes)
-    external_resources = external_repo.get_external_resources()
 
     num_partitioned_assets_in_repo = 0
     num_multi_partitioned_assets_in_repo = 0
@@ -481,7 +476,6 @@ def get_stats_from_external_repo(external_repo: "ExternalRepository") -> Mapping
     num_observable_source_assets_in_repo = 0
     num_dbt_assets_in_repo = 0
     num_assets_with_code_versions_in_repo = 0
-
     for asset in external_asset_nodes:
         if asset.partitions_def_data:
             num_partitioned_assets_in_repo += 1
@@ -520,7 +514,6 @@ def get_stats_from_external_repo(external_repo: "ExternalRepository") -> Mapping
     )
 
     return {
-        **get_resource_stats(external_resources=list(external_resources)),
         "num_pipelines_in_repo": str(num_pipelines_in_repo),
         "num_schedules_in_repo": str(num_schedules_in_repo),
         "num_sensors_in_repo": str(num_sensors_in_repo),
@@ -542,27 +535,6 @@ def get_stats_from_external_repo(external_repo: "ExternalRepository") -> Mapping
         "num_dbt_assets_in_repo": str(num_dbt_assets_in_repo),
         "num_assets_with_code_versions_in_repo": str(num_assets_with_code_versions_in_repo),
         "num_asset_reconciliation_sensors_in_repo": str(num_asset_reconciliation_sensors_in_repo),
-    }
-
-
-def get_resource_stats(external_resources: Sequence["ExternalResource"]) -> Mapping[str, str]:
-    used_dagster_resources = []
-    used_custom_resources = False
-
-    for resource in external_resources:
-        resource_type = resource.resource_type
-        split_resource_type = resource_type.split(".")
-        module_name = split_resource_type[0]
-        class_name = split_resource_type[-1]
-
-        if resource.is_dagster_maintained:
-            used_dagster_resources.append({"module_name": module_name, "class_name": class_name})
-        else:
-            used_custom_resources = True
-
-    return {
-        "dagster_resources": str(used_dagster_resources),
-        "has_custom_resources": str(used_custom_resources),
     }
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_general_pythonic_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_general_pythonic_resources.py
@@ -1531,22 +1531,3 @@ def test_context_on_resource_nested() -> None:
 
         assert defs.get_implicit_global_asset_job_def().execute_in_process().success
         assert executed["yes"]
-
-
-def test_telemetry_custom_resource():
-    class MyResource(ConfigurableResource):
-        my_value: str
-
-    assert not MyResource(my_value="foo")._dagster_maintained  # noqa: SLF001
-
-
-def test_telemetry_dagster_resource():
-    class MyResource(ConfigurableResource):
-        my_value: str
-
-        @classmethod
-        @property
-        def _dagster_maintained(cls) -> bool:
-            return True
-
-    assert MyResource(my_value="foo")._dagster_maintained  # noqa: SLF001

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_resource_definition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_resource_definition.py
@@ -25,10 +25,7 @@ from dagster import (
     resource,
 )
 from dagster._core.definitions.job_base import InMemoryJob
-from dagster._core.definitions.resource_definition import (
-    dagster_maintained_resource,
-    make_values_resource,
-)
+from dagster._core.definitions.resource_definition import make_values_resource
 from dagster._core.errors import DagsterConfigMappingFunctionError, DagsterInvalidDefinitionError
 from dagster._core.events.log import EventLogEntry, construct_event_logger
 from dagster._core.execution.api import create_execution_plan, execute_plan
@@ -1213,28 +1210,3 @@ def test_context_manager_resource():
 
     assert call_basic.execute_in_process(resources={"cm": cm_resource}).success
     assert event_list == ["foo", "compute", "finally"]
-
-
-def test_telemetry_custom_resource():
-    class MyResource:
-        def foo(self) -> str:
-            return "bar"
-
-    @resource
-    def my_resource():
-        return MyResource()
-
-    assert not my_resource._dagster_maintained  # noqa: SLF001
-
-
-def test_telemetry_dagster_io_manager():
-    class MyResource:
-        def foo(self) -> str:
-            return "bar"
-
-    @dagster_maintained_resource
-    @resource
-    def my_resource():
-        return MyResource()
-
-    assert my_resource._dagster_maintained  # noqa: SLF001

--- a/python_modules/dagster/dagster_tests/storage_tests/test_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_io_manager.py
@@ -40,7 +40,7 @@ from dagster._core.execution.api import create_execution_plan, execute_plan
 from dagster._core.execution.context.output import get_output_context
 from dagster._core.execution.plan.outputs import StepOutputHandle
 from dagster._core.storage.fs_io_manager import custom_path_fs_io_manager, fs_io_manager
-from dagster._core.storage.io_manager import IOManager, dagster_maintained_io_manager, io_manager
+from dagster._core.storage.io_manager import IOManager, io_manager
 from dagster._core.storage.mem_io_manager import InMemoryIOManager, mem_io_manager
 from dagster._core.system_config.objects import ResolvedRunConfig
 from dagster._core.test_utils import instance_for_test
@@ -1086,34 +1086,3 @@ def test_instance_set_on_asset_loader():
         defs.load_asset_value("another_asset", instance=instance)
 
         assert executed["yes"]
-
-
-def test_telemetry_custom_io_manager():
-    class MyIOManager(IOManager):
-        def handle_output(self, context, obj):
-            return {}
-
-        def load_input(self, context):
-            return 1
-
-    @io_manager
-    def my_io_manager():
-        return MyIOManager()
-
-    assert not my_io_manager._dagster_maintained  # noqa: SLF001
-
-
-def test_telemetry_dagster_io_manager():
-    class MyIOManager(IOManager):
-        def handle_output(self, context, obj):
-            return {}
-
-        def load_input(self, context):
-            return 1
-
-    @dagster_maintained_io_manager
-    @io_manager
-    def my_io_manager():
-        return MyIOManager()
-
-    assert my_io_manager._dagster_maintained  # noqa: SLF001

--- a/python_modules/dagster/dagster_tests/storage_tests/test_io_managers_pythonic_config.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_io_managers_pythonic_config.py
@@ -4,7 +4,6 @@ from typing import Any, Type
 
 from dagster import (
     Config,
-    ConfigurableIOManagerFactory,
     DataVersion,
     Definitions,
     FilesystemIOManager,
@@ -20,7 +19,6 @@ from dagster import (
 )
 from dagster._config.pythonic_config import ConfigurableIOManager, ConfigurableResource
 from dagster._config.type_printer import print_config_type_to_string
-from dagster._core.storage.io_manager import IOManager
 
 
 def type_string_from_config_schema(config_schema):
@@ -490,65 +488,3 @@ def test_observable_source_asset_io_manager_def() -> None:
         result = defs.get_implicit_global_asset_job_def().execute_in_process()
         assert result.success
         assert result.output_for_node("my_downstream_asset") == "foobar"
-
-
-def test_telemetry_custom_io_manager():
-    class MyIOManager(ConfigurableIOManager):
-        def handle_output(self, context, obj):
-            return {}
-
-        def load_input(self, context):
-            return 1
-
-    assert not MyIOManager._dagster_maintained
-
-
-def test_telemetry_dagster_io_manager():
-    class MyIOManager(ConfigurableIOManager):
-        @classmethod
-        @property
-        def _dagster_maintained(cls) -> bool:
-            return True
-
-        def handle_output(self, context, obj):
-            return {}
-
-        def load_input(self, context):
-            return 1
-
-    assert MyIOManager()._dagster_maintained  # noqa: SLF001
-
-
-def test_telemetry_custom_io_manager_factory():
-    class MyIOManager(IOManager):
-        def handle_output(self, context, obj):
-            return {}
-
-        def load_input(self, context):
-            return 1
-
-    class AnIOManagerFactory(ConfigurableIOManagerFactory):
-        def create_io_manager(self, _) -> IOManager:
-            return MyIOManager()
-
-    assert not AnIOManagerFactory()._dagster_maintained  # noqa: SLF001
-
-
-def test_telemetry_dagster_io_manager_factory():
-    class MyIOManager(IOManager):
-        def handle_output(self, context, obj):
-            return {}
-
-        def load_input(self, context):
-            return 1
-
-    class AnIOManagerFactory(ConfigurableIOManagerFactory):
-        @classmethod
-        @property
-        def _dagster_maintained(cls) -> bool:
-            return True
-
-        def create_io_manager(self, _) -> IOManager:
-            return MyIOManager()
-
-    assert AnIOManagerFactory()._dagster_maintained  # noqa: SLF001

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
@@ -16,7 +16,6 @@ from dagster import (
     resource,
 )
 from dagster._config.pythonic_config import infer_schema_from_config_class
-from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._utils.cached_method import cached_method
 from dagster._utils.merger import deep_merge_dicts
 from pydantic import Field
@@ -69,11 +68,6 @@ class BaseAirbyteResource(ConfigurableResource):
             " that do not impact your Airbyte deployment."
         ),
     )
-
-    @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
-        return True
 
     @property
     @cached_method
@@ -666,7 +660,6 @@ class AirbyteResource(BaseAirbyteResource):
         return AirbyteOutput(job_details=job_details, connection_details=connection_details)
 
 
-@dagster_maintained_resource
 @resource(config_schema=AirbyteResource.to_config_schema())
 def airbyte_resource(context) -> AirbyteResource:
     """This resource allows users to programatically interface with the Airbyte REST API to launch
@@ -704,7 +697,6 @@ def airbyte_resource(context) -> AirbyteResource:
     return AirbyteResource.from_resource_context(context)
 
 
-@dagster_maintained_resource
 @resource(config_schema=infer_schema_from_config_class(AirbyteCloudResource))
 def airbyte_cloud_resource(context) -> AirbyteCloudResource:
     """This resource allows users to programatically interface with the Airbyte Cloud REST API to launch

--- a/python_modules/libraries/dagster-aws/dagster_aws/athena/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/athena/resources.py
@@ -14,7 +14,6 @@ from dagster import (
     resource,
 )
 from dagster._annotations import deprecated
-from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._core.execution.context.init import InitResourceContext
 from pydantic import Field
 
@@ -265,11 +264,6 @@ class AthenaClientResource(ResourceWithAthenaConfig):
 
     """
 
-    @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
-        return True
-
     def get_client(self) -> AthenaClient:
         """Returns an Athena client object."""
         client = boto3.client(
@@ -285,7 +279,6 @@ class AthenaClientResource(ResourceWithAthenaConfig):
         )
 
 
-@dagster_maintained_resource
 @resource(
     config_schema=ResourceWithAthenaConfig.to_config_schema(),
     description="Resource for connecting to AWS Athena",
@@ -310,7 +303,6 @@ def athena_resource(context: InitResourceContext) -> AthenaClient:
     return AthenaClientResource.from_resource_context(context).get_client()
 
 
-@dagster_maintained_resource
 @resource(
     config_schema=ResourceWithAthenaConfig.to_config_schema(),
     description="Fake resource for connecting to AWS Athena",

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecr/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecr/resources.py
@@ -3,7 +3,6 @@ import datetime
 import boto3
 from botocore.stub import Stubber
 from dagster import ConfigurableResource, resource
-from dagster._core.definitions.resource_definition import dagster_maintained_resource
 
 
 class ECRPublicClient:
@@ -39,11 +38,6 @@ class ECRPublicResource(ConfigurableResource):
     Similar to the AWS CLI's `aws ecr-public get-login-password` command.
     """
 
-    @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
-        return True
-
     def get_client(self) -> ECRPublicClient:
         return ECRPublicClient()
 
@@ -53,16 +47,10 @@ class FakeECRPublicResource(ConfigurableResource):
     requests and always returns `'token'` as its login password.
     """
 
-    @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
-        return True
-
     def get_client(self) -> FakeECRPublicClient:
         return FakeECRPublicClient()
 
 
-@dagster_maintained_resource
 @resource(
     description=(
         "This resource enables connecting to AWS Public and getting a login password from it."
@@ -73,7 +61,6 @@ def ecr_public_resource(context) -> ECRPublicClient:
     return ECRPublicResource.from_resource_context(context).get_client()
 
 
-@dagster_maintained_resource
 @resource(
     description=(
         "This resource behaves like ecr_public_resource except it stubs out the real AWS API"

--- a/python_modules/libraries/dagster-aws/dagster_aws/emr/pyspark_step_launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/emr/pyspark_step_launcher.py
@@ -12,7 +12,6 @@ from dagster import (
     _check as check,
     resource,
 )
-from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._core.definitions.step_launcher import StepLauncher
 from dagster._core.errors import DagsterInvariantViolationError, raise_execution_interrupts
 from dagster._core.execution.plan.external_step import (
@@ -32,7 +31,6 @@ EMR_SPARK_HOME = "/usr/lib/spark/"
 CODE_ZIP_NAME = "code.zip"
 
 
-@dagster_maintained_resource
 @resource(
     {
         "spark_config": get_spark_config(),

--- a/python_modules/libraries/dagster-aws/dagster_aws/redshift/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/redshift/resources.py
@@ -12,7 +12,6 @@ from dagster import (
     resource,
 )
 from dagster._annotations import deprecated
-from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from pydantic import Field
 
 
@@ -335,11 +334,6 @@ class RedshiftClientResource(ConfigurableResource):
         ),
     )
 
-    @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
-        return True
-
     def get_client(self) -> RedshiftClient:
         conn_args = {
             k: getattr(self, k, None)
@@ -363,7 +357,6 @@ class FakeRedshiftClientResource(RedshiftClientResource):
         return FakeRedshiftClient(get_dagster_logger())
 
 
-@dagster_maintained_resource
 @resource(
     config_schema=RedshiftClientResource.to_config_schema(),
     description="Resource for connecting to the Redshift data warehouse",
@@ -396,7 +389,6 @@ def redshift_resource(context) -> RedshiftClient:
     return RedshiftClientResource.from_resource_context(context).get_client()
 
 
-@dagster_maintained_resource
 @resource(
     config_schema=FakeRedshiftClientResource.to_config_schema(),
     description=(

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
@@ -11,7 +11,6 @@ from dagster import (
     _check as check,
     io_manager,
 )
-from dagster._core.storage.io_manager import dagster_maintained_io_manager
 from dagster._core.storage.upath_io_manager import UPathIOManager
 from dagster._utils import PICKLE_PROTOCOL
 from dagster._utils.cached_method import cached_method
@@ -130,11 +129,6 @@ class ConfigurablePickledObjectS3IOManager(ConfigurableIOManager):
         default="dagster", description="Prefix to use for the S3 bucket for this file manager."
     )
 
-    @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
-        return True
-
     @cached_method
     def inner_io_manager(self) -> PickledObjectS3IOManager:
         return PickledObjectS3IOManager(
@@ -150,7 +144,6 @@ class ConfigurablePickledObjectS3IOManager(ConfigurableIOManager):
         return self.inner_io_manager().handle_output(context, obj)
 
 
-@dagster_maintained_io_manager
 @io_manager(
     config_schema=ConfigurablePickledObjectS3IOManager.to_config_schema(),
     required_resource_keys={"s3"},

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/resources.py
@@ -1,7 +1,6 @@
 from typing import Any, Optional, TypeVar
 
 from dagster import ConfigurableResource, IAttachDifferentObjectToOpContext, resource
-from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from pydantic import Field
 
 from .file_manager import S3FileManager
@@ -83,11 +82,6 @@ class S3Resource(ResourceWithS3Configuration, IAttachDifferentObjectToOpContext)
 
     """
 
-    @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
-        return True
-
     def get_client(self) -> Any:
         return construct_s3_client(
             max_attempts=self.max_attempts,
@@ -106,7 +100,6 @@ class S3Resource(ResourceWithS3Configuration, IAttachDifferentObjectToOpContext)
         return self.get_client()
 
 
-@dagster_maintained_resource
 @resource(config_schema=S3Resource.to_config_schema())
 def s3_resource(context) -> Any:
     """Resource that gives access to S3.
@@ -208,7 +201,6 @@ class S3FileManagerResource(ResourceWithS3Configuration, IAttachDifferentObjectT
         return self.get_client()
 
 
-@dagster_maintained_resource
 @resource(
     config_schema=S3FileManagerResource.to_config_schema(),
 )

--- a/python_modules/libraries/dagster-aws/dagster_aws/secretsmanager/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/secretsmanager/resources.py
@@ -7,7 +7,6 @@ from dagster import (
     resource,
 )
 from dagster._config.field_utils import Shape
-from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._core.test_utils import environ
 from dagster._utils.merger import merge_dicts
 from pydantic import Field
@@ -50,11 +49,6 @@ class SecretsManagerResource(ResourceWithBoto3Configuration):
             )
     """
 
-    @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
-        return True
-
     def get_client(self) -> "botocore.client.SecretsManager":
         return construct_secretsmanager_client(
             max_attempts=self.max_attempts,
@@ -63,7 +57,6 @@ class SecretsManagerResource(ResourceWithBoto3Configuration):
         )
 
 
-@dagster_maintained_resource
 @resource(SecretsManagerResource.to_config_schema())
 def secretsmanager_resource(context) -> "botocore.client.SecretsManager":
     """Resource that gives access to AWS SecretsManager.
@@ -166,11 +159,6 @@ class SecretsManagerSecretsResource(ResourceWithBoto3Configuration):
         description="AWS Secrets Manager secrets with this tag will be fetched and made available.",
     )
 
-    @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
-        return True
-
     @contextmanager
     def secrets_in_environment(
         self,
@@ -240,7 +228,6 @@ LEGACY_SECRETSMANAGER_SECRETS_SCHEMA = {
 }
 
 
-@dagster_maintained_resource
 @resource(config_schema=LEGACY_SECRETSMANAGER_SECRETS_SCHEMA)
 @contextmanager
 def secretsmanager_secrets_resource(context):

--- a/python_modules/libraries/dagster-aws/dagster_aws/ssm/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ssm/resources.py
@@ -8,7 +8,6 @@ from dagster import (
     resource,
 )
 from dagster._config.field_utils import Shape
-from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._core.test_utils import environ
 from dagster._utils.merger import merge_dicts
 from pydantic import Field
@@ -57,11 +56,6 @@ class SSMResource(ResourceWithBoto3Configuration):
             )
     """
 
-    @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
-        return True
-
     def get_client(self) -> "botocore.client.ssm":
         return construct_ssm_client(
             max_attempts=self.max_attempts,
@@ -70,7 +64,6 @@ class SSMResource(ResourceWithBoto3Configuration):
         )
 
 
-@dagster_maintained_resource
 @resource(config_schema=SSMResource.to_config_schema())
 def ssm_resource(context) -> "botocore.client.ssm":
     """Resource that gives access to AWS Systems Manager Parameter Store.
@@ -189,11 +182,6 @@ class ParameterStoreResource(ResourceWithBoto3Configuration):
         ),
     )
 
-    @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
-        return True
-
     @contextmanager
     def parameters_in_environment(
         self,
@@ -288,7 +276,6 @@ LEGACY_PARAMETERSTORE_SCHEMA = {
 }
 
 
-@dagster_maintained_resource
 @resource(config_schema=LEGACY_PARAMETERSTORE_SCHEMA)
 @contextmanager
 def parameter_store_resource(context) -> Any:

--- a/python_modules/libraries/dagster-azure/dagster_azure/adls2/fake_adls2_resource.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/adls2/fake_adls2_resource.py
@@ -5,7 +5,6 @@ from unittest import mock
 
 from dagster import resource
 from dagster._config.pythonic_config import ConfigurableResource
-from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._utils.cached_method import cached_method
 
 from dagster_azure.blob import FakeBlobServiceClient
@@ -13,7 +12,6 @@ from dagster_azure.blob import FakeBlobServiceClient
 from .utils import ResourceNotFoundError
 
 
-@dagster_maintained_resource
 @resource({"account_name": str})
 def fake_adls2_resource(context):
     return FakeADLS2Resource(account_name=context.resource_config["account_name"])
@@ -27,11 +25,6 @@ class FakeADLS2Resource(ConfigurableResource):
 
     account_name: str
     storage_account: Optional[str] = None
-
-    @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
-        return True
 
     @property
     @cached_method

--- a/python_modules/libraries/dagster-azure/dagster_azure/adls2/io_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/adls2/io_manager.py
@@ -10,7 +10,6 @@ from dagster import (
     io_manager,
 )
 from dagster._config.pythonic_config import ConfigurableIOManager
-from dagster._core.storage.io_manager import dagster_maintained_io_manager
 from dagster._core.storage.upath_io_manager import UPathIOManager
 from dagster._utils import PICKLE_PROTOCOL
 from dagster._utils.cached_method import cached_method
@@ -178,11 +177,6 @@ class ConfigurablePickledObjectADLS2IOManager(ConfigurableIOManager):
         default="dagster", description="ADLS Gen2 file system prefix to write to."
     )
 
-    @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
-        return True
-
     @property
     @cached_method
     def _internal_io_manager(self) -> PickledObjectADLS2IOManager:
@@ -201,7 +195,6 @@ class ConfigurablePickledObjectADLS2IOManager(ConfigurableIOManager):
         self._internal_io_manager.handle_output(context, obj)
 
 
-@dagster_maintained_io_manager
 @io_manager(
     config_schema=ConfigurablePickledObjectADLS2IOManager.to_config_schema(),
     required_resource_keys={"adls2"},

--- a/python_modules/libraries/dagster-azure/dagster_azure/adls2/resources.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/adls2/resources.py
@@ -11,7 +11,6 @@ from dagster import (
     StringSource,
     resource,
 )
-from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._utils.cached_method import cached_method
 from dagster._utils.merger import merge_dicts
 from pydantic import Field
@@ -73,11 +72,6 @@ class ADLS2Resource(ADLS2BaseResource):
     of each.
     """
 
-    @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
-        return True
-
     @property
     @cached_method
     def _raw_credential(self) -> Any:
@@ -106,7 +100,6 @@ class ADLS2Resource(ADLS2BaseResource):
 # Due to a limitation of the discriminated union type, we can't directly mirror these old
 # config fields in the new resource config. Instead, we'll just use the old config fields
 # to construct the new config and then use that to construct the resource.
-@dagster_maintained_resource
 @resource(ADLS2_CLIENT_CONFIG)
 def adls2_resource(context):
     """Resource that gives ops access to Azure Data Lake Storage Gen2.
@@ -160,7 +153,6 @@ def adls2_resource(context):
     return _adls2_resource_from_config(context.resource_config)
 
 
-@dagster_maintained_resource
 @resource(
     merge_dicts(
         ADLS2_CLIENT_CONFIG,

--- a/python_modules/libraries/dagster-census/dagster_census/resources.py
+++ b/python_modules/libraries/dagster-census/dagster_census/resources.py
@@ -6,7 +6,6 @@ from typing import Any, Mapping, Optional
 
 import requests
 from dagster import Failure, Field, StringSource, __version__, get_dagster_logger, resource
-from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from requests.auth import HTTPBasicAuth
 from requests.exceptions import RequestException
 
@@ -239,7 +238,6 @@ class CensusResource:
         )
 
 
-@dagster_maintained_resource
 @resource(
     config_schema={
         "api_key": Field(

--- a/python_modules/libraries/dagster-dask/dagster_dask/resources.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/resources.py
@@ -1,5 +1,4 @@
 from dagster import Bool, Field, Int, Permissive, Selector, Shape, String, resource
-from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dask.distributed import Client
 
 DaskClusterTypes = {
@@ -66,7 +65,6 @@ class DaskResource:
         self._client, self._cluster = None, None
 
 
-@dagster_maintained_resource
 @resource(
     description="Dask Client resource.",
     config_schema=Shape(

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
@@ -15,7 +15,6 @@ from dagster import (
     _check as check,
     resource,
 )
-from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._core.definitions.step_launcher import StepLauncher
 from dagster._core.errors import raise_execution_interrupts
 from dagster._core.execution.plan.external_step import (
@@ -60,7 +59,6 @@ DAGSTER_SYSTEM_ENV_VARS = {
 }
 
 
-@dagster_maintained_resource
 @resource(
     {
         "run_config": define_databricks_submit_run_config(),

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/resources.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/resources.py
@@ -5,7 +5,6 @@ from dagster import (
     IAttachDifferentObjectToOpContext,
     resource,
 )
-from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from pydantic import Field
 
 from .databricks import DatabricksClient
@@ -27,11 +26,6 @@ class DatabricksClientResource(ConfigurableResource, IAttachDifferentObjectToOpC
         ),
     )
 
-    @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
-        return True
-
     def get_client(self) -> DatabricksClient:
         return DatabricksClient(
             host=self.host,
@@ -43,7 +37,6 @@ class DatabricksClientResource(ConfigurableResource, IAttachDifferentObjectToOpC
         return self.get_client()
 
 
-@dagster_maintained_resource
 @resource(config_schema=DatabricksClientResource.to_config_schema())
 def databricks_client(init_context) -> DatabricksClient:
     return DatabricksClientResource.from_resource_context(init_context).get_client()

--- a/python_modules/libraries/dagster-datadog/dagster_datadog/resources.py
+++ b/python_modules/libraries/dagster-datadog/dagster_datadog/resources.py
@@ -1,5 +1,4 @@
 from dagster import ConfigurableResource, resource
-from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from datadog import DogStatsd, initialize, statsd
 from pydantic import Field
 
@@ -86,16 +85,10 @@ class DatadogResource(ConfigurableResource):
         )
     )
 
-    @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
-        return True
-
     def get_client(self) -> DatadogClient:
         return DatadogClient(self.api_key, self.app_key)
 
 
-@dagster_maintained_resource
 @resource(
     config_schema=DatadogResource.to_config_schema(),
     description="This resource is for publishing to DataDog",

--- a/python_modules/libraries/dagster-datahub/dagster_datahub/resources.py
+++ b/python_modules/libraries/dagster-datahub/dagster_datahub/resources.py
@@ -2,7 +2,6 @@ from typing import Any, Dict, List, Optional
 
 from dagster import InitResourceContext, resource
 from dagster._config.pythonic_config import Config, ConfigurableResource
-from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from datahub.emitter.kafka_emitter import (
     DEFAULT_MCE_KAFKA_TOPIC,
     DEFAULT_MCP_KAFKA_TOPIC,
@@ -28,11 +27,6 @@ class DatahubRESTEmitterResource(ConfigurableResource):
     server_telemetry_id: Optional[str] = None
     disable_ssl_verification: bool = False
 
-    @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
-        return True
-
     def get_emitter(self) -> DatahubRestEmitter:
         return DatahubRestEmitter(
             gms_server=self.connection,
@@ -49,7 +43,6 @@ class DatahubRESTEmitterResource(ConfigurableResource):
         )
 
 
-@dagster_maintained_resource
 @resource(config_schema=DatahubRESTEmitterResource.to_config_schema())
 def datahub_rest_emitter(init_context: InitResourceContext) -> DatahubRestEmitter:
     emitter = DatahubRestEmitter(
@@ -88,18 +81,12 @@ class DatahubKafkaEmitterResource(ConfigurableResource):
         }
     )
 
-    @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
-        return True
-
     def get_emitter(self) -> DatahubKafkaEmitter:
         return DatahubKafkaEmitter(
             KafkaEmitterConfig.parse_obj(self._convert_to_config_dictionary())
         )
 
 
-@dagster_maintained_resource
 @resource(config_schema=DatahubKafkaEmitterResource.to_config_schema())
 def datahub_kafka_emitter(init_context: InitResourceContext) -> DatahubKafkaEmitter:
     return DatahubKafkaEmitter(KafkaEmitterConfig.parse_obj(init_context.resource_config))

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources.py
@@ -4,7 +4,6 @@ import dagster._check as check
 from dagster import resource
 from dagster._annotations import public
 from dagster._config.pythonic_config import ConfigurableResource, IAttachDifferentObjectToOpContext
-from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._utils.merger import merge_dicts
 from pydantic import Field
 
@@ -478,11 +477,6 @@ class DbtCliClientResource(ConfigurableResourceWithCliFlags, IAttachDifferentObj
     class Config:
         extra = "allow"
 
-    @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
-        return True
-
     def get_dbt_client(self) -> DbtCliClient:
         context = self.get_resource_context()
         default_flags = {
@@ -508,7 +502,6 @@ class DbtCliClientResource(ConfigurableResourceWithCliFlags, IAttachDifferentObj
         return self.get_dbt_client()
 
 
-@dagster_maintained_resource
 @resource(config_schema=DbtCliClientResource.to_config_schema())
 def dbt_cli_resource(context) -> DbtCliClient:
     """This resource issues dbt CLI commands against a configured dbt project."""

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/resources.py
@@ -17,7 +17,6 @@ from dagster import (
     get_dagster_logger,
     resource,
 )
-from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._utils.merger import deep_merge_dicts
 from pydantic import Field
 from requests.exceptions import RequestException
@@ -639,11 +638,6 @@ class DbtCloudClientResource(ConfigurableResource, IAttachDifferentObjectToOpCon
         ),
     )
 
-    @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
-        return True
-
     def get_dbt_client(self) -> DbtCloudClient:
         context = self.get_resource_context()
         assert context.log
@@ -662,7 +656,6 @@ class DbtCloudClientResource(ConfigurableResource, IAttachDifferentObjectToOpCon
         return self.get_dbt_client()
 
 
-@dagster_maintained_resource
 @resource(
     config_schema=DbtCloudClientResource.to_config_schema(),
     description="This resource helps interact with dbt Cloud connectors",

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/rpc/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/rpc/resources.py
@@ -18,10 +18,7 @@ from dagster import (
     _check as check,
     resource,
 )
-from dagster._core.definitions.resource_definition import (
-    ResourceDefinition,
-    dagster_maintained_resource,
-)
+from dagster._core.definitions.resource_definition import ResourceDefinition
 from dagster._core.utils import coerce_valid_log_level
 
 from ..dbt_resource import DbtResource
@@ -580,7 +577,6 @@ class DbtRpcSyncResource(DbtRpcResource):
         return out
 
 
-@dagster_maintained_resource
 @resource(
     description="A resource representing a dbt RPC client.",
     config_schema={
@@ -610,7 +606,6 @@ def dbt_rpc_resource(context) -> DbtRpcResource:
     )
 
 
-@dagster_maintained_resource
 @resource(
     description="A resource representing a synchronous dbt RPC client.",
     config_schema={

--- a/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas/duckdb_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas/duckdb_pandas_type_handler.py
@@ -191,11 +191,6 @@ class DuckDBPandasIOManager(DuckDBIOManager):
 
     """
 
-    @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
-        return True
-
     @staticmethod
     def type_handlers() -> Sequence[DbTypeHandler]:
         return [DuckDBPandasTypeHandler()]

--- a/python_modules/libraries/dagster-duckdb-polars/dagster_duckdb_polars/duckdb_polars_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-polars/dagster_duckdb_polars/duckdb_polars_type_handler.py
@@ -193,11 +193,6 @@ class DuckDBPolarsIOManager(DuckDBIOManager):
 
     """
 
-    @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
-        return True
-
     @staticmethod
     def type_handlers() -> Sequence[DbTypeHandler]:
         return [DuckDBPolarsTypeHandler()]

--- a/python_modules/libraries/dagster-duckdb-pyspark/dagster_duckdb_pyspark/duckdb_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pyspark/dagster_duckdb_pyspark/duckdb_pyspark_type_handler.py
@@ -200,11 +200,6 @@ class DuckDBPySparkIOManager(DuckDBIOManager):
 
     """
 
-    @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
-        return True
-
     @staticmethod
     def type_handlers() -> Sequence[DbTypeHandler]:
         return [DuckDBPySparkTypeHandler()]

--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
@@ -15,7 +15,6 @@ from dagster._core.storage.db_io_manager import (
     TablePartitionDimension,
     TableSlice,
 )
-from dagster._core.storage.io_manager import dagster_maintained_io_manager
 from dagster._utils.backoff import backoff
 from pydantic import Field
 
@@ -84,7 +83,6 @@ def build_duckdb_io_manager(
 
     """
 
-    @dagster_maintained_io_manager
     @io_manager(config_schema=DuckDBIOManager.to_config_schema())
     def duckdb_io_manager(init_context):
         """IO Manager for storing outputs in a DuckDB database.

--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb/resource.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb/resource.py
@@ -34,11 +34,6 @@ class DuckDBResource(ConfigurableResource):
         )
     )
 
-    @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
-        return True
-
     @contextmanager
     def get_connection(self):
         conn = backoff(

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
@@ -16,7 +16,6 @@ from dagster import (
     resource,
 )
 from dagster._config.pythonic_config import ConfigurableResource
-from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._utils.cached_method import cached_method
 from dateutil import parser
 from pydantic import Field
@@ -57,11 +56,6 @@ class FivetranResource(ConfigurableResource):
         default=0.25,
         description="Time (in seconds) to wait between each request retry.",
     )
-
-    @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
-        return True
 
     @property
     def _auth(self) -> HTTPBasicAuth:
@@ -397,7 +391,6 @@ class FivetranResource(ConfigurableResource):
         return FivetranOutput(connector_details=final_details, schema_config=schema_config)
 
 
-@dagster_maintained_resource
 @resource(config_schema=FivetranResource.to_config_schema())
 def fivetran_resource(context: InitResourceContext) -> FivetranResource:
     """This resource allows users to programatically interface with the Fivetran REST API to launch

--- a/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas/bigquery/bigquery_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas/bigquery/bigquery_pandas_type_handler.py
@@ -225,11 +225,6 @@ class BigQueryPandasIOManager(BigQueryIOManager):
 
     """
 
-    @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
-        return True
-
     @staticmethod
     def type_handlers() -> Sequence[DbTypeHandler]:
         return [BigQueryPandasTypeHandler()]

--- a/python_modules/libraries/dagster-gcp-pyspark/dagster_gcp_pyspark/bigquery/bigquery_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-gcp-pyspark/dagster_gcp_pyspark/bigquery/bigquery_pyspark_type_handler.py
@@ -232,11 +232,6 @@ class BigQueryPySparkIOManager(BigQueryIOManager):
 
     """
 
-    @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
-        return True
-
     @staticmethod
     def type_handlers() -> Sequence[DbTypeHandler]:
         return [BigQueryPySparkTypeHandler()]

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/io_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/io_manager.py
@@ -15,7 +15,6 @@ from dagster._core.storage.db_io_manager import (
     TableSlice,
     TimeWindow,
 )
-from dagster._core.storage.io_manager import dagster_maintained_io_manager
 from google.api_core.exceptions import NotFound
 from google.cloud import bigquery
 from pydantic import Field
@@ -102,7 +101,6 @@ def build_bigquery_io_manager(
         the base64 encoded with this shell command: cat $GOOGLE_APPLICATION_CREDENTIALS | base64
     """
 
-    @dagster_maintained_io_manager
     @io_manager(config_schema=BigQueryIOManager.to_config_schema())
     def bigquery_io_manager(init_context):
         """I/O Manager for storing outputs in a BigQuery database.

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/resources.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/resources.py
@@ -2,7 +2,6 @@ from contextlib import contextmanager
 from typing import Any, Iterator, Optional
 
 from dagster import ConfigurableResource, IAttachDifferentObjectToOpContext, resource
-from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from google.cloud import bigquery
 from pydantic import Field
 
@@ -56,11 +55,6 @@ class BigQueryResource(ConfigurableResource, IAttachDifferentObjectToOpContext):
         ),
     )
 
-    @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
-        return True
-
     @contextmanager
     def get_client(self) -> Iterator[bigquery.Client]:
         """Context manager to create a BigQuery Client.
@@ -88,7 +82,6 @@ class BigQueryResource(ConfigurableResource, IAttachDifferentObjectToOpContext):
             yield client
 
 
-@dagster_maintained_resource
 @resource(
     config_schema=BigQueryResource.to_config_schema(),
     description="Dagster resource for connecting to BigQuery",

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/dataproc/resources.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/dataproc/resources.py
@@ -6,7 +6,6 @@ from typing import Any, Dict, Mapping, Optional
 import dagster._check as check
 import yaml
 from dagster import ConfigurableResource, IAttachDifferentObjectToOpContext, resource
-from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from googleapiclient.discovery import build
 from oauth2client.client import GoogleCredentials
 from pydantic import Field
@@ -199,11 +198,6 @@ class DataprocResource(ConfigurableResource, IAttachDifferentObjectToOpContext):
         ),
     )
 
-    @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
-        return True
-
     def _read_yaml_config(self, path: str) -> Mapping[str, Any]:
         with open(path, "r", encoding="utf8") as f:
             return yaml.safe_load(f)
@@ -254,7 +248,6 @@ class DataprocResource(ConfigurableResource, IAttachDifferentObjectToOpContext):
         return self.get_client()
 
 
-@dagster_maintained_resource
 @resource(
     config_schema=define_dataproc_create_cluster_config(),
     description="Manage a Dataproc cluster resource",

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/io_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/io_manager.py
@@ -9,7 +9,6 @@ from dagster import (
     _check as check,
     io_manager,
 )
-from dagster._core.storage.io_manager import dagster_maintained_io_manager
 from dagster._core.storage.upath_io_manager import UPathIOManager
 from dagster._utils import PICKLE_PROTOCOL
 from dagster._utils.backoff import backoff
@@ -146,11 +145,6 @@ class ConfigurablePickledObjectGCSIOManager(ConfigurableIOManager):
     gcs_bucket: str = Field(description="GCS bucket to store files")
     gcs_prefix: str = Field(default="dagster", description="Prefix to add to all file paths")
 
-    @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
-        return True
-
     @property
     @cached_method
     def _internal_io_manager(self) -> PickledObjectGCSIOManager:
@@ -165,7 +159,6 @@ class ConfigurablePickledObjectGCSIOManager(ConfigurableIOManager):
         self._internal_io_manager.handle_output(context, obj)
 
 
-@dagster_maintained_io_manager
 @io_manager(
     config_schema=ConfigurablePickledObjectGCSIOManager.to_config_schema(),
     required_resource_keys={"gcs"},

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/resources.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/resources.py
@@ -1,7 +1,6 @@
 from typing import Any, Optional
 
 from dagster import ConfigurableResource, IAttachDifferentObjectToOpContext, resource
-from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from google.cloud import storage
 from pydantic import Field
 
@@ -18,7 +17,6 @@ class GCSResource(ConfigurableResource, IAttachDifferentObjectToOpContext):
         return self.get_client()
 
 
-@dagster_maintained_resource
 @resource(
     config_schema=GCSResource.to_config_schema(),
     description="This resource provides a GCS client",
@@ -44,7 +42,6 @@ class GCSFileManagerResource(ConfigurableResource, IAttachDifferentObjectToOpCon
         return self.get_client()
 
 
-@dagster_maintained_resource
 @resource(config_schema=GCSFileManagerResource.to_config_schema())
 def gcs_file_manager(context):
     """FileManager that provides abstract access to GCS.

--- a/python_modules/libraries/dagster-ge/dagster_ge/factory.py
+++ b/python_modules/libraries/dagster-ge/dagster_ge/factory.py
@@ -15,7 +15,6 @@ from dagster import (
     op,
     resource,
 )
-from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster_pandas import DataFrame
 from great_expectations.render.renderer import ValidationResultsPageRenderer
 from great_expectations.render.view import DefaultMarkdownPageView
@@ -44,7 +43,6 @@ class GEContextResource(ConfigurableResource, IAttachDifferentObjectToOpContext)
         return self.get_data_context()
 
 
-@dagster_maintained_resource
 @resource(config_schema=GEContextResource.to_config_schema())
 def ge_data_context(context):
     return GEContextResource.from_resource_context(context).get_data_context()

--- a/python_modules/libraries/dagster-github/dagster_github/resources.py
+++ b/python_modules/libraries/dagster-github/dagster_github/resources.py
@@ -5,7 +5,6 @@ from typing import Optional
 import jwt
 import requests
 from dagster import ConfigurableResource, resource
-from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from pydantic import Field
 
 
@@ -181,11 +180,6 @@ class GithubResource(ConfigurableResource):
         ),
     )
 
-    @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
-        return True
-
     def get_client(self) -> GithubClient:
         return GithubClient(
             client=requests.Session(),
@@ -196,7 +190,6 @@ class GithubResource(ConfigurableResource):
         )
 
 
-@dagster_maintained_resource
 @resource(
     config_schema=GithubResource.to_config_schema(),
     description="This resource is for connecting to Github",

--- a/python_modules/libraries/dagster-mlflow/dagster_mlflow/resources.py
+++ b/python_modules/libraries/dagster-mlflow/dagster_mlflow/resources.py
@@ -10,7 +10,6 @@ from typing import Any, Optional
 
 import mlflow
 from dagster import Field, Noneable, Permissive, StringSource, resource
-from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from mlflow.entities.run_status import RunStatus
 
 CONFIG_SCHEMA = {
@@ -219,7 +218,6 @@ class MlFlow(metaclass=MlflowMeta):
             yield {k: params[k] for k in islice(it, size)}
 
 
-@dagster_maintained_resource
 @resource(config_schema=CONFIG_SCHEMA)
 def mlflow_tracking(context):
     """This resource initializes an MLflow run that's used for all steps within a Dagster run.

--- a/python_modules/libraries/dagster-msteams/dagster_msteams/resources.py
+++ b/python_modules/libraries/dagster-msteams/dagster_msteams/resources.py
@@ -1,5 +1,4 @@
 from dagster import ConfigurableResource, resource
-from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from pydantic import Field
 
 from dagster_msteams.client import TeamsClient
@@ -61,11 +60,6 @@ class MSTeamsResource(ConfigurableResource):
         default=True, description="Whether to verify SSL certificates, defaults to True"
     )
 
-    @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
-        return True
-
     def get_client(self) -> TeamsClient:
         return TeamsClient(
             hook_url=self.hook_url,
@@ -76,7 +70,6 @@ class MSTeamsResource(ConfigurableResource):
         )
 
 
-@dagster_maintained_resource
 @resource(
     config_schema=MSTeamsResource.to_config_schema(),
     description="This resource is for connecting to MS Teams",

--- a/python_modules/libraries/dagster-pagerduty/dagster_pagerduty/resources.py
+++ b/python_modules/libraries/dagster-pagerduty/dagster_pagerduty/resources.py
@@ -4,7 +4,6 @@ import pypd
 from dagster import ConfigurableResource, resource
 from dagster._annotations import quiet_experimental_warnings
 from dagster._config.pythonic_config import infer_schema_from_config_class
-from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from pydantic import Field as PyField
 
 
@@ -30,11 +29,6 @@ class PagerDutyService(ConfigurableResource):
             "routing_key in the event payload."
         ),
     )
-
-    @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
-        return True
 
     def EventV2_create(
         self,
@@ -166,7 +160,6 @@ class PagerDutyService(ConfigurableResource):
         return pypd.EventV2.create(data=data)
 
 
-@dagster_maintained_resource
 @resource(
     config_schema=infer_schema_from_config_class(PagerDutyService),
     description="""This resource is for posting events to PagerDuty.""",

--- a/python_modules/libraries/dagster-prometheus/dagster_prometheus/resources.py
+++ b/python_modules/libraries/dagster-prometheus/dagster_prometheus/resources.py
@@ -3,7 +3,6 @@ from dagster import (
     ConfigurableResource,
     resource,
 )
-from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._core.execution.context.init import InitResourceContext
 from prometheus_client.exposition import default_handler
 from pydantic import Field, PrivateAttr
@@ -50,11 +49,6 @@ class PrometheusResource(ConfigurableResource):
         description="is how long delete will attempt to connect before giving up. Defaults to 30s.",
     )
     _registry: prometheus_client.CollectorRegistry = PrivateAttr(default=None)
-
-    @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
-        return True
 
     def setup_for_execution(self, context: InitResourceContext) -> None:
         self._registry = prometheus_client.CollectorRegistry()
@@ -151,7 +145,6 @@ class PrometheusResource(ConfigurableResource):
         )
 
 
-@dagster_maintained_resource
 @resource(
     config_schema=PrometheusResource.to_config_schema(),
     description="""This resource is for sending metrics to a Prometheus Pushgateway.""",

--- a/python_modules/libraries/dagster-pyspark/dagster_pyspark/resources.py
+++ b/python_modules/libraries/dagster-pyspark/dagster_pyspark/resources.py
@@ -2,7 +2,6 @@ from typing import Any, Dict
 
 import dagster._check as check
 from dagster import ConfigurableResource, resource
-from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._core.execution.context.init import InitResourceContext
 from dagster_spark.configs_spark import spark_config
 from dagster_spark.utils import flatten_dict
@@ -48,11 +47,6 @@ class PySparkResource(ConfigurableResource):
     spark_config: Dict[str, Any]
     _spark_session = PrivateAttr(default=None)
 
-    @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
-        return True
-
     def setup_for_execution(self, context: InitResourceContext) -> None:
         self._spark_session = spark_session_from_config(self.spark_config)
 
@@ -65,7 +59,6 @@ class PySparkResource(ConfigurableResource):
         return self.spark_session.sparkContext
 
 
-@dagster_maintained_resource
 @resource({"spark_conf": spark_config()})
 def pyspark_resource(init_context) -> PySparkResource:
     """This resource provides access to a PySpark SparkSession for executing PySpark code within Dagster.
@@ -122,11 +115,6 @@ class LazyPySparkResource(ConfigurableResource):
     spark_config: Dict[str, Any]
     _spark_session = PrivateAttr(default=None)
 
-    @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
-        return True
-
     def _init_session(self) -> None:
         if self._spark_session is None:
             self._spark_session = spark_session_from_config(self.spark_config)
@@ -142,7 +130,6 @@ class LazyPySparkResource(ConfigurableResource):
         return self._spark_session.sparkContext
 
 
-@dagster_maintained_resource
 @resource({"spark_conf": spark_config()})
 def lazy_pyspark_resource(init_context: InitResourceContext) -> LazyPySparkResource:
     """This resource provides access to a lazily-created  PySpark SparkSession for executing PySpark

--- a/python_modules/libraries/dagster-slack/dagster_slack/resources.py
+++ b/python_modules/libraries/dagster-slack/dagster_slack/resources.py
@@ -1,5 +1,4 @@
 from dagster import ConfigurableResource, resource
-from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from pydantic import Field
 from slack_sdk.web.client import WebClient
 
@@ -44,17 +43,11 @@ class SlackResource(ConfigurableResource):
         ),
     )
 
-    @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
-        return True
-
     def get_client(self) -> WebClient:
         """Returns a ``slack_sdk.WebClient`` for interacting with the Slack API."""
         return WebClient(self.token)
 
 
-@dagster_maintained_resource
 @resource(
     config_schema=SlackResource.to_config_schema(),
 )

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
@@ -291,11 +291,6 @@ class SnowflakePandasIOManager(SnowflakeIOManager):
 
     """
 
-    @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
-        return True
-
     @staticmethod
     def type_handlers() -> Sequence[DbTypeHandler]:
         return [SnowflakePandasTypeHandler()]

--- a/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark/snowflake_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark/snowflake_pyspark_type_handler.py
@@ -236,11 +236,6 @@ class SnowflakePySparkIOManager(SnowflakeIOManager):
 
     """
 
-    @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
-        return True
-
     @staticmethod
     def type_handlers() -> Sequence[DbTypeHandler]:
         return [SnowflakePySparkTypeHandler()]

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
@@ -14,7 +14,6 @@ from dagster import (
     resource,
 )
 from dagster._annotations import public
-from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._core.storage.event_log.sql_event_log import SqlDbConnection
 from dagster._utils.cached_method import cached_method
 from pydantic import Field, root_validator, validator
@@ -287,11 +286,6 @@ class SnowflakeResource(ConfigurableResource, IAttachDifferentObjectToOpContext)
         )
 
         return values
-
-    @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
-        return True
 
     @property
     @cached_method
@@ -649,7 +643,6 @@ class SnowflakeConnection:
         self.execute_queries(sql_queries)
 
 
-@dagster_maintained_resource
 @resource(
     config_schema=SnowflakeResource.to_config_schema(),
     description="This resource is for connecting to the Snowflake data warehouse",

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
@@ -14,7 +14,6 @@ from dagster._core.storage.db_io_manager import (
     TablePartitionDimension,
     TableSlice,
 )
-from dagster._core.storage.io_manager import dagster_maintained_io_manager
 from pydantic import Field
 from sqlalchemy.exc import ProgrammingError
 
@@ -92,7 +91,6 @@ def build_snowflake_io_manager(
 
     """
 
-    @dagster_maintained_io_manager
     @io_manager(config_schema=SnowflakeIOManager.to_config_schema())
     def snowflake_io_manager(init_context):
         return DbIOManager(

--- a/python_modules/libraries/dagster-spark/dagster_spark/resources.py
+++ b/python_modules/libraries/dagster-spark/dagster_spark/resources.py
@@ -3,7 +3,6 @@ import subprocess
 
 import dagster._check as check
 from dagster import resource
-from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._core.log_manager import DagsterLogManager
 
 from .types import SparkOpError
@@ -61,7 +60,6 @@ class SparkResource:
             raise SparkOpError("Spark job failed. Please consult your logs.")
 
 
-@dagster_maintained_resource
 @resource
 def spark_resource(context):
     return SparkResource(context.log)

--- a/python_modules/libraries/dagster-ssh/dagster_ssh/resources.py
+++ b/python_modules/libraries/dagster-ssh/dagster_ssh/resources.py
@@ -11,7 +11,6 @@ from dagster import (
     _check as check,
     resource,
 )
-from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._utils import mkdir_p
 from dagster._utils.merger import merge_dicts
 from paramiko.config import SSH_PORT
@@ -213,7 +212,6 @@ class SSHResource:
         return local_filepath
 
 
-@dagster_maintained_resource
 @resource(
     config_schema={
         "remote_host": Field(

--- a/python_modules/libraries/dagster-twilio/dagster_twilio/resources.py
+++ b/python_modules/libraries/dagster-twilio/dagster_twilio/resources.py
@@ -1,5 +1,4 @@
 from dagster import ConfigurableResource, resource
-from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._core.execution.context.init import InitResourceContext
 from pydantic import Field
 from twilio.rest import Client
@@ -22,16 +21,10 @@ class TwilioResource(ConfigurableResource):
         ),
     )
 
-    @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
-        return True
-
     def create_client(self) -> Client:
         return Client(self.account_sid, self.auth_token)
 
 
-@dagster_maintained_resource
 @resource(
     config_schema=TwilioResource.to_config_schema(),
     description="This resource is for connecting to Twilio",

--- a/python_modules/libraries/dagster-wandb/dagster_wandb/io_manager.py
+++ b/python_modules/libraries/dagster-wandb/dagster_wandb/io_manager.py
@@ -19,7 +19,6 @@ from dagster import (
     String,
     io_manager,
 )
-from dagster._core.storage.io_manager import dagster_maintained_io_manager
 from wandb.sdk.data_types.base_types.wb_value import WBValue
 from wandb.sdk.wandb_artifacts import Artifact
 
@@ -581,7 +580,6 @@ class ArtifactsIOManager(IOManager):
             raise WandbArtifactsIOManagerError() from exception
 
 
-@dagster_maintained_io_manager
 @io_manager(
     required_resource_keys={"wandb_resource", "wandb_config"},
     description="IO manager to read and write W&B Artifacts",

--- a/python_modules/libraries/dagster-wandb/dagster_wandb/resources.py
+++ b/python_modules/libraries/dagster-wandb/dagster_wandb/resources.py
@@ -2,13 +2,11 @@ from typing import Any, Dict
 
 import wandb
 from dagster import Field, InitResourceContext, String, StringSource, resource
-from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from wandb.sdk.internal.internal_api import Api
 
 WANDB_CLOUD_HOST: str = "https://api.wandb.ai"
 
 
-@dagster_maintained_resource
 @resource(
     config_schema={
         "api_key": Field(

--- a/python_modules/libraries/dagstermill/dagstermill/io_managers.py
+++ b/python_modules/libraries/dagstermill/dagstermill/io_managers.py
@@ -13,7 +13,7 @@ from dagster import (
 from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.execution.context.input import InputContext
 from dagster._core.execution.context.output import OutputContext
-from dagster._core.storage.io_manager import dagster_maintained_io_manager, io_manager
+from dagster._core.storage.io_manager import io_manager
 from dagster._utils import mkdir_p
 from pydantic import Field
 
@@ -100,11 +100,6 @@ class ConfigurableLocalOutputNotebookIOManager(ConfigurableIOManagerFactory):
         ),
     )
 
-    @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
-        return True
-
     def create_io_manager(self, context: InitResourceContext) -> "LocalOutputNotebookIOManager":
         return LocalOutputNotebookIOManager(
             base_dir=self.base_dir or check.not_none(context.instance).storage_directory(),
@@ -112,7 +107,6 @@ class ConfigurableLocalOutputNotebookIOManager(ConfigurableIOManagerFactory):
         )
 
 
-@dagster_maintained_io_manager
 @io_manager(config_schema=ConfigurableLocalOutputNotebookIOManager.to_config_schema())
 def local_output_notebook_io_manager(init_context) -> LocalOutputNotebookIOManager:
     """Built-in IO Manager that handles output notebooks."""


### PR DESCRIPTION
Reverts dagster-io/dagster#14025

Tests are breaking on Python 3.7 and 3.8 (which we don't explicitly test on the branch - only on main).

I'm reverting for now to get builds passing again.