### PR TITLE
Telemetry for resources and io managers

### DIFF
--- a/examples/project_fully_featured/project_fully_featured/resources/__init__.py
+++ b/examples/project_fully_featured/project_fully_featured/resources/__init__.py
@@ -4,11 +4,7 @@ from dagster._utils import file_relative_path
 from dagster_aws.s3 import S3Resource
 from dagster_aws.s3.io_manager import ConfigurablePickledObjectS3IOManager
 from dagster_dbt import DbtCliClientResource
-from dagster_gcp import bigquery_resource, BigQueryResource
 from dagster_pyspark import pyspark_resource
-from dagster_snowflake import SnowflakeResource, snowflake_resource
-from dagster_snowflake_pandas import SnowflakePandasIOManager, snowflake_pandas_io_manager
-from dagster_duckdb_pandas import duckdb_pandas_io_manager, DuckDBPandasIOManager
 
 from .duckdb_parquet_io_manager import DuckDBPartitionedParquetIOManager
 from .hn_resource import HNAPIClient, HNAPISubsampleClient
@@ -98,20 +94,4 @@ RESOURCES_LOCAL = {
     ),
     "hn_client": HNAPIClient(),
     "dbt": dbt_local_resource,
-    "old_style_io": snowflake_pandas_io_manager,
-    "old_style_resource": snowflake_resource,
-    "old_style_resource_configured": bigquery_resource.configured({"project": "bar"}),
-    "old_style_io_configured": duckdb_pandas_io_manager.configured({"database": "bar"}),
-    "new_style_io_configured": SnowflakePandasIOManager(
-        database="foo", account="foo", password="foo", user="foo"
-    ),
-    "new_style_resource_configured": SnowflakeResource(
-        database="foo", account="foo", password="foo", user="foo"
-    ),
-    "new_style_io": DuckDBPandasIOManager.configure_at_launch(),
-    "new_style_resource": BigQueryResource.configure_at_launch(),
-    "custom_configure_at_launch": DuckDBPartitionedParquetIOManager.configure_at_launch(),
-    "duplicate_resource": SnowflakeResource(
-        database="foo", account="foo", password="foo", user="foo"
-    ),
 }

--- a/examples/project_fully_featured/project_fully_featured/resources/__init__.py
+++ b/examples/project_fully_featured/project_fully_featured/resources/__init__.py
@@ -14,8 +14,6 @@ from .parquet_io_manager import (
 )
 from .snowflake_io_manager import SnowflakeIOManager
 
