### PR TITLE
Use new upstream partition mapping method

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -33,7 +33,7 @@ from .assets import AssetsDefinition
 from .events import AssetKey, AssetKeyPartitionKey
 from .freshness_policy import FreshnessPolicy
 from .partition import PartitionsDefinition, PartitionsSubset
-from .partition_mapping import PartitionMapping, infer_partition_mapping, MappedPartitionsResult
+from .partition_mapping import MappedPartitionsResult, PartitionMapping, infer_partition_mapping
 from .source_asset import SourceAsset
 from .time_window_partitions import (
     TimeWindowPartitionsDefinition,
@@ -303,16 +303,19 @@ class AssetGraph:
                     dynamic_partitions_store=dynamic_partitions_store,
                     current_time=current_time,
                 )
-                for (
-                    valid_partition
-                ) in mapped_partitions_result.partitions_subset.get_partition_keys():
-                    valid_parent_partitions.add(
+
+                valid_parent_partitions.update(
+                    {
                         AssetKeyPartitionKey(parent_asset_key, valid_partition)
-                    )
-                for invalid_partition in mapped_partitions_result.invalid_partitions_mapped_to:
-                    invalid_parent_partitions.add(
+                        for valid_partition in mapped_partitions_result.partitions_subset.get_partition_keys()
+                    }
+                )
+                invalid_parent_partitions.update(
+                    {
                         AssetKeyPartitionKey(parent_asset_key, invalid_partition)
-                    )
+                        for invalid_partition in mapped_partitions_result.invalid_partitions_mapped_to
+                    }
+                )
             else:
                 valid_parent_partitions.add(AssetKeyPartitionKey(parent_asset_key))
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -33,7 +33,7 @@ from .assets import AssetsDefinition
 from .events import AssetKey, AssetKeyPartitionKey
 from .freshness_policy import FreshnessPolicy
 from .partition import PartitionsDefinition, PartitionsSubset
