### PR TITLE
Use typing.get_type_hints for input/output and resource/config type inference

### DIFF
--- a/python_modules/dagster/dagster/_core/decorator_utils.py
+++ b/python_modules/dagster/dagster/_core/decorator_utils.py
@@ -1,8 +1,23 @@
+import functools
 import textwrap
 from inspect import Parameter, signature
-from typing import Any, Callable, Optional, Sequence, Set, TypeVar, Union
+from typing import (
+    Any,
+    Callable,
+    Mapping,
+    Optional,
+    Sequence,
+    Set,
+    TypeVar,
+    Union,
+)
 
-from typing_extensions import Concatenate, ParamSpec, TypeGuard
+from typing_extensions import (
+    Concatenate,
+    ParamSpec,
+    TypeGuard,
+    get_type_hints as typing_get_type_hints,
+)
 
 R = TypeVar("R")
 T = TypeVar("T")
@@ -34,6 +49,11 @@ def _is_param_valid(param: Parameter, expected_positional: str) -> bool:
 
 def get_function_params(fn: Callable[..., Any]) -> Sequence[Parameter]:
     return list(signature(fn).parameters.values())
+
+
+def get_type_hints(fn: Callable) -> Mapping[str, Any]:
+    target = fn.func if isinstance(fn, functools.partial) else fn
+    return typing_get_type_hints(target, include_extras=True)
 
 
 def validate_expected_params(

--- a/python_modules/dagster/dagster/_core/definitions/decorators/sensor_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/sensor_decorator.py
@@ -187,7 +187,7 @@ def asset_sensor(
 
         # Preserve any resource arguments from the underlying function, for when we inspect the
         # wrapped function later on
-        _wrapped_fn.__signature__ = inspect.signature(fn)
+        _wrapped_fn = update_wrapper(_wrapped_fn, wrapped=fn)
 
         return AssetSensorDefinition(
             name=sensor_name,

--- a/python_modules/dagster/dagster/_core/definitions/resource_annotation.py
+++ b/python_modules/dagster/dagster/_core/definitions/resource_annotation.py
@@ -1,26 +1,31 @@
 from inspect import Parameter
-from typing import Sequence, TypeVar
+from typing import Any, Optional, Sequence, Type, TypeVar
 
 from typing_extensions import Annotated
 
-from dagster._core.decorator_utils import get_function_params
+from dagster._core.decorator_utils import get_function_params, get_type_hints
 from dagster._core.definitions.resource_definition import ResourceDefinition
 
 
 def get_resource_args(fn) -> Sequence[Parameter]:
-    return [param for param in get_function_params(fn) if _is_resource_annotated(param)]
+    type_annotations = get_type_hints(fn)
+    return [
+        param
+        for param in get_function_params(fn)
+        if _is_resource_annotation(type_annotations.get(param.name))
+    ]
 
 
 RESOURCE_PARAM_METADATA = "resource_param"
 
 
-def _is_resource_annotated(param: Parameter) -> bool:
+def _is_resource_annotation(annotation: Optional[Type[Any]]) -> bool:
     from dagster._config.pythonic_config import ConfigurableResourceFactory
 
     extends_resource_definition = False
     try:
-        extends_resource_definition = isinstance(param.annotation, type) and issubclass(
-            param.annotation, (ResourceDefinition, ConfigurableResourceFactory)
+        extends_resource_definition = isinstance(annotation, type) and issubclass(
+            annotation, (ResourceDefinition, ConfigurableResourceFactory)
         )
     except TypeError:
         # Using builtin Python types in python 3.9+ will raise a TypeError when using issubclass
@@ -29,8 +34,8 @@ def _is_resource_annotated(param: Parameter) -> bool:
         pass
 
     return (extends_resource_definition) or (
-        hasattr(param.annotation, "__metadata__")
-        and getattr(param.annotation, "__metadata__") == (RESOURCE_PARAM_METADATA,)
+        hasattr(annotation, "__metadata__")
+        and getattr(annotation, "__metadata__") == (RESOURCE_PARAM_METADATA,)
     )
 
 

--- a/python_modules/dagster/dagster/_core/definitions/source_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/source_asset.py
@@ -1,8 +1,5 @@
-from __future__ import annotations
-
 import warnings
 from typing import (
-    TYPE_CHECKING,
     AbstractSet,
     Any,
     Callable,
@@ -53,12 +50,6 @@ from dagster._core.errors import (
 from dagster._core.storage.io_manager import IOManagerDefinition
 from dagster._utils.backcompat import ExperimentalWarning, experimental_arg_warning
 from dagster._utils.merger import merge_dicts
-
-if TYPE_CHECKING:
-    from dagster._core.execution.context.compute import (
-        OpExecutionContext,
-    )
-
 
 # Going with this catch-all for the time-being to permit pythonic resources
 SourceAssetObserveFunction: TypeAlias = Callable[..., Any]
@@ -192,6 +183,9 @@ class SourceAsset(ResourceAddable):
         from dagster._core.definitions.decorators.op_decorator import (
             DecoratedOpFunction,
             is_context_provided,
+        )
+        from dagster._core.execution.context.compute import (
+            OpExecutionContext,
         )
 
         observe_fn_has_context = is_context_provided(get_function_params(observe_fn))

--- a/python_modules/dagster/dagster_tests/general_tests/py3_tests/test_inference.py
+++ b/python_modules/dagster/dagster_tests/general_tests/py3_tests/test_inference.py
@@ -111,6 +111,20 @@ def test_single_typed_input_and_output_lambda():
     assert add_one.output_defs[0].dagster_type.unique_name == "Int"
 
 
+def test_string_typed_input_and_output():
+    @op
+    def add_one(_context, num: "Optional[int]") -> "int":
+        return num + 1 if num else 1
+
+    assert add_one
+    assert len(add_one.input_defs) == 1
+    assert add_one.input_defs[0].name == "num"
+    assert add_one.input_defs[0].dagster_type.display_name == "Int?"
+
+    assert len(add_one.output_defs) == 1
+    assert add_one.output_defs[0].dagster_type.unique_name == "Int"
+
+
 def test_wrapped_input_and_output_lambda():
     @op
     def add_one(nums: List[int]) -> Optional[List[int]]:

--- a/python_modules/dagster/dagster_tests/general_tests/py3_tests/test_inference.py
+++ b/python_modules/dagster/dagster_tests/general_tests/py3_tests/test_inference.py
@@ -125,6 +125,23 @@ def test_string_typed_input_and_output():
     assert add_one.output_defs[0].dagster_type.unique_name == "Int"
 
 
+def _make_foo():
+    class Foo:
+        pass
+
+    def foo(x: "Foo") -> "Foo":
+        return x
+
+    return foo
+
+
+def test_invalid_string_typed_input():
+    with pytest.raises(
+        DagsterInvalidDefinitionError, match='Failed to resolve type annotation "Foo"'
+    ):
+        op(_make_foo())
+
+
 def test_wrapped_input_and_output_lambda():
     @op
     def add_one(nums: List[int]) -> Optional[List[int]]:


### PR DESCRIPTION
## Summary & Motivation

Fixes #14571 

Currently, `Parameter.annotation` is used when inferring the dagster type from an op compute function signature. This causes an error if either: (a) a string is used directly by the user for the parameter annotation; (b) `from __future__ import annotations` is used. This is because both cases cause the value of `Parameter.annotation` to be a string, and our dagster type resolution logic does not handle strings.

This PR replaces direct access to `Parameter.annotation` with `typing.get_type_hints`, which handles evaluation of a string annotation into an actual class which can be handled by our dagster type resolution logic. Note that this only works if the referents of a string annotation is module-level scope-- it will fail for a local scope.

Still this is an upgrade and will fix the problem in most cases. It will:

- Allows users to use string annotations or `from __future__ import annotations` together with dagster type signature inference
- Allows us to use `from __future__ import annotations` in our own code, which is necessary to allow Ruff to auto-sort typing-only imports-- see https://github.com/dagster-io/dagster/pull/14675. Not clear whether this is a good idea.

## How I Tested These Changes

New unit test using string annotations.
