### PR TITLE
[ruff] Update 0.0.255 -> 0.0.277

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,6 @@ repos:
       name: black-jupyter [docs-snippets]
       files: "^examples/docs_snippets/.*.py"
 - repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: v0.0.255
+  rev: v0.0.276
   hooks:
     - id: ruff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,6 @@ repos:
       name: black-jupyter [docs-snippets]
       files: "^examples/docs_snippets/.*.py"
 - repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: v0.0.276
+  rev: v0.0.277
   hooks:
     - id: ruff

--- a/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
@@ -157,7 +157,7 @@ def my_directory_sensor_cursor(context):
                 continue
 
             # the run key should include mtime if we want to kick off new runs based on file modifications
-            run_key = f"{filename}:{str(file_mtime)}"
+            run_key = f"{filename}:{file_mtime}"
             run_config = {"ops": {"process_file": {"config": {"filename": filename}}}}
             yield RunRequest(run_key=run_key, run_config=run_config)
             max_mtime = max(max_mtime, file_mtime)
@@ -376,7 +376,7 @@ def my_directory_sensor_cursor(context):
                 continue
 
             # the run key should include mtime if we want to kick off new runs based on file modifications
-            run_key = f"{filename}:{str(file_mtime)}"
+            run_key = f"{filename}:{file_mtime}"
             run_config = {"ops": {"process_file": {"config": {"filename": filename}}}}
             yield RunRequest(run_key=run_key, run_config=run_config)
             max_mtime = max(max_mtime, file_mtime)

--- a/docs/content/guides/dagster/dagster_type_factories.mdx
+++ b/docs/content/guides/dagster/dagster_type_factories.mdx
@@ -30,7 +30,7 @@ set_containing_1 = DagsterType(
     type_check_fn=lambda _context, obj: isinstance(obj, set) and 1 in obj,
 )
 
-check_dagster_type(set_containing_1, {1, 2}).success  # => True
+assert check_dagster_type(set_containing_1, {1, 2}).success  # => True
 ```
 
 Sometimes, we may even need to define an entire suite of related types. Factory functions are an efficient solution to this problem. Here is a factory function that generalizes the set-membership-check pattern for arbitrary values:
@@ -45,7 +45,7 @@ def set_has_element_type_factory(x):
 
 
 set_containing_2 = set_has_element_type_factory(2)
-check_dagster_type(set_containing_2, {1, 2}).success  # => True
+assert check_dagster_type(set_containing_2, {1, 2}).success  # => True
 ```
 
 Factories are particularly powerful when interfacing with external data validation libraries. Below, we'll see how a small factory function allows us to integrate the [Pandera](https://github.com/pandera-dev/pandera) dataframe validation library into our Dagster jobs. Pandera provides an API for defining dataframe schemas. Schemas encode data type, boundaries, nullability, and other constraints at both the dataframe and individual column level. They can be used to validate dataframes from [Pandas](https://pandas.pydata.org/), [Dask](https://dask.org/), or several other popular Python libraries.

--- a/docs/content/integrations/bigquery/reference.mdx
+++ b/docs/content/integrations/bigquery/reference.mdx
@@ -62,7 +62,6 @@ import pandas as pd
 
 from dagster import AssetIn, asset
 
-
 # this example uses the iris_data asset from Step 2 of the Using Dagster with BigQuery tutorial
 
 

--- a/docs/content/integrations/duckdb/reference.mdx
+++ b/docs/content/integrations/duckdb/reference.mdx
@@ -26,7 +26,6 @@ import pandas as pd
 
 from dagster import AssetIn, asset
 
-
 # this example uses the iris_dataset asset from Step 2 of the Using Dagster with DuckDB tutorial
 
 

--- a/docs/content/integrations/snowflake/reference.mdx
+++ b/docs/content/integrations/snowflake/reference.mdx
@@ -83,7 +83,6 @@ import pandas as pd
 
 from dagster import AssetIn, asset
 
-
 # this example uses the iris_dataset asset from Step 2 of the Using Dagster with Snowflake tutorial
 
 

--- a/docs/sphinx/_ext/autodoc_dagster.py
+++ b/docs/sphinx/_ext/autodoc_dagster.py
@@ -103,7 +103,7 @@ def config_field_to_lines(field, name=None) -> List[str]:
                     lines.append(" " * 12 + ln)
             else:
                 lines.append("")
-                lines.append(f"    **Default Value:** {repr(val)}")
+                lines.append(f"    **Default Value:** {val!r}")
 
     # if field has subfields, recurse
     if hasattr(field.config_type, "fields") and len(field.config_type.fields) > 0:

--- a/examples/assets_dynamic_partitions/assets_dynamic_partitions_tests/test_release_sensor.py
+++ b/examples/assets_dynamic_partitions/assets_dynamic_partitions_tests/test_release_sensor.py
@@ -2,8 +2,9 @@ import json
 import os
 from unittest.mock import MagicMock, patch
 
-from assets_dynamic_partitions.release_sensor import release_sensor
 from dagster import DagsterInstance, SkipReason, build_sensor_context
+
+from assets_dynamic_partitions.release_sensor import release_sensor
 
 
 def test_release_sensor_no_new_releases():

--- a/examples/assets_pandas_pyspark/assets_pandas_pyspark_tests/test_assets.py
+++ b/examples/assets_pandas_pyspark/assets_pandas_pyspark_tests/test_assets.py
@@ -1,6 +1,7 @@
-from assets_pandas_pyspark.assets import spark_asset, table_assets
 from dagster import load_assets_from_modules, materialize
 from dagster._core.test_utils import instance_for_test
+
+from assets_pandas_pyspark.assets import spark_asset, table_assets
 
 
 def test_weather_assets():

--- a/examples/assets_pandas_type_metadata/assets_pandas_type_metadata_tests/test_bollinger_analysis.py
+++ b/examples/assets_pandas_type_metadata/assets_pandas_type_metadata_tests/test_bollinger_analysis.py
@@ -1,10 +1,11 @@
+from dagster import AssetSelection, define_asset_job, with_resources
+
 from assets_pandas_type_metadata.assets.bollinger_analysis import (
     sp500_anomalous_events,
     sp500_bollinger_bands,
     sp500_prices,
 )
 from assets_pandas_type_metadata.resources.csv_io_manager import LocalCsvIOManager
-from dagster import AssetSelection, define_asset_job, with_resources
 
 
 def test_bollinger_analysis():

--- a/examples/assets_smoke_test/assets_smoke_test_tests/test_smoke_pure_python_assets.py
+++ b/examples/assets_smoke_test/assets_smoke_test_tests/test_smoke_pure_python_assets.py
@@ -1,6 +1,7 @@
-from assets_smoke_test import pure_python_assets
 from dagster import InMemoryIOManager, TableSchema, load_assets_from_modules, materialize
 from pandas import DataFrame, Series
+
+from assets_smoke_test import pure_python_assets
 
 
 def empty_dataframe_from_column_schema(column_schema: TableSchema) -> DataFrame:

--- a/examples/assets_smoke_test/assets_smoke_test_tests/test_smoke_python_and_dbt_assets.py
+++ b/examples/assets_smoke_test/assets_smoke_test_tests/test_smoke_python_and_dbt_assets.py
@@ -1,15 +1,16 @@
 import os
 
 import snowflake.connector
+from dagster import load_assets_from_modules, materialize
+from dagster_dbt import DbtCliClientResource
+from dagster_snowflake_pandas import SnowflakePandasIOManager
+
 from assets_smoke_test import python_and_dbt_assets
 from assets_smoke_test.python_and_dbt_assets import (
     DBT_PROFILES_DIR,
     DBT_PROJECT_DIR,
     raw_country_populations,
 )
-from dagster import load_assets_from_modules, materialize
-from dagster_dbt import DbtCliClientResource
-from dagster_snowflake_pandas import SnowflakePandasIOManager
 
 
 def smoke_all_test():

--- a/examples/development_to_production/development_to_production_tests/test_assets.py
+++ b/examples/development_to_production/development_to_production_tests/test_assets.py
@@ -1,5 +1,6 @@
 import pandas as pd
 from dagster import build_op_context
+
 from development_to_production.assets import comments, items, stories
 from development_to_production.resources import StubHNClient
 

--- a/examples/docs_snippets/docs_snippets/concepts/assets/asset_group_module.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/asset_group_module.py
@@ -1,5 +1,5 @@
 # pyright: reportMissingImports=false
-# isort: off
+# ruff: isort: off
 
 from dagster import (
     load_assets_from_package_module,

--- a/examples/docs_snippets/docs_snippets/concepts/assets/graph_backed_asset.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/graph_backed_asset.py
@@ -1,4 +1,4 @@
-# isort: skip_file
+# ruff: isort: skip_file
 from dagster import (
     AssetKey,
     load_assets_from_current_module,

--- a/examples/docs_snippets/docs_snippets/concepts/assets/materialization_ops.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/materialization_ops.py
@@ -1,4 +1,4 @@
-# isort: skip_file
+# ruff: isort: skip_file
 
 
 def read_df():

--- a/examples/docs_snippets/docs_snippets/concepts/assets/multi_assets.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/multi_assets.py
@@ -1,4 +1,4 @@
-# isort: skip_file
+# ruff: isort: skip_file
 
 
 # start_basic_multi_asset

--- a/examples/docs_snippets/docs_snippets/concepts/assets/observable_source_assets.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/observable_source_assets.py
@@ -2,7 +2,7 @@ def read_some_file():
     return "foo"
 
 
-# isort: split
+# ruff: isort: split
 # start_plain
 from hashlib import sha256
 
@@ -19,7 +19,7 @@ def foo_source_asset():  # type: ignore  # (didactic)
 
 # end_plain
 
-# isort: split
+# ruff: isort: split
 # start_schedule
 from dagster import (
     DataVersion,

--- a/examples/docs_snippets/docs_snippets/concepts/assets/observations.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/observations.py
@@ -1,4 +1,4 @@
-# isort: skip_file
+# ruff: isort: skip_file
 
 from dagster import job, op
 

--- a/examples/docs_snippets/docs_snippets/concepts/dagit/graphql/client_example.py
+++ b/examples/docs_snippets/docs_snippets/concepts/dagit/graphql/client_example.py
@@ -1,4 +1,4 @@
-# isort: skip_file
+# ruff: isort: skip_file
 # start_setup_marker
 from dagster_graphql import DagsterGraphQLClient
 

--- a/examples/docs_snippets/docs_snippets/concepts/io_management/custom_io_manager.py
+++ b/examples/docs_snippets/docs_snippets/concepts/io_management/custom_io_manager.py
@@ -1,4 +1,4 @@
-# isort: skip_file
+# ruff: isort: skip_file
 
 from typing import List
 from dagster import job, op

--- a/examples/docs_snippets/docs_snippets/concepts/io_management/test_build_io_context.py
+++ b/examples/docs_snippets/docs_snippets/concepts/io_management/test_build_io_context.py
@@ -50,7 +50,7 @@ def test_build_input_context_with_cm_resource():
             ),
         ),
     ):
