### PR TITLE
feat(dbt-assets): automatically apply metadata replacements using the manifest

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
@@ -74,6 +74,7 @@ def dbt_assets(
             input_asset_key_replacements=manifest.asset_key_replacements,
             output_asset_key_replacements=manifest.asset_key_replacements,
             descriptions_by_key=manifest.descriptions_by_asset_key,
+            metadata_by_key=manifest.metadata_by_asset_key,
         )
 
     return inner

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources_v2.py
@@ -23,7 +23,12 @@ from dbt.node_types import NodeType
 from pydantic import Field
 from typing_extensions import Literal
 
-from ..asset_utils import default_asset_key_fn, default_description_fn, output_name_fn
+from ..asset_utils import (
+    default_asset_key_fn,
+    default_description_fn,
+    default_metadata_fn,
+    output_name_fn,
+)
 
 logger = get_dagster_logger()
 
@@ -71,6 +76,10 @@ class DbtManifest:
     def node_info_to_description(cls, node_info: Mapping[str, Any]) -> str:
         return default_description_fn(node_info)
 
+    @classmethod
+    def node_info_to_metadata(cls, node_info: Mapping[str, Any]) -> Mapping[str, Any]:
+        return default_metadata_fn(node_info)
+
     @property
     def node_info_by_asset_key(self) -> Mapping[AssetKey, Mapping[str, Any]]:
         """A mapping of the default asset key for a dbt node to the node's dictionary representation in the manifest.
@@ -101,6 +110,15 @@ class DbtManifest:
         """
         return {
             self.node_info_to_asset_key(node): self.node_info_to_description(node)
+            for node in self.node_info_by_dbt_unique_id.values()
+        }
+
+    @property
+    def metadata_by_asset_key(self) -> Mapping[AssetKey, Mapping[Any, str]]:
+        """A mapping of the default asset key for a dbt node to the node's metadata in the manifest.
+        """
+        return {
+            self.node_info_to_asset_key(node): self.node_info_to_metadata(node)
             for node in self.node_info_by_dbt_unique_id.values()
         }
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_decorator.py
@@ -193,6 +193,24 @@ def test_with_description_replacements() -> None:
         assert description == expected_description
 
 
+def test_with_metadata_replacements() -> None:
+    expected_metadata = {"customized": "metadata"}
+
+    class CustomizedDbtManifest(DbtManifest):
+        @classmethod
+        def node_info_to_metadata(cls, node_info: Mapping[str, Any]) -> Mapping[str, Any]:
+            return expected_metadata
+
+    manifest = CustomizedDbtManifest.read(path=manifest_path)
+
+    @dbt_assets(manifest=manifest)
+    def my_dbt_assets():
+        ...
+
+    for metadata in my_dbt_assets.metadata_by_key.values():
+        assert metadata["customized"] == "metadata"
+
+
 def test_auto_materialize_policy() -> None:
     @dbt_assets(manifest=test_dagster_metadata_manifest)
     def my_dbt_assets():


### PR DESCRIPTION
## Summary & Motivation

The original dbt load functions accepted metadata from two places, the dbt manifest (how we show column schemas) and from a user supplied function `node_info_to_definition_metadata_fn`. This latter was particularly useful  in order for partitioned dbt assets to specify a `partition_expr` metadata attribute for attached io managers. 

This PR unblocks this use case for the new asset decorator, but instead of a helper function, it prefers setting metadata directly on the asset decorator and then merging that metadata with any found in the dbt manifest.


## How I Tested These Changes

I tested this on hooli and added unit tests