### PR TITLE
[ruff] Ban `from __future__ import annotations` and enable TCH (typing import autosort)

### DIFF
--- a/examples/docs_snippets/pyproject.toml
+++ b/examples/docs_snippets/pyproject.toml
@@ -12,7 +12,7 @@ target-version = ['py38', 'py39', 'py310', 'py311']
 
 [tool.ruff]
 
-# Extend root configuration.
+# Extend example root configuration.
 extend = "../pyproject.toml"
 
 # Match black. Note that this also checks comment line length, but black does not format comments.
@@ -34,6 +34,12 @@ extend-ignore = [
   # purposes.
   "F841",
 
+  # (isort): No need to automatically insert imports in docs snippets.
+  "I002",
+
+  # (flake8-type-checking) We can't use this in docs_snippets because we don't auto-insert `from
+  # __future__ import annotations`. But we also don't need it becasse we don't use `TYPE_CHECKING`.
+  "TCH",
 ]
 
 [tool.ruff.isort]

--- a/examples/docs_snippets/pyproject.toml
+++ b/examples/docs_snippets/pyproject.toml
@@ -34,11 +34,7 @@ extend-ignore = [
   # purposes.
   "F841",
 
-  # (isort): No need to automatically insert imports in docs snippets.
-  "I002",
-
-  # (flake8-type-checking) We can't use this in docs_snippets because we don't auto-insert `from
-  # __future__ import annotations`. But we also don't need it becasse we don't use `TYPE_CHECKING`.
+  # (flake8-type-checking) No need to complicate docs snippets with `if TYPE_CHECKING` blocks.
   "TCH",
 ]
 

--- a/examples/pyproject.toml
+++ b/examples/pyproject.toml
@@ -4,3 +4,14 @@
 # has the effect of making each example package treated as first-party, where `dagster` and
 # integrations will be treated as third-party. This is appropriate for example code.
 extend = "../pyproject.toml"
+
+extend-ignore = [
+
+  # (isort): No need to automatically insert imports in docs snippets.
+  "I002",
+
+  # (flake8-type-checking) We can't use this in docs_snippets because we don't auto-insert `from
+  # __future__ import annotations`. But we also don't need it becasse we don't use `TYPE_CHECKING`.
+  "TCH",
+
+]

--- a/examples/pyproject.toml
+++ b/examples/pyproject.toml
@@ -4,14 +4,3 @@
 # has the effect of making each example package treated as first-party, where `dagster` and
 # integrations will be treated as third-party. This is appropriate for example code.
 extend = "../pyproject.toml"