-        context.resources
+        context.resources  # noqa: B018
 
     del context
 
@@ -91,7 +91,7 @@ def test_build_output_context_with_cm_resource():
             ),
         ),
     ):
-        context.resources
+        context.resources  # noqa: B018
 
     del context
 

--- a/examples/docs_snippets/docs_snippets/concepts/logging/builtin_logger.py
+++ b/examples/docs_snippets/docs_snippets/concepts/logging/builtin_logger.py
@@ -1,4 +1,4 @@
-# isort: skip_file
+# ruff: isort: skip_file
 
 
 from dagster import Definitions

--- a/examples/docs_snippets/docs_snippets/concepts/logging/custom_logger.py
+++ b/examples/docs_snippets/docs_snippets/concepts/logging/custom_logger.py
@@ -1,4 +1,4 @@
-# isort: skip_file
+# ruff: isort: skip_file
 import json
 import logging
 

--- a/examples/docs_snippets/docs_snippets/concepts/logging/file_output_pipeline.py
+++ b/examples/docs_snippets/docs_snippets/concepts/logging/file_output_pipeline.py
@@ -1,4 +1,4 @@
-# isort: skip_file
+# ruff: isort: skip_file
 from dagster import job, op
 
 # start_custom_file_output_log

--- a/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/dep_dsl.py
+++ b/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/dep_dsl.py
@@ -1,6 +1,6 @@
 from dagster._utils.yaml_utils import load_yaml_from_path
 
-# isort: split
+# ruff: isort: split
 
 # start
 import os

--- a/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/dynamic.py
+++ b/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/dynamic.py
@@ -1,4 +1,4 @@
-# isort: skip_file
+# ruff: isort: skip_file
 
 
 from dagster import DynamicOut, DynamicOutput, job, op

--- a/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/graphs/graphs.py
+++ b/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/graphs/graphs.py
@@ -1,4 +1,4 @@
-# isort: skip_file
+# ruff: isort: skip_file
 
 
 from dagster import graph, op

--- a/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/job_execution.py
+++ b/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/job_execution.py
@@ -1,4 +1,4 @@
-# isort: skip_file
+# ruff: isort: skip_file
 
 # start_pipeline_marker
 

--- a/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/jobs.py
+++ b/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/jobs.py
@@ -1,4 +1,4 @@
-# isort: skip_file
+# ruff: isort: skip_file
 
 
 from dagster import DependencyDefinition, GraphDefinition, job, op

--- a/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/jobs_from_graphs.py
+++ b/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/jobs_from_graphs.py
@@ -1,4 +1,4 @@
-# isort: skip_file
+# ruff: isort: skip_file
 
 # start_define_graph
 from dagster import graph, op, ConfigurableResource

--- a/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/nested_graphs.py
+++ b/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/nested_graphs.py
@@ -1,4 +1,4 @@
-# isort: skip_file
+# ruff: isort: skip_file
 
 
 from dagster import graph, job, op

