### PR TITLE
[ui] Don’t display “upstream partitions missing” for source upstream assets

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -771,6 +771,7 @@ export const LAUNCH_ASSET_WARNINGS_QUERY = gql`
   query LaunchAssetWarningsQuery($upstreamAssetKeys: [AssetKeyInput!]!) {
     assetNodes(assetKeys: $upstreamAssetKeys) {
       id
+      isSource
       assetKey {
         path
       }
@@ -819,6 +820,7 @@ const Warnings: React.FC<{
       (upstreamAssets || [])
         .filter(
           (a) =>
+            !a.isSource &&
             a.partitionDefinition &&
             displayedPartitionDefinition &&
             partitionDefinitionsEqual(a.partitionDefinition, displayedPartitionDefinition),

--- a/js_modules/dagit/packages/core/src/assets/types/LaunchAssetChoosePartitionsDialog.types.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/LaunchAssetChoosePartitionsDialog.types.ts
@@ -11,6 +11,7 @@ export type LaunchAssetWarningsQuery = {
   assetNodes: Array<{
     __typename: 'AssetNode';
     id: string;
+    isSource: boolean;
     assetKey: {__typename: 'AssetKey'; path: Array<string>};
     partitionDefinition: {
       __typename: 'PartitionDefinition';


### PR DESCRIPTION
## Summary & Motivation

Fixes https://github.com/dagster-io/dagster/issues/14662

Having never observed some partitions of an upstream observable source asset doesn't mean you can't materialize downstream partitioned assets. This PR is a one-line fix to ignore source assets in this warning.

## How I Tested These Changes

I tested this manually using the repro case below:

```
@observable_source_asset(
    group_name="mapped",
    partitions_def=WeeklyPartitionsDefinition(start_date="2019-01-01"))
def upstream_partitioned_source_asset():
    return DataVersion(1)

@asset(
    group_name="mapped",
    partitions_def=WeeklyPartitionsDefinition(start_date="2019-01-01"),
    ins={"asset_downstream": AssetIn(partition_mapping=TimeWindowPartitionMapping(start_offset=-10000, end_offset=-1))},
)
def asset_downstream(asset_downstream, upstream_partitioned_source_asset):
    return 2

```