### PR TITLE
Handle partitions with invalid parents in auto-materialize

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
@@ -701,6 +701,10 @@ def determine_asset_partitions_to_auto_materialize(
             candidate
         ):
             return False
+        elif not asset_graph.partition_maps_to_valid_parents(
+            instance_queryer, evaluation_time, candidate
+        ):
+            return False
 
         return True
 
@@ -736,7 +740,6 @@ def determine_asset_partitions_to_auto_materialize(
             if instance_queryer.is_reconciled(
                 asset_partition=parent,
                 asset_graph=asset_graph,
-                dynamic_partitions_store=instance_queryer,
             ):
                 continue
 
@@ -782,7 +785,6 @@ def determine_asset_partitions_to_auto_materialize(
         elif auto_materialize_policy.on_new_parent_data and not instance_queryer.is_reconciled(
             asset_partition=candidate,
             asset_graph=asset_graph,
-            dynamic_partitions_store=instance_queryer,
         ):
             conditions.add(ParentMaterializedAutoMaterializeCondition())
 
@@ -821,13 +823,8 @@ def determine_asset_partitions_to_auto_materialize(
             return False
 
         if all(
-            asset_graph.partition_maps_to_valid_parents(
-                instance_queryer, evaluation_time, candidate
-            )
-            and (
-                will_be_materialized_for_freshness(candidate)
-                or parents_will_be_reconciled(asset_graph, candidate)
-            )
+            will_be_materialized_for_freshness(candidate)
+            or parents_will_be_reconciled(asset_graph, candidate)
             for candidate in candidates_unit
         ):
             unit_conditions = set().union(

--- a/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
@@ -167,6 +167,41 @@ class PartitionMapping(ABC):
             )
         )
 
+    def downstream_partition_has_valid_upstream_partitions(
+        self,
+        downstream_partitions_def: PartitionsDefinition,
+        downstream_partition_key: str,
+        upstream_partitions_def: PartitionsDefinition,
+        current_time: Optional[datetime] = None,
+        dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
+    ) -> bool:
+        """Returns a bool representing whether the mapped upstream partition key exists for
+        the provided downstream partition key.
+        """
+        return True
+
+    def get_valid_upstream_partitions_for_partitions(
+        self,
+        downstream_partitions_subset: Optional[PartitionsSubset],
+        upstream_partitions_def: PartitionsDefinition,
+        current_time: Optional[datetime] = None,
+        dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
+    ) -> PartitionsSubset:
+        """Returns the subset of partition keys in the upstream asset that are existent. The existent
+        partitions are not necessarily the full set of parent partitions that the downstream subset
+        depends on.
+
+        For example, if an upstream asset is time-partitioned and starts in June 2023, and the
+        downstream asset is time-partitioned and starts in May 2023, this function would return
+        an empty subset when the downstream subset contains a May partition.
+        """
+        return self.get_upstream_partitions_for_partitions(
+            downstream_partitions_subset,
+            upstream_partitions_def,
+            current_time,
+            dynamic_partitions_store,
+        )
+
 
 @whitelist_for_serdes
 class IdentityPartitionMapping(PartitionMapping, NamedTuple("_IdentityPartitionMapping", [])):

--- a/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
@@ -38,6 +38,20 @@ from dagster._utils.backcompat import ExperimentalWarning
 from dagster._utils.cached_method import cached_method
 
 
+class MappedPartitionsResult(NamedTuple):
+    """Represents the result of mapping a PartitionsSubset to the corresponding
+    partitions in another PartitionsDefinition.
+
+    partitions_subset (PartitionsSubset): The resulting partitions subset that was
+        mapped to. Only contains partitions for existent partitions, filtering out nonexistent partitions.
+    invalid_partitions_mapped_to (Sequence[str]): A list containing invalid partition keys in to_partitions_def
+        that partitions in from_partitions_subset were mapped to.
+    """
+
+    partitions_subset: PartitionsSubset
+    invalid_partitions_mapped_to: Sequence[str]
+
+
 class PartitionMapping(ABC):
     """Defines a correspondence between the partitions in an asset and the partitions in an asset
     that it depends on.
@@ -167,39 +181,32 @@ class PartitionMapping(ABC):
             )
         )
 
-    def downstream_partition_has_valid_upstream_partitions(
-        self,
-        downstream_partitions_def: PartitionsDefinition,
-        downstream_partition_key: str,
-        upstream_partitions_def: PartitionsDefinition,
-        current_time: Optional[datetime] = None,
-        dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
-    ) -> bool:
-        """Returns a bool representing whether the mapped upstream partition key exists for
-        the provided downstream partition key.
-        """
-        return True
-
-    def get_valid_upstream_partitions_for_partitions(
+    def get_upstream_mapped_partitions_result_for_partitions(
         self,
         downstream_partitions_subset: Optional[PartitionsSubset],
         upstream_partitions_def: PartitionsDefinition,
         current_time: Optional[datetime] = None,
         dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
-    ) -> PartitionsSubset:
-        """Returns the subset of partition keys in the upstream asset that are existent. The existent
-        partitions are not necessarily the full set of parent partitions that the downstream subset
-        depends on.
+    ) -> MappedPartitionsResult:
+        """Returns a MappedPartitionsResult object containing the partition keys the downstream
+        partitions subset was mapped to in the upstream partitions definition.
+
+        Valid upstream partitions will be included in MappedPartitionsResult.partitions_subset.
+        Invalid upstream partitions will be included in MappedPartitionsResult.invalid_partitions_mapped_to.
 
         For example, if an upstream asset is time-partitioned and starts in June 2023, and the
-        downstream asset is time-partitioned and starts in May 2023, this function would return
-        an empty subset when the downstream subset contains a May partition.
+        downstream asset is time-partitioned and starts in May 2023, this function would return a
+        MappedPartitionsResult(PartitionsSubset("2023-06-01"), invalid_partitions_mapped_to=["2023-05-01"])
+        when downstream_partitions_subset contains 2023-05-01 and 2023-06-01.
         """
-        return self.get_upstream_partitions_for_partitions(
-            downstream_partitions_subset,
-            upstream_partitions_def,
-            current_time,
-            dynamic_partitions_store,
+        return MappedPartitionsResult(
+            self.get_upstream_partitions_for_partitions(
+                downstream_partitions_subset,
+                upstream_partitions_def,
+                current_time,
+                dynamic_partitions_store,
+            ),
+            [],
         )
 
 

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
@@ -299,34 +299,29 @@ class TimeWindowPartitionMapping(
                 # If allowed to have nonexistent upstream partitions, do not consider
                 # out of range partitions to be invalid
                 continue
-            elif not (first_window and last_window) or (
-                time_window.start < first_window.start and time_window.end > last_window.end
-            ):
-                invalid_partitions_mapped_to.update(
-                    set(
-                        to_partitions_def.get_partition_keys_in_time_window(time_window=time_window)
+            else:
+                invalid_time_window = None
+                if not (first_window and last_window) or (
+                    time_window.start < first_window.start and time_window.end > last_window.end
+                ):
+                    invalid_time_window = time_window
+                elif time_window.start < first_window.start:
+                    invalid_time_window = TimeWindow(
+                        time_window.start, min(time_window.end, first_window.start)
                     )
-                )
-            elif time_window.start < first_window.start:
-                invalid_partitions_mapped_to.update(
-                    set(
-                        to_partitions_def.get_partition_keys_in_time_window(
-                            time_window=TimeWindow(
-                                time_window.start, min(time_window.end, first_window.start)
+                elif time_window.end > last_window.end:
+                    invalid_time_window = TimeWindow(
+                        max(time_window.start, last_window.end), time_window.end
+                    )
+
+                if invalid_time_window:
+                    invalid_partitions_mapped_to.update(
+                        set(
+                            to_partitions_def.get_partition_keys_in_time_window(
+                                time_window=invalid_time_window
                             )
                         )
                     )
-                )
-            elif time_window.end > last_window.end:
-                invalid_partitions_mapped_to.update(
-                    set(
-                        to_partitions_def.get_partition_keys_in_time_window(
-                            time_window=TimeWindow(
-                                max(time_window.start, last_window.end), time_window.end
-                            )
-                        )
-                    )
-                )
 
         if (
             filtered_time_windows != time_windows

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -571,7 +571,6 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
         *,
         asset_partition: AssetKeyPartitionKey,
         asset_graph: AssetGraph,
-        dynamic_partitions_store: DynamicPartitionsStore,
     ) -> bool:
         """Returns a boolean representing if the given `asset_partition` is currently reconciled.
         An asset (partition) is considered unreconciled if any of:
@@ -592,7 +591,9 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
         )
 
         for parent in asset_graph.get_valid_parent_partitions(
-            dynamic_partitions_store, self._evaluation_time, asset_partition
+            dynamic_partitions_store=self,
+            current_time=self._evaluation_time,
+            candidate=asset_partition,
         ):
             # when mapping from time or dynamic downstream to unpartitioned upstream, only check
             # for existence of upstream materialization, do not worry about timestamps
@@ -615,11 +616,7 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
                     continue
             elif self._materialization_of_a_exists_after_b(a=parent, b=asset_partition):
                 return False
-            elif not self.is_reconciled(
-                asset_partition=parent,
-                asset_graph=asset_graph,
-                dynamic_partitions_store=dynamic_partitions_store,
-            ):
+            elif not self.is_reconciled(asset_partition=parent, asset_graph=asset_graph):
                 return False
 
         return True

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -567,7 +567,11 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
 
     @cached_method
     def is_reconciled(
-        self, *, asset_partition: AssetKeyPartitionKey, asset_graph: AssetGraph
+        self,
+        *,
+        asset_partition: AssetKeyPartitionKey,
+        asset_graph: AssetGraph,
+        dynamic_partitions_store: DynamicPartitionsStore,
     ) -> bool:
         """Returns a boolean representing if the given `asset_partition` is currently reconciled.
         An asset (partition) is considered unreconciled if any of:
@@ -586,11 +590,9 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
             asset_graph.get_partitions_def(asset_partition.asset_key),
             (TimeWindowPartitionsDefinition, DynamicPartitionsDefinition),
         )
-        for parent in asset_graph.get_parents_partitions(
-            self,
-            self._evaluation_time,
-            asset_partition.asset_key,
-            asset_partition.partition_key,
+
+        for parent in asset_graph.get_valid_parent_partitions(
+            dynamic_partitions_store, self._evaluation_time, asset_partition
         ):
             # when mapping from time or dynamic downstream to unpartitioned upstream, only check
             # for existence of upstream materialization, do not worry about timestamps
@@ -613,7 +615,11 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
                     continue
             elif self._materialization_of_a_exists_after_b(a=parent, b=asset_partition):
                 return False
-            elif not self.is_reconciled(asset_partition=parent, asset_graph=asset_graph):
+            elif not self.is_reconciled(
+                asset_partition=parent,
+                asset_graph=asset_graph,
+                dynamic_partitions_store=dynamic_partitions_store,
+            ):
                 return False
 
         return True

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_time_window_partition_mapping.py
@@ -593,3 +593,45 @@ def test_daily_upstream_of_yearly():
         "2023-01-03",
         "2023-01-04",
     ]
+
+
+def test_downstream_partition_has_valid_upstream_partitions():
+    may_partitions_def = DailyPartitionsDefinition("2023-05-01")
+    june_partitions_def = DailyPartitionsDefinition("2023-06-01")
+
+    assert (
+        TimeWindowPartitionMapping().downstream_partition_has_valid_upstream_partitions(
+            downstream_partitions_def=may_partitions_def,
+            downstream_partition_key="2023-05-10",
+            upstream_partitions_def=june_partitions_def,
+        )
+        is False
+    )
+
+    assert (
+        TimeWindowPartitionMapping(
+            allow_nonexistent_upstream_partitions=True
+        ).downstream_partition_has_valid_upstream_partitions(
+            downstream_partitions_def=may_partitions_def,
+            downstream_partition_key="2023-05-10",
+            upstream_partitions_def=june_partitions_def,
+        )
+        is True
+    )
+
+    assert (
+        TimeWindowPartitionMapping()
+        .get_valid_upstream_partitions_for_partitions(
+            downstream_partitions_subset=subset_with_keys(may_partitions_def, ["2023-05-10"]),
+            upstream_partitions_def=june_partitions_def,
+        )
+        .get_partition_keys()
+        == []
+    )
+
+    assert TimeWindowPartitionMapping().get_valid_upstream_partitions_for_partitions(
+        downstream_partitions_subset=subset_with_keys(
+            may_partitions_def, ["2023-05-10", "2023-06-05"]
+        ),
+        upstream_partitions_def=june_partitions_def,
+    ).get_partition_keys() == ["2023-06-05"]

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/exotic_partition_mapping_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/exotic_partition_mapping_scenarios.py
@@ -17,6 +17,7 @@ from dagster._seven.compat.pendulum import create_pendulum_time
 from .asset_reconciliation_scenario import (
     AssetReconciliationScenario,
     asset_def,
+    run,
     run_request,
     single_asset_run,
 )
@@ -94,6 +95,42 @@ multipartitioned_self_dependency = [
             )
         },
     )
+]
+
+unpartitioned_downstream_of_asymmetric_time_assets_in_series = [
+    asset_def("asset1", partitions_def=DailyPartitionsDefinition("2023-01-05")),
+    asset_def("asset2", partitions_def=DailyPartitionsDefinition("2023-01-01"), deps=["asset1"]),
+    asset_def("unpartitioned", partitions_def=None, deps=["asset2"]),
+]
+
+upstream_starts_later_than_downstream = [
+    asset_def("asset1", partitions_def=HourlyPartitionsDefinition("2023-01-01-03:00")),
+    asset_def(
+        "asset2", partitions_def=HourlyPartitionsDefinition("2023-01-01-00:00"), deps=["asset1"]
+    ),
+]
+
+one_parent_starts_later_and_nonexistent_upstream_partitions_not_allowed = [
+    asset_def("asset1", partitions_def=HourlyPartitionsDefinition("2023-01-01-03:00")),
+    asset_def("asset2", partitions_def=HourlyPartitionsDefinition("2023-01-01-00:00")),
+    asset_def(
+        "asset3",
+        partitions_def=HourlyPartitionsDefinition("2023-01-01-00:00"),
+        deps=["asset1", "asset2"],
+    ),
+]
+
+one_parent_starts_later_and_nonexistent_upstream_partitions_allowed = [
+    asset_def("asset1", partitions_def=HourlyPartitionsDefinition("2023-01-01-03:00")),
+    asset_def("asset2", partitions_def=HourlyPartitionsDefinition("2023-01-01-00:00")),
+    asset_def(
+        "asset3",
+        partitions_def=HourlyPartitionsDefinition("2023-01-01-00:00"),
+        deps={
+            "asset1": TimeWindowPartitionMapping(allow_nonexistent_upstream_partitions=True),
+            "asset2": TimeWindowPartitionMapping(),
+        },
+    ),
 ]
 
 
@@ -262,5 +299,60 @@ exotic_partition_mapping_scenarios = {
             )
         ],
         current_time=create_pendulum_time(year=2020, month=1, day=3, hour=4),
+    ),
+    "unpartitioned_downstream_of_asymmetric_time_assets_in_series": AssetReconciliationScenario(
+        assets=unpartitioned_downstream_of_asymmetric_time_assets_in_series,
+        unevaluated_runs=[
+            run(["asset1"], partition_key)
+            for partition_key in [f"2023-01-0{str(x)}" for x in range(5, 9)]
+        ]
+        + [
+            run(["asset2"], partition_key)
+            for partition_key in [f"2023-01-0{str(x)}" for x in range(1, 9)]
+        ],
+        current_time=create_pendulum_time(2023, 1, 9, 0),
+        expected_run_requests=[run_request(asset_keys=["unpartitioned"])],
+    ),
+    "upstream_starts_later_than_downstream": AssetReconciliationScenario(
+        assets=upstream_starts_later_than_downstream,
+        unevaluated_runs=[
+            single_asset_run("asset1", "2023-01-01-03:00"),
+            single_asset_run("asset1", "2023-01-01-04:00"),
+        ],
+        cursor_from=AssetReconciliationScenario(
+            assets=upstream_starts_later_than_downstream,
+            unevaluated_runs=[],
+        ),
+        current_time=create_pendulum_time(2023, 1, 1, 5),
+        expected_run_requests=[
+            run_request(asset_keys=["asset2"], partition_key="2023-01-01-03:00"),
+            run_request(asset_keys=["asset2"], partition_key="2023-01-01-04:00"),
+        ],
+    ),
+    "one_parent_starts_later_and_nonexistent_upstream_partitions_allowed": AssetReconciliationScenario(
+        assets=one_parent_starts_later_and_nonexistent_upstream_partitions_allowed,
+        unevaluated_runs=[
+            single_asset_run("asset1", "2023-01-01-03:00"),
+            single_asset_run("asset1", "2023-01-01-04:00"),
+        ]
+        + [single_asset_run("asset2", f"2023-01-01-0{x}:00") for x in range(0, 5)],
+        current_time=create_pendulum_time(2023, 1, 1, 5),
+        expected_run_requests=[
+            run_request(asset_keys=["asset3"], partition_key=f"2023-01-01-0{x}:00")
+            for x in range(0, 5)
+        ],
+    ),
+    "one_parent_starts_later_and_nonexistent_upstream_partitions_not_allowed": AssetReconciliationScenario(
+        assets=one_parent_starts_later_and_nonexistent_upstream_partitions_not_allowed,
+        unevaluated_runs=[
+            single_asset_run("asset1", "2023-01-01-03:00"),
+            single_asset_run("asset1", "2023-01-01-04:00"),
+        ]
+        + [single_asset_run("asset2", f"2023-01-01-0{x}:00") for x in range(0, 5)],
+        current_time=create_pendulum_time(2023, 1, 1, 5),
+        expected_run_requests=[
+            run_request(asset_keys=["asset3"], partition_key="2023-01-01-03:00"),
+            run_request(asset_keys=["asset3"], partition_key="2023-01-01-04:00"),
+        ],
     ),
 }


