### PR TITLE
[ui] Linkify assets in the “Backfill target” column

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/AssetKeyTagCollection.tsx
+++ b/js_modules/dagit/packages/core/src/runs/AssetKeyTagCollection.tsx
@@ -21,8 +21,8 @@ const MAX_ASSET_TAGS = 3;
 export const AssetKeyTagCollection: React.FC<{
   assetKeys: AssetKey[] | null;
   modalTitle?: string;
-  clickableTags?: boolean;
-}> = React.memo(({assetKeys, clickableTags, modalTitle = 'Assets in Run'}) => {
+  useTags?: boolean;
+}> = React.memo(({assetKeys, useTags, modalTitle = 'Assets in Run'}) => {
   const [showMore, setShowMore] = React.useState(false);
 
   if (!assetKeys || !assetKeys.length) {
@@ -33,7 +33,50 @@ export const AssetKeyTagCollection: React.FC<{
   const displayed = assetCount <= MAX_ASSET_TAGS ? assetKeys : [];
   const hidden = assetCount - displayed.length;
 
-  if (clickableTags) {
+  const showMoreDialog =
+    hidden > 0 ? (
+      <Dialog
+        title={modalTitle}
+        onClose={() => setShowMore(false)}
+        style={{minWidth: '400px', maxWidth: '80vw', maxHeight: '70vh'}}
+        isOpen={showMore}
+      >
+        {showMore ? (
+          <Box
+            padding={{bottom: 12}}
+            border={{side: 'bottom', color: Colors.KeylineGray, width: 1}}
+            style={{overflowY: 'auto'}}
+            background={Colors.White}
+          >
+            <Table>
+              <thead>
+                <tr>
+                  <th>Asset key</th>
+                </tr>
+              </thead>
+              <tbody>
+                {assetKeys.map((assetKey, ii) => (
+                  <tr key={`${tokenForAssetKey(assetKey)}-${ii}`}>
+                    <td>
+                      <Link to={assetDetailsPathForKey(assetKey)} key={tokenForAssetKey(assetKey)}>
+                        {displayNameForAssetKey(assetKey)}
+                      </Link>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </Table>
+          </Box>
+        ) : null}
+        <DialogFooter>
+          <Button intent="primary" autoFocus onClick={() => setShowMore(false)}>
+            OK
+          </Button>
+        </DialogFooter>
+      </Dialog>
+    ) : undefined;
+
+  if (useTags) {
     return (
       <>
         {displayed.map((assetKey, ii) => (
@@ -50,63 +93,32 @@ export const AssetKeyTagCollection: React.FC<{
             </Tag>
           </ButtonLink>
         )}
-        <Dialog
-          title={modalTitle}
-          onClose={() => setShowMore(false)}
-          style={{minWidth: '400px', maxWidth: '80vw', maxHeight: '70vh'}}
-          isOpen={showMore}
-        >
-          {showMore ? (
-            <Box
-              padding={{bottom: 12}}
-              border={{side: 'bottom', color: Colors.KeylineGray, width: 1}}
-              style={{overflowY: 'auto'}}
-              background={Colors.White}
-            >
-              <Table>
-                <thead>
-                  <tr>
-                    <th>Asset key</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {assetKeys.map((assetKey, ii) => (
-                    <tr key={`${tokenForAssetKey(assetKey)}-${ii}`}>
-                      <td>
-                        <Link
-                          to={assetDetailsPathForKey(assetKey)}
-                          key={tokenForAssetKey(assetKey)}
-                        >
-                          {displayNameForAssetKey(assetKey)}
-                        </Link>
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </Table>
-            </Box>
-          ) : null}
-          <DialogFooter>
-            <Button intent="primary" autoFocus onClick={() => setShowMore(false)}>
-              OK
-            </Button>
-          </DialogFooter>
-        </Dialog>
+        {showMoreDialog}
       </>
     );
   }
 
   return (
-    <Box flex={{direction: 'row', gap: 8, wrap: 'wrap', alignItems: 'center'}}>
-      <Icon color={Colors.Gray400} name="asset" size={16} />
-      {`${displayed.map(displayNameForAssetKey).join(', ')}
-      ${
-        hidden > 0 && displayed.length > 0
-          ? ` + ${hidden} more`
-          : hidden > 0
-          ? `${hidden} assets`
-          : ''
-      }`}
+    <Box flex={{direction: 'row', gap: 8}}>
+      <Icon color={Colors.Gray400} name="asset" size={16} style={{marginTop: 2}} />
+      <Box style={{flex: 1}} flex={{wrap: 'wrap', display: 'inline-flex'}}>
+        {displayed.map((assetKey, idx) => (
+          <Link
+            to={assetDetailsPathForKey(assetKey)}
+            key={tokenForAssetKey(assetKey)}
+            style={{marginRight: 4}}
+          >
+            {`${displayNameForAssetKey(assetKey)}${idx < displayed.length - 1 ? ',' : ''}`}
+          </Link>
+        ))}
+
+        {hidden > 0 && displayed.length > 0 ? (
+          <ButtonLink onClick={() => setShowMore(true)}>{` + ${hidden} more`}</ButtonLink>
+        ) : hidden > 0 ? (
+          <ButtonLink onClick={() => setShowMore(true)}>{`${hidden} assets`}</ButtonLink>
+        ) : undefined}
+      </Box>
+      {showMoreDialog}
     </Box>
   );
 });

--- a/js_modules/dagit/packages/core/src/runs/RunRoot.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunRoot.tsx
@@ -73,7 +73,7 @@ export const RunRoot = () => {
               <>
                 <RunStatusTag status={run.status} />
                 {isHiddenAssetGroupJob(run.pipelineName) ? (
-                  <AssetKeyTagCollection assetKeys={assetKeysForRun(run)} clickableTags />
+                  <AssetKeyTagCollection assetKeys={assetKeysForRun(run)} useTags />
                 ) : (
                   <>
                     <Tag icon="run">
@@ -86,7 +86,7 @@ export const RunRoot = () => {
                         isJob={isJob}
                       />
                     </Tag>
-                    <AssetKeyTagCollection assetKeys={run.assets.map((a) => a.key)} clickableTags />
+                    <AssetKeyTagCollection assetKeys={run.assets.map((a) => a.key)} useTags />
                   </>
                 )}
                 <Box flex={{direction: 'row', alignItems: 'flex-start', gap: 12, wrap: 'wrap'}}>

--- a/js_modules/dagit/packages/core/src/runs/RunTable.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTable.tsx
@@ -334,7 +334,7 @@ const RunRow: React.FC<{
         </Link>
       </td>
       <td>
-        <Box flex={{direction: 'column', gap: 8}}>
+        <Box flex={{direction: 'column', gap: 4}}>
           <RunTime run={run} />
           {isReexecution ? (
             <div>

--- a/js_modules/dagit/packages/core/src/runs/__tests__/AssetKeyTagCollection.test.tsx
+++ b/js_modules/dagit/packages/core/src/runs/__tests__/AssetKeyTagCollection.test.tsx
@@ -15,7 +15,7 @@ describe('AssetKeyTagCollection', () => {
   it('renders individual tags if <= 3', async () => {
     render(
       <MemoryRouter>
-        <AssetKeyTagCollection assetKeys={makeKeys(3)} clickableTags />
+        <AssetKeyTagCollection assetKeys={makeKeys(3)} useTags />
       </MemoryRouter>,
     );
 
@@ -30,7 +30,7 @@ describe('AssetKeyTagCollection', () => {
     await act(async () => {
       render(
         <MemoryRouter>
-          <AssetKeyTagCollection assetKeys={makeKeys(5)} clickableTags />
+          <AssetKeyTagCollection assetKeys={makeKeys(5)} useTags />
         </MemoryRouter>,
       );
     });


### PR DESCRIPTION
## Summary & Motivation

Fixes https://github.com/dagster-io/dagster/issues/14262. Also aligns the "Re-execution" tag with the tags shown beneath the asset list (see second "before" screenshot)

## How I Tested These Changes

Before: 
<img width="897" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/ff305aca-260f-49fa-8fa2-1f6a29d5843e">

<img width="792" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/096cc918-a21c-4d75-a316-4f5551c06b56">


After:
<img width="904" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/ff0c8128-94b1-4ca4-8be8-2a9243f77ba9">

<img width="795" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/f3d6c7ce-dc03-465a-aa8e-702c20e55008">

<img width="370" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/591d34af-39f7-4edf-a18a-7b283ac9c56c">
