### PR TITLE
disable alembic quiet calls for sensor logging test

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/sql.py
+++ b/python_modules/dagster/dagster/_core/storage/sql.py
@@ -1,3 +1,4 @@
+import os
 import threading
 from functools import lru_cache
 from typing import Any, Optional, Tuple, Union
@@ -64,8 +65,14 @@ _alembic_lock = threading.Lock()
 
 
 def stamp_alembic_rev(
-    alembic_config: Config, conn: Connection, rev: str = "head", quiet: bool = True
+    alembic_config: Config, conn: Connection, rev: str = "head", quiet: Optional[bool] = False
 ) -> None:
+    if quiet is None:
+        quiet = (
+            bool(os.environ["OVERRIDE_ALEMBIC_QUIET"])
+            if "OVERRIDE_ALEMBIC_QUIET" in os.environ
+            else True
+        )
     with _alembic_lock, quieten(quiet):
         alembic_config.attributes["connection"] = conn
         stamp(alembic_config, rev)

--- a/python_modules/dagster/dagster/_core/storage/sql.py
+++ b/python_modules/dagster/dagster/_core/storage/sql.py
@@ -1,4 +1,3 @@
-import os
 import threading
 from functools import lru_cache
 from typing import Any, Optional, Tuple, Union
@@ -14,7 +13,6 @@ from sqlalchemy.ext.compiler import compiles
 from typing_extensions import TypeAlias
 
 from dagster._utils import file_relative_path
-from dagster._utils.log import quieten
 
 create_engine = db.create_engine  # exported
 
