### PR TITLE
remove bucket queries for run storage

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
@@ -17,8 +17,7 @@ from dagster._core.host_representation.external_data import (
     ExternalAssetNode,
 )
 from dagster._core.scheduler.instigation import InstigatorState, InstigatorType
-from dagster._core.storage.dagster_run import JobBucket, RunRecord, RunsFilter, TagBucket
-from dagster._core.storage.tags import REPOSITORY_LABEL_TAG, SCHEDULE_NAME_TAG, SENSOR_NAME_TAG
+from dagster._core.storage.dagster_run import RunRecord, RunsFilter
 from dagster._core.workspace.context import WorkspaceRequestContext
 
 
@@ -67,121 +66,7 @@ class RepositoryScopedBatchLoader:
 
         fetched: Dict[str, List[Any]] = defaultdict(list)
 
-        if data_type == RepositoryDataType.JOB_RUNS:
-            job_names = [x.name for x in self._repository.get_all_external_jobs()]
-            if self._instance.supports_bucket_queries and len(job_names) > 1:
-                records = self._instance.get_run_records(
-                    filters=RunsFilter(
-                        tags={
-                            REPOSITORY_LABEL_TAG: (
-                                self._repository.get_external_origin().get_label()
-                            ),
-                        },
-                    ),
-                    bucket_by=JobBucket(bucket_limit=limit, job_names=job_names),
-                )
-            else:
-                records = []
-                for job_name in job_names:
-                    records.extend(
-                        list(
-                            self._instance.get_run_records(
-                                filters=RunsFilter(
-                                    job_name=job_name,
-                                    tags={
-                                        REPOSITORY_LABEL_TAG: (
-                                            self._repository.get_external_origin().get_label()
-                                        ),
-                                    },
-                                ),
-                                limit=limit,
-                            )
-                        )
-                    )
-            for record in records:
-                fetched[record.dagster_run.job_name].append(record)
-
-        elif data_type == RepositoryDataType.SCHEDULE_RUNS:
-            schedule_names = [
-                schedule.name for schedule in self._repository.get_external_schedules()
-            ]
-            if self._instance.supports_bucket_queries and len(schedule_names) > 1:
-                records = self._instance.get_run_records(
-                    filters=RunsFilter(
-                        tags={
-                            REPOSITORY_LABEL_TAG: (
-                                self._repository.get_external_origin().get_label()
-                            ),
-                        }
-                    ),
-                    bucket_by=TagBucket(
-                        tag_key=SCHEDULE_NAME_TAG,
-                        bucket_limit=limit,
-                        tag_values=schedule_names,
-                    ),
-                )
-            else:
-                records = []
-                for schedule_name in schedule_names:
-                    records.extend(
-                        list(
-                            self._instance.get_run_records(
-                                filters=RunsFilter(
-                                    tags={
-                                        SCHEDULE_NAME_TAG: schedule_name,
-                                        REPOSITORY_LABEL_TAG: (
-                                            self._repository.get_external_origin().get_label()
-                                        ),
-                                    }
-                                ),
-                                limit=limit,
-                            )
-                        )
-                    )
-            for record in records:
-                tag: str = check.not_none(record.dagster_run.tags.get(SCHEDULE_NAME_TAG))
-                fetched[tag].append(record)
-
-        elif data_type == RepositoryDataType.SENSOR_RUNS:
-            sensor_names = [sensor.name for sensor in self._repository.get_external_sensors()]
-            if self._instance.supports_bucket_queries and len(sensor_names) > 1:
-                records = self._instance.get_run_records(
-                    filters=RunsFilter(
-                        tags={
-                            REPOSITORY_LABEL_TAG: (
-                                self._repository.get_external_origin().get_label()
-                            ),
-                        }
-                    ),
-                    bucket_by=TagBucket(
-                        tag_key=SENSOR_NAME_TAG,
-                        bucket_limit=limit,
-                        tag_values=sensor_names,
-                    ),
-                )
-            else:
-                records = []
-                for sensor_name in sensor_names:
-                    records.extend(
-                        list(
-                            self._instance.get_run_records(
-                                filters=RunsFilter(
-                                    tags={
-                                        SENSOR_NAME_TAG: sensor_name,
-                                        REPOSITORY_LABEL_TAG: (
-                                            self._repository.get_external_origin().get_label()
-                                        ),
-                                    }
-                                ),
-                                limit=limit,
-                            )
-                        )
-                    )
-            for record in records:
-                tag = check.not_none(record.dagster_run.tags.get(SENSOR_NAME_TAG))
-                fetched[tag].append(record)
-
-        elif data_type == RepositoryDataType.SCHEDULE_STATES:
+        if data_type == RepositoryDataType.SCHEDULE_STATES:
             schedule_states = self._instance.all_instigator_state(
                 repository_origin_id=self._repository.get_external_origin_id(),
                 repository_selector_id=self._repository.selector_id,
@@ -238,18 +123,6 @@ class RepositoryScopedBatchLoader:
 
         self._data[data_type] = fetched
         self._limits[data_type] = limit
-
-    def get_run_records_for_job(self, job_name: str, limit: int) -> Sequence[Any]:
-        check.invariant(self._repository.has_external_job(job_name))
-        return self._get(RepositoryDataType.JOB_RUNS, job_name, limit)
-
-    def get_run_records_for_schedule(self, schedule_name: str, limit: int) -> Sequence[Any]:
-        check.invariant(self._repository.has_external_schedule(schedule_name))
-        return self._get(RepositoryDataType.SCHEDULE_RUNS, schedule_name, limit)
-
-    def get_run_records_for_sensor(self, sensor_name: str, limit: int) -> Sequence[Any]:
-        check.invariant(self._repository.has_external_sensor(sensor_name))
-        return self._get(RepositoryDataType.SENSOR_RUNS, sensor_name, limit)
 
     def get_schedule_state(self, schedule_name: str) -> Optional[InstigatorState]:
         check.invariant(self._repository.has_external_schedule(schedule_name))

--- a/python_modules/dagster-graphql/dagster_graphql/schema/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/external.py
@@ -288,7 +288,7 @@ class GrapheneRepository(graphene.ObjectType):
 
     def resolve_pipelines(self, _graphene_info: ResolveInfo):
         return [
-            GraphenePipeline(pipeline, self._batch_loader)
+            GraphenePipeline(pipeline)
             for pipeline in sorted(
                 self._repository.get_all_external_jobs(), key=lambda pipeline: pipeline.name
             )
@@ -296,7 +296,7 @@ class GrapheneRepository(graphene.ObjectType):
 
     def resolve_jobs(self, _graphene_info: ResolveInfo):
         return [
-            GrapheneJob(pipeline, self._batch_loader)
+            GrapheneJob(pipeline)
             for pipeline in sorted(
                 self._repository.get_all_external_jobs(), key=lambda pipeline: pipeline.name
             )

--- a/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
@@ -587,16 +587,6 @@ class GrapheneInstigationState(graphene.ObjectType):
     def resolve_runs(self, graphene_info: ResolveInfo, limit: Optional[int] = None):
         from .pipelines.pipeline import GrapheneRun
 
-        if limit and self._batch_loader:
-            records = (
-                self._batch_loader.get_run_records_for_sensor(self._instigator_state.name, limit)
-                if self._instigator_state.instigator_type == InstigatorType.SENSOR
-                else self._batch_loader.get_run_records_for_schedule(
-                    self._instigator_state.name, limit
-                )
-            )
-            return [GrapheneRun(record) for record in records]
-
         repository_label = self._instigator_state.origin.external_repository_origin.get_label()
         if self._instigator_state.instigator_type == InstigatorType.SENSOR:
             filters = RunsFilter(

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -27,7 +27,7 @@ from ...implementation.fetch_pipelines import get_job_reference_or_raise
 from ...implementation.fetch_runs import get_runs, get_stats, get_step_stats
 from ...implementation.fetch_schedules import get_schedules_for_pipeline
 from ...implementation.fetch_sensors import get_sensors_for_pipeline
-from ...implementation.loader import BatchRunLoader, RepositoryScopedBatchLoader
+from ...implementation.loader import BatchRunLoader
 from ...implementation.utils import UserFacingGraphQLError, capture_error
 from ..asset_key import GrapheneAssetKey
 from ..dagster_types import (
@@ -864,16 +864,9 @@ class GraphenePipeline(GrapheneIPipelineSnapshotMixin, graphene.ObjectType):
         interfaces = (GrapheneSolidContainer, GrapheneIPipelineSnapshot)
         name = "Pipeline"
 
-    def __init__(
-        self, external_job: ExternalJob, batch_loader: Optional[RepositoryScopedBatchLoader] = None
-    ):
+    def __init__(self, external_job: ExternalJob):
         super().__init__()
         self._external_job = check.inst_param(external_job, "external_job", ExternalJob)
-        # optional run loader, provided by a parent GrapheneRepository object that instantiates
-        # multiple pipelines
-        self._batch_loader = check.opt_inst_param(
-            batch_loader, "batch_loader", RepositoryScopedBatchLoader
-        )
 
     def resolve_id(self, _graphene_info: ResolveInfo):
         return self._external_job.get_external_origin_id()
@@ -907,17 +900,6 @@ class GraphenePipeline(GrapheneIPipelineSnapshotMixin, graphene.ObjectType):
             location,
         )
 
-    def resolve_runs(
-        self, graphene_info: ResolveInfo, cursor: Optional[str] = None, limit: Optional[int] = None
-    ) -> Sequence[GrapheneRun]:
-        # override the implementation to use the batch run loader
-        if not cursor and limit and self._batch_loader:
-            records = self._batch_loader.get_run_records_for_job(self._external_job.name, limit)
-            return [GrapheneRun(record) for record in records]
-
-        # otherwise, fall back to the default implementation
-        return super().resolve_runs(graphene_info, cursor=cursor, limit=limit)
-
 
 class GrapheneJob(GraphenePipeline):
     class Meta:
@@ -925,14 +907,9 @@ class GrapheneJob(GraphenePipeline):
         name = "Job"
 
     # doesn't inherit from base class
-    def __init__(self, external_job, batch_loader=None):
+    def __init__(self, external_job):
         super().__init__()
         self._external_job = check.inst_param(external_job, "external_job", ExternalJob)
-        # optional run loader, provided by a parent GrapheneRepository object that instantiates
-        # multiple pipelines
-        self._batch_loader = check.opt_inst_param(
-            batch_loader, "batch_loader", RepositoryScopedBatchLoader
-        )
 
 
 class GrapheneGraph(graphene.ObjectType):

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_scheduler.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_scheduler.py
@@ -800,7 +800,7 @@ def test_future_ticks_until(graphql_context):
 
 def test_repository_batching(graphql_context):
     instance = graphql_context.instance
-    if not instance.supports_batch_tick_queries or not instance.supports_bucket_queries:
+    if not instance.supports_batch_tick_queries:
         pytest.skip("storage cannot batch fetch")
 
     traced_counter.set(Counter())
@@ -818,14 +818,12 @@ def test_repository_batching(graphql_context):
     assert counts
     assert len(counts) == 3
 
-    # We should have a single batch call to fetch run records (to fetch schedule runs) and a single
-    # batch call to fetch instigator state, instead of separate calls for each schedule (~18
-    # distinct schedules in the repo)
-    # 1) `get_run_records` is fetched to instantiate GrapheneRun
+    # We should have a single batch call to fetch instigator state, instead of separate calls for
+    # each schedule (~18 distinct schedules in the repo)
+    # 1) `get_batch_ticks` is fetched to grab ticks
     # 2) `all_instigator_state` is fetched to instantiate GrapheneSchedule
-    assert counts.get("DagsterInstance.get_run_records") == 1
-    assert counts.get("DagsterInstance.all_instigator_state") == 1
     assert counts.get("DagsterInstance.get_batch_ticks") == 1
+    assert counts.get("DagsterInstance.all_instigator_state") == 1
 
 
 def test_start_schedule_with_default_status(graphql_context):

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
@@ -975,7 +975,7 @@ def test_sensor_tick_range(graphql_context: WorkspaceRequestContext):
 
 def test_repository_batching(graphql_context: WorkspaceRequestContext):
     instance = graphql_context.instance
-    if not instance.supports_batch_tick_queries or not instance.supports_bucket_queries:
+    if not instance.supports_batch_tick_queries:
         pytest.skip("storage cannot batch fetch")
 
     traced_counter.set(Counter())
@@ -993,14 +993,12 @@ def test_repository_batching(graphql_context: WorkspaceRequestContext):
     assert counts
     assert len(counts) == 3
 
-    # We should have a single batch call to fetch run records (to fetch sensor runs) and a single
-    # batch call to fetch instigator state, instead of separate calls for each sensor (~5 distinct
-    # sensors in the repo)
-    # 1) `get_run_records` is fetched to instantiate GrapheneRun
+    # We should have a single batch call to fetch instigator state, instead of separate calls for
+    # each sensor (~5 distinct sensors in the repo)
+    # 1) `get_batch_ticks` is called to fetch all the ticks for the sensors
     # 2) `all_instigator_state` is fetched to instantiate GrapheneSensor
-    assert counts.get("DagsterInstance.get_run_records") == 1
-    assert counts.get("DagsterInstance.all_instigator_state") == 1
     assert counts.get("DagsterInstance.get_batch_ticks") == 1
+    assert counts.get("DagsterInstance.all_instigator_state") == 1
 
 
 def test_sensor_ticks_filtered(graphql_context: WorkspaceRequestContext):

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -1693,10 +1693,6 @@ class DagsterInstance(DynamicPartitionsStore):
             filters, limit, order_by, ascending, cursor, bucket_by
         )
 
-    @property
-    def supports_bucket_queries(self) -> bool:
-        return self._run_storage.supports_bucket_queries
-
     @traced
     def get_run_partition_data(self, runs_filter: RunsFilter) -> Sequence[RunPartitionData]:
         """Get run partition data for a given partitioned job."""

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -287,10 +287,6 @@ class LegacyRunStorage(RunStorage, ConfigurableClass):
     def delete_run(self, run_id: str) -> None:
         return self._storage.run_storage.delete_run(run_id)
 
-    @property
-    def supports_bucket_queries(self) -> bool:
-        return self._storage.run_storage.supports_bucket_queries
-
     def migrate(self, print_fn: Optional[PrintFn] = None, force_rebuild_all: bool = False) -> None:
         return self._storage.run_storage.migrate(print_fn, force_rebuild_all)
 

--- a/python_modules/dagster/dagster/_core/storage/runs/base.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/base.py
@@ -336,7 +336,7 @@ class RunStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance], DaemonCursorSto
 
     @property
     def supports_bucket_queries(self) -> bool:
-        return True
+        return False
 
     @abstractmethod
     def get_run_partition_data(self, runs_filter: RunsFilter) -> Sequence[RunPartitionData]:

--- a/python_modules/dagster/dagster/_core/storage/runs/sqlite/sqlite_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sqlite/sqlite_run_storage.py
@@ -22,7 +22,7 @@ from dagster._core.storage.sql import (
     run_alembic_upgrade,
     stamp_alembic_rev,
 )
-from dagster._core.storage.sqlite import create_db_conn_string, get_sqlite_version
+from dagster._core.storage.sqlite import create_db_conn_string
 from dagster._serdes import ConfigurableClass, ConfigurableClassData
 from dagster._utils import mkdir_p
 
@@ -122,21 +122,6 @@ class SqliteRunStorage(SqlRunStorage, ConfigurableClass):
         alembic_config = get_alembic_config(__file__)
         with self.connect() as conn:
             run_alembic_downgrade(alembic_config, conn, rev=rev)
-
-    @property
-    def supports_bucket_queries(self) -> bool:
-        parts = get_sqlite_version().split(".")
-        try:
-            for i in range(min(len(parts), len(MINIMUM_SQLITE_BUCKET_VERSION))):
-                curr = int(parts[i])
-                if curr < MINIMUM_SQLITE_BUCKET_VERSION[i]:
-                    return False
-                if curr > MINIMUM_SQLITE_BUCKET_VERSION[i]:
-                    return True
-        except ValueError:
-            return False
-
-        return False
 
     def upgrade(self) -> None:
         self._check_for_version_066_migration_and_perform()

--- a/python_modules/dagster/dagster_tests/storage_tests/test_daemon_cursor_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_daemon_cursor_storage.py
@@ -3,7 +3,6 @@ import pytest
 from .test_run_storage import (
     create_in_memory_storage,
     create_legacy_run_storage,
-    create_non_bucket_sqlite_run_storage,
     create_sqlite_run_storage,
 )
 from .utils.daemon_cursor_storage import TestDaemonCursorStorage
@@ -17,7 +16,6 @@ class TestDaemonCursorStorages(TestDaemonCursorStorage):
         params=[
             create_in_memory_storage,
             create_sqlite_run_storage,
-            create_non_bucket_sqlite_run_storage,
             create_legacy_run_storage,
         ],
     )

--- a/python_modules/dagster/dagster_tests/storage_tests/test_run_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_run_storage.py
@@ -1,14 +1,10 @@
 import tempfile
 from contextlib import contextmanager
-from typing import Any, Mapping
 
-import mock
 import pytest
 from dagster._core.storage.legacy_storage import LegacyRunStorage
 from dagster._core.storage.runs import InMemoryRunStorage, SqliteRunStorage
 from dagster._core.storage.sqlite_storage import DagsterSqliteStorage
-from dagster._serdes.config_class import ConfigurableClassData
-from typing_extensions import Self
 
 from dagster_tests.storage_tests.utils.run_storage import TestRunStorage
 
@@ -17,24 +13,6 @@ from dagster_tests.storage_tests.utils.run_storage import TestRunStorage
 def create_sqlite_run_storage():
     with tempfile.TemporaryDirectory() as tempdir:
         yield SqliteRunStorage.from_local(tempdir)
-
-
-@contextmanager
-def create_non_bucket_sqlite_run_storage():
-    with tempfile.TemporaryDirectory() as tempdir:
-        yield NonBucketQuerySqliteRunStorage.from_local(tempdir)
-
-
-class NonBucketQuerySqliteRunStorage(SqliteRunStorage):
-    @property
-    def supports_bucket_queries(self):
-        return False
-
-    @classmethod
-    def from_config_value(
-        cls, inst_data: ConfigurableClassData, config_value: Mapping[str, Any]
-    ) -> Self:
-        return NonBucketQuerySqliteRunStorage.from_local(inst_data=inst_data, **config_value)
 
 
 @contextmanager
@@ -63,34 +41,6 @@ class TestSqliteImplementation(TestRunStorage):
     __test__ = True
 
     @pytest.fixture(name="storage", params=[create_sqlite_run_storage])
-    def run_storage(self, request):
-        with request.param() as s:
-            yield s
-
-    def test_bucket_gating(self, storage):
-        with mock.patch(
-            "dagster._core.storage.runs.sqlite.sqlite_run_storage.get_sqlite_version",
-            return_value="3.7.17",
-        ):
-            assert not storage.supports_bucket_queries
-
-        with mock.patch(
-            "dagster._core.storage.runs.sqlite.sqlite_run_storage.get_sqlite_version",
-            return_value="3.25.1",
-        ):
-            assert storage.supports_bucket_queries
-
-        with mock.patch(
-            "dagster._core.storage.runs.sqlite.sqlite_run_storage.get_sqlite_version",
-            return_value="3.25.19",
-        ):
-            assert storage.supports_bucket_queries
-
-
-class TestNonBucketQuerySqliteImplementation(TestRunStorage):
-    __test__ = True
-
-    @pytest.fixture(name="storage", params=[create_non_bucket_sqlite_run_storage])
     def run_storage(self, request):
         with request.param() as s:
             yield s

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/run_storage/run_storage.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/run_storage/run_storage.py
@@ -159,18 +159,6 @@ class MySQLRunStorage(SqlRunStorage, ConfigurableClass):
             del self._index_migration_cache[migration_name]
 
     @property
-    def supports_bucket_queries(self) -> bool:
-        if not super().supports_bucket_queries:
-            return False
-
-        if not self._mysql_version:
-            return False
-
-        return parse_mysql_version(self._mysql_version) >= parse_mysql_version(
-            MINIMUM_MYSQL_BUCKET_VERSION
-        )
-
-    @property
     def supports_intersect(self) -> bool:
         return parse_mysql_version(self._mysql_version) >= parse_mysql_version(  # type: ignore
             MINIMUM_MYSQL_INTERSECT_VERSION

--- a/python_modules/libraries/dagster-mysql/dagster_mysql_tests/test_run_storage.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql_tests/test_run_storage.py
@@ -4,7 +4,6 @@ import pytest
 import yaml
 from dagster._core.test_utils import environ, instance_for_test
 from dagster_mysql.run_storage import MySQLRunStorage
-from dagster_mysql.utils import parse_mysql_version
 from dagster_tests.storage_tests.utils.run_storage import TestRunStorage
 
 TestRunStorage.__test__ = False
@@ -81,23 +80,3 @@ class TestMySQLRunStorage(TestRunStorage):
                         from_url_instance._run_storage.mysql_url  # noqa: SLF001
                         == from_env_instance._run_storage.mysql_url  # noqa: SLF001
                     )
-
-
-def test_mysql_version(conn_string):
-    class FakeNonBucketing(MySQLRunStorage):
-        def get_server_version(self):
-            # override the server version to make sure the parsing works
-            return "5.7.38-log"
-
-    storage = FakeNonBucketing(conn_string)
-    assert parse_mysql_version("5.7.38-log") == (5, 7, 38)
-    assert not storage.supports_bucket_queries
-
-    class FakeBucketing(MySQLRunStorage):
-        def get_server_version(self):
-            # override the server version to make sure the parsing works
-            return "8.0.31-google"
-
-    storage = FakeBucketing(conn_string)
-    assert parse_mysql_version("8.0.31-google") == (8, 0, 31)
-    assert storage.supports_bucket_queries


### PR DESCRIPTION
## Summary & Motivation
Once we started virtualizing the tables for repository objects (runs, schedules, sensors), we haven't really used the bucket run queries at all.  This removes a bunch of complexity and versioning logic from the run storage layer.

## How I Tested These Changes
Tested this by first raising an Exception in the repository batch loader for run queries, and loaded instance/repo level pages in dagit.

Then grepped through and first removed dead calls to the graphene resolvers, then to the bucket args themselves.
