### PR TITLE
Fix daemon restarting gRPC servers more than expected when running `dagster code-server start`

### DIFF
--- a/python_modules/dagit/dagit/debug.py
+++ b/python_modules/dagit/dagit/debug.py
@@ -56,6 +56,9 @@ class DagitDebugWorkspaceProcessContext(IWorkspaceProcessContext):
     def reload_workspace(self) -> None:
         pass
 
+    def refresh_workspace(self) -> None:
+        pass
+
     @property
     def instance(self) -> DagsterInstance:
         return self._instance

--- a/python_modules/dagster/dagster/_core/host_representation/grpc_server_registry.py
+++ b/python_modules/dagster/dagster/_core/host_representation/grpc_server_registry.py
@@ -148,6 +148,12 @@ class GrpcServerRegistry(AbstractContextManager):
     def supports_reload(self) -> bool:
         return True
 
+    def clear_all_grpc_endpoints(self):
+        # Free the map entry for all origins so that subsequent calls to _get_grpc_endpoint wil
+        # create a new process
+        with self._lock:
+            self._active_entries.clear()
+
     def reload_grpc_endpoint(
         self, code_location_origin: ManagedGrpcPythonEnvCodeLocationOrigin
     ) -> GrpcServerEndpoint:

--- a/python_modules/dagster/dagster/_core/workspace/context.py
+++ b/python_modules/dagster/dagster/_core/workspace/context.py
@@ -409,6 +409,12 @@ class IWorkspaceProcessContext(ABC):
 
     @abstractmethod
     def reload_workspace(self) -> None:
+        """Reload the code in each code location."""
+        pass
+
+    @abstractmethod
+    def refresh_workspace(self) -> None:
+        """Refresh the snapshots for each code location, without reloading the underlying code."""
         pass
 
     @property
@@ -653,6 +659,13 @@ class WorkspaceProcessContext(IWorkspaceProcessContext):
     def shutdown_code_location(self, name: str) -> None:
         with self._lock:
             self._location_entry_dict[name].origin.shutdown_server()
+
+    def refresh_workspace(self) -> None:
+        updated_locations = {
+            origin.location_name: self._load_location(origin, reload=False)
+            for origin in self._origins
+        }
+        self._update_workspace(updated_locations)
 
     def reload_workspace(self) -> None:
         updated_locations = {

--- a/python_modules/dagster/dagster/_daemon/controller.py
+++ b/python_modules/dagster/dagster/_daemon/controller.py
@@ -268,7 +268,7 @@ class DagsterDaemonController(AbstractContextManager):
 
                 # periodically refresh the shared workspace context
                 if (time.time() - last_workspace_update_time) > RELOAD_WORKSPACE_INTERVAL:
-                    self._workspace_process_context.reload_workspace()
+                    self._workspace_process_context.refresh_workspace()
                     last_workspace_update_time = time.time()
 
                 if self._instance.daemon_skip_heartbeats_without_errors:


### PR DESCRIPTION
Summary:
This fixes a latent bit of weirdness in the daemon that was exposed with the addition of the `dagster code-server start` CLI endpoint. The daemon was actually reloading the gRPC servers in two different ways when it was responsible for managing its own gRPC servers:
a) it creates a GrpcServerRegistry on startup and sets a reload_interval there, so the code is automatically reloaded on that interval
b) it calls reload_workspace periodically on an interval as well so tha

What it actually wants to do here is to "refresh" the workspace snapshot - re-generate the snapshots used by the context in case the code has changed, but not necessarily trigger a reload of the code, that is managed elsewhere (by the GrpcServerRegistry if the daemon is managing its own code servers, or by the server itself if it is being managed separately). Before, there wasn't a meaningful distinction between reload and refresh in that second case, but now there is.

Test Plan:
In addition to existing BK coverage on the daemon, verify:
- Run dagster dev with no separate code server, change code, verify that after 1-2 minutes the change is reflected in the daemon (e.g. adding a schedule)
- Run a code server via `dagster api grpc`, make a code change, restart the process, verify after 1-2 minutes the change is reflected in the daemon
- Run a code server via `dagster code-server start`, make a code change, reload via dagit, verify that after 1-2 minutes the change is reflected in the daemon

## Summary & Motivation

## How I Tested These Changes