@@ -64,16 +62,8 @@ def run_alembic_downgrade(
 _alembic_lock = threading.Lock()
 
 
-def stamp_alembic_rev(
-    alembic_config: Config, conn: Connection, rev: str = "head", quiet: Optional[bool] = False
-) -> None:
-    if quiet is None:
-        quiet = (
-            bool(os.environ["OVERRIDE_ALEMBIC_QUIET"])
-            if "OVERRIDE_ALEMBIC_QUIET" in os.environ
-            else True
-        )
-    with _alembic_lock, quieten(quiet):
+def stamp_alembic_rev(alembic_config: Config, conn: Connection, rev: str = "head") -> None:
+    with _alembic_lock:
         alembic_config.attributes["connection"] = conn
         stamp(alembic_config, rev)
 

--- a/python_modules/dagster/dagster/_utils/log.py
+++ b/python_modules/dagster/dagster/_utils/log.py
@@ -2,7 +2,6 @@ import copy
 import logging
 import sys
 import traceback
-from contextlib import contextmanager
 from typing import Mapping, NamedTuple, Optional
 
 import coloredlogs
@@ -215,17 +214,6 @@ def default_date_format_string():
 
 def define_default_formatter():
     return logging.Formatter(default_format_string(), default_date_format_string())
-
-
-@contextmanager
-def quieten(quiet=True, level=logging.WARNING):
-    if quiet:
-        logging.disable(level)
-    try:
-        yield
-    finally:
-        if quiet:
-            logging.disable(logging.NOTSET)
 
 
 def configure_loggers(handler="default", log_level="INFO"):

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_run_status_sensors.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_run_status_sensors.py
@@ -22,6 +22,7 @@ from dagster._core.storage.event_log.base import EventRecordsFilter
 from dagster._core.test_utils import create_test_daemon_workspace_context, instance_for_test
 from dagster._core.workspace.context import WorkspaceProcessContext
 from dagster._core.workspace.load_target import WorkspaceFileTarget, WorkspaceLoadTarget
+from dagster._utils.env import environ
 
 from .conftest import create_workspace_load_target
 from .test_sensor_run import (
@@ -1239,58 +1240,59 @@ def test_logging_run_status_sensor(
     workspace_context: WorkspaceProcessContext,
     external_repo: ExternalRepository,
 ):
-    freeze_datetime = pendulum.now()
-    with pendulum.test(freeze_datetime):
-        success_sensor = external_repo.get_external_sensor("logging_status_sensor")
-        instance.start_sensor(success_sensor)
+    with environ({"OVERRIDE_ALEMBIC_QUIET": "False"}):
+        freeze_datetime = pendulum.now()
+        with pendulum.test(freeze_datetime):
+            success_sensor = external_repo.get_external_sensor("logging_status_sensor")
+            instance.start_sensor(success_sensor)
 
-        evaluate_sensors(workspace_context, executor)
+            evaluate_sensors(workspace_context, executor)
 
-        ticks = instance.get_ticks(
-            success_sensor.get_external_origin_id(), success_sensor.selector_id
-        )
-        assert len(ticks) == 1
-        validate_tick(
-            ticks[0],
-            success_sensor,
-            freeze_datetime,
-            TickStatus.SKIPPED,
-        )
+            ticks = instance.get_ticks(
+                success_sensor.get_external_origin_id(), success_sensor.selector_id
+            )
+            assert len(ticks) == 1
+            validate_tick(
+                ticks[0],
+                success_sensor,
+                freeze_datetime,
+                TickStatus.SKIPPED,
+            )
 
-        freeze_datetime = freeze_datetime.add(seconds=60)
-        time.sleep(1)
+            freeze_datetime = freeze_datetime.add(seconds=60)
 
-    with pendulum.test(freeze_datetime):
-        external_job = external_repo.get_full_external_job("foo_job")
-        run = instance.create_run_for_job(
-            foo_job,
-            external_job_origin=external_job.get_external_origin(),
-            job_code_origin=external_job.get_python_origin(),
-        )
-        instance.submit_run(run.run_id, workspace_context.create_request_context())
-        wait_for_all_runs_to_finish(instance)
-        run = instance.get_runs()[0]
-        assert run.status == DagsterRunStatus.SUCCESS
-        freeze_datetime = freeze_datetime.add(seconds=60)
+        with pendulum.test(freeze_datetime):
+            external_job = external_repo.get_full_external_job("foo_job")
+            run = instance.create_run_for_job(
+                foo_job,
+                external_job_origin=external_job.get_external_origin(),
+                job_code_origin=external_job.get_python_origin(),
+            )
+            instance.submit_run(run.run_id, workspace_context.create_request_context())
+            wait_for_all_runs_to_finish(instance)
+            run = instance.get_runs()[0]
+            assert run.status == DagsterRunStatus.SUCCESS
+            freeze_datetime = freeze_datetime.add(seconds=60)
 
-    with pendulum.test(freeze_datetime):
-        # should fire the success sensor and the started sensor
-        evaluate_sensors(workspace_context, executor)
+        with pendulum.test(freeze_datetime):
+            # should fire the success sensor and the started sensor
+            evaluate_sensors(workspace_context, executor)
 
-        ticks = instance.get_ticks(
-            success_sensor.get_external_origin_id(), success_sensor.selector_id
-        )
-        assert len(ticks) == 2
-        validate_tick(
-            ticks[0],
-            success_sensor,
-            freeze_datetime,
-            TickStatus.SUCCESS,
-        )
-        tick = ticks[0]
-        assert tick.log_key
-        records = get_instigation_log_records(instance, tick.log_key)
-        assert len(records) == 1
-        record = records[0]
-        assert record[DAGSTER_META_KEY]["orig_message"] == f"run succeeded: {run.run_id}"
-        instance.compute_log_manager.delete_logs(log_key=tick.log_key)  # type: ignore
+            ticks = instance.get_ticks(
+                success_sensor.get_external_origin_id(), success_sensor.selector_id
+            )
+            assert len(ticks) == 2
+            validate_tick(
+                ticks[0],
+                success_sensor,
+                freeze_datetime,
+                TickStatus.SUCCESS,
+            )
+            tick = ticks[0]
+            assert tick.log_key
+            records = get_instigation_log_records(instance, tick.log_key)
+            assert len(records) == 1
+            assert records
+            record = records[0]
+            assert record[DAGSTER_META_KEY]["orig_message"] == f"run succeeded: {run.run_id}"
+            instance.compute_log_manager.delete_logs(log_key=tick.log_key)  # type: ignore

--- a/python_modules/libraries/dagster-mysql/dagster_mysql_tests/test_instance.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql_tests/test_instance.py
@@ -115,7 +115,7 @@ def test_load_instance(conn_string):
         file_relative_path(__file__, "../dagster_mysql/__init__.py")
     )
     with engine.connect() as conn:
-        stamp_alembic_rev(alembic_config, conn, rev=None, quiet=False)
+        stamp_alembic_rev(alembic_config, conn, rev=None)
 
     # Now load from scratch, verify it loads without errors
     with instance_for_test(overrides=yaml.safe_load(full_mysql_config(hostname, port))):


### PR DESCRIPTION
## Summary & Motivation
The stamp alembic call temporarily disables the python logging at the root logger.  This is interfering with some sensor logging tests which checks to see if some python logs are being captured.  This was not an issue seen before, but is being exposed by the switch to sqlalchemy 2, which is causing some race conditions between the logging module reset and the call to log from the sensor.

## How I Tested These Changes
BK, local tests w/ sqlalchemy 2 installed.  Should only affect tests.  Will be extra tested with a revert of https://github.com/dagster-io/dagster/pull/14586