### PR TITLE
Only check per-location permissions for the specific asset keys being backfilled

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/test/utils.py
+++ b/python_modules/dagster-graphql/dagster_graphql/test/utils.py
@@ -102,14 +102,26 @@ def execute_dagster_graphql_and_finish_runs(
 
 @contextmanager
 def define_out_of_process_context(
-    python_file: str, fn_name: str, instance: DagsterInstance, read_only: bool = False
+    python_file: str,
+    fn_name: str,
+    instance: DagsterInstance,
+    read_only: bool = False,
+    read_only_locations: Optional[Mapping[str, bool]] = None,
 ) -> Iterator[WorkspaceRequestContext]:
     check.inst_param(instance, "instance", DagsterInstance)
 
     with define_out_of_process_workspace(
         python_file, fn_name, instance, read_only=read_only
     ) as workspace_process_context:
-        yield workspace_process_context.create_request_context()
+        yield WorkspaceRequestContext(
+            instance=instance,
+            workspace_snapshot=workspace_process_context.create_snapshot(),
+            process_context=workspace_process_context,
+            version=workspace_process_context.version,
+            source=None,
+            read_only=read_only,
+            read_only_locations=read_only_locations,
+        )
 
 
 def define_out_of_process_workspace(

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py
@@ -20,6 +20,7 @@ from dagster_graphql.test.utils import (
     GqlResult,
     define_out_of_process_context,
     execute_dagster_graphql,
+    main_repo_location_name,
 )
 
 GET_PARTITION_BACKFILLS_QUERY = """
@@ -148,6 +149,36 @@ def test_launch_asset_backfill_read_only_context():
             assert (
                 launch_backfill_result.data["launchPartitionBackfill"]["__typename"]
                 == "UnauthorizedError"
+            )
+
+        location_name = main_repo_location_name()
+
+        # context with per-location permissions on the specific location succeeds
+        with define_out_of_process_context(
+            __file__,
+            "get_repo",
+            instance,
+            read_only=True,
+            read_only_locations={location_name: False},  # not read-only in this specific location
+        ) as read_only_context:
+            assert read_only_context.read_only
+            # launchPartitionBackfill
+            launch_backfill_result = execute_dagster_graphql(
+                read_only_context,
+                LAUNCH_PARTITION_BACKFILL_MUTATION,
+                variables={
+                    "backfillParams": {
+                        "partitionNames": ["a", "b"],
+                        "assetSelection": [key.to_graphql_input() for key in all_asset_keys],
+                    }
+                },
+            )
+            assert launch_backfill_result
+            assert launch_backfill_result.data
+
+            assert (
+                launch_backfill_result.data["launchPartitionBackfill"]["__typename"]
+                == "LaunchBackfillSuccess"
             )
 
 

--- a/python_modules/dagster/dagster/_core/workspace/context.py
+++ b/python_modules/dagster/dagster/_core/workspace/context.py
@@ -312,6 +312,7 @@ class WorkspaceRequestContext(BaseWorkspaceRequestContext):
         version: Optional[str],
         source: Optional[object],
         read_only: bool,
+        read_only_locations: Optional[Mapping[str, bool]] = None,
     ):
         self._instance = instance
         self._workspace_snapshot = workspace_snapshot
@@ -319,6 +320,9 @@ class WorkspaceRequestContext(BaseWorkspaceRequestContext):
         self._version = version
         self._source = source
         self._read_only = read_only
+        self._read_only_locations = check.opt_mapping_param(
+            read_only_locations, "read_only_locations"
+        )
         self._checked_permissions: Set[str] = set()
 
     @property
@@ -354,6 +358,8 @@ class WorkspaceRequestContext(BaseWorkspaceRequestContext):
         return get_user_permissions(self._read_only)
 
     def permissions_for_location(self, *, location_name: str) -> Mapping[str, PermissionResult]:
+        if location_name in self._read_only_locations:
+            return get_location_scoped_user_permissions(self._read_only_locations[location_name])
         return get_location_scoped_user_permissions(self._read_only)
 
     def has_permission(self, permission: str) -> bool:


### PR DESCRIPTION
Summary:
Before we were checking every code location with an asset on it during a backfill - now we check the specific locations that are associated with the asset selection

## Summary & Motivation

## How I Tested These Changes
