### PR TITLE
change schema for dynamic partitions

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/event_log/schema.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/schema.py
@@ -74,7 +74,12 @@ AssetEventTagsTable = db.Table(
 DynamicPartitionsTable = db.Table(
     "dynamic_partitions",
     SqlEventLogStorageMetadata,
-    db.Column("id", db.Integer, primary_key=True, autoincrement=True),
+    db.Column(
+        "id",
+        db.BigInteger().with_variant(sqlite.INTEGER(), "sqlite"),
+        primary_key=True,
+        autoincrement=True,
+    ),
     db.Column("partitions_def_name", db.Text, nullable=False),
     db.Column("partition", db.Text, nullable=False),
     db.Column("create_timestamp", db.DateTime, server_default=get_current_timestamp()),


### PR DESCRIPTION
## Summary & Motivation
The alembic migration had the bigint type, but not the original schema, which means new users will have int types vs bigint types.

## How I Tested These Changes
BK