### PR TITLE
Show evaluation counts instead of timestamps

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AssetAutomaterializePolicyPage.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AssetAutomaterializePolicyPage.tsx
@@ -266,16 +266,17 @@ function LeftPanel({
                   <div>
                     {evaluation.startTimestamp ? (
                       <>
-                        <TimestampDisplay timestamp={evaluation.startTimestamp} />
-                        {' - '}
+                        {evaluation.amount} evaluation{evaluation.amount === 1 ? '' : 's'}
                       </>
                     ) : (
-                      'Before '
-                    )}
-                    {evaluation.endTimestamp === 'now' ? (
-                      'now'
-                    ) : (
-                      <TimestampDisplay timestamp={evaluation.endTimestamp} />
+                      <>
+                        {'Before'}{' '}
+                        {evaluation.endTimestamp === 'now' ? (
+                          'now'
+                        ) : (
+                          <TimestampDisplay timestamp={evaluation.endTimestamp} />
+                        )}
+                      </>
                     )}
                   </div>
                 </Box>
@@ -550,7 +551,7 @@ const MiddlePanel = ({
 
       // skip conditions
       waitingOnUpstreamData: boolean;
-      exceedsXMaterializationsPerHour: boolean;
+      exceedsMaxMaterializationsPerMinute: boolean;
     }> = {};
     evaluationData?.conditions.forEach((cond) => {
       switch (cond.__typename) {
@@ -570,7 +571,7 @@ const MiddlePanel = ({
           results.waitingOnUpstreamData = true;
           break;
         case 'MaxMaterializationsExceededAutoMaterializeCondition':
-          results.exceedsXMaterializationsPerHour = true;
+          results.exceedsMaxMaterializationsPerMinute = true;
           break;
         default:
           console.error('Unexpected condition', (cond as any).__typename);
@@ -711,7 +712,7 @@ const MiddlePanel = ({
           />
           <Condition
             text={`Exceeds ${maxMaterializationsPerMinute} materializations per minute`}
-            met={!!conditionResults.exceedsXMaterializationsPerHour}
+            met={!!conditionResults.exceedsMaxMaterializationsPerMinute}
             skip={true}
           />
         </Box>


### PR DESCRIPTION
Per offline discussion. Showing the timestamps doesn't really provide any additional information. Showing the number of evaluations can help the user be confident that the daemon is running

![image](https://github.com/dagster-io/dagster/assets/22018973/709ec0ab-0168-40b3-ae61-6217a9bd0949)

For the last item, we don't show an evaluation count because 
- it'd be a huge number
- we don't know when this asset was added. If it's a new asset it's wrong to say it was considered for all the previous evaluations

<img width="309" alt="Screen Shot 2023-06-06 at 1 29 38 PM" src="https://github.com/dagster-io/dagster/assets/22018973/4aa55fa0-8712-4546-927b-8880ffb5b944">



If there's no evaluations besides the `no materialization conditions met`, we say `Before now` for similar reasons

<img width="309" alt="Screen Shot 2023-06-06 at 1 33 39 PM" src="https://github.com/dagster-io/dagster/assets/22018973/bbb7f322-f513-4b50-a511-97e8335dbc5a">
