### PR TITLE
Update dunder methods for TimeWindowPartitionsDefinition to consider the new end_date attribute

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -291,6 +291,8 @@ class TimeWindowPartitionsDefinition(
         partition_def_str = (
             f"{schedule_str}, starting {self.start.strftime(self.fmt)} {self.timezone}."
         )
+        if self.end is not None:
+            partition_def_str += f" Ending {self.end.strftime(self.fmt)} {self.timezone}."
         if self.end_offset != 0:
             partition_def_str += (
                 " End offsetted by"
@@ -299,23 +301,34 @@ class TimeWindowPartitionsDefinition(
         return partition_def_str
 
     def __eq__(self, other):
-        return (
-            isinstance(other, TimeWindowPartitionsDefinition)
-            and pendulum.instance(self.start, tz=self.timezone).timestamp()
-            == pendulum.instance(other.start, tz=other.timezone).timestamp()
-            and self.timezone == other.timezone
-            and self.fmt == other.fmt
-            and self.end_offset == other.end_offset
-            and self.cron_schedule == other.cron_schedule
+    return (
+        isinstance(other, TimeWindowPartitionsDefinition)
+        and pendulum.instance(self.start, tz=self.timezone).timestamp()
+        == pendulum.instance(other.start, tz=other.timezone).timestamp()
+        and self.timezone == other.timezone
+        and self.fmt == other.fmt
+        and self.end_offset == other.end_offset
+        and self.cron_schedule == other.cron_schedule
+        and (
+            (self.end is None and other.end is None)
+            or (
+                self.end is not None
+                and other.end is not None
+                and pendulum.instance(self.end, tz=self.timezone).timestamp()
+                == pendulum.instance(other.end, tz=other.timezone).timestamp()
+            )
         )
+    )
 
     def __repr__(self):
         # Between python 3.8 and 3.9 the repr of a datetime object changed.
         # Replaces start time with timestamp as a workaround to make sure the repr is consistent across versions.
+        start_timestamp = self.start.timestamp()
+        end_timestamp = self.end.timestamp() if self.end is not None else None
         return (
-            f"TimeWindowPartitionsDefinition(start={self.start.timestamp()},"
-            f" timezone='{self.timezone}', fmt='{self.fmt}', end_offset={self.end_offset},"
-            f" cron_schedule='{self.cron_schedule}')"
+            f"TimeWindowPartitionsDefinition(start={start_timestamp},"
+            f" end={end_timestamp}, timezone='{self.timezone}', fmt='{self.fmt}',"
+            f" end_offset={self.end_offset}, cron_schedule='{self.cron_schedule}')"
         )
 
     def __hash__(self):

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -301,24 +301,24 @@ class TimeWindowPartitionsDefinition(
         return partition_def_str
 
     def __eq__(self, other):
-    return (
-        isinstance(other, TimeWindowPartitionsDefinition)
-        and pendulum.instance(self.start, tz=self.timezone).timestamp()
-        == pendulum.instance(other.start, tz=other.timezone).timestamp()
-        and self.timezone == other.timezone
-        and self.fmt == other.fmt
-        and self.end_offset == other.end_offset
-        and self.cron_schedule == other.cron_schedule
-        and (
-            (self.end is None and other.end is None)
-            or (
-                self.end is not None
-                and other.end is not None
-                and pendulum.instance(self.end, tz=self.timezone).timestamp()
-                == pendulum.instance(other.end, tz=other.timezone).timestamp()
+        return (
+            isinstance(other, TimeWindowPartitionsDefinition)
+            and pendulum.instance(self.start, tz=self.timezone).timestamp()
+            == pendulum.instance(other.start, tz=other.timezone).timestamp()
+            and self.timezone == other.timezone
+            and self.fmt == other.fmt
+            and self.end_offset == other.end_offset
+            and self.cron_schedule == other.cron_schedule
+            and (
+                (self.end is None and other.end is None)
+                or (
+                    self.end is not None
+                    and other.end is not None
+                    and pendulum.instance(self.end, tz=self.timezone).timestamp()
+                    == pendulum.instance(other.end, tz=other.timezone).timestamp()
+                )
             )
         )
-    )
 
     def __repr__(self):
         # Between python 3.8 and 3.9 the repr of a datetime object changed.


### PR DESCRIPTION
## Summary and Motivation
Update dunder methods for `TimeWindowPartitionsDefinition` to support end_date/end attribute. This is a follow PR based on https://github.com/dagster-io/dagster/pull/14155. We ran into some problems when upgrading to the latest version of Dagster (1.3.7), because the new end_date attribute is not being considered when creating the `base_asset_jobs` https://github.com/dagster-io/dagster/blob/95664a9671003068d9e1c7cbe8d11cec6a167150/python_modules/dagster/dagster/_core/definitions/assets_job.py#L58. This caused some issues when trying to create assets with the same `start_date` but a different `end_date`, mainly due to this https://github.com/dagster-io/dagster/blob/95664a9671003068d9e1c7cbe8d11cec6a167150/python_modules/dagster/dagster/_core/definitions/assets_job.py#L68 line throwing these `partition_def` into the same list while the should be considered separately. Including `end_date` in the dunder methods should solve this issue.  

## How I Tested These Changes
Not sure if we want to explicitly add any new tests since the current tests will already test these changes for the most part. If we think more tests are needed I will add them. We currently have our own patch running our test environment to test these changes as well.