### PR TITLE
add annotations to helm chart migrate job and pod

### DIFF
--- a/helm/dagster/schema/schema_tests/test_instance_migrate.py
+++ b/helm/dagster/schema/schema_tests/test_instance_migrate.py
@@ -2,8 +2,12 @@ import subprocess
 
 import pytest
 from kubernetes.client import models
+from schema.charts.dagster.subschema.dagit import (
+    Dagit,
+)
 from schema.charts.dagster.subschema.migrate import Migrate
 from schema.charts.dagster.values import DagsterHelmValues
+from schema.charts.utils import kubernetes
 from schema.utils.helm_template import HelmTemplate
 
 
@@ -44,3 +48,23 @@ def test_job_instance_migrate_image(template: HelmTemplate, chart_version: str):
     _, tag = image.split(":")
 
     assert tag == chart_version
+
+
+def test_job_instance_migrate_keeps_annotations(template: HelmTemplate):
+    annotations = {"annotation_1": "an_annotation_1", "annotation_2": "an_annotation_2"}
+
+    helm_values_migrate_enabled = DagsterHelmValues.construct(
+        migrate=Migrate(enabled=True),
+        dagit=Dagit.construct(
+            annotations=kubernetes.Annotations.parse_obj(annotations),
+        ),
+    )
+
+    jobs = template.render(helm_values_migrate_enabled)
+
+    assert len(jobs) == 1
+
+    job = jobs[0]
+
+    assert job.metadata.annotations == annotations
+    assert job.spec.template.metadata.annotations == annotations

--- a/helm/dagster/templates/job-instance-migrate.yaml
+++ b/helm/dagster/templates/job-instance-migrate.yaml
@@ -3,10 +3,18 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ include "dagster.dagit.migrate" . | quote }}
+  annotations:
+    {{- range $key, $value := .Values.dagit.annotations }}
+    {{ $key }}: {{ $value | squote }}
+    {{- end }}
 spec:
   template:
     metadata:
       name: {{ include "dagster.dagit.migrate" . | quote }}
+      annotations:
+        {{- range $key, $value := .Values.dagit.annotations }}
+        {{ $key }}: {{ $value | squote }}
+        {{- end }}
     spec:
       imagePullSecrets: {{ .Values.imagePullSecrets | toYaml | nindent 8 }}
       serviceAccountName: {{ include "dagster.serviceAccountName" . }}


### PR DESCRIPTION
Summary:
User pointed out that these annotations are sometimes needed for the instance to load.

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes
