### PR TITLE
[dagster-dbt] Fix dependency issue for ephemeral models

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -148,7 +148,8 @@ def get_deps(
             if is_non_asset_node(parent_node_info):
                 visited = set()
                 replaced_parent_ids = set()
-                queue = parent_node_info.get("depends_on", {}).get("nodes", [])
+                # make a copy to avoid mutating the actual dictionary
+                queue = list(parent_node_info.get("depends_on", {}).get("nodes", []))
                 while queue:
                     candidate_parent_id = queue.pop()
                     if candidate_parent_id in visited:


### PR DESCRIPTION
## Summary & Motivation

When we're doing this BFS thing, if we don't make a copy of the "depends_on" list, then we end up popping elements off of the actual manifest dictionary, causing weird problems.

Looks like this fix got lost in: https://github.com/dagster-io/dagster/pull/13364/files

## How I Tested These Changes