### PR DESCRIPTION
Background here: https://www.notion.so/dagster/Handle-invalid-parents-in-auto-materialize-5fe6dbdfba0f43a6beae88fb61ccc07d?pvs=4

This PR builds upon https://github.com/dagster-io/dagster/pull/14449 and introduces graceful handling for auto-materialize cases where an invalid parent exists. Errors are currently raised in `PartitionMapping.get_upstream_partitions_for_partitions` when mapped upstream partitions were nonexistent. It is good that an error occurs when launching backfills and runs in these cases, but undesirable for the error to occur in auto-materialization. This PR introduces logic to gracefully handle invalid parents without erroring in auto-materialize.

**Modifies the auto-materialize logic:**
- Only considers partitions that can be materialized. If a partition has invalid upstreams, it should not be possible to auto-materialize it.
- Modifies `is_reconciled` to recursively check only valid upstream partitions. If all of a partition's parents are invalid, then returns `True` if the partition is materialized, `False` if not. This enables reconciling downstream assets.

**Adds new methods to `PartitionMapping`:**
- `downstream_partition_has_valid_upstream_partitions`: Users should be able to define on the partition mapping whether some dependency relationship is allowed or not. This method enables gracefully checking if a particular partition has valid parents (rather than raising an error within `get_upstream_partitions_for_partitions`) 
- `get_valid_upstream_partitions_for_partitions`:  a particular partition can have multiple upstream assets, each of which can contain valid or invalid mapped partitions. In our reconciliation checks, we want to still check that the valid upstream parents are reconciled, and skip checking the invalid upstream parents. This necessitates defining a function that filters for valid parents.
