### PR TITLE
[fix] Fix error from field without subfields while assembling rootDefaultYaml

### DIFF
--- a/python_modules/dagster/dagster/_core/snap/snap_to_yaml.py
+++ b/python_modules/dagster/dagster/_core/snap/snap_to_yaml.py
@@ -25,8 +25,10 @@ def default_values_from_type_snap(type_snap: ConfigTypeSnap, snapshot: ConfigSch
     snap, recursively assembling a default if the type snap does not have a default value
     explicitly set.
     """
-    defaults_by_field = {}
+    if not type_snap.fields:
+        return {}
 
+    defaults_by_field = {}
     for field_name in type_snap.field_names:
         field = type_snap.get_field(field_name)
 

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_snap_to_yaml.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_snap_to_yaml.py
@@ -18,6 +18,12 @@ def test_basic_default():
     assert yaml_str == "a: foo\n"
 
 
+def test_basic_no_nested_fields():
+    snap = snap_from_config_type(resolve_to_config_type(str))
+    yaml_str = default_values_yaml_from_type_snap(ConfigSchemaSnapshot({}), snap)
+    assert yaml_str == "{}\n"
+
+
 def test_with_spaces():
     snap = snap_from_config_type(resolve_to_config_type({"a": Field(str, "with spaces")}))
     yaml_str = default_values_yaml_from_type_snap(ConfigSchemaSnapshot({}), snap)


### PR DESCRIPTION
## Summary

Fixes an error which arose when the root `type_snap` had no subfields. We would try to access `field_names`, which has a `check` assertion that `fields` is not empty.