-from .partition_mapping import PartitionMapping, infer_partition_mapping
+from .partition_mapping import PartitionMapping, infer_partition_mapping, MappedPartitionsResult
 from .source_asset import SourceAsset
 from .time_window_partitions import (
     TimeWindowPartitionsDefinition,
@@ -44,6 +44,11 @@ from .time_window_partitions import (
 
 if TYPE_CHECKING:
     from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
+
+
+class ParentPartitionsResult(NamedTuple):
+    valid_parent_partitions: Set[AssetKeyPartitionKey]
+    invalid_parent_partitions: Set[AssetKeyPartitionKey]
 
 
 class AssetGraph:
@@ -277,102 +282,41 @@ class AssetGraph:
 
         return list(child_partitions_subset.get_partition_keys())
 
-    def partition_maps_to_valid_parents(
-        self,
-        dynamic_partitions_store: DynamicPartitionsStore,
-        current_time: datetime,
-        candidate: AssetKeyPartitionKey,
-    ) -> bool:
-        """Returns a bool representing whether the given asset partition maps to valid parents upstream.
-        """
-        for parent_asset_key in self.get_parents(candidate.asset_key):
-            if self.is_partitioned(parent_asset_key):
-                child_partitions_def = self.get_partitions_def(candidate.asset_key)
-                parent_partitions_def = self.get_partitions_def(parent_asset_key)
-
-                partition_mapping = self.get_partition_mapping(
-                    candidate.asset_key, parent_asset_key
-                )
-
-                if not candidate.partition_key:
-                    pass
-                elif (
-                    len(
-                        partition_mapping.get_upstream_mapped_partitions_result_for_partitions(
-                            cast(PartitionsDefinition, child_partitions_def)
-                            .empty_subset()
-                            .with_partition_keys([candidate.partition_key]),
-                            cast(PartitionsDefinition, parent_partitions_def),
-                            current_time,
-                            dynamic_partitions_store,
-                        ).invalid_partitions_mapped_to
-                    )
-                    > 0
-                ):
-                    return False
-
-        return True
-
-    def get_valid_parent_partitions(
-        self,
-        dynamic_partitions_store: DynamicPartitionsStore,
-        current_time: datetime,
-        candidate: AssetKeyPartitionKey,
-    ) -> AbstractSet[AssetKeyPartitionKey]:
-        result: Set[AssetKeyPartitionKey] = set()
-        for parent_asset_key in self.get_parents(candidate.asset_key):
-            if self.is_partitioned(parent_asset_key):
-                child_partitions_def = self.get_partitions_def(candidate.asset_key)
-                parent_partitions_def = self.get_partitions_def(parent_asset_key)
-
-                partition_mapping = self.get_partition_mapping(
-                    candidate.asset_key, parent_asset_key
-                )
-
-                if not candidate.partition_key:
-                    pass
-                else:
-                    parent_materializable_subset = (
-                        partition_mapping.get_upstream_mapped_partitions_result_for_partitions(
-                            cast(PartitionsDefinition, child_partitions_def)
-                            .empty_subset()
-                            .with_partition_keys([candidate.partition_key]),
-                            cast(PartitionsDefinition, parent_partitions_def),
-                            current_time,
-                            dynamic_partitions_store,
-                        ).partitions_subset
-                    )
-                    for parent_partition_key in parent_materializable_subset.get_partition_keys():
-                        result.add(AssetKeyPartitionKey(parent_asset_key, parent_partition_key))
-            else:
-                result.add(AssetKeyPartitionKey(parent_asset_key))
-
-        return result
-
     def get_parents_partitions(
         self,
         dynamic_partitions_store: DynamicPartitionsStore,
         current_time: datetime,
         asset_key: AssetKey,
         partition_key: Optional[str] = None,
-    ) -> AbstractSet[AssetKeyPartitionKey]:
+    ) -> ParentPartitionsResult:
         """Returns every partition in every of the given asset's parents that the given partition of
         that asset depends on.
         """
-        result: Set[AssetKeyPartitionKey] = set()
+        valid_parent_partitions: Set[AssetKeyPartitionKey] = set()
+        invalid_parent_partitions: Set[AssetKeyPartitionKey] = set()
         for parent_asset_key in self.get_parents(asset_key):
             if self.is_partitioned(parent_asset_key):
-                for parent_partition_key in self.get_parent_partition_keys_for_child(
+                mapped_partitions_result = self.get_parent_partition_keys_for_child(
                     partition_key,
                     parent_asset_key,
                     asset_key,
                     dynamic_partitions_store=dynamic_partitions_store,
                     current_time=current_time,
-                ):
-                    result.add(AssetKeyPartitionKey(parent_asset_key, parent_partition_key))
+                )
+                for (
+                    valid_partition
+                ) in mapped_partitions_result.partitions_subset.get_partition_keys():
+                    valid_parent_partitions.add(
+                        AssetKeyPartitionKey(parent_asset_key, valid_partition)
+                    )
+                for invalid_partition in mapped_partitions_result.invalid_partitions_mapped_to:
+                    invalid_parent_partitions.add(
+                        AssetKeyPartitionKey(parent_asset_key, invalid_partition)
+                    )
             else:
-                result.add(AssetKeyPartitionKey(parent_asset_key))
-        return result
+                valid_parent_partitions.add(AssetKeyPartitionKey(parent_asset_key))
+
+        return ParentPartitionsResult(valid_parent_partitions, invalid_parent_partitions)
 
     def get_parent_partition_keys_for_child(
         self,
@@ -381,7 +325,7 @@ class AssetGraph:
         child_asset_key: AssetKey,
         dynamic_partitions_store: DynamicPartitionsStore,
         current_time: datetime,
-    ) -> Sequence[str]:
+    ) -> MappedPartitionsResult:
         """Converts a partition key from one asset to the corresponding partition keys in one of its
         parent assets. Uses the existing partition mapping between the child asset and the parent
         asset.
@@ -422,15 +366,7 @@ class AssetGraph:
             )
         )
 
-        if parent_partitions_result.invalid_partitions_mapped_to:
-            raise DagsterInvariantViolationError(
-                f"Partition {partition_key} in downstream asset"
-                f" keys {child_asset_key} depends on invalid partition keys"
-                f" {parent_partitions_result.invalid_partitions_mapped_to} in upstream"
-                f" asset {parent_asset_key}"
-            )
-
-        return list(parent_partitions_result.partitions_subset.get_partition_keys())
+        return parent_partitions_result
 
     def is_source(self, asset_key: AssetKey) -> bool:
         return asset_key in self.source_asset_keys or asset_key not in self.all_asset_keys

--- a/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
@@ -181,6 +181,7 @@ class PartitionMapping(ABC):
             )
         )
 
+    @public
     def get_upstream_mapped_partitions_result_for_partitions(
         self,
         downstream_partitions_subset: Optional[PartitionsSubset],

--- a/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
@@ -38,18 +38,18 @@ from dagster._utils.backcompat import ExperimentalWarning
 from dagster._utils.cached_method import cached_method
 
 
-class MappedPartitionsResult(NamedTuple):
+class UpstreamPartitionsResult(NamedTuple):
     """Represents the result of mapping a PartitionsSubset to the corresponding
     partitions in another PartitionsDefinition.
 
     partitions_subset (PartitionsSubset): The resulting partitions subset that was
         mapped to. Only contains partitions for existent partitions, filtering out nonexistent partitions.