-
-
 DBT_PROJECT_DIR = file_relative_path(__file__, "../../dbt_project")
 DBT_PROFILES_DIR = DBT_PROJECT_DIR + "/config"
 dbt_local_resource = DbtCliClientResource(

--- a/examples/project_fully_featured/project_fully_featured/resources/__init__.py
+++ b/examples/project_fully_featured/project_fully_featured/resources/__init__.py
@@ -14,6 +14,8 @@ from .parquet_io_manager import (
 )
 from .snowflake_io_manager import SnowflakeIOManager
 
+
+
 DBT_PROJECT_DIR = file_relative_path(__file__, "../../dbt_project")
 DBT_PROFILES_DIR = DBT_PROJECT_DIR + "/config"
 dbt_local_resource = DbtCliClientResource(

--- a/examples/project_fully_featured/project_fully_featured/resources/__init__.py
+++ b/examples/project_fully_featured/project_fully_featured/resources/__init__.py
@@ -4,7 +4,11 @@ from dagster._utils import file_relative_path
 from dagster_aws.s3 import S3Resource
 from dagster_aws.s3.io_manager import ConfigurablePickledObjectS3IOManager
 from dagster_dbt import DbtCliClientResource
+from dagster_gcp import bigquery_resource, BigQueryResource
 from dagster_pyspark import pyspark_resource
+from dagster_snowflake import SnowflakeResource, snowflake_resource
+from dagster_snowflake_pandas import SnowflakePandasIOManager, snowflake_pandas_io_manager
+from dagster_duckdb_pandas import duckdb_pandas_io_manager, DuckDBPandasIOManager
 
 from .duckdb_parquet_io_manager import DuckDBPartitionedParquetIOManager
 from .hn_resource import HNAPIClient, HNAPISubsampleClient
@@ -94,4 +98,20 @@ RESOURCES_LOCAL = {
     ),
     "hn_client": HNAPIClient(),
     "dbt": dbt_local_resource,
+    "old_style_io": snowflake_pandas_io_manager,
+    "old_style_resource": snowflake_resource,
+    "old_style_resource_configured": bigquery_resource.configured({"project": "bar"}),
+    "old_style_io_configured": duckdb_pandas_io_manager.configured({"database": "bar"}),
+    "new_style_io_configured": SnowflakePandasIOManager(
+        database="foo", account="foo", password="foo", user="foo"
+    ),
+    "new_style_resource_configured": SnowflakeResource(
+        database="foo", account="foo", password="foo", user="foo"
+    ),
+    "new_style_io": DuckDBPandasIOManager.configure_at_launch(),
+    "new_style_resource": BigQueryResource.configure_at_launch(),
+    "custom_configure_at_launch": DuckDBPartitionedParquetIOManager.configure_at_launch(),
+    "duplicate_resource": SnowflakeResource(
+        database="foo", account="foo", password="foo", user="foo"
+    ),
 }

--- a/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
@@ -647,6 +647,9 @@ class ConfigurableResourceFactoryResourceDefinition(ResourceDefinition, AllowDel
     ) -> AbstractSet[str]:
         return self._resolve_resource_keys(resource_mapping)
 
+    def _is_dagster_maintained(self) -> bool:
+        return self._dagster_maintained
+
 
 class ConfigurableIOManagerFactoryResourceDefinition(IOManagerDefinition, AllowDelayedDependencies):
     def __init__(
@@ -815,9 +818,8 @@ class ConfigurableResourceFactory(
         return self._state__internal__.resolved_config_dict
 
     @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
-        """This property should be overridden to return True by all dagster maintained resources and IO managers.
+    def _is_dagster_maintained(cls) -> bool:
+        """This should be overridden to return True by all dagster maintained resources and IO managers.
         """
         return False
 
@@ -844,7 +846,7 @@ class ConfigurableResourceFactory(
             description=self.__doc__,
             resolve_resource_keys=self._resolve_required_resource_keys,
             nested_resources=self.nested_resources,
-            dagster_maintained=self._dagster_maintained,
+            dagster_maintained=self._is_dagster_maintained(),
         )
 
     @abstractmethod
@@ -1173,7 +1175,7 @@ class PartialResource(Generic[TResValue], AllowDelayedDependencies, MakeConfigCa
             description=self._state__internal__.description,
             resolve_resource_keys=self._resolve_required_resource_keys,
             nested_resources=self.nested_resources,
-            dagster_maintained=self.resource_cls._dagster_maintained,  # noqa: SLF001
+            dagster_maintained=self.resource_cls._is_dagster_maintained(),  # noqa: SLF001
         )
 
 
@@ -1243,7 +1245,7 @@ class ConfigurableLegacyResourceAdapter(ConfigurableResource, ABC):
             description=self.__doc__,
             resolve_resource_keys=self._resolve_required_resource_keys,
             nested_resources=self.nested_resources,
-            dagster_maintained=self._dagster_maintained,
+            dagster_maintained=self._is_dagster_maintained(),
         )
 
     def __call__(self, *args, **kwargs):
@@ -1324,7 +1326,7 @@ class ConfigurableIOManagerFactory(ConfigurableResourceFactory[TIOManagerValue])
             nested_resources=self.nested_resources,
             input_config_schema=self.__class__.input_config_schema(),
             output_config_schema=self.__class__.output_config_schema(),
-            dagster_maintained=self._dagster_maintained,
+            dagster_maintained=self._is_dagster_maintained(),
         )
 
     @classmethod
@@ -1368,7 +1370,7 @@ class PartialIOManager(Generic[TResValue], PartialResource[TResValue]):
             nested_resources=self._state__internal__.nested_resources,
             input_config_schema=input_config_schema,
             output_config_schema=output_config_schema,
-            dagster_maintained=self.resource_cls._dagster_maintained,  # noqa: SLF001
+            dagster_maintained=self.resource_cls._is_dagster_maintained(),  # noqa: SLF001
         )
 
 
@@ -1624,7 +1626,7 @@ class ConfigurableLegacyIOManagerAdapter(ConfigurableIOManagerFactory):
             description=self.__doc__,
             resolve_resource_keys=self._resolve_required_resource_keys,
             nested_resources=self.nested_resources,
-            dagster_maintained=self._dagster_maintained,
+            dagster_maintained=self._is_dagster_maintained(),
         )
 
 

--- a/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
@@ -620,6 +620,7 @@ class ConfigurableResourceFactoryResourceDefinition(ResourceDefinition, AllowDel
         description: Optional[str],
         resolve_resource_keys: Callable[[Mapping[int, str]], AbstractSet[str]],
         nested_resources: Mapping[str, CoercibleToResource],
+        dagster_maintained: bool = False,
     ):
         super().__init__(
             resource_fn=resource_fn,
@@ -629,6 +630,7 @@ class ConfigurableResourceFactoryResourceDefinition(ResourceDefinition, AllowDel
         self._configurable_resource_cls = configurable_resource_cls
         self._resolve_resource_keys = resolve_resource_keys
         self._nested_resources = nested_resources
+        self._dagster_maintained = dagster_maintained
 
     @property
     def configurable_resource_cls(self) -> Type:
@@ -657,6 +659,7 @@ class ConfigurableIOManagerFactoryResourceDefinition(IOManagerDefinition, AllowD
         nested_resources: Mapping[str, CoercibleToResource],
         input_config_schema: Optional[Union[CoercableToConfigSchema, Type[Config]]] = None,
         output_config_schema: Optional[Union[CoercableToConfigSchema, Type[Config]]] = None,
+        dagster_maintained: bool = False,
     ):
         input_config_schema_resolved: CoercableToConfigSchema = (
             cast(Type[Config], input_config_schema).to_config_schema()
@@ -678,6 +681,7 @@ class ConfigurableIOManagerFactoryResourceDefinition(IOManagerDefinition, AllowD
         self._resolve_resource_keys = resolve_resource_keys
         self._nested_resources = nested_resources
         self._configurable_resource_cls = configurable_resource_cls
+        self._dagster_maintained = dagster_maintained
 
     @property
     def configurable_resource_cls(self) -> Type:
@@ -811,6 +815,13 @@ class ConfigurableResourceFactory(
         return self._state__internal__.resolved_config_dict
 
     @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        """This property should be overridden to return True by all dagster maintained resources and IO managers.
+        """
+        return False
+
+    @classmethod
     def _is_cm_resource_cls(cls: Type["ConfigurableResourceFactory"]) -> bool:
         return (
             cls.yield_for_execution != ConfigurableResourceFactory.yield_for_execution
@@ -833,6 +844,7 @@ class ConfigurableResourceFactory(
             description=self.__doc__,
             resolve_resource_keys=self._resolve_required_resource_keys,
             nested_resources=self.nested_resources,
+            dagster_maintained=self._dagster_maintained,
         )
 
     @abstractmethod
@@ -1155,12 +1167,13 @@ class PartialResource(Generic[TResValue], AllowDelayedDependencies, MakeConfigCa
     @cached_method
     def get_resource_definition(self) -> ConfigurableResourceFactoryResourceDefinition:
         return ConfigurableResourceFactoryResourceDefinition(
-            self.__class__,
+            self.resource_cls,
             resource_fn=self._state__internal__.resource_fn,
             config_schema=self._state__internal__.config_schema,
             description=self._state__internal__.description,
             resolve_resource_keys=self._resolve_required_resource_keys,
             nested_resources=self.nested_resources,
+            dagster_maintained=self.resource_cls._dagster_maintained,  # noqa: SLF001
         )
 
 
@@ -1230,6 +1243,7 @@ class ConfigurableLegacyResourceAdapter(ConfigurableResource, ABC):
             description=self.__doc__,
             resolve_resource_keys=self._resolve_required_resource_keys,
             nested_resources=self.nested_resources,
+            dagster_maintained=self._dagster_maintained,
         )
 
     def __call__(self, *args, **kwargs):
@@ -1310,6 +1324,7 @@ class ConfigurableIOManagerFactory(ConfigurableResourceFactory[TIOManagerValue])
             nested_resources=self.nested_resources,
             input_config_schema=self.__class__.input_config_schema(),
             output_config_schema=self.__class__.output_config_schema(),
+            dagster_maintained=self._dagster_maintained,
         )
 
     @classmethod
@@ -1345,7 +1360,7 @@ class PartialIOManager(Generic[TResValue], PartialResource[TResValue]):
             output_config_schema = factory_cls.output_config_schema()
 
         return ConfigurableIOManagerFactoryResourceDefinition(
-            self.__class__,
+            self.resource_cls,
             resource_fn=self._state__internal__.resource_fn,
             config_schema=self._state__internal__.config_schema,
             description=self._state__internal__.description,
@@ -1353,6 +1368,7 @@ class PartialIOManager(Generic[TResValue], PartialResource[TResValue]):
             nested_resources=self._state__internal__.nested_resources,
             input_config_schema=input_config_schema,
             output_config_schema=output_config_schema,
+            dagster_maintained=self.resource_cls._dagster_maintained,  # noqa: SLF001
         )
 
 
@@ -1608,6 +1624,7 @@ class ConfigurableLegacyIOManagerAdapter(ConfigurableIOManagerFactory):
             description=self.__doc__,
             resolve_resource_keys=self._resolve_required_resource_keys,
             nested_resources=self.nested_resources,
+            dagster_maintained=self._dagster_maintained,
         )
 
 

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -54,7 +54,11 @@ from dagster._core.selector.subset_selector import (
     AssetSelectionData,
     OpSelectionData,
 )
-from dagster._core.storage.io_manager import IOManagerDefinition, io_manager
+from dagster._core.storage.io_manager import (
+    IOManagerDefinition,
+    dagster_maintained_io_manager,
+    io_manager,
+)
 from dagster._core.storage.tags import MEMOIZED_RUN_TAG
 from dagster._core.types.dagster_type import DagsterType
 from dagster._core.utils import str_format_set
@@ -988,6 +992,7 @@ def _swap_default_io_man(resources: Mapping[str, ResourceDefinition], job: JobDe
     return resources
 
 
+@dagster_maintained_io_manager
 @io_manager(
     description="Built-in filesystem IO manager that stores and retrieves values using pickling."
 )
@@ -1028,6 +1033,7 @@ def default_job_io_manager(init_context: "InitResourceContext"):
     return PickledObjectFilesystemIOManager(base_dir=instance.storage_directory())
 
 
+@dagster_maintained_io_manager
 @io_manager(
     description="Built-in filesystem IO manager that stores and retrieves values using pickling.",
     config_schema={"base_dir": Field(StringSource, is_required=False)},

--- a/python_modules/dagster/dagster/_core/definitions/no_step_launcher.py
+++ b/python_modules/dagster/dagster/_core/definitions/no_step_launcher.py
@@ -1,6 +1,8 @@
 from dagster import resource
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 
 
+@dagster_maintained_resource
 @resource
 def no_step_launcher(_):
     return None

--- a/python_modules/dagster/dagster/_core/definitions/resource_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/resource_definition.py
@@ -150,8 +150,7 @@ class ResourceDefinition(AnonymousConfigurableDefinition, RequiresResources, IHa
     def required_resource_keys(self) -> AbstractSet[str]:
         return self._required_resource_keys
 
-    @property
-    def dagster_maintained(self) -> bool:
+    def _is_dagster_maintained(self) -> bool:
         return self._dagster_maintained
 
     @public
@@ -221,7 +220,7 @@ class ResourceDefinition(AnonymousConfigurableDefinition, RequiresResources, IHa
             version=self.version,
         )
 
-        resource_def._dagster_maintained = self.dagster_maintained  # noqa: SLF001
+        resource_def._dagster_maintained = self._is_dagster_maintained()  # noqa: SLF001
 
         return resource_def
 

--- a/python_modules/dagster/dagster/_core/definitions/resource_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/resource_definition.py
@@ -107,6 +107,9 @@ class ResourceDefinition(AnonymousConfigurableDefinition, RequiresResources, IHa
         if version:
             experimental_arg_warning("version", "ResourceDefinition.__init__")
 
+        # this attribute will be updated by the @dagster_maintained_resource and @dagster_maintained_io_manager decorators
+        self._dagster_maintained = False
+
     @staticmethod
     def dagster_internal_init(
         *,
@@ -146,6 +149,10 @@ class ResourceDefinition(AnonymousConfigurableDefinition, RequiresResources, IHa
     @property
     def required_resource_keys(self) -> AbstractSet[str]:
         return self._required_resource_keys
+
+    @property
+    def dagster_maintained(self) -> bool:
+        return self._dagster_maintained
 
     @public
     @staticmethod
@@ -206,13 +213,17 @@ class ResourceDefinition(AnonymousConfigurableDefinition, RequiresResources, IHa
         description: Optional[str],
         config_schema: CoercableToConfigSchema,
     ) -> "ResourceDefinition":
-        return ResourceDefinition.dagster_internal_init(
+        resource_def = ResourceDefinition.dagster_internal_init(
             config_schema=config_schema,
             description=description or self.description,
             resource_fn=self.resource_fn,
             required_resource_keys=self.required_resource_keys,
             version=self.version,
         )
+
+        resource_def._dagster_maintained = self.dagster_maintained  # noqa: SLF001
+
+        return resource_def
 
     def __call__(self, *args, **kwargs):
         from dagster._core.execution.context.init import UnboundInitResourceContext
@@ -263,6 +274,13 @@ class ResourceDefinition(AnonymousConfigurableDefinition, RequiresResources, IHa
         source_key = cast(str, outer_context)
         for resource_key in sorted(list(self.required_resource_keys)):
             yield ResourceDependencyRequirement(key=resource_key, source_key=source_key)
+
+
+def dagster_maintained_resource(
+    resource_def: ResourceDefinition,
+) -> ResourceDefinition:
+    resource_def._dagster_maintained = True  # noqa: SLF001
+    return resource_def
 
 
 class _ResourceDecoratorCallable:

--- a/python_modules/dagster/dagster/_core/execution/plan/external_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/external_step.py
@@ -9,7 +9,7 @@ import dagster._check as check
 from dagster._config import Field, StringSource
 from dagster._core.code_pointer import FileCodePointer, ModuleCodePointer
 from dagster._core.definitions.reconstruct import ReconstructableJob, ReconstructableRepository
-from dagster._core.definitions.resource_definition import resource
+from dagster._core.definitions.resource_definition import dagster_maintained_resource, resource
 from dagster._core.definitions.step_launcher import StepLauncher, StepRunRef
 from dagster._core.errors import raise_execution_interrupts
 from dagster._core.events import DagsterEvent
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
     from dagster._core.execution.plan.step import ExecutionStep
 
 
+@dagster_maintained_resource
 @resource(
     config_schema={
         "scratch_dir": Field(

--- a/python_modules/dagster/dagster/_core/host_representation/external.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external.py
@@ -585,6 +585,10 @@ class ExternalResource:
     def job_ops_using(self) -> List[ResourceJobUsageEntry]:
         return self._external_resource_data.job_ops_using
 
+    @property
+    def is_dagster_maintained(self) -> bool:
+        return self._external_resource_data.dagster_maintained
+
 
 class ExternalSchedule:
     def __init__(self, external_schedule_data: ExternalScheduleData, handle: RepositoryHandle):

--- a/python_modules/dagster/dagster/_core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external_data.py
@@ -1633,7 +1633,7 @@ def external_resource_data_from_def(
         resource_type = _get_class_name(type(resource_type_def))
 
     dagster_maintained = (
-        resource_type_def._dagster_maintained  # noqa: SLF001
+        resource_type_def._is_dagster_maintained()  # noqa: SLF001
         if type(resource_type_def)
         in (
             ResourceDefinition,

--- a/python_modules/dagster/dagster/_core/storage/file_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/file_manager.py
@@ -11,7 +11,7 @@ from typing_extensions import TypeAlias
 import dagster._check as check
 from dagster._annotations import public
 from dagster._config import Field, StringSource
-from dagster._core.definitions.resource_definition import resource
+from dagster._core.definitions.resource_definition import dagster_maintained_resource, resource
 from dagster._core.execution.context.init import InitResourceContext
 from dagster._core.instance import DagsterInstance
 from dagster._utils import mkdir_p
@@ -167,6 +167,7 @@ class FileManager(ABC):
         raise NotImplementedError()
 
 
+@dagster_maintained_resource
 @resource(config_schema={"base_dir": Field(StringSource, is_required=False)})
 def local_file_manager(init_context: InitResourceContext) -> "LocalFileManager":
     """FileManager that provides abstract access to a local filesystem.

--- a/python_modules/dagster/dagster/_core/storage/fs_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/fs_io_manager.py
@@ -121,8 +121,7 @@ class FilesystemIOManager(ConfigurableIOManagerFactory["PickledObjectFilesystemI
     base_dir: Optional[str] = Field(default=None, description="Base directory for storing files.")
 
     @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
+    def _is_dagster_maintained(cls) -> bool:
         return True
 
     def create_io_manager(self, context: InitResourceContext) -> "PickledObjectFilesystemIOManager":

--- a/python_modules/dagster/dagster/_core/storage/fs_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/fs_io_manager.py
@@ -18,7 +18,7 @@ from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.execution.context.init import InitResourceContext
 from dagster._core.execution.context.input import InputContext
 from dagster._core.execution.context.output import OutputContext
-from dagster._core.storage.io_manager import IOManager, io_manager
+from dagster._core.storage.io_manager import IOManager, dagster_maintained_io_manager, io_manager
 from dagster._core.storage.upath_io_manager import UPathIOManager
 from dagster._utils import PICKLE_PROTOCOL, mkdir_p
 
@@ -120,11 +120,17 @@ class FilesystemIOManager(ConfigurableIOManagerFactory["PickledObjectFilesystemI
 
     base_dir: Optional[str] = Field(default=None, description="Base directory for storing files.")
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def create_io_manager(self, context: InitResourceContext) -> "PickledObjectFilesystemIOManager":
         base_dir = self.base_dir or check.not_none(context.instance).storage_directory()
         return PickledObjectFilesystemIOManager(base_dir=base_dir)
 
 
+@dagster_maintained_io_manager
 @io_manager(
     config_schema=FilesystemIOManager.to_config_schema(),
     description="Built-in filesystem IO manager that stores and retrieves values using pickling.",
@@ -327,6 +333,7 @@ class CustomPathPickledObjectFilesystemIOManager(IOManager):
             return pickle.load(read_obj)
 
 
+@dagster_maintained_io_manager
 @io_manager(config_schema={"base_dir": DagsterField(StringSource, is_required=True)})
 @experimental
 def custom_path_fs_io_manager(

--- a/python_modules/dagster/dagster/_core/storage/io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/io_manager.py
@@ -101,7 +101,7 @@ class IOManagerDefinition(ResourceDefinition, IInputManagerDefinition, IOutputMa
             output_config_schema=self.output_config_schema,
         )
 
-        io_def._dagster_maintained = self.dagster_maintained()  # noqa: SLF001
+        io_def._dagster_maintained = self._is_dagster_maintained()  # noqa: SLF001
 
         return io_def
 

--- a/python_modules/dagster/dagster/_core/storage/io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/io_manager.py
@@ -92,7 +92,7 @@ class IOManagerDefinition(ResourceDefinition, IInputManagerDefinition, IOutputMa
         description: Optional[str],
         config_schema: CoercableToConfigSchema,
     ) -> "IOManagerDefinition":
-        return IOManagerDefinition(
+        io_def = IOManagerDefinition(
             config_schema=config_schema,
             description=description or self.description,
             resource_fn=self.resource_fn,
@@ -100,6 +100,10 @@ class IOManagerDefinition(ResourceDefinition, IInputManagerDefinition, IOutputMa
             input_config_schema=self.input_config_schema,
             output_config_schema=self.output_config_schema,
         )
+
+        io_def._dagster_maintained = self.dagster_maintained  # noqa: SLF001
+
+        return io_def
 
     @public
     @staticmethod
@@ -238,6 +242,11 @@ def io_manager(
         )(resource_fn)
 
     return _wrap
+
+
+def dagster_maintained_io_manager(io_manager_def: IOManagerDefinition) -> IOManagerDefinition:
+    io_manager_def._dagster_maintained = True  # noqa: SLF001
+    return io_manager_def
 
 
 class _IOManagerDecoratorCallable:

--- a/python_modules/dagster/dagster/_core/storage/io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/io_manager.py
@@ -101,7 +101,7 @@ class IOManagerDefinition(ResourceDefinition, IInputManagerDefinition, IOutputMa
             output_config_schema=self.output_config_schema,
         )
 
-        io_def._dagster_maintained = self.dagster_maintained  # noqa: SLF001
+        io_def._dagster_maintained = self.dagster_maintained()  # noqa: SLF001
 
         return io_def
 

--- a/python_modules/dagster/dagster/_core/storage/mem_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/mem_io_manager.py
@@ -2,7 +2,7 @@ from typing import Dict, Tuple
 
 from dagster._core.execution.context.input import InputContext
 from dagster._core.execution.context.output import OutputContext
-from dagster._core.storage.io_manager import IOManager, io_manager
+from dagster._core.storage.io_manager import IOManager, dagster_maintained_io_manager, io_manager
 
 
 class InMemoryIOManager(IOManager):
@@ -18,6 +18,7 @@ class InMemoryIOManager(IOManager):
         return self.values[keys]
 
 
+@dagster_maintained_io_manager
 @io_manager(description="Built-in IO manager that stores and retrieves values in memory.")
 def mem_io_manager(_) -> InMemoryIOManager:
     """Built-in IO manager that stores and retrieves values in memory."""

--- a/python_modules/dagster/dagster/_core/storage/memoizable_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/memoizable_io_manager.py
@@ -9,7 +9,7 @@ from dagster._config import Field, StringSource
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.execution.context.input import InputContext
 from dagster._core.execution.context.output import OutputContext
-from dagster._core.storage.io_manager import IOManager, io_manager
+from dagster._core.storage.io_manager import IOManager, dagster_maintained_io_manager, io_manager
 from dagster._utils import PICKLE_PROTOCOL, mkdir_p
 
 
@@ -92,6 +92,7 @@ class VersionedPickledObjectFilesystemIOManager(MemoizableIOManager):
         return os.path.exists(filepath) and not os.path.isdir(filepath)
 
 
+@dagster_maintained_io_manager
 @io_manager(config_schema={"base_dir": Field(StringSource, is_required=False)})
 @experimental
 def versioned_filesystem_io_manager(init_context):

--- a/python_modules/dagster/dagster/_core/storage/temp_file_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/temp_file_manager.py
@@ -3,7 +3,7 @@ import os
 import shutil
 import tempfile
 
-from dagster._core.definitions.resource_definition import resource
+from dagster._core.definitions.resource_definition import dagster_maintained_resource, resource
 
 
 class TempfileManager:
@@ -42,6 +42,7 @@ def _tempfile_manager():
         manager.close()
 
 
+@dagster_maintained_resource
 @resource
 def tempfile_resource(_init_context):
     with _tempfile_manager() as manager:

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_telemetry.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_telemetry.py
@@ -371,8 +371,7 @@ def test_get_stats_from_external_repo_resources():
         foo: str
 
         @classmethod
-        @property
-        def _dagster_maintained(cls) -> bool:
+        def _is_dagster_maintained(cls) -> bool:
             return True
 
     class CustomResource(ConfigurableResource):
@@ -407,8 +406,7 @@ def test_get_stats_from_external_repo_io_managers():
         foo: str
 
         @classmethod
-        @property
-        def _dagster_maintained(cls) -> bool:
+        def _is_dagster_maintained(cls) -> bool:
             return True
 
         def handle_output(self, context: OutputContext, obj: Any) -> None:
@@ -523,16 +521,14 @@ def test_get_stats_from_external_repo_delayed_resource_configuration():
         foo: str
 
         @classmethod
-        @property
-        def _dagster_maintained(cls) -> bool:
+        def _is_dagster_maintained(cls) -> bool:
             return True
 
     class MyIOManager(ConfigurableIOManager):
         foo: str
 
         @classmethod
-        @property
-        def _dagster_maintained(cls) -> bool:
+        def _is_dagster_maintained(cls) -> bool:
             return True
 
         def handle_output(self, context: OutputContext, obj: Any) -> None:

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_telemetry.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_telemetry.py
@@ -2,10 +2,13 @@ import json
 import os
 import tempfile
 from difflib import SequenceMatcher
+from typing import Any
 from unittest.mock import MagicMock
 
 from click.testing import CliRunner
 from dagster import (
+    ConfigurableIOManager,
+    ConfigurableResource,
     DailyPartitionsDefinition,
     Definitions,
     DynamicPartitionsDefinition,
@@ -15,15 +18,21 @@ from dagster import (
     StaticPartitionsDefinition,
     asset,
     define_asset_job,
+    io_manager,
     observable_source_asset,
     repository,
+    resource,
 )
 from dagster._cli.job import job_execute_command
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.definitions.reconstruct import get_ephemeral_repository_name
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
+from dagster._core.execution.context.input import InputContext
+from dagster._core.execution.context.output import OutputContext
 from dagster._core.host_representation.external import ExternalRepository
 from dagster._core.host_representation.external_data import external_repository_data_from_def
 from dagster._core.host_representation.handle import RepositoryHandle
+from dagster._core.storage.io_manager import dagster_maintained_io_manager
 from dagster._core.telemetry import (
     TELEMETRY_STR,
     UPDATE_REPO_STATS,
@@ -355,6 +364,224 @@ def test_get_stats_from_external_repo_dbt():
     )
     stats = get_stats_from_external_repo(external_repo)
     assert stats["num_dbt_assets_in_repo"] == "1"
+
+
+def test_get_stats_from_external_repo_resources():
+    class MyResource(ConfigurableResource):
+        foo: str
+
+        @classmethod
+        @property
+        def _dagster_maintained(cls) -> bool:
+            return True
+
+    class CustomResource(ConfigurableResource):
+        baz: str
+
+    @asset
+    def asset1(my_resource: MyResource, custom_resource: CustomResource):
+        ...
+
+    external_repo = ExternalRepository(
+        external_repository_data_from_def(
+            Definitions(
+                assets=[asset1],
+                resources={
+                    "my_resource": MyResource(foo="bar"),
+                    "custom_resource": CustomResource(baz="qux"),
+                },
+            ).get_repository_def()
+        ),
+        repository_handle=MagicMock(spec=RepositoryHandle),
+    )
+    stats = get_stats_from_external_repo(external_repo)
+    assert (
+        stats["dagster_resources"]
+        == "[{'module_name': 'dagster_tests', 'class_name': 'MyResource'}]"
+    )
+    assert stats["has_custom_resources"] == "True"
+
+
+def test_get_stats_from_external_repo_io_managers():
+    class MyIOManager(ConfigurableIOManager):
+        foo: str
+
+        @classmethod
+        @property
+        def _dagster_maintained(cls) -> bool:
+            return True
+
+        def handle_output(self, context: OutputContext, obj: Any) -> None:
+            return None
+
+        def load_input(self, context: InputContext) -> Any:
+            return 1
+
+    class CustomIOManager(ConfigurableIOManager):
+        baz: str
+
+        def handle_output(self, context: OutputContext, obj: Any) -> None:
+            return None
+
+        def load_input(self, context: InputContext) -> Any:
+            return 1
+
+    @asset
+    def asset1():
+        ...
+
+    external_repo = ExternalRepository(
+        external_repository_data_from_def(
+            Definitions(
+                assets=[asset1],
+                resources={
+                    "my_io_manager": MyIOManager(foo="bar"),
+                    "custom_io_manager": CustomIOManager(baz="qux"),
+                },
+            ).get_repository_def()
+        ),
+        repository_handle=MagicMock(spec=RepositoryHandle),
+    )
+    stats = get_stats_from_external_repo(external_repo)
+    assert (
+        stats["dagster_resources"]
+        == "[{'module_name': 'dagster_tests', 'class_name': 'MyIOManager'}]"
+    )
+    assert stats["has_custom_resources"] == "True"
+
+
+def test_get_stats_from_external_repo_functional_resources():
+    @dagster_maintained_resource
+    @resource(config_schema={"foo": str})
+    def my_resource():
+        return 1
+
+    @resource(config_schema={"baz": str})
+    def custom_resource():
+        return 2
+
+    @asset(required_resource_keys={"my_resource", "custom_resource"})
+    def asset1():
+        ...
+
+    external_repo = ExternalRepository(
+        external_repository_data_from_def(
+            Definitions(
+                assets=[asset1],
+                resources={
+                    "my_resource": my_resource.configured({"foo": "bar"}),
+                    "custom_resource": custom_resource.configured({"baz": "qux"}),
+                },
+            ).get_repository_def()
+        ),
+        repository_handle=MagicMock(spec=RepositoryHandle),
+    )
+    stats = get_stats_from_external_repo(external_repo)
+    assert (
+        stats["dagster_resources"]
+        == "[{'module_name': 'dagster_tests', 'class_name': 'my_resource'}]"
+    )
+    assert stats["has_custom_resources"] == "True"
+
+
+def test_get_stats_from_external_repo_functional_io_managers():
+    @dagster_maintained_io_manager
+    @io_manager(config_schema={"foo": str})
+    def my_io_manager():
+        return 1
+
+    @io_manager(config_schema={"baz": str})
+    def custom_io_manager():
+        return 2
+
+    @asset
+    def asset1():
+        ...
+
+    external_repo = ExternalRepository(
+        external_repository_data_from_def(
+            Definitions(
+                assets=[asset1],
+                resources={
+                    "my_io_manager": my_io_manager.configured({"foo": "bar"}),
+                    "custom_io_manager": custom_io_manager.configured({"baz": "qux"}),
+                },
+            ).get_repository_def()
+        ),
+        repository_handle=MagicMock(spec=RepositoryHandle),
+    )
+    stats = get_stats_from_external_repo(external_repo)
+    assert (
+        stats["dagster_resources"]
+        == "[{'module_name': 'dagster_tests', 'class_name': 'my_io_manager'}]"
+    )
+    assert stats["has_custom_resources"] == "True"
+
+
+def test_get_stats_from_external_repo_delayed_resource_configuration():
+    class MyResource(ConfigurableResource):
+        foo: str
+
+        @classmethod
+        @property
+        def _dagster_maintained(cls) -> bool:
+            return True
+
+    class MyIOManager(ConfigurableIOManager):
+        foo: str
+
+        @classmethod
+        @property
+        def _dagster_maintained(cls) -> bool:
+            return True
+
+        def handle_output(self, context: OutputContext, obj: Any) -> None:
+            return None
+
+        def load_input(self, context: InputContext) -> Any:
+            return 1
+
+    @dagster_maintained_resource
+    @resource(config_schema={"foo": str})
+    def my_resource():
+        return 1
+
+    @dagster_maintained_io_manager
+    @io_manager(config_schema={"foo": str})
+    def my_io_manager():
+        return 1
+
+    @asset
+    def asset1(my_resource: MyResource):
+        ...
+
+    @asset(required_resource_keys={"my_other_resource"})
+    def asset2():
+        ...
+
+    external_repo = ExternalRepository(
+        external_repository_data_from_def(
+            Definitions(
+                assets=[asset1, asset2],
+                resources={
+                    "my_io_manager": MyIOManager.configure_at_launch(),
+                    "my_other_io_manager": my_io_manager,
+                    "my_resource": MyResource.configure_at_launch(),
+                    "my_other_resource": my_resource,
+                },
+            ).get_repository_def()
+        ),
+        repository_handle=MagicMock(spec=RepositoryHandle),
+    )
+    stats = get_stats_from_external_repo(external_repo)
+    assert (
+        stats["dagster_resources"]
+        == "[{'module_name': 'dagster_tests', 'class_name': 'MyIOManager'}, {'module_name':"
+        " 'dagster_tests', 'class_name': 'my_io_manager'}, {'module_name': 'dagster_tests',"
+        " 'class_name': 'my_resource'}, {'module_name': 'dagster_tests', 'class_name':"
+        " 'MyResource'}]"
+    )
+    assert stats["has_custom_resources"] == "False"
 
 
 # TODO - not sure what this test is testing for, so unclear as to how to update it to jobs

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_general_pythonic_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_general_pythonic_resources.py
@@ -1552,16 +1552,4 @@ def test_telemetry_dagster_resource():
         def _is_dagster_maintained(cls) -> bool:
             return True
 
-    assert MyResource(my_value="foo")._is_dagster_maintained() is True  # noqa: SLF001
-
-
-def test_classmethod():
-    class MyResource(ConfigurableResource):
-        my_value: str
-
-        @classmethod
-        @property
-        def my_custom_method(cls):
-            return "foo"
-
-    assert MyResource.my_custom_method == "foo"
+    assert MyResource(my_value="foo")._is_dagster_maintained()  # noqa: SLF001

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_general_pythonic_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_general_pythonic_resources.py
@@ -1531,3 +1531,22 @@ def test_context_on_resource_nested() -> None:
 
         assert defs.get_implicit_global_asset_job_def().execute_in_process().success
         assert executed["yes"]
+
+
+def test_telemetry_custom_resource():
+    class MyResource(ConfigurableResource):
+        my_value: str
+
+    assert not MyResource(my_value="foo")._dagster_maintained  # noqa: SLF001
+
+
+def test_telemetry_dagster_resource():
+    class MyResource(ConfigurableResource):
+        my_value: str
+
+        @classmethod
+        @property
+        def _dagster_maintained(cls) -> bool:
+            return True
+
+    assert MyResource(my_value="foo")._dagster_maintained  # noqa: SLF001

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_general_pythonic_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_general_pythonic_resources.py
@@ -1537,7 +1537,11 @@ def test_telemetry_custom_resource():
     class MyResource(ConfigurableResource):
         my_value: str
 
-    assert not MyResource(my_value="foo")._dagster_maintained  # noqa: SLF001
+        @classmethod
+        def _is_dagster_maintained(cls) -> bool:
+            return False
+
+    assert not MyResource(my_value="foo")._is_dagster_maintained()  # noqa: SLF001
 
 
 def test_telemetry_dagster_resource():
@@ -1545,8 +1549,19 @@ def test_telemetry_dagster_resource():
         my_value: str
 
         @classmethod
-        @property
-        def _dagster_maintained(cls) -> bool:
+        def _is_dagster_maintained(cls) -> bool:
             return True
 
-    assert MyResource(my_value="foo")._dagster_maintained  # noqa: SLF001
+    assert MyResource(my_value="foo")._is_dagster_maintained() is True  # noqa: SLF001
+
+
+def test_classmethod():
+    class MyResource(ConfigurableResource):
+        my_value: str
+
+        @classmethod
+        @property
+        def my_custom_method(cls):
+            return "foo"
+
+    assert MyResource.my_custom_method == "foo"

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_resource_definition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_resource_definition.py
@@ -1224,7 +1224,7 @@ def test_telemetry_custom_resource():
     def my_resource():
         return MyResource()
 
-    assert not my_resource._dagster_maintained()  # noqa: SLF001
+    assert not my_resource._is_dagster_maintained()  # noqa: SLF001
 
 
 def test_telemetry_dagster_io_manager():
@@ -1237,4 +1237,4 @@ def test_telemetry_dagster_io_manager():
     def my_resource():
         return MyResource()
 
-    assert my_resource._dagster_maintained()  # noqa: SLF001
+    assert my_resource._is_dagster_maintained()  # noqa: SLF001

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_resource_definition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_resource_definition.py
@@ -25,7 +25,10 @@ from dagster import (
     resource,
 )
 from dagster._core.definitions.job_base import InMemoryJob
-from dagster._core.definitions.resource_definition import make_values_resource
+from dagster._core.definitions.resource_definition import (
+    dagster_maintained_resource,
+    make_values_resource,
+)
 from dagster._core.errors import DagsterConfigMappingFunctionError, DagsterInvalidDefinitionError
 from dagster._core.events.log import EventLogEntry, construct_event_logger
 from dagster._core.execution.api import create_execution_plan, execute_plan
@@ -1210,3 +1213,28 @@ def test_context_manager_resource():
 
     assert call_basic.execute_in_process(resources={"cm": cm_resource}).success
     assert event_list == ["foo", "compute", "finally"]
+
+
+def test_telemetry_custom_resource():
+    class MyResource:
+        def foo(self) -> str:
+            return "bar"
+
+    @resource
+    def my_resource():
+        return MyResource()
+
+    assert not my_resource._dagster_maintained  # noqa: SLF001
+
+
+def test_telemetry_dagster_io_manager():
+    class MyResource:
+        def foo(self) -> str:
+            return "bar"
+
+    @dagster_maintained_resource
+    @resource
+    def my_resource():
+        return MyResource()
+
+    assert my_resource._dagster_maintained  # noqa: SLF001

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_resource_definition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_resource_definition.py
@@ -1224,7 +1224,7 @@ def test_telemetry_custom_resource():
     def my_resource():
         return MyResource()
 
-    assert not my_resource._dagster_maintained  # noqa: SLF001
+    assert not my_resource._dagster_maintained()  # noqa: SLF001
 
 
 def test_telemetry_dagster_io_manager():
@@ -1237,4 +1237,4 @@ def test_telemetry_dagster_io_manager():
     def my_resource():
         return MyResource()
 
-    assert my_resource._dagster_maintained  # noqa: SLF001
+    assert my_resource._dagster_maintained()  # noqa: SLF001

--- a/python_modules/dagster/dagster_tests/storage_tests/test_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_io_manager.py
@@ -1100,7 +1100,7 @@ def test_telemetry_custom_io_manager():
     def my_io_manager():
         return MyIOManager()
 
-    assert not my_io_manager._dagster_maintained()  # noqa: SLF001
+    assert not my_io_manager._is_dagster_maintained()  # noqa: SLF001
 
 
 def test_telemetry_dagster_io_manager():
@@ -1116,4 +1116,4 @@ def test_telemetry_dagster_io_manager():
     def my_io_manager():
         return MyIOManager()
 
-    assert my_io_manager._dagster_maintained()  # noqa: SLF001
+    assert my_io_manager._is_dagster_maintained()  # noqa: SLF001

--- a/python_modules/dagster/dagster_tests/storage_tests/test_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_io_manager.py
@@ -1100,7 +1100,7 @@ def test_telemetry_custom_io_manager():
     def my_io_manager():
         return MyIOManager()
 
-    assert not my_io_manager._dagster_maintained  # noqa: SLF001
+    assert not my_io_manager._dagster_maintained()  # noqa: SLF001
 
 
 def test_telemetry_dagster_io_manager():
@@ -1116,4 +1116,4 @@ def test_telemetry_dagster_io_manager():
     def my_io_manager():
         return MyIOManager()
 
-    assert my_io_manager._dagster_maintained  # noqa: SLF001
+    assert my_io_manager._dagster_maintained()  # noqa: SLF001

--- a/python_modules/dagster/dagster_tests/storage_tests/test_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_io_manager.py
@@ -40,7 +40,7 @@ from dagster._core.execution.api import create_execution_plan, execute_plan
 from dagster._core.execution.context.output import get_output_context
 from dagster._core.execution.plan.outputs import StepOutputHandle
 from dagster._core.storage.fs_io_manager import custom_path_fs_io_manager, fs_io_manager
-from dagster._core.storage.io_manager import IOManager, io_manager
+from dagster._core.storage.io_manager import IOManager, dagster_maintained_io_manager, io_manager
 from dagster._core.storage.mem_io_manager import InMemoryIOManager, mem_io_manager
 from dagster._core.system_config.objects import ResolvedRunConfig
 from dagster._core.test_utils import instance_for_test
@@ -1086,3 +1086,34 @@ def test_instance_set_on_asset_loader():
         defs.load_asset_value("another_asset", instance=instance)
 
         assert executed["yes"]
+
+
+def test_telemetry_custom_io_manager():
+    class MyIOManager(IOManager):
+        def handle_output(self, context, obj):
+            return {}
+
+        def load_input(self, context):
+            return 1
+
+    @io_manager
+    def my_io_manager():
+        return MyIOManager()
+
+    assert not my_io_manager._dagster_maintained  # noqa: SLF001
+
+
+def test_telemetry_dagster_io_manager():
+    class MyIOManager(IOManager):
+        def handle_output(self, context, obj):
+            return {}
+
+        def load_input(self, context):
+            return 1
+
+    @dagster_maintained_io_manager
+    @io_manager
+    def my_io_manager():
+        return MyIOManager()
+
+    assert my_io_manager._dagster_maintained  # noqa: SLF001

--- a/python_modules/dagster/dagster_tests/storage_tests/test_io_managers_pythonic_config.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_io_managers_pythonic_config.py
@@ -4,6 +4,7 @@ from typing import Any, Type
 
 from dagster import (
     Config,
+    ConfigurableIOManagerFactory,
     DataVersion,
     Definitions,
     FilesystemIOManager,
@@ -19,6 +20,7 @@ from dagster import (
 )
 from dagster._config.pythonic_config import ConfigurableIOManager, ConfigurableResource
 from dagster._config.type_printer import print_config_type_to_string
+from dagster._core.storage.io_manager import IOManager
 
 
 def type_string_from_config_schema(config_schema):
@@ -488,3 +490,65 @@ def test_observable_source_asset_io_manager_def() -> None:
         result = defs.get_implicit_global_asset_job_def().execute_in_process()
         assert result.success
         assert result.output_for_node("my_downstream_asset") == "foobar"
+
+
+def test_telemetry_custom_io_manager():
+    class MyIOManager(ConfigurableIOManager):
+        def handle_output(self, context, obj):
+            return {}
+
+        def load_input(self, context):
+            return 1
+
+    assert not MyIOManager._dagster_maintained
+
+
+def test_telemetry_dagster_io_manager():
+    class MyIOManager(ConfigurableIOManager):
+        @classmethod
+        @property
+        def _dagster_maintained(cls) -> bool:
+            return True
+
+        def handle_output(self, context, obj):
+            return {}
+
+        def load_input(self, context):
+            return 1
+
+    assert MyIOManager()._dagster_maintained  # noqa: SLF001
+
+
+def test_telemetry_custom_io_manager_factory():
+    class MyIOManager(IOManager):
+        def handle_output(self, context, obj):
+            return {}
+
+        def load_input(self, context):
+            return 1
+
+    class AnIOManagerFactory(ConfigurableIOManagerFactory):
+        def create_io_manager(self, _) -> IOManager:
+            return MyIOManager()
+
+    assert not AnIOManagerFactory()._dagster_maintained  # noqa: SLF001
+
+
+def test_telemetry_dagster_io_manager_factory():
+    class MyIOManager(IOManager):
+        def handle_output(self, context, obj):
+            return {}
+
+        def load_input(self, context):
+            return 1
+
+    class AnIOManagerFactory(ConfigurableIOManagerFactory):
+        @classmethod
+        @property
+        def _dagster_maintained(cls) -> bool:
+            return True
+
+        def create_io_manager(self, _) -> IOManager:
+            return MyIOManager()
+
+    assert AnIOManagerFactory()._dagster_maintained  # noqa: SLF001

--- a/python_modules/dagster/dagster_tests/storage_tests/test_io_managers_pythonic_config.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_io_managers_pythonic_config.py
@@ -500,14 +500,13 @@ def test_telemetry_custom_io_manager():
         def load_input(self, context):
             return 1
 
-    assert not MyIOManager._dagster_maintained
+    assert not MyIOManager._is_dagster_maintained()
 
 
 def test_telemetry_dagster_io_manager():
     class MyIOManager(ConfigurableIOManager):
         @classmethod
-        @property
-        def _dagster_maintained(cls) -> bool:
+        def _is_dagster_maintained(cls) -> bool:
             return True
 
         def handle_output(self, context, obj):
@@ -516,7 +515,7 @@ def test_telemetry_dagster_io_manager():
         def load_input(self, context):
             return 1
 
-    assert MyIOManager()._dagster_maintained  # noqa: SLF001
+    assert MyIOManager()._is_dagster_maintained()  # noqa: SLF001
 
 
 def test_telemetry_custom_io_manager_factory():
@@ -531,7 +530,7 @@ def test_telemetry_custom_io_manager_factory():
         def create_io_manager(self, _) -> IOManager:
             return MyIOManager()
 
-    assert not AnIOManagerFactory()._dagster_maintained  # noqa: SLF001
+    assert not AnIOManagerFactory()._is_dagster_maintained()  # noqa: SLF001
 
 
 def test_telemetry_dagster_io_manager_factory():
@@ -544,11 +543,10 @@ def test_telemetry_dagster_io_manager_factory():
 
     class AnIOManagerFactory(ConfigurableIOManagerFactory):
         @classmethod
-        @property
-        def _dagster_maintained(cls) -> bool:
+        def _is_dagster_maintained(cls) -> bool:
             return True
 
         def create_io_manager(self, _) -> IOManager:
             return MyIOManager()
 
-    assert AnIOManagerFactory()._dagster_maintained  # noqa: SLF001
+    assert AnIOManagerFactory()._is_dagster_maintained()  # noqa: SLF001

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
@@ -71,8 +71,7 @@ class BaseAirbyteResource(ConfigurableResource):
     )
 
     @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
+    def _is_dagster_maintained(cls) -> bool:
         return True
 
     @property

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
@@ -16,6 +16,7 @@ from dagster import (
     resource,
 )
 from dagster._config.pythonic_config import infer_schema_from_config_class
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._utils.cached_method import cached_method
 from dagster._utils.merger import deep_merge_dicts
 from pydantic import Field
@@ -68,6 +69,11 @@ class BaseAirbyteResource(ConfigurableResource):
             " that do not impact your Airbyte deployment."
         ),
     )
+
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
 
     @property
     @cached_method
@@ -660,6 +666,7 @@ class AirbyteResource(BaseAirbyteResource):
         return AirbyteOutput(job_details=job_details, connection_details=connection_details)
 
 
+@dagster_maintained_resource
 @resource(config_schema=AirbyteResource.to_config_schema())
 def airbyte_resource(context) -> AirbyteResource:
     """This resource allows users to programatically interface with the Airbyte REST API to launch
@@ -697,6 +704,7 @@ def airbyte_resource(context) -> AirbyteResource:
     return AirbyteResource.from_resource_context(context)
 
 
+@dagster_maintained_resource
 @resource(config_schema=infer_schema_from_config_class(AirbyteCloudResource))
 def airbyte_cloud_resource(context) -> AirbyteCloudResource:
     """This resource allows users to programatically interface with the Airbyte Cloud REST API to launch

--- a/python_modules/libraries/dagster-aws/dagster_aws/athena/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/athena/resources.py
@@ -14,6 +14,7 @@ from dagster import (
     resource,
 )
 from dagster._annotations import deprecated
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._core.execution.context.init import InitResourceContext
 from pydantic import Field
 
@@ -264,6 +265,11 @@ class AthenaClientResource(ResourceWithAthenaConfig):
 
     """
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def get_client(self) -> AthenaClient:
         """Returns an Athena client object."""
         client = boto3.client(
@@ -279,6 +285,7 @@ class AthenaClientResource(ResourceWithAthenaConfig):
         )
 
 
+@dagster_maintained_resource
 @resource(
     config_schema=ResourceWithAthenaConfig.to_config_schema(),
     description="Resource for connecting to AWS Athena",
@@ -303,6 +310,7 @@ def athena_resource(context: InitResourceContext) -> AthenaClient:
     return AthenaClientResource.from_resource_context(context).get_client()
 
 
+@dagster_maintained_resource
 @resource(
     config_schema=ResourceWithAthenaConfig.to_config_schema(),
     description="Fake resource for connecting to AWS Athena",

--- a/python_modules/libraries/dagster-aws/dagster_aws/athena/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/athena/resources.py
@@ -266,8 +266,7 @@ class AthenaClientResource(ResourceWithAthenaConfig):
     """
 
     @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
+    def _is_dagster_maintained(cls) -> bool:
         return True
 
     def get_client(self) -> AthenaClient:

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecr/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecr/resources.py
@@ -40,8 +40,7 @@ class ECRPublicResource(ConfigurableResource):
     """
 
     @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
+    def _is_dagster_maintained(cls) -> bool:
         return True
 
     def get_client(self) -> ECRPublicClient:
@@ -54,8 +53,7 @@ class FakeECRPublicResource(ConfigurableResource):
     """
 
     @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
+    def _is_dagster_maintained(cls) -> bool:
         return True
 
     def get_client(self) -> FakeECRPublicClient:

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecr/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecr/resources.py
@@ -3,6 +3,7 @@ import datetime
 import boto3
 from botocore.stub import Stubber
 from dagster import ConfigurableResource, resource
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 
 
 class ECRPublicClient:
@@ -38,6 +39,11 @@ class ECRPublicResource(ConfigurableResource):
     Similar to the AWS CLI's `aws ecr-public get-login-password` command.
     """
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def get_client(self) -> ECRPublicClient:
         return ECRPublicClient()
 
@@ -47,10 +53,16 @@ class FakeECRPublicResource(ConfigurableResource):
     requests and always returns `'token'` as its login password.
     """
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def get_client(self) -> FakeECRPublicClient:
         return FakeECRPublicClient()
 
 
+@dagster_maintained_resource
 @resource(
     description=(
         "This resource enables connecting to AWS Public and getting a login password from it."
@@ -61,6 +73,7 @@ def ecr_public_resource(context) -> ECRPublicClient:
     return ECRPublicResource.from_resource_context(context).get_client()
 
 
+@dagster_maintained_resource
 @resource(
     description=(
         "This resource behaves like ecr_public_resource except it stubs out the real AWS API"

--- a/python_modules/libraries/dagster-aws/dagster_aws/emr/pyspark_step_launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/emr/pyspark_step_launcher.py
@@ -12,6 +12,7 @@ from dagster import (
     _check as check,
     resource,
 )
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._core.definitions.step_launcher import StepLauncher
 from dagster._core.errors import DagsterInvariantViolationError, raise_execution_interrupts
 from dagster._core.execution.plan.external_step import (
@@ -31,6 +32,7 @@ EMR_SPARK_HOME = "/usr/lib/spark/"
 CODE_ZIP_NAME = "code.zip"
 
 
+@dagster_maintained_resource
 @resource(
     {
         "spark_config": get_spark_config(),

--- a/python_modules/libraries/dagster-aws/dagster_aws/redshift/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/redshift/resources.py
@@ -336,8 +336,7 @@ class RedshiftClientResource(ConfigurableResource):
     )
 
     @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
+    def _is_dagster_maintained(cls) -> bool:
         return True
 
     def get_client(self) -> RedshiftClient:

--- a/python_modules/libraries/dagster-aws/dagster_aws/redshift/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/redshift/resources.py
@@ -12,6 +12,7 @@ from dagster import (
     resource,
 )
 from dagster._annotations import deprecated
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from pydantic import Field
 
 
@@ -334,6 +335,11 @@ class RedshiftClientResource(ConfigurableResource):
         ),
     )
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def get_client(self) -> RedshiftClient:
         conn_args = {
             k: getattr(self, k, None)
@@ -357,6 +363,7 @@ class FakeRedshiftClientResource(RedshiftClientResource):
         return FakeRedshiftClient(get_dagster_logger())
 
 
+@dagster_maintained_resource
 @resource(
     config_schema=RedshiftClientResource.to_config_schema(),
     description="Resource for connecting to the Redshift data warehouse",
@@ -389,6 +396,7 @@ def redshift_resource(context) -> RedshiftClient:
     return RedshiftClientResource.from_resource_context(context).get_client()
 
 
+@dagster_maintained_resource
 @resource(
     config_schema=FakeRedshiftClientResource.to_config_schema(),
     description=(

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
@@ -131,8 +131,7 @@ class ConfigurablePickledObjectS3IOManager(ConfigurableIOManager):
     )
 
     @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
+    def _is_dagster_maintained(cls) -> bool:
         return True
 
     @cached_method

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
@@ -11,6 +11,7 @@ from dagster import (
     _check as check,
     io_manager,
 )
+from dagster._core.storage.io_manager import dagster_maintained_io_manager
 from dagster._core.storage.upath_io_manager import UPathIOManager
 from dagster._utils import PICKLE_PROTOCOL
 from dagster._utils.cached_method import cached_method
@@ -129,6 +130,11 @@ class ConfigurablePickledObjectS3IOManager(ConfigurableIOManager):
         default="dagster", description="Prefix to use for the S3 bucket for this file manager."
     )
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @cached_method
     def inner_io_manager(self) -> PickledObjectS3IOManager:
         return PickledObjectS3IOManager(
@@ -144,6 +150,7 @@ class ConfigurablePickledObjectS3IOManager(ConfigurableIOManager):
         return self.inner_io_manager().handle_output(context, obj)
 
 
+@dagster_maintained_io_manager
 @io_manager(
     config_schema=ConfigurablePickledObjectS3IOManager.to_config_schema(),
     required_resource_keys={"s3"},

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/resources.py
@@ -1,6 +1,7 @@
 from typing import Any, Optional, TypeVar
 
 from dagster import ConfigurableResource, IAttachDifferentObjectToOpContext, resource
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from pydantic import Field
 
 from .file_manager import S3FileManager
@@ -82,6 +83,11 @@ class S3Resource(ResourceWithS3Configuration, IAttachDifferentObjectToOpContext)
 
     """
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def get_client(self) -> Any:
         return construct_s3_client(
             max_attempts=self.max_attempts,
@@ -100,6 +106,7 @@ class S3Resource(ResourceWithS3Configuration, IAttachDifferentObjectToOpContext)
         return self.get_client()
 
 
+@dagster_maintained_resource
 @resource(config_schema=S3Resource.to_config_schema())
 def s3_resource(context) -> Any:
     """Resource that gives access to S3.
@@ -201,6 +208,7 @@ class S3FileManagerResource(ResourceWithS3Configuration, IAttachDifferentObjectT
         return self.get_client()
 
 
+@dagster_maintained_resource
 @resource(
     config_schema=S3FileManagerResource.to_config_schema(),
 )

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/resources.py
@@ -84,8 +84,7 @@ class S3Resource(ResourceWithS3Configuration, IAttachDifferentObjectToOpContext)
     """
 
     @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
+    def _is_dagster_maintained(cls) -> bool:
         return True
 
     def get_client(self) -> Any:

--- a/python_modules/libraries/dagster-aws/dagster_aws/secretsmanager/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/secretsmanager/resources.py
@@ -7,6 +7,7 @@ from dagster import (
     resource,
 )
 from dagster._config.field_utils import Shape
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._core.test_utils import environ
 from dagster._utils.merger import merge_dicts
 from pydantic import Field
@@ -49,6 +50,11 @@ class SecretsManagerResource(ResourceWithBoto3Configuration):
             )
     """
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def get_client(self) -> "botocore.client.SecretsManager":
         return construct_secretsmanager_client(
             max_attempts=self.max_attempts,
@@ -57,6 +63,7 @@ class SecretsManagerResource(ResourceWithBoto3Configuration):
         )
 
 
+@dagster_maintained_resource
 @resource(SecretsManagerResource.to_config_schema())
 def secretsmanager_resource(context) -> "botocore.client.SecretsManager":
     """Resource that gives access to AWS SecretsManager.
@@ -159,6 +166,11 @@ class SecretsManagerSecretsResource(ResourceWithBoto3Configuration):
         description="AWS Secrets Manager secrets with this tag will be fetched and made available.",
     )
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @contextmanager
     def secrets_in_environment(
         self,
@@ -228,6 +240,7 @@ LEGACY_SECRETSMANAGER_SECRETS_SCHEMA = {
 }
 
 
+@dagster_maintained_resource
 @resource(config_schema=LEGACY_SECRETSMANAGER_SECRETS_SCHEMA)
 @contextmanager
 def secretsmanager_secrets_resource(context):

--- a/python_modules/libraries/dagster-aws/dagster_aws/secretsmanager/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/secretsmanager/resources.py
@@ -51,8 +51,7 @@ class SecretsManagerResource(ResourceWithBoto3Configuration):
     """
 
     @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
+    def _is_dagster_maintained(cls) -> bool:
         return True
 
     def get_client(self) -> "botocore.client.SecretsManager":
@@ -167,8 +166,7 @@ class SecretsManagerSecretsResource(ResourceWithBoto3Configuration):
     )
 
     @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
+    def _is_dagster_maintained(cls) -> bool:
         return True
 
     @contextmanager

--- a/python_modules/libraries/dagster-aws/dagster_aws/ssm/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ssm/resources.py
@@ -8,6 +8,7 @@ from dagster import (
     resource,
 )
 from dagster._config.field_utils import Shape
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._core.test_utils import environ
 from dagster._utils.merger import merge_dicts
 from pydantic import Field
@@ -56,6 +57,11 @@ class SSMResource(ResourceWithBoto3Configuration):
             )
     """
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def get_client(self) -> "botocore.client.ssm":
         return construct_ssm_client(
             max_attempts=self.max_attempts,
@@ -64,6 +70,7 @@ class SSMResource(ResourceWithBoto3Configuration):
         )
 
 
+@dagster_maintained_resource
 @resource(config_schema=SSMResource.to_config_schema())
 def ssm_resource(context) -> "botocore.client.ssm":
     """Resource that gives access to AWS Systems Manager Parameter Store.
@@ -182,6 +189,11 @@ class ParameterStoreResource(ResourceWithBoto3Configuration):
         ),
     )
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @contextmanager
     def parameters_in_environment(
         self,
@@ -276,6 +288,7 @@ LEGACY_PARAMETERSTORE_SCHEMA = {
 }
 
 
+@dagster_maintained_resource
 @resource(config_schema=LEGACY_PARAMETERSTORE_SCHEMA)
 @contextmanager
 def parameter_store_resource(context) -> Any:

--- a/python_modules/libraries/dagster-aws/dagster_aws/ssm/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ssm/resources.py
@@ -58,8 +58,7 @@ class SSMResource(ResourceWithBoto3Configuration):
     """
 
     @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
+    def _is_dagster_maintained(cls) -> bool:
         return True
 
     def get_client(self) -> "botocore.client.ssm":
@@ -190,8 +189,7 @@ class ParameterStoreResource(ResourceWithBoto3Configuration):
     )
 
     @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
+    def _is_dagster_maintained(cls) -> bool:
         return True
 
     @contextmanager

--- a/python_modules/libraries/dagster-azure/dagster_azure/adls2/fake_adls2_resource.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/adls2/fake_adls2_resource.py
@@ -5,6 +5,7 @@ from unittest import mock
 
 from dagster import resource
 from dagster._config.pythonic_config import ConfigurableResource
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._utils.cached_method import cached_method
 
 from dagster_azure.blob import FakeBlobServiceClient
@@ -12,6 +13,7 @@ from dagster_azure.blob import FakeBlobServiceClient
 from .utils import ResourceNotFoundError
 
 
+@dagster_maintained_resource
 @resource({"account_name": str})
 def fake_adls2_resource(context):
     return FakeADLS2Resource(account_name=context.resource_config["account_name"])
@@ -25,6 +27,11 @@ class FakeADLS2Resource(ConfigurableResource):
 
     account_name: str
     storage_account: Optional[str] = None
+
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
 
     @property
     @cached_method

--- a/python_modules/libraries/dagster-azure/dagster_azure/adls2/fake_adls2_resource.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/adls2/fake_adls2_resource.py
@@ -29,8 +29,7 @@ class FakeADLS2Resource(ConfigurableResource):
     storage_account: Optional[str] = None
 
     @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
+    def _is_dagster_maintained(cls) -> bool:
         return True
 
     @property

--- a/python_modules/libraries/dagster-azure/dagster_azure/adls2/io_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/adls2/io_manager.py
@@ -10,6 +10,7 @@ from dagster import (
     io_manager,
 )
 from dagster._config.pythonic_config import ConfigurableIOManager
+from dagster._core.storage.io_manager import dagster_maintained_io_manager
 from dagster._core.storage.upath_io_manager import UPathIOManager
 from dagster._utils import PICKLE_PROTOCOL
 from dagster._utils.cached_method import cached_method
@@ -177,6 +178,11 @@ class ConfigurablePickledObjectADLS2IOManager(ConfigurableIOManager):
         default="dagster", description="ADLS Gen2 file system prefix to write to."
     )
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @property
     @cached_method
     def _internal_io_manager(self) -> PickledObjectADLS2IOManager:
@@ -195,6 +201,7 @@ class ConfigurablePickledObjectADLS2IOManager(ConfigurableIOManager):
         self._internal_io_manager.handle_output(context, obj)
 
 
+@dagster_maintained_io_manager
 @io_manager(
     config_schema=ConfigurablePickledObjectADLS2IOManager.to_config_schema(),
     required_resource_keys={"adls2"},

--- a/python_modules/libraries/dagster-azure/dagster_azure/adls2/io_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/adls2/io_manager.py
@@ -179,8 +179,7 @@ class ConfigurablePickledObjectADLS2IOManager(ConfigurableIOManager):
     )
 
     @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
+    def _is_dagster_maintained(cls) -> bool:
         return True
 
     @property

--- a/python_modules/libraries/dagster-azure/dagster_azure/adls2/resources.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/adls2/resources.py
@@ -11,6 +11,7 @@ from dagster import (
     StringSource,
     resource,
 )
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._utils.cached_method import cached_method
 from dagster._utils.merger import merge_dicts
 from pydantic import Field
@@ -72,6 +73,11 @@ class ADLS2Resource(ADLS2BaseResource):
     of each.
     """
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @property
     @cached_method
     def _raw_credential(self) -> Any:
@@ -100,6 +106,7 @@ class ADLS2Resource(ADLS2BaseResource):
 # Due to a limitation of the discriminated union type, we can't directly mirror these old
 # config fields in the new resource config. Instead, we'll just use the old config fields
 # to construct the new config and then use that to construct the resource.
+@dagster_maintained_resource
 @resource(ADLS2_CLIENT_CONFIG)
 def adls2_resource(context):
     """Resource that gives ops access to Azure Data Lake Storage Gen2.
@@ -153,6 +160,7 @@ def adls2_resource(context):
     return _adls2_resource_from_config(context.resource_config)
 
 
+@dagster_maintained_resource
 @resource(
     merge_dicts(
         ADLS2_CLIENT_CONFIG,

--- a/python_modules/libraries/dagster-azure/dagster_azure/adls2/resources.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/adls2/resources.py
@@ -74,8 +74,7 @@ class ADLS2Resource(ADLS2BaseResource):
     """
 
     @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
+    def _is_dagster_maintained(cls) -> bool:
         return True
 
     @property

--- a/python_modules/libraries/dagster-census/dagster_census/resources.py
+++ b/python_modules/libraries/dagster-census/dagster_census/resources.py
@@ -6,6 +6,7 @@ from typing import Any, Mapping, Optional
 
 import requests
 from dagster import Failure, Field, StringSource, __version__, get_dagster_logger, resource
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from requests.auth import HTTPBasicAuth
 from requests.exceptions import RequestException
 
@@ -238,6 +239,7 @@ class CensusResource:
         )
 
 
+@dagster_maintained_resource
 @resource(
     config_schema={
         "api_key": Field(

--- a/python_modules/libraries/dagster-dask/dagster_dask/resources.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/resources.py
@@ -1,4 +1,5 @@
 from dagster import Bool, Field, Int, Permissive, Selector, Shape, String, resource
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dask.distributed import Client
 
 DaskClusterTypes = {
@@ -65,6 +66,7 @@ class DaskResource:
         self._client, self._cluster = None, None
 
 
+@dagster_maintained_resource
 @resource(
     description="Dask Client resource.",
     config_schema=Shape(

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
@@ -15,6 +15,7 @@ from dagster import (
     _check as check,
     resource,
 )
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._core.definitions.step_launcher import StepLauncher
 from dagster._core.errors import raise_execution_interrupts
 from dagster._core.execution.plan.external_step import (
@@ -59,6 +60,7 @@ DAGSTER_SYSTEM_ENV_VARS = {
 }
 
 
+@dagster_maintained_resource
 @resource(
     {
         "run_config": define_databricks_submit_run_config(),

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/resources.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/resources.py
@@ -5,6 +5,7 @@ from dagster import (
     IAttachDifferentObjectToOpContext,
     resource,
 )
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from pydantic import Field
 
 from .databricks import DatabricksClient
@@ -26,6 +27,11 @@ class DatabricksClientResource(ConfigurableResource, IAttachDifferentObjectToOpC
         ),
     )
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def get_client(self) -> DatabricksClient:
         return DatabricksClient(
             host=self.host,
@@ -37,6 +43,7 @@ class DatabricksClientResource(ConfigurableResource, IAttachDifferentObjectToOpC
         return self.get_client()
 
 
+@dagster_maintained_resource
 @resource(config_schema=DatabricksClientResource.to_config_schema())
 def databricks_client(init_context) -> DatabricksClient:
     return DatabricksClientResource.from_resource_context(init_context).get_client()

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/resources.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/resources.py
@@ -28,8 +28,7 @@ class DatabricksClientResource(ConfigurableResource, IAttachDifferentObjectToOpC
     )
 
     @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
+    def _is_dagster_maintained(cls) -> bool:
         return True
 
     def get_client(self) -> DatabricksClient:

--- a/python_modules/libraries/dagster-datadog/dagster_datadog/resources.py
+++ b/python_modules/libraries/dagster-datadog/dagster_datadog/resources.py
@@ -1,4 +1,5 @@
 from dagster import ConfigurableResource, resource
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from datadog import DogStatsd, initialize, statsd
 from pydantic import Field
 
@@ -85,10 +86,16 @@ class DatadogResource(ConfigurableResource):
         )
     )
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def get_client(self) -> DatadogClient:
         return DatadogClient(self.api_key, self.app_key)
 
 
+@dagster_maintained_resource
 @resource(
     config_schema=DatadogResource.to_config_schema(),
     description="This resource is for publishing to DataDog",

--- a/python_modules/libraries/dagster-datadog/dagster_datadog/resources.py
+++ b/python_modules/libraries/dagster-datadog/dagster_datadog/resources.py
@@ -87,8 +87,7 @@ class DatadogResource(ConfigurableResource):
     )
 
     @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
+    def _is_dagster_maintained(cls) -> bool:
         return True
 
     def get_client(self) -> DatadogClient:

--- a/python_modules/libraries/dagster-datahub/dagster_datahub/resources.py
+++ b/python_modules/libraries/dagster-datahub/dagster_datahub/resources.py
@@ -29,8 +29,7 @@ class DatahubRESTEmitterResource(ConfigurableResource):
     disable_ssl_verification: bool = False
 
     @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
+    def _is_dagster_maintained(cls) -> bool:
         return True
 
     def get_emitter(self) -> DatahubRestEmitter:
@@ -89,8 +88,7 @@ class DatahubKafkaEmitterResource(ConfigurableResource):
     )
 
     @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
+    def _is_dagster_maintained(cls) -> bool:
         return True
 
     def get_emitter(self) -> DatahubKafkaEmitter:

--- a/python_modules/libraries/dagster-datahub/dagster_datahub/resources.py
+++ b/python_modules/libraries/dagster-datahub/dagster_datahub/resources.py
@@ -2,6 +2,7 @@ from typing import Any, Dict, List, Optional
 
 from dagster import InitResourceContext, resource
 from dagster._config.pythonic_config import Config, ConfigurableResource
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from datahub.emitter.kafka_emitter import (
     DEFAULT_MCE_KAFKA_TOPIC,
     DEFAULT_MCP_KAFKA_TOPIC,
@@ -27,6 +28,11 @@ class DatahubRESTEmitterResource(ConfigurableResource):
     server_telemetry_id: Optional[str] = None
     disable_ssl_verification: bool = False
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def get_emitter(self) -> DatahubRestEmitter:
         return DatahubRestEmitter(
             gms_server=self.connection,
@@ -43,6 +49,7 @@ class DatahubRESTEmitterResource(ConfigurableResource):
         )
 
 
+@dagster_maintained_resource
 @resource(config_schema=DatahubRESTEmitterResource.to_config_schema())
 def datahub_rest_emitter(init_context: InitResourceContext) -> DatahubRestEmitter:
     emitter = DatahubRestEmitter(
@@ -81,12 +88,18 @@ class DatahubKafkaEmitterResource(ConfigurableResource):
         }
     )
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def get_emitter(self) -> DatahubKafkaEmitter:
         return DatahubKafkaEmitter(
             KafkaEmitterConfig.parse_obj(self._convert_to_config_dictionary())
         )
 
 
+@dagster_maintained_resource
 @resource(config_schema=DatahubKafkaEmitterResource.to_config_schema())
 def datahub_kafka_emitter(init_context: InitResourceContext) -> DatahubKafkaEmitter:
     return DatahubKafkaEmitter(KafkaEmitterConfig.parse_obj(init_context.resource_config))

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources.py
@@ -4,6 +4,7 @@ import dagster._check as check
 from dagster import resource
 from dagster._annotations import public
 from dagster._config.pythonic_config import ConfigurableResource, IAttachDifferentObjectToOpContext
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._utils.merger import merge_dicts
 from pydantic import Field
 
@@ -477,6 +478,11 @@ class DbtCliClientResource(ConfigurableResourceWithCliFlags, IAttachDifferentObj
     class Config:
         extra = "allow"
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def get_dbt_client(self) -> DbtCliClient:
         context = self.get_resource_context()
         default_flags = {
@@ -502,6 +508,7 @@ class DbtCliClientResource(ConfigurableResourceWithCliFlags, IAttachDifferentObj
         return self.get_dbt_client()
 
 
+@dagster_maintained_resource
 @resource(config_schema=DbtCliClientResource.to_config_schema())
 def dbt_cli_resource(context) -> DbtCliClient:
     """This resource issues dbt CLI commands against a configured dbt project."""

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources.py
@@ -479,8 +479,7 @@ class DbtCliClientResource(ConfigurableResourceWithCliFlags, IAttachDifferentObj
         extra = "allow"
 
     @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
+    def _is_dagster_maintained(cls) -> bool:
         return True
 
     def get_dbt_client(self) -> DbtCliClient:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/resources.py
@@ -17,6 +17,7 @@ from dagster import (
     get_dagster_logger,
     resource,
 )
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._utils.merger import deep_merge_dicts
 from pydantic import Field
 from requests.exceptions import RequestException
@@ -638,6 +639,11 @@ class DbtCloudClientResource(ConfigurableResource, IAttachDifferentObjectToOpCon
         ),
     )
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def get_dbt_client(self) -> DbtCloudClient:
         context = self.get_resource_context()
         assert context.log
@@ -656,6 +662,7 @@ class DbtCloudClientResource(ConfigurableResource, IAttachDifferentObjectToOpCon
         return self.get_dbt_client()
 
 
+@dagster_maintained_resource
 @resource(
     config_schema=DbtCloudClientResource.to_config_schema(),
     description="This resource helps interact with dbt Cloud connectors",

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/resources.py
@@ -640,8 +640,7 @@ class DbtCloudClientResource(ConfigurableResource, IAttachDifferentObjectToOpCon
     )
 
     @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
+    def _is_dagster_maintained(cls) -> bool:
         return True
 
     def get_dbt_client(self) -> DbtCloudClient:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/rpc/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/rpc/resources.py
@@ -18,7 +18,10 @@ from dagster import (
     _check as check,
     resource,
 )
-from dagster._core.definitions.resource_definition import ResourceDefinition
+from dagster._core.definitions.resource_definition import (
+    ResourceDefinition,
+    dagster_maintained_resource,
+)
 from dagster._core.utils import coerce_valid_log_level
 
 from ..dbt_resource import DbtResource
@@ -577,6 +580,7 @@ class DbtRpcSyncResource(DbtRpcResource):
         return out
 
 
+@dagster_maintained_resource
 @resource(
     description="A resource representing a dbt RPC client.",
     config_schema={
@@ -606,6 +610,7 @@ def dbt_rpc_resource(context) -> DbtRpcResource:
     )
 
 
+@dagster_maintained_resource
 @resource(
     description="A resource representing a synchronous dbt RPC client.",
     config_schema={

--- a/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas/duckdb_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas/duckdb_pandas_type_handler.py
@@ -191,6 +191,11 @@ class DuckDBPandasIOManager(DuckDBIOManager):
 
     """
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @staticmethod
     def type_handlers() -> Sequence[DbTypeHandler]:
         return [DuckDBPandasTypeHandler()]

--- a/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas/duckdb_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas/duckdb_pandas_type_handler.py
@@ -192,8 +192,7 @@ class DuckDBPandasIOManager(DuckDBIOManager):
     """
 
     @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
+    def _is_dagster_maintained(cls) -> bool:
         return True
 
     @staticmethod

--- a/python_modules/libraries/dagster-duckdb-polars/dagster_duckdb_polars/duckdb_polars_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-polars/dagster_duckdb_polars/duckdb_polars_type_handler.py
@@ -194,8 +194,7 @@ class DuckDBPolarsIOManager(DuckDBIOManager):
     """
 
     @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
+    def _is_dagster_maintained(cls) -> bool:
         return True
 
     @staticmethod

--- a/python_modules/libraries/dagster-duckdb-polars/dagster_duckdb_polars/duckdb_polars_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-polars/dagster_duckdb_polars/duckdb_polars_type_handler.py
@@ -193,6 +193,11 @@ class DuckDBPolarsIOManager(DuckDBIOManager):
 
     """
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @staticmethod
     def type_handlers() -> Sequence[DbTypeHandler]:
         return [DuckDBPolarsTypeHandler()]

--- a/python_modules/libraries/dagster-duckdb-pyspark/dagster_duckdb_pyspark/duckdb_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pyspark/dagster_duckdb_pyspark/duckdb_pyspark_type_handler.py
@@ -201,8 +201,7 @@ class DuckDBPySparkIOManager(DuckDBIOManager):
     """
 
     @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
+    def _is_dagster_maintained(cls) -> bool:
         return True
 
     @staticmethod

--- a/python_modules/libraries/dagster-duckdb-pyspark/dagster_duckdb_pyspark/duckdb_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pyspark/dagster_duckdb_pyspark/duckdb_pyspark_type_handler.py
@@ -200,6 +200,11 @@ class DuckDBPySparkIOManager(DuckDBIOManager):
 
     """
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @staticmethod
     def type_handlers() -> Sequence[DbTypeHandler]:
         return [DuckDBPySparkTypeHandler()]

--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
@@ -15,6 +15,7 @@ from dagster._core.storage.db_io_manager import (
     TablePartitionDimension,
     TableSlice,
 )
+from dagster._core.storage.io_manager import dagster_maintained_io_manager
 from dagster._utils.backoff import backoff
 from pydantic import Field
 
@@ -83,6 +84,7 @@ def build_duckdb_io_manager(
 
     """
 
+    @dagster_maintained_io_manager
     @io_manager(config_schema=DuckDBIOManager.to_config_schema())
     def duckdb_io_manager(init_context):
         """IO Manager for storing outputs in a DuckDB database.

--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb/resource.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb/resource.py
@@ -34,6 +34,11 @@ class DuckDBResource(ConfigurableResource):
         )
     )
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @contextmanager
     def get_connection(self):
         conn = backoff(

--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb/resource.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb/resource.py
@@ -35,8 +35,7 @@ class DuckDBResource(ConfigurableResource):
     )
 
     @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
+    def _is_dagster_maintained(cls) -> bool:
         return True
 
     @contextmanager

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
@@ -59,8 +59,7 @@ class FivetranResource(ConfigurableResource):
     )
 
     @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
+    def _is_dagster_maintained(cls) -> bool:
         return True
 
     @property

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
@@ -16,6 +16,7 @@ from dagster import (
     resource,
 )
 from dagster._config.pythonic_config import ConfigurableResource
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._utils.cached_method import cached_method
 from dateutil import parser
 from pydantic import Field
@@ -56,6 +57,11 @@ class FivetranResource(ConfigurableResource):
         default=0.25,
         description="Time (in seconds) to wait between each request retry.",
     )
+
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
 
     @property
     def _auth(self) -> HTTPBasicAuth:
@@ -391,6 +397,7 @@ class FivetranResource(ConfigurableResource):
         return FivetranOutput(connector_details=final_details, schema_config=schema_config)
 
 
+@dagster_maintained_resource
 @resource(config_schema=FivetranResource.to_config_schema())
 def fivetran_resource(context: InitResourceContext) -> FivetranResource:
     """This resource allows users to programatically interface with the Fivetran REST API to launch

--- a/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas/bigquery/bigquery_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas/bigquery/bigquery_pandas_type_handler.py
@@ -226,8 +226,7 @@ class BigQueryPandasIOManager(BigQueryIOManager):
     """
 
     @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
+    def _is_dagster_maintained(cls) -> bool:
         return True
 
     @staticmethod

--- a/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas/bigquery/bigquery_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas/bigquery/bigquery_pandas_type_handler.py
@@ -225,6 +225,11 @@ class BigQueryPandasIOManager(BigQueryIOManager):
 
     """
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @staticmethod
     def type_handlers() -> Sequence[DbTypeHandler]:
         return [BigQueryPandasTypeHandler()]

--- a/python_modules/libraries/dagster-gcp-pyspark/dagster_gcp_pyspark/bigquery/bigquery_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-gcp-pyspark/dagster_gcp_pyspark/bigquery/bigquery_pyspark_type_handler.py
@@ -233,8 +233,7 @@ class BigQueryPySparkIOManager(BigQueryIOManager):
     """
 
     @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
+    def _is_dagster_maintained(cls) -> bool:
         return True
 
     @staticmethod

--- a/python_modules/libraries/dagster-gcp-pyspark/dagster_gcp_pyspark/bigquery/bigquery_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-gcp-pyspark/dagster_gcp_pyspark/bigquery/bigquery_pyspark_type_handler.py
@@ -232,6 +232,11 @@ class BigQueryPySparkIOManager(BigQueryIOManager):
 
     """
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @staticmethod
     def type_handlers() -> Sequence[DbTypeHandler]:
         return [BigQueryPySparkTypeHandler()]

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/io_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/io_manager.py
@@ -15,6 +15,7 @@ from dagster._core.storage.db_io_manager import (
     TableSlice,
     TimeWindow,
 )
+from dagster._core.storage.io_manager import dagster_maintained_io_manager
 from google.api_core.exceptions import NotFound
 from google.cloud import bigquery
 from pydantic import Field
@@ -101,6 +102,7 @@ def build_bigquery_io_manager(
         the base64 encoded with this shell command: cat $GOOGLE_APPLICATION_CREDENTIALS | base64
     """
 
+    @dagster_maintained_io_manager
     @io_manager(config_schema=BigQueryIOManager.to_config_schema())
     def bigquery_io_manager(init_context):
         """I/O Manager for storing outputs in a BigQuery database.

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/resources.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/resources.py
@@ -57,8 +57,7 @@ class BigQueryResource(ConfigurableResource, IAttachDifferentObjectToOpContext):
     )
 
     @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
+    def _is_dagster_maintained(cls) -> bool:
         return True
 
     @contextmanager

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/resources.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/resources.py
@@ -2,6 +2,7 @@ from contextlib import contextmanager
 from typing import Any, Iterator, Optional
 
 from dagster import ConfigurableResource, IAttachDifferentObjectToOpContext, resource
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from google.cloud import bigquery
 from pydantic import Field
 
@@ -55,6 +56,11 @@ class BigQueryResource(ConfigurableResource, IAttachDifferentObjectToOpContext):
         ),
     )
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @contextmanager
     def get_client(self) -> Iterator[bigquery.Client]:
         """Context manager to create a BigQuery Client.
@@ -82,6 +88,7 @@ class BigQueryResource(ConfigurableResource, IAttachDifferentObjectToOpContext):
             yield client
 
 
+@dagster_maintained_resource
 @resource(
     config_schema=BigQueryResource.to_config_schema(),
     description="Dagster resource for connecting to BigQuery",

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/dataproc/resources.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/dataproc/resources.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, Mapping, Optional
 import dagster._check as check
 import yaml
 from dagster import ConfigurableResource, IAttachDifferentObjectToOpContext, resource
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from googleapiclient.discovery import build
 from oauth2client.client import GoogleCredentials
 from pydantic import Field
@@ -198,6 +199,11 @@ class DataprocResource(ConfigurableResource, IAttachDifferentObjectToOpContext):
         ),
     )
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def _read_yaml_config(self, path: str) -> Mapping[str, Any]:
         with open(path, "r", encoding="utf8") as f:
             return yaml.safe_load(f)
@@ -248,6 +254,7 @@ class DataprocResource(ConfigurableResource, IAttachDifferentObjectToOpContext):
         return self.get_client()
 
 
+@dagster_maintained_resource
 @resource(
     config_schema=define_dataproc_create_cluster_config(),
     description="Manage a Dataproc cluster resource",

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/dataproc/resources.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/dataproc/resources.py
@@ -200,8 +200,7 @@ class DataprocResource(ConfigurableResource, IAttachDifferentObjectToOpContext):
     )
 
     @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
+    def _is_dagster_maintained(cls) -> bool:
         return True
 
     def _read_yaml_config(self, path: str) -> Mapping[str, Any]:

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/io_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/io_manager.py
@@ -9,6 +9,7 @@ from dagster import (
     _check as check,
     io_manager,
 )
+from dagster._core.storage.io_manager import dagster_maintained_io_manager
 from dagster._core.storage.upath_io_manager import UPathIOManager
 from dagster._utils import PICKLE_PROTOCOL
 from dagster._utils.backoff import backoff
@@ -145,6 +146,11 @@ class ConfigurablePickledObjectGCSIOManager(ConfigurableIOManager):
     gcs_bucket: str = Field(description="GCS bucket to store files")
     gcs_prefix: str = Field(default="dagster", description="Prefix to add to all file paths")
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @property
     @cached_method
     def _internal_io_manager(self) -> PickledObjectGCSIOManager:
@@ -159,6 +165,7 @@ class ConfigurablePickledObjectGCSIOManager(ConfigurableIOManager):
         self._internal_io_manager.handle_output(context, obj)
 
 
+@dagster_maintained_io_manager
 @io_manager(
     config_schema=ConfigurablePickledObjectGCSIOManager.to_config_schema(),
     required_resource_keys={"gcs"},

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/io_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/io_manager.py
@@ -147,8 +147,7 @@ class ConfigurablePickledObjectGCSIOManager(ConfigurableIOManager):
     gcs_prefix: str = Field(default="dagster", description="Prefix to add to all file paths")
 
     @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
+    def _is_dagster_maintained(cls) -> bool:
         return True
 
     @property

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/resources.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/resources.py
@@ -1,6 +1,7 @@
 from typing import Any, Optional
 
 from dagster import ConfigurableResource, IAttachDifferentObjectToOpContext, resource
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from google.cloud import storage
 from pydantic import Field
 
@@ -17,6 +18,7 @@ class GCSResource(ConfigurableResource, IAttachDifferentObjectToOpContext):
         return self.get_client()
 
 
+@dagster_maintained_resource
 @resource(
     config_schema=GCSResource.to_config_schema(),
     description="This resource provides a GCS client",
@@ -42,6 +44,7 @@ class GCSFileManagerResource(ConfigurableResource, IAttachDifferentObjectToOpCon
         return self.get_client()
 
 
+@dagster_maintained_resource
 @resource(config_schema=GCSFileManagerResource.to_config_schema())
 def gcs_file_manager(context):
     """FileManager that provides abstract access to GCS.

--- a/python_modules/libraries/dagster-ge/dagster_ge/factory.py
+++ b/python_modules/libraries/dagster-ge/dagster_ge/factory.py
@@ -15,6 +15,7 @@ from dagster import (
     op,
     resource,
 )
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster_pandas import DataFrame
 from great_expectations.render.renderer import ValidationResultsPageRenderer
 from great_expectations.render.view import DefaultMarkdownPageView
@@ -43,6 +44,7 @@ class GEContextResource(ConfigurableResource, IAttachDifferentObjectToOpContext)
         return self.get_data_context()
 
 
+@dagster_maintained_resource
 @resource(config_schema=GEContextResource.to_config_schema())
 def ge_data_context(context):
     return GEContextResource.from_resource_context(context).get_data_context()

--- a/python_modules/libraries/dagster-github/dagster_github/resources.py
+++ b/python_modules/libraries/dagster-github/dagster_github/resources.py
@@ -5,6 +5,7 @@ from typing import Optional
 import jwt
 import requests
 from dagster import ConfigurableResource, resource
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from pydantic import Field
 
 
@@ -180,6 +181,11 @@ class GithubResource(ConfigurableResource):
         ),
     )
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def get_client(self) -> GithubClient:
         return GithubClient(
             client=requests.Session(),
@@ -190,6 +196,7 @@ class GithubResource(ConfigurableResource):
         )
 
 
+@dagster_maintained_resource
 @resource(
     config_schema=GithubResource.to_config_schema(),
     description="This resource is for connecting to Github",

--- a/python_modules/libraries/dagster-github/dagster_github/resources.py
+++ b/python_modules/libraries/dagster-github/dagster_github/resources.py
@@ -182,8 +182,7 @@ class GithubResource(ConfigurableResource):
     )
 
     @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
+    def _is_dagster_maintained(cls) -> bool:
         return True
 
     def get_client(self) -> GithubClient:

--- a/python_modules/libraries/dagster-mlflow/dagster_mlflow/resources.py
+++ b/python_modules/libraries/dagster-mlflow/dagster_mlflow/resources.py
@@ -10,6 +10,7 @@ from typing import Any, Optional
 
 import mlflow
 from dagster import Field, Noneable, Permissive, StringSource, resource
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from mlflow.entities.run_status import RunStatus
 
 CONFIG_SCHEMA = {
@@ -218,6 +219,7 @@ class MlFlow(metaclass=MlflowMeta):
             yield {k: params[k] for k in islice(it, size)}
 
 
+@dagster_maintained_resource
 @resource(config_schema=CONFIG_SCHEMA)
 def mlflow_tracking(context):
     """This resource initializes an MLflow run that's used for all steps within a Dagster run.

--- a/python_modules/libraries/dagster-msteams/dagster_msteams/resources.py
+++ b/python_modules/libraries/dagster-msteams/dagster_msteams/resources.py
@@ -1,4 +1,5 @@
 from dagster import ConfigurableResource, resource
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from pydantic import Field
 
 from dagster_msteams.client import TeamsClient
@@ -60,6 +61,11 @@ class MSTeamsResource(ConfigurableResource):
         default=True, description="Whether to verify SSL certificates, defaults to True"
     )
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def get_client(self) -> TeamsClient:
         return TeamsClient(
             hook_url=self.hook_url,
@@ -70,6 +76,7 @@ class MSTeamsResource(ConfigurableResource):
         )
 
 
+@dagster_maintained_resource
 @resource(
     config_schema=MSTeamsResource.to_config_schema(),
     description="This resource is for connecting to MS Teams",

--- a/python_modules/libraries/dagster-msteams/dagster_msteams/resources.py
+++ b/python_modules/libraries/dagster-msteams/dagster_msteams/resources.py
@@ -62,8 +62,7 @@ class MSTeamsResource(ConfigurableResource):
     )
 
     @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
+    def _is_dagster_maintained(cls) -> bool:
         return True
 
     def get_client(self) -> TeamsClient:

--- a/python_modules/libraries/dagster-pagerduty/dagster_pagerduty/resources.py
+++ b/python_modules/libraries/dagster-pagerduty/dagster_pagerduty/resources.py
@@ -32,8 +32,7 @@ class PagerDutyService(ConfigurableResource):
     )
 
     @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
+    def _is_dagster_maintained(cls) -> bool:
         return True
 
     def EventV2_create(

--- a/python_modules/libraries/dagster-pagerduty/dagster_pagerduty/resources.py
+++ b/python_modules/libraries/dagster-pagerduty/dagster_pagerduty/resources.py
@@ -4,6 +4,7 @@ import pypd
 from dagster import ConfigurableResource, resource
 from dagster._annotations import quiet_experimental_warnings
 from dagster._config.pythonic_config import infer_schema_from_config_class
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from pydantic import Field as PyField
 
 
@@ -29,6 +30,11 @@ class PagerDutyService(ConfigurableResource):
             "routing_key in the event payload."
         ),
     )
+
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
 
     def EventV2_create(
         self,
@@ -160,6 +166,7 @@ class PagerDutyService(ConfigurableResource):
         return pypd.EventV2.create(data=data)
 
 
+@dagster_maintained_resource
 @resource(
     config_schema=infer_schema_from_config_class(PagerDutyService),
     description="""This resource is for posting events to PagerDuty.""",

--- a/python_modules/libraries/dagster-prometheus/dagster_prometheus/resources.py
+++ b/python_modules/libraries/dagster-prometheus/dagster_prometheus/resources.py
@@ -52,8 +52,7 @@ class PrometheusResource(ConfigurableResource):
     _registry: prometheus_client.CollectorRegistry = PrivateAttr(default=None)
 
     @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
+    def _is_dagster_maintained(cls) -> bool:
         return True
 
     def setup_for_execution(self, context: InitResourceContext) -> None:

--- a/python_modules/libraries/dagster-prometheus/dagster_prometheus/resources.py
+++ b/python_modules/libraries/dagster-prometheus/dagster_prometheus/resources.py
@@ -3,6 +3,7 @@ from dagster import (
     ConfigurableResource,
     resource,
 )
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._core.execution.context.init import InitResourceContext
 from prometheus_client.exposition import default_handler
 from pydantic import Field, PrivateAttr
@@ -49,6 +50,11 @@ class PrometheusResource(ConfigurableResource):
         description="is how long delete will attempt to connect before giving up. Defaults to 30s.",
     )
     _registry: prometheus_client.CollectorRegistry = PrivateAttr(default=None)
+
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
 
     def setup_for_execution(self, context: InitResourceContext) -> None:
         self._registry = prometheus_client.CollectorRegistry()
@@ -145,6 +151,7 @@ class PrometheusResource(ConfigurableResource):
         )
 
 
+@dagster_maintained_resource
 @resource(
     config_schema=PrometheusResource.to_config_schema(),
     description="""This resource is for sending metrics to a Prometheus Pushgateway.""",

--- a/python_modules/libraries/dagster-pyspark/dagster_pyspark/resources.py
+++ b/python_modules/libraries/dagster-pyspark/dagster_pyspark/resources.py
@@ -2,6 +2,7 @@ from typing import Any, Dict
 
 import dagster._check as check
 from dagster import ConfigurableResource, resource
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._core.execution.context.init import InitResourceContext
 from dagster_spark.configs_spark import spark_config
 from dagster_spark.utils import flatten_dict
@@ -47,6 +48,11 @@ class PySparkResource(ConfigurableResource):
     spark_config: Dict[str, Any]
     _spark_session = PrivateAttr(default=None)
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def setup_for_execution(self, context: InitResourceContext) -> None:
         self._spark_session = spark_session_from_config(self.spark_config)
 
@@ -59,6 +65,7 @@ class PySparkResource(ConfigurableResource):
         return self.spark_session.sparkContext
 
 
+@dagster_maintained_resource
 @resource({"spark_conf": spark_config()})
 def pyspark_resource(init_context) -> PySparkResource:
     """This resource provides access to a PySpark SparkSession for executing PySpark code within Dagster.
@@ -115,6 +122,11 @@ class LazyPySparkResource(ConfigurableResource):
     spark_config: Dict[str, Any]
     _spark_session = PrivateAttr(default=None)
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def _init_session(self) -> None:
         if self._spark_session is None:
             self._spark_session = spark_session_from_config(self.spark_config)
@@ -130,6 +142,7 @@ class LazyPySparkResource(ConfigurableResource):
         return self._spark_session.sparkContext
 
 
+@dagster_maintained_resource
 @resource({"spark_conf": spark_config()})
 def lazy_pyspark_resource(init_context: InitResourceContext) -> LazyPySparkResource:
     """This resource provides access to a lazily-created  PySpark SparkSession for executing PySpark

--- a/python_modules/libraries/dagster-pyspark/dagster_pyspark/resources.py
+++ b/python_modules/libraries/dagster-pyspark/dagster_pyspark/resources.py
@@ -49,8 +49,7 @@ class PySparkResource(ConfigurableResource):
     _spark_session = PrivateAttr(default=None)
 
     @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
+    def _is_dagster_maintained(cls) -> bool:
         return True
 
     def setup_for_execution(self, context: InitResourceContext) -> None:
@@ -123,8 +122,7 @@ class LazyPySparkResource(ConfigurableResource):
     _spark_session = PrivateAttr(default=None)
 
     @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
+    def _is_dagster_maintained(cls) -> bool:
         return True
 
     def _init_session(self) -> None:

--- a/python_modules/libraries/dagster-slack/dagster_slack/resources.py
+++ b/python_modules/libraries/dagster-slack/dagster_slack/resources.py
@@ -45,8 +45,7 @@ class SlackResource(ConfigurableResource):
     )
 
     @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
+    def _is_dagster_maintained(cls) -> bool:
         return True
 
     def get_client(self) -> WebClient:

--- a/python_modules/libraries/dagster-slack/dagster_slack/resources.py
+++ b/python_modules/libraries/dagster-slack/dagster_slack/resources.py
@@ -1,4 +1,5 @@
 from dagster import ConfigurableResource, resource
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from pydantic import Field
 from slack_sdk.web.client import WebClient
 
@@ -43,11 +44,17 @@ class SlackResource(ConfigurableResource):
         ),
     )
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def get_client(self) -> WebClient:
         """Returns a ``slack_sdk.WebClient`` for interacting with the Slack API."""
         return WebClient(self.token)
 
 
+@dagster_maintained_resource
 @resource(
     config_schema=SlackResource.to_config_schema(),
 )

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
@@ -292,8 +292,7 @@ class SnowflakePandasIOManager(SnowflakeIOManager):
     """
 
     @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
+    def _is_dagster_maintained(cls) -> bool:
         return True
 
     @staticmethod

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
@@ -291,6 +291,11 @@ class SnowflakePandasIOManager(SnowflakeIOManager):
 
     """
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @staticmethod
     def type_handlers() -> Sequence[DbTypeHandler]:
         return [SnowflakePandasTypeHandler()]

--- a/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark/snowflake_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark/snowflake_pyspark_type_handler.py
@@ -237,8 +237,7 @@ class SnowflakePySparkIOManager(SnowflakeIOManager):
     """
 
     @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
+    def _is_dagster_maintained(cls) -> bool:
         return True
 
     @staticmethod

--- a/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark/snowflake_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark/snowflake_pyspark_type_handler.py
@@ -236,6 +236,11 @@ class SnowflakePySparkIOManager(SnowflakeIOManager):
 
     """
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     @staticmethod
     def type_handlers() -> Sequence[DbTypeHandler]:
         return [SnowflakePySparkTypeHandler()]

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
@@ -14,6 +14,7 @@ from dagster import (
     resource,
 )
 from dagster._annotations import public
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._core.storage.event_log.sql_event_log import SqlDbConnection
 from dagster._utils.cached_method import cached_method
 from pydantic import Field, root_validator, validator
@@ -286,6 +287,11 @@ class SnowflakeResource(ConfigurableResource, IAttachDifferentObjectToOpContext)
         )
 
         return values
+
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
 
     @property
     @cached_method
@@ -643,6 +649,7 @@ class SnowflakeConnection:
         self.execute_queries(sql_queries)
 
 
+@dagster_maintained_resource
 @resource(
     config_schema=SnowflakeResource.to_config_schema(),
     description="This resource is for connecting to the Snowflake data warehouse",

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
@@ -289,8 +289,7 @@ class SnowflakeResource(ConfigurableResource, IAttachDifferentObjectToOpContext)
         return values
 
     @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
+    def _is_dagster_maintained(cls) -> bool:
         return True
 
     @property

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
@@ -14,6 +14,7 @@ from dagster._core.storage.db_io_manager import (
     TablePartitionDimension,
     TableSlice,
 )
+from dagster._core.storage.io_manager import dagster_maintained_io_manager
 from pydantic import Field
 from sqlalchemy.exc import ProgrammingError
 
@@ -91,6 +92,7 @@ def build_snowflake_io_manager(
 
     """
 
+    @dagster_maintained_io_manager
     @io_manager(config_schema=SnowflakeIOManager.to_config_schema())
     def snowflake_io_manager(init_context):
         return DbIOManager(

--- a/python_modules/libraries/dagster-spark/dagster_spark/resources.py
+++ b/python_modules/libraries/dagster-spark/dagster_spark/resources.py
@@ -3,6 +3,7 @@ import subprocess
 
 import dagster._check as check
 from dagster import resource
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._core.log_manager import DagsterLogManager
 
 from .types import SparkOpError
@@ -60,6 +61,7 @@ class SparkResource:
             raise SparkOpError("Spark job failed. Please consult your logs.")
 
 
+@dagster_maintained_resource
 @resource
 def spark_resource(context):
     return SparkResource(context.log)

--- a/python_modules/libraries/dagster-ssh/dagster_ssh/resources.py
+++ b/python_modules/libraries/dagster-ssh/dagster_ssh/resources.py
@@ -11,6 +11,7 @@ from dagster import (
     _check as check,
     resource,
 )
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._utils import mkdir_p
 from dagster._utils.merger import merge_dicts
 from paramiko.config import SSH_PORT
@@ -212,6 +213,7 @@ class SSHResource:
         return local_filepath
 
 
+@dagster_maintained_resource
 @resource(
     config_schema={
         "remote_host": Field(

--- a/python_modules/libraries/dagster-twilio/dagster_twilio/resources.py
+++ b/python_modules/libraries/dagster-twilio/dagster_twilio/resources.py
@@ -23,8 +23,7 @@ class TwilioResource(ConfigurableResource):
     )
 
     @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
+    def _is_dagster_maintained(cls) -> bool:
         return True
 
     def create_client(self) -> Client:

--- a/python_modules/libraries/dagster-twilio/dagster_twilio/resources.py
+++ b/python_modules/libraries/dagster-twilio/dagster_twilio/resources.py
@@ -1,4 +1,5 @@
 from dagster import ConfigurableResource, resource
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._core.execution.context.init import InitResourceContext
 from pydantic import Field
 from twilio.rest import Client
@@ -21,10 +22,16 @@ class TwilioResource(ConfigurableResource):
         ),
     )
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def create_client(self) -> Client:
         return Client(self.account_sid, self.auth_token)
 
 
+@dagster_maintained_resource
 @resource(
     config_schema=TwilioResource.to_config_schema(),
     description="This resource is for connecting to Twilio",

--- a/python_modules/libraries/dagster-wandb/dagster_wandb/io_manager.py
+++ b/python_modules/libraries/dagster-wandb/dagster_wandb/io_manager.py
@@ -19,6 +19,7 @@ from dagster import (
     String,
     io_manager,
 )
+from dagster._core.storage.io_manager import dagster_maintained_io_manager
 from wandb.sdk.data_types.base_types.wb_value import WBValue
 from wandb.sdk.wandb_artifacts import Artifact
 
@@ -580,6 +581,7 @@ class ArtifactsIOManager(IOManager):
             raise WandbArtifactsIOManagerError() from exception
 
 
+@dagster_maintained_io_manager
 @io_manager(
     required_resource_keys={"wandb_resource", "wandb_config"},
     description="IO manager to read and write W&B Artifacts",

--- a/python_modules/libraries/dagster-wandb/dagster_wandb/resources.py
+++ b/python_modules/libraries/dagster-wandb/dagster_wandb/resources.py
@@ -2,11 +2,13 @@ from typing import Any, Dict
 
 import wandb
 from dagster import Field, InitResourceContext, String, StringSource, resource
+from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from wandb.sdk.internal.internal_api import Api
 
 WANDB_CLOUD_HOST: str = "https://api.wandb.ai"
 
 
+@dagster_maintained_resource
 @resource(
     config_schema={
         "api_key": Field(

--- a/python_modules/libraries/dagstermill/dagstermill/io_managers.py
+++ b/python_modules/libraries/dagstermill/dagstermill/io_managers.py
@@ -101,8 +101,7 @@ class ConfigurableLocalOutputNotebookIOManager(ConfigurableIOManagerFactory):
     )
 
     @classmethod
-    @property
-    def _dagster_maintained(cls) -> bool:
+    def _is_dagster_maintained(cls) -> bool:
         return True
 
     def create_io_manager(self, context: InitResourceContext) -> "LocalOutputNotebookIOManager":

--- a/python_modules/libraries/dagstermill/dagstermill/io_managers.py
+++ b/python_modules/libraries/dagstermill/dagstermill/io_managers.py
@@ -13,7 +13,7 @@ from dagster import (
 from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.execution.context.input import InputContext
 from dagster._core.execution.context.output import OutputContext
-from dagster._core.storage.io_manager import io_manager
+from dagster._core.storage.io_manager import dagster_maintained_io_manager, io_manager
 from dagster._utils import mkdir_p
 from pydantic import Field
 
@@ -100,6 +100,11 @@ class ConfigurableLocalOutputNotebookIOManager(ConfigurableIOManagerFactory):
         ),
     )
 
+    @classmethod
+    @property
+    def _dagster_maintained(cls) -> bool:
+        return True
+
     def create_io_manager(self, context: InitResourceContext) -> "LocalOutputNotebookIOManager":
         return LocalOutputNotebookIOManager(
             base_dir=self.base_dir or check.not_none(context.instance).storage_directory(),
@@ -107,6 +112,7 @@ class ConfigurableLocalOutputNotebookIOManager(ConfigurableIOManagerFactory):
         )
 
 
+@dagster_maintained_io_manager
 @io_manager(config_schema=ConfigurableLocalOutputNotebookIOManager.to_config_schema())
 def local_output_notebook_io_manager(init_context) -> LocalOutputNotebookIOManager:
     """Built-in IO Manager that handles output notebooks."""


### PR DESCRIPTION
"Reverts" dagster-io/dagster#14607 which reverted https://github.com/dagster-io/dagster/pull/14025 and  https://github.com/dagster-io/dagster/pull/14463

This should fix the bug/python error in the original PRs. Basically only python 3.9 and 3.10 support stacked `@classmethod` and `@property` decorators. https://docs.python.org/3.11/library/functions.html?highlight=classmethod#classmethod

Since the `@property` decorator isn't strictly required for telemetry to function, we remove it in this version and update the naming so that there aren't name collisions


Ran this version of telemetry on project fully featured like in https://github.com/dagster-io/dagster/pull/14468 and confirmed that the correct telemetry logs were produced