### PR TITLE
[ui] Turn on noUncheckedIndexedAccess for TS, Part 1

### DIFF
--- a/js_modules/dagit/packages/core/src/app/FallthroughRoot.tsx
+++ b/js_modules/dagit/packages/core/src/app/FallthroughRoot.tsx
@@ -51,7 +51,7 @@ const FinalRedirectOrLoadingRoot = () => {
           to={workspacePath(
             repoWithAssetGroup.repository.name,
             repoWithAssetGroup.repositoryLocation.name,
-            `/asset-groups/${repoWithAssetGroup.repository.assetGroups[0].groupName}`,
+            `/asset-groups/${repoWithAssetGroup.repository.assetGroups[0]!.groupName}`,
           )}
         />
       );
@@ -59,19 +59,22 @@ const FinalRedirectOrLoadingRoot = () => {
   }
 
   // If we have exactly one repo with one job, route to the job overview
-  if (reposWithVisibleJobs.length === 1 && getVisibleJobs(reposWithVisibleJobs[0]).length === 1) {
-    const repo = reposWithVisibleJobs[0];
-    const job = getVisibleJobs(repo)[0];
-    return (
-      <Redirect
-        to={workspacePipelinePath({
-          repoName: repo.repository.name,
-          repoLocation: repo.repositoryLocation.name,
-          pipelineName: job.name,
-          isJob: job.isJob,
-        })}
-      />
-    );
+  if (reposWithVisibleJobs.length === 1) {
+    const repo = reposWithVisibleJobs[0]!;
+    const visibleJobs = getVisibleJobs(repo);
+    if (visibleJobs.length === 1) {
+      const job = visibleJobs[0]!;
+      return (
+        <Redirect
+          to={workspacePipelinePath({
+            repoName: repo.repository.name,
+            repoLocation: repo.repositoryLocation.name,
+            pipelineName: job.name,
+            isJob: job.isJob,
+          })}
+        />
+      );
+    }
   }
 
   // If we have more than one repo with a job, route to the instance overview

--- a/js_modules/dagit/packages/core/src/app/GraphQueryImpl.ts
+++ b/js_modules/dagit/packages/core/src/app/GraphQueryImpl.ts
@@ -108,25 +108,29 @@ export function filterByQuery<T extends GraphQueryItem>(items: T[], query: strin
     }
     const [, parentsClause, itemName, descendentsClause] = parts;
 
-    const itemsMatching = items.filter((s) => {
-      if (isPlannedDynamicStep(itemName.replace(/\"/g, ''))) {
-        // When unresolved dynamic step (i.e ends with `[?]`) is selected, match all dynamic steps
-        return s.name.startsWith(dynamicKeyWithoutIndex(itemName.replace(/\"/g, '')));
-      } else {
-        return /\".*\"/.test(itemName)
-          ? s.name === itemName.replace(/\"/g, '')
-          : s.name.includes(itemName);
+    const itemsMatching = itemName
+      ? items.filter((s) => {
+          if (isPlannedDynamicStep(itemName.replace(/\"/g, ''))) {
+            // When unresolved dynamic step (i.e ends with `[?]`) is selected, match all dynamic steps
+            return s.name.startsWith(dynamicKeyWithoutIndex(itemName.replace(/\"/g, '')));
+          } else {
+            return /\".*\"/.test(itemName)
+              ? s.name === itemName.replace(/\"/g, '')
+              : s.name.includes(itemName);
+          }
+        })
+      : [];
+
+    if (parentsClause && descendentsClause) {
+      for (const item of itemsMatching) {
+        const upDepth = expansionDepthForClause(parentsClause);
+        const downDepth = expansionDepthForClause(descendentsClause);
+
+        focus.add(item);
+        results.add(item);
+        traverser.fetchUpstream(item, upDepth).forEach((other) => results.add(other));
+        traverser.fetchDownstream(item, downDepth).forEach((other) => results.add(other));
       }
-    });
-
-    for (const item of itemsMatching) {
-      const upDepth = expansionDepthForClause(parentsClause);
-      const downDepth = expansionDepthForClause(descendentsClause);
-
-      focus.add(item);
-      results.add(item);
-      traverser.fetchUpstream(item, upDepth).forEach((other) => results.add(other));
-      traverser.fetchDownstream(item, downDepth).forEach((other) => results.add(other));
     }
   }
 

--- a/js_modules/dagit/packages/core/src/app/Permissions.tsx
+++ b/js_modules/dagit/packages/core/src/app/Permissions.tsx
@@ -213,7 +213,7 @@ export const usePermissionsForLocation = (
   const {unscopedPermissions, locationPermissions, loading} = React.useContext(PermissionsContext);
   let permissionsForLocation = unscopedPermissions;
   if (locationName && locationPermissions.hasOwnProperty(locationName)) {
-    permissionsForLocation = locationPermissions[locationName];
+    permissionsForLocation = locationPermissions[locationName]!;
   }
 
   const unpacked = unpackPermissions(permissionsForLocation);

--- a/js_modules/dagit/packages/core/src/app/Util.tsx
+++ b/js_modules/dagit/packages/core/src/app/Util.tsx
@@ -51,7 +51,10 @@ export const withMiddleTruncation = (text: string, options: {maxLength: number})
     // breakpoint which would give us more prefix. All else equal,
     // "my_great_l…_name" looks better than "my_g…_solid_name"
     const middleIdx = Math.floor(breakpoints.length / 2);
-    breakpoint = breakpoints[Math.max(firstUsableIdx, middleIdx)];
+    const breakpointAtIndex = breakpoints[Math.max(firstUsableIdx, middleIdx)];
+    if (breakpointAtIndex !== undefined) {
+      breakpoint = breakpointAtIndex;
+    }
   }
 
   const result = [

--- a/js_modules/dagit/packages/core/src/app/time/TimezoneSelect.tsx
+++ b/js_modules/dagit/packages/core/src/app/time/TimezoneSelect.tsx
@@ -18,7 +18,7 @@ const extractOffset = (targetDate: Date, timeZone: string) => {
     timeZoneName: 'longOffset',
   });
   const [_, gmtOffset] = formatted.split(', ');
-  const stripped = gmtOffset.replace(/^GMT/, '').replace(/:/, '');
+  const stripped = gmtOffset!.replace(/^GMT/, '').replace(/:/, '');
 
   // Already GMT.
   if (stripped === '') {

--- a/js_modules/dagit/packages/core/src/app/time/browserTimezone.ts
+++ b/js_modules/dagit/packages/core/src/app/time/browserTimezone.ts
@@ -9,6 +9,6 @@ export const timezoneAbbreviation = memoize((timeZone: string) => {
     timeZoneName: 'short',
   });
   const [_, abbreviation] = dateString.split(', ');
-  return abbreviation;
+  return abbreviation!;
 });
 export const automaticLabel = memoize(() => `Automatic (${browserTimezoneAbbreviation()})`);

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
@@ -142,11 +142,11 @@ const AssetGraphExplorerWithData: React.FC<WithDataProps> = ({
 
   const [highlighted, setHighlighted] = React.useState<string | null>(null);
 
-  const selectedAssetValues = explorerPath.opNames[explorerPath.opNames.length - 1].split(',');
+  const selectedAssetValues = explorerPath.opNames[explorerPath.opNames.length - 1]!.split(',');
   const selectedGraphNodes = Object.values(assetGraphData.nodes).filter((node) =>
     selectedAssetValues.includes(tokenForAssetKey(node.definition.assetKey)),
   );
-  const lastSelectedNode = selectedGraphNodes[selectedGraphNodes.length - 1];
+  const lastSelectedNode = selectedGraphNodes[selectedGraphNodes.length - 1]!;
 
   const selectedDefinitions = selectedGraphNodes.map((a) => a.definition);
   const allDefinitionsForMaterialize = applyingEmptyDefault
@@ -187,14 +187,14 @@ const AssetGraphExplorerWithData: React.FC<WithDataProps> = ({
           }
         }
 
-        const existing = explorerPath.opNames[0].split(',');
+        const existing = explorerPath.opNames[0]!.split(',');
         nextOpsNameSelection = (existing.includes(token)
           ? without(existing, token)
           : uniq([...existing, ...tokensToAdd])
         ).join(',');
       }
 
-      const nextCenter = layout?.nodes[nextOpsNameSelection[nextOpsNameSelection.length - 1]];
+      const nextCenter = layout?.nodes[nextOpsNameSelection[nextOpsNameSelection.length - 1]!];
       if (nextCenter) {
         viewportEl.current?.zoomToSVGCoords(nextCenter.bounds.x, nextCenter.bounds.y, true);
       }
@@ -258,7 +258,7 @@ const AssetGraphExplorerWithData: React.FC<WithDataProps> = ({
     const node = nextId && assetGraphData.nodes[nextId];
     if (node && viewportEl.current) {
       onSelectNode(e, node.assetKey, node);
-      viewportEl.current.zoomToSVGBox(layout.nodes[nextId].bounds, true);
+      viewportEl.current.zoomToSVGBox(layout.nodes[nextId]!.bounds, true);
     }
   };
 
@@ -332,7 +332,7 @@ const AssetGraphExplorerWithData: React.FC<WithDataProps> = ({
                     ))}
 
                   {Object.values(layout.nodes).map(({id, bounds}) => {
-                    const graphNode = assetGraphData.nodes[id];
+                    const graphNode = assetGraphData.nodes[id]!;
                     const path = JSON.parse(id);
                     if (allowGroupsOnlyZoomLevel && scale < GROUPS_ONLY_SCALE) {
                       return;
@@ -480,7 +480,7 @@ const graphDirectionOf = ({
     const node = stack.pop()!;
 
     const downstream = [...Object.keys(graph.downstream[node.id] || {})]
-      .map((n) => graph.nodes[n])
+      .map((n) => graph.nodes[n]!)
       .filter(Boolean);
     if (downstream.some((d) => d.id === to.id)) {
       return 'downstream';
@@ -506,7 +506,7 @@ const opsInRange = (
   }
 
   const downstream = [...Object.keys(graph.downstream[from.id] || {})]
-    .map((n) => graph.nodes[n])
+    .map((n) => graph.nodes[n]!)
     .filter(Boolean);
 
   const ledToTarget: string[] = [];

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
@@ -46,7 +46,7 @@ export const AssetNode: React.FC<{
   liveData?: LiveDataForNode;
   selected: boolean;
 }> = React.memo(({definition, selected, liveData}) => {
-  const displayName = definition.assetKey.path[definition.assetKey.path.length - 1];
+  const displayName = definition.assetKey.path[definition.assetKey.path.length - 1]!;
   const isSource = definition.isSource;
 
   return (
@@ -442,7 +442,7 @@ export const AssetNodeMinimal: React.FC<{
 }> = ({selected, definition, liveData}) => {
   const {isSource, assetKey} = definition;
   const {border, background} = buildAssetNodeStatusContent({assetKey, definition, liveData});
-  const displayName = assetKey.path[assetKey.path.length - 1];
+  const displayName = assetKey.path[assetKey.path.length - 1]!;
   return (
     <AssetInsetForHoverEffect>
       <MinimalAssetNodeContainer $selected={selected}>

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetRunLogObserver.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetRunLogObserver.tsx
@@ -19,8 +19,8 @@ function removeCallback(runId: string, callback: ObservedRunCallback) {
   if (!ObservedRuns[runId]) {
     console.log('[ObserveRuns]: Attempted to release runId that has already been released.');
   }
-  ObservedRuns[runId] = ObservedRuns[runId].filter((w) => w !== callback);
-  if (ObservedRuns[runId].length === 0) {
+  ObservedRuns[runId] = ObservedRuns[runId]!.filter((w) => w !== callback);
+  if (ObservedRuns[runId]!.length === 0) {
     delete ObservedRuns[runId];
   }
 }

--- a/js_modules/dagit/packages/core/src/asset-graph/ForeignNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/ForeignNode.tsx
@@ -9,7 +9,7 @@ import {ASSET_LINK_NAME_MAX_LENGTH} from './layout';
 export const AssetNodeLink: React.FC<{
   assetKey: {path: string[]};
 }> = React.memo(({assetKey}) => {
-  const label = assetKey.path[assetKey.path.length - 1];
+  const label = assetKey.path[assetKey.path.length - 1]!;
   return (
     <AssetNodeLinkContainer>
       <Icon name="open_in_new" color={Colors.Link} />

--- a/js_modules/dagit/packages/core/src/asset-graph/Utils.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/Utils.tsx
@@ -203,7 +203,7 @@ export const buildLiveDataForNode = (
     lastObservation,
     staleStatus: assetNode.staleStatus,
     staleCauses: assetNode.staleCauses,
-    stepKey: assetNode.opNames[0],
+    stepKey: assetNode.opNames[0]!,
     freshnessInfo: assetNode.freshnessInfo,
     inProgressRunIds: assetLatestInfo?.inProgressRunIds || [],
     unstartedRunIds: assetLatestInfo?.unstartedRunIds || [],

--- a/js_modules/dagit/packages/core/src/asset-graph/__stories__/SidebarAssetInfo.stories.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/__stories__/SidebarAssetInfo.stories.tsx
@@ -212,7 +212,11 @@ const TestContainer: React.FC<{
   <MockedProvider
     cache={createAppCache()}
     mocks={
-      mocks || [EventsMock, buildPartitionHealthMock(MockAssetKey.path[0]), buildSidebarQueryMock()]
+      mocks || [
+        EventsMock,
+        buildPartitionHealthMock(MockAssetKey.path[0]!),
+        buildSidebarQueryMock(),
+      ]
     }
   >
     <WorkspaceProvider>
@@ -234,7 +238,7 @@ export const AssetWithPolicies = () => {
     <TestContainer
       mocks={[
         EventsMock,
-        buildPartitionHealthMock(MockAssetKey.path[0]),
+        buildPartitionHealthMock(MockAssetKey.path[0]!),
         buildSidebarQueryMock({
           autoMaterializePolicy: buildAutoMaterializePolicy({
             policyType: AutoMaterializePolicyType.EAGER,

--- a/js_modules/dagit/packages/core/src/asset-graph/__tests__/AssetNode.test.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/__tests__/AssetNode.test.tsx
@@ -30,7 +30,7 @@ describe('AssetNode', () => {
 
       await waitFor(() => {
         const assetKey = scenario.definition.assetKey;
-        const displayName = assetKey.path[assetKey.path.length - 1];
+        const displayName = assetKey.path[assetKey.path.length - 1]!;
         expect(screen.getByText(displayName)).toBeVisible();
         for (const text of scenario.expectedText) {
           expect(screen.getByText(new RegExp(text))).toBeVisible();

--- a/js_modules/dagit/packages/core/src/asset-graph/layout.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/layout.ts
@@ -99,8 +99,8 @@ export const layoutAssetGraph = (graphData: GraphData): AssetGraphLayout => {
 
   // Add the edges to the graph, and accumulate a set of "foreign nodes" (for which
   // we have an inbound/outbound edge, but we don't have the `node` in the graphData).
-  Object.keys(graphData.downstream).forEach((upstreamId) => {
-    const downstreamIds = Object.keys(graphData.downstream[upstreamId]);
+  Object.entries(graphData.downstream).forEach(([upstreamId, graphDataDownstream]) => {
+    const downstreamIds = Object.keys(graphDataDownstream);
     downstreamIds.forEach((downstreamId) => {
       if (
         !shouldRender(graphData.nodes[downstreamId]) &&
@@ -155,10 +155,11 @@ export const layoutAssetGraph = (graphData: GraphData): AssetGraphLayout => {
     for (const node of renderedNodes) {
       if (node.definition.groupName) {
         const groupId = parentNodeIdForNode(node);
-        groups[groupId].bounds =
-          groups[groupId].bounds.width === 0
-            ? nodes[node.id].bounds
-            : extendBounds(groups[groupId].bounds, nodes[node.id].bounds);
+        const groupForId = groups[groupId]!;
+        groupForId.bounds =
+          groupForId.bounds.width === 0
+            ? nodes[node.id]!.bounds
+            : extendBounds(groupForId.bounds, nodes[node.id]!.bounds);
       }
     }
     for (const group of Object.values(groups)) {

--- a/js_modules/dagit/packages/core/src/asset-graph/useAssetGraphData.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/useAssetGraphData.tsx
@@ -127,19 +127,19 @@ const removeEdgesToHiddenAssets = (graphData: GraphData, allNodes: AssetNode[]) 
   const notSourceAsset = (id: string) => !!allNodesById[id];
 
   for (const node of Object.keys(graphData.upstream)) {
-    for (const edge of Object.keys(graphData.upstream[node])) {
+    for (const edge of Object.keys(graphData.upstream[node]!)) {
       if (!graphData.nodes[edge] && notSourceAsset(node)) {
-        delete graphData.upstream[node][edge];
-        delete graphData.downstream[edge][node];
+        delete graphData.upstream[node]![edge];
+        delete graphData.downstream[edge]![node];
       }
     }
   }
 
   for (const node of Object.keys(graphData.downstream)) {
-    for (const edge of Object.keys(graphData.downstream[node])) {
+    for (const edge of Object.keys(graphData.downstream[node]!)) {
       if (!graphData.nodes[edge] && notSourceAsset(node)) {
-        delete graphData.upstream[edge][node];
-        delete graphData.downstream[node][edge];
+        delete graphData.upstream[edge]![node];
+        delete graphData.downstream[node]![edge];
       }
     }
   }
@@ -153,16 +153,16 @@ export const calculateGraphDistances = (items: GraphQueryItem[], assetKey: Asset
   }
 
   const dfsUpstream = (name: string, depth: number): number => {
-    const next = map[name].inputs
-      .flatMap((i) => i.dependsOn.map((d) => d.solid.name))
-      .filter((dname) => dname !== name);
+    const next = map[name]!.inputs.flatMap((i) => i.dependsOn.map((d) => d.solid.name)).filter(
+      (dname) => dname !== name,
+    );
 
     return Math.max(depth, ...next.map((dname) => dfsUpstream(dname, depth + 1)));
   };
   const dfsDownstream = (name: string, depth: number): number => {
-    const next = map[name].outputs
-      .flatMap((i) => i.dependedBy.map((d) => d.solid.name))
-      .filter((dname) => dname !== name);
+    const next = map[name]!.outputs.flatMap((i) => i.dependedBy.map((d) => d.solid.name)).filter(
+      (dname) => dname !== name,
+    );
 
     return Math.max(depth, ...next.map((dname) => dfsDownstream(dname, depth + 1)));
   };

--- a/js_modules/dagit/packages/core/src/assets/AllIndividualEventsLink.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AllIndividualEventsLink.tsx
@@ -147,14 +147,14 @@ const MetadataEntriesRow: React.FC<{
                 </React.Fragment>
               ))}
 
-              {hasLineage && (
+              {hasLineage && timestamp ? (
                 <tr>
                   <td>Parent Materializations</td>
                   <td>
                     <AssetLineageElements elements={assetLineage} timestamp={timestamp} />
                   </td>
                 </tr>
-              )}
+              ) : null}
             </tbody>
           </DetailsTable>
         ) : (
@@ -302,8 +302,8 @@ export const AllIndividualEventsLink: React.FC<PredecessorDialogProps> = ({
     [events],
   );
   const title = () => {
-    if (hasPartitions) {
-      const partition = events[0].partition;
+    if (hasPartitions && events.length) {
+      const partition = events[0]!.partition;
       if (partition) {
         return `Materialization and observation events for ${partition}`;
       }

--- a/js_modules/dagit/packages/core/src/assets/AssetEventList.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetEventList.tsx
@@ -44,7 +44,7 @@ export const AssetEventList: React.FC<{
     <AssetListContainer ref={parentRef}>
       <Inner $totalHeight={totalHeight}>
         {items.map(({index, key, size, start}) => {
-          const group = groups[index];
+          const group = groups[index]!;
           return (
             <AssetListRow
               key={key}

--- a/js_modules/dagit/packages/core/src/assets/AssetNodePartitionCounts.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodePartitionCounts.tsx
@@ -19,15 +19,16 @@ const countMissing = (partitionStats: LiveDataForNode['partitionStats'] | null |
       partitionStats.numMaterialized
     : undefined;
 
-export const StyleForAssetPartitionStatus: {
-  [state: string]: {
+export const StyleForAssetPartitionStatus: Record<
+  AssetPartitionStatus,
+  {
     background: string;
     foreground: string;
     border: string;
     icon: IconName;
     adjective: string;
-  };
-} = {
+  }
+> = {
   [AssetPartitionStatus.FAILED]: {
     background: Colors.Red50,
     foreground: Colors.Red700,

--- a/js_modules/dagit/packages/core/src/assets/AssetPartitionDetail.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetPartitionDetail.tsx
@@ -74,7 +74,9 @@ export const AssetPartitionDetailLoader: React.FC<{assetKey: AssetKey; partition
     };
   }, [result.data]);
 
-  if (result.loading || !result.data) {
+  const latest = materializations[0];
+
+  if (result.loading || !result.data || !latest) {
     return <AssetPartitionDetailEmpty partitionKey={props.partitionKey} />;
   }
 
@@ -84,8 +86,8 @@ export const AssetPartitionDetailLoader: React.FC<{assetKey: AssetKey; partition
       latestRunForPartition={latestRunForPartition}
       hasLineage={hasLineage}
       group={{
-        latest: materializations[0],
-        timestamp: materializations[0]?.timestamp,
+        latest,
+        timestamp: latest.timestamp,
         partition: props.partitionKey,
         all: [...materializations, ...observations].sort(
           (a, b) => Number(b.timestamp) - Number(a.timestamp),

--- a/js_modules/dagit/packages/core/src/assets/AssetPartitionList.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetPartitionList.tsx
@@ -23,7 +23,7 @@ export const AssetPartitionList: React.FC<AssetPartitionListProps> = ({
 
   const rowVirtualizer = useVirtualizer({
     count: partitions.length,
-    getItemKey: (idx) => partitions[idx],
+    getItemKey: (idx) => partitions[idx]!,
     getScrollElement: () => parentRef.current,
     estimateSize: () => 36,
     overscan: 10,
@@ -59,7 +59,7 @@ export const AssetPartitionList: React.FC<AssetPartitionListProps> = ({
     >
       <Inner $totalHeight={totalHeight}>
         {items.map(({index, key, size, start}) => {
-          const dimensionKey = partitions[index];
+          const dimensionKey = partitions[index]!;
           const state = statusForPartition(dimensionKey);
           return (
             <AssetListRow

--- a/js_modules/dagit/packages/core/src/assets/AssetPartitionStatus.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetPartitionStatus.tsx
@@ -56,10 +56,10 @@ export const assetPartitionStatusesToStyle = (status: AssetPartitionStatus[]): C
     return {background: Colors.Gray200};
   }
   if (status.length === 1) {
-    return {background: assetPartitionStatusToColor(status[0])};
+    return {background: assetPartitionStatusToColor(status[0]!)};
   }
-  const a = assetPartitionStatusToColor(status[0]);
-  const b = assetPartitionStatusToColor(status[1]);
+  const a = assetPartitionStatusToColor(status[0]!);
+  const b = assetPartitionStatusToColor(status[1]!);
 
   return {
     backgroundImage: `linear-gradient(135deg, ${a} 25%, ${b} 25%, ${b} 50%, ${a} 50%, ${a} 75%, ${b} 75%, ${b} 100%)`,

--- a/js_modules/dagit/packages/core/src/assets/AssetPartitions.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetPartitions.tsx
@@ -57,7 +57,7 @@ export const AssetPartitions: React.FC<Props> = ({
   setParams,
   dataRefreshHint,
 }) => {
-  const [assetHealth] = usePartitionHealthData([assetKey], dataRefreshHint);
+  const assetHealth = usePartitionHealthData([assetKey], dataRefreshHint)[0]!;
   const [selections, setSelections] = usePartitionDimensionSelections({
     knownDimensionNames: assetPartitionDimensions,
     modifyQueryString: true,
@@ -83,7 +83,7 @@ export const AssetPartitions: React.FC<Props> = ({
     params,
     setParams,
     dimensionCount: selections.length,
-    defaultKeyInDimension: (dimensionIdx) => dimensionKeysInSelection(dimensionIdx)[0],
+    defaultKeyInDimension: (dimensionIdx) => dimensionKeysInSelection(dimensionIdx)[0]!,
   });
 
   // Get asset health on all dimensions, with the non-time dimensions scoped
@@ -97,9 +97,9 @@ export const AssetPartitions: React.FC<Props> = ({
       assetHealth.rangesForSingleDimension(
         idx,
         idx === 1 && focusedDimensionKeys[0]
-          ? [selectionRangeWithSingleKey(focusedDimensionKeys[0], selections[0].dimension)]
+          ? [selectionRangeWithSingleKey(focusedDimensionKeys[0], selections[0]!.dimension)]
           : timeDimensionIdx !== -1 && idx !== timeDimensionIdx
-          ? selections[timeDimensionIdx].selectedRanges
+          ? selections[timeDimensionIdx]!.selectedRanges
           : undefined,
       ),
     );
@@ -116,13 +116,13 @@ export const AssetPartitions: React.FC<Props> = ({
     }
     // Special case: If you have cleared the time selection in the top bar, we
     // clear all dimension columns, (even though you still have a dimension 2 selection)
-    if (timeDimensionIdx !== -1 && selections[timeDimensionIdx].selectedRanges.length === 0) {
+    if (timeDimensionIdx !== -1 && selections[timeDimensionIdx]!.selectedRanges.length === 0) {
       return [];
     }
 
-    const {dimension, selectedRanges} = selections[idx];
+    const {dimension, selectedRanges} = selections[idx]!;
     const allKeys = dimension.partitionKeys;
-    const sort = selectionSorts[idx] || defaultSort(selections[idx].dimension.type);
+    const sort = selectionSorts[idx] || defaultSort(selections[idx]!.dimension.type);
 
     const getSelectionKeys = () =>
       uniq(selectedRanges.flatMap(({start, end}) => allKeys.slice(start.idx, end.idx + 1)));
@@ -133,7 +133,7 @@ export const AssetPartitions: React.FC<Props> = ({
     }
 
     const healthRangesInSelection = rangesClippedToSelection(
-      rangesForEachDimension[idx],
+      rangesForEachDimension[idx]!,
       selectedRanges,
     );
     const getKeysWithStates = (states: AssetPartitionStatus[]) => {
@@ -178,15 +178,15 @@ export const AssetPartitions: React.FC<Props> = ({
           border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
         >
           <DimensionRangeWizard
-            partitionKeys={selections[timeDimensionIdx].dimension.partitionKeys}
-            health={{ranges: rangesForEachDimension[timeDimensionIdx]}}
-            selected={selections[timeDimensionIdx].selectedKeys}
+            partitionKeys={selections[timeDimensionIdx]!.dimension.partitionKeys}
+            health={{ranges: rangesForEachDimension[timeDimensionIdx]!}}
+            selected={selections[timeDimensionIdx]!.selectedKeys}
             setSelected={(selectedKeys) =>
               setSelections(
                 selections.map((r, idx) => (idx === timeDimensionIdx ? {...r, selectedKeys} : r)),
               )
             }
-            dimensionType={selections[timeDimensionIdx].dimension.type}
+            dimensionType={selections[timeDimensionIdx]!.dimension.type}
           />
         </Box>
       )}
@@ -239,7 +239,7 @@ export const AssetPartitions: React.FC<Props> = ({
                     if (copy[idx]) {
                       copy[idx] = copy[idx] === -1 ? 1 : -1;
                     } else {
-                      copy[idx] = (defaultSort(selections[idx].dimension.type) * -1) as -1 | 1;
+                      copy[idx] = (defaultSort(selections[idx]!.dimension.type) * -1) as -1 | 1;
                     }
                     return copy;
                   });
@@ -262,7 +262,7 @@ export const AssetPartitions: React.FC<Props> = ({
                   }
                   const dimensionKeyIdx = selection.dimension.partitionKeys.indexOf(dimensionKey);
                   return partitionStatusAtIndex(
-                    rangesForEachDimension[idx],
+                    rangesForEachDimension[idx]!,
                     dimensionKeyIdx,
                   ).filter((s) => statusFilters.includes(s));
                 }}

--- a/js_modules/dagit/packages/core/src/assets/AssetValueGraph.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetValueGraph.tsx
@@ -105,7 +105,7 @@ export const AssetValueGraph: React.FC<{
         props.onHoverX(null);
         return;
       }
-      props.onHoverX(props.data.values[itemIdx].x);
+      props.onHoverX(props.data.values[itemIdx]!.x);
     },
   };
 

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AssetAutomaterializePolicyPage.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AssetAutomaterializePolicyPage.tsx
@@ -213,8 +213,7 @@ export function getEvaluationsWithEmptyAdded({
   }
   const evalsWithSkips = [];
   let current = isFirstPage ? currentEvaluationId : evaluations[0]?.evaluationId || 1;
-  for (let i = 0; i < evaluations.length; i++) {
-    const evaluation = evaluations[i];
+  evaluations.forEach((evaluation, i) => {
     const prevEvaluation = evaluations[i - 1];
     if (evaluation.evaluationId !== current) {
       evalsWithSkips.push({
@@ -227,7 +226,7 @@ export function getEvaluationsWithEmptyAdded({
     }
     evalsWithSkips.push(evaluation);
     current = evaluation.evaluationId - 1;
-  }
+  });
   if (isLastPage && current > 0) {
     const lastEvaluation = evaluations[evaluations.length - 1];
     evalsWithSkips.push({

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/__tests__/getEvaluationsWithEmptyAdded.test.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/__tests__/getEvaluationsWithEmptyAdded.test.tsx
@@ -73,7 +73,7 @@ describe('getEvaluationsWithEmptyAdded', () => {
           __typename: 'no_conditions_met',
           evaluationId: 10,
           amount: 7,
-          startTimestamp: evaluations[0].timestamp + 60,
+          startTimestamp: evaluations[0]!.timestamp + 60,
           endTimestamp: 'now',
         },
         ...evaluations,
@@ -81,7 +81,7 @@ describe('getEvaluationsWithEmptyAdded', () => {
           __typename: 'no_conditions_met',
           evaluationId: 1,
           amount: 1,
-          endTimestamp: evaluations[1].timestamp - 60,
+          endTimestamp: evaluations[1]!.timestamp - 60,
           startTimestamp: 0,
         },
       ]);
@@ -124,8 +124,8 @@ describe('getEvaluationsWithEmptyAdded', () => {
         __typename: 'no_conditions_met',
         evaluationId: 2,
         amount: 1,
-        endTimestamp: evaluations[0].timestamp - 60,
-        startTimestamp: evaluations[1].timestamp + 60,
+        endTimestamp: evaluations[0]!.timestamp - 60,
+        startTimestamp: evaluations[1]!.timestamp + 60,
       },
       evaluations[1],
     ]);

--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -97,7 +97,7 @@ export const LaunchAssetChoosePartitionsDialog: React.FC<Props> = (props) => {
   const displayName =
     props.assets.length > 1
       ? `${props.assets.length} assets`
-      : displayNameForAssetKey(props.assets[0].assetKey);
+      : displayNameForAssetKey(props.assets[0]!.assetKey);
 
   const title = `Launch runs to materialize ${displayName}`;
 
@@ -177,7 +177,7 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
 
   const displayedPartitionDefinition = displayedBaseAsset?.partitionDefinition;
 
-  const knownDimensions = partitionedAssets[0].partitionDefinition?.dimensionTypes || [];
+  const knownDimensions = partitionedAssets[0]!.partitionDefinition?.dimensionTypes || [];
   const [missingFailedOnly, setMissingFailedOnly] = React.useState(false);
 
   const [selections, setSelections] = usePartitionDimensionSelections({
@@ -281,7 +281,7 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
           repositoryName: repoAddress.name,
         },
         partitionSetName: target.partitionSetName,
-        partitionName: keysFiltered[0].partitionKey,
+        partitionName: keysFiltered[0]!.partitionKey,
       },
     });
 
@@ -318,11 +318,11 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
       allTags = allTags.filter((t) => !t.key.startsWith(DagsterTag.Partition));
       allTags.push({
         key: DagsterTag.AssetPartitionRangeStart,
-        value: keysInSelection[0].partitionKey,
+        value: keysInSelection[0]!.partitionKey,
       });
       allTags.push({
         key: DagsterTag.AssetPartitionRangeEnd,
-        value: keysInSelection[keysInSelection.length - 1].partitionKey,
+        value: keysInSelection[keysInSelection.length - 1]!.partitionKey,
       });
     }
 
@@ -511,7 +511,7 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
                   health={{
                     ranges: displayedHealth.rangesForSingleDimension(
                       idx,
-                      selections.length === 2 ? selections[1 - idx].selectedRanges : undefined,
+                      selections.length === 2 ? selections[1 - idx]!.selectedRanges : undefined,
                     ),
                   }}
                   dimensionType={range.dimension.type}
@@ -727,7 +727,7 @@ const UpstreamUnavailableWarning: React.FC<{
 
   const upstreamUnavailableSpans =
     selections.length === 1
-      ? assembleIntoSpans(selections[0].selectedKeys, upstreamUnavailable).filter(
+      ? assembleIntoSpans(selections[0]!.selectedKeys, upstreamUnavailable).filter(
           (s) => s.status === true,
         )
       : [];
@@ -740,8 +740,9 @@ const UpstreamUnavailableWarning: React.FC<{
     if (selections.length > 1) {
       throw new Error('Assertion failed, this feature is only available for 1 dimensional assets');
     }
+    const selection = selections[0]!;
     setSelections([
-      {...selections[0], selectedKeys: reject(selections[0].selectedKeys, upstreamUnavailable)},
+      {...selection, selectedKeys: reject(selection.selectedKeys, upstreamUnavailable)},
     ]);
   };
 
@@ -752,7 +753,7 @@ const UpstreamUnavailableWarning: React.FC<{
       description={
         <>
           {upstreamUnavailableSpans
-            .map((span) => stringForSpan(span, selections[0].selectedKeys))
+            .map((span) => stringForSpan(span, selections[0]!.selectedKeys))
             .join(', ')}
           {
             ' cannot be materialized because upstream materializations are missing. Consider materializing upstream assets or '

--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
@@ -160,7 +160,7 @@ export const LaunchAssetExecutionButton: React.FC<{
   const [isOpen, setIsOpen] = React.useState(false);
 
   const options = optionsForButton(scope, liveDataForStale);
-  const firstOption = options[0];
+  const firstOption = options[0]!;
   const hasMaterializePermission = firstOption.hasMaterializePermission;
 
   const {MaterializeButton} = useLaunchPadHooks();
@@ -433,8 +433,8 @@ async function stateForLaunchingAssets(
     query: LAUNCH_ASSET_LOADER_RESOURCE_QUERY,
     variables: {
       pipelineName: jobName,
-      repositoryName: assets[0].repository.name,
-      repositoryLocationName: assets[0].repository.location.name,
+      repositoryName: assets[0]!.repository.name,
+      repositoryLocationName: assets[0]!.repository.location.name,
     },
   });
   const pipeline = resourceResult.data.pipelineOrError;
@@ -448,7 +448,7 @@ async function stateForLaunchingAssets(
 
   const partitionSetName = partitionSets.results[0]?.name;
   const requiredResourceKeys = assets.flatMap((a) => a.requiredResources.map((r) => r.resourceKey));
-  const resources = pipeline.modes[0].resources.filter((r) =>
+  const resources = pipeline.modes[0]!.resources.filter((r) =>
     requiredResourceKeys.includes(r.name),
   );
   const anyResourcesHaveRequiredConfig = resources.some((r) => r.configField?.isRequired);
@@ -478,7 +478,7 @@ async function stateForLaunchingAssets(
       },
     };
   }
-  if (partitionDefinition) {
+  if (partitionDefinition && partitionSetName) {
     return {
       type: 'partitions',
       assets,
@@ -528,6 +528,7 @@ function getAnchorAssetForPartitionMappedBackfill(assets: LaunchAssetExecutionAs
   // the anchor asset but we do it alphabetically so that it is deterministic.
   const first = partitionedRoots[0];
   if (
+    first &&
     !partitionedRoots.every((r) =>
       partitionDefinitionsEqual(first.partitionDefinition!, r.partitionDefinition!),
     )

--- a/js_modules/dagit/packages/core/src/assets/MultipartitioningSupport.tsx
+++ b/js_modules/dagit/packages/core/src/assets/MultipartitioningSupport.tsx
@@ -45,7 +45,7 @@ export function mergedAssetHealth(assetHealth: PartitionHealthData[]): Partition
     };
   }
 
-  const dimensions = assetHealth[0].dimensions;
+  const dimensions = assetHealth[0]!.dimensions;
 
   if (!assetHealth.every((h) => h.dimensions.length === dimensions.length)) {
     throw new Error('Attempting to show unified asset health for assets with different dimensions');
@@ -54,7 +54,7 @@ export function mergedAssetHealth(assetHealth: PartitionHealthData[]): Partition
   if (
     !assetHealth.every((h) =>
       h.dimensions.every(
-        (dim, idx) => dim.partitionKeys.length === dimensions[idx].partitionKeys.length,
+        (dim, idx) => dim.partitionKeys.length === dimensions[idx]!.partitionKeys.length,
       ),
     )
   ) {
@@ -73,7 +73,7 @@ export function mergedAssetHealth(assetHealth: PartitionHealthData[]): Partition
       uniq(assetHealth.map((health) => health.stateForKey(dimensionKeys))),
     rangesForSingleDimension: (dimensionIdx, otherDimensionSelectedRanges?) =>
       mergedRanges(
-        dimensions[dimensionIdx].partitionKeys,
+        dimensions[dimensionIdx]!.partitionKeys,
         assetHealth.map((health) =>
           health.rangesForSingleDimension(dimensionIdx, otherDimensionSelectedRanges),
         ),
@@ -101,7 +101,7 @@ export function mergedAssetHealth(assetHealth: PartitionHealthData[]): Partition
  */
 export function mergedRanges(allKeys: string[], rangeSets: Range[][]): Range[] {
   if (rangeSets.length === 1) {
-    return rangeSets[0];
+    return rangeSets[0]!;
   }
 
   const transitions: Transition[] = [];
@@ -177,9 +177,9 @@ export function assembleRangesFromTransitions(
 
     if (!isEqual(last?.value, value)) {
       if (last) {
-        last.end = {idx: idx - 1, key: allKeys[idx - 1]};
+        last.end = {idx: idx - 1, key: allKeys[idx - 1]!};
       }
-      result.push({start: {idx, key: allKeys[idx]}, end: {idx, key: allKeys[idx]}, value});
+      result.push({start: {idx, key: allKeys[idx]!}, end: {idx, key: allKeys[idx]!}, value});
     }
   }
   return result.filter(
@@ -206,7 +206,7 @@ export function explodePartitionKeysInSelection(
     return [];
   }
   if (selections.length === 1) {
-    return selections[0].selectedKeys.map((key) => {
+    return selections[0]!.selectedKeys.map((key) => {
       return {
         partitionKey: key,
         state: stateForKey([key]),
@@ -215,8 +215,8 @@ export function explodePartitionKeysInSelection(
   }
   if (selections.length === 2) {
     const all: {partitionKey: string; state: AssetPartitionStatus[]}[] = [];
-    for (const key of selections[0].selectedKeys) {
-      for (const subkey of selections[1].selectedKeys) {
+    for (const key of selections[0]!.selectedKeys) {
+      for (const subkey of selections[1]!.selectedKeys) {
         all.push({
           partitionKey: `${key}|${subkey}`,
           state: stateForKey([key, subkey]),

--- a/js_modules/dagit/packages/core/src/assets/PartitionHealthSummary.tsx
+++ b/js_modules/dagit/packages/core/src/assets/PartitionHealthSummary.tsx
@@ -54,11 +54,11 @@ export const PartitionHealthSummary: React.FC<{
             small
             partitionNames={dimension.partitionKeys}
             splitPartitions={!isTimeseriesDimension(dimension)}
-            selected={selections ? selections[dimensionIdx].selectedKeys : undefined}
+            selected={selections ? selections[dimensionIdx]!.selectedKeys : undefined}
             health={{
               ranges: assetData.rangesForSingleDimension(
                 dimensionIdx,
-                selections?.length === 2 ? selections[1 - dimensionIdx].selectedRanges : undefined,
+                selections?.length === 2 ? selections[1 - dimensionIdx]!.selectedRanges : undefined,
               ),
             }}
           />

--- a/js_modules/dagit/packages/core/src/assets/__stories__/PartitionHealthSummary.stories.tsx
+++ b/js_modules/dagit/packages/core/src/assets/__stories__/PartitionHealthSummary.stories.tsx
@@ -28,7 +28,7 @@ const PartitionHealthSummaryWithData: React.FC<{
   const selections =
     data[0] && ranges
       ? ranges.map((range, idx) => {
-          const dim = data[0].dimensions[idx]!;
+          const dim = data[0]!.dimensions[idx]!;
           const idx0 = dim.partitionKeys.indexOf(range[0]);
           const idx1 = dim.partitionKeys.indexOf(range[1]);
           return {

--- a/js_modules/dagit/packages/core/src/assets/__tests__/usePartitionHealthData.test.tsx
+++ b/js_modules/dagit/packages/core/src/assets/__tests__/usePartitionHealthData.test.tsx
@@ -251,8 +251,8 @@ function selectionWithSlice(
     selectedKeys: dim.partitionKeys.slice(start, end + 1),
     selectedRanges: [
       {
-        start: {idx: start, key: dim.partitionKeys[start]},
-        end: {idx: end, key: dim.partitionKeys[end]},
+        start: {idx: start, key: dim.partitionKeys[start]!},
+        end: {idx: end, key: dim.partitionKeys[end]!},
       },
     ],
   };
@@ -669,7 +669,7 @@ describe('usePartitionHealthData utilities', () => {
       const one = buildPartitionHealthData(ONE_DIMENSIONAL_ASSET, {path: ['asset']});
 
       expect(
-        keyCountByStateInSelection(one, [selectionWithSlice(one.dimensions[0], 0, 5)]),
+        keyCountByStateInSelection(one, [selectionWithSlice(one.dimensions[0]!, 0, 5)]),
       ).toEqual({
         ...emptyAssetPartitionStatusCounts(),
         [AssetPartitionStatus.FAILED]: 2,
@@ -678,7 +678,7 @@ describe('usePartitionHealthData utilities', () => {
       });
 
       expect(
-        keyCountByStateInSelection(one, [selectionWithSlice(one.dimensions[0], 0, 2)]),
+        keyCountByStateInSelection(one, [selectionWithSlice(one.dimensions[0]!, 0, 2)]),
       ).toEqual({
         ...emptyAssetPartitionStatusCounts(),
         [AssetPartitionStatus.MISSING]: 3,
@@ -690,8 +690,8 @@ describe('usePartitionHealthData utilities', () => {
 
       expect(
         keyCountByStateInSelection(two, [
-          selectionWithSlice(two.dimensions[0], 0, 5),
-          selectionWithSlice(two.dimensions[1], 0, 4),
+          selectionWithSlice(two.dimensions[0]!, 0, 5),
+          selectionWithSlice(two.dimensions[1]!, 0, 4),
         ]),
       ).toEqual({
         ...emptyAssetPartitionStatusCounts(),
@@ -702,8 +702,8 @@ describe('usePartitionHealthData utilities', () => {
 
       expect(
         keyCountByStateInSelection(two, [
-          selectionWithSlice(two.dimensions[0], 0, 3),
-          selectionWithSlice(two.dimensions[1], 0, 3),
+          selectionWithSlice(two.dimensions[0]!, 0, 3),
+          selectionWithSlice(two.dimensions[1]!, 0, 3),
         ]),
       ).toEqual({
         ...emptyAssetPartitionStatusCounts(),
@@ -713,8 +713,8 @@ describe('usePartitionHealthData utilities', () => {
 
       expect(
         keyCountByStateInSelection(two, [
-          selectionWithSlice(two.dimensions[0], 0, 5),
-          selectionWithSlice(two.dimensions[1], 4, 4),
+          selectionWithSlice(two.dimensions[0]!, 0, 5),
+          selectionWithSlice(two.dimensions[1]!, 4, 4),
         ]),
       ).toEqual({
         ...emptyAssetPartitionStatusCounts(),
@@ -727,8 +727,8 @@ describe('usePartitionHealthData utilities', () => {
 
       expect(
         keyCountByStateInSelection(twoEmpty, [
-          selectionWithSlice(twoEmpty.dimensions[0], 0, 5),
-          selectionWithSlice(twoEmpty.dimensions[1], 0, 4),
+          selectionWithSlice(twoEmpty.dimensions[0]!, 0, 5),
+          selectionWithSlice(twoEmpty.dimensions[1]!, 0, 4),
         ]),
       ).toEqual({
         ...emptyAssetPartitionStatusCounts(),

--- a/js_modules/dagit/packages/core/src/assets/groupByPartition.tsx
+++ b/js_modules/dagit/packages/core/src/assets/groupByPartition.tsx
@@ -13,7 +13,7 @@ type Event = AssetMaterializationFragment | AssetObservationFragment;
 export type AssetEventGroup = {
   latest: Event | null;
   all: Event[];
-  timestamp: string;
+  timestamp?: string;
   partition?: string;
 };
 

--- a/js_modules/dagit/packages/core/src/assets/usePartitionDimensionSelections.tsx
+++ b/js_modules/dagit/packages/core/src/assets/usePartitionDimensionSelections.tsx
@@ -138,7 +138,7 @@ export const usePartitionDimensionSelections = (opts: {
         name: r.dimension.name,
         rangeText: rangeText !== allPartitionsSpan(r.dimension) ? rangeText : undefined,
         isFromPartitionQueryStringParam:
-          saved?.rangeText === rangeText ? saved.isFromPartitionQueryStringParam : false,
+          saved && saved?.rangeText === rangeText ? saved.isFromPartitionQueryStringParam : false,
       };
     });
     if (modifyQueryString) {

--- a/js_modules/dagit/packages/core/src/configeditor/ConfigEditorUtils.tsx
+++ b/js_modules/dagit/packages/core/src/configeditor/ConfigEditorUtils.tsx
@@ -134,7 +134,7 @@ export function responseToYamlValidationResult(
   const topLevelKey = Object.keys(parsed);
   errors.forEach((error) => {
     if (error.path.length === 0 && topLevelKey.length) {
-      error.path = [topLevelKey[0]];
+      error.path = [topLevelKey[0]!];
     }
   });
 

--- a/js_modules/dagit/packages/core/src/gantt/DynamicStepSupport.tsx
+++ b/js_modules/dagit/packages/core/src/gantt/DynamicStepSupport.tsx
@@ -23,9 +23,9 @@ export function invocationsOfPlannedDynamicStep(plannedStepKey: string, runtimeS
 }
 
 export function dynamicKeyWithoutIndex(stepKey: string) {
-  return stepKey.split('[')[0];
+  return stepKey.split('[')[0]!;
 }
 
 export function replacePlannedIndex(stepKey: string, stepKeyWithIndex: string) {
-  return stepKey.replace('[?]', stepKeyWithIndex.match(/(\[.*\])/)![1]);
+  return stepKey.replace('[?]', stepKeyWithIndex.match(/(\[.*\])/)![1]!);
 }

--- a/js_modules/dagit/packages/core/src/gantt/GanttChartTimescale.tsx
+++ b/js_modules/dagit/packages/core/src/gantt/GanttChartTimescale.tsx
@@ -146,12 +146,12 @@ export const GanttChartTimescale = ({
             key="highlight-duration"
             className="tick duration"
             style={{
-              left: (highlightedMs[0] - startMs) * pxPerMs + 2,
-              width: (highlightedMs[1] - highlightedMs[0]) * pxPerMs - 2,
+              left: (highlightedMs[0]! - startMs) * pxPerMs + 2,
+              width: (highlightedMs[1]! - highlightedMs[0]!) * pxPerMs - 2,
               transform,
             }}
           >
-            {formatElapsedTime(highlightedMs[1] - highlightedMs[0])}
+            {formatElapsedTime(highlightedMs[1]! - highlightedMs[0]!)}
           </div>
         )}
         {highlightedMs.map((ms, idx) => {

--- a/js_modules/dagit/packages/core/src/gantt/GanttStatusPanel.tsx
+++ b/js_modules/dagit/packages/core/src/gantt/GanttStatusPanel.tsx
@@ -43,7 +43,7 @@ export const GanttStatusPanel: React.FC<GanttStatusPanelProps> = ({
     const succeeded = [];
     const notExecuted = [];
     for (const key of keys) {
-      const state = metadata.steps[key].state;
+      const state = metadata.steps[key]!.state;
       switch (state) {
         case IStepState.PREPARING:
           preparing.push(key);

--- a/js_modules/dagit/packages/core/src/gantt/__stories__/GanttChart.stories.tsx
+++ b/js_modules/dagit/packages/core/src/gantt/__stories__/GanttChart.stories.tsx
@@ -364,9 +364,9 @@ const LOGS: RunMetadataProviderMessageFragment[] = [
   },
 ];
 
-for (let ii = 0; ii < LOGS.length; ii++) {
-  LOGS[ii].timestamp = `${R2_START * 1000 + ii * 3000000}`;
-}
+LOGS.forEach((log, ii) => {
+  log.timestamp = `${R2_START * 1000 + ii * 3000000}`;
+});
 
 // eslint-disable-next-line import/no-default-export
 export default {

--- a/js_modules/dagit/packages/core/src/gantt/__tests__/GanttChartLayout.test.ts
+++ b/js_modules/dagit/packages/core/src/gantt/__tests__/GanttChartLayout.test.ts
@@ -32,7 +32,7 @@ describe('toGraphQueryItems', () => {
       x: 16,
       y: 0,
     });
-    expect(result.boxes[0].children.length).toEqual(1);
+    expect(result.boxes[0]!.children.length).toEqual(1);
     expect(result.boxes[1]).toMatchObject({
       key: 'depends_on_yesterday',
       root: false,

--- a/js_modules/dagit/packages/core/src/gantt/toGraphQueryItems.tsx
+++ b/js_modules/dagit/packages/core/src/gantt/toGraphQueryItems.tsx
@@ -51,7 +51,7 @@ export const toGraphQueryItems = (
   // Step 2: Create a graph node for each resolved step without any inputs or outputs.
   const nodeTable: {[key: string]: GraphQueryItem} = {};
   for (const step of plan.steps) {
-    const stepRuntimeKeys = keyExpansionMap[step.key] ? keyExpansionMap[step.key] : [step.key];
+    const stepRuntimeKeys = keyExpansionMap[step.key] || [step.key];
     for (const key of stepRuntimeKeys) {
       nodeTable[key] = {
         name: key,
@@ -64,12 +64,12 @@ export const toGraphQueryItems = (
   // Step 3: For each step in the original plan, visit each input and create inputs/outputs
   // in our Gantt Node result set.
   for (const step of plan.steps) {
-    const stepRuntimeKeys = keyExpansionMap[step.key] ? keyExpansionMap[step.key] : [step.key];
+    const stepRuntimeKeys = keyExpansionMap[step.key] || [step.key];
     for (const key of stepRuntimeKeys) {
       for (const input of step.inputs) {
         // Add the input to our node in the result set
         const nodeInput: GraphQueryItem['inputs'][0] = {dependsOn: []};
-        nodeTable[key].inputs.push(nodeInput);
+        nodeTable[key]!.inputs.push(nodeInput);
 
         // For each upstream step in the plan, map it to upstream nodes in the runtime graph
         // and attach inputs / outputs to our result graph.
@@ -94,10 +94,10 @@ export const toGraphQueryItems = (
               continue;
             }
             nodeInput.dependsOn.push({solid: {name: upstreamKey}});
-            let upstreamOutput: GraphQueryItem['outputs'][0] = nodeTable[upstreamKey].outputs[0];
+            let upstreamOutput: GraphQueryItem['outputs'][0] = nodeTable[upstreamKey]!.outputs[0]!;
             if (!upstreamOutput) {
               upstreamOutput = {dependedBy: []};
-              nodeTable[upstreamKey].outputs.push(upstreamOutput);
+              nodeTable[upstreamKey]!.outputs.push(upstreamOutput);
             }
             upstreamOutput.dependedBy.push({
               solid: {name: key},

--- a/js_modules/dagit/packages/core/src/graph/__stories__/OpGraph.stories.tsx
+++ b/js_modules/dagit/packages/core/src/graph/__stories__/OpGraph.stories.tsx
@@ -31,7 +31,7 @@ function buildEdge(descriptor: string): Edge {
     throw new Error(`Cannot parse ${descriptor}`);
   }
   const [_, fromOp, fromIO, toOp, toIO] = match;
-  return {fromOp, fromIO, toOp, toIO};
+  return {fromOp: fromOp!, fromIO: fromIO!, toOp: toOp!, toIO: toIO!};
 }
 
 function buildGraphSolidFragment(sname: string, ins: string[], outs: string[], edges: Edge[]) {
@@ -147,7 +147,7 @@ export const Tagged = () => {
   const ops = buildBasicDAG();
 
   ['ipynb', 'sql', 'verylongtypename', 'story'].forEach((kind, idx) =>
-    ops[idx].definition.metadata.push({
+    ops[idx]!.definition.metadata.push({
       key: 'kind',
       value: kind,
       __typename: 'MetadataItemDefinition',
@@ -186,22 +186,22 @@ export const Composite = () => {
     inputMappings: [
       {
         __typename: 'InputMapping',
-        definition: composite.definition.inputDefinitions[0],
+        definition: composite.definition.inputDefinitions[0]!,
         mappedInput: {
           __typename: 'Input',
-          solid: childOps[0],
-          definition: childOps[0].definition.inputDefinitions[0],
+          solid: childOps[0]!,
+          definition: childOps[0]!.definition.inputDefinitions[0]!,
         },
       },
     ],
     outputMappings: [
       {
         __typename: 'OutputMapping',
-        definition: composite.definition.outputDefinitions[0],
+        definition: composite.definition.outputDefinitions[0]!,
         mappedOutput: {
           __typename: 'Output',
-          solid: childOps[1],
-          definition: childOps[1].definition.outputDefinitions[0],
+          solid: childOps[1]!,
+          definition: childOps[1]!.definition.outputDefinitions[0]!,
         },
       },
     ],

--- a/js_modules/dagit/packages/core/src/graph/layout.ts
+++ b/js_modules/dagit/packages/core/src/graph/layout.ts
@@ -192,8 +192,7 @@ export function layoutOpGraph(pipelineOps: ILayoutOp[], parentOp?: ILayoutOp): O
 
   // Read the Dagre layout and map "nodes" back to our solids, but with
   // X,Y coordinates this time.
-  Object.keys(dagreNodes).forEach((opName) => {
-    const node = dagreNodes[opName];
+  Object.entries(dagreNodes).forEach(([opName, node]) => {
     const op = pipelineOps.find(({name}) => name === opName);
     if (!op) {
       return;
@@ -211,9 +210,9 @@ export function layoutOpGraph(pipelineOps: ILayoutOp[], parentOp?: ILayoutOp): O
   g.edges().forEach(function (e) {
     const conn = edges.find((c) => c.from.opName === e.v && c.to.opName === e.w);
     const points = g.edge(e).points;
-    if (conn) {
-      conn.from.point = points[0];
-      conn.to.point = points[points.length - 1];
+    if (conn && points.length > 0) {
+      conn.from.point = points[0]!;
+      conn.to.point = points[points.length - 1]!;
     }
   });
 

--- a/js_modules/dagit/packages/core/src/instigation/LiveTickTimeline.tsx
+++ b/js_modules/dagit/packages/core/src/instigation/LiveTickTimeline.tsx
@@ -132,7 +132,7 @@ export const LiveTickTimeline: React.FC<{
               // This is the future tick
               return '';
             }
-            const tick = ticks[tooltipItem.dataIndex];
+            const tick = ticks[tooltipItem.dataIndex]!;
             const cursorLabel = tick.cursor ? `Cursor: ${tick.cursor}\n` : '';
 
             // returning an array of strings ensures that each string is displayed on its own line

--- a/js_modules/dagit/packages/core/src/launchpad/scaffoldType.ts
+++ b/js_modules/dagit/packages/core/src/launchpad/scaffoldType.ts
@@ -8,7 +8,7 @@ export const scaffoldType = (
   configTypeKey: string,
   typeLookup: {[key: string]: AllConfigTypesForEditorFragment},
 ): any => {
-  const type = typeLookup[configTypeKey];
+  const type = typeLookup[configTypeKey]!;
 
   switch (type.__typename) {
     case 'CompositeConfigType':
@@ -34,7 +34,7 @@ export const scaffoldType = (
     case 'NullableConfigType':
       // If a type is nullable we include it in the scaffolded config anyway
       // by using the inner type
-      const innerType = type.typeParamKeys[0];
+      const innerType = type.typeParamKeys[0]!;
       return scaffoldType(innerType, typeLookup);
     case 'EnumConfigType':
       // Here we just join all the potential enum values with a |. The user needs to delete

--- a/js_modules/dagit/packages/core/src/partitions/PartitionStatus.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionStatus.tsx
@@ -257,8 +257,8 @@ export const PartitionStatus: React.FC<PartitionStatusProps> = ({
                 left: 0,
                 width: indexToPct(
                   Math.min(
-                    partitionNames.indexOf(selected[selected.length - 1]),
-                    partitionNames.indexOf(selected[0]),
+                    partitionNames.indexOf(selected[selected.length - 1]!),
+                    partitionNames.indexOf(selected[0]!),
                   ),
                 ),
                 height: small ? 14 : 24,
@@ -268,14 +268,14 @@ export const PartitionStatus: React.FC<PartitionStatusProps> = ({
               style={{
                 left: `min(calc(100% - 3px), ${indexToPct(
                   Math.min(
-                    partitionNames.indexOf(selected[0]),
-                    partitionNames.indexOf(selected[selected.length - 1]),
+                    partitionNames.indexOf(selected[0]!),
+                    partitionNames.indexOf(selected[selected.length - 1]!),
                   ),
                 )})`,
                 width: indexToPct(
                   Math.abs(
-                    partitionNames.indexOf(selected[selected.length - 1]) -
-                      partitionNames.indexOf(selected[0]),
+                    partitionNames.indexOf(selected[selected.length - 1]!) -
+                      partitionNames.indexOf(selected[0]!),
                   ) + 1,
                 ),
                 height: small ? 14 : 24,
@@ -289,8 +289,8 @@ export const PartitionStatus: React.FC<PartitionStatusProps> = ({
                   partitionNames.length -
                     1 -
                     Math.max(
-                      partitionNames.indexOf(selected[selected.length - 1]),
-                      partitionNames.indexOf(selected[0]),
+                      partitionNames.indexOf(selected[selected.length - 1]!),
+                      partitionNames.indexOf(selected[0]!),
                     ),
                 ),
                 height: small ? 14 : 24,
@@ -349,8 +349,8 @@ function splitColorSegments(partitionNames: string[], segments: ColorSegment[]):
   for (const segment of segments) {
     for (let idx = segment.start.idx; idx <= segment.end.idx; idx++) {
       result.push({
-        start: {idx, key: partitionNames[idx]},
-        end: {idx, key: partitionNames[idx]},
+        start: {idx, key: partitionNames[idx]!},
+        end: {idx, key: partitionNames[idx]!},
         label: segment.label,
         style: segment.style,
       });

--- a/js_modules/dagit/packages/core/src/runs/RunTimeline.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTimeline.tsx
@@ -99,11 +99,10 @@ export const RunTimeline = (props: Props) => {
 
   const flattened: RowType[] = React.useMemo(() => {
     const flat: RowType[] = [];
-    for (const repoKey in buckets) {
-      const bucket = buckets[repoKey];
+    Object.entries(buckets).forEach(([repoKey, bucket]) => {
       const repoAddress = repoAddressFromPath(repoKey);
       if (!repoAddress) {
-        continue;
+        return;
       }
 
       flat.push({type: 'header', repoAddress, jobCount: bucket.length});
@@ -112,7 +111,7 @@ export const RunTimeline = (props: Props) => {
           flat.push({type: 'job', repoAddress, job});
         });
       }
-    }
+    });
 
     return flat;
   }, [buckets, expandedKeys]);

--- a/js_modules/dagit/packages/core/src/runs/TerminationDialog.tsx
+++ b/js_modules/dagit/packages/core/src/runs/TerminationDialog.tsx
@@ -144,8 +144,7 @@ export const TerminationDialog = (props: Props) => {
     dispatch({type: 'start'});
 
     const runList = Object.keys(state.frozenRuns);
-    for (let ii = 0; ii < runList.length; ii++) {
-      const runId = runList[ii];
+    for (const runId of runList) {
       const {data} = await terminate({variables: {runId, terminatePolicy: policy}});
 
       if (data?.terminatePipelineExecution.__typename === 'TerminateRunSuccess') {

--- a/js_modules/dagit/packages/core/src/runs/__tests__/batchRunsForTimeline.test.tsx
+++ b/js_modules/dagit/packages/core/src/runs/__tests__/batchRunsForTimeline.test.tsx
@@ -22,7 +22,7 @@ describe('batchRunsForTimeline', () => {
 
       const batched = getBatch(runs);
       expect(batched.length).toBe(1);
-      const batch = batched[0];
+      const batch = batched[0]!;
       expect(batch.startTime).toBe(10);
       expect(batch.endTime).toBe(70);
       expect(batch.left).toBe(10);
@@ -42,7 +42,7 @@ describe('batchRunsForTimeline', () => {
 
       const batched = getBatch(runs);
       expect(batched.length).toBe(1);
-      const batch = batched[0];
+      const batch = batched[0]!;
       expect(batch.startTime).toBe(10);
       expect(batch.endTime).toBe(50);
       expect(batch.left).toBe(10);
@@ -64,7 +64,7 @@ describe('batchRunsForTimeline', () => {
 
       const batched = getBatch(runs);
       expect(batched.length).toBe(1);
-      const batch = batched[0];
+      const batch = batched[0]!;
       expect(batch.startTime).toBe(10);
       expect(batch.endTime).toBe(90);
       expect(batch.left).toBe(10);
@@ -87,7 +87,7 @@ describe('batchRunsForTimeline', () => {
 
       const batched = getBatch(runs);
       expect(batched.length).toBe(1);
-      const batch = batched[0];
+      const batch = batched[0]!;
       expect(batch.startTime).toBe(10);
       expect(batch.endTime).toBe(90);
       expect(batch.left).toBe(10);
@@ -108,7 +108,7 @@ describe('batchRunsForTimeline', () => {
 
       const batched = getBatch(runs);
       expect(batched.length).toBe(1);
-      const batch = batched[0];
+      const batch = batched[0]!;
       expect(batch.startTime).toBe(10);
       expect(batch.endTime).toBe(100);
       expect(batch.left).toBe(10);
@@ -128,7 +128,7 @@ describe('batchRunsForTimeline', () => {
 
       const batched = getBatch(runs);
       expect(batched.length).toBe(1);
-      const batch = batched[0];
+      const batch = batched[0]!;
       expect(batch.startTime).toBe(10);
       expect(batch.endTime).toBe(70);
       expect(batch.left).toBe(10);
@@ -152,7 +152,8 @@ describe('batchRunsForTimeline', () => {
       expect(batched.length).toBe(2);
 
       // Batch A contains the later run due to sorting.
-      const [batchB, batchA] = batched;
+      const batchB = batched[0]!;
+      const batchA = batched[1]!;
 
       expect(batchA.startTime).toBe(10);
       expect(batchA.endTime).toBe(30);
@@ -182,7 +183,9 @@ describe('batchRunsForTimeline', () => {
       expect(batched.length).toBe(3);
 
       // Sorting results in later runs being in the first batch.
-      const [batchC, batchB, batchA] = batched;
+      const batchC = batched[0]!;
+      const batchB = batched[1]!;
+      const batchA = batched[2]!;
 
       expect(batchA.startTime).toBe(10);
       expect(batchA.endTime).toBe(30);
@@ -209,7 +212,7 @@ describe('batchRunsForTimeline', () => {
       const tinyRun = {startTime: 10, endTime: 11};
       const batched = getBatch([tinyRun]);
 
-      const [batch] = batched;
+      const batch = batched[0]!;
       expect(batch.startTime).toBe(10);
       expect(batch.endTime).toBe(11);
       expect(batch.left).toBe(10);
@@ -222,7 +225,7 @@ describe('batchRunsForTimeline', () => {
       const tinyRunB = {startTime: 10, endTime: 12};
       const batched = getBatch([tinyRunA, tinyRunB]);
 
-      const [batch] = batched;
+      const batch = batched[0]!;
       expect(batch.startTime).toBe(10);
       expect(batch.endTime).toBe(12);
       expect(batch.left).toBe(10);
@@ -255,7 +258,7 @@ describe('batchRunsForTimeline', () => {
 
       const batched = getBatch(runs);
       expect(batched.length).toBe(1);
-      const batch = batched[0];
+      const batch = batched[0]!;
       expect(batch.startTime).toBe(10);
       expect(batch.endTime).toBe(70);
       expect(batch.left).toBe(10);
@@ -277,7 +280,9 @@ describe('batchRunsForTimeline', () => {
 
       const batched = getBatch(runs);
       expect(batched.length).toBe(2);
-      const [batchB, batchA] = batched;
+
+      const batchB = batched[0]!;
+      const batchA = batched[1]!;
 
       expect(batchA.startTime).toBe(10);
       expect(batchA.endTime).toBe(40);

--- a/js_modules/dagit/packages/core/src/runs/useQueryPersistedLogFilter.ts
+++ b/js_modules/dagit/packages/core/src/runs/useQueryPersistedLogFilter.ts
@@ -42,14 +42,19 @@ export const DefaultQuerystring: {[key: string]: string} = {
  *   - Scrolls directly to log with specified time, if no `logs` filter
  */
 export const decodeRunPageFilters = (qs: {[key: string]: string}) => {
-  const logValues = qs['logs'].split(DELIMITER);
-  const focusedTime = qs['focusedTime'] && !qs['logs'] ? Number(qs['focusedTime']) : null;
-  const hideNonMatches = qs['hideNonMatches'] === 'true' ? true : false;
+  const logsQuery = qs['logs'] || '';
+  const focusedTimeQuery = qs['focusedTime'] || '';
+  const hideNonMatchesQuery = qs['hideNonMatches'] || '';
+  const levelsQuery = qs['levels'] || '';
+
+  const logValues = logsQuery.split(DELIMITER);
+  const focusedTime = focusedTimeQuery && !logsQuery ? Number(focusedTimeQuery) : null;
+  const hideNonMatches = hideNonMatchesQuery === 'true';
 
   const providers = getRunFilterProviders();
   const logQuery = logValues.map((token) => tokenizedValueFromString(token, providers));
 
-  const levelsValues = qs['levels'].split(DELIMITER);
+  const levelsValues = levelsQuery.split(DELIMITER);
 
   return {
     sinceTime: 0,

--- a/js_modules/dagit/packages/core/src/runs/useRunsForTimeline.tsx
+++ b/js_modules/dagit/packages/core/src/runs/useRunsForTimeline.tsx
@@ -180,7 +180,7 @@ export const useRunsForTimeline = (range: [number, number], runsFilter: RunsFilt
       return {...accum, [job.key]: Math.min(...startTimes)};
     }, {} as {[jobKey: string]: number});
 
-    return jobs.sort((a, b) => earliest[a.key] - earliest[b.key]);
+    return jobs.sort((a, b) => earliest[a.key]! - earliest[b.key]!);
   }, [workspaceOrError, runsByJobKey, start, end]);
 
   return React.useMemo(

--- a/js_modules/dagit/packages/core/src/schedules/ScheduleDetails.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/ScheduleDetails.tsx
@@ -90,7 +90,7 @@ export const ScheduleDetails: React.FC<{
               <Tag icon="timer">
                 Next tick:{' '}
                 <TimestampDisplay
-                  timestamp={futureTicks.results[0].timestamp!}
+                  timestamp={futureTicks.results[0]!.timestamp!}
                   timezone={executionTimezone}
                   timeFormat={TIME_FORMAT}
                 />

--- a/js_modules/dagit/packages/core/src/schedules/ScheduleStateChangeDialog.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/ScheduleStateChangeDialog.tsx
@@ -110,8 +110,7 @@ export const ScheduleStateChangeDialog = (props: Props) => {
     }
 
     dispatch({type: 'start'});
-    for (let ii = 0; ii < schedules.length; ii++) {
-      const schedule = schedules[ii];
+    for (const schedule of schedules) {
       if (openWithIntent === 'start') {
         await start(schedule);
       } else {

--- a/js_modules/dagit/packages/core/src/schedules/SchedulerInfo.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/SchedulerInfo.tsx
@@ -14,9 +14,9 @@ export const SchedulerInfo: React.FC<Props> = ({daemonHealth, ...boxProps}) => {
     const schedulerHealths = daemonHealth.allDaemonStatuses.filter(
       (daemon) => daemon.daemonType === 'SCHEDULER',
     );
-    if (schedulerHealths) {
-      const schedulerHealth = schedulerHealths[0];
-      healthy = !!(schedulerHealth.required && schedulerHealth.healthy);
+    if (schedulerHealths.length > 0) {
+      const schedulerHealth = schedulerHealths[0]!;
+      healthy = schedulerHealth.required && schedulerHealth.healthy;
     }
   }
 

--- a/js_modules/dagit/packages/core/src/schedules/SchedulesNextTicks.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/SchedulesNextTicks.tsx
@@ -85,7 +85,7 @@ export const SchedulesNextTicks: React.FC<{
     const minMaxTimestamp = Math.min(
       ...futureTickSchedules.map(
         (schedule) =>
-          schedule.futureTicks.results[schedule.futureTicks.results.length - 1].timestamp!,
+          schedule.futureTicks.results[schedule.futureTicks.results.length - 1]!.timestamp!,
       ),
     );
 
@@ -322,7 +322,7 @@ const NextTickDialog: React.FC<{
     setSelectedRunRequest,
   ] = React.useState<ScheduleFutureTickRunRequestFragment | null>(
     evaluationResult && evaluationResult.runRequests && evaluationResult.runRequests.length === 1
-      ? evaluationResult.runRequests[0]
+      ? evaluationResult.runRequests[0]!
       : null,
   );
 

--- a/js_modules/dagit/packages/core/src/sensors/SensorInfo.tsx
+++ b/js_modules/dagit/packages/core/src/sensors/SensorInfo.tsx
@@ -14,8 +14,8 @@ export const SensorInfo: React.FC<Props> = ({daemonHealth, ...boxProps}) => {
     const sensorHealths = daemonHealth.allDaemonStatuses.filter(
       (daemon) => daemon.daemonType === 'SENSOR',
     );
-    if (sensorHealths) {
-      const sensorHealth = sensorHealths[0];
+    if (sensorHealths.length > 0) {
+      const sensorHealth = sensorHealths[0]!;
       healthy = !!(sensorHealth.required && sensorHealth.healthy);
     }
   }

--- a/js_modules/dagit/packages/core/src/sensors/SensorPreviousRuns.tsx
+++ b/js_modules/dagit/packages/core/src/sensors/SensorPreviousRuns.tsx
@@ -25,7 +25,7 @@ export const SensorPreviousRuns: React.FC<{
       variables: {
         limit: RUNS_LIMIT,
         filter: {
-          pipelineName: sensor.targets?.length === 1 ? sensor.targets[0].pipelineName : undefined,
+          pipelineName: sensor.targets?.length === 1 ? sensor.targets[0]!.pipelineName : undefined,
           tags: [{key: DagsterTag.SensorName, value: sensor.name}],
         },
       },

--- a/js_modules/dagit/packages/core/src/sensors/SensorStateChangeDialog.tsx
+++ b/js_modules/dagit/packages/core/src/sensors/SensorStateChangeDialog.tsx
@@ -110,8 +110,7 @@ export const SensorStateChangeDialog = (props: Props) => {
     }
 
     dispatch({type: 'start'});
-    for (let ii = 0; ii < sensors.length; ii++) {
-      const sensor = sensors[ii];
+    for (const sensor of sensors) {
       if (openWithIntent === 'start') {
         await start(sensor);
       } else {

--- a/js_modules/dagit/packages/core/src/ticks/EvaluateScheduleDialog.tsx
+++ b/js_modules/dagit/packages/core/src/ticks/EvaluateScheduleDialog.tsx
@@ -117,7 +117,7 @@ const EvaluateSchedule: React.FC<Props> = ({repoAddress, name, onClose, jobName}
         },
       }),
     }));
-    selectedTimestampRef.current = _selectedTimestamp || timestamps[0];
+    selectedTimestampRef.current = _selectedTimestamp || timestamps[0] || null;
     return (
       <SelectWrapper>
         <ScheduleDescriptor>Select a mock evaluation time</ScheduleDescriptor>
@@ -147,7 +147,7 @@ const EvaluateSchedule: React.FC<Props> = ({repoAddress, name, onClose, jobName}
               onClick={() => setIsTickSelectionOpen((isOpen) => !isOpen)}
               data-testid={testId('tick-selection')}
             >
-              {selectedTimestampRef.current.label}
+              {selectedTimestampRef.current?.label}
             </Button>
           </div>
         </Popover>

--- a/js_modules/dagit/packages/core/src/ticks/__tests__/DynamicPartitionRequests.test.tsx
+++ b/js_modules/dagit/packages/core/src/ticks/__tests__/DynamicPartitionRequests.test.tsx
@@ -37,18 +37,21 @@ describe('DynamicPartitionRequests', () => {
     expect(headerRow).toBeVisible();
 
     //First row
-    expect(getByText(allRows[1], 'part1')).toBeVisible();
-    expect(getByText(allRows[1], 'Add Partition')).toBeVisible();
-    expect(getByText(allRows[1], 'def1')).toBeVisible();
+    const firstRow = allRows[1]!;
+    expect(getByText(firstRow, 'part1')).toBeVisible();
+    expect(getByText(firstRow, 'Add Partition')).toBeVisible();
+    expect(getByText(firstRow, 'def1')).toBeVisible();
 
     //Second row
-    expect(getByText(allRows[2], 'part2')).toBeVisible();
-    expect(getByText(allRows[2], 'Add Partition')).toBeVisible();
-    expect(getByText(allRows[2], 'def1')).toBeVisible();
+    const secondRow = allRows[2]!;
+    expect(getByText(secondRow, 'part2')).toBeVisible();
+    expect(getByText(secondRow, 'Add Partition')).toBeVisible();
+    expect(getByText(secondRow, 'def1')).toBeVisible();
 
     //Third row
-    expect(getByText(allRows[3], 'part3')).toBeVisible();
-    expect(getByText(allRows[3], 'Delete Partition')).toBeVisible();
-    expect(getByText(allRows[3], 'def2')).toBeVisible();
+    const thirdRow = allRows[3]!;
+    expect(getByText(thirdRow, 'part3')).toBeVisible();
+    expect(getByText(thirdRow, 'Delete Partition')).toBeVisible();
+    expect(getByText(thirdRow, 'def2')).toBeVisible();
   });
 });

--- a/js_modules/dagit/packages/core/src/typeexplorer/TypeList.tsx
+++ b/js_modules/dagit/packages/core/src/typeexplorer/TypeList.tsx
@@ -36,16 +36,14 @@ export const TypeList: React.FC<ITypeListProps> = (props) => {
       <Box padding={{vertical: 16, horizontal: 24}}>
         <SidebarTitle>{props.isGraph ? 'Graph types' : 'Pipeline types'}</SidebarTitle>
       </Box>
-      {Object.keys(groups).map((title, idx) => {
-        const typesForSection = groups[title];
-        const collapsedByDefault = idx !== 0 || groups[title].length === 0;
-
+      {Object.entries(groups).map(([title, typesForSection], idx) => {
+        const collapsedByDefault = idx !== 0 || typesForSection.length === 0;
         return (
           <SidebarSection key={idx} title={title} collapsedByDefault={collapsedByDefault}>
             <Box padding={{vertical: 16, horizontal: 24}}>
               {typesForSection.length ? (
                 <StyledUL>
-                  {groups[title].map((type, i) => (
+                  {typesForSection.map((type, i) => (
                     <TypeLI key={i}>
                       <TypeWithTooltip type={type} />
                     </TypeLI>

--- a/js_modules/dagit/packages/core/src/typeexplorer/TypeListContainer.tsx
+++ b/js_modules/dagit/packages/core/src/typeexplorer/TypeListContainer.tsx
@@ -34,7 +34,7 @@ export const TypeListContainer: React.FC<ITypeListContainerProps> = ({
     if (!repoAddress) {
       const reposWithMatch = findRepoContainingPipeline(options, pipelineName, snapshotId);
       return reposWithMatch.length
-        ? buildPipelineSelector(optionToRepoAddress(reposWithMatch[0]), pipelineName)
+        ? buildPipelineSelector(optionToRepoAddress(reposWithMatch[0]!), pipelineName)
         : null;
     }
     return buildPipelineSelector(repoAddress, pipelineName);

--- a/js_modules/dagit/packages/core/src/ui/Filters/__tests__/FilterDropdown.test.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Filters/__tests__/FilterDropdown.test.tsx
@@ -63,8 +63,8 @@ describe('FilterDropdown', () => {
     await userEvent.type(searchInput, 'type');
     await waitFor(() => expect(screen.getByText('Type 1')).toBeInTheDocument());
     await waitFor(() => expect(screen.getByText('Type 2')).toBeInTheDocument());
-    await waitFor(() => expect(mockFilters[0].getResults).toHaveBeenCalledWith('type'));
-    await waitFor(() => expect(mockFilters[1].getResults).toHaveBeenCalledWith('type'));
+    await waitFor(() => expect(mockFilters[0]!.getResults).toHaveBeenCalledWith('type'));
+    await waitFor(() => expect(mockFilters[1]!.getResults).toHaveBeenCalledWith('type'));
   });
 
   test('displays no results when no filters match', async () => {
@@ -165,7 +165,7 @@ describe('FilterDropdown Accessibility', () => {
     await userEvent.keyboard(enterKey);
 
     await waitFor(() => {
-      expect(mockFilters[1].onSelect).toHaveBeenCalled();
+      expect(mockFilters[1]!.onSelect).toHaveBeenCalled();
     });
   };
 

--- a/js_modules/dagit/packages/core/src/ui/GraphQueryInput.tsx
+++ b/js_modules/dagit/packages/core/src/ui/GraphQueryInput.tsx
@@ -141,7 +141,7 @@ const buildSuggestions = (
       : [];
 
   // No need to show a match if our string exactly matches the one suggestion.
-  if (matching.length === 1 && matching[0].name.toLowerCase() === lastElementLower) {
+  if (matching.length === 1 && matching[0]!.name.toLowerCase() === lastElementLower) {
     return [];
   }
 
@@ -167,7 +167,7 @@ export const GraphQueryInput = React.memo(
 
     const [, prefix, lastElementName, suffix] = lastClause || [];
     const suggestions = React.useMemo(
-      () => buildSuggestions(lastElementName, props.items, suffix),
+      () => buildSuggestions(lastElementName!, props.items, suffix!),
       [lastElementName, props.items, suffix],
     );
 

--- a/js_modules/dagit/packages/core/src/ui/SectionedLeftNav.tsx
+++ b/js_modules/dagit/packages/core/src/ui/SectionedLeftNav.tsx
@@ -197,7 +197,7 @@ export const SectionedLeftNav = () => {
     count: flattened.length,
     getScrollElement: () => parentRef.current,
     estimateSize: (index: number) => {
-      const item = flattened[index];
+      const item = flattened[index]!;
       switch (item.type) {
         case 'code-location':
           return 48;
@@ -231,7 +231,7 @@ export const SectionedLeftNav = () => {
     <Container ref={parentRef}>
       <Inner $totalHeight={totalHeight}>
         {items.map(({index, key, size, start}) => {
-          const row: RowType = flattened[index];
+          const row: RowType = flattened[index]!;
           const type = row!.type;
 
           if (type === 'code-location') {

--- a/js_modules/dagit/packages/core/src/workspace/GuessJobLocationRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/GuessJobLocationRoot.tsx
@@ -51,7 +51,7 @@ export const GuessJobLocationRoot = () => {
   }
 
   if (reposWithMatch.length === 1) {
-    const match = reposWithMatch[0];
+    const match = reposWithMatch[0]!;
     const repoAddress = optionToRepoAddress(match);
     const isJob = isThisThingAJob(match, pipelineName);
     const to = workspacePathFromAddress(

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedAssetTable.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedAssetTable.tsx
@@ -49,13 +49,12 @@ export const VirtualizedAssetTable: React.FC<Props> = (props) => {
   const items = rowVirtualizer.getVirtualItems();
 
   const rows: Row[] = React.useMemo(() => {
-    return Object.keys(groups).map((displayKey) => {
+    return Object.entries(groups).map(([displayKey, assets]) => {
       const path = [...prefixPath, ...JSON.parse(displayKey)];
-      const assets = groups[displayKey];
-      const isFolder = assets.length > 1 || path.join('/') !== assets[0].key.path.join('/');
+      const isFolder = assets.length > 1 || path.join('/') !== assets[0]!.key.path.join('/');
       return isFolder
         ? {type: 'folder', path, displayKey, assets}
-        : {type: 'asset', path, displayKey, asset: assets[0]};
+        : {type: 'asset', path, displayKey, asset: assets[0]!};
     });
   }, [prefixPath, groups]);
 
@@ -65,7 +64,7 @@ export const VirtualizedAssetTable: React.FC<Props> = (props) => {
         <VirtualizedAssetCatalogHeader headerCheckbox={headerCheckbox} view={view} />
         <Inner $totalHeight={totalHeight}>
           {items.map(({index, key, size, start}) => {
-            const row: Row = rows[index];
+            const row: Row = rows[index]!;
             const rowType = () => {
               if (row.type === 'folder') {
                 return 'folder';

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedGraphTable.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedGraphTable.tsx
@@ -50,7 +50,7 @@ export const VirtualizedGraphTable: React.FC<Props> = ({repoAddress, graphs}) =>
         <Container ref={parentRef}>
           <Inner $totalHeight={totalHeight}>
             {items.map(({index, key, size, start}) => {
-              const row: Graph = graphs[index];
+              const row: Graph = graphs[index]!;
               return (
                 <GraphRow
                   key={key}

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedJobRow.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedJobRow.tsx
@@ -98,7 +98,7 @@ export const VirtualizedJobRow = (props: JobRowProps) => {
         <RowCell>
           {latestRuns.length ? (
             <LastRunSummary
-              run={latestRuns[0]}
+              run={latestRuns[0]!}
               showButton={false}
               showHover
               showSummary={false}

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedJobTable.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedJobTable.tsx
@@ -33,7 +33,7 @@ export const VirtualizedJobTable: React.FC<Props> = ({repoAddress, jobs}) => {
         <Container ref={parentRef}>
           <Inner $totalHeight={totalHeight}>
             {items.map(({index, key, size, start}) => {
-              const row: Job = jobs[index];
+              const row: Job = jobs[index]!;
               return (
                 <VirtualizedJobRow
                   key={key}

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedRepoAssetTable.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedRepoAssetTable.tsx
@@ -49,8 +49,7 @@ export const VirtualizedRepoAssetTable: React.FC<Props> = ({repoAddress, assets}
 
   const flattened: RowType[] = React.useMemo(() => {
     const flat: RowType[] = [];
-    Object.keys(grouped).forEach((groupName) => {
-      const assetsForGroup = grouped[groupName];
+    Object.entries(grouped).forEach(([groupName, assetsForGroup]) => {
       flat.push({type: 'group', name: groupName, assetCount: assetsForGroup.length});
       if (expandedKeys.includes(groupName)) {
         assetsForGroup.forEach((asset) => {
@@ -81,7 +80,7 @@ export const VirtualizedRepoAssetTable: React.FC<Props> = ({repoAddress, assets}
         <Container ref={parentRef}>
           <Inner $totalHeight={totalHeight}>
             {items.map(({index, key, size, start}) => {
-              const row: RowType = flattened[index];
+              const row: RowType = flattened[index]!;
               const type = row!.type;
               return type === 'group' ? (
                 <GroupNameRow

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedScheduleRow.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedScheduleRow.tsx
@@ -216,7 +216,7 @@ export const VirtualizedScheduleRow = (props: ScheduleRowProps) => {
           {scheduleData?.scheduleState.ticks.length ? (
             <div>
               <TickTag
-                tick={scheduleData.scheduleState.ticks[0]}
+                tick={scheduleData.scheduleState.ticks[0]!}
                 instigationType={InstigationType.SCHEDULE}
               />
             </div>
@@ -227,7 +227,7 @@ export const VirtualizedScheduleRow = (props: ScheduleRowProps) => {
         <RowCell>
           {scheduleData?.scheduleState && scheduleData?.scheduleState.runs.length > 0 ? (
             <LastRunSummary
-              run={scheduleData.scheduleState.runs[0]}
+              run={scheduleData.scheduleState.runs[0]!}
               name={name}
               showButton={false}
               showHover

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedScheduleTable.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedScheduleTable.tsx
@@ -44,7 +44,7 @@ export const VirtualizedScheduleTable = ({
         <Container ref={parentRef}>
           <Inner $totalHeight={totalHeight}>
             {items.map(({index, key, size, start}) => {
-              const row: ScheduleInfo = schedules[index];
+              const row: ScheduleInfo = schedules[index]!;
               const scheduleKey = makeScheduleKey(repoAddress, row.name);
               return (
                 <VirtualizedScheduleRow

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedSensorRow.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedSensorRow.tsx
@@ -184,7 +184,7 @@ export const VirtualizedSensorRow = (props: SensorRowProps) => {
           {sensorData?.sensorState.ticks.length ? (
             <div>
               <TickTag
-                tick={sensorData.sensorState.ticks[0]}
+                tick={sensorData.sensorState.ticks[0]!}
                 instigationType={InstigationType.SENSOR}
               />
             </div>
@@ -195,7 +195,7 @@ export const VirtualizedSensorRow = (props: SensorRowProps) => {
         <RowCell>
           {sensorData?.sensorState && sensorData?.sensorState.runs.length > 0 ? (
             <LastRunSummary
-              run={sensorData.sensorState.runs[0]}
+              run={sensorData.sensorState.runs[0]!}
               name={name}
               showButton={false}
               showHover

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedSensorTable.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedSensorTable.tsx
@@ -44,7 +44,7 @@ export const VirtualizedSensorTable = ({
         <Container ref={parentRef}>
           <Inner $totalHeight={totalHeight}>
             {items.map(({index, key, size, start}) => {
-              const row: SensorInfo = sensors[index];
+              const row: SensorInfo = sensors[index]!;
               const sensorKey = makeSensorKey(repoAddress, row.name);
               return (
                 <VirtualizedSensorRow

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceContext.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceContext.tsx
@@ -361,7 +361,7 @@ export const useActivePipelineForName = (pipelineName: string, snapshotId?: stri
   const {options} = useRepositoryOptions();
   const reposWithMatch = findRepoContainingPipeline(options, pipelineName, snapshotId);
   if (reposWithMatch.length) {
-    const match = reposWithMatch[0];
+    const match = reposWithMatch[0]!;
     return match.repository.pipelines.find((pipeline) => pipeline.name === pipelineName) || null;
   }
   return null;

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceGraphsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceGraphsRoot.tsx
@@ -65,11 +65,14 @@ export const WorkspaceGraphsRoot = ({repoAddress}: {repoAddress: RepoAddress}) =
 
     repo.usedSolids.forEach((s) => {
       if (s.definition.__typename === 'CompositeSolidDefinition') {
-        items.push({
-          name: s.definition.name,
-          path: `/graphs/${s.invocations[0].pipeline.name}/${s.invocations[0].solidHandle.handleID}/`,
-          description: s.definition.description,
-        });
+        const invocation = s.invocations[0];
+        if (invocation) {
+          items.push({
+            name: s.definition.name,
+            path: `/graphs/${invocation.pipeline.name}/${invocation.solidHandle.handleID}/`,
+            description: s.definition.description,
+          });
+        }
       }
     });
 

--- a/js_modules/dagit/packages/core/src/workspace/useRepositoryForRun.ts
+++ b/js_modules/dagit/packages/core/src/workspace/useRepositoryForRun.ts
@@ -103,7 +103,7 @@ export const useRepositoryForRunWithoutSnapshot = (
   }
   const jobNameMatches = jobNameMatchesForRun(options, run);
   if (jobNameMatches && jobNameMatches.length) {
-    return {match: jobNameMatches[0], type: 'pipeline-name-only'};
+    return {match: jobNameMatches[0]!, type: 'pipeline-name-only'};
   }
   return null;
 };
@@ -141,11 +141,11 @@ export const useRepositoryForRunWithParentSnapshot = (
   }
 
   if (snapshotMatches && snapshotMatches.length) {
-    return {match: snapshotMatches[0], type: 'snapshot-only'};
+    return {match: snapshotMatches[0]!, type: 'snapshot-only'};
   }
 
   if (jobNameMatches && jobNameMatches.length) {
-    return {match: jobNameMatches[0], type: 'pipeline-name-only'};
+    return {match: jobNameMatches[0]!, type: 'pipeline-name-only'};
   }
 
   return null;

--- a/js_modules/dagit/packages/core/tsconfig.json
+++ b/js_modules/dagit/packages/core/tsconfig.json
@@ -5,23 +5,17 @@
     },
     "module": "es2022",
     "target": "es2022",
+    "strict": true,
     "sourceMap": true,
     "allowJs": true,
     "jsx": "react",
     "moduleResolution": "node",
     "forceConsistentCasingInFileNames": true,
     "noImplicitReturns": true,
-    "noImplicitThis": true,
-    "noImplicitAny": true,
-    "strictNullChecks": true,
     "allowSyntheticDefaultImports": true,
-    "types": [
-      "jest",
-      "node"
-    ],
+    "types": ["jest", "node"],
     "skipLibCheck": true,
     "esModuleInterop": true,
-    "strict": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
@@ -38,9 +32,5 @@
     "scripts",
     "webpack"
   ],
-  "include": [
-    "src",
-    "types",
-    "typings.d.ts"
-  ]
+  "include": ["src", "types", "typings.d.ts"]
 }

--- a/js_modules/dagit/packages/ui/tsconfig.json
+++ b/js_modules/dagit/packages/ui/tsconfig.json
@@ -3,6 +3,7 @@
     "module": "es2022",
     "target": "es2022",
     "rootDir": "src",
+    "strict": true,
     "noEmit": true,
     "sourceMap": true,
     "allowJs": true,
@@ -10,29 +11,15 @@
     "moduleResolution": "node",
     "forceConsistentCasingInFileNames": true,
     "noImplicitReturns": true,
-    "noImplicitThis": true,
-    "noImplicitAny": true,
-    "strictNullChecks": true,
     "noUncheckedIndexedAccess": true,
     "allowSyntheticDefaultImports": true,
-    "types": [
-      "jest",
-      "node"
-    ],
+    "types": ["jest", "node"],
     "skipLibCheck": true,
     "esModuleInterop": true,
-    "strict": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noFallthroughCasesInSwitch": true
   },
-  "exclude": [
-    "node_modules",
-    "lib",
-  ],
-  "include": [
-    "src",
-    "types"
-  ]
+  "exclude": ["node_modules", "lib"],
+  "include": ["src", "types"]
 }
-  


### PR DESCRIPTION
## Summary & Motivation

The first wave of changes made to allow us to enable `noUncheckedIndexedAccess` in TypeScript in `packages/core`.

This generally consists of a few different approaches:

- Use the `!` assertion operator on array/object key access. I used this when it looked like a previous check had validated the presence of the key, e.g. checking `.length` on an array and subsequently looking up `[0]`.
- Use `.forEach` instead of `for (let ii = ...)` style loops where possible, since then we don't need to key into the array.
- Similarly, use `Object.entries()` for loops that currently use `Object.keys()` and then index into the object based on the key.

It is possible that this will surface new errors, especially in situations where the `!` assertion is inaccurate. Fortunately, the error should now be very obvious at that point in code, instead of surfacing downstream.

There will be one or two more PRs to finish this for OSS.

## How I Tested These Changes

ts, lint, jest.
