### PR TITLE
Add MockThreadPoolExecutor

### DIFF
--- a/python_modules/dagster/dagster/_core/test_utils.py
+++ b/python_modules/dagster/dagster/_core/test_utils.py
@@ -629,6 +629,29 @@ class SingleThreadPoolExecutor(ThreadPoolExecutor):
         super().__init__(max_workers=1, thread_name_prefix="sensor_daemon_worker")
 
 
+class SynchronousThreadPoolExecutor:
+    """Utility class for testing threadpool executor logic which executes functions synchronously for
+    easier unit testing.
+    """
+
+    def __init__(self, **kwargs):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        pass
+
+    def submit(self, fn, *args, **kwargs):
+        future = Future()
+        future.set_result(fn(*args, **kwargs))
+        return future
+
+    def shutdown(self, wait=True):
+        pass
+
+
 def ignore_warning(message_substr: str):
     """Ignores warnings within the decorated function that contain the given string."""
 


### PR DESCRIPTION
Useful for testing the metadaemon. Could go in an internal util instead, but I think it's generic enough to be potentially useful.