### PR TITLE
Add server_ecs_tags and run_ecs_tags to EcsContainerContext

### DIFF
--- a/docs/content/dagster-cloud/deployment/agents/amazon-ecs/configuration-reference.mdx
+++ b/docs/content/dagster-cloud/deployment/agents/amazon-ecs/configuration-reference.mdx
@@ -67,6 +67,11 @@ locations:
             environment:
               - name: ECS_FARGATE
                 value: true
+        server_ecs_tags:
+          - key: MyEcsTagKey
+            value: MyEcsTagValue
+        run_ecs_tags:
+          - key: MyEcsTagKeyWithoutValue
 ```
 
 ### Environment variables and secrets
@@ -158,7 +163,12 @@ user_code_launcher:
     mount_points:
       - <List of mountPoints to pass into register_task_definition>
     volumes:
-      - <List of volumes to pass into register_tastk_definition>
+      - <List of volumes to pass into register_task_definition>
+    server_ecs_tags:
+      - key: MyEcsTagKey
+        value: MyEcsTagValue
+    run_ecs_tags:
+      - key: MyEcsTagKeyWithoutValue
 ```
 
 ### dagster_cloud_api properties
@@ -277,5 +287,13 @@ user_code_launcher:
   <ReferenceTableItem
   propertyName="config.volumes">
   Additional volumes to include in the task definition. If set, should be a list of dictionaries matching the volumes argument to <code>register_task_definition</code> in boto3.
+  </ReferenceTableItem>
+  <ReferenceTableItem
+  propertyName="config.server_ecs_tags">
+  Additional ECS tags to include in the service for each code location. If set, must be a list of dictionaries, each with a <code>key</code> key and optional <code>value> key.
+  </ReferenceTableItem>
+  <ReferenceTableItem
+  propertyName="config.run_ecs_tags">
+  Additional ECS tags to include in the task for each run. If set, must be a list of dictionaries, each with a <code>key</code> key and optional <code>value> key.
   </ReferenceTableItem>
 </ReferenceTable>

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/container_context.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/container_context.py
@@ -53,6 +53,16 @@ SHARED_ECS_SCHEMA = {
             }
         )
     ),
+    "run_ecs_tags": Field(
+        Array(
+            {
+                "key": Field(StringSource, is_required=True),
+                "value": Field(StringSource, is_required=False),
+            }
+        ),
+        is_required=False,
+        description="Additional tags to apply to the launched ECS task.",
+    ),
 }
 
 SHARED_TASK_DEFINITION_FIELDS = {
@@ -175,6 +185,16 @@ ECS_CONTAINER_CONTEXT_SCHEMA = {
         is_required=False,
         description="Additional sidecar containers to include in code server task definitions.",
     ),
+    "server_ecs_tags": Field(
+        Array(
+            {
+                "key": Field(StringSource, is_required=True),
+                "value": Field(StringSource, is_required=False),
+            }
+        ),
+        is_required=False,
+        description="Additional tags to apply to the launched ECS task for a code server.",
+    ),
     "run_sidecar_containers": Field(
         Array(Permissive({})),
         is_required=False,
@@ -203,6 +223,8 @@ class EcsContainerContext(
             ("volumes", Sequence[Mapping[str, Any]]),
             ("server_sidecar_containers", Sequence[Mapping[str, Any]]),
             ("run_sidecar_containers", Sequence[Mapping[str, Any]]),
+            ("server_ecs_tags", Sequence[Mapping[str, Optional[str]]]),
+            ("run_ecs_tags", Sequence[Mapping[str, Optional[str]]]),
         ],
     )
 ):
@@ -224,6 +246,8 @@ class EcsContainerContext(
         volumes: Optional[Sequence[Mapping[str, Any]]] = None,
         server_sidecar_containers: Optional[Sequence[Mapping[str, Any]]] = None,
         run_sidecar_containers: Optional[Sequence[Mapping[str, Any]]] = None,
+        server_ecs_tags: Optional[Sequence[Mapping[str, Optional[str]]]] = None,
+        run_ecs_tags: Optional[Sequence[Mapping[str, Optional[str]]]] = None,
     ):
         return super(EcsContainerContext, cls).__new__(
             cls,
@@ -247,6 +271,8 @@ class EcsContainerContext(
             run_sidecar_containers=check.opt_sequence_param(
                 run_sidecar_containers, "run_sidecar_containers"
             ),
+            server_ecs_tags=check.opt_sequence_param(server_ecs_tags, "server_ecs_tags"),
+            run_ecs_tags=check.opt_sequence_param(run_ecs_tags, "run_tags"),
         )
 
     def merge(self, other: "EcsContainerContext") -> "EcsContainerContext":
@@ -268,6 +294,8 @@ class EcsContainerContext(
                 *self.server_sidecar_containers,
             ],
             run_sidecar_containers=[*other.run_sidecar_containers, *self.run_sidecar_containers],
+            server_ecs_tags=[*other.server_ecs_tags, *self.server_ecs_tags],
+            run_ecs_tags=[*other.run_ecs_tags, *self.run_ecs_tags],
         )
 
     def get_secrets_dict(self, secrets_manager) -> Mapping[str, str]:
@@ -297,6 +325,7 @@ class EcsContainerContext(
                     mount_points=run_launcher.mount_points,
                     volumes=run_launcher.volumes,
                     run_sidecar_containers=run_launcher.run_sidecar_containers,
+                    run_ecs_tags=run_launcher.run_ecs_tags,
                 )
             )
 
