### PR TITLE
call setup_for_execution for inner IOManagers of the BranchingIOManager

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/branching/branching_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/branching/branching_io_manager.py
@@ -1,6 +1,8 @@
 from typing import Any, Optional
 
 from dagster import InputContext, OutputContext
+from dagster._core.execution.context.init import InitResourceContext
+from dagster._config.pythonic_config import ConfigurableIOManager
 from dagster._core.definitions.events import AssetKey, AssetMaterialization
 from dagster._core.definitions.metadata import TextMetadataValue
 from dagster._core.event_api import EventRecordsFilter
@@ -31,7 +33,7 @@ def latest_materialization_log_entry(
     return event_records[0].event_log_entry if event_records else None
 
 
-class BranchingIOManager(IOManager):
+class BranchingIOManager(ConfigurableIOManager):
     """A branching I/O manager composes two I/O managers.
 
     1) The parent I/O manager, typically your production environment.
@@ -101,3 +103,8 @@ class BranchingIOManager(IOManager):
             f'Branching Manager: Writing "{context.asset_key.to_user_string()}" to branch'
             f' "{self.branch_name}"'
         )
+
+    def setup_for_execution(self, context: InitResourceContext):
+        self.parent_io_manager.setup_for_execution(context)
+        self.branch_io_manager.setup_for_execution(context)
+

--- a/python_modules/dagster/dagster/_core/storage/branching/branching_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/branching/branching_io_manager.py
@@ -1,13 +1,13 @@
 from typing import Any, Optional
 
 from dagster import InputContext, OutputContext
-from dagster._core.execution.context.init import InitResourceContext
 from dagster._config.pythonic_config import ConfigurableIOManager, ConfigurableResourceFactory
 from dagster._core.definitions.events import AssetKey, AssetMaterialization
 from dagster._core.definitions.metadata import TextMetadataValue
 from dagster._core.event_api import EventRecordsFilter
 from dagster._core.events import DagsterEventType
 from dagster._core.events.log import EventLogEntry
+from dagster._core.execution.context.init import InitResourceContext
 from dagster._core.instance import DagsterInstance
 from dagster._core.storage.io_manager import IOManager
 

--- a/python_modules/dagster/dagster/_core/storage/branching/branching_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/branching/branching_io_manager.py
@@ -2,7 +2,7 @@ from typing import Any, Optional
 
 from dagster import InputContext, OutputContext
 from dagster._core.execution.context.init import InitResourceContext
-from dagster._config.pythonic_config import ConfigurableIOManager
+from dagster._config.pythonic_config import ConfigurableIOManager, ConfigurableResourceFactory
 from dagster._core.definitions.events import AssetKey, AssetMaterialization
 from dagster._core.definitions.metadata import TextMetadataValue
 from dagster._core.event_api import EventRecordsFilter
@@ -105,6 +105,13 @@ class BranchingIOManager(ConfigurableIOManager):
         )
 
     def setup_for_execution(self, context: InitResourceContext):
-        self.parent_io_manager.setup_for_execution(context)
-        self.branch_io_manager.setup_for_execution(context)
+        if isinstance(self.parent_io_manager, ConfigurableResourceFactory):
+            self.parent_io_manager.setup_for_execution(context)
+        if isinstance(self.branch_io_manager, ConfigurableResourceFactory):
+            self.branch_io_manager.setup_for_execution(context)
 
+    def teardown_after_execution(self, context: InitResourceContext) -> None:
+        if isinstance(self.parent_io_manager, ConfigurableResourceFactory):
+            self.parent_io_manager.teardown_after_execution(context)
+        if isinstance(self.branch_io_manager, ConfigurableResourceFactory):
+            self.branch_io_manager.teardown_after_execution(context)


### PR DESCRIPTION
## Summary & Motivation

The `BranchingIOManager` was drafted by @schrockn before the introduction of lifecycle hooks. 

This PR adds `setup_for_execution` and `teardown_after_execution` calls to the inner IOManagers.

## How I Tested These Changes
Not yet