### PR TITLE
Migrate to official Databricks Python SDK

### DIFF
--- a/docs/content/integrations/databricks.mdx
+++ b/docs/content/integrations/databricks.mdx
@@ -80,6 +80,8 @@ def my_databricks_job():
 <TabItem name="Creating a custom op using resources">
 
 ```python startafter=start_define_databricks_custom_op endbefore=end_define_databricks_custom_op file=/integrations/databricks/databricks.py dedent=4
+from databricks_cli.sdk import DbfsService
+
 from dagster import (
     AssetExecutionContext,
     job,
@@ -88,9 +90,10 @@ from dagster import (
 
 @op(required_resource_keys={"databricks"})
 def my_databricks_op(context: AssetExecutionContext) -> None:
-    databricks_client = context.resources.databricks.workspace_client
+    databricks_api_client = context.resources.databricks.api_client
+    dbfs_service = DbfsService(databricks_api_client)
 
-    databricks_client.dbfs.read(path="/tmp/HelloWorld.txt")
+    dbfs_service.read(path="/tmp/HelloWorld.txt")
 
 @job(resource_defs={"databricks": databricks_client_instance})
 def my_databricks_job():
@@ -102,6 +105,8 @@ def my_databricks_job():
 <TabItem name="Creating a custom asset using resources">
 
 ```python startafter=start_define_databricks_custom_asset endbefore=end_define_databricks_custom_asset file=/integrations/databricks/databricks.py dedent=4
