### PR TITLE
feat(dbt): add method to retrieve success of dbt CLI process

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources_v2.py
@@ -238,6 +238,14 @@ class DbtCliTask:
         """
         return list(self.stream_raw_events())
 
+    def is_successful(self) -> bool:
+        """Return whether the dbt CLI process completed successfully.
+
+        Returns:
+            bool: True, if the dbt CLI process returns with a zero exit code, and False otherwise.
+        """
+        return self.process.wait() == 0
+
     def stream(self) -> Iterator[Union[Output, AssetObservation]]:
         """Stream the events from the dbt CLI process and convert them to Dagster events.
 
@@ -265,11 +273,8 @@ class DbtCliTask:
 
             yield event
 
-        # TODO: handle the return codes here!
-        # https://docs.getdbt.com/reference/exit-codes
-        return_code = self.process.wait()
-
-        return return_code
+        # Ensure that the dbt CLI process has completed.
+        self.process.wait()
 
     def get_artifact(
         self,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_resources_v2.py
@@ -23,7 +23,16 @@ def test_dbt_cli(global_config: List[str], command: str) -> None:
     list(dbt_cli_task.stream())
 
     assert dbt_cli_task.process.args == ["dbt", *global_config, command]
+    assert dbt_cli_task.is_successful()
     assert dbt_cli_task.process.returncode == 0
+
+
+def test_dbt_cli_failure() -> None:
+    dbt = DbtCli(project_dir=TEST_PROJECT_DIR)
+    dbt_cli_task = dbt.cli(["run", "--profiles-dir", "nonexistent"], manifest=manifest)
+
+    assert not dbt_cli_task.is_successful()
+    assert dbt_cli_task.process.returncode == 2
 
 
 def test_dbt_cli_get_artifact() -> None:


### PR DESCRIPTION
## Summary & Motivation

- According to https://docs.getdbt.com/reference/exit-codes, the only contract with dbt exit codes is that a zero exit code is a success.
- We should not raise an exception on behalf of the user. This behavior should be explicitly handled by the user. This is similar to the behavior in https://docs.getdbt.com/reference/programmatic-invocations#dbtrunnerresult.

## How I Tested These Changes
pytest
