### PR TITLE
turn off concurrency tests for consolidated sqlite

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/event_log/sqlite/consolidated_sqlite_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sqlite/consolidated_sqlite_event_log.py
@@ -145,6 +145,10 @@ class ConsolidatedSqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
 
         self._watchers[run_id][callback] = cursor
 
+    @property
+    def supports_global_concurrency_limits(self) -> bool:
+        return False
+
     def on_modified(self):
         keys = [
             (run_id, callback)


### PR DESCRIPTION
## Summary & Motivation
Saw a test flake for the consolidated sqlite threaded multi-run concurrency test.  I think we should not officially support sqlite backend with the instance-based op concurrency limits.

## How I Tested These Changes
BK