+from databricks_cli.sdk import JobsService
+
 from dagster import (
     AssetExecutionContext,
     AssetSelection,
@@ -111,9 +116,10 @@ from dagster import (
 
 @asset(required_resource_keys={"databricks"})
 def my_databricks_table(context: AssetExecutionContext) -> None:
-    databricks_client = context.resources.databricks.workspace_client
+    databricks_api_client = context.resources.databricks.api_client
+    jobs_service = JobsService(databricks_api_client)
 
-    databricks_client.jobs.run_now(job_id=DATABRICKS_JOB_ID)
+    jobs_service.run_now(job_id=DATABRICKS_JOB_ID)
 
 materialize_databricks_table = define_asset_job(
     name="materialize_databricks_table",

--- a/docs/content/integrations/databricks.mdx
+++ b/docs/content/integrations/databricks.mdx
@@ -80,8 +80,6 @@ def my_databricks_job():
 <TabItem name="Creating a custom op using resources">
 
 ```python startafter=start_define_databricks_custom_op endbefore=end_define_databricks_custom_op file=/integrations/databricks/databricks.py dedent=4
-from databricks_cli.sdk import DbfsService
-
 from dagster import (
     AssetExecutionContext,
     job,
@@ -90,10 +88,9 @@ from dagster import (
 
 @op(required_resource_keys={"databricks"})
 def my_databricks_op(context: AssetExecutionContext) -> None:
-    databricks_api_client = context.resources.databricks.api_client
-    dbfs_service = DbfsService(databricks_api_client)
+    databricks_client = context.resources.databricks.workspace_client
 
-    dbfs_service.read(path="/tmp/HelloWorld.txt")
+    databricks_client.dbfs.read(path="/tmp/HelloWorld.txt")
 
 @job(resource_defs={"databricks": databricks_client_instance})
 def my_databricks_job():
@@ -105,8 +102,6 @@ def my_databricks_job():
 <TabItem name="Creating a custom asset using resources">
 
 ```python startafter=start_define_databricks_custom_asset endbefore=end_define_databricks_custom_asset file=/integrations/databricks/databricks.py dedent=4
-from databricks_cli.sdk import JobsService
-
 from dagster import (
     AssetExecutionContext,
     AssetSelection,
@@ -116,10 +111,9 @@ from dagster import (
 
 @asset(required_resource_keys={"databricks"})
 def my_databricks_table(context: AssetExecutionContext) -> None:
-    databricks_api_client = context.resources.databricks.api_client
-    jobs_service = JobsService(databricks_api_client)
+    databricks_client = context.resources.databricks.workspace_client
 
-    jobs_service.run_now(job_id=DATABRICKS_JOB_ID)
+    databricks_client.jobs.run_now(job_id=DATABRICKS_JOB_ID)
 
 materialize_databricks_table = define_asset_job(
     name="materialize_databricks_table",

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -134,6 +134,7 @@ autodoc_mock_imports = [
     "coloredlogs",
     "croniter",
     "dask",
+    "databricks",
     "databricks_api",
     "databricks_cli",
     "datadog",

--- a/examples/docs_snippets/setup.py
+++ b/examples/docs_snippets/setup.py
@@ -49,6 +49,7 @@ setup(
             "numpy",
             "pandas",
             "pandera",
+            "plotly",
             "pytest",
             "requests",
             "seaborn",

--- a/pyright/alt-1/requirements-pinned.txt
+++ b/pyright/alt-1/requirements-pinned.txt
@@ -1,45 +1,43 @@
-agate==1.7.0
-aiobotocore==2.5.2
-aiofile==3.8.7
+agate==1.7.1
+aiobotocore==2.5.4
+aiofile==3.8.8
 aiohttp==3.8.5
 aioitertools==0.11.0
 aiosignal==1.3.1
-alembic==1.11.1
+alembic==1.11.3
 aniso8601==9.0.1
 anyio==3.7.1
 appnope==0.1.3
-argon2-cffi==21.3.0
+argon2-cffi==23.1.0
 argon2-cffi-bindings==21.2.0
-arrow==1.2.3
 asn1crypto==1.5.1
 -e examples/assets_pandas_type_metadata
 astroid==2.15.6
 asttokens==2.2.1
-async-lru==2.0.4
-async-timeout==4.0.2
+async-timeout==4.0.3
 attrs==23.1.0
 Babel==2.12.1
 backcall==0.2.0
 backoff==2.2.1
 beautifulsoup4==4.12.2
 bleach==6.0.0
-boto3==1.26.161
-botocore==1.29.161
+boto3==1.28.17
+botocore==1.31.17
 buildkite-test-collector==0.1.7
 cachetools==5.3.1
-caio==0.9.12
+caio==0.9.13
 certifi==2023.7.22
 cffi==1.15.1
 charset-normalizer==3.2.0
-click==8.1.3
+click==8.1.7
 colorama==0.4.6
 colored==1.4.4
 coloredlogs==14.0
-comm==0.1.3
+comm==0.1.4
 contourpy==1.1.0
-coverage==7.2.7
+coverage==7.3.0
 croniter==1.4.1
-cryptography==41.0.2
+cryptography==41.0.3
 cycler==0.11.0
 -e python_modules/dagster
 -e python_modules/libraries/dagster-aws
@@ -48,7 +46,7 @@ cycler==0.11.0
 -e python_modules/libraries/dagster-duckdb-pandas
 -e python_modules/libraries/dagster-duckdb-pyspark
 -e python_modules/dagster-graphql
-dagster-pandas==0.11.14
+-e python_modules/libraries/dagster-pandas
 -e python_modules/libraries/dagster-pandera
 -e python_modules/libraries/dagster-postgres
 -e python_modules/libraries/dagster-pyspark
@@ -58,11 +56,12 @@ dagster-pandas==0.11.14
 -e python_modules/libraries/dagster-snowflake-pyspark
 -e python_modules/libraries/dagster-spark
 -e python_modules/dagster-webserver
-dbt-core==1.5.4
-dbt-duckdb==1.5.2
+dbt-core==1.6.1
+dbt-duckdb==1.6.0
 dbt-extractor==0.4.1
-dbt-snowflake==1.5.2
-debugpy==1.6.7
+dbt-semantic-interfaces==0.2.0
+dbt-snowflake==1.6.1
+debugpy==1.6.7.post1
 decorator==5.1.1
 defusedxml==0.7.1
 dill==0.3.7
@@ -70,16 +69,15 @@ distlib==0.3.7
 docker==6.1.3
 docstring-parser==0.15
 duckdb==0.8.1
-exceptiongroup==1.1.2
+entrypoints==0.4
+exceptiongroup==1.1.3
 execnet==2.0.2
 executing==1.2.0
 fastjsonschema==2.18.0
 filelock==3.12.2
-fonttools==4.41.1
-fqdn==1.5.1
+fonttools==4.42.1
 frozenlist==1.4.0
 fsspec==2023.6.0
-future==0.18.3
 gcsfs==2023.6.0
 google-api-core==2.11.1
 google-auth==2.22.0
@@ -93,9 +91,9 @@ gql==3.4.1
 graphene==3.3
 graphql-core==3.2.3
 graphql-relay==3.2.0
-grpcio==1.56.2
-grpcio-health-checking==1.56.2
-grpcio-tools==1.56.2
+grpcio==1.57.0
+grpcio-health-checking==1.57.0
+grpcio-tools==1.57.0
 h11==0.14.0
 hologram==0.0.16
 httptools==0.6.0
@@ -103,29 +101,26 @@ humanfriendly==10.0
 idna==3.4
 importlib-metadata==6.8.0
 iniconfig==2.0.0
-ipykernel==6.25.0
+ipykernel==6.25.1
 ipython==8.14.0
+ipython-genutils==0.2.0
 isodate==0.6.1
-isoduration==20.11.0
 isort==5.12.0
 jaraco.classes==3.3.0
 jedi==0.19.0
 Jinja2==3.1.2
 jmespath==1.0.1
-joblib==1.3.1
+joblib==1.3.2
 json5==0.9.14
-jsonpointer==2.4
-jsonschema==4.18.4
-jsonschema-specifications==2023.7.1
-jupyter-events==0.7.0
-jupyter-lsp==2.2.0
-jupyter_client==8.3.0
+jsonschema==3.2.0
+jupyter-events==0.6.3
+jupyter_client==7.4.9
 jupyter_core==5.3.1
-jupyter_server==2.7.0
+jupyter_server==2.7.2
 jupyter_server_terminals==0.4.4
-jupyterlab==4.0.3
+jupyterlab==3.5.3
 jupyterlab-pygments==0.2.2
-jupyterlab_server==2.24.0
+jupyterlab_server==2.16.6
 keyring==24.2.0
 kiwisolver==1.4.4
 lazy-object-proxy==1.9.0
@@ -134,7 +129,7 @@ Logbook==1.5.3
 Mako==1.2.4
 markdown-it-py==3.0.0
 MarkupSafe==2.1.3
-mashumaro==3.6
+mashumaro==3.8.1
 matplotlib==3.7.2
 matplotlib-inline==0.1.6
 mccabe==0.7.0
@@ -142,32 +137,34 @@ mdurl==0.1.2
 minimal-snowplow-tracker==0.0.2
 mistune==3.0.1
 mock==3.0.5
-more-itertools==10.0.0
+more-itertools==8.14.0
 morefs==0.1.2
 msgpack==1.0.5
 multidict==6.0.4
 multimethod==1.9.1
-mypy==1.4.1
+mypy==1.5.1
 mypy-extensions==1.0.0
+nbclassic==1.0.0
 nbclient==0.8.0
-nbconvert==7.7.3
+nbconvert==7.7.4
 nbformat==5.9.2
 nest-asyncio==1.5.7
-networkx==2.8.8
+networkx==3.1
 nodeenv==1.8.0
+notebook==6.5.5
 notebook_shim==0.2.3
 numpy==1.25.2
 oauthlib==3.2.2
 objgraph==3.6.0
-orjson==3.9.2
+orjson==3.9.5
 oscrypto==1.3.0
-overrides==7.3.1
+overrides==7.4.0
 packaging==23.1
 pandas==2.0.3
-pandas-stubs==2.0.2.230605
+pandas-stubs==2.0.3.230814
 pandera==0.16.1
 pandocfilters==1.5.0
-parsedatetime==2.4
+parsedatetime==2.6
 parso==0.8.3
 pathspec==0.11.2
 pendulum==2.1.2
@@ -179,9 +176,9 @@ pluggy==1.2.0
 -e examples/project_fully_featured
 prometheus-client==0.17.1
 prompt-toolkit==3.0.39
-protobuf==4.23.4
+protobuf==4.24.1
 psutil==5.9.5
-psycopg2-binary==2.9.6
+psycopg2-binary==2.9.7
 ptyprocess==0.7.0
 pure-eval==0.2.2
 py==1.11.0
@@ -192,12 +189,13 @@ pyasn1-modules==0.3.0
 pycparser==2.21
 pycryptodomex==3.18.0
 pydantic==1.10.12
-Pygments==2.15.1
+Pygments==2.16.1
 PyJWT==2.8.0
 pylint==2.17.5
 pyOpenSSL==23.2.0
 pyparsing==3.0.9
 pyright==1.1.316
+pyrsistent==0.19.3
 pyspark==3.4.1
 pytest==7.0.1
 pytest-cov==2.10.1
@@ -215,8 +213,7 @@ pytimeparse==1.1.8
 pytz==2023.3
 pytzdata==2020.1
 PyYAML==6.0.1
-pyzmq==25.1.0
-referencing==0.30.0
+pyzmq==24.0.1
 requests==2.31.0
 requests-oauthlib==1.3.1
 requests-toolbelt==0.10.1
@@ -224,12 +221,11 @@ responses==0.23.1
 rfc3339-validator==0.1.4
 rfc3986-validator==0.1.1
 rich==13.5.2
-rpds-py==0.9.2
 rsa==4.9
 s3fs==2023.6.0
-s3transfer==0.6.1
+s3transfer==0.6.2
 scikit-learn==1.3.0
-scipy==1.11.1
+scipy==1.11.2
 seaborn==0.12.2
 Send2Trash==1.8.2
 six==1.16.0
@@ -253,11 +249,11 @@ toml==0.10.2
 tomli==2.0.1
 tomlkit==0.12.1
 toposort==1.10
-tornado==6.3.2
+tornado==6.3.3
 tox==3.25.0
-tqdm==4.65.0
+tqdm==4.66.1
 traitlets==5.9.0
-typeguard==4.1.0
+typeguard==4.1.2
 typer==0.9.0
 types-backports==0.1.3
 types-certifi==2021.10.8.3
@@ -269,7 +265,7 @@ types-paramiko==3.3.0.0
 types-pkg-resources==0.1.3
 types-pyOpenSSL==23.2.0.2
 types-python-dateutil==2.8.19.14
-types-pytz==2023.3.0.0
+types-pytz==2023.3.0.1
 types-PyYAML==6.0.12.11
 types-requests==2.31.0.2
 types-simplejson==3.19.0.2
@@ -282,8 +278,7 @@ types-urllib3==1.26.25.14
 typing-inspect==0.9.0
 typing_extensions==4.7.1
 tzdata==2023.3
-universal-pathlib==0.0.24
-uri-template==1.3.0
+universal-pathlib==0.1.1
 urllib3==1.26.16
 uvicorn==0.23.2
 uvloop==0.17.0
@@ -291,11 +286,9 @@ virtualenv==20.24.1
 watchdog==3.0.0
 watchfiles==0.19.0
 wcwidth==0.2.6
-webcolors==1.13
 webencodings==0.5.1
-websocket-client==1.6.1
+websocket-client==1.6.2
 websockets==11.0.3
-Werkzeug==2.3.6
 wrapt==1.15.0
 yamllint==1.32.0
 yarl==1.9.2

--- a/pyright/alt-1/requirements.txt
+++ b/pyright/alt-1/requirements.txt
@@ -37,6 +37,7 @@
   -e python_modules/libraries/dagster-duckdb-pandas/
     -e python_modules/libraries/dagster-duckdb/
     -e python_modules/libraries/dagster-duckdb-pyspark/
+  -e python_modules/libraries/dagster-pandas/
   -e python_modules/libraries/dagster-postgres/
   -e python_modules/libraries/dagster-pyspark/
   -e python_modules/libraries/dagster-slack/

--- a/pyright/master/requirements-pinned.txt
+++ b/pyright/master/requirements-pinned.txt
@@ -1,29 +1,29 @@
 acryl-datahub==0.10.2
 agate==1.7.0
-aiofile==3.8.7
+aiofile==3.8.8
 aiohttp==3.8.5
 aiohttp-retry==2.8.3
 aiosignal==1.3.1
-alembic==1.11.1
+alembic==1.11.3
 altair==4.2.2
 amqp==5.1.1
 aniso8601==9.0.1
 ansiwrap==0.8.4
 anyio==3.7.1
-apache-airflow==2.6.3
-apache-airflow-providers-apache-spark==4.1.1
-apache-airflow-providers-cncf-kubernetes==7.3.0
-apache-airflow-providers-common-sql==1.6.0
-apache-airflow-providers-docker==3.7.1
-apache-airflow-providers-ftp==3.4.2
+apache-airflow==2.7.0
+apache-airflow-providers-apache-spark==4.1.3
+apache-airflow-providers-cncf-kubernetes==7.4.2
+apache-airflow-providers-common-sql==1.7.0
+apache-airflow-providers-docker==3.7.3
+apache-airflow-providers-ftp==3.5.0
 apache-airflow-providers-http==4.1.0
-apache-airflow-providers-imap==3.2.2
-apache-airflow-providers-sqlite==3.4.2
-apispec==5.2.2
+apache-airflow-providers-imap==3.3.0
+apache-airflow-providers-sqlite==3.4.3
+apispec==6.3.0
 appdirs==1.4.4
 appnope==0.1.3
 argcomplete==3.1.1
-argon2-cffi==21.3.0
+argon2-cffi==23.1.0
 argon2-cffi-bindings==21.2.0
 arrow==1.2.3
 asgiref==3.7.2
@@ -32,14 +32,14 @@ asn1crypto==1.5.1
 -e examples/assets_pandas_pyspark
 asttokens==2.2.1
 async-lru==2.0.4
-async-timeout==4.0.2
+async-timeout==4.0.3
 attrs==23.1.0
 autoflake==2.2.0
 -e python_modules/automation
 avro==1.10.2
 avro-gen3==0.7.10
-azure-core==1.28.0
-azure-identity==1.13.0
+azure-core==1.29.1
+azure-identity==1.14.0
 azure-storage-blob==12.17.0
 azure-storage-file-datalake==12.12.0
 Babel==2.12.1
@@ -51,23 +51,23 @@ billiard==4.1.0
 bitmath==1.3.3.1
 bleach==6.0.0
 blinker==1.6.2
-bokeh==3.2.1
-boto3==1.28.16
-botocore==1.31.16
+bokeh==3.2.2
+boto3==1.28.33
+botocore==1.31.33
 buildkite-test-collector==0.1.7
 cached-property==1.5.2
 cachelib==0.9.0
 cachetools==5.3.1
-caio==0.9.12
+caio==0.9.13
 callee==0.3.1
 cattrs==23.1.2
 celery==5.3.1
 certifi==2023.7.22
 cffi==1.15.1
-chardet==5.1.0
+chardet==5.2.0
 charset-normalizer==3.2.0
-click==8.1.3
-click-default-group==1.2.2
+click==8.1.7
+click-default-group==1.2.4
 click-didyoumean==0.3.0
 click-plugins==1.1.1
 click-repl==0.3.0
@@ -78,19 +78,18 @@ colorama==0.4.6
 colored==1.4.4
 coloredlogs==14.0
 colorlog==4.8.0
-comm==0.1.3
+comm==0.1.4
 ConfigUpdater==3.1.1
 confluent-kafka==2.2.0
 connexion==2.14.2
 contourpy==1.1.0
-coverage==7.2.7
+coverage==7.3.0
 cron-descriptor==1.4.0
 croniter==1.4.1
-cryptography==41.0.2
+cryptography==41.0.3
 cycler==0.11.0
 -e python_modules/dagit
 -e python_modules/dagster
--e python_modules/dagster-externals
 -e python_modules/libraries/dagster-airbyte
 -e python_modules/libraries/dagster-airflow
 -e python_modules/libraries/dagster-aws
@@ -109,6 +108,7 @@ cycler==0.11.0
 -e python_modules/libraries/dagster-duckdb-pandas
 -e python_modules/libraries/dagster-duckdb-polars
 -e python_modules/libraries/dagster-duckdb-pyspark
+-e python_modules/dagster-externals
 -e python_modules/libraries/dagster-fivetran
 -e python_modules/libraries/dagster-gcp
 -e python_modules/libraries/dagster-gcp-pandas
@@ -142,19 +142,20 @@ cycler==0.11.0
 -e python_modules/libraries/dagster-wandb
 -e python_modules/dagster-webserver
 -e python_modules/libraries/dagstermill
-dask==2023.7.1
+dask==2023.8.1
 dask-jobqueue==0.8.2
 dask-kubernetes==2022.9.0
 dask-yarn==0.9
 databricks-api==0.9.0
 databricks-cli==0.17.7
+databricks-sdk==0.6.0
 datadog==0.46.0
 DataProperty==1.0.1
 db-dtypes==1.1.1
-dbt-core==1.5.4
+dbt-core==1.5.6
 dbt-duckdb==1.5.2
 dbt-extractor==0.4.1
-debugpy==1.6.7
+debugpy==1.6.7.post1
 decorator==5.1.1
 defusedxml==0.7.1
 Deprecated==1.2.14
@@ -162,8 +163,8 @@ Deprecated==1.2.14
 diff-match-patch==20200713
 dill==0.3.7
 distlib==0.3.7
-distributed==2023.7.1
-dnspython==2.4.1
+distributed==2023.8.1
+dnspython==2.4.2
 docker==5.0.3
 docker-image-py==0.1.12
 docker-pycreds==0.4.0
@@ -173,26 +174,26 @@ docutils==0.20.1
 duckdb==0.8.1
 email-validator==1.3.1
 entrypoints==0.4
-exceptiongroup==1.1.2
+exceptiongroup==1.1.3
 execnet==2.0.2
 executing==1.2.0
-expandvars==0.9.0
+expandvars==0.11.0
 fastavro==1.8.2
 fastjsonschema==2.18.0
 -e examples/feature_graph_backed_assets
 filelock==3.12.2
 Flask==2.2.5
-Flask-AppBuilder==4.3.1
+Flask-AppBuilder==4.3.3
 Flask-Babel==2.0.0
 Flask-Caching==2.0.2
 Flask-JWT-Extended==4.5.2
-Flask-Limiter==3.3.1
+Flask-Limiter==3.4.0
 Flask-Login==0.6.2
 Flask-Session==0.5.0
 Flask-SQLAlchemy==2.5.1
 Flask-WTF==1.1.1
 flatbuffers==23.5.26
-fonttools==4.41.1
+fonttools==4.42.1
 fqdn==1.5.1
 frozenlist==1.4.0
 fsspec==2023.6.0
@@ -200,7 +201,7 @@ future==0.18.3
 gitdb==4.0.10
 GitPython==3.1.32
 google-api-core==2.11.1
-google-api-python-client==2.95.0
+google-api-python-client==2.97.0
 google-auth==2.22.0
 google-auth-httplib2==0.1.0
 google-auth-oauthlib==1.0.0
@@ -217,12 +218,12 @@ graphene==3.3
 graphql-core==3.2.3
 graphql-relay==3.2.0
 graphviz==0.20.1
-great-expectations==0.17.7
-grpcio==1.56.2
-grpcio-health-checking==1.56.2
-grpcio-status==1.56.2
-grpcio-tools==1.56.2
-gunicorn==20.1.0
+great-expectations==0.17.11
+grpcio==1.57.0
+grpcio-health-checking==1.57.0
+grpcio-status==1.57.0
+grpcio-tools==1.57.0
+gunicorn==21.2.0
 h11==0.14.0
 hologram==0.0.16
 httpcore==0.17.3
@@ -233,10 +234,10 @@ humanfriendly==10.0
 idna==3.4
 ijson==3.2.3
 importlib-metadata==6.8.0
-importlib-resources==6.0.0
+importlib-resources==6.0.1
 inflection==0.5.1
 iniconfig==2.0.0
-ipykernel==6.25.0
+ipykernel==6.25.1
 ipython==8.14.0
 ipython-genutils==0.2.0
 ipywidgets==8.1.0
@@ -247,20 +248,20 @@ itsdangerous==2.1.2
 jedi==0.19.0
 Jinja2==3.1.2
 jmespath==1.0.1
-joblib==1.3.1
+joblib==1.3.2
 json5==0.9.14
 jsonpatch==1.33
 jsonpointer==2.4
 jsonref==1.1.0
-jsonschema==4.18.4
+jsonschema==4.19.0
 jsonschema-specifications==2023.7.1
 jupyter-events==0.7.0
 jupyter-lsp==2.2.0
 jupyter_client==7.4.9
 jupyter_core==5.3.1
-jupyter_server==2.7.0
+jupyter_server==2.7.2
 jupyter_server_terminals==0.4.4
-jupyterlab==4.0.3
+jupyterlab==4.0.5
 jupyterlab-pygments==0.2.2
 jupyterlab-widgets==3.0.8
 jupyterlab_server==2.24.0
@@ -283,7 +284,6 @@ Markdown==3.4.4
 markdown-it-py==3.0.0
 MarkupSafe==2.1.3
 marshmallow==3.20.1
-marshmallow-enum==1.5.1
 marshmallow-oneofschema==3.0.1
 marshmallow-sqlalchemy==0.26.1
 mashumaro==3.6
@@ -295,10 +295,10 @@ mdurl==0.1.2
 minimal-snowplow-tracker==0.0.2
 mistune==3.0.1
 mixpanel==4.10.0
-mlflow==2.5.0
+mlflow==2.6.0
 mock==3.0.5
 morefs==0.1.2
-moto==4.1.14
+moto==4.2.0
 mpmath==1.3.0
 msal==1.23.0
 msal-extensions==1.0.0
@@ -308,13 +308,13 @@ multimethod==1.9.1
 mypy-extensions==1.0.0
 mysql-connector-python==8.1.0
 nbclient==0.8.0
-nbconvert==7.7.3
+nbconvert==7.7.4
 nbformat==5.9.2
 nest-asyncio==1.5.7
 networkx==2.8.8
 nodeenv==1.8.0
 noteable-origami==0.0.35
-notebook==7.0.1
+notebook==7.0.2
 notebook_shim==0.2.3
 numpy==1.25.2
 oauth2client==4.1.3
@@ -323,14 +323,21 @@ objgraph==3.6.0
 onnx==1.14.0
 onnxconverter-common==1.13.0
 onnxruntime==1.15.1
+opentelemetry-api==1.15.0
+opentelemetry-exporter-otlp==1.15.0
+opentelemetry-exporter-otlp-proto-grpc==1.15.0
+opentelemetry-exporter-otlp-proto-http==1.15.0
+opentelemetry-proto==1.15.0
+opentelemetry-sdk==1.15.0
+opentelemetry-semantic-conventions==0.36b0
 ordered-set==4.1.0
-orjson==3.9.2
+orjson==3.9.5
 oscrypto==1.3.0
-overrides==7.3.1
+overrides==7.4.0
 packaging==23.1
 pandas==2.0.3
 pandas-gbq==0.19.2
-pandas-stubs==2.0.2.230605
+pandas-stubs==2.0.3.230814
 pandera==0.16.1
 pandocfilters==1.5.0
 papermill==2.4.0
@@ -340,7 +347,7 @@ parsedatetime==2.4
 parso==0.8.3
 partd==1.4.0
 path==16.7.1
-pathspec==0.9.0
+pathspec==0.11.2
 pathtools==0.1.2
 pathvalidate==3.1.0
 pendulum==2.1.2
@@ -349,9 +356,9 @@ pickleshare==0.7.5
 Pillow==10.0.0
 pkginfo==1.9.6
 platformdirs==2.6.2
-plotly==5.15.0
+plotly==5.16.1
 pluggy==1.2.0
-polars==0.18.11
+polars==0.18.15
 portalocker==2.7.0
 prison==0.2.1
 progressbar2==4.2.0
@@ -360,7 +367,7 @@ prompt-toolkit==3.0.39
 proto-plus==1.22.3
 protobuf==4.21.12
 psutil==5.9.5
-psycopg2-binary==2.9.6
+psycopg2-binary==2.9.7
 ptyprocess==0.7.0
 pure-eval==0.2.2
 py==1.11.0
@@ -371,9 +378,9 @@ pyasn1-modules==0.3.0
 pycparser==2.21
 pycryptodomex==3.18.0
 pydantic==1.10.12
-pydata-google-auth==1.8.1
+pydata-google-auth==1.8.2
 pyflakes==3.1.0
-Pygments==2.15.1
+Pygments==2.16.1
 PyJWT==2.8.0
 PyNaCl==1.5.0
 pyOpenSSL==23.2.0
@@ -402,12 +409,12 @@ pytimeparse==1.1.8
 pytz==2023.3
 pytzdata==2020.1
 PyYAML==6.0.1
-pyzmq==25.1.0
+pyzmq==25.1.1
 querystring-parser==1.2.4
 ratelimiter==1.2.0.post0
-readme-renderer==40.0
-referencing==0.30.0
-regex==2023.6.3
+readme-renderer==41.0
+referencing==0.30.2
+regex==2023.8.8
 requests==2.31.0
 requests-file==1.5.1
 requests-mock==1.11.0
@@ -417,13 +424,13 @@ responses==0.23.1
 rfc3339-validator==0.1.4
 rfc3986-validator==0.1.1
 rich==13.5.2
-rich-argparse==1.2.0
+rich-argparse==1.3.0
 rpds-py==0.9.2
 rsa==4.9
 ruamel.yaml==0.17.17
-s3transfer==0.6.1
-scikit-learn==1.2.2
-scipy==1.11.1
+s3transfer==0.6.2
+scikit-learn==1.3.0
+scipy==1.11.2
 scrapbook==0.5.0
 seaborn==0.12.2
 Send2Trash==1.8.2
@@ -432,7 +439,7 @@ sentry-sdk==1.29.2
 setproctitle==1.3.2
 six==1.16.0
 skein==0.8.2
-skl2onnx==1.14.1
+skl2onnx==1.15.0
 slack-sdk==3.21.3
 smmap==5.0.0
 sniffio==1.3.0
@@ -453,7 +460,7 @@ syrupy==3.0.6
 tabledata==1.3.1
 tabulate==0.9.0
 tblib==2.0.0
-tenacity==8.2.2
+tenacity==8.2.3
 termcolor==2.3.0
 terminado==0.17.1
 text-unidecode==1.3
@@ -467,9 +474,9 @@ toolz==0.12.0
 toposort==1.10
 torch==2.0.1
 torchvision==0.15.2
-tornado==6.3.2
+tornado==6.3.3
 tox==3.25.0
-tqdm==4.65.0
+tqdm==4.66.1
 traitlets==5.9.0
 -e examples/tutorial_notebook_assets
 twilio==8.5.0
@@ -487,7 +494,7 @@ types-paramiko==3.3.0.0
 types-pkg-resources==0.1.3
 types-pyOpenSSL==23.2.0.2
 types-python-dateutil==2.8.19.14
-types-pytz==2023.3.0.0
+types-pytz==2023.3.0.1
 types-PyYAML==6.0.12.11
 types-requests==2.31.0.2
 types-simplejson==3.19.0.2
@@ -503,7 +510,7 @@ tzdata==2023.3
 tzlocal==5.0.1
 uc-micro-py==1.0.2
 unicodecsv==0.14.1
-universal-pathlib==0.0.24
+universal-pathlib==0.1.1
 uri-template==1.3.0
 uritemplate==4.1.1
 urllib3==1.26.16
@@ -511,13 +518,13 @@ uvicorn==0.23.2
 uvloop==0.17.0
 vine==5.0.0
 virtualenv==20.13.2
-wandb==0.15.3
+wandb==0.15.4
 watchdog==3.0.0
 watchfiles==0.19.0
 wcwidth==0.2.6
 webcolors==1.13
 webencodings==0.5.1
-websocket-client==1.6.1
+websocket-client==1.6.2
 websockets==11.0.3
 Werkzeug==2.2.3
 widgetsnbextension==4.0.8

--- a/pyright/master/requirements.txt
+++ b/pyright/master/requirements.txt
@@ -84,6 +84,12 @@
 pandas_gbq  # (quickstart_gcp)
 wordcloud  # (quickstart-*)
 
+# This is a temporary pin due to version conflicts between dbt 1.6 and some higher-order
+# dependencies of other integration libs. It is not important that the pyright typechecking env support
+# dbt 1.6, so we can pin. The pin can be removed at any time in the future so long as the env builds
+# successfully.
+dbt-core<1.6
+
 ### EXAMPLES
 
 # -e examples/assets_dbt_python # it includes dagster-cloud

--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_persistent_db/test_persistent_airflow_2_db.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_persistent_db/test_persistent_airflow_2_db.py
@@ -136,7 +136,7 @@ def test_pools(postgres_airflow_db: str):
             "test_pool",
             slots=1,
             description="Limit to 1 run",
-            include_deferred=True,  # type: ignore
+            include_deferred=True,
         )
 
         airflow_db = make_persistent_airflow_db_resource(uri=postgres_airflow_db)

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
@@ -431,7 +431,7 @@ class DatabricksPySparkStepLauncher(StepLauncher):
         for permission, accessors in input_permissions.items():
             access_control_list.extend(
                 [
-                    jobs.AccessControlRequest.from_dict(
+                    jobs.JobAccessControlRequest.from_dict(
                         {"permission_level": permission, **accessor}
                     )
                     for accessor in accessors

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/ops.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/ops.py
@@ -8,7 +8,7 @@ from dagster import (
     op,
 )
 from dagster._core.definitions.op_definition import OpDefinition
-from databricks_cli.sdk import JobsService
+from databricks.sdk.service import jobs
 from pydantic import Field
 
 DEFAULT_POLL_INTERVAL_SECONDS = 10
@@ -108,21 +108,19 @@ def create_databricks_run_now_op(
     )
     def _databricks_run_now_op(context: OpExecutionContext, config: DatabricksRunNowOpConfig):
         databricks: DatabricksClient = getattr(context.resources, databricks_resource_key)
-        jobs_service = JobsService(databricks.api_client)
+        jobs_service = databricks.workspace_client.jobs
 
-        run_id = cast(
-            int,
-            jobs_service.run_now(
-                job_id=databricks_job_id,
-                **(databricks_job_configuration or {}),
-            )["run_id"],
+        run = jobs_service.run_now(
+            job_id=databricks_job_id,
+            **(databricks_job_configuration or {}),
         )
+        run_id = run.bind()["run_id"]
 
-        get_run_response: dict = jobs_service.get_run(run_id=run_id)
+        get_run_response = jobs_service.get_run(run_id=run_id)
 
         context.log.info(
-            f"Launched databricks job run for '{get_run_response['run_name']}' (`{run_id}`). URL:"
-            f" {get_run_response['run_page_url']}. Waiting to run to complete."
+            f"Launched databricks job run for '{get_run_response.run_name}' (`{run_id}`). URL:"
+            f" {get_run_response.run_page_url}. Waiting to run to complete."
         )
 
         databricks.wait_for_run_to_complete(
@@ -224,15 +222,18 @@ def create_databricks_submit_run_op(
         context: OpExecutionContext, config: DatabricksSubmitRunOpConfig
     ) -> None:
         databricks: DatabricksClient = getattr(context.resources, databricks_resource_key)
-        jobs_service = JobsService(databricks.api_client)
+        jobs_service = databricks.workspace_client.jobs
 
-        run_id: int = jobs_service.submit_run(**databricks_job_configuration)["run_id"]
+        run = jobs_service.submit(
+            tasks=[jobs.RunSubmitTaskSettings.from_dict(databricks_job_configuration)],
+        )
+        run_id: int = run.bind()["run_id"]
 
-        get_run_response: dict = jobs_service.get_run(run_id=run_id)
+        get_run_response = jobs_service.get_run(run_id=run_id)
 
         context.log.info(
-            f"Launched databricks job run for '{get_run_response['run_name']}' (`{run_id}`). URL:"
-            f" {get_run_response['run_page_url']}. Waiting to run to complete."
+            f"Launched databricks job run for '{get_run_response.run_name}' (`{run_id}`). URL:"
+            f" {get_run_response.run_page_url}. Waiting to run to complete."
         )
 
         databricks.wait_for_run_to_complete(

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/ops.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/ops.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional, cast
+from typing import TYPE_CHECKING, Optional
 
 from dagster import (
     In,
@@ -225,7 +225,7 @@ def create_databricks_submit_run_op(
         jobs_service = databricks.workspace_client.jobs
 
         run = jobs_service.submit(
-            tasks=[jobs.RunSubmitTaskSettings.from_dict(databricks_job_configuration)],
+            tasks=[jobs.SubmitTask.from_dict(databricks_job_configuration)],
         )
         run_id: int = run.bind()["run_id"]
 

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/resources.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/resources.py
@@ -21,9 +21,9 @@ class DatabricksClientResource(ConfigurableResource, IAttachDifferentObjectToOpC
     workspace_id: Optional[str] = Field(
         default=None,
         description=(
-            "The Databricks workspace ID, as described in"
+            "DEPRECATED: The Databricks workspace ID, as described in"
             " https://docs.databricks.com/workspace/workspace-details.html#workspace-instance-names-urls-and-ids."
-            " This is used to log a URL for accessing the job in the Databricks UI."
+            " This is no longer used and will be removed in a 0.20."
         ),
     )
 

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/resources.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/resources.py
@@ -23,7 +23,7 @@ class DatabricksClientResource(ConfigurableResource, IAttachDifferentObjectToOpC
         description=(
             "DEPRECATED: The Databricks workspace ID, as described in"
             " https://docs.databricks.com/workspace/workspace-details.html#workspace-instance-names-urls-and-ids."
-            " This is no longer used and will be removed in a 0.20."
+            " This is no longer used and will be removed in a 0.21."
         ),
     )
 

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/types.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/types.py
@@ -43,16 +43,16 @@ class DatabricksRunLifeCycleState(str, Enum):
 class DatabricksRunState(NamedTuple):
     """Represents the state of a Databricks job run."""
 
-    life_cycle_state: "DatabricksRunLifeCycleState"
+    life_cycle_state: Optional["DatabricksRunLifeCycleState"]
     result_state: Optional["DatabricksRunResultState"]
     state_message: str
 
     def has_terminated(self) -> bool:
         """Has the job terminated?"""
-        return self.life_cycle_state.has_terminated()
+        return self.life_cycle_state.has_terminated()  # type: ignore  # (possible none)
 
     def is_skipped(self) -> bool:
-        return self.life_cycle_state.is_skipped()
+        return self.life_cycle_state.is_skipped()  # type: ignore  # (possible none)
 
     def is_successful(self) -> bool:
         """Was the job successful?"""
@@ -61,11 +61,15 @@ class DatabricksRunState(NamedTuple):
     @classmethod
     def from_databricks(cls, run_state: jobs.RunState) -> "DatabricksRunState":
         return cls(
-            life_cycle_state=DatabricksRunLifeCycleState(run_state.life_cycle_state.value)
-            if run_state.life_cycle_state
-            else None,
-            result_state=DatabricksRunResultState(run_state.result_state.value)
-            if run_state.result_state
-            else None,
+            life_cycle_state=(
+                DatabricksRunLifeCycleState(run_state.life_cycle_state.value)
+                if run_state.life_cycle_state
+                else None
+            ),
+            result_state=(
+                DatabricksRunResultState(run_state.result_state.value)
+                if run_state.result_state
+                else None
+            ),
             state_message=run_state.state_message,
         )

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_databricks.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_databricks.py
@@ -10,45 +10,58 @@ from dagster_databricks.types import (
     DatabricksRunLifeCycleState,
     DatabricksRunResultState,
 )
+from databricks.sdk.service import compute, jobs
 from pytest_mock import MockerFixture
 
 HOST = "https://uksouth.azuredatabricks.net"
 TOKEN = "super-secret-token"
 
 
-@mock.patch("databricks_cli.sdk.JobsService.submit_run")
+@mock.patch("databricks.sdk.JobsAPI.submit")
 def test_databricks_submit_job_existing_cluster(mock_submit_run, databricks_run_config):
-    mock_submit_run.return_value = {"run_id": 1}
+    mock_submit_run_response = mock.Mock()
+    mock_submit_run_response.bind.return_value = {"run_id": 1}
+    mock_submit_run.return_value = mock_submit_run_response
 
     runner = DatabricksJobRunner(HOST, TOKEN)
     task = databricks_run_config.pop("task")
+    expected_task = jobs.RunSubmitTaskSettings.from_dict(task)
+    expected_task.existing_cluster_id = databricks_run_config["cluster"]["existing"]
+    expected_task.libraries = [
+        jobs.Library(pypi=compute.PythonPyPiLibrary(package=f"dagster=={dagster.__version__}")),
+        jobs.Library(
+            pypi=compute.PythonPyPiLibrary(
+                package=f"dagster-databricks=={dagster_databricks.__version__}"
+            )
+        ),
+        jobs.Library(
+            pypi=compute.PythonPyPiLibrary(
+                package=f"dagster-pyspark=={dagster_pyspark.__version__}"
+            )
+        ),
+    ]
+
     runner.submit_run(databricks_run_config, task)
     mock_submit_run.assert_called_with(
         run_name=databricks_run_config["run_name"],
-        new_cluster=None,
-        existing_cluster_id=databricks_run_config["cluster"]["existing"],
-        spark_jar_task=task["spark_jar_task"],
-        libraries=[
-            {"pypi": {"package": f"dagster=={dagster.__version__}"}},
-            {"pypi": {"package": f"dagster-databricks=={dagster_databricks.__version__}"}},
-            {"pypi": {"package": f"dagster-pyspark=={dagster_pyspark.__version__}"}},
-        ],
+        tasks=[expected_task],
     )
 
     databricks_run_config["install_default_libraries"] = False
+    expected_task.libraries = []
+
     runner.submit_run(databricks_run_config, task)
     mock_submit_run.assert_called_with(
         run_name=databricks_run_config["run_name"],
-        new_cluster=None,
-        existing_cluster_id=databricks_run_config["cluster"]["existing"],
-        spark_jar_task=task["spark_jar_task"],
-        libraries=[],
+        tasks=[expected_task],
     )
 
 
-@mock.patch("databricks_cli.sdk.JobsService.submit_run")
+@mock.patch("databricks.sdk.JobsAPI.submit")
 def test_databricks_submit_job_new_cluster(mock_submit_run, databricks_run_config):
-    mock_submit_run.return_value = {"run_id": 1}
+    mock_submit_run_response = mock.Mock()
+    mock_submit_run_response.bind.return_value = {"run_id": 1}
+    mock_submit_run.return_value = mock_submit_run_response
 
     runner = DatabricksJobRunner(HOST, TOKEN)
 
@@ -60,62 +73,73 @@ def test_databricks_submit_job_new_cluster(mock_submit_run, databricks_run_confi
     databricks_run_config["cluster"] = {"new": NEW_CLUSTER}
 
     task = databricks_run_config.pop("task")
+    expected_task = jobs.RunSubmitTaskSettings.from_dict(task)
+    expected_task.new_cluster = compute.BaseClusterInfo(
+        node_type_id=NEW_CLUSTER["nodes"]["node_types"]["node_type_id"],
+        spark_version=NEW_CLUSTER["spark_version"],
+        num_workers=NEW_CLUSTER["size"]["num_workers"],
+        custom_tags={"__dagster_version": dagster.__version__},
+    )
+    expected_task.libraries = [
+        jobs.Library(pypi=compute.PythonPyPiLibrary(package=f"dagster=={dagster.__version__}")),
+        jobs.Library(
+            pypi=compute.PythonPyPiLibrary(
+                package=f"dagster-databricks=={dagster_databricks.__version__}"
+            )
+        ),
+        jobs.Library(
+            pypi=compute.PythonPyPiLibrary(
+                package=f"dagster-pyspark=={dagster_pyspark.__version__}"
+            )
+        ),
+    ]
+
     runner.submit_run(databricks_run_config, task)
     mock_submit_run.assert_called_once_with(
         run_name=databricks_run_config["run_name"],
-        new_cluster={
-            "num_workers": 1,
-            "spark_version": "6.5.x-scala2.11",
-            "node_type_id": "Standard_DS3_v2",
-            "custom_tags": [{"key": "__dagster_version", "value": dagster.__version__}],
-        },
-        existing_cluster_id=None,
-        spark_jar_task=task["spark_jar_task"],
-        libraries=[
-            {"pypi": {"package": f"dagster=={dagster.__version__}"}},
-            {"pypi": {"package": f"dagster-databricks=={dagster_databricks.__version__}"}},
-            {"pypi": {"package": f"dagster-pyspark=={dagster_pyspark.__version__}"}},
-        ],
+        tasks=[expected_task],
     )
 
 
 def test_databricks_wait_for_run(mocker: MockerFixture):
     context = build_op_context()
-    mock_submit_run = mocker.patch("databricks_cli.sdk.JobsService.submit_run")
-    mock_get_run = mocker.patch("databricks_cli.sdk.JobsService.get_run")
+    mock_submit_run = mocker.patch("databricks.sdk.JobsAPI.submit")
+    mock_get_run = mocker.patch("databricks.sdk.JobsAPI.get_run")
 
-    mock_submit_run.return_value = {"run_id": 1}
+    mock_submit_run_response = mock.Mock()
+    mock_submit_run_response.bind.return_value = {"run_id": 1}
+    mock_submit_run.return_value = mock_submit_run_response
 
     databricks_client = DatabricksClient(host=HOST, token=TOKEN)
 
     calls = {
         "num_calls": 0,
-        "final_state": {
-            "state": {
-                "result_state": DatabricksRunResultState.SUCCESS,
-                "life_cycle_state": DatabricksRunLifeCycleState.TERMINATED,
-                "state_message": "Finished",
-            }
-        },
+        "final_state": jobs.Run(
+            state=jobs.RunState(
+                result_state=DatabricksRunResultState.SUCCESS,
+                life_cycle_state=DatabricksRunLifeCycleState.TERMINATED,
+                state_message="Finished",
+            ),
+        ),
     }
 
     def _get_run(*args, **kwargs) -> dict:
         calls["num_calls"] += 1
 
         if calls["num_calls"] == 1:
-            return {
-                "state": {
-                    "life_cycle_state": DatabricksRunLifeCycleState.PENDING,
-                    "state_message": "",
-                }
-            }
+            return jobs.Run(
+                state=jobs.RunState(
+                    life_cycle_state=DatabricksRunLifeCycleState.PENDING,
+                    state_message="",
+                ),
+            )
         elif calls["num_calls"] == 2:
-            return {
-                "state": {
-                    "life_cycle_state": DatabricksRunLifeCycleState.RUNNING,
-                    "state_message": "",
-                }
-            }
+            return jobs.Run(
+                state=jobs.RunState(
+                    life_cycle_state=DatabricksRunLifeCycleState.RUNNING,
+                    state_message="",
+                ),
+            )
         else:
             return calls["final_state"]
 
@@ -130,13 +154,13 @@ def test_databricks_wait_for_run(mocker: MockerFixture):
     )
 
     calls["num_calls"] = 0
-    calls["final_state"] = {
-        "state": {
-            "result_state": None,
-            "life_cycle_state": DatabricksRunLifeCycleState.SKIPPED,
-            "state_message": "Skipped",
-        }
-    }
+    calls["final_state"] = jobs.Run(
+        state=jobs.RunState(
+            result_state=None,
+            life_cycle_state=DatabricksRunLifeCycleState.SKIPPED,
+            state_message="Skipped",
+        ),
+    )
 
     databricks_client.wait_for_run_to_complete(
         logger=context.log,
@@ -147,13 +171,13 @@ def test_databricks_wait_for_run(mocker: MockerFixture):
     )
 
     calls["num_calls"] = 0
-    calls["final_state"] = {
-        "state": {
-            "result_state": DatabricksRunResultState.FAILED,
-            "life_cycle_state": DatabricksRunLifeCycleState.TERMINATED,
-            "state_message": "Failed",
-        }
-    }
+    calls["final_state"] = jobs.Run(
+        state=jobs.RunState(
+            result_state=DatabricksRunResultState.FAILED,
+            life_cycle_state=DatabricksRunLifeCycleState.TERMINATED,
+            state_message="Failed",
+        ),
+    )
 
     with pytest.raises(DatabricksError) as exc_info:
         databricks_client.wait_for_run_to_complete(
@@ -169,7 +193,11 @@ def test_databricks_wait_for_run(mocker: MockerFixture):
 
 def test_dagster_databricks_user_agent() -> None:
     databricks_client = DatabricksClient(host=HOST, token=TOKEN)
+
+    # TODO: Remove this once databricks_cli is removed
     assert "dagster-databricks" in databricks_client.api_client.default_headers["user-agent"]
 
-    # Remove this once databricks_api is deprecated
+    # TODO: Remove this once databricks_api is removed
     assert "dagster-databricks" in databricks_client.client.client.default_headers["user-agent"]
+
+    assert "dagster-databricks" in databricks_client.workspace_client.config.user_agent

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_databricks.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_databricks.py
@@ -25,16 +25,16 @@ def test_databricks_submit_job_existing_cluster(mock_submit_run, databricks_run_
 
     runner = DatabricksJobRunner(HOST, TOKEN)
     task = databricks_run_config.pop("task")
-    expected_task = jobs.RunSubmitTaskSettings.from_dict(task)
+    expected_task = jobs.SubmitTask.from_dict(task)
     expected_task.existing_cluster_id = databricks_run_config["cluster"]["existing"]
     expected_task.libraries = [
-        jobs.Library(pypi=compute.PythonPyPiLibrary(package=f"dagster=={dagster.__version__}")),
-        jobs.Library(
+        compute.Library(pypi=compute.PythonPyPiLibrary(package=f"dagster=={dagster.__version__}")),
+        compute.Library(
             pypi=compute.PythonPyPiLibrary(
                 package=f"dagster-databricks=={dagster_databricks.__version__}"
             )
         ),
-        jobs.Library(
+        compute.Library(
             pypi=compute.PythonPyPiLibrary(
                 package=f"dagster-pyspark=={dagster_pyspark.__version__}"
             )
@@ -48,7 +48,7 @@ def test_databricks_submit_job_existing_cluster(mock_submit_run, databricks_run_
     )
 
     databricks_run_config["install_default_libraries"] = False
-    expected_task.libraries = []
+    expected_task.libraries = None
 
     runner.submit_run(databricks_run_config, task)
     mock_submit_run.assert_called_with(
@@ -73,21 +73,21 @@ def test_databricks_submit_job_new_cluster(mock_submit_run, databricks_run_confi
     databricks_run_config["cluster"] = {"new": NEW_CLUSTER}
 
     task = databricks_run_config.pop("task")
-    expected_task = jobs.RunSubmitTaskSettings.from_dict(task)
-    expected_task.new_cluster = compute.BaseClusterInfo(
+    expected_task = jobs.SubmitTask.from_dict(task)
+    expected_task.new_cluster = compute.ClusterSpec(
         node_type_id=NEW_CLUSTER["nodes"]["node_types"]["node_type_id"],
         spark_version=NEW_CLUSTER["spark_version"],
         num_workers=NEW_CLUSTER["size"]["num_workers"],
         custom_tags={"__dagster_version": dagster.__version__},
     )
     expected_task.libraries = [
-        jobs.Library(pypi=compute.PythonPyPiLibrary(package=f"dagster=={dagster.__version__}")),
-        jobs.Library(
+        compute.Library(pypi=compute.PythonPyPiLibrary(package=f"dagster=={dagster.__version__}")),
+        compute.Library(
             pypi=compute.PythonPyPiLibrary(
                 package=f"dagster-databricks=={dagster_databricks.__version__}"
             )
         ),
-        jobs.Library(
+        compute.Library(
             pypi=compute.PythonPyPiLibrary(
                 package=f"dagster-pyspark=={dagster_pyspark.__version__}"
             )

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_ops.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_ops.py
@@ -12,7 +12,7 @@ from databricks.sdk.service import jobs
 from pytest_mock import MockerFixture
 
 
-def _mock_get_run_response() -> Sequence[dict]:
+def _mock_get_run_response() -> Sequence[jobs.Run]:
     return [
         jobs.Run(
             run_name="my_databricks_run",
@@ -185,7 +185,7 @@ def test_databricks_submit_run_op(
 
     assert result.success
     mock_submit_run.assert_called_once_with(
-        tasks=[jobs.RunSubmitTaskSettings.from_dict(databricks_job_configuration)],
+        tasks=[jobs.SubmitTask.from_dict(databricks_job_configuration)],
     )
     assert mock_get_run.call_count == 4
 

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_ops.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_ops.py
@@ -8,38 +8,35 @@ from dagster_databricks.ops import (
     create_databricks_run_now_op,
     create_databricks_submit_run_op,
 )
-from dagster_databricks.types import (
-    DatabricksRunLifeCycleState,
-    DatabricksRunResultState,
-)
+from databricks.sdk.service import jobs
 from pytest_mock import MockerFixture
 
 
 def _mock_get_run_response() -> Sequence[dict]:
     return [
-        {
-            "run_name": "my_databricks_run",
-            "run_page_url": "https://abc123.cloud.databricks.com/?o=12345#job/1/run/1",
-        },
-        {
-            "state": {
-                "life_cycle_state": DatabricksRunLifeCycleState.PENDING,
-                "state_message": "",
-            }
-        },
-        {
-            "state": {
-                "life_cycle_state": DatabricksRunLifeCycleState.RUNNING,
-                "state_message": "",
-            }
-        },
-        {
-            "state": {
-                "result_state": DatabricksRunResultState.SUCCESS,
-                "life_cycle_state": DatabricksRunLifeCycleState.TERMINATED,
-                "state_message": "Finished",
-            }
-        },
+        jobs.Run(
+            run_name="my_databricks_run",
+            run_page_url="https://abc123.cloud.databricks.com/?o=12345#job/1/run/1",
+        ),
+        jobs.Run(
+            state=jobs.RunState(
+                life_cycle_state=jobs.RunLifeCycleState.PENDING,
+                state_message="",
+            ),
+        ),
+        jobs.Run(
+            state=jobs.RunState(
+                life_cycle_state=jobs.RunLifeCycleState.RUNNING,
+                state_message="",
+            ),
+        ),
+        jobs.Run(
+            state=jobs.RunState(
+                result_state=jobs.RunResultState.SUCCESS,
+                life_cycle_state=jobs.RunLifeCycleState.TERMINATED,
+                state_message="Finished",
+            ),
+        ),
     ]
 
 
@@ -80,11 +77,13 @@ def test_databricks_run_now_op(
     databricks_job_configuration: Optional[dict],
     databricks_resource_key: Optional[str],
 ) -> None:
-    mock_run_now = mocker.patch("databricks_cli.sdk.JobsService.run_now")
-    mock_get_run = mocker.patch("databricks_cli.sdk.JobsService.get_run")
+    mock_run_now = mocker.patch("databricks.sdk.JobsAPI.run_now")
+    mock_get_run = mocker.patch("databricks.sdk.JobsAPI.get_run")
     databricks_job_id = 10
 
-    mock_run_now.return_value = {"run_id": 1}
+    mock_run_now_response = mocker.Mock()
+    mock_run_now_response.bind.return_value = {"run_id": 1}
+    mock_run_now.return_value = mock_run_now_response
     mock_get_run.side_effect = _mock_get_run_response()
 
     if databricks_resource_key is not None:
@@ -139,8 +138,8 @@ def test_databricks_submit_run_op(
     mocker: MockerFixture,
     databricks_resource_key: Optional[str],
 ) -> None:
-    mock_submit_run = mocker.patch("databricks_cli.sdk.JobsService.submit_run")
-    mock_get_run = mocker.patch("databricks_cli.sdk.JobsService.get_run")
+    mock_submit_run = mocker.patch("databricks.sdk.JobsAPI.submit")
+    mock_get_run = mocker.patch("databricks.sdk.JobsAPI.get_run")
     databricks_job_configuration = {
         "new_cluster": {
             "spark_version": "2.1.0-db3-scala2.11",
@@ -151,7 +150,9 @@ def test_databricks_submit_run_op(
         },
     }
 
-    mock_submit_run.return_value = {"run_id": 1}
+    mock_submit_run_response = mocker.Mock()
+    mock_submit_run_response.bind.return_value = {"run_id": 1}
+    mock_submit_run.return_value = mock_submit_run_response
     mock_get_run.side_effect = _mock_get_run_response()
 
     if databricks_resource_key is not None:
@@ -183,7 +184,9 @@ def test_databricks_submit_run_op(
     result = test_databricks_job.execute_in_process()
 
     assert result.success
-    mock_submit_run.assert_called_once_with(**databricks_job_configuration)
+    mock_submit_run.assert_called_once_with(
+        tasks=[jobs.RunSubmitTaskSettings.from_dict(databricks_job_configuration)],
+    )
     assert mock_get_run.call_count == 4
 
 

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_pyspark.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_pyspark.py
@@ -167,13 +167,14 @@ def test_local():
     assert result.success
 
 
-@mock.patch("databricks_cli.sdk.JobsService.submit_run")
+@mock.patch("databricks.sdk.core.Config")
+@mock.patch("databricks.sdk.JobsAPI.submit")
 @mock.patch("dagster_databricks.databricks.DatabricksClient.read_file")
 @mock.patch("dagster_databricks.databricks.DatabricksClient.put_file")
 @mock.patch("dagster_databricks.DatabricksPySparkStepLauncher.get_step_events")
-@mock.patch("databricks_cli.sdk.JobsService.get_run")
+@mock.patch("databricks.sdk.JobsAPI.get_run")
 @mock.patch("dagster_databricks.databricks.DatabricksClient.get_run_state")
-@mock.patch("databricks_cli.sdk.api_client.ApiClient.perform_query")
+@mock.patch("databricks.sdk.core.ApiClient.do")
 def test_pyspark_databricks(
     mock_perform_query,
     mock_get_run_state,
@@ -182,8 +183,11 @@ def test_pyspark_databricks(
     mock_put_file,
     mock_read_file,
     mock_submit_run,
+    mock_config,
 ):
-    mock_submit_run.return_value = {"run_id": 12345}
+    mock_submit_run_response = mock.Mock()
+    mock_submit_run_response.bind.return_value = {"run_id": 12345}
+    mock_submit_run.return_value = mock_submit_run_response
     mock_read_file.return_value = "somefilecontents".encode()
 
     running_state = DatabricksRunState(DatabricksRunLifeCycleState.RUNNING, None, "")

--- a/python_modules/libraries/dagster-databricks/setup.py
+++ b/python_modules/libraries/dagster-databricks/setup.py
@@ -35,8 +35,9 @@ setup(
     install_requires=[
         f"dagster{pin}",
         f"dagster-pyspark{pin}",
-        "databricks-cli~=0.17",
-        "databricks_api",  # Divest from this library in the future since it is unnecessary indirection.
+        "databricks-cli~=0.17",  # TODO: Remove this dependency in the next minor release.
+        "databricks_api",  # TODO: Remove this dependency in the next minor release.
+        "databricks-sdk",
     ],
     zip_safe=False,
 )

--- a/python_modules/libraries/dagster-databricks/setup.py
+++ b/python_modules/libraries/dagster-databricks/setup.py
@@ -37,7 +37,7 @@ setup(
         f"dagster-pyspark{pin}",
         "databricks-cli~=0.17",  # TODO: Remove this dependency in the next minor release.
         "databricks_api",  # TODO: Remove this dependency in the next minor release.
-        "databricks-sdk",
+        "databricks-sdk<0.7",  # Breaking changes occur in minor versions.
     ],
     zip_safe=False,
 )


### PR DESCRIPTION
## Summary & Motivation

Databricks has released an official Python SDK: https://github.com/databricks/databricks-sdk-py

Dagster should probably be using it as it is the future of Databricks Python interaction.

I believe that the only user-facing change that this causes is that the User Agent has some additional information appended to it.

## How I Tested These Changes
