### PR TITLE
dagster project from-example use current version

### DIFF
--- a/python_modules/dagster/dagster/_generate/download.py
+++ b/python_modules/dagster/dagster/_generate/download.py
@@ -6,10 +6,10 @@ from io import BytesIO
 import click
 import requests
 
+from dagster.version import __version__ as dagster_version
+
 from .generate import _should_skip_file
 
-# Currently we only download from 'master' branch
-DEFAULT_GITHUB_URL = "https://codeload.github.com/dagster-io/dagster/tar.gz/master"
 # Examples aren't that can't be downloaded from the dagster project CLI
 EXAMPLES_TO_IGNORE = ["docs_snippets", "experimental"]
 # Hardcoded list of available examples. The list is tested against the examples folder in this mono
@@ -43,6 +43,14 @@ AVAILABLE_EXAMPLES = [
 ]
 
 
+def _get_url_for_version(version: str) -> str:
+    if version == "1!0+dev":
+        target = "master"
+    else:
+        target = version
+    return f"https://codeload.github.com/dagster-io/dagster/tar.gz/{target}"
+
+
 def download_example_from_github(path: str, example: str):
     if example not in AVAILABLE_EXAMPLES:
         click.echo(
@@ -59,7 +67,7 @@ def download_example_from_github(path: str, example: str):
 
     click.echo(f"Downloading example '{example}'. This may take a while.")
 
-    response = requests.get(DEFAULT_GITHUB_URL, stream=True)
+    response = requests.get(_get_url_for_version(dagster_version), stream=True)
     with tarfile.open(fileobj=BytesIO(response.raw.read()), mode="r:gz") as tar_file:
         # Extract the selected example folder to destination
         subdir_and_files = [

--- a/python_modules/dagster/dagster_tests/cli_tests/test_project_commands.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/test_project_commands.py
@@ -10,7 +10,7 @@ from dagster._cli.project import (
     scaffold_repository_command,
 )
 from dagster._core.workspace.load_target import get_origins_from_toml
-from dagster._generate.download import AVAILABLE_EXAMPLES, EXAMPLES_TO_IGNORE
+from dagster._generate.download import AVAILABLE_EXAMPLES, EXAMPLES_TO_IGNORE, _get_url_for_version
 from dagster._generate.generate import _should_skip_file
 
 
@@ -137,3 +137,8 @@ def test_scaffold_repository_command_succeeds():
         assert os.path.exists("my_dagster_repo/my_dagster_repo")
         assert os.path.exists("my_dagster_repo/my_dagster_repo_tests")
         assert not os.path.exists("my_dagster_repo/workspace.yaml")
+
+
+def test_versioned_download():
+    assert _get_url_for_version("1.3.3").endswith("1.3.3")
+    assert _get_url_for_version("1!0+dev").endswith("master")


### PR DESCRIPTION
to reduce risk of landed changes breaking examples for users, have the download script grab the version sycned with whats installed in `dagster`

## How I Tested These Changes

added test, manually run from-example