### PR TITLE
feat(dbt): allow customization profile and target on the resource

### DIFF
--- a/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/__init__.py
+++ b/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/__init__.py
@@ -7,6 +7,11 @@ from .assets.build import my_dbt_assets
 defs = Definitions(
     assets=[my_dbt_assets],
     resources={
-        "dbt": DbtCli(project_dir=DBT_PROJECT_DIR, global_config=["--no-use-colors"]),
+        "dbt": DbtCli(
+            project_dir=DBT_PROJECT_DIR,
+            global_config=["--no-use-colors"],
+            profile="jaffle_shop",
+            target="dev",
+        ),
     },
 )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources_v2.py
@@ -321,7 +321,7 @@ class DbtCli(ConfigurableResource):
         ...,
         description=(
             "The path to your dbt project directory. This directory should contain a"
-            " `dbt_project.yml`. https://docs.getdbt.com/reference/dbt_project.yml for more"
+            " `dbt_project.yml`. See https://docs.getdbt.com/reference/dbt_project.yml for more"
             " information."
         ),
     )
@@ -330,6 +330,22 @@ class DbtCli(ConfigurableResource):
         description=(
             "A list of global flags configuration to pass to the dbt CLI invocation. See"
             " https://docs.getdbt.com/reference/global-configs for a full list of configuration."
+        ),
+    )
+    profile: Optional[str] = Field(
+        default=None,
+        description=(
+            "The profile from your dbt `profiles.yml` to use for execution. See"
+            " https://docs.getdbt.com/docs/core/connect-data-platform/connection-profiles for more"
+            " information."
+        ),
+    )
+    target: Optional[str] = Field(
+        default=None,
+        description=(
+            "The target from your dbt `profiles.yml` to use for execution. See"
+            " https://docs.getdbt.com/docs/core/connect-data-platform/connection-profiles for more"
+            " information."
         ),
     )
 
@@ -407,7 +423,14 @@ class DbtCli(ConfigurableResource):
                 exclude=context.op.tags.get("dagster-dbt/exclude"),
             )
 
-        args = ["dbt"] + self.global_config + args + selection_args
+        profile_args: List[str] = []
+        if self.profile:
+            profile_args = ["--profile", self.profile]
+
+        if self.target:
+            profile_args += ["--target", self.target]
+
+        args = ["dbt"] + self.global_config + args + profile_args + selection_args
         logger.info(f"Running dbt command: `{' '.join(args)}`.")
 
         # Create a subprocess that runs the dbt CLI command.

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_resources_v2.py
@@ -64,6 +64,16 @@ def test_dbt_cli_get_artifact() -> None:
     assert manifest_json_1 != manifest_json_2
 
 
+def test_dbt_profile_configuration(monkeypatch) -> None:
+    dbt = DbtCli(project_dir=TEST_PROJECT_DIR, profile="duckdb", target="dev")
+
+    dbt_cli_task = dbt.cli(["parse"], manifest=manifest)
+    dbt_cli_task.wait()
+
+    assert dbt_cli_task.process.args == ["dbt", "parse", "--profile", "duckdb", "--target", "dev"]
+    assert dbt_cli_task.is_successful()
+
+
 def test_dbt_cli_subsetted_execution(mocker: MockerFixture) -> None:
     mock_context = mocker.MagicMock()
     mock_selected_output_names = ["least_caloric", "sort_by_calories"]


### PR DESCRIPTION
## Summary & Motivation
We add Dagster configuration for `profile` and `target`, then concatenate the associated command line flags to the dbt command that the user specifies in `DbtCli.cli(...)`. 

Arguably, the command line flags to specify the profile (`--profile`) and associated target (`--target`) should be configurable at the dbt global config level (https://docs.getdbt.com/reference/global-configs/about-global-configs). They are options in every single dbt command.

## How I Tested These Changes
pytest