@@ -356,5 +385,7 @@ class EcsContainerContext(
                 volumes=processed_context_value.get("volumes"),
                 server_sidecar_containers=processed_context_value.get("server_sidecar_containers"),
                 run_sidecar_containers=processed_context_value.get("run_sidecar_containers"),
+                server_ecs_tags=processed_context_value.get("server_ecs_tags"),
+                run_ecs_tags=processed_context_value.get("run_ecs_tags"),
             )
         )

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -336,6 +336,9 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
         self._instance.add_run_tags(run_id, tags)
 
     def build_ecs_tags_for_run_task(self, run, container_context: EcsContainerContext):
+        if any(tag["key"] == "dagster/run_id" for tag in container_context.run_ecs_tags):
+            raise Exception("Cannot override system ECS tag: dagster/run_id")
+
         return [{"key": "dagster/run_id", "value": run.run_id}, *container_context.run_ecs_tags]
 
     def _get_run_tags(self, run_id):

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/conftest.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/conftest.py
@@ -158,7 +158,14 @@ def instance_cm(stub_aws, stub_ecs_metadata) -> Callable[..., ContextManager[Dag
 def instance(
     instance_cm: Callable[..., ContextManager[DagsterInstance]]
 ) -> Iterator[DagsterInstance]:
-    with instance_cm() as dagster_instance:
+    with instance_cm(
+        {
+            "run_ecs_tags": [
+                {"key": "HAS_VALUE", "value": "SEE"},
+                {"key": "DOES_NOT_HAVE_VALUE"},
+            ]
+        }
+    ) as dagster_instance:
         yield dagster_instance
 
 
@@ -465,6 +472,12 @@ def container_context_config(configured_secret: Secret) -> Mapping[str, Any]:
                     "image": "busybox:latest",
                 }
             ],
+            "server_ecs_tags": [
+                {
+                    "key": "FOO",  # no value
+                }
+            ],
+            "run_ecs_tags": [{"key": "ABC", "value": "DEF"}],  # with value
         },
     }
 
@@ -518,6 +531,12 @@ def other_container_context_config(other_configured_secret):
                 {
                     "name": "OtherRunAgent",
                     "image": "otherrun:latest",
+                }
+            ],
+            "server_ecs_tags": [{"key": "BAZ", "value": "QUUX"}],
+            "run_ecs_tags": [
+                {
+                    "key": "GHI",
                 }
             ],
         },

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_container_context.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_container_context.py
@@ -89,6 +89,14 @@ def test_merge(
         "ephemeral_storage": 25,
     }
 
+    assert merged.server_ecs_tags == [
+        {"key": "BAZ", "value": "QUUX"},
+        {
+            "key": "FOO",  # no value
+        },
+    ]
+    assert merged.run_ecs_tags == [{"key": "GHI"}, {"key": "ABC", "value": "DEF"}]
+
     assert merged.task_role_arn == "other-task-role"
     assert merged.execution_role_arn == "other-fake-execution-role"
 

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
@@ -920,6 +920,12 @@ def test_launch_run_with_container_context(
     task_arn = list(set(tasks).difference(existing_tasks))[0]
     task = ecs.describe_tasks(tasks=[task_arn])["tasks"][0]
 
+    assert any(tag == {"key": "HAS_VALUE", "value": "SEE"} for tag in task["tags"])
+    assert any(tag == {"key": "DOES_NOT_HAVE_VALUE"} for tag in task["tags"])
+    assert any(
+        tag == {"key": "ABC", "value": "DEF"} for tag in task["tags"]
+    )  # from container context
+
     assert (
         task.get("overrides").get("memory")
         == container_context_config["ecs"]["run_resources"]["memory"]

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
@@ -906,6 +906,21 @@ def test_launcher_run_resources(
     assert task.get("overrides").get("cpu") == "1024"
 
 
+def test_launch_cannot_use_system_tags(instance_cm, workspace, job, external_job):
+    with instance_cm(
+        {
+            "run_ecs_tags": [{"key": "dagster/run_id", "value": "NOPE"}],
+        }
+    ) as instance:
+        run = instance.create_run_for_job(
+            job,
+            external_job_origin=external_job.get_external_origin(),
+            job_code_origin=external_job.get_python_origin(),
+        )
+        with pytest.raises(Exception, match="Cannot override system ECS tag: dagster/run_id"):
+            instance.launch_run(run.run_id, workspace)
+
+
 def test_launch_run_with_container_context(
     ecs,
     instance,

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/stubbed_ecs.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/stubbed_ecs.py
@@ -424,6 +424,9 @@ class StubbedEcs:
                         "capacityProvider"
                     ]
 
+                if tags:
+                    task["tags"] = tags
+
                 if vpc_configuration:
                     for subnet_name in vpc_configuration["subnets"]:
                         ec2 = boto3.resource("ec2", region_name=self.client.meta.region_name)


### PR DESCRIPTION
Summary:
This PR has two purposes:
- add the ability to set ECS tags on both runs and code servers
- document the general process of adding additional fields to EcsContainerContext so that they can be configured per code location in OSS and cloud.

I'll add comments in the PR that walk through what the various things do and answer any questions, so that while I am out hopefully the process of adding these is distributed across the team.

## Summary & Motivation

## How I Tested These Changes