-    invalid_partitions_mapped_to (Sequence[str]): A list containing invalid partition keys in to_partitions_def
+    required_but_nonexistent_partition_keys (Sequence[str]): A list containing invalid partition keys in to_partitions_def
         that partitions in from_partitions_subset were mapped to.
     """
 
     partitions_subset: PartitionsSubset
-    invalid_partitions_mapped_to: Sequence[str]
+    required_but_nonexistent_partition_keys: Sequence[str]
 
 
 class PartitionMapping(ABC):
@@ -188,19 +188,19 @@ class PartitionMapping(ABC):
         upstream_partitions_def: PartitionsDefinition,
         current_time: Optional[datetime] = None,
         dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
-    ) -> MappedPartitionsResult:
-        """Returns a MappedPartitionsResult object containing the partition keys the downstream
+    ) -> UpstreamPartitionsResult:
+        """Returns a UpstreamPartitionsResult object containing the partition keys the downstream
         partitions subset was mapped to in the upstream partitions definition.
 
-        Valid upstream partitions will be included in MappedPartitionsResult.partitions_subset.
-        Invalid upstream partitions will be included in MappedPartitionsResult.invalid_partitions_mapped_to.
+        Valid upstream partitions will be included in UpstreamPartitionsResult.partitions_subset.
+        Invalid upstream partitions will be included in UpstreamPartitionsResult.required_but_nonexistent_partition_keys.
 
         For example, if an upstream asset is time-partitioned and starts in June 2023, and the
         downstream asset is time-partitioned and starts in May 2023, this function would return a
-        MappedPartitionsResult(PartitionsSubset("2023-06-01"), invalid_partitions_mapped_to=["2023-05-01"])
+        UpstreamPartitionsResult(PartitionsSubset("2023-06-01"), required_but_nonexistent_partition_keys=["2023-05-01"])
         when downstream_partitions_subset contains 2023-05-01 and 2023-06-01.
         """
