### PR TITLE
[fix] Fix issue when recreating Sensors with resource reqs

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -494,7 +494,7 @@ class SensorDefinition(IHasInternalInit):
             job=new_jobs[0] if len(new_jobs) == 1 else None,
             default_status=self.default_status,
             asset_selection=self.asset_selection,
-            required_resource_keys=self.required_resource_keys,
+            required_resource_keys=self._raw_required_resource_keys,
         )
 
     def with_updated_job(self, new_job: ExecutableDefinition) -> "SensorDefinition":
@@ -596,10 +596,10 @@ class SensorDefinition(IHasInternalInit):
                 " the decorated function"
             ),
         )
-        self._required_resource_keys = (
-            check.opt_set_param(required_resource_keys, "required_resource_keys", of_type=str)
-            or resource_arg_names
+        self._raw_required_resource_keys = check.opt_set_param(
+            required_resource_keys, "required_resource_keys", of_type=str
         )
+        self._required_resource_keys = self._raw_required_resource_keys or resource_arg_names
 
     @staticmethod
     def dagster_internal_init(

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
@@ -206,6 +206,26 @@ def test_sensor_invocation_resources_direct() -> None:
     ).run_config == {"foo": "foo"}
 
 
+def test_recreating_sensor_with_resource_arg() -> None:
+    class MyResource(ConfigurableResource):
+        a_str: str
+
+    @sensor(job_name="foo_job")
+    def basic_sensor_with_context_resource_req(my_resource: MyResource, context):
+        return RunRequest(run_key=None, run_config={"foo": my_resource.a_str}, tags={})
+
+    @job
+    def junk_job():
+        pass
+
+    updated_sensor = basic_sensor_with_context_resource_req.with_updated_job(junk_job)
+
+    assert cast(
+        RunRequest,
+        updated_sensor(build_sensor_context(), my_resource=MyResource(a_str="foo")),
+    ).run_config == {"foo": "foo"}
+
+
 def test_sensor_invocation_resources_direct_many() -> None:
     class MyResource(ConfigurableResource):
         a_str: str


### PR DESCRIPTION
## Summary

Fixes an issue that rolled out in the last update which occurs when:

- A user annotates a sensor function with a resource
- An updated job is bound to the sensor (e.g. the job uses a late-bound resource)

## Test Plan

Previously erroring test case.
