### PR TITLE
[Assets Overview] Fix filtering issue when asset is not part of any asset group.

### DIFF
--- a/js_modules/dagit/packages/core/src/overview/OverviewAssetsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/overview/OverviewAssetsRoot.tsx
@@ -72,7 +72,7 @@ export const OverviewAssetsRoot = ({Header, TabButton}: Props) => {
     }
     return groupedAssetsUnfiltered.filter((group) => {
       return (
-        group.groupName.toLowerCase().includes(searchValue.toLowerCase()) ||
+        (group.groupName || UNGROUPED_ASSETS).toLowerCase().includes(searchValue.toLowerCase()) ||
         group.repositoryName.toLowerCase().includes(searchValue.toLowerCase())
       );
     });
@@ -160,7 +160,7 @@ function groupAssets(assets: Assets) {
   const groups: Record<
     string,
     {
-      groupName: string;
+      groupName?: string;
       repositoryName: string;
       assets: Assets;
     }
@@ -210,6 +210,7 @@ function VirtualHeaderRow() {
   );
 }
 
+const UNGROUPED_ASSETS = 'Ungrouped Assets';
 type RowProps = {
   height: number;
   start: number;
@@ -302,12 +303,16 @@ function VirtualRow({height, start, group}: RowProps) {
           <Box flex={{direction: 'column', gap: 2}}>
             <Box flex={{direction: 'row', gap: 8}}>
               <Icon name="asset_group" />
-              <Link
-                style={{fontWeight: 700}}
-                to={workspacePathFromAddress(repoAddress, `/asset-groups/${group.groupName}`)}
-              >
-                {group.groupName}
-              </Link>
+              {group.groupName ? (
+                <Link
+                  style={{fontWeight: 700}}
+                  to={workspacePathFromAddress(repoAddress, `/asset-groups/${group.groupName}`)}
+                >
+                  {group.groupName}
+                </Link>
+              ) : (
+                UNGROUPED_ASSETS
+              )}
             </Box>
             <div {...containerProps}>
               <RepositoryLinkWrapper maxWidth={viewport.width}>


### PR DESCRIPTION
## Summary & Motivation

I assumed all assets would have a group (eg. at least `default`) but turns out some assets have no group at all!

Josh is going to raise this at the next core-ui meeting so we can get to the bottom of it but in the mean time lets just show these assets as "Ungrouped Assets"


## How I Tested These Changes

I manually ungrouped all of the assets to take this screenshot:

<img width="1726" alt="Screen Shot 2023-06-06 at 10 46 48 AM" src="https://github.com/dagster-io/dagster/assets/2286579/663d86f7-7d3b-479f-b20b-4512018a61cf">