-
-extend-ignore = [
-
-  # (isort): No need to automatically insert imports in docs snippets.
-  "I002",
-
-  # (flake8-type-checking) We can't use this in docs_snippets because we don't auto-insert `from
-  # __future__ import annotations`. But we also don't need it becasse we don't use `TYPE_CHECKING`.
-  "TCH",
-
-]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -230,6 +230,10 @@ select = [
   # (private member access) Flag access to `_`-prefixed symbols. By default the various special
   # methods on `NamedTuple` are ignored (e.g. `_replace`).
   "SLF001",
+  
+  # (flake8-type-checking) Auto-sort imports into TYPE_CHECKING blocks depending on whether
+  # they are runtime or type-only imports.
+  "TCH",
 
   # (disallow print statements) keep debugging statements out of the codebase
   "T20",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -233,7 +233,10 @@ select = [
   
   # (flake8-type-checking) Auto-sort imports into TYPE_CHECKING blocks depending on whether
   # they are runtime or type-only imports.
-  "TCH",
+  # "TCH",
+
+  # (banned-api) Flag use of banned APIs. See tool.ruff.flake8-tidy-imports.banned-api for details.
+  "TID251",
 
   # (disallow print statements) keep debugging statements out of the codebase
   "T20",
@@ -252,6 +255,11 @@ required-version = "0.0.277"
 
 # We use `id` in many places and almost never want to use the python builtin.
 builtins-ignorelist = ["id"]
+
+[tool.ruff.flake8-tidy-imports.banned-api]
+
+"__future__.annotations".msg = "Test"
+
 
 [tool.ruff.isort]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -233,7 +233,7 @@ select = [
   
   # (flake8-type-checking) Auto-sort imports into TYPE_CHECKING blocks depending on whether
   # they are runtime or type-only imports.
-  # "TCH",
+  "TCH",
 
   # (banned-api) Flag use of banned APIs. See tool.ruff.flake8-tidy-imports.banned-api for details.
   "TID251",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -258,8 +258,7 @@ builtins-ignorelist = ["id"]
 
 [tool.ruff.flake8-tidy-imports.banned-api]
 
-"__future__.annotations".msg = "Test"
-
+"__future__.annotations".msg = "Directly quote annotations instead."
 
 [tool.ruff.isort]
 

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/launch_execution.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/launch_execution.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING, cast
 import dagster._check as check
 from dagster._core.definitions.selector import JobSubsetSelector
 from dagster._core.execution.plan.resume_retry import ReexecutionStrategy
-from dagster._core.instance import DagsterInstance
 from dagster._core.storage.dagster_run import DagsterRun, RunsFilter
 from dagster._core.workspace.permissions import Permissions
 
@@ -16,6 +15,8 @@ from ..utils import (
 from .run_lifecycle import create_valid_pipeline_run
 
 if TYPE_CHECKING:
+    from dagster._core.instance import DagsterInstance
+
     from dagster_graphql.schema.runs import GrapheneLaunchRunSuccess
     from dagster_graphql.schema.util import ResolveInfo
 

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/external.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import sys
 from typing import TYPE_CHECKING, Mapping, Optional, Sequence, Union
 
@@ -107,7 +105,7 @@ def get_external_execution_plan_or_raise(
     )
 
 
-def fetch_repositories(graphene_info: "ResolveInfo") -> GrapheneRepositoryConnection:
+def fetch_repositories(graphene_info: "ResolveInfo") -> "GrapheneRepositoryConnection":
     from ..schema.external import GrapheneRepository, GrapheneRepositoryConnection
 
     return GrapheneRepositoryConnection(
@@ -125,7 +123,7 @@ def fetch_repositories(graphene_info: "ResolveInfo") -> GrapheneRepositoryConnec
 
 def fetch_repository(
     graphene_info: "ResolveInfo", repository_selector: RepositorySelector
-) -> Union[GrapheneRepository, GrapheneRepositoryNotFoundError]:
+) -> Union["GrapheneRepository", "GrapheneRepositoryNotFoundError"]:
     from ..schema.errors import GrapheneRepositoryNotFoundError
     from ..schema.external import GrapheneRepository
 
@@ -145,7 +143,7 @@ def fetch_repository(
     )
 
 
-def fetch_workspace(workspace_request_context: WorkspaceRequestContext) -> GrapheneWorkspace:
+def fetch_workspace(workspace_request_context: WorkspaceRequestContext) -> "GrapheneWorkspace":
     from ..schema.external import GrapheneWorkspace, GrapheneWorkspaceLocationEntry
 
     check.inst_param(
@@ -162,7 +160,7 @@ def fetch_workspace(workspace_request_context: WorkspaceRequestContext) -> Graph
 
 def fetch_location_statuses(
     workspace_request_context: WorkspaceRequestContext,
-) -> GrapheneWorkspaceLocationStatusEntries:
+) -> "GrapheneWorkspaceLocationStatusEntries":
     from ..schema.external import (
         GrapheneRepositoryLocationLoadStatus,
         GrapheneWorkspaceLocationStatusEntries,

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_env_vars.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_env_vars.py
@@ -1,6 +1,7 @@
+from typing import TYPE_CHECKING
+
 import dagster._check as check
 from dagster._core.definitions.selector import RepositorySelector
-from dagster._core.host_representation.code_location import CodeLocation
 from graphene import ResolveInfo
 
 from dagster_graphql.schema.env_vars import (
@@ -8,6 +9,9 @@ from dagster_graphql.schema.env_vars import (
     GrapheneEnvVarWithConsumersList,
     GrapheneEnvVarWithConsumersListOrError,
 )
+
+if TYPE_CHECKING:
+    from dagster._core.host_representation.code_location import CodeLocation
 
 
 def get_utilized_env_vars_or_error(

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_resources.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_resources.py
@@ -2,12 +2,13 @@ from typing import TYPE_CHECKING
 
 import dagster._check as check
 from dagster._core.definitions.selector import RepositorySelector, ResourceSelector
-from dagster._core.host_representation.code_location import CodeLocation
 from graphene import ResolveInfo
 
 from .utils import UserFacingGraphQLError
 
 if TYPE_CHECKING:
+    from dagster._core.host_representation.code_location import CodeLocation
+
     from ..schema.resources import GrapheneResourceDetails, GrapheneResourceDetailsList
 
 

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import sys
 from contextlib import contextmanager
 from contextvars import ContextVar

--- a/python_modules/dagster-graphql/dagster_graphql/schema/dagster_types.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/dagster_types.py
@@ -1,9 +1,8 @@
-from typing import Any, Dict, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 import dagster._check as check
 import graphene
 from dagster._core.snap import JobSnapshot
-from dagster._core.snap.dagster_types import DagsterTypeSnap
 from dagster._core.types.dagster_type import DagsterTypeKind
 from typing_extensions import TypeAlias
 
@@ -17,6 +16,9 @@ from .errors import (
     GraphenePythonError,
 )
 from .util import non_null_list
+
+if TYPE_CHECKING:
+    from dagster._core.snap.dagster_types import DagsterTypeSnap
 
 GrapheneDagsterTypeUnion: TypeAlias = Union[
     "GrapheneListDagsterType", "GrapheneNullableDagsterType", "GrapheneRegularDagsterType"

--- a/python_modules/dagster-graphql/dagster_graphql/schema/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/external.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Dict, List
+from typing import TYPE_CHECKING, Dict, List
 
 import graphene
 from dagster import (
@@ -14,7 +14,6 @@ from dagster._core.host_representation import (
     GrpcServerCodeLocation,
     ManagedGrpcPythonEnvCodeLocationOrigin,
 )
-from dagster._core.host_representation.external_data import ExternalAssetNode
 from dagster._core.host_representation.grpc_server_state_subscriber import (
     LocationStateChangeEvent,
     LocationStateChangeEventType,
@@ -45,6 +44,9 @@ from .schedules import GrapheneSchedule
 from .sensors import GrapheneSensor
 from .used_solid import GrapheneUsedSolid
 from .util import ResolveInfo, non_null_list
+
+if TYPE_CHECKING:
+    from dagster._core.host_representation.external_data import ExternalAssetNode
 
 GrapheneLocationStateChangeEventType = graphene.Enum.from_enum(LocationStateChangeEventType)
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/resources.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/resources.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import TYPE_CHECKING, List
 
 import dagster._check as check
 import graphene
@@ -10,7 +10,6 @@ from dagster._core.host_representation.external_data import (
     NestedResourceType,
     ResourceJobUsageEntry,
 )
-from dagster._core.workspace.workspace import IWorkspace
 
 from dagster_graphql.schema.asset_key import GrapheneAssetKey
 from dagster_graphql.schema.errors import (
@@ -23,6 +22,9 @@ from dagster_graphql.schema.solids import GrapheneSolidHandle, build_solid_handl
 from dagster_graphql.schema.util import non_null_list
 
 from .config_types import GrapheneConfigTypeField
+
+if TYPE_CHECKING:
+    from dagster._core.workspace.workspace import IWorkspace
 
 
 class GrapheneConfiguredValueType(graphene.Enum):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/run_config.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/run_config.py
@@ -1,8 +1,7 @@
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 import dagster._check as check
 import graphene
-from dagster._config.snap import ConfigSchemaSnapshot
 from dagster._core.host_representation import RepresentedJob
 from dagster._core.host_representation.external_data import DEFAULT_MODE_NAME
 from dagster._core.snap.snap_to_yaml import default_values_yaml_from_type_snap
@@ -19,6 +18,9 @@ from .errors import (
 from .pipelines.config_result import GraphenePipelineConfigValidationResult
 from .runs import GrapheneRunConfigData, parse_run_config_input
 from .util import ResolveInfo, non_null_list
+
+if TYPE_CHECKING:
+    from dagster._config.snap import ConfigSchemaSnapshot
 
 
 class GrapheneRunConfigSchema(graphene.ObjectType):

--- a/python_modules/dagster-graphql/dagster_graphql_tests/conftest.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/conftest.py
@@ -1,8 +1,11 @@
 import os
+from typing import TYPE_CHECKING
 
 import pytest
 from syrupy.extensions.amber import AmberSnapshotExtension
-from syrupy.types import SnapshotIndex
+
+if TYPE_CHECKING:
+    from syrupy.types import SnapshotIndex
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/python_modules/dagster-webserver/dagster_webserver/graphql.py
+++ b/python_modules/dagster-webserver/dagster_webserver/graphql.py
@@ -1,7 +1,18 @@
 from abc import ABC, abstractmethod
 from asyncio import Task, get_event_loop
 from enum import Enum
-from typing import Any, AsyncGenerator, Dict, List, Optional, Sequence, Tuple, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    AsyncGenerator,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+    cast,
+)
 
 import dagster._check as check
 from dagster._serdes import pack_value
@@ -14,7 +25,6 @@ from graphql.execution import ExecutionResult
 from starlette import status
 from starlette.applications import Starlette
 from starlette.concurrency import run_in_threadpool
-from starlette.datastructures import QueryParams
 from starlette.middleware import Middleware
 from starlette.requests import HTTPConnection, Request
 from starlette.responses import HTMLResponse, JSONResponse, PlainTextResponse
@@ -22,6 +32,9 @@ from starlette.routing import BaseRoute
 from starlette.websockets import WebSocket, WebSocketDisconnect, WebSocketState
 
 from dagster_webserver.templates.playground import TEMPLATE
+
+if TYPE_CHECKING:
+    from starlette.datastructures import QueryParams
 
 
 class GraphQLWS(str, Enum):

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -567,7 +567,7 @@ if TYPE_CHECKING:
     # from dagster.some.module import (
     #     Foo as Foo,
     # )
-    pass
+    pass  # noqa: TCH005
 
 
 _DEPRECATED: Final[Mapping[str, TypingTuple[str, str, str]]] = {

--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -812,8 +812,6 @@ def _subset_assets_defs(
     """Given a list of asset key selection queries, generate a set of AssetsDefinition objects
     representing the included/excluded definitions.
     """
-    from dagster._core.definitions import AssetsDefinition
-
     included_assets: Set[AssetsDefinition] = set()
     excluded_assets: Set[AssetsDefinition] = set()
 

--- a/python_modules/dagster/dagster/_core/definitions/decorators/schedule_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/schedule_decorator.py
@@ -1,7 +1,6 @@
 import copy
 from functools import update_wrapper
 from typing import (
-    TYPE_CHECKING,
     Callable,
     List,
     Mapping,
@@ -37,9 +36,6 @@ from ..schedule_definition import (
 )
 from ..target import ExecutableDefinition
 from ..utils import validate_tags
-
-if TYPE_CHECKING:
-    pass
 
 
 def schedule(

--- a/python_modules/dagster/dagster/_core/definitions/freshness_based_auto_materialize.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_based_auto_materialize.py
@@ -9,11 +9,10 @@
 """
 import datetime
 from collections import defaultdict
-from typing import AbstractSet, Dict, Mapping, Optional, Set, Tuple, cast
+from typing import TYPE_CHECKING, AbstractSet, Dict, Mapping, Optional, Set, Tuple, cast
 
 import pendulum
 
-from dagster._core.definitions.data_time import CachingDataTimeResolver
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
 from dagster._utils.schedules import cron_string_iterator
@@ -25,6 +24,9 @@ from .auto_materialize_condition import (
     DownstreamFreshnessAutoMaterializeCondition,
     FreshnessAutoMaterializeCondition,
 )
+
+if TYPE_CHECKING:
+    from dagster._core.definitions.data_time import CachingDataTimeResolver
 
 
 def get_execution_period_for_policy(

--- a/python_modules/dagster/dagster/_core/definitions/freshness_policy_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_policy_sensor_definition.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Callable, Dict, Mapping, NamedTuple, Optional, Set, cast
+from typing import Callable, Dict, Mapping, NamedTuple, Optional, Set, cast
 
 import pendulum
 
@@ -35,9 +35,6 @@ from .sensor_definition import (
     get_sensor_context_from_args_or_kwargs,
     validate_and_get_resource_dict,
 )
-
-if TYPE_CHECKING:
-    pass
 
 
 @whitelist_for_serdes

--- a/python_modules/dagster/dagster/_core/definitions/logger_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/logger_definition.py
@@ -1,4 +1,3 @@
-import logging
 from typing import TYPE_CHECKING, Any, Callable, Optional, Union, cast, overload
 
 import dagster._check as check
@@ -14,6 +13,8 @@ from .definition_config_schema import (
 )
 
 if TYPE_CHECKING:
+    import logging
+
     from dagster._core.definitions import JobDefinition
     from dagster._core.execution.context.logger import InitLoggerContext, UnboundInitLoggerContext
 

--- a/python_modules/dagster/dagster/_core/definitions/materialize.py
+++ b/python_modules/dagster/dagster/_core/definitions/materialize.py
@@ -1,7 +1,6 @@
 from typing import TYPE_CHECKING, Any, Mapping, Optional, Sequence, Set, Union
 
 import dagster._check as check
-from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.unresolved_asset_job_definition import define_asset_job
 from dagster._utils.merger import merge_dicts
 
@@ -14,6 +13,7 @@ from .source_asset import SourceAsset
 
 if TYPE_CHECKING:
     from dagster._core.definitions.asset_selection import CoercibleToAssetSelection
+    from dagster._core.definitions.events import AssetKey
 
     from ..execution.execute_in_process_result import ExecuteInProcessResult
 

--- a/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
@@ -230,7 +230,6 @@ class MultiAssetSensorEvaluationContext(SensorEvaluationContext):
     ):
         from dagster._core.definitions.definitions_class import Definitions
         from dagster._core.definitions.repository_definition import RepositoryDefinition
-        from dagster._core.storage.event_log.base import EventLogRecord
 
         self._repository_def = normalize_to_repository(
             check.opt_inst_param(definitions, "definitions", Definitions),
@@ -388,8 +387,6 @@ class MultiAssetSensorEvaluationContext(SensorEvaluationContext):
             materialization event for the asset. If there is no materialization event for the asset,
             the value in the mapping will be None.
         """
-        from dagster._core.storage.event_log.base import EventLogRecord
-
         # Do not evaluate unconsumed events, only events newer than the cursor
         # if there are no new events after the cursor, the cursor points to the most
         # recent event.

--- a/python_modules/dagster/dagster/_core/definitions/op_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_selection.py
@@ -1,5 +1,6 @@
 import itertools
 from typing import (
+    TYPE_CHECKING,
     AbstractSet,
     Dict,
     Iterable,
@@ -25,9 +26,11 @@ from dagster._core.definitions.dependency import (
     NodeOutput,
 )
 from dagster._core.definitions.graph_definition import GraphDefinition, SubselectedGraphDefinition
-from dagster._core.definitions.node_definition import NodeDefinition
 from dagster._core.errors import DagsterInvalidSubsetError
 from dagster._core.selector.subset_selector import parse_op_queries
+
+if TYPE_CHECKING:
+    from dagster._core.definitions.node_definition import NodeDefinition
 
 
 class OpSelection:

--- a/python_modules/dagster/dagster/_core/definitions/reconstruct.py
+++ b/python_modules/dagster/dagster/_core/definitions/reconstruct.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import inspect
 import json
 import os
@@ -87,7 +85,7 @@ class ReconstructableRepository(
         executable_path: Optional[str] = None,
         entry_point: Optional[Sequence[str]] = None,
         container_context: Optional[Mapping[str, Any]] = None,
-        repository_load_data: Optional[RepositoryLoadData] = None,
+        repository_load_data: Optional["RepositoryLoadData"] = None,
     ):
         from dagster._core.definitions.repository_definition import RepositoryLoadData
 
@@ -119,7 +117,7 @@ class ReconstructableRepository(
     def get_definition(self) -> "RepositoryDefinition":
         return repository_def_from_pointer(self.pointer, self.repository_load_data)
 
-    def get_reconstructable_job(self, name: str) -> ReconstructableJob:
+    def get_reconstructable_job(self, name: str) -> "ReconstructableJob":
         return ReconstructableJob(self, name)
 
     @classmethod
@@ -130,7 +128,7 @@ class ReconstructableRepository(
         working_directory: Optional[str] = None,
         container_image: Optional[str] = None,
         container_context: Optional[Mapping[str, Any]] = None,
-    ) -> ReconstructableRepository:
+    ) -> "ReconstructableRepository":
         if not working_directory:
             working_directory = os.getcwd()
         return cls(
@@ -147,7 +145,7 @@ class ReconstructableRepository(
         working_directory: Optional[str] = None,
         container_image: Optional[str] = None,
         container_context: Optional[Mapping[str, Any]] = None,
-    ) -> ReconstructableRepository:
+    ) -> "ReconstructableRepository":
         return cls(
             ModuleCodePointer(module, fn_name, working_directory),
             container_image=container_image,
@@ -247,13 +245,13 @@ class ReconstructableJob(
 
     def with_repository_load_data(
         self, metadata: Optional["RepositoryLoadData"]
-    ) -> ReconstructableJob:
+    ) -> "ReconstructableJob":
         return self._replace(repository=self.repository.with_repository_load_data(metadata))
 
     # Keep the most recent 1 definition (globally since this is a NamedTuple method)
     # This allows repeated calls to get_definition in execution paths to not reload the job
     @lru_cache(maxsize=1)
-    def get_definition(self) -> JobDefinition:
+    def get_definition(self) -> "JobDefinition":
         return self.repository.get_definition().get_maybe_subset_job_def(
             self.job_name,
             self.op_selection,
@@ -287,18 +285,18 @@ class ReconstructableJob(
         )
 
     @staticmethod
-    def for_file(python_file: str, fn_name: str) -> ReconstructableJob:
+    def for_file(python_file: str, fn_name: str) -> "ReconstructableJob":
         return bootstrap_standalone_recon_job(FileCodePointer(python_file, fn_name, os.getcwd()))
 
     @staticmethod
-    def for_module(module: str, fn_name: str) -> ReconstructableJob:
+    def for_module(module: str, fn_name: str) -> "ReconstructableJob":
         return bootstrap_standalone_recon_job(ModuleCodePointer(module, fn_name, os.getcwd()))
 
     def to_dict(self) -> Mapping[str, object]:
         return pack_value(self)
 
     @staticmethod
-    def from_dict(val: Mapping[str, Any]) -> ReconstructableJob:
+    def from_dict(val: Mapping[str, Any]) -> "ReconstructableJob":
         check.mapping_param(val, "val")
 
         inst = unpack_value(val)

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
@@ -2,6 +2,7 @@ import json
 from collections import defaultdict
 from inspect import isfunction
 from typing import (
+    TYPE_CHECKING,
     Any,
     Dict,
     List,
@@ -24,7 +25,6 @@ from dagster._core.definitions.assets_job import (
     get_base_asset_jobs,
     is_base_asset_job_name,
 )
-from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.executor_definition import ExecutorDefinition
 from dagster._core.definitions.graph_definition import GraphDefinition
 from dagster._core.definitions.job_definition import JobDefinition
@@ -41,6 +41,9 @@ from dagster._core.errors import DagsterInvalidDefinitionError
 
 from .repository_data import CachingRepositoryData
 from .valid_definitions import VALID_REPOSITORY_DATA_DICT_KEYS, RepositoryListDefinition
+
+if TYPE_CHECKING:
+    from dagster._core.definitions.events import AssetKey
 
 
 def _find_env_vars(config_entry: Any) -> Set[str]:

--- a/python_modules/dagster/dagster/_core/errors.py
+++ b/python_modules/dagster/dagster/_core/errors.py
@@ -15,8 +15,6 @@ The wrapped exceptions include additional context for the original exceptions, i
 Dagster runtime.
 """
 
-from __future__ import annotations
-
 import sys
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Callable, Iterator, Optional, Type
@@ -257,9 +255,9 @@ def raise_execution_interrupts() -> Iterator[None]:
 
 @contextmanager
 def user_code_error_boundary(
-    error_cls: Type[DagsterUserCodeExecutionError],
+    error_cls: Type["DagsterUserCodeExecutionError"],
     msg_fn: Callable[[], str],
-    log_manager: Optional[DagsterLogManager] = None,
+    log_manager: Optional["DagsterLogManager"] = None,
     **kwargs: object,
 ) -> Iterator[None]:
     """Wraps the execution of user-space code in an error boundary. This places a uniform

--- a/python_modules/dagster/dagster/_core/execution/api.py
+++ b/python_modules/dagster/dagster/_core/execution/api.py
@@ -1,6 +1,7 @@
 import sys
 from contextlib import contextmanager
 from typing import (
+    TYPE_CHECKING,
     AbstractSet,
     Any,
     Callable,
@@ -25,7 +26,6 @@ from dagster._core.errors import DagsterExecutionInterruptedError, DagsterInvari
 from dagster._core.events import DagsterEvent, EngineEventData
 from dagster._core.execution.context.system import PlanOrchestrationContext
 from dagster._core.execution.plan.execute_plan import inner_plan_execution_iterator
-from dagster._core.execution.plan.outputs import StepOutputHandle
 from dagster._core.execution.plan.plan import ExecutionPlan
 from dagster._core.execution.plan.state import KnownExecutionState
 from dagster._core.execution.retries import RetryMode
@@ -46,6 +46,9 @@ from .context_creation_job import (
     scoped_job_context,
 )
 from .job_execution_result import JobExecutionResult
+
+if TYPE_CHECKING:
+    from dagster._core.execution.plan.outputs import StepOutputHandle
 
 ## Brief guide to the execution APIs
 # | function name               | operates over      | sync  | supports    | creates new DagsterRun  |

--- a/python_modules/dagster/dagster/_core/execution/execute_in_process.py
+++ b/python_modules/dagster/dagster/_core/execution/execute_in_process.py
@@ -1,10 +1,9 @@
-from typing import Any, Dict, FrozenSet, Mapping, Optional, cast
+from typing import TYPE_CHECKING, Any, Dict, FrozenSet, Mapping, Optional, cast
 
 from dagster._core.definitions import GraphDefinition, JobDefinition, Node, NodeHandle, OpDefinition
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.job_base import InMemoryJob
 from dagster._core.errors import DagsterInvalidInvocationError
-from dagster._core.execution.plan.outputs import StepOutputHandle
 from dagster._core.instance import DagsterInstance
 from dagster._core.storage.dagster_run import DagsterRun
 from dagster._core.types.dagster_type import DagsterTypeKind
@@ -20,6 +19,9 @@ from .context_creation_job import (
     orchestration_context_event_generator,
 )
 from .execute_in_process_result import ExecuteInProcessResult
+
+if TYPE_CHECKING:
+    from dagster._core.execution.plan.outputs import StepOutputHandle
 
 
 def core_execute_in_process(

--- a/python_modules/dagster/dagster/_core/execution/plan/local_external_step_main.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/local_external_step_main.py
@@ -1,9 +1,8 @@
 import os
 import pickle
 import sys
-from typing import List
+from typing import TYPE_CHECKING, List
 
-from dagster._core.events.log import EventLogEntry
 from dagster._core.execution.plan.external_step import (
     PICKLED_EVENTS_FILE_NAME,
     external_instance_from_step_run_ref,
@@ -11,6 +10,9 @@ from dagster._core.execution.plan.external_step import (
 )
 from dagster._core.storage.file_manager import LocalFileHandle, LocalFileManager
 from dagster._serdes import serialize_value
+
+if TYPE_CHECKING:
+    from dagster._core.events.log import EventLogEntry
 
 
 def main(step_run_ref_path: str) -> None:

--- a/python_modules/dagster/dagster/_core/executor/step_delegating/step_delegating_executor.py
+++ b/python_modules/dagster/dagster/_core/executor/step_delegating/step_delegating_executor.py
@@ -1,7 +1,7 @@
 import os
 import sys
 import time
-from typing import Any, Dict, List, Optional, Sequence, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, cast
 
 import pendulum
 
@@ -13,13 +13,15 @@ from dagster._core.execution.plan.active import ActiveExecution
 from dagster._core.execution.plan.instance_concurrency_context import InstanceConcurrencyContext
 from dagster._core.execution.plan.objects import StepFailureData
 from dagster._core.execution.plan.plan import ExecutionPlan
-from dagster._core.execution.plan.step import ExecutionStep
 from dagster._core.execution.retries import RetryMode
 from dagster._core.executor.step_delegating.step_handler.base import StepHandler, StepHandlerContext
 from dagster._grpc.types import ExecuteStepArgs
 from dagster._utils.error import serializable_error_info_from_exc_info
 
 from ..base import Executor
+
+if TYPE_CHECKING:
+    from dagster._core.execution.plan.step import ExecutionStep
 
 DEFAULT_SLEEP_SECONDS = float(
     os.environ.get("DAGSTER_STEP_DELEGATING_EXECUTOR_SLEEP_SECONDS", "1.0")

--- a/python_modules/dagster/dagster/_core/host_representation/external.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external.py
@@ -43,7 +43,6 @@ from dagster._core.host_representation.origin import (
 from dagster._core.instance import DagsterInstance
 from dagster._core.origin import JobPythonOrigin, RepositoryPythonOrigin
 from dagster._core.snap import ExecutionPlanSnapshot
-from dagster._core.snap.execution_plan_snapshot import ExecutionStepSnap
 from dagster._core.utils import toposort
 from dagster._serdes import create_snapshot_id
 from dagster._utils.cached_method import cached_method
@@ -73,6 +72,7 @@ from .represented import RepresentedJob
 
 if TYPE_CHECKING:
     from dagster._core.scheduler.instigation import InstigatorState
+    from dagster._core.snap.execution_plan_snapshot import ExecutionStepSnap
 
 
 class ExternalRepository:
@@ -673,7 +673,7 @@ class ExternalSchedule:
 
     def get_current_instigator_state(
         self, stored_state: Optional["InstigatorState"]
-    ) -> InstigatorState:
+    ) -> "InstigatorState":
         from dagster._core.scheduler.instigation import (
             InstigatorState,
             InstigatorStatus,
@@ -805,7 +805,7 @@ class ExternalSensor:
 
     def get_current_instigator_state(
         self, stored_state: Optional["InstigatorState"]
-    ) -> InstigatorState:
+    ) -> "InstigatorState":
         from dagster._core.scheduler.instigation import (
             InstigatorState,
             InstigatorStatus,

--- a/python_modules/dagster/dagster/_core/host_representation/external.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from datetime import datetime
 from threading import RLock
 from typing import (
@@ -132,7 +130,7 @@ class ExternalRepository:
 
     @property
     @cached_method
-    def _external_schedules(self) -> Dict[str, ExternalSchedule]:
+    def _external_schedules(self) -> Dict[str, "ExternalSchedule"]:
         return {
             external_schedule_data.name: ExternalSchedule(external_schedule_data, self._handle)
             for external_schedule_data in self.external_repository_data.external_schedule_datas
@@ -141,15 +139,15 @@ class ExternalRepository:
     def has_external_schedule(self, schedule_name: str) -> bool:
         return schedule_name in self._external_schedules
 
-    def get_external_schedule(self, schedule_name: str) -> ExternalSchedule:
+    def get_external_schedule(self, schedule_name: str) -> "ExternalSchedule":
         return self._external_schedules[schedule_name]
 
-    def get_external_schedules(self) -> Sequence[ExternalSchedule]:
+    def get_external_schedules(self) -> Sequence["ExternalSchedule"]:
         return list(self._external_schedules.values())
 
     @property
     @cached_method
-    def _external_resources(self) -> Dict[str, ExternalResource]:
+    def _external_resources(self) -> Dict[str, "ExternalResource"]:
         return {
             external_resource_data.name: ExternalResource(external_resource_data, self._handle)
             for external_resource_data in (
@@ -160,10 +158,10 @@ class ExternalRepository:
     def has_external_resource(self, resource_name: str) -> bool:
         return resource_name in self._external_resources
 
-    def get_external_resource(self, resource_name: str) -> ExternalResource:
+    def get_external_resource(self, resource_name: str) -> "ExternalResource":
         return self._external_resources[resource_name]
 
-    def get_external_resources(self) -> Iterable[ExternalResource]:
+    def get_external_resources(self) -> Iterable["ExternalResource"]:
         return self._external_resources.values()
 
     @property
@@ -175,7 +173,7 @@ class ExternalRepository:
 
     @property
     @cached_method
-    def _external_sensors(self) -> Dict[str, ExternalSensor]:
+    def _external_sensors(self) -> Dict[str, "ExternalSensor"]:
         return {
             external_sensor_data.name: ExternalSensor(external_sensor_data, self._handle)
             for external_sensor_data in self.external_repository_data.external_sensor_datas
@@ -184,15 +182,15 @@ class ExternalRepository:
     def has_external_sensor(self, sensor_name: str) -> bool:
         return sensor_name in self._external_sensors
 
-    def get_external_sensor(self, sensor_name: str) -> ExternalSensor:
+    def get_external_sensor(self, sensor_name: str) -> "ExternalSensor":
         return self._external_sensors[sensor_name]
 
-    def get_external_sensors(self) -> Sequence[ExternalSensor]:
+    def get_external_sensors(self) -> Sequence["ExternalSensor"]:
         return list(self._external_sensors.values())
 
     @property
     @cached_method
-    def _external_partition_sets(self) -> Dict[str, ExternalPartitionSet]:
+    def _external_partition_sets(self) -> Dict[str, "ExternalPartitionSet"]:
         return {
             external_partition_set_data.name: ExternalPartitionSet(
                 external_partition_set_data, self._handle
@@ -203,16 +201,16 @@ class ExternalRepository:
     def has_external_partition_set(self, partition_set_name: str) -> bool:
         return partition_set_name in self._external_partition_sets
 
-    def get_external_partition_set(self, partition_set_name: str) -> ExternalPartitionSet:
+    def get_external_partition_set(self, partition_set_name: str) -> "ExternalPartitionSet":
         return self._external_partition_sets[partition_set_name]
 
-    def get_external_partition_sets(self) -> Sequence[ExternalPartitionSet]:
+    def get_external_partition_sets(self) -> Sequence["ExternalPartitionSet"]:
         return list(self._external_partition_sets.values())
 
     def has_external_job(self, job_name: str) -> bool:
         return job_name in self._job_map
 
-    def get_full_external_job(self, job_name: str) -> ExternalJob:
+    def get_full_external_job(self, job_name: str) -> "ExternalJob":
         check.str_param(job_name, "job_name")
         check.invariant(
             self.has_external_job(job_name), f'No external job named "{job_name}" found'
@@ -240,7 +238,7 @@ class ExternalRepository:
 
             return self._cached_jobs[job_name]
 
-    def get_all_external_jobs(self) -> Sequence[ExternalJob]:
+    def get_all_external_jobs(self) -> Sequence["ExternalJob"]:
         return [self.get_full_external_job(pn) for pn in self._job_map]
 
     @property

--- a/python_modules/dagster/dagster/_core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external_data.py
@@ -9,6 +9,7 @@ from abc import ABC, abstractmethod
 from collections import defaultdict
 from enum import Enum
 from typing import (
+    TYPE_CHECKING,
     Any,
     Dict,
     Iterable,
@@ -44,7 +45,6 @@ from dagster._core.definitions import (
     ScheduleDefinition,
     SourceAsset,
 )
-from dagster._core.definitions.asset_layer import AssetOutputInfo
 from dagster._core.definitions.asset_sensor_definition import AssetSensorDefinition
 from dagster._core.definitions.assets_job import is_base_asset_job_name
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
@@ -87,6 +87,9 @@ from dagster._core.snap.mode import ResourceDefSnap, build_resource_def_snap
 from dagster._core.storage.io_manager import IOManagerDefinition
 from dagster._serdes import whitelist_for_serdes
 from dagster._utils.error import SerializableErrorInfo
+
+if TYPE_CHECKING:
+    from dagster._core.definitions.asset_layer import AssetOutputInfo
 
 DEFAULT_MODE_NAME = "default"
 DEFAULT_PRESET_NAME = "default"

--- a/python_modules/dagster/dagster/_core/host_representation/grpc_server_registry.py
+++ b/python_modules/dagster/dagster/_core/host_representation/grpc_server_registry.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import sys
 import threading
 import uuid

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 import logging.config
 import os
@@ -335,7 +333,7 @@ class DagsterInstance(DynamicPartitionsStore):
     # Stores TemporaryDirectory instances that were created for DagsterInstance.local_temp() calls
     # to be removed once the instance is garbage collected.
     _TEMP_DIRS: weakref.WeakKeyDictionary[
-        DagsterInstance, TemporaryDirectory
+        "DagsterInstance", TemporaryDirectory
     ] = weakref.WeakKeyDictionary()
 
     def __init__(
@@ -1137,9 +1135,9 @@ class DagsterInstance(DynamicPartitionsStore):
         tags: Mapping[str, str],
         root_run_id: Optional[str],
         parent_run_id: Optional[str],
-        job_snapshot: Optional[JobSnapshot],
-        execution_plan_snapshot: Optional[ExecutionPlanSnapshot],
-        parent_job_snapshot: Optional[JobSnapshot],
+        job_snapshot: Optional["JobSnapshot"],
+        execution_plan_snapshot: Optional["ExecutionPlanSnapshot"],
+        parent_job_snapshot: Optional["JobSnapshot"],
         asset_selection: Optional[AbstractSet[AssetKey]] = None,
         op_selection: Optional[Sequence[str]] = None,
         external_job_origin: Optional["ExternalJobOrigin"] = None,
@@ -1335,9 +1333,9 @@ class DagsterInstance(DynamicPartitionsStore):
         root_run_id: Optional[str],
         parent_run_id: Optional[str],
         step_keys_to_execute: Optional[Sequence[str]],
-        execution_plan_snapshot: Optional[ExecutionPlanSnapshot],
-        job_snapshot: Optional[JobSnapshot],
-        parent_job_snapshot: Optional[JobSnapshot],
+        execution_plan_snapshot: Optional["ExecutionPlanSnapshot"],
+        job_snapshot: Optional["JobSnapshot"],
+        parent_job_snapshot: Optional["JobSnapshot"],
         asset_selection: Optional[AbstractSet[AssetKey]],
         resolved_op_selection: Optional[AbstractSet[str]],
         op_selection: Optional[Sequence[str]],
@@ -1565,9 +1563,9 @@ class DagsterInstance(DynamicPartitionsStore):
         tags: Mapping[str, str],
         root_run_id: Optional[str],
         parent_run_id: Optional[str],
-        job_snapshot: Optional[JobSnapshot],
-        execution_plan_snapshot: Optional[ExecutionPlanSnapshot],
-        parent_job_snapshot: Optional[JobSnapshot],
+        job_snapshot: Optional["JobSnapshot"],
+        execution_plan_snapshot: Optional["ExecutionPlanSnapshot"],
+        parent_job_snapshot: Optional["JobSnapshot"],
         op_selection: Optional[Sequence[str]] = None,
         job_code_origin: Optional[JobPythonOrigin] = None,
     ) -> DagsterRun:
@@ -1728,7 +1726,7 @@ class DagsterInstance(DynamicPartitionsStore):
         cursor: Optional[int] = None,
         of_type: Optional["DagsterEventType"] = None,
         limit: Optional[int] = None,
-    ) -> Sequence[EventLogEntry]:
+    ) -> Sequence["EventLogEntry"]:
         return self._event_storage.get_logs_for_run(
             run_id,
             cursor=cursor,
@@ -1741,7 +1739,7 @@ class DagsterInstance(DynamicPartitionsStore):
         self,
         run_id: str,
         of_type: Optional[Union["DagsterEventType", Set["DagsterEventType"]]] = None,
-    ) -> Sequence[EventLogEntry]:
+    ) -> Sequence["EventLogEntry"]:
         return self._event_storage.get_logs_for_run(run_id, of_type=of_type)
 
     @traced
@@ -1861,8 +1859,8 @@ class DagsterInstance(DynamicPartitionsStore):
         self,
         asset_key: AssetKey,
         partition_keys: Sequence[str],
-        partitions_def: PartitionsDefinition,
-    ) -> Optional[Mapping[str, AssetPartitionStatus]]:
+        partitions_def: "PartitionsDefinition",
+    ) -> Optional[Mapping[str, "AssetPartitionStatus"]]:
         """Get the current status of provided partition_keys for the provided asset.
 
         Args:
@@ -1967,7 +1965,7 @@ class DagsterInstance(DynamicPartitionsStore):
 
     @traced
     def get_latest_storage_id_by_partition(
-        self, asset_key: AssetKey, event_type: DagsterEventType
+        self, asset_key: AssetKey, event_type: "DagsterEventType"
     ) -> Mapping[str, int]:
         """Fetch the latest materialzation storage id for each partition for a given asset key.
 
@@ -2076,10 +2074,10 @@ class DagsterInstance(DynamicPartitionsStore):
         handlers.extend(self._get_yaml_python_handlers())
         return handlers
 
-    def store_event(self, event: EventLogEntry) -> None:
+    def store_event(self, event: "EventLogEntry") -> None:
         self._event_storage.store_event(event)
 
-    def handle_new_event(self, event: EventLogEntry) -> None:
+    def handle_new_event(self, event: "EventLogEntry") -> None:
         run_id = event.run_id
 
         self._event_storage.store_event(event)
@@ -2097,12 +2095,12 @@ class DagsterInstance(DynamicPartitionsStore):
         self,
         message: str,
         dagster_run: Optional[DagsterRun] = None,
-        engine_event_data: Optional[EngineEventData] = None,
+        engine_event_data: Optional["EngineEventData"] = None,
         cls: Optional[Type[object]] = None,
         step_key: Optional[str] = None,
         job_name: Optional[str] = None,
         run_id: Optional[str] = None,
-    ) -> DagsterEvent:
+    ) -> "DagsterEvent":
         """Report a EngineEvent that occurred outside of a job execution context."""
         from dagster._core.events import DagsterEvent, DagsterEventType, EngineEventData
 
@@ -2186,7 +2184,7 @@ class DagsterInstance(DynamicPartitionsStore):
         self,
         dagster_run: DagsterRun,
         message: Optional[str] = None,
-    ) -> DagsterEvent:
+    ) -> "DagsterEvent":
         from dagster._core.events import DagsterEvent, DagsterEventType
 
         check.inst_param(dagster_run, "dagster_run", DagsterRun)
@@ -2207,7 +2205,7 @@ class DagsterInstance(DynamicPartitionsStore):
 
     def report_run_failed(
         self, dagster_run: DagsterRun, message: Optional[str] = None
-    ) -> DagsterEvent:
+    ) -> "DagsterEvent":
         from dagster._core.events import DagsterEvent, DagsterEventType
 
         check.inst_param(dagster_run, "dagster_run", DagsterRun)
@@ -2398,7 +2396,7 @@ class DagsterInstance(DynamicPartitionsStore):
 
     # Scheduler
 
-    def start_schedule(self, external_schedule: "ExternalSchedule") -> InstigatorState:
+    def start_schedule(self, external_schedule: "ExternalSchedule") -> "InstigatorState":
         return self._scheduler.start_schedule(self, external_schedule)  # type: ignore
 
     def stop_schedule(
@@ -2406,7 +2404,7 @@ class DagsterInstance(DynamicPartitionsStore):
         schedule_origin_id: str,
         schedule_selector_id: str,
         external_schedule: Optional["ExternalSchedule"],
-    ) -> InstigatorState:
+    ) -> "InstigatorState":
         return self._scheduler.stop_schedule(  # type: ignore
             self, schedule_origin_id, schedule_selector_id, external_schedule
         )
@@ -2439,7 +2437,7 @@ class DagsterInstance(DynamicPartitionsStore):
 
     # Schedule / Sensor Storage
 
-    def start_sensor(self, external_sensor: "ExternalSensor") -> InstigatorState:
+    def start_sensor(self, external_sensor: "ExternalSensor") -> "InstigatorState":
         from dagster._core.definitions.run_request import InstigatorType
         from dagster._core.scheduler.instigation import (
             InstigatorState,
@@ -2472,7 +2470,7 @@ class DagsterInstance(DynamicPartitionsStore):
         instigator_origin_id: str,
         selector_id: str,
         external_sensor: Optional["ExternalSensor"],
-    ) -> InstigatorState:
+    ) -> "InstigatorState":
         from dagster._core.definitions.run_request import InstigatorType
         from dagster._core.scheduler.instigation import (
             InstigatorState,
@@ -2508,8 +2506,8 @@ class DagsterInstance(DynamicPartitionsStore):
         self,
         repository_origin_id: Optional[str] = None,
         repository_selector_id: Optional[str] = None,
-        instigator_type: Optional[InstigatorType] = None,
-        instigator_statuses: Optional[Set[InstigatorStatus]] = None,
+        instigator_type: Optional["InstigatorType"] = None,
+        instigator_statuses: Optional[Set["InstigatorStatus"]] = None,
     ):
         if not self._schedule_storage:
             check.failed("Schedule storage not available")
@@ -2554,7 +2552,7 @@ class DagsterInstance(DynamicPartitionsStore):
     @traced
     def get_tick(
         self, origin_id: str, selector_id: str, timestamp: float
-    ) -> Optional[InstigatorTick]:
+    ) -> Optional["InstigatorTick"]:
         matches = self._schedule_storage.get_ticks(  # type: ignore  # (possible none)
             origin_id, selector_id, before=timestamp + 1, after=timestamp - 1, limit=1
         )
@@ -2568,8 +2566,8 @@ class DagsterInstance(DynamicPartitionsStore):
         before: Optional[float] = None,
         after: Optional[float] = None,
         limit: Optional[int] = None,
-        statuses: Optional[Sequence[TickStatus]] = None,
-    ) -> Sequence[InstigatorTick]:
+        statuses: Optional[Sequence["TickStatus"]] = None,
+    ) -> Sequence["InstigatorTick"]:
         return self._schedule_storage.get_ticks(  # type: ignore  # (possible none)
             origin_id, selector_id, before=before, after=after, limit=limit, statuses=statuses
         )
@@ -2585,7 +2583,7 @@ class DagsterInstance(DynamicPartitionsStore):
         origin_id: str,
         selector_id: str,
         before: float,
-        tick_statuses: Optional[Sequence[TickStatus]] = None,
+        tick_statuses: Optional[Sequence["TickStatus"]] = None,
     ) -> None:
         self._schedule_storage.purge_ticks(origin_id, selector_id, before, tick_statuses)  # type: ignore  # (possible none)
 
@@ -2722,7 +2720,7 @@ class DagsterInstance(DynamicPartitionsStore):
         self,
         key: AssetKey,
         is_source: Optional[bool] = None,
-    ) -> Optional[EventLogRecord]:
+    ) -> Optional["EventLogRecord"]:
         from dagster._core.event_api import EventRecordsFilter
         from dagster._core.events import DagsterEventType
 

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -231,7 +231,7 @@ T_DagsterInstance = TypeVar("T_DagsterInstance", bound="DagsterInstance", defaul
 class MayHaveInstanceWeakref(Generic[T_DagsterInstance]):
     """Mixin for classes that can have a weakref back to a Dagster instance."""
 
-    _instance_weakref: Optional[weakref.ReferenceType[T_DagsterInstance]]
+    _instance_weakref: "Optional[weakref.ReferenceType[T_DagsterInstance]]"
 
     def __init__(self):
         self._instance_weakref = None
@@ -332,9 +332,9 @@ class DagsterInstance(DynamicPartitionsStore):
 
     # Stores TemporaryDirectory instances that were created for DagsterInstance.local_temp() calls
     # to be removed once the instance is garbage collected.
-    _TEMP_DIRS: weakref.WeakKeyDictionary[
-        "DagsterInstance", TemporaryDirectory
-    ] = weakref.WeakKeyDictionary()
+    _TEMP_DIRS: "weakref.WeakKeyDictionary[DagsterInstance, TemporaryDirectory]" = (
+        weakref.WeakKeyDictionary()
+    )
 
     def __init__(
         self,

--- a/python_modules/dagster/dagster/_core/log_manager.py
+++ b/python_modules/dagster/dagster/_core/log_manager.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import datetime
 import logging
 from typing import TYPE_CHECKING, Any, Mapping, NamedTuple, Optional, Sequence, Union, cast
@@ -20,7 +18,7 @@ DAGSTER_META_KEY = "dagster_meta"
 
 class IDagsterMeta(Protocol):
     @property
-    def dagster_meta(self) -> DagsterLoggingMetadata:
+    def dagster_meta(self) -> "DagsterLoggingMetadata":
         ...
 
 
@@ -224,7 +222,7 @@ class DagsterLogHandler(logging.Handler):
     def logging_metadata(self) -> DagsterLoggingMetadata:
         return self._logging_metadata
 
-    def with_tags(self, **new_tags: str) -> DagsterLogHandler:
+    def with_tags(self, **new_tags: str) -> "DagsterLogHandler":
         return DagsterLogHandler(
             logging_metadata=self.logging_metadata._replace(**new_tags),
             loggers=self._loggers,
@@ -423,7 +421,7 @@ class DagsterLogManager(logging.Logger):
         if self.isEnabledFor(level) or ("extra" in kwargs and DAGSTER_META_KEY in kwargs["extra"]):
             self._log(level, msg, args, **kwargs)
 
-    def with_tags(self, **new_tags: str) -> DagsterLogManager:
+    def with_tags(self, **new_tags: str) -> "DagsterLogManager":
         """Add new tags in "new_tags" to the set of tags attached to this log manager instance, and
         return a new DagsterLogManager with the merged set of tags.
 

--- a/python_modules/dagster/dagster/_core/log_manager.py
+++ b/python_modules/dagster/dagster/_core/log_manager.py
@@ -5,13 +5,13 @@ from typing import TYPE_CHECKING, Any, Mapping, NamedTuple, Optional, Sequence, 
 from typing_extensions import Protocol
 
 import dagster._check as check
-from dagster._core.storage.dagster_run import DagsterRun
 from dagster._core.utils import coerce_valid_log_level, make_new_run_id
 from dagster._utils.log import get_dagster_logger
 
 if TYPE_CHECKING:
     from dagster import DagsterInstance
     from dagster._core.events import DagsterEvent
+    from dagster._core.storage.dagster_run import DagsterRun
 
 DAGSTER_META_KEY = "dagster_meta"
 

--- a/python_modules/dagster/dagster/_core/storage/captured_log_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/captured_log_manager.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from typing import IO, Callable, Generator, Iterator, NamedTuple, Optional, Sequence
@@ -107,7 +105,9 @@ class CapturedLogMetadata(
 
 
 class CapturedLogSubscription:
-    def __init__(self, manager: CapturedLogManager, log_key: Sequence[str], cursor: Optional[str]):
+    def __init__(
+        self, manager: "CapturedLogManager", log_key: Sequence[str], cursor: Optional[str]
+    ):
         self._manager = manager
         self._log_key = log_key
         self._cursor = cursor

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -18,7 +18,6 @@ from dagster._core.assets import AssetDetails
 from dagster._core.definitions.events import AssetKey
 from dagster._core.event_api import EventHandlerFn, EventLogRecord, EventRecordsFilter
 from dagster._core.events import DagsterEventType
-from dagster._core.events.log import EventLogEntry
 from dagster._core.execution.stats import (
     RunStepKeyStatsSnapshot,
     build_run_stats_from_events,
@@ -32,6 +31,7 @@ from dagster._utils import PrintFn
 from dagster._utils.concurrency import ConcurrencyClaimStatus, ConcurrencyKeyInfo
 
 if TYPE_CHECKING:
+    from dagster._core.events.log import EventLogEntry
     from dagster._core.storage.partition_status_cache import AssetStatusCacheValue
 
 

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -36,6 +36,7 @@ from dagster._core.errors import (
 )
 from dagster._core.event_api import RunShardedEventsCursor
 from dagster._core.events import ASSET_EVENTS, MARKER_EVENTS, DagsterEventType
+from dagster._core.events.log import EventLogEntry
 from dagster._core.execution.stats import RunStepKeyStatsSnapshot, build_run_step_stats_from_events
 from dagster._core.storage.sql import SqlAlchemyQuery, SqlAlchemyRow
 from dagster._core.storage.sqlalchemy_compat import (
@@ -67,7 +68,6 @@ from .base import (
     AssetRecord,
     EventLogConnection,
     EventLogCursor,
-    EventLogEntry,
     EventLogRecord,
     EventLogStorage,
     EventRecordsFilter,

--- a/python_modules/dagster/dagster/_core/types/config_schema.py
+++ b/python_modules/dagster/dagster/_core/types/config_schema.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import hashlib
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, AbstractSet, Any, Callable, Iterator, Optional, cast

--- a/python_modules/dagster/dagster/_daemon/auto_run_reexecution/event_log_consumer.py
+++ b/python_modules/dagster/dagster/_daemon/auto_run_reexecution/event_log_consumer.py
@@ -1,16 +1,18 @@
 import logging
 import os
-from typing import Callable, Dict, Iterator, List, Mapping, Optional, Sequence
+from typing import TYPE_CHECKING, Callable, Dict, Iterator, List, Mapping, Optional, Sequence
 
 import dagster._check as check
 from dagster import DagsterEventType
-from dagster._core.events.log import EventLogEntry
 from dagster._core.instance import DagsterInstance
 from dagster._core.storage.dagster_run import RunRecord, RunsFilter
 from dagster._core.workspace.context import IWorkspaceProcessContext
 
 from ..daemon import IntervalDaemon
 from .auto_run_reexecution import consume_new_runs_for_automatic_reexecution
+
+if TYPE_CHECKING:
+    from dagster._core.events.log import EventLogEntry
 
 _INTERVAL_SECONDS = int(os.environ.get("DAGSTER_EVENT_LOG_CONSUMER_DAEMON_INTERVAL_SECONDS", 5))
 _EVENT_LOG_FETCH_LIMIT = int(os.environ.get("DAGSTER_EVENT_LOG_CONSUMER_DAEMON_FETCH_LIMIT", 500))

--- a/python_modules/dagster/dagster/_grpc/proxy_server.py
+++ b/python_modules/dagster/dagster/_grpc/proxy_server.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 import sys
 import threading

--- a/python_modules/dagster/dagster/_grpc/proxy_server.py
+++ b/python_modules/dagster/dagster/_grpc/proxy_server.py
@@ -2,7 +2,7 @@ import logging
 import sys
 import threading
 from contextlib import ExitStack
-from typing import Dict, Optional
+from typing import TYPE_CHECKING, Dict, Optional
 
 import dagster._check as check
 from dagster._core.host_representation.grpc_server_registry import GrpcServerRegistry
@@ -11,7 +11,6 @@ from dagster._core.host_representation.origin import (
 )
 from dagster._core.instance import InstanceRef
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
-from dagster._grpc.client import DagsterGrpcClient
 from dagster._serdes import deserialize_value, serialize_value
 from dagster._utils.error import serializable_error_info_from_exc_info
 
@@ -24,6 +23,9 @@ from .types import (
     ShutdownServerResult,
     StartRunResult,
 )
+
+if TYPE_CHECKING:
+    from dagster._grpc.client import DagsterGrpcClient
 
 CLEANUP_TICK = 1
 

--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -11,11 +11,21 @@ import uuid
 import warnings
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import ExitStack
-from multiprocessing.synchronize import Event as MPEvent
-from subprocess import Popen
 from threading import Event as ThreadingEventType
 from time import sleep
-from typing import Any, Dict, Iterable, Iterator, List, Mapping, Optional, Sequence, Tuple, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+    cast,
+)
 
 import grpc
 from grpc_health.v1 import health, health_pb2, health_pb2_grpc
@@ -87,6 +97,10 @@ from .types import (
     StartRunResult,
 )
 from .utils import get_loadable_targets, max_rx_bytes, max_send_bytes
+
+if TYPE_CHECKING:
+    from multiprocessing.synchronize import Event as MPEvent
+    from subprocess import Popen
 
 EVENT_QUEUE_POLL_INTERVAL = 0.1
 
@@ -1122,7 +1136,7 @@ def open_server_process(
 def _open_server_process_on_dynamic_port(
     max_retries: int = 10,
     **kwargs,
-) -> Tuple[Optional[Popen[str]], Optional[int]]:
+) -> Tuple[Optional["Popen[str]"], Optional[int]]:
     server_process = None
     retries = 0
     port = None

--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import json
 import logging
 import math
@@ -1070,7 +1068,7 @@ def open_server_process(
     env: Optional[Dict[str, str]] = None,
     inject_env_vars_from_instance: bool = True,
     container_image: Optional[str] = None,
-    container_context: Optional[dict[str, Any]] = None,
+    container_context: Optional[Dict[str, Any]] = None,
 ):
     check.invariant((port or socket) and not (port and socket), "Set only port or socket")
     check.opt_inst_param(loadable_target_origin, "loadable_target_origin", LoadableTargetOrigin)

--- a/python_modules/dagster/dagster/_serdes/config_class.py
+++ b/python_modules/dagster/dagster/_serdes/config_class.py
@@ -1,11 +1,21 @@
 import importlib
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Mapping, NamedTuple, Optional, Type, TypeVar, Union, overload
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Mapping,
+    NamedTuple,
+    Optional,
+    Type,
+    TypeVar,
+    Union,
+    overload,
+)
 
 from typing_extensions import Self
 
 import dagster._check as check
-from dagster._config.config_schema import UserConfigSchema
 from dagster._utils import convert_dagster_submodule_name
 from dagster._utils.yaml_utils import load_run_config_yaml
 
@@ -13,6 +23,9 @@ from .serdes import (
     NamedTupleSerializer,
     whitelist_for_serdes,
 )
+
+if TYPE_CHECKING:
+    from dagster._config.config_schema import UserConfigSchema
 
 T_ConfigurableClass = TypeVar("T_ConfigurableClass")
 

--- a/python_modules/dagster/dagster/_serdes/ipc.py
+++ b/python_modules/dagster/dagster/_serdes/ipc.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import os
 import signal
 import subprocess

--- a/python_modules/dagster/dagster/_serdes/ipc.py
+++ b/python_modules/dagster/dagster/_serdes/ipc.py
@@ -42,7 +42,7 @@ def ipc_write_unary_response(output_file: str, obj: NamedTuple) -> None:
 
 
 def read_unary_response(
-    output_file: str, timeout: int = 30, ipc_process: Optional[Popen[bytes]] = None
+    output_file: str, timeout: int = 30, ipc_process: "Optional[Popen[bytes]]" = None
 ) -> Optional[NamedTuple]:
     messages = list(ipc_read_event_stream(output_file, timeout=timeout, ipc_process=ipc_process))
     check.invariant(len(messages) == 1)
@@ -139,7 +139,7 @@ def _process_line(file_pointer: TextIOWrapper, sleep_interval: float = 0.1) -> O
         sleep(sleep_interval)
 
 
-def _poll_process(ipc_process: Optional[Popen[bytes]]) -> None:
+def _poll_process(ipc_process: "Optional[Popen[bytes]]") -> None:
     if not ipc_process:
         return
     if ipc_process.poll() is not None:
@@ -151,7 +151,7 @@ def _poll_process(ipc_process: Optional[Popen[bytes]]) -> None:
 
 
 def ipc_read_event_stream(
-    file_path: str, timeout: int = 30, ipc_process: Optional[Popen[bytes]] = None
+    file_path: str, timeout: int = 30, ipc_process: "Optional[Popen[bytes]]" = None
 ) -> Iterator[Optional[NamedTuple]]:
     # Wait for file to be ready
     sleep_interval = 0.1
@@ -195,7 +195,7 @@ def ipc_read_event_stream(
 # https://stefan.sofa-rockers.org/2013/08/15/handling-sub-process-hierarchies-python-linux-os-x/
 
 
-def open_ipc_subprocess(parts: Sequence[str], **kwargs: Any) -> Popen[bytes]:
+def open_ipc_subprocess(parts: Sequence[str], **kwargs: Any) -> "Popen[bytes]":
     """Sets the correct flags to support graceful termination."""
     check.list_param(parts, "parts", str)
 
@@ -210,7 +210,7 @@ def open_ipc_subprocess(parts: Sequence[str], **kwargs: Any) -> Popen[bytes]:
     )
 
 
-def interrupt_ipc_subprocess(proc: Popen[bytes]) -> None:
+def interrupt_ipc_subprocess(proc: "Popen[bytes]") -> None:
     """Send CTRL_BREAK on Windows, SIGINT on other platforms."""
     if sys.platform == "win32":
         proc.send_signal(signal.CTRL_BREAK_EVENT)

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_snap_to_yaml.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_snap_to_yaml.py
@@ -1,15 +1,17 @@
 import os
 import sys
-from typing import Dict, List, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional
 
 from dagster import Config, Field, job, op
 from dagster._config.field import resolve_to_config_type
 from dagster._config.snap import ConfigSchemaSnapshot, snap_from_config_type
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.host_representation import InProcessCodeLocationOrigin
-from dagster._core.host_representation.external import ExternalJob
 from dagster._core.snap.snap_to_yaml import default_values_yaml_from_type_snap
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
+
+if TYPE_CHECKING:
+    from dagster._core.host_representation.external import ExternalJob
 
 
 def test_basic_default():

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_generated_classes.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_generated_classes.py
@@ -1,8 +1,10 @@
 import inspect
-from typing import Any, Union, get_type_hints
+from typing import TYPE_CHECKING, Any, Union, get_type_hints
 
-from dagster_airbyte import AirbyteDestination, AirbyteSource
 from dagster_airbyte.managed.generated import destinations, sources
+
+if TYPE_CHECKING:
+    from dagster_airbyte import AirbyteDestination, AirbyteSource
 
 
 def instantiate(obj: Any) -> Any:

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/airflow_dag_converter.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/airflow_dag_converter.py
@@ -1,7 +1,7 @@
 import importlib
+from typing import TYPE_CHECKING
 
 import airflow
-from airflow.models.baseoperator import BaseOperator
 from airflow.models.dag import DAG
 from dagster import (
     DependencyDefinition,
@@ -22,6 +22,9 @@ from dagster_airflow.utils import (
     normalized_name,
     replace_airflow_logger_handlers,
 )
+
+if TYPE_CHECKING:
+    from airflow.models.baseoperator import BaseOperator
 
 
 def get_graph_definition_args(

--- a/python_modules/libraries/dagster-aws/dagster_aws/secretsmanager/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/secretsmanager/resources.py
@@ -1,7 +1,6 @@
 from contextlib import contextmanager
-from typing import Dict, Generator, List, Optional, cast
+from typing import TYPE_CHECKING, Dict, Generator, List, Optional, cast
 
-import botocore
 from dagster import (
     Field as LegacyDagsterField,
     resource,
@@ -15,6 +14,9 @@ from pydantic import Field
 from dagster_aws.utils import ResourceWithBoto3Configuration
 
 from .secrets import construct_secretsmanager_client, get_secrets_from_arns, get_tagged_secrets
+
+if TYPE_CHECKING:
+    import botocore
 
 
 class SecretsManagerResource(ResourceWithBoto3Configuration):

--- a/python_modules/libraries/dagster-aws/dagster_aws/ssm/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ssm/resources.py
@@ -1,7 +1,6 @@
 from contextlib import contextmanager
-from typing import Any, Dict, Generator, List, Optional, cast
+from typing import TYPE_CHECKING, Any, Dict, Generator, List, Optional, cast
 
-import botocore
 from dagster import (
     Config,
     Field as LegacyDagsterField,
@@ -21,6 +20,9 @@ from .parameters import (
     get_parameters_by_paths,
     get_parameters_by_tags,
 )
+
+if TYPE_CHECKING:
+    import botocore
 
 
 class SSMResource(ResourceWithBoto3Configuration):

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/ops.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/ops.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from dagster import (
     In,
@@ -11,12 +11,13 @@ from dagster._core.definitions.op_definition import OpDefinition
 from databricks_cli.sdk import JobsService
 from pydantic import Field
 
-from .databricks import DatabricksClient
-
 DEFAULT_POLL_INTERVAL_SECONDS = 10
 # wait at most 24 hours by default for run execution
 DEFAULT_MAX_WAIT_TIME_SECONDS = 24 * 60 * 60
 from dagster import Config
+
+if TYPE_CHECKING:
+    from .databricks import DatabricksClient
 
 
 def create_databricks_run_now_op(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_app.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_app.py
@@ -4,11 +4,14 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
-from dagster import Definitions
 from dagster_dbt.cli.app import app
 from typer.testing import CliRunner
+
+if TYPE_CHECKING:
+    from dagster import Definitions
 
 pytest.importorskip("dbt.version", minversion="1.4")
 

--- a/python_modules/libraries/dagstermill/dagstermill/manager.py
+++ b/python_modules/libraries/dagstermill/dagstermill/manager.py
@@ -1,7 +1,7 @@
 import os
 import pickle
 import uuid
-from typing import AbstractSet, Any, Mapping, Optional, cast
+from typing import TYPE_CHECKING, AbstractSet, Any, Mapping, Optional, cast
 
 from dagster import (
     AssetMaterialization,
@@ -19,7 +19,6 @@ from dagster._core.definitions.events import RetryRequested
 from dagster._core.definitions.graph_definition import GraphDefinition
 from dagster._core.definitions.job_base import InMemoryJob
 from dagster._core.definitions.job_definition import JobDefinition
-from dagster._core.definitions.node_definition import NodeDefinition
 from dagster._core.definitions.op_definition import OpDefinition
 from dagster._core.definitions.reconstruct import ReconstructableJob
 from dagster._core.definitions.resource_definition import ScopedResourcesBuilder
@@ -45,6 +44,9 @@ from dagster._utils import EventGenerationManager
 from .context import DagstermillExecutionContext, DagstermillRuntimeExecutionContext
 from .errors import DagstermillError
 from .serialize import PICKLE_PROTOCOL
+
+if TYPE_CHECKING:
+    from dagster._core.definitions.node_definition import NodeDefinition
 
 
 class DagstermillResourceEventGenerationManager(EventGenerationManager):


### PR DESCRIPTION
## Summary & Motivation

Internal companion PR: https://github.com/dagster-io/internal/pull/5847

- Turn on TID251 (banned imports) and configure it to ban `from __future__ import annotations`.
- Turn on TCH suite of rules, which allows auto-sort to automatically place typing-only imports in a `TYPE_CHECKING` block.

This PR was a journey. The goal was to get automatic sorting of imports only used in type annotations into `TYPE_CHECKING` blocks. Ruff offers the `TCH` set of rules for this, for which autofix was recently added. Unfortunately, it turned out to be more complicated than just turning on these rules, because the way things currently work, ruff will only autosort the imports if the annotations are already all strings, which most of the time means `from __future__ import annotations` is imported.

The initial plan was actually opposite the current state of this PR-- the idea was to _inject_ `from __future__ import annotations` (using `I002`) into all Python modules for maximum `TCH` power. However, for reasons explained below, `from __future__ import annotations` (a) does not work well with Dagster in particular; (b) is not a good thing to add everywhere because it's not part of the future of Python.

Therefore, I think the best thing to do for simplicity and future-proofing of the codebase is to ban use of `from __future__ import annotations`. It was imported in ~15 of our 2500 source files-- this PR removes them, adds needed quotes to affected type annotations, and turns on `TID251` to flag any future use of `from __future__ import annotations`.

Without `from __future__ import annotations`, typing-only import auto-sort (`TCH`) is relatively limited. However, I have submitted a [ruff feature request](https://github.com/astral-sh/ruff/issues/5559) to get a new ruff setting that will make it much more powerful for codebases not using `from __future__ import annotations`.

---

The issues with string annotations, `TYPE_CHECKING`, and `from __future__ import annotations` are complex and merit a thorough explanation.

Suppose I have the following module:

```
from dagster._core.definitions.events import AssetKey

def do_something_to_asset(key: AssetKey):
    ...
```

`AssetKey` above is only used in a type annotation. However, if we move it to a `TYPE_CHECKING` block with no other changes, then our code will crash. That's because, by default, Python evaluates type annotations (in function sigs and module-scope variables, but _not_ local var annotations) as standard expressions at runtime. If the `AssetKey` import is in a `TYPE_CHECKING` block, then it won't execute at runtime, and when the `AssetKey` annotation is encountered, Python will be unable to evaluate the symbol `AssetKey` and will error. Therefore we can only move the `AssetKey` import to a typing block under two conditions (1) we turn it into a string annotation; (2) the evaluated expression never needs to be accessed. Let's consider both of these separately:

## 1. Turning annotation into a string

There are two ways to do this:

1. Quote the `AssetKey` annotation.
2. Add `from __future__ import annotations` to the file. This will cause _all_ annotations in the file to be interpreted it as strings. It is equivalent to quoting all annotations in the file.

Option (2) is smoother and eliminates the extra visual complexity of having some arguments quoted and others not. It also improves import time. (Improvement for Dagster is 10-20%; I performed a rough experiment timing `import dagster` on this branch vs master) This was one of the motivations for PEP 562, which introduced `from __future__ import annotations` and _was_ scheduled to become the standard way annotations are evaluated in Python 3.11-- but that plan has been changed, see below.

Turning _all_ annotations into strings does not play nicely with most libs that do runtime processing of annotations. This includes Pydantic and... Dagster. The reason is that these libs need access to the result of the evaluated expression, not just a string:

```
from dagster import op
from pandas import DataFrame

@op
def foo(bar: "DataFrame"):  # This is currently an error
    ...
```

This problem can be somewhat mitigated by using `typing.get_type_hints` on functions that might have string annotations-- `get_type_hints` evaluates the annotations and returns them, providing the necessary runtime values. The problem is that it doesn't always work-- if string annotations refer to symbols in local scope, `get_type_hints` can't resolve them:

```
from typing import get_type_hints

class Foo:
    ...

def foo(x: "Foo"):
     ...

# works to dereference "Foo" since referent `Foo` is in module-level scope
get_type_hints(foo)  # => {'x': <class '__main__.Foo'>}

def make_bar():
    class Bar:
        ...

    def bar(x: "Bar"):
        ...
    return bar

bar = make_bar()

# does not work to dereference "Bar" since referent `Bar` vanished with local scope
get_type_hints(bar)  # => NameError: name 'Bar' is not defined.
```

So string annotations, either explicit or via `from __future__ import annotations`, are flatly incompatible with any situation where (1) annotations are being created in a local scope; (2) an annotation references a symbol only available in that local scope; (3) the annotation must be operated on at runtime (and therefore evaluated with `get_type_hints`).

For the above reasons (and because of the popularity of Pydantic), the Python Steering Committee nixed plans to adopt string annotations in Python 3.11. The new plan is described in [PEP 649](https://peps.python.org/pep-0649/) and will instead package all annotations in a lazily evaluated function. This both enables forward references _and_ ensures that the evaluated value of an annotation can always be accessed.

Unfortunately, PEP 649 won't become part of Python until 3.12, and it's unclear to me whether it will be backportable via another `from __future__` import (but I suspect no). Since we need to support Python <3.12 for many years, that means we probably won't have access to this solution.

## 2. Evaluated expression never needs to be accessed

Even if we had access to PEP 649 the problems discussed in the preceding section were solved, the ability to move "annotation-only" imports to a `TYPE_CHECKING` block is still limited by whether the evaluated value _ever_ needs to be accessed. If it does, you can't move an import to a `TYPE_CHECKING` block.

For us, this mostly means that any type used in an annotation for a Dagster decorator should never be moved to a `TYPE_CHECKING` block:

```
# This is only used in an annotation but it will break dagster if it is moved to a `TYPE_CHECKING` class
from foo import SomeDagsterConfigClass

@asset
def an_asset(config: SomeDagsterConfigClass):
    ...
```

Fortunately ruff allows configuring `TCH` rules to detect special decorators like `@asset`, so I don't think this limitation should block us.

## How I Tested These Changes

ruff
