### PR TITLE
Surface auto materialize run ids

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -3063,6 +3063,7 @@ type AutoMaterializeAssetEvaluationRecord {
   numDiscarded: Int!
   conditions: [AutoMaterializeCondition!]!
   timestamp: Float!
+  runIds: [String!]!
 }
 
 union AutoMaterializeCondition =

--- a/js_modules/dagit/packages/core/src/graphql/types.ts
+++ b/js_modules/dagit/packages/core/src/graphql/types.ts
@@ -318,6 +318,7 @@ export type AutoMaterializeAssetEvaluationRecord = {
   numDiscarded: Scalars['Int'];
   numRequested: Scalars['Int'];
   numSkipped: Scalars['Int'];
+  runIds: Array<Scalars['String']>;
   timestamp: Scalars['Float'];
 };
 
@@ -4744,6 +4745,7 @@ export const buildAutoMaterializeAssetEvaluationRecord = (
     numRequested:
       overrides && overrides.hasOwnProperty('numRequested') ? overrides.numRequested! : 2522,
     numSkipped: overrides && overrides.hasOwnProperty('numSkipped') ? overrides.numSkipped! : 6444,
+    runIds: overrides && overrides.hasOwnProperty('runIds') ? overrides.runIds! : [],
     timestamp: overrides && overrides.hasOwnProperty('timestamp') ? overrides.timestamp! : 0.19,
   };
 };

--- a/python_modules/dagster-graphql/dagster_graphql/schema/auto_materialize_asset_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/auto_materialize_asset_evaluations.py
@@ -160,6 +160,7 @@ class GrapheneAutoMaterializeAssetEvaluationRecord(graphene.ObjectType):
     numDiscarded = graphene.NonNull(graphene.Int)
     conditions = non_null_list(GrapheneAutoMaterializeCondition)
     timestamp = graphene.NonNull(graphene.Float)
+    runIds = non_null_list(graphene.String)
 
     class Meta:
         name = "AutoMaterializeAssetEvaluationRecord"
@@ -180,6 +181,7 @@ class GrapheneAutoMaterializeAssetEvaluationRecord(graphene.ObjectType):
                 for c in record.evaluation.partition_subsets_by_condition
             ],
             timestamp=record.timestamp,
+            runIds=record.evaluation.run_ids,
         )
 
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
@@ -78,6 +78,17 @@ class AutoMaterializeAssetEvaluation(NamedTuple):
     num_requested: int
     num_skipped: int
     num_discarded: int
+    run_ids: Set[str] = set()
+
+    def with_run_ids(self, run_ids: Set[str]) -> "AutoMaterializeAssetEvaluation":
+        return AutoMaterializeAssetEvaluation(
+            self.asset_key,
+            self.partition_subsets_by_condition,
+            self.num_requested,
+            self.num_skipped,
+            self.num_discarded,
+            run_ids,
+        )
 
     @staticmethod
     def from_conditions(

--- a/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
@@ -80,16 +80,6 @@ class AutoMaterializeAssetEvaluation(NamedTuple):
     num_discarded: int
     run_ids: Set[str] = set()
 
-    def with_run_ids(self, run_ids: Set[str]) -> "AutoMaterializeAssetEvaluation":
-        return AutoMaterializeAssetEvaluation(
-            self.asset_key,
-            self.partition_subsets_by_condition,
-            self.num_requested,
-            self.num_skipped,
-            self.num_discarded,
-            run_ids,
-        )
-
     @staticmethod
     def from_conditions(
         asset_graph: AssetGraph,

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -172,8 +172,8 @@ class AssetDaemon(IntervalDaemon):
             # add run id to evaluations
             for asset_key in asset_keys:
                 evaluation = evaluations_by_asset_key[asset_key]
-                evaluations_by_asset_key[asset_key] = evaluation.with_run_ids(
-                    evaluation.run_ids | {run.run_id}
+                evaluations_by_asset_key[asset_key] = evaluation._replace(
+                    run_ids=evaluation.run_ids | {run.run_id}
                 )
 
         instance.daemon_cursor_storage.set_cursor_values({CURSOR_KEY: new_cursor.serialize()})

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_daemon.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_daemon.py
@@ -1,4 +1,5 @@
 import pytest
+from dagster import AssetKey
 from dagster._core.instance_for_test import instance_for_test
 from dagster._core.storage.dagster_run import DagsterRunStatus
 from dagster._core.storage.tags import PARTITION_NAME_TAG
@@ -171,3 +172,53 @@ def test_daemon_paused():
             + scenario.unevaluated_runs
             + (scenario.cursor_from.unevaluated_runs if scenario.cursor_from else [])
         )
+
+
+def test_run_ids():
+    scenario_name = "auto_materialize_policy_eager_with_freshness_policies"
+    scenario = auto_materialize_policy_scenarios[scenario_name]
+
+    with instance_for_test(
+        overrides={
+            "run_launcher": {
+                "module": "dagster._core.launcher.sync_in_memory_run_launcher",
+                "class": "SyncInMemoryRunLauncher",
+            },
+        }
+    ) as instance:
+        set_auto_materialize_paused(instance, False)
+
+        scenario.do_daemon_scenario(instance, scenario_name=scenario_name)
+
+        runs = instance.get_runs()
+
+        assert len(runs) == len(
+            scenario.expected_run_requests
+            + scenario.unevaluated_runs
+            + (scenario.cursor_from.unevaluated_runs if scenario.cursor_from else [])
+        )
+
+        for run in runs:
+            assert run.status == DagsterRunStatus.SUCCESS
+
+        def sort_run_request_key_fn(run_request):
+            return (min(run_request.asset_selection), run_request.partition_key)
+
+        def sort_run_key_fn(run):
+            return (min(run.asset_selection), run.tags.get(PARTITION_NAME_TAG))
+
+        sorted_runs = sorted(runs[: len(scenario.expected_run_requests)], key=sort_run_key_fn)
+        sorted_expected_run_requests = sorted(
+            scenario.expected_run_requests, key=sort_run_request_key_fn
+        )
+        for run, expected_run_request in zip(sorted_runs, sorted_expected_run_requests):
+            assert run.asset_selection is not None
+            assert set(run.asset_selection) == set(expected_run_request.asset_selection)
+            assert run.tags.get(PARTITION_NAME_TAG) == expected_run_request.partition_key
+
+        evaluations = instance.schedule_storage.get_auto_materialize_asset_evaluations(
+            asset_key=AssetKey("asset4"), limit=100
+        )
+        assert len(evaluations) == 1
+        assert evaluations[0].evaluation.asset_key == AssetKey("asset4")
+        assert evaluations[0].evaluation.run_ids == {run.run_id for run in sorted_runs}


### PR DESCRIPTION
Add run ids for launched runs to the stored evaluations, and return them in gql

Test plan:
unit, and manually ran some policies and ran the gql query