### PR TITLE
Attempt to run graphql tests in parallel

### DIFF
--- a/python_modules/dagster-graphql/tox.ini
+++ b/python_modules/dagster-graphql/tox.ini
@@ -21,7 +21,7 @@ commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   not_graphql_context_test_suite: pytest -c ../../pyproject.toml -m "not graphql_context_test_suite and not graphql_context_variants and not python_client_test_suite" -vv {posargs}
   sqlite_instance_multi_location: pytest -c ../../pyproject.toml -m "graphql_context_test_suite and sqlite_instance and multi_location" -vv {posargs}
-  sqlite_instance_managed_grpc_env: pytest -c ../../pyproject.toml -m "graphql_context_test_suite and sqlite_instance and managed_grpc_env" -vv {posargs}
+  sqlite_instance_managed_grpc_env: pytest -c ../../pyproject.toml -m "graphql_context_test_suite and sqlite_instance and managed_grpc_env" -n 2 -vv {posargs}
   sqlite_instance_deployed_grpc_env: pytest -c ../../pyproject.toml -m "graphql_context_test_suite and sqlite_instance and deployed_grpc_env" -vv {posargs}
   sqlite_instance_code_server_cli_grpc_env: pytest -c ../../pyproject.toml -m "graphql_context_test_suite and sqlite_instance and code_server_cli_grpc_env" -vv {posargs}
   graphql_python_client: pytest -c ../../pyproject.toml -m "python_client_test_suite" -vv {posargs}

--- a/python_modules/dagster-graphql/tox.ini
+++ b/python_modules/dagster-graphql/tox.ini
@@ -22,7 +22,7 @@ commands =
   not_graphql_context_test_suite: pytest -c ../../pyproject.toml -m "not graphql_context_test_suite and not graphql_context_variants and not python_client_test_suite" -vv {posargs}
   sqlite_instance_multi_location: pytest -c ../../pyproject.toml -m "graphql_context_test_suite and sqlite_instance and multi_location" -vv {posargs}
   sqlite_instance_managed_grpc_env: pytest -c ../../pyproject.toml -m "graphql_context_test_suite and sqlite_instance and managed_grpc_env" -n 2 -vv {posargs}
-  sqlite_instance_deployed_grpc_env: pytest -c ../../pyproject.toml -m "graphql_context_test_suite and sqlite_instance and deployed_grpc_env" -vv {posargs}
+  sqlite_instance_deployed_grpc_env: pytest -c ../../pyproject.toml -m "graphql_context_test_suite and sqlite_instance and deployed_grpc_env" -n 2 -vv {posargs}
   sqlite_instance_code_server_cli_grpc_env: pytest -c ../../pyproject.toml -m "graphql_context_test_suite and sqlite_instance and code_server_cli_grpc_env" -vv {posargs}
   graphql_python_client: pytest -c ../../pyproject.toml -m "python_client_test_suite" -vv {posargs}
   postgres-graphql_context_variants: pytest -c ../../pyproject.toml -m "not graphql_context_test_suite and graphql_context_variants" -vv {posargs}


### PR DESCRIPTION
Some of our graphql test suites have crept up to their 25 minute limit. The test orchestration here is...complicated.

I'm going to just try the easiest possible solution which is to give pytest 2 parallel workers and see what happens.