--- a/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/op_events.py
+++ b/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/op_events.py
@@ -1,4 +1,4 @@
-# isort: skip_file
+# ruff: isort: skip_file
 
 from dagster import (
     AssetMaterialization,

--- a/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/op_hooks.py
+++ b/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/op_hooks.py
@@ -1,4 +1,4 @@
-# isort: skip_file
+# ruff: isort: skip_file
 from unittest import mock
 
 import yaml

--- a/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/op_hooks_context.py
+++ b/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/op_hooks_context.py
@@ -1,4 +1,4 @@
-# isort: skip_file
+# ruff: isort: skip_file
 
 # start_failure_hook_op_exception
 from dagster import HookContext, failure_hook

--- a/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/ops.py
+++ b/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/ops.py
@@ -1,4 +1,4 @@
-# isort: skip_file
+# ruff: isort: skip_file
 
 
 import requests

--- a/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/unit_tests.py
+++ b/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/unit_tests.py
@@ -1,4 +1,4 @@
-# isort: skip_file
+# ruff: isort: skip_file
 
 from dagster import (
     AssetMaterialization,

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/partitioned_config_test.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/partitioned_config_test.py
@@ -1,4 +1,4 @@
-# isort: skip_file
+# ruff: isort: skip_file
 
 
 from docs_snippets.concepts.partitions_schedules_sensors.partitioned_job import (

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/partitioned_job.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/partitioned_job.py
@@ -1,4 +1,4 @@
-# isort: skip_file
+# ruff: isort: skip_file
 from dagster import job, op
 
 

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/partitioned_job_test.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/partitioned_job_test.py
@@ -1,4 +1,4 @@
-# isort: skip_file
+# ruff: isort: skip_file
 
 from docs_snippets.concepts.partitions_schedules_sensors.partitioned_job import (
     do_stuff_partitioned,

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/schedule_from_partitions.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/schedule_from_partitions.py
@@ -1,4 +1,4 @@
-# isort: skip_file
+# ruff: isort: skip_file
 
 from .partitioned_job import my_partitioned_config
 

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/schedules/schedule_examples.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/schedules/schedule_examples.py
@@ -1,4 +1,4 @@
-# isort: skip_file
+# ruff: isort: skip_file
 import datetime
 
 from .schedules import configurable_job_schedule, configurable_job

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/sensor_alert.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/sensor_alert.py
@@ -1,4 +1,4 @@
-# isort: skip_file
+# ruff: isort: skip_file
 
 
 # start_alert_sensor_marker

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/sensors.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/sensors.py
@@ -1,4 +1,4 @@
-# isort: skip_file
+# ruff: isort: skip_file
 
 
 from dagster import (

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/sensors.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/sensors.py
@@ -140,7 +140,7 @@ def my_directory_sensor_cursor(context):
                 continue
 
             # the run key should include mtime if we want to kick off new runs based on file modifications
-            run_key = f"{filename}:{str(file_mtime)}"
+            run_key = f"{filename}:{file_mtime}"
             run_config = {"ops": {"process_file": {"config": {"filename": filename}}}}
             yield RunRequest(run_key=run_key, run_config=run_config)
             max_mtime = max(max_mtime, file_mtime)

--- a/examples/docs_snippets/docs_snippets/concepts/resources/pythonic_resources.py
+++ b/examples/docs_snippets/docs_snippets/concepts/resources/pythonic_resources.py
@@ -561,7 +561,13 @@ def new_io_manager() -> None:
 def raw_github_resource_factory() -> None:
     # start_raw_github_resource_factory
 
-    from dagster import ConfigurableResourceFactory, Resource, asset, EnvVar
+    from dagster import (
+        ConfigurableResourceFactory,
+        Resource,
+        asset,
+        Definitions,
+        EnvVar,
+    )
 
     class GitHubResource(ConfigurableResourceFactory[GitHub]):
         access_token: str

--- a/examples/docs_snippets/docs_snippets/concepts/resources/pythonic_resources.py
+++ b/examples/docs_snippets/docs_snippets/concepts/resources/pythonic_resources.py
@@ -1,4 +1,4 @@
-# isort: skip_file
+# ruff: isort: skip_file
 # ruff: noqa: T201
 
 from typing import TYPE_CHECKING

--- a/examples/docs_snippets/docs_snippets/concepts/resources/resources.py
+++ b/examples/docs_snippets/docs_snippets/concepts/resources/resources.py
@@ -1,4 +1,4 @@
-# isort: skip_file
+# ruff: isort: skip_file
 
 from dagster import ResourceDefinition, graph, job
 

--- a/examples/docs_snippets/docs_snippets/concepts/resources/tests.py
+++ b/examples/docs_snippets/docs_snippets/concepts/resources/tests.py
@@ -1,4 +1,4 @@
-# isort: skip_file
+# ruff: isort: skip_file
 
 
 from dagster import ResourceDefinition

--- a/examples/docs_snippets/docs_snippets/concepts/types/types.py
+++ b/examples/docs_snippets/docs_snippets/concepts/types/types.py
@@ -1,4 +1,4 @@
-# isort: skip_file
+# ruff: isort: skip_file
 
 from dagster import DagsterType, In, Out, asset, op
 

--- a/examples/docs_snippets/docs_snippets/deploying/executors/executors.py
+++ b/examples/docs_snippets/docs_snippets/deploying/executors/executors.py
@@ -1,4 +1,4 @@
-# isort: skip_file
+# ruff: isort: skip_file
 
 # start_executor_on_job
 from dagster import graph, job, multiprocess_executor

--- a/examples/docs_snippets/docs_snippets/guides/dagster/asset_tutorial/cereal.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/asset_tutorial/cereal.py
@@ -1,4 +1,4 @@
-# isort: skip_file
+# ruff: isort: skip_file
 
 import csv
 import requests

--- a/examples/docs_snippets/docs_snippets/guides/dagster/asset_tutorial/complex_asset_graph_tests.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/asset_tutorial/complex_asset_graph_tests.py
@@ -1,4 +1,4 @@
-# isort: skip_file
+# ruff: isort: skip_file
 from docs_snippets.guides.dagster.asset_tutorial.complex_asset_graph import (
     cereal_protein_fractions,
     cereals,

--- a/examples/docs_snippets/docs_snippets/guides/dagster/asset_tutorial/non_argument_deps.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/asset_tutorial/non_argument_deps.py
@@ -1,4 +1,4 @@
-# isort: skip_file
+# ruff: isort: skip_file
 import csv
 
 import requests

--- a/examples/docs_snippets/docs_snippets/guides/dagster/automating_pipelines/s3_sensor.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/automating_pipelines/s3_sensor.py
@@ -1,4 +1,4 @@
-# isort: skip_file
+# ruff: isort: skip_file
 
 from dagster_aws.s3.sensor import get_s3_keys
 from dagster import sensor, op, job, build_sensor_context, RunRequest, SkipReason

--- a/examples/docs_snippets/docs_snippets/guides/dagster/automating_pipelines/vanilla_schedule.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/automating_pipelines/vanilla_schedule.py
@@ -1,4 +1,4 @@
-# isort: skip_file
+# ruff: isort: skip_file
 
 from dagster import asset
 

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_type_factories/simple_example.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_type_factories/simple_example.py
@@ -8,7 +8,7 @@ set_containing_1 = DagsterType(
     type_check_fn=lambda _context, obj: isinstance(obj, set) and 1 in obj,
 )
 
-check_dagster_type(set_containing_1, {1, 2}).success  # => True
+assert check_dagster_type(set_containing_1, {1, 2}).success  # => True
 
 # one_off_type_end
 
@@ -24,6 +24,6 @@ def set_has_element_type_factory(x):
 
 
 set_containing_2 = set_has_element_type_factory(2)
-check_dagster_type(set_containing_2, {1, 2}).success  # => True
+assert check_dagster_type(set_containing_2, {1, 2}).success  # => True
 
 # type_factory_end

--- a/examples/docs_snippets/docs_snippets/guides/dagster/development_to_production/assets_v2.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/development_to_production/assets_v2.py
@@ -2,7 +2,6 @@ import pandas as pd
 
 from dagster import asset
 
-
 # start_items
 # assets.py
 

--- a/examples/docs_snippets/docs_snippets/guides/dagster/ingestion_as_code/airbyte.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/ingestion_as_code/airbyte.py
@@ -1,4 +1,4 @@
-# isort: skip_file
+# ruff: isort: skip_file
 
 
 def scope_define_reconciler():

--- a/examples/docs_snippets/docs_snippets/guides/dagster/managing_ml/managing_ml_code.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/managing_ml/managing_ml_code.py
@@ -1,4 +1,4 @@
-# isort: skip_file
+# ruff: isort: skip_file
 
 ## eager_materilization_start
 

--- a/examples/docs_snippets/docs_snippets/guides/dagster/ml_pipelines/ml_pipeline.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/ml_pipelines/ml_pipeline.py
@@ -1,4 +1,4 @@
-# isort: skip_file
+# ruff: isort: skip_file
 
 ## data_ingestion_start
 import requests

--- a/examples/docs_snippets/docs_snippets/guides/dagster/pythonic_config/pythonic_config.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/pythonic_config/pythonic_config.py
@@ -1,4 +1,4 @@
-# isort: skip_file
+# ruff: isort: skip_file
 
 
 from typing import Dict, List

--- a/examples/docs_snippets/docs_snippets/guides/dagster/reexecution/reexecution_api.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/reexecution/reexecution_api.py
@@ -1,4 +1,4 @@
-# isort: split
+# ruff: isort: split
 from_failure_result = None
 result = None
 # start_initial_execution_marker
@@ -19,7 +19,7 @@ if not initial_result.success:
 
 
 # end_initial_execution_marker
-# isort: split
+# ruff: isort: split
 
 # start_partial_execution_marker
 

--- a/examples/docs_snippets/docs_snippets/guides/dagster/run_attribution/custom_run_coordinator_skeleton.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/run_attribution/custom_run_coordinator_skeleton.py
@@ -1,4 +1,4 @@
-# isort: skip_file
+# ruff: isort: skip_file
 
 CUSTOM_HEADER_NAME = "X-SOME-HEADER"
 # start_custom_run_coordinator_marker

--- a/examples/docs_snippets/docs_snippets/integrations/airbyte/airbyte.py
+++ b/examples/docs_snippets/docs_snippets/integrations/airbyte/airbyte.py
@@ -1,4 +1,4 @@
-# isort: skip_file
+# ruff: isort: skip_file
 
 
 def scope_define_instance():

--- a/examples/docs_snippets/docs_snippets/integrations/bigquery/downstream_columns.py
+++ b/examples/docs_snippets/docs_snippets/integrations/bigquery/downstream_columns.py
@@ -2,7 +2,6 @@ import pandas as pd
 
 from dagster import AssetIn, asset
 
-
 # this example uses the iris_data asset from Step 2 of the Using Dagster with BigQuery tutorial
 
 

--- a/examples/docs_snippets/docs_snippets/integrations/dagstermill/iris_notebook_op.py
+++ b/examples/docs_snippets/docs_snippets/integrations/dagstermill/iris_notebook_op.py
@@ -1,4 +1,4 @@
-# isort: split
+# ruff: isort: split
 # start
 
 from dagstermill import ConfigurableLocalOutputNotebookIOManager, define_dagstermill_op

--- a/examples/docs_snippets/docs_snippets/integrations/dbt/dbt.py
+++ b/examples/docs_snippets/docs_snippets/integrations/dbt/dbt.py
@@ -1,4 +1,4 @@
-# isort: skip_file
+# ruff: isort: skip_file
 
 
 def scope_load_assets_from_dbt_project():

--- a/examples/docs_snippets/docs_snippets/integrations/dbt/dbt_cloud.py
+++ b/examples/docs_snippets/docs_snippets/integrations/dbt/dbt_cloud.py
@@ -1,4 +1,4 @@
-# isort: skip_file
+# ruff: isort: skip_file
 
 
 def scope_define_instance():

--- a/examples/docs_snippets/docs_snippets/integrations/duckdb/downstream_columns.py
+++ b/examples/docs_snippets/docs_snippets/integrations/duckdb/downstream_columns.py
@@ -2,7 +2,6 @@ import pandas as pd
 
 from dagster import AssetIn, asset
 
-
 # this example uses the iris_dataset asset from Step 2 of the Using Dagster with DuckDB tutorial
 
 

--- a/examples/docs_snippets/docs_snippets/integrations/fivetran/fivetran.py
+++ b/examples/docs_snippets/docs_snippets/integrations/fivetran/fivetran.py
@@ -1,4 +1,4 @@
-# isort: skip_file
+# ruff: isort: skip_file
 
 
 def scope_define_instance():

--- a/examples/docs_snippets/docs_snippets/integrations/snowflake/downstream_columns.py
+++ b/examples/docs_snippets/docs_snippets/integrations/snowflake/downstream_columns.py
@@ -2,7 +2,6 @@ import pandas as pd
 
 from dagster import AssetIn, asset
 
-
 # this example uses the iris_dataset asset from Step 2 of the Using Dagster with Snowflake tutorial
 
 

--- a/examples/docs_snippets/docs_snippets/intro_tutorial/basics/single_op_job/hello.py
+++ b/examples/docs_snippets/docs_snippets/intro_tutorial/basics/single_op_job/hello.py
@@ -1,4 +1,4 @@
-# isort: skip_file
+# ruff: isort: skip_file
 
 # start_op_marker
 import os

--- a/examples/docs_snippets/docs_snippets/tutorial/saving/add_db_io_manager.py
+++ b/examples/docs_snippets/docs_snippets/tutorial/saving/add_db_io_manager.py
@@ -1,4 +1,4 @@
-# isort: skip_file
+# ruff: isort: skip_file
 all_assets = None
 hackernews_schedule = None
 

--- a/examples/docs_snippets/docs_snippets/tutorial/saving/add_fs_io_manager.py
+++ b/examples/docs_snippets/docs_snippets/tutorial/saving/add_fs_io_manager.py
@@ -1,4 +1,4 @@
-# isort: skip_file
+# ruff: isort: skip_file
 all_assets = None
 
 # start_imports_and_definitions

--- a/examples/docs_snippets/docs_snippets_tests/guides_tests/managing_ml_tests/managing_ml_tests.py
+++ b/examples/docs_snippets/docs_snippets_tests/guides_tests/managing_ml_tests/managing_ml_tests.py
@@ -1,4 +1,4 @@
-# isort: skip_file
+# ruff: isort: skip_file
 
 from dagster import load_assets_from_modules
 from dagster import materialize

--- a/examples/docs_snippets/pyproject.toml
+++ b/examples/docs_snippets/pyproject.toml
@@ -13,7 +13,7 @@ target-version = ['py37', 'py38', 'py39', 'py310', 'py311']
 [tool.ruff]
 
 # Extend root configuration.
-extend = "../../pyproject.toml"
+extend = "../pyproject.toml"
 
 # Match black. Note that this also checks comment line length, but black does not format comments.
 line-length = 88

--- a/examples/feature_graph_backed_assets/feature_graph_backed_assets_tests/test_assets.py
+++ b/examples/feature_graph_backed_assets/feature_graph_backed_assets_tests/test_assets.py
@@ -1,4 +1,5 @@
 from dagster._core.test_utils import instance_for_test
+
 from feature_graph_backed_assets import defs
 
 

--- a/examples/project_fully_featured/project_fully_featured_tests/recommender_tests/assets_tests/test_comment_stories.py
+++ b/examples/project_fully_featured/project_fully_featured_tests/recommender_tests/assets_tests/test_comment_stories.py
@@ -1,5 +1,6 @@
 import pytest
 from pandas import DataFrame
+
 from project_fully_featured.assets.recommender.comment_stories import comment_stories
 
 

--- a/examples/project_fully_featured/project_fully_featured_tests/recommender_tests/assets_tests/test_user_story_matrix.py
+++ b/examples/project_fully_featured/project_fully_featured_tests/recommender_tests/assets_tests/test_user_story_matrix.py
@@ -1,5 +1,6 @@
 import pytest
 from pandas import DataFrame
+
 from project_fully_featured.assets.recommender.user_story_matrix import (
     user_story_matrix,
 )

--- a/examples/project_fully_featured/project_fully_featured_tests/recommender_tests/assets_tests/test_user_top_recommended_stories.py
+++ b/examples/project_fully_featured/project_fully_featured_tests/recommender_tests/assets_tests/test_user_top_recommended_stories.py
@@ -1,13 +1,14 @@
 import numpy as np
 from pandas import DataFrame, Series
+from scipy.sparse import coo_matrix
+from sklearn.decomposition import TruncatedSVD
+
 from project_fully_featured.assets.recommender.user_story_matrix import (
     IndexedCooMatrix,
 )
 from project_fully_featured.assets.recommender.user_top_recommended_stories import (
     user_top_recommended_stories,
 )
-from scipy.sparse import coo_matrix
-from sklearn.decomposition import TruncatedSVD
 
 
 def test_user_top_recommended_stories():

--- a/examples/project_fully_featured/project_fully_featured_tests/test_core.py
+++ b/examples/project_fully_featured/project_fully_featured_tests/test_core.py
@@ -8,6 +8,7 @@ from dagster import (
     mem_io_manager,
 )
 from dagster_pyspark import pyspark_resource
+
 from project_fully_featured.assets import core
 from project_fully_featured.resources.hn_resource import HNSnapshotClient
 from project_fully_featured.resources.parquet_io_manager import (

--- a/examples/project_fully_featured/project_fully_featured_tests/test_resources/test_parquet_io_manager.py
+++ b/examples/project_fully_featured/project_fully_featured_tests/test_resources/test_parquet_io_manager.py
@@ -4,11 +4,12 @@ import tempfile
 import pandas
 from dagster import asset, materialize
 from dagster_pyspark import pyspark_resource
+from pyspark.sql import DataFrame as SparkDF
+
 from project_fully_featured.partitions import hourly_partitions
 from project_fully_featured.resources.parquet_io_manager import (
     LocalPartitionedParquetIOManager,
 )
-from pyspark.sql import DataFrame as SparkDF
 
 
 def test_io_manager():

--- a/examples/project_fully_featured/project_fully_featured_tests/test_resources/test_snowflake_io_manager.py
+++ b/examples/project_fully_featured/project_fully_featured_tests/test_resources/test_snowflake_io_manager.py
@@ -8,13 +8,14 @@ from dagster import AssetKey, asset, build_input_context, build_output_context
 from dagster._core.execution.context.input import InputContext
 from dagster._core.execution.context.output import OutputContext
 from pandas import DataFrame as PandasDataFrame
+from pyspark.sql import Row, SparkSession
+from pyspark.sql.types import IntegerType, StringType, StructField, StructType
+
 from project_fully_featured.resources import SHARED_SNOWFLAKE_CONF
 from project_fully_featured.resources.snowflake_io_manager import (
     SnowflakeIOManager,
     connect_snowflake,
 )
-from pyspark.sql import Row, SparkSession
-from pyspark.sql.types import IntegerType, StringType, StructField, StructType
 
 
 def mock_output_context(asset_key: AssetKey) -> OutputContext:

--- a/examples/project_fully_featured/project_fully_featured_tests/test_sensors/test_hn_tables_updated_sensor.py
+++ b/examples/project_fully_featured/project_fully_featured_tests/test_sensors/test_hn_tables_updated_sensor.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 from dagster import EventLogRecord, GraphDefinition, build_sensor_context
 from dagster._core.test_utils import instance_for_test
+
 from project_fully_featured.sensors.hn_tables_updated_sensor import (
     make_hn_tables_updated_sensor,
 )

--- a/examples/project_fully_featured/project_fully_featured_tests/test_sensors/test_slack_on_failure_sensor.py
+++ b/examples/project_fully_featured/project_fully_featured_tests/test_sensors/test_slack_on_failure_sensor.py
@@ -1,4 +1,5 @@
 from dagster import repository
+
 from project_fully_featured.sensors.slack_on_failure_sensor import (
     make_slack_on_failure_sensor,
 )

--- a/examples/pyproject.toml
+++ b/examples/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.ruff]
+
+# Extend root configuration. Note that having this [tool.ruff] section in a pyproject in examples
+# has the effect of making each example package treated as first-party, where `dagster` and
+# integrations will be treated as third-party. This is appropriate for example code.
+extend = "../pyproject.toml"

--- a/examples/with_great_expectations/with_great_expectations_tests/test_ge_example.py
+++ b/examples/with_great_expectations/with_great_expectations_tests/test_ge_example.py
@@ -2,6 +2,7 @@ import pytest
 from dagster import RunConfig
 from dagster._utils import file_relative_path
 from dagster_ge.factory import GEContextResource
+
 from with_great_expectations import defs
 from with_great_expectations.ge_demo import GEOpConfig, payroll_data
 

--- a/examples/with_pyspark_emr/with_pyspark_emr_tests/test_emr_pyspark.py
+++ b/examples/with_pyspark_emr/with_pyspark_emr_tests/test_emr_pyspark.py
@@ -4,6 +4,7 @@ import os
 from dagster import materialize_to_memory
 from dagster._core.execution.api import create_execution_plan
 from dagster_pyspark import PySparkResource
+
 from with_pyspark_emr.definitions import defs, people, people_over_50
 
 

--- a/helm/dagster/schema/schema/utils/helm_template.py
+++ b/helm/dagster/schema/schema/utils/helm_template.py
@@ -27,7 +27,7 @@ class HelmTemplate:
     output: Optional[str] = None
     model: Optional[Any] = None
     release_name: str = "release-name"
-    api_client: ApiClient = ApiClient()
+    api_client: ApiClient = ApiClient()  # noqa: RUF009
     namespace: str = "default"
 
     def render(

--- a/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/integration_utils.py
+++ b/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/integration_utils.py
@@ -169,7 +169,7 @@ def launch_run_over_graphql(
 
     result = _execute_query_over_graphql(dagit_url, LAUNCH_PIPELINE_MUTATION, variables)
 
-    print(f"Launch pipeline result: {str(result)}")
+    print(f"Launch pipeline result: {result}")
 
     assert (
         "data" in result
@@ -185,7 +185,7 @@ def can_terminate_run_over_graphql(
 ) -> bool:
     variables = json.dumps({"runId": run_id})
     result = _execute_query_over_graphql(dagit_url, CAN_TERMINATE_RUN_QUERY, variables)
-    print(f"Can terminate result: {str(result)}")
+    print(f"Can terminate result: {result}")
     assert "data" in result and result["data"]["runOrError"]["__typename"] == "Run"
     return result["data"]["runOrError"]["canTerminate"]
 
@@ -193,7 +193,7 @@ def can_terminate_run_over_graphql(
 def terminate_run_over_graphql(dagit_url, run_id):
     variables = json.dumps({"runId": run_id})
     result = _execute_query_over_graphql(dagit_url, TERMINATE_RUN_MUTATION, variables)
-    print(f"Terminate result: {str(result)}")
+    print(f"Terminate result: {result}")
     assert (
         "data" in result and result["data"]["terminateRun"]["__typename"] == "TerminateRunSuccess"
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,9 +109,9 @@ filterwarnings = [
 # ########################
 
 # [Docs root]
-#   https://github.com/charliermarsh/ruff#ruff
+#   https://beta.ruff.rs/docs/
 # [Config option reference]
-#   https://github.com/charliermarsh/ruff#reference
+#   https://beta.ruff.rs/docs/configuration/
 #
 # As of 2022-12-05, the entire documentation of Ruff is in its very long
 # README.
@@ -163,6 +163,10 @@ ignore = [
 
   # (no concatenation) Existing codebase has many concatentations, no reason to disallow them.
   "RUF005",
+
+  # (use ClassVar for attr declarations with defaults) This is a good rule for vanilla Python, but
+  # triggers false positives for many libs that have DSLs that make use of attr defaults.
+  "RUF012",
 
   ##### TEMPORARY DISABLES
 
@@ -218,6 +222,10 @@ select = [
   # methods on `NamedTuple` are ignored (e.g. `_replace`).
   "SLF001",
 
+  # (flake8-type-checking) Auto-sort imports into TYPE_CHECKING blocks depending on whether
+  # they are runtime or type-only imports.
+  "TCH",
+
   # (disallow print statements) keep debugging statements out of the codebase
   "T20",
 
@@ -229,7 +237,7 @@ select = [
 ]
 
 # Fail if Ruff is not running this version.
-required-version = "0.0.255"
+required-version = "0.0.276"
 
 [tool.ruff.flake8-builtins]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,10 +222,6 @@ select = [
   # methods on `NamedTuple` are ignored (e.g. `_replace`).
   "SLF001",
 
-  # (flake8-type-checking) Auto-sort imports into TYPE_CHECKING blocks depending on whether
-  # they are runtime or type-only imports.
-  "TCH",
-
   # (disallow print statements) keep debugging statements out of the codebase
   "T20",
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -233,7 +233,7 @@ select = [
 ]
 
 # Fail if Ruff is not running this version.
-required-version = "0.0.276"
+required-version = "0.0.277"
 
 [tool.ruff.flake8-builtins]
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/config.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/config.py
@@ -206,7 +206,7 @@ class GraphenePipelineConfigValidationError(graphene.Interface):
                 incoming_fields=error.error_data.incoming_fields,
             )
         else:
-            check.failed(f"Error type not supported {repr(error.error_data)}")
+            check.failed(f"Error type not supported {error.error_data!r}")
 
 
 class GrapheneRuntimeMismatchConfigError(graphene.ObjectType):

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_permissions.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_permissions.py
@@ -242,7 +242,7 @@ class TestPermissionsQuery(NonLaunchableGraphQLContextTestMatrix):
             if permission_result:
                 pass
 
-        permission_result.enabled
+        permission_result.enabled  # noqa: B018
 
 
 class TestWorkspacePermissionsQuery(NonLaunchableGraphQLContextTestMatrix):

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs.py
@@ -839,8 +839,12 @@ def test_filtered_runs_multiple_filters():
 def test_filtered_runs_count():
     with instance_for_test() as instance:
         repo = get_repo_at_time_1()
-        instance.create_run_for_job(repo.get_job("foo_job"), status=DagsterRunStatus.STARTED).run_id
-        instance.create_run_for_job(repo.get_job("foo_job"), status=DagsterRunStatus.FAILURE).run_id
+        instance.create_run_for_job(  # noqa: B018
+            repo.get_job("foo_job"), status=DagsterRunStatus.STARTED
+        ).run_id
+        instance.create_run_for_job(  # noqa: B018
+            repo.get_job("foo_job"), status=DagsterRunStatus.FAILURE
+        ).run_id
         with define_out_of_process_context(__file__, "get_repo_at_time_1", instance) as context:
             result = execute_dagster_graphql(
                 context,

--- a/python_modules/dagster-test/dagster_test/toys/sensors.py
+++ b/python_modules/dagster-test/dagster_test/toys/sensors.py
@@ -64,7 +64,7 @@ def get_toys_sensors():
 
         for filename, mtime in directory_files:
             yield RunRequest(
-                run_key=f"{filename}:{str(mtime)}",
+                run_key=f"{filename}:{mtime}",
                 run_config={
                     "ops": {
                         "read_file": {"config": {"directory": directory_name, "filename": filename}}

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -545,7 +545,7 @@ from dagster._utils.dagster_type import check_dagster_type as check_dagster_type
 from dagster._utils.log import get_dagster_logger as get_dagster_logger
 from dagster.version import __version__ as __version__
 
-# isort: split
+# ruff: isort: split
 
 # ########################
 # ##### DYNAMIC IMPORTS

--- a/python_modules/dagster/dagster/_check/__init__.py
+++ b/python_modules/dagster/dagster/_check/__init__.py
@@ -1706,8 +1706,7 @@ def _element_check_error(
 ) -> ElementCheckError:
     additional_message = " " + additional_message if additional_message else ""
     return ElementCheckError(
-        f"Value {value!r} from key {key} is not a {ttype!r}. Dict: {ddict!r}."
-        f"{additional_message}"
+        f"Value {value!r} from key {key} is not a {ttype!r}. Dict: {ddict!r}.{additional_message}"
     )
 
 

--- a/python_modules/dagster/dagster/_check/__init__.py
+++ b/python_modules/dagster/dagster/_check/__init__.py
@@ -1584,7 +1584,7 @@ def _check_tuple_items(
                     additional_message = ""
                 raise CheckError(
                     f"Member of tuple mismatches type at index {i}. Expected {of_shape_i}. Got "
-                    f"{repr(obj)} of type {type(obj)}.{additional_message}"
+                    f"{obj!r} of type {type(obj)}.{additional_message}"
                 )
 
     elif of_type is not None:
@@ -1706,7 +1706,7 @@ def _element_check_error(
 ) -> ElementCheckError:
     additional_message = " " + additional_message if additional_message else ""
     return ElementCheckError(
-        f"Value {repr(value)} from key {key} is not a {repr(ttype)}. Dict: {repr(ddict)}."
+        f"Value {value!r} from key {key} is not a {ttype!r}. Dict: {ddict!r}."
         f"{additional_message}"
     )
 
@@ -1721,12 +1721,12 @@ def _param_type_mismatch_exception(
     if isinstance(ttype, tuple):
         type_names = sorted([t.__name__ for t in ttype])
         return ParameterCheckError(
-            f'Param "{param_name}" is not one of {type_names}. Got {repr(obj)} which is type'
+            f'Param "{param_name}" is not one of {type_names}. Got {obj!r} which is type'
             f" {type(obj)}.{additional_message}"
         )
     else:
         return ParameterCheckError(
-            f'Param "{param_name}" is not a {ttype.__name__}. Got {repr(obj)} which is type'
+            f'Param "{param_name}" is not a {ttype.__name__}. Got {obj!r} which is type'
             f" {type(obj)}.{additional_message}"
         )
 
@@ -1742,7 +1742,7 @@ def _param_class_mismatch_exception(
     opt_clause = optional and "be None or" or ""
     subclass_clause = superclass and f"that inherits from {superclass.__name__}" or ""
     return ParameterCheckError(
-        f'Param "{param_name}" must {opt_clause}be a class{subclass_clause}. Got {repr(obj)} of'
+        f'Param "{param_name}" must {opt_clause}be a class{subclass_clause}. Got {obj!r} of'
         f" type {type(obj)}.{additional_message}"
     )
 
@@ -1768,7 +1768,7 @@ def _param_not_callable_exception(
 ) -> ParameterCheckError:
     additional_message = " " + additional_message if additional_message else ""
     return ParameterCheckError(
-        f'Param "{param_name}" is not callable. Got {repr(obj)} with type {type(obj)}.'
+        f'Param "{param_name}" is not callable. Got {obj!r} with type {type(obj)}.'
         f"{additional_message}"
     )
 
@@ -1795,7 +1795,7 @@ def _check_iterable_items(
                 additional_message = ""
             raise CheckError(
                 f"Member of {collection_name} mismatches type. Expected {of_type}. Got"
-                f" {repr(obj)} of type {type(obj)}.{additional_message}"
+                f" {obj!r} of type {type(obj)}.{additional_message}"
             )
 
     return obj_iter
@@ -1817,14 +1817,14 @@ def _check_mapping_entries(
     for key, value in obj.items():
         if key_type and not key_check(key, key_type):
             raise CheckError(
-                f"Key in {mapping_type.__name__} mismatches type. Expected {repr(key_type)}. Got"
-                f" {repr(key)}"
+                f"Key in {mapping_type.__name__} mismatches type. Expected {key_type!r}. Got"
+                f" {key!r}"
             )
 
         if value_type and not value_check(value, value_type):
             raise CheckError(
                 f"Value in {mapping_type.__name__} mismatches expected type for key {key}. Expected"
-                f" value of type {repr(value_type)}. Got value {value} of type {type(value)}."
+                f" value of type {value_type!r}. Got value {value} of type {type(value)}."
             )
 
     return obj

--- a/python_modules/dagster/dagster/_config/field_utils.py
+++ b/python_modules/dagster/dagster/_config/field_utils.py
@@ -401,7 +401,7 @@ def expand_map(original_root: object, the_dict: Mapping[object, object], stack: 
             original_root,
             the_dict,
             stack,
-            f"Map dict must have a scalar type as its only key. Got key {repr(key)}",
+            f"Map dict must have a scalar type as its only key. Got key {key!r}",
         )
 
     inner_type = _convert_potential_type(original_root, the_dict[key], stack)

--- a/python_modules/dagster/dagster/_core/definitions/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/__init__.py
@@ -113,7 +113,7 @@ from .sensor_definition import (
     SensorEvaluationContext as SensorEvaluationContext,
 )
 
-# isort: split
+# ruff: isort: split
 from .asset_in import AssetIn as AssetIn
 from .asset_out import AssetOut as AssetOut
 from .asset_selection import AssetSelection as AssetSelection

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -1160,7 +1160,7 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
         if overlapping_keys:
             overlapping_keys_str = ", ".join(sorted(list(overlapping_keys)))
             raise DagsterInvalidInvocationError(
-                f"{str(self)} has conflicting resource "
+                f"{self} has conflicting resource "
                 "definitions with provided resources for the following keys: "
                 f"{overlapping_keys_str}. Either remove the existing "
                 "resources from the asset or change the resource keys so that "
@@ -1275,7 +1275,7 @@ def _build_invocation_context_with_included_resources(
     for resource_key in sorted(list(invocation_resources.keys())):
         if resource_key in resource_defs:
             raise DagsterInvalidInvocationError(
-                f"Error when invoking {str(assets_def)}: resource '{resource_key}' "
+                f"Error when invoking {assets_def}: resource '{resource_key}' "
                 "provided on both the definition and invocation context. Please "
                 "provide on only one or the other."
             )

--- a/python_modules/dagster/dagster/_core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/graph_definition.py
@@ -88,7 +88,7 @@ def _check_node_defs_arg(
                 )
             )
         else:
-            raise DagsterInvalidDefinitionError(f"Invalid item in node list: {repr(node_def)}")
+            raise DagsterInvalidDefinitionError(f"Invalid item in node list: {node_def!r}")
 
     return node_defs
 

--- a/python_modules/dagster/dagster/_core/definitions/multi_dimensional_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_dimensional_partitions.py
@@ -339,8 +339,8 @@ class MultiPartitionsDefinition(PartitionsDefinition[MultiPartitionKey]):
         dimension_2 = self._partitions_defs[1]
         partition_str = (
             "Multi-partitioned, with dimensions: \n"
-            f"{dimension_1.name.capitalize()}: {str(dimension_1.partitions_def)} \n"
-            f"{dimension_2.name.capitalize()}: {str(dimension_2.partitions_def)}"
+            f"{dimension_1.name.capitalize()}: {dimension_1.partitions_def} \n"
+            f"{dimension_2.name.capitalize()}: {dimension_2.partitions_def}"
         )
         return partition_str
 

--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -1047,8 +1047,8 @@ class DefaultPartitionsSubset(PartitionsSubset[T_str]):
     def __eq__(self, other: object) -> bool:
         return (
             isinstance(other, DefaultPartitionsSubset)
-            and self._partitions_def == other._partitions_def  # noqa: SLF001
-            and self._subset == other._subset  # noqa: SLF001
+            and self._partitions_def == other._partitions_def
+            and self._subset == other._subset
         )
 
     def __len__(self) -> int:

--- a/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
@@ -396,7 +396,7 @@ class MultiToSingleDimensionPartitionMapping(
         for key in multipartitions_def.get_partition_keys(
             current_time=None, dynamic_partitions_store=dynamic_partitions_store
         ):
-            key = cast(MultiPartitionKey, key)  # noqa: PLW2901
+            key = cast(MultiPartitionKey, key)
             if (
                 key.keys_by_dimension[partition_dimension_name]
                 in partitions_subset.get_partition_keys()

--- a/python_modules/dagster/dagster/_core/definitions/reconstruct.py
+++ b/python_modules/dagster/dagster/_core/definitions/reconstruct.py
@@ -602,7 +602,7 @@ def _check_is_loadable(definition: T_LoadableDefinition) -> T_LoadableDefinition
     ):
         raise DagsterInvariantViolationError(
             "Loadable attributes must be either a JobDefinition, GraphDefinition, "
-            f"or RepositoryDefinition. Got {repr(definition)}."
+            f"or RepositoryDefinition. Got {definition!r}."
         )
     return definition
 

--- a/python_modules/dagster/dagster/_core/definitions/resource_requirement.py
+++ b/python_modules/dagster/dagster/_core/definitions/resource_requirement.py
@@ -224,9 +224,9 @@ def ensure_requirements_satisfied(
         if not requirement.resources_contain_key(resource_defs):
             raise DagsterInvalidDefinitionError(
                 f"{requirement.describe_requirement()} was not provided. Please"
-                f" provide a {str(requirement.expected_type)} to key '{requirement.key}', or change"
+                f" provide a {requirement.expected_type} to key '{requirement.key}', or change"
                 " the required key to one of the following keys which points to an"
-                f" {str(requirement.expected_type)}:"
+                f" {requirement.expected_type}:"
                 f" {requirement.keys_of_expected_type(resource_defs)}"
             )
 

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -1616,13 +1616,12 @@ class TimeWindowPartitionsSubset(PartitionsSubset):
     def __eq__(self, other):
         return (
             isinstance(other, TimeWindowPartitionsSubset)
-            and self._partitions_def == other._partitions_def  # noqa: SLF001
+            and self._partitions_def == other._partitions_def
             and (
                 # faster comparison, but will not catch all cases
                 (
-                    self._included_time_windows == other._included_time_windows  # noqa: SLF001
-                    and self._included_partition_keys
-                    == other._included_partition_keys  # noqa: SLF001
+                    self._included_time_windows == other._included_time_windows
+                    and self._included_partition_keys == other._included_partition_keys
                 )
                 # slower comparison, catches all cases
                 or self.included_time_windows == other.included_time_windows

--- a/python_modules/dagster/dagster/_core/definitions/utils.py
+++ b/python_modules/dagster/dagster/_core/definitions/utils.py
@@ -82,7 +82,7 @@ def is_valid_name(name: str) -> bool:
 
 
 def _kv_str(key: object, value: object) -> str:
-    return f'{key}="{repr(value)}"'
+    return f'{key}="{value!r}"'
 
 
 def struct_to_string(name: str, **kwargs: object) -> str:

--- a/python_modules/dagster/dagster/_core/errors.py
+++ b/python_modules/dagster/dagster/_core/errors.py
@@ -103,7 +103,7 @@ Unable to resolve config type {invalid_type} to a supported Dagster config type.
 
 {PYTHONIC_CONFIG_ERROR_VERBIAGE}"""
     ).format(
-        config_class=f" {repr(config_class)}" if config_class else "",
+        config_class=f" {config_class!r}" if config_class else "",
         field_name=f" on field '{field_name}'" if field_name else "",
         invalid_type=repr(invalid_type),
         PYTHONIC_CONFIG_ERROR_VERBIAGE=pythonic_config_error_verbiage,

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -475,7 +475,7 @@ def execute_asset_backfill_iteration(
             if unloadable_locations
             else ""
         )
-        raise DagsterAssetBackfillDataLoadError(f"{str(ex)}. {unloadable_locations_error}")
+        raise DagsterAssetBackfillDataLoadError(f"{ex}. {unloadable_locations_error}")
 
     backfill_start_time = utc_datetime_from_timestamp(backfill.backfill_timestamp)
 

--- a/python_modules/dagster/dagster/_core/execution/context/system.py
+++ b/python_modules/dagster/dagster/_core/execution/context/system.py
@@ -563,7 +563,7 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
         return self.job_def.get_retry_policy_for_handle(self.node_handle)
 
     def describe_op(self) -> str:
-        return f'op "{str(self.node_handle)}"'
+        return f'op "{self.node_handle}"'
 
     def get_io_manager(self, step_output_handle: StepOutputHandle) -> IOManager:
         step_output = self.execution_plan.get_step_output(step_output_handle)

--- a/python_modules/dagster/dagster/_core/execution/execute_in_process.py
+++ b/python_modules/dagster/dagster/_core/execution/execute_in_process.py
@@ -132,6 +132,6 @@ def _check_top_level_inputs_for_node(
             raise DagsterInvalidInvocationError(
                 f"Attempted to invoke execute_in_process for '{job_name}' without specifying an"
                 f" input_value for input '{top_level_input_name}', but downstream input"
-                f" {input_def.name} of op '{str(cur_node_handle)}' has no other way of being"
+                f" {input_def.name} of op '{cur_node_handle}' has no other way of being"
                 " loaded."
             )

--- a/python_modules/dagster/dagster/_core/execution/plan/active.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/active.py
@@ -382,7 +382,7 @@ class ActiveExecution:
             steps.append(step)
             self._in_flight.add(key)
             self._pending_skip.remove(key)
-            self._gathering_dynamic_outputs
+            self._gathering_dynamic_outputs  # noqa: B018
             self._skip_for_dynamic_outputs(step)
 
         return sorted(steps, key=self._sort_key_fn)

--- a/python_modules/dagster/dagster/_core/execution/plan/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/compute.py
@@ -198,6 +198,6 @@ def execute_core_compute(
     omitted_outputs = op_output_names.difference(emitted_result_names)
     if omitted_outputs:
         step_context.log.info(
-            f"{step_context.op_def.node_type_str} '{str(step.node_handle)}' did not fire "
-            f"outputs {repr(omitted_outputs)}"
+            f"{step_context.op_def.node_type_str} '{step.node_handle}' did not fire "
+            f"outputs {omitted_outputs!r}"
         )

--- a/python_modules/dagster/dagster/_core/execution/plan/plan.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/plan.py
@@ -1077,7 +1077,7 @@ class ExecutionPlan(
                     step_snap.tags,
                 )
             else:
-                raise Exception(f"Unexpected step kind {str(step_snap.kind)}")
+                raise Exception(f"Unexpected step kind {step_snap.kind}")
 
             step_dict[step.handle] = step
             step_dict_by_key[step.key] = step

--- a/python_modules/dagster/dagster/_core/execution/with_resources.py
+++ b/python_modules/dagster/dagster/_core/execution/with_resources.py
@@ -87,7 +87,7 @@ def with_resources(
                 raise DagsterInvalidInvocationError(
                     f"Error with config for resource key '{key}': Expected a "
                     "dictionary of the form {'config': ...}, but received "
-                    f"{str(resource_config)}"
+                    f"{resource_config}"
                 )
 
             outer_config_shape = Shape({"config": resource_def.get_config_field()})

--- a/python_modules/dagster/dagster/_core/host_representation/__init__.py
+++ b/python_modules/dagster/dagster/_core/host_representation/__init__.py
@@ -52,7 +52,7 @@ from .origin import (
     ManagedGrpcPythonEnvCodeLocationOrigin as ManagedGrpcPythonEnvCodeLocationOrigin,
 )
 
-# isort: split
+# ruff: isort: split
 from .code_location import (
     CodeLocation as CodeLocation,
     GrpcServerCodeLocation as GrpcServerCodeLocation,

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -204,7 +204,7 @@ class _EventListenerLogHandler(logging.Handler):
         try:
             self._instance.handle_new_event(event)
         except Exception as e:
-            sys.stderr.write(f"Exception while writing logger call to event log: {str(e)}\n")
+            sys.stderr.write(f"Exception while writing logger call to event log: {e}\n")
             if event.dagster_event:
                 # Swallow user-generated log failures so that the entire step/run doesn't fail, but
                 # raise failures writing system-generated log events since they are the source of

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -731,8 +731,6 @@ class DagsterInstance(DynamicPartitionsStore):
 
     @property
     def run_coordinator(self) -> "RunCoordinator":
-        from dagster._core.run_coordinator import RunCoordinator
-
         # Lazily load in case the run coordinator requires dependencies that are not available
         # everywhere that loads the instance
         if not self._run_coordinator:
@@ -741,7 +739,7 @@ class DagsterInstance(DynamicPartitionsStore):
             )
             run_coordinator = cast(InstanceRef, self._ref).run_coordinator
             check.invariant(run_coordinator, "Run coordinator not configured in instance ref")
-            self._run_coordinator = cast(RunCoordinator, run_coordinator)
+            self._run_coordinator = cast("RunCoordinator", run_coordinator)
             self._run_coordinator.register_instance(self)
         return self._run_coordinator
 
@@ -749,15 +747,13 @@ class DagsterInstance(DynamicPartitionsStore):
 
     @property
     def run_launcher(self) -> "RunLauncher":
-        from dagster._core.launcher import RunLauncher
-
         # Lazily load in case the launcher requires dependencies that are not available everywhere
         # that loads the instance (e.g. The EcsRunLauncher requires boto3)
         if not self._run_launcher:
             check.invariant(self._ref, "Run launcher not provided, and no instance ref available")
             launcher = cast(InstanceRef, self._ref).run_launcher
             check.invariant(launcher, "Run launcher not configured in instance ref")
-            self._run_launcher = cast(RunLauncher, launcher)
+            self._run_launcher = cast("RunLauncher", launcher)
             self._run_launcher.register_instance(self)
         return self._run_launcher
 
@@ -765,8 +761,6 @@ class DagsterInstance(DynamicPartitionsStore):
 
     @property
     def compute_log_manager(self) -> "ComputeLogManager":
-        from dagster._core.storage.compute_log_manager import ComputeLogManager
-
         if not self._compute_log_manager:
             check.invariant(
                 self._ref, "Compute log manager not provided, and no instance ref available"
@@ -775,7 +769,7 @@ class DagsterInstance(DynamicPartitionsStore):
             check.invariant(
                 compute_log_manager, "Compute log manager not configured in instance ref"
             )
-            self._compute_log_manager = cast(ComputeLogManager, compute_log_manager)
+            self._compute_log_manager = cast("ComputeLogManager", compute_log_manager)
             self._compute_log_manager.register_instance(self)
         return self._compute_log_manager
 

--- a/python_modules/dagster/dagster/_daemon/monitoring/run_monitoring.py
+++ b/python_modules/dagster/dagster/_daemon/monitoring/run_monitoring.py
@@ -201,7 +201,7 @@ def execute_run_monitoring_iteration(
         except Exception:
             error_info = serializable_error_info_from_exc_info(sys.exc_info())
             logger.error(
-                f"Hit error while monitoring run {run_record.dagster_run.run_id}: {str(error_info)}"
+                f"Hit error while monitoring run {run_record.dagster_run.run_id}: {error_info}"
             )
             yield error_info
         else:

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -636,9 +636,7 @@ def _submit_run_request(
         )
     except Exception:
         error_info = serializable_error_info_from_exc_info(sys.exc_info())
-        logger.error(
-            f"Run {run.run_id} created successfully but failed to launch: {str(error_info)}"
-        )
+        logger.error(f"Run {run.run_id} created successfully but failed to launch: {error_info}")
 
     _check_for_debug_crash(sensor_debug_crash_flags, "RUN_LAUNCHED")
     return SubmitRunRequestResult(run_key=run_request.run_key, error_info=error_info, run=run)

--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -1038,7 +1038,7 @@ def wait_for_grpc_server(server_process, client, subprocess_args, timeout=60):
         if timeout > 0 and (time.time() - start_time > timeout):
             raise Exception(
                 f"Timed out waiting for gRPC server to start after {timeout}s with arguments:"
-                f" \"{' '.join(subprocess_args)}\". Most recent connection error: {str(last_error)}"
+                f" \"{' '.join(subprocess_args)}\". Most recent connection error: {last_error}"
             )
 
         if server_process.poll() is not None:

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -1454,7 +1454,7 @@ def test_context_assets_def():
 def test_invalid_context_assets_def():
     @op
     def my_op(context):
-        context.assets_def
+        context.assets_def  # noqa: B018
 
     @job
     def my_job():

--- a/python_modules/dagster/dagster_tests/cli_tests/test_project_commands.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/test_project_commands.py
@@ -134,7 +134,11 @@ def test_available_examples_in_sync_with_example_folder():
     available_examples_in_folder = [
         e
         for e in os.listdir(example_folder)
-        if (e not in EXAMPLES_TO_IGNORE and not _should_skip_file(e))
+        if (
+            os.path.isdir(os.path.join(example_folder, e))
+            and e not in EXAMPLES_TO_IGNORE
+            and not _should_skip_file(e)
+        )
     ]
     assert set(available_examples_in_folder) == set(AVAILABLE_EXAMPLES)
 

--- a/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_config_schema.py
+++ b/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_config_schema.py
@@ -22,10 +22,10 @@ def test_op_field_backcompat():
     assert op_with_schema.config_schema.description is None
 
     with pytest.raises(CheckError):
-        op_with_schema.config_schema.default_value
+        op_with_schema.config_schema.default_value  # noqa: B018
 
     with pytest.raises(CheckError):
-        op_with_schema.config_schema.default_value_as_json_str
+        op_with_schema.config_schema.default_value_as_json_str  # noqa: B018
 
     @op(config_schema=Field(int, default_value=4, description="foo"))
     def op_with_all_properties(_):
@@ -58,10 +58,10 @@ def test_composite_field_backwards_compat():
     assert graph_with_int.config_schema.default_provided is False
 
     with pytest.raises(CheckError):
-        graph_with_int.config_schema.default_value
+        graph_with_int.config_schema.default_value  # noqa: B018
 
     with pytest.raises(CheckError):
-        graph_with_int.config_schema.default_value_as_json_str
+        graph_with_int.config_schema.default_value_as_json_str  # noqa: B018
 
     @graph(
         config=ConfigMapping(

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_build_init_resource_context.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_build_init_resource_context.py
@@ -46,7 +46,7 @@ def test_build_with_cm_resource():
 
     context = build_init_resource_context(resources={"foo": foo})
     with pytest.raises(DagsterInvariantViolationError):
-        context.resources
+        context.resources  # noqa: B018
 
     del context
     assert entered == ["true"]

--- a/python_modules/dagster/dagster_tests/core_tests/serdes_tests/compute_log_subprocess.py
+++ b/python_modules/dagster/dagster_tests/core_tests/serdes_tests/compute_log_subprocess.py
@@ -20,9 +20,9 @@ if __name__ == "__main__":
         fd.write("opened_compute_log_subprocess")
     with mirror_stream_to_file(sys.stdout, stdout_filepath) as stdout_pids:
         with mirror_stream_to_file(sys.stderr, stderr_filepath) as stderr_pids:
-            sys.stdout.write(f"stdout pids: {str(stdout_pids)}")
+            sys.stdout.write(f"stdout pids: {stdout_pids}")
             sys.stdout.flush()
-            sys.stderr.write(f"stderr pids: {str(stderr_pids)}")
+            sys.stderr.write(f"stderr pids: {stderr_pids}")
             sys.stderr.flush()
             try:
                 while True:

--- a/python_modules/dagster/dagster_tests/core_tests/serdes_tests/compute_log_subprocess_segfault.py
+++ b/python_modules/dagster/dagster_tests/core_tests/serdes_tests/compute_log_subprocess_segfault.py
@@ -9,8 +9,8 @@ if __name__ == "__main__":
     stdout_pids_file, stderr_pids_file = (sys.argv[1], sys.argv[2])
     with mirror_stream_to_file(sys.stdout, stdout_pids_file) as stdout_pids:
         with mirror_stream_to_file(sys.stderr, stderr_pids_file) as stderr_pids:
-            sys.stdout.write(f"stdout pids: {str(stdout_pids)}")
+            sys.stdout.write(f"stdout pids: {stdout_pids}")
             sys.stdout.flush()
-            sys.stderr.write(f"stderr pids: {str(stderr_pids)}")
+            sys.stderr.write(f"stderr pids: {stderr_pids}")
             sys.stderr.flush()
             segfault()

--- a/python_modules/dagster/dagster_tests/core_tests/test_op_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_op_invocation.py
@@ -1212,7 +1212,7 @@ def test_assets_def_invocation():
 
     @op
     def non_asset_op(context):
-        context.assets_def
+        context.assets_def  # noqa: B018
 
     with build_op_context(
         partition_key="2023-02-02",

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/exotic_partition_mapping_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/exotic_partition_mapping_scenarios.py
@@ -324,11 +324,11 @@ exotic_partition_mapping_scenarios = {
         assets=unpartitioned_downstream_of_asymmetric_time_assets_in_series,
         unevaluated_runs=[
             run(["asset1"], partition_key)
-            for partition_key in [f"2023-01-0{str(x)}" for x in range(5, 9)]
+            for partition_key in [f"2023-01-0{x}" for x in range(5, 9)]
         ]
         + [
             run(["asset2"], partition_key)
-            for partition_key in [f"2023-01-0{str(x)}" for x in range(1, 9)]
+            for partition_key in [f"2023-01-0{x}" for x in range(1, 9)]
         ],
         current_time=create_pendulum_time(2023, 1, 9, 0),
         expected_run_requests=[run_request(asset_keys=["unpartitioned"])],

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_multi_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_multi_partitions.py
@@ -502,7 +502,7 @@ def test_context_invalid_partition_time_window():
 
     @asset(partitions_def=partitions_def)
     def my_asset(context):
-        context.partition_time_window
+        context.partition_time_window  # noqa: B018
 
     multipartitioned_job = define_asset_job(
         "my_job", [my_asset], partitions_def=partitions_def

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_schedule.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_schedule.py
@@ -39,4 +39,4 @@ def test_jobs_attr():
         DagsterInvalidDefinitionError,
         match="No job was provided to ScheduleDefinition.",
     ):
-        schedule.job
+        schedule.job  # noqa: B018

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_schedule_invocation.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_schedule_invocation.py
@@ -72,7 +72,7 @@ def test_instance_access():
         DagsterInvariantViolationError,
         match="Attempted to initialize dagster instance, but no instance reference was provided.",
     ):
-        build_schedule_context().instance
+        build_schedule_context().instance  # noqa: B018
 
     with instance_for_test() as instance:
         assert isinstance(build_schedule_context(instance).instance, DagsterInstance)

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_sensor.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_sensor.py
@@ -18,7 +18,7 @@ def test_jobs_attr():
     with pytest.raises(
         DagsterInvalidDefinitionError, match="No job was provided to SensorDefinition."
     ):
-        sensor.job
+        sensor.job  # noqa: B018
 
     @graph
     def my_second_graph():
@@ -29,7 +29,7 @@ def test_jobs_attr():
         DagsterInvalidDefinitionError,
         match="Job property not available when SensorDefinition has multiple jobs.",
     ):
-        sensor.job
+        sensor.job  # noqa: B018
 
 
 def test_direct_sensor_definition_instantiation():

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
@@ -494,7 +494,7 @@ def test_instance_access_built_sensor():
         DagsterInvariantViolationError,
         match="Attempted to initialize dagster instance, but no instance reference was provided.",
     ):
-        build_sensor_context().instance
+        build_sensor_context().instance  # noqa: B018
 
     with instance_for_test() as instance:
         assert isinstance(build_sensor_context(instance).instance, DagsterInstance)

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/grpc_repo_that_times_out.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/grpc_repo_that_times_out.py
@@ -1,4 +1,4 @@
-# isort: skip_file
+# ruff: isort: skip_file
 
 import time
 

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_cron_string_iterator.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_cron_string_iterator.py
@@ -87,4 +87,4 @@ def test_dst_spring_forward_transition_advances(execution_timezone, cron_string,
 
             assert (
                 next_time.timestamp() == times[j].timestamp()
-            ), f"Expected {times[i]} to advance to {times[j]}, got {str(next_time)}"
+            ), f"Expected {times[i]} to advance to {times[j]}, got {next_time}"

--- a/python_modules/dagster/dagster_tests/storage_tests/test_local_instance.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_local_instance.py
@@ -264,10 +264,10 @@ def test_threaded_ephemeral_instance(caplog):
                 with DagsterInstance.ephemeral() as instance:
                     instance.get_runs_count()  # call run storage
                     instance.all_asset_keys()  # call event log storage
-                    instance.root_directory  # access TemporaryDirectory
+                    assert instance.root_directory  # access TemporaryDirectory
                     shared_instance.get_runs_count()
                     shared_instance.all_asset_keys()
-                    shared_instance.root_directory
+                    assert shared_instance.root_directory
                 return True
 
             with ThreadPoolExecutor(

--- a/python_modules/dagster/dagster_tests/storage_tests/test_local_instance.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_local_instance.py
@@ -286,21 +286,6 @@ def test_threaded_ephemeral_instance(caplog):
         gc.enable()
 
 
-def test_threadsafe_ephemeral_instance():
-    n = 25
-    with DagsterInstance.ephemeral() as shared:
-
-        def _run(_):
-            shared.root_directory  # noqa: B018
-            with DagsterInstance.ephemeral() as instance:
-                instance.root_directory  # noqa: B018
-            return True
-
-        with ThreadPoolExecutor(max_workers=n) as executor:
-            results = executor.map(_run, range(n))
-            assert all(results)
-
-
 def test_threadsafe_local_temp_instance():
     n = 25
     gc.collect()

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/__init__.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/__init__.py
@@ -5,7 +5,7 @@ import pytest
 # We need to explicitly inform pytest that these asserts are part of the test cases, and not just
 # arbitrary library calls.
 pytest.register_assert_rewrite("dagster_tests.storage_tests.utils.event_log_storage")
-from . import event_log_storage as event_log_storage  # isort:skip
+from . import event_log_storage as event_log_storage  # ruff: isort:skip
 
 pytest.register_assert_rewrite("dagster_tests.storage_tests.utils.run_storage")
-from . import run_storage as run_storage  # isort:skip
+from . import run_storage as run_storage  # ruff: isort:skip

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -154,7 +154,7 @@ setup(
             "types-toml",  # version will be resolved against toml
         ],
         "ruff": [
-            "ruff==0.0.276",
+            "ruff==0.0.277",
         ],
     },
     entry_points={

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -154,7 +154,7 @@ setup(
             "types-toml",  # version will be resolved against toml
         ],
         "ruff": [
-            "ruff==0.0.255",
+            "ruff==0.0.276",
         ],
     },
     entry_points={

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/managed/reconciliation.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/managed/reconciliation.py
@@ -732,7 +732,7 @@ class AirbyteManagedElementCacheableAssetsDefinition(AirbyteInstanceCacheableAss
                 )
             )
         elif isinstance(diff, ManagedElementError):
-            raise ValueError(f"Error checking Airbyte connections: {str(diff)}")
+            raise ValueError(f"Error checking Airbyte connections: {diff}")
 
         return super()._get_connections()
 

--- a/python_modules/libraries/dagster-azure/dagster_azure/adls2/__init__.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/adls2/__init__.py
@@ -14,7 +14,6 @@ from .io_manager import (
 )
 from .resources import (
     ADLS2DefaultAzureCredential as ADLS2DefaultAzureCredential,
-    ADLS2FileManager as ADLS2FileManager,
     ADLS2Key as ADLS2Key,
     ADLS2Resource as ADLS2Resource,
     ADLS2SASToken as ADLS2SASToken,

--- a/python_modules/libraries/dagster-celery/dagster_celery/cli.py
+++ b/python_modules/libraries/dagster-celery/dagster_celery/cli.py
@@ -87,7 +87,7 @@ def get_config_dir(config_yaml=None):
             )
         if "config_source" in validated_config and validated_config["config_source"]:
             for key, value in validated_config["config_source"].items():
-                fd.write(f"{key} = {repr(value)}\n")
+                fd.write(f"{key} = {value!r}\n")
 
     # n.b. right now we don't attempt to clean up this cache, but it might make sense to delete
     # any files older than some time if there are more than some number of files present, etc.

--- a/python_modules/libraries/dagster-celery/dagster_celery_tests/test_execute.py
+++ b/python_modules/libraries/dagster-celery/dagster_celery_tests/test_execute.py
@@ -10,7 +10,7 @@ from dagster._core.execution.api import execute_job, execute_run_iterator
 from dagster._core.instance import DagsterInstance
 from dagster._utils import send_interrupt
 
-from .utils import (  # isort:skip
+from .utils import (  # ruff: isort:skip
     REPO_FILE,
     events_of_type,
     execute_eagerly_on_celery,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/__init__.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/__init__.py
@@ -40,7 +40,7 @@ from .ops import (
 from .types import DbtOutput as DbtOutput
 from .version import __version__ as __version__
 
-# isort: split
+# ruff: isort: split
 
 # ########################
 # ##### EXPERIMENTAL IMPORTS

--- a/python_modules/libraries/dagster-docker/dagster_docker/docker_executor.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/docker_executor.py
@@ -275,7 +275,7 @@ class DockerStepHandler(StepHandler):
             return CheckStepHealthResult.healthy()
 
         return CheckStepHealthResult.unhealthy(
-            reason=f"Container status is {container.status}. Return code is {str(ret_code)}."
+            reason=f"Container status is {container.status}. Return code is {ret_code}."
         )
 
     def terminate_step(self, step_handler_context: StepHandlerContext) -> Iterator[DagsterEvent]:

--- a/python_modules/libraries/dagster-docker/dagster_docker_tests/test_example_docker_container_op.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker_tests/test_example_docker_container_op.py
@@ -1,4 +1,4 @@
-# isort: skip_file
+# ruff: isort: skip_file
 # fmt: off
 # start_marker
 from dagster_docker import docker_container_op

--- a/python_modules/libraries/dagster-docker/dagster_docker_tests/test_example_executor.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker_tests/test_example_executor.py
@@ -1,4 +1,4 @@
-# isort: skip_file
+# ruff: isort: skip_file
 # fmt: off
 # start_marker
 from dagster_docker import docker_executor

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
@@ -773,7 +773,7 @@ class DagsterKubernetesClient:
                 log_str = f"Last 25 log lines:\n{pod_logs}" if pod_logs else "No logs in pod."
 
             except kubernetes.client.rest.ApiException as e:
-                log_str = f"Failure fetching pod logs: {str(e)}"
+                log_str = f"Failure fetching pod logs: {e}"
 
         if not K8S_EVENTS_API_PRESENT:
             warning_str = (
@@ -795,7 +795,7 @@ class DagsterKubernetesClient:
                     warning_str = "Warning events for pod:\n" + "\n".join(event_strs)
 
             except kubernetes.client.rest.ApiException as e:
-                warning_str = f"Failure fetching pod events: {str(e)}"
+                warning_str = f"Failure fetching pod events: {e}"
 
         return (
             f"Debug information for pod {pod_name}:"

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_example_executor_mode_def.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_example_executor_mode_def.py
@@ -1,4 +1,4 @@
-# isort: skip_file
+# ruff: isort: skip_file
 # fmt: off
 # start_marker
 from dagster_k8s import k8s_job_executor

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_example_k8s_job_op.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_example_k8s_job_op.py
@@ -1,4 +1,4 @@
-# isort: skip_file
+# ruff: isort: skip_file
 # fmt: off
 # start_marker
 from dagster_k8s import k8s_job_op

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_executor.py
@@ -239,7 +239,7 @@ def test_executor_init_override_in_cluster_config(
     mock_load_incluster_config,
     mock_load_kubeconfig_file,
 ):
-    k8s_run_launcher_instance.run_launcher
+    k8s_run_launcher_instance.run_launcher  # noqa: B018
     mock_load_kubeconfig_file.reset_mock()
     _get_executor(
         k8s_run_launcher_instance,
@@ -260,7 +260,7 @@ def test_executor_init_override_kubeconfig_file(
     mock_load_incluster_config,
     mock_load_kubeconfig_file,
 ):
-    k8s_run_launcher_instance.run_launcher
+    k8s_run_launcher_instance.run_launcher  # noqa: B018
     mock_load_kubeconfig_file.reset_mock()
     _get_executor(
         k8s_run_launcher_instance,

--- a/python_modules/libraries/dagstermill/dagstermill/examples/repository.py
+++ b/python_modules/libraries/dagstermill/dagstermill/examples/repository.py
@@ -59,7 +59,7 @@ class BasicTest:
         self.x = x
 
     def __repr__(self):
-        return f"BasicTest: {str(self.x)}"
+        return f"BasicTest: {self.x}"
 
 
 def nb_test_path(name):

--- a/python_modules/libraries/dagstermill/dagstermill/factory.py
+++ b/python_modules/libraries/dagstermill/dagstermill/factory.py
@@ -326,7 +326,7 @@ def _make_dagstermill_compute_fn(
                     op_context.log.warning(
                         "Error when attempting to materialize executed notebook using file"
                         " manager:"
-                        f" {str(serializable_error_info_from_exc_info(sys.exc_info()))}\nNow"
+                        f" {serializable_error_info_from_exc_info(sys.exc_info())}\nNow"
                         " falling back to local: notebook execution was temporarily materialized"
                         f" at {executed_notebook_path}\nIf you have supplied a file manager and"
                         " expect to use it for materializing the notebook, please include"

--- a/python_modules/libraries/dagstermill/dagstermill/manager.py
+++ b/python_modules/libraries/dagstermill/dagstermill/manager.py
@@ -358,7 +358,7 @@ class Manager:
         # deferred import for perf
         import scrapbook
 
-        event_id = f"event-{str(uuid.uuid4())}"
+        event_id = f"event-{uuid.uuid4()}"
         out_file_path = os.path.join(self.marshal_dir, event_id)
         with open(out_file_path, "wb") as fd:
             fd.write(pickle.dumps(dagster_event, PICKLE_PROTOCOL))


### PR DESCRIPTION
## Summary & Motivation

Internal companion PR: https://github.com/dagster-io/internal/pull/5846

Updates ruff from 0.0.255 to 0.0.277.

This introduces autofix for the TCH rule, which allows auto-sorting type-checking only imports into `TYPE_CHECKING` blocks. Because the changes resulting from enabling this rule are large, they are in an upstack PR.

This PR contains only the ruff version update, a few fixes for issues surfaced by ruff behavior changes to already-enabled rules, and the new rules RUF009 and RUF010 (which are enabled because we enable the whole category of RUF* rules).

- RUF009 flags function calls in field defaults for dataclasses
- RUF010 converts e.g. this: `f"foo {repr(some_var)}"` to the more idiomatic `f"foo {some_var!r}"` using [f-string conversion flags](https://peps.python.org/pep-0498/#specification).

## How I Tested These Changes

ruff
