### PR TITLE
RFC: [example] make sure tests for quickstart-* run

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -24,7 +24,7 @@ def build_example_packages_steps() -> List[BuildkiteStep]:
     ]
 
     example_packages = EXAMPLE_PACKAGES_WITH_CUSTOM_CONFIG + example_packages_with_standard_config
-    print("!!!!!!!!!! example_packages", example_packages)
+    # print("!!!!!!!!!! example_packages", example_packages)
 
     # TODO: these tests were failing to install due to using editable install dagster and published
     # dagster-cloud.
@@ -33,7 +33,7 @@ def build_example_packages_steps() -> List[BuildkiteStep]:
         for pkg in example_packages
         if pkg.directory not in ["examples/assets_dbt_python", "examples/assets_modern_data_stack"]
     ]
-    print("!!!!!!!!!! example_packages_filtered", example_packages_filtered)
+    # print("!!!!!!!!!! example_packages_filtered", example_packages_filtered)
 
     return _build_steps_from_package_specs(example_packages_filtered)
 

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -24,6 +24,7 @@ def build_example_packages_steps() -> List[BuildkiteStep]:
     ]
 
     example_packages = EXAMPLE_PACKAGES_WITH_CUSTOM_CONFIG + example_packages_with_standard_config
+    print("!!!!!!!!!! example_packages", example_packages)
 
     # TODO: these tests were failing to install due to using editable install dagster and published
     # dagster-cloud.
@@ -32,6 +33,7 @@ def build_example_packages_steps() -> List[BuildkiteStep]:
         for pkg in example_packages
         if pkg.directory not in ["examples/assets_dbt_python", "examples/assets_modern_data_stack"]
     ]
+    print("!!!!!!!!!! example_packages_filtered", example_packages_filtered)
 
     return _build_steps_from_package_specs(example_packages_filtered)
 

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -24,16 +24,14 @@ def build_example_packages_steps() -> List[BuildkiteStep]:
     ]
 
     example_packages = EXAMPLE_PACKAGES_WITH_CUSTOM_CONFIG + example_packages_with_standard_config
-    # print("!!!!!!!!!! example_packages", example_packages)
 
-    # TODO: these tests were failing to install due to using editable install dagster and published
+    # [HERE] TODO: these tests were failing to install due to using editable install dagster and published
     # dagster-cloud.
     example_packages_filtered = [
         pkg
         for pkg in example_packages
         if pkg.directory not in ["examples/assets_dbt_python", "examples/assets_modern_data_stack"]
     ]
-    # print("!!!!!!!!!! example_packages_filtered", example_packages_filtered)
 
     return _build_steps_from_package_specs(example_packages_filtered)
 

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -25,7 +25,7 @@ def build_example_packages_steps() -> List[BuildkiteStep]:
 
     example_packages = EXAMPLE_PACKAGES_WITH_CUSTOM_CONFIG + example_packages_with_standard_config
 
-    # [HERE] TODO: these tests were failing to install due to using editable install dagster and published
+    # TODO: these tests were failing to install due to using editable install dagster and published
     # dagster-cloud.
     example_packages_filtered = [
         pkg

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -25,7 +25,7 @@ def build_example_packages_steps() -> List[BuildkiteStep]:
 
     example_packages = EXAMPLE_PACKAGES_WITH_CUSTOM_CONFIG + example_packages_with_standard_config
 
-    # TODO: these tests were failing to install due to using editable install dagster and published
+    # [HERE] TODO: these tests were failing to install due to using editable install dagster and published
     # dagster-cloud.
     example_packages_filtered = [
         pkg

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -238,7 +238,7 @@ def skip_if_no_docs_changes():
         return None
 
     # If anything changes in the examples directory. This is where our docs snippets live.
-    if any(Path("examples/docs_snippets") in path.parents for path in ChangedFiles.all):
+    if any(Path("examples") in path.parents for path in ChangedFiles.all):
         logging.info("Run docs steps because files in the examples directory changed")
         return None
 

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -238,7 +238,7 @@ def skip_if_no_docs_changes():
         return None
 
     # If anything changes in the examples directory. This is where our docs snippets live.
-    if any(Path("examples") in path.parents for path in ChangedFiles.all):
+    if any(Path("examples/docs_snippets") in path.parents for path in ChangedFiles.all):
         logging.info("Run docs steps because files in the examples directory changed")
         return None
 

--- a/examples/quickstart_aws/tox.ini
+++ b/examples/quickstart_aws/tox.ini
@@ -1,0 +1,22 @@
+[tox]
+envlist = py{38, 37}
+skipsdist = true
+
+[testenv]
+download = true
+passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
+deps =
+  -e ../../python_modules/dagster[test]
+  -e ../../python_modules/dagit
+  -e ../../python_modules/libraries/dagster-aws/
+  pandas
+  matplotlib
+  textblob
+  tweepy
+  wordcloud
+  ; -e .
+allowlist_externals =
+  /bin/bash
+commands =
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  pytest -c ../../pyproject.toml -vv

--- a/examples/quickstart_aws/tox.ini
+++ b/examples/quickstart_aws/tox.ini
@@ -18,5 +18,5 @@ deps =
 allowlist_externals =
   /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit -v dagster-graphql'
   pytest -c ../../pyproject.toml -vv


### PR DESCRIPTION
## Summary & Motivation
add `tox.ini` files to `quickstart-*` to make sure unit tests are running in bk, because we only include packages with tox.ini in bk runs (https://github.com/dagster-io/dagster/blob/master/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py#L85)

this pr currently only tests for one example. will do it for all quickstart examples once i have a path forward for the following situation:

related to https://github.com/dagster-io/dagster/pull/13615, because these examples require `dagster-cloud` which cannot be installed as `dev+0` so it causes version conflict in tox. the change in PR can pass tox build but isn't ideal. a couple ideas:
1. move these tests to internal, where editable dagster-cloud is available
2. move dagster-cloud to oss
3. find a way to skip dagster-cloud install in tox (help needed. i can't figure out tox magic to do this)





## How I Tested These Changes