-        return MappedPartitionsResult(
+        return UpstreamPartitionsResult(
             self.get_upstream_partitions_for_partitions(
                 downstream_partitions_subset,
                 upstream_partitions_def,

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
@@ -136,7 +136,7 @@ class TimeWindowPartitionMapping(
             downstream_partitions_subset,
             self.start_offset,
             self.end_offset,
-            raise_error_on_invalid_mapped_partition=False,
+            # raise_error_on_invalid_mapped_partition=False,
             current_time=current_time,
         )
 
@@ -161,7 +161,7 @@ class TimeWindowPartitionMapping(
             downstream_partitions_subset,
             self.start_offset,
             self.end_offset,
-            raise_error_on_invalid_mapped_partition=True,
+            # raise_error_on_invalid_mapped_partition=True,
             current_time=current_time,
         ).partitions_subset
 
@@ -191,7 +191,7 @@ class TimeWindowPartitionMapping(
             upstream_partitions_subset,
             -self.start_offset,
             -self.end_offset,
-            raise_error_on_invalid_mapped_partition=False,
+            # raise_error_on_invalid_mapped_partition=False,
             current_time=current_time,
         ).partitions_subset
 
@@ -202,7 +202,7 @@ class TimeWindowPartitionMapping(
         from_partitions_subset: PartitionsSubset,
         start_offset: int,
         end_offset: int,
-        raise_error_on_invalid_mapped_partition: bool,
+        # raise_error_on_invalid_mapped_partition: bool,
         current_time: Optional[datetime] = None,
     ) -> MappedPartitionsResult:
         """Maps the partitions in from_partitions_subset to partitions in to_partitions_def.
@@ -323,15 +323,15 @@ class TimeWindowPartitionMapping(
                         )
                     )
 
-        if (
-            filtered_time_windows != time_windows
-            and not self.allow_nonexistent_upstream_partitions
-            and raise_error_on_invalid_mapped_partition
-        ):
-            raise DagsterInvalidInvocationError(
-                f"Provided time windows {time_windows} contain nonexistent time windows for"
-                f" partitions definition {to_partitions_def}"
-            )
+        # if (
+        #     filtered_time_windows != time_windows
+        #     and not self.allow_nonexistent_upstream_partitions
+        #     and raise_error_on_invalid_mapped_partition
+        # ):
+        #     raise DagsterInvalidInvocationError(
+        #         f"Provided time windows {time_windows} contain nonexistent time windows for"
+        #         f" partitions definition {to_partitions_def}"
+        #     )
 
         return MappedPartitionsResult(
             TimeWindowPartitionsSubset(

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
@@ -11,7 +11,7 @@ from dagster._core.definitions.time_window_partitions import (
     TimeWindowPartitionsDefinition,
     TimeWindowPartitionsSubset,
 )
-from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvalidInvocationError
+from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.instance import DynamicPartitionsStore
 from dagster._serdes import whitelist_for_serdes
 from dagster._utils.backcompat import (
@@ -136,7 +136,6 @@ class TimeWindowPartitionMapping(
             downstream_partitions_subset,
             self.start_offset,
             self.end_offset,
-            # raise_error_on_invalid_mapped_partition=False,
             current_time=current_time,
         )
 
@@ -161,7 +160,6 @@ class TimeWindowPartitionMapping(
             downstream_partitions_subset,
             self.start_offset,
             self.end_offset,
-            # raise_error_on_invalid_mapped_partition=True,
             current_time=current_time,
         ).partitions_subset
 
@@ -191,7 +189,6 @@ class TimeWindowPartitionMapping(
             upstream_partitions_subset,
             -self.start_offset,
             -self.end_offset,
-            # raise_error_on_invalid_mapped_partition=False,
             current_time=current_time,
         ).partitions_subset
 
@@ -202,7 +199,6 @@ class TimeWindowPartitionMapping(
         from_partitions_subset: PartitionsSubset,
         start_offset: int,
         end_offset: int,
-        # raise_error_on_invalid_mapped_partition: bool,
         current_time: Optional[datetime] = None,
     ) -> MappedPartitionsResult:
         """Maps the partitions in from_partitions_subset to partitions in to_partitions_def.
@@ -322,16 +318,6 @@ class TimeWindowPartitionMapping(
                             )
                         )
                     )
-
-        # if (
-        #     filtered_time_windows != time_windows
-        #     and not self.allow_nonexistent_upstream_partitions
-        #     and raise_error_on_invalid_mapped_partition
-        # ):
-        #     raise DagsterInvalidInvocationError(
-        #         f"Provided time windows {time_windows} contain nonexistent time windows for"
-        #         f" partitions definition {to_partitions_def}"
-        #     )
 
         return MappedPartitionsResult(
             TimeWindowPartitionsSubset(

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -858,14 +858,14 @@ def should_backfill_atomic_asset_partitions_unit(
             dynamic_partitions_store, current_time, *candidate
         )
 
-        if parent_partitions_result.invalid_parent_partitions:
+        if parent_partitions_result.required_but_nonexistent_parents_partitions:
             raise DagsterInvariantViolationError(
                 f"Asset partition {candidate}"
                 " depends on invalid partition keys"
-                f" {parent_partitions_result.invalid_parent_partitions}"
+                f" {parent_partitions_result.required_but_nonexistent_parents_partitions}"
             )
 
-        for parent in parent_partitions_result.valid_parent_partitions:
+        for parent in parent_partitions_result.parent_partitions:
             can_run_with_parent = (
                 parent in asset_partitions_to_request
                 and asset_graph.have_same_partitioning(parent.asset_key, candidate.asset_key)

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -24,7 +24,6 @@ from dagster._core.definitions.asset_reconciliation_sensor import (
     build_run_requests,
     find_parent_materialized_asset_partitions,
 )
-from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.definitions.asset_selection import AssetSelection
 from dagster._core.definitions.assets_job import is_base_asset_job_name
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
@@ -32,7 +31,7 @@ from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
 from dagster._core.definitions.partition import PartitionsSubset
 from dagster._core.definitions.run_request import RunRequest
 from dagster._core.definitions.selector import JobSubsetSelector
-from dagster._core.errors import DagsterBackfillFailedError
+from dagster._core.errors import DagsterBackfillFailedError, DagsterInvariantViolationError
 from dagster._core.events import DagsterEventType
 from dagster._core.host_representation import (
     ExternalExecutionPlan,

--- a/python_modules/dagster/dagster/_core/execution/context/system.py
+++ b/python_modules/dagster/dagster/_core/execution/context/system.py
@@ -972,12 +972,12 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
                     )
                 )
 
-                if mapped_partitions_result.invalid_partitions_mapped_to:
+                if mapped_partitions_result.required_but_nonexistent_partition_keys:
                     raise DagsterInvariantViolationError(
                         f"Partition key range {self.asset_partition_key_range} in"
                         f" {self.node_handle.name} depends on invalid partition keys"
-                        f" {mapped_partitions_result.invalid_partitions_mapped_to} in upstream"
-                        f" asset {upstream_asset_key}"
+                        f" {mapped_partitions_result.required_but_nonexistent_partition_keys} in"
+                        f" upstream asset {upstream_asset_key}"
                     )
 
                 return mapped_partitions_result.partitions_subset

--- a/python_modules/dagster/dagster/_core/execution/context/system.py
+++ b/python_modules/dagster/dagster/_core/execution/context/system.py
@@ -949,11 +949,6 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
             upstream_asset_partitions_def = asset_layer.partitions_def_for_asset(upstream_asset_key)
 
             if upstream_asset_partitions_def is not None:
-                if assets_def is None:
-                    check.failed(
-                        "Attempted to fetch asset_partitions_subset_for_input for a non-asset node"
-                    )
-
                 partitions_def = assets_def.partitions_def if assets_def else None
                 partitions_subset = (
                     partitions_def.empty_subset().with_partition_key_range(
@@ -979,8 +974,8 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
 
                 if mapped_partitions_result.invalid_partitions_mapped_to:
                     raise DagsterInvariantViolationError(
-                        f"Partition key range {self.asset_partition_key_range} in downstream asset"
-                        f" keys {assets_def.keys} depends on invalid partition keys"
+                        f"Partition key range {self.asset_partition_key_range} in"
+                        f" {self.node_handle.name} depends on invalid partition keys"
                         f" {mapped_partitions_result.invalid_partitions_mapped_to} in upstream"
                         f" asset {upstream_asset_key}"
                     )

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -590,11 +590,12 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
             (TimeWindowPartitionsDefinition, DynamicPartitionsDefinition),
         )
 
-        for parent in asset_graph.get_valid_parent_partitions(
+        for parent in asset_graph.get_parents_partitions(
             dynamic_partitions_store=self,
             current_time=self._evaluation_time,
-            candidate=asset_partition,
-        ):
+            asset_key=asset_partition.asset_key,
+            partition_key=asset_partition.partition_key,
+        ).valid_parent_partitions:
             # when mapping from time or dynamic downstream to unpartitioned upstream, only check
             # for existence of upstream materialization, do not worry about timestamps
             if time_or_dynamic_partitioned and parent.partition_key is None:

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -595,7 +595,7 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
             current_time=self._evaluation_time,
             asset_key=asset_partition.asset_key,
             partition_key=asset_partition.partition_key,
-        ).valid_parent_partitions:
+        ).parent_partitions:
             # when mapping from time or dynamic downstream to unpartitioned upstream, only check
             # for existence of upstream materialization, do not worry about timestamps
             if time_or_dynamic_partitioned and parent.partition_key is None:

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_time_window_partition_mapping.py
@@ -426,7 +426,9 @@ def test_get_upstream_with_current_time(
     assert (
         upstream_partitions_result.partitions_subset.get_partition_keys() == expected_upstream_keys
     )
-    assert upstream_partitions_result.invalid_partitions_mapped_to == invalid_upstream_keys
+    assert (
+        upstream_partitions_result.required_but_nonexistent_partition_keys == invalid_upstream_keys
+    )
 
 
 @pytest.mark.parametrize(
@@ -527,7 +529,7 @@ def test_different_start_time_partitions_defs():
         )
     )
     assert upstream_partitions_result.partitions_subset.get_partition_keys() == []
-    assert upstream_partitions_result.invalid_partitions_mapped_to == ["2023-01-15"]
+    assert upstream_partitions_result.required_but_nonexistent_partition_keys == ["2023-01-15"]
 
     assert (
         TimeWindowPartitionMapping(allow_nonexistent_upstream_partitions=True)
@@ -566,7 +568,7 @@ def test_different_end_time_partitions_defs():
         )
     )
     assert upstream_partitions_result.partitions_subset.get_partition_keys() == []
-    assert upstream_partitions_result.invalid_partitions_mapped_to == ["2023-02-15"]
+    assert upstream_partitions_result.required_but_nonexistent_partition_keys == ["2023-02-15"]
 
     assert (
         TimeWindowPartitionMapping(allow_nonexistent_upstream_partitions=True)
@@ -603,7 +605,7 @@ def test_daily_upstream_of_yearly():
 
 
 @pytest.mark.parametrize(
-    "downstream_partitions_subset,upstream_partitions_def,allow_nonexistent_upstream_partitions,current_time,valid_partitions_mapped_to,invalid_partitions_mapped_to",
+    "downstream_partitions_subset,upstream_partitions_def,allow_nonexistent_upstream_partitions,current_time,valid_partitions_mapped_to,required_but_nonexistent_partition_keys",
     [
         (
             DailyPartitionsDefinition(start_date="2023-05-01")
@@ -653,7 +655,7 @@ def test_downstream_partition_has_valid_upstream_partitions(
     allow_nonexistent_upstream_partitions: bool,
     current_time: datetime,
     valid_partitions_mapped_to: Sequence[str],
-    invalid_partitions_mapped_to: Sequence[str],
+    required_but_nonexistent_partition_keys: Sequence[str],
 ):
     result = TimeWindowPartitionMapping(
         allow_nonexistent_upstream_partitions=allow_nonexistent_upstream_partitions
@@ -663,4 +665,4 @@ def test_downstream_partition_has_valid_upstream_partitions(
         current_time=current_time,
     )
     assert result.partitions_subset.get_partition_keys() == valid_partitions_mapped_to
-    assert result.invalid_partitions_mapped_to == invalid_partitions_mapped_to
+    assert result.required_but_nonexistent_partition_keys == required_but_nonexistent_partition_keys

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
@@ -122,13 +122,13 @@ def test_get_parent_partitions_unpartitioned_child_partitioned_parent():
 
         assert internal_asset_graph.get_parents_partitions(
             instance, current_time, child.key
-        ).valid_parent_partitions == set(
+        ).parent_partitions == set(
             [AssetKeyPartitionKey(parent.key, "a"), AssetKeyPartitionKey(parent.key, "b")]
         )
 
         assert external_asset_graph.get_parents_partitions(
             instance, current_time, child.key
-        ).valid_parent_partitions == set(
+        ).parent_partitions == set(
             [AssetKeyPartitionKey(parent.key, "a"), AssetKeyPartitionKey(parent.key, "b")]
         )
 
@@ -182,7 +182,7 @@ def test_get_parent_partitions_fan_in():
 
         assert internal_asset_graph.get_parents_partitions(
             instance, current_time, child.key, "2022-01-03"
-        ).valid_parent_partitions == set(
+        ).parent_partitions == set(
             [
                 AssetKeyPartitionKey(parent.key, f"2022-01-03-{str(hour).zfill(2)}:00")
                 for hour in range(24)
@@ -191,7 +191,7 @@ def test_get_parent_partitions_fan_in():
 
         assert external_asset_graph.get_parents_partitions(
             instance, current_time, child.key, "2022-01-03"
-        ).valid_parent_partitions == set(
+        ).parent_partitions == set(
             [
                 AssetKeyPartitionKey(parent.key, f"2022-01-03-{str(hour).zfill(2)}:00")
                 for hour in range(24)
@@ -218,18 +218,18 @@ def test_get_parent_partitions_non_default_partition_mapping():
             mapped_partitions_result = internal_asset_graph.get_parents_partitions(
                 instance, current_time, child.key
             )
-            mapped_partitions_result.valid_parent_partitions == {
+            mapped_partitions_result.parent_partitions == {
                 AssetKeyPartitionKey(parent.key, "2022-01-02")
             }
-            mapped_partitions_result.invalid_parent_partitions == {}
+            mapped_partitions_result.required_but_nonexistent_parents_partitions == {}
 
             mapped_partitions_result = external_asset_graph.get_parents_partitions(
                 instance, current_time, child.key
             )
-            mapped_partitions_result.valid_parent_partitions == {
+            mapped_partitions_result.parent_partitions == {
                 AssetKeyPartitionKey(parent.key, "2022-01-02")
             }
-            mapped_partitions_result.invalid_parent_partitions == {}
+            mapped_partitions_result.required_but_nonexistent_parents_partitions == {}
 
 
 def test_custom_unsupported_partition_mapping():
@@ -277,7 +277,7 @@ def test_custom_unsupported_partition_mapping():
 
         assert internal_asset_graph.get_parents_partitions(
             instance, current_time, child.key, "2"
-        ).valid_parent_partitions == {
+        ).parent_partitions == {
             AssetKeyPartitionKey(parent.key, "1"),
             AssetKeyPartitionKey(parent.key, "2"),
         }
@@ -285,7 +285,7 @@ def test_custom_unsupported_partition_mapping():
         # external falls back to default PartitionMapping
         assert external_asset_graph.get_parents_partitions(
             instance, current_time, child.key, "2"
-        ).valid_parent_partitions == {AssetKeyPartitionKey(parent.key, "2")}
+        ).parent_partitions == {AssetKeyPartitionKey(parent.key, "2")}
 
 
 def test_required_multi_asset_sets_non_subsettable_multi_asset():

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
@@ -31,7 +31,7 @@ from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
 from dagster._core.definitions.time_window_partitions import TimeWindow
-from dagster._core.errors import DagsterInvalidInvocationError
+from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.storage.tags import (
     ASSET_PARTITION_RANGE_END_TAG,
     ASSET_PARTITION_RANGE_START_TAG,
@@ -683,7 +683,10 @@ def test_error_on_nonexistent_upstream_partition():
         return upstream_asset + 1
 
     with pendulum.test(create_pendulum_time(2020, 1, 2, 10, 0)):
-        with pytest.raises(DagsterInvalidInvocationError, match="nonexistent time windows"):
+        with pytest.raises(
+            DagsterInvariantViolationError,
+            match="invalid partition keys",
+        ):
             materialize(
                 [downstream_asset, upstream_asset.to_source_asset()],
                 partition_key="2020-01-02-05:00",

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
@@ -457,7 +457,7 @@ def run_backfill_to_completion(
                 *asset_partition,
             )
 
-            for parent_asset_partition in parent_partitions_result.valid_parent_partitions:
+            for parent_asset_partition in parent_partitions_result.parent_partitions:
                 if (
                     parent_asset_partition in backfill_data.target_subset
                     and parent_asset_partition not in backfill_data.materialized_subset


### PR DESCRIPTION
This PR follows up from https://github.com/dagster-io/dagster/pull/14706 and switches internal callsites that call `get_upstream_partitions_from_partitions` to the new `get_upstream_mapped_partitions_result_for_partitions` method.

The new `get_upstream_mapped_partitions_result_for_partitions` method returns an object with two fields: the valid parent partitions subset and invalid parent partition keys. This object must be handled at callsites:
- In reconciliation, do not materialize candidates if invalid parent partitions exist. 
- In backfills and manual runs, raise an error with the invalid parent partition keys. Previously the error was raised within the `get_upstream_partitions_from_partitions` method.

In the next PR, will remove these old functions from partition mappings:
- `get_upstream_partitions_from_partitions`
- `get_upstream_partitions_for_partition_range`