### PR TITLE
remigrate nonexample callsites to AssetExecutionContext

### DIFF
--- a/docs/content/concepts/io-management/io-managers.mdx
+++ b/docs/content/concepts/io-management/io-managers.mdx
@@ -427,9 +427,9 @@ from typing import Dict
 import pandas as pd
 
 from dagster import (
+    AssetExecutionContext,
     DailyPartitionsDefinition,
     HourlyPartitionsDefinition,
-    OpExecutionContext,
     asset,
     materialize,
 )
@@ -441,7 +441,7 @@ daily_partitions = DailyPartitionsDefinition(start_date=f"{start:%Y-%m-%d}")
 
 
 @asset(partitions_def=hourly_partitions)
-def upstream_asset(context: OpExecutionContext) -> pd.DataFrame:
+def upstream_asset(context: AssetExecutionContext) -> pd.DataFrame:
     return pd.DataFrame({"date": [context.partition_key]})
 
 

--- a/docs/content/guides/dagster/migrating-to-pythonic-resources-and-config.mdx
+++ b/docs/content/guides/dagster/migrating-to-pythonic-resources-and-config.mdx
@@ -22,10 +22,10 @@ We designed this new API with this in mind, allowing for old code and new code t
 Let's take some existing code we have, using the old configuration system:
 
 ```python file=/guides/dagster/migrating_to_python_resources_and_config/migrating_config.py  startafter=begin_old_config endbefore=end_old_config dedent=4
-from dagster import Definitions, OpExecutionContext, asset
+from dagster import AssetExecutionContext, Definitions, asset
 
 @asset(config_schema={"conn_string": str, "port": int})
-def an_asset(context: OpExecutionContext, upstream_asset):
+def an_asset(context: AssetExecutionContext, upstream_asset):
     assert context.op_config["conn_string"]
     assert context.op_config["port"]
 
@@ -80,9 +80,9 @@ For the rest of this guide, we will be working from this example:
 
 ```python file=/guides/dagster/migrating_to_python_resources_and_config/migrating_resources.py  startafter=begin_initial_codebase endbefore=end_initial_codebase dedent=4
 from dagster import (
+    AssetExecutionContext,
     Definitions,
     InitResourceContext,
-    OpExecutionContext,
     asset,
     resource,
 )
@@ -99,11 +99,11 @@ def fancy_db_resource(context: InitResourceContext) -> FancyDbResource:
     return FancyDbResource(context.resource_config["conn_string"])
 
 @asset(required_resource_keys={"fancy_db"})
-def asset_one(context: OpExecutionContext) -> None:
+def asset_one(context: AssetExecutionContext) -> None:
     assert context.resources.fancy_db
 
 @asset(required_resource_keys={"fancy_db"})
-def asset_two(context: OpExecutionContext) -> None:
+def asset_two(context: AssetExecutionContext) -> None:
     assert context.resources.fancy_db
 
 defs = Definitions(
@@ -156,7 +156,7 @@ In this example, we've written a Pythonic resource while passing the old-style r
 Next, we'll change <PyObject object="Definitions" /> to include the Pythonic resource. Note that we don't need to migrate our asset code at the same time, as Pythonic resources are available via the asset's context:
 
 ```python file=/guides/dagster/migrating_to_python_resources_and_config/migrating_resources.py  startafter=begin_new_style_resource_on_context endbefore=end_new_style_resource_on_context dedent=4
-from dagster import ConfigurableResource, Definitions, OpExecutionContext, asset
+from dagster import AssetExecutionContext, ConfigurableResource, Definitions, asset
 
 class FancyDbResource(ConfigurableResource):
     conn_string: str
@@ -165,7 +165,7 @@ class FancyDbResource(ConfigurableResource):
         ...
 
 @asset(required_resource_keys={"fancy_db"})
-def asset_one(context: OpExecutionContext) -> None:
+def asset_one(context: AssetExecutionContext) -> None:
     # this still works because the resource is still available on the context
     assert context.resources.fancy_db
 
@@ -180,10 +180,10 @@ defs = Definitions(
 Lastly, we'll update the asset to take the resource as a parameter:
 
 ```python file=/guides/dagster/migrating_to_python_resources_and_config/migrating_resources.py  startafter=begin_new_style_resource_on_param endbefore=end_new_style_resource_on_param dedent=4
-from dagster import OpExecutionContext, asset
+from dagster import AssetExecutionContext, asset
 
 @asset
-def asset_one(context: OpExecutionContext, fancy_db: FancyDbResource) -> None:
+def asset_one(context: AssetExecutionContext, fancy_db: FancyDbResource) -> None:
     assert fancy_db
 ```
 

--- a/docs/content/integrations/databricks.mdx
+++ b/docs/content/integrations/databricks.mdx
@@ -83,13 +83,13 @@ def my_databricks_job():
 from databricks_cli.sdk import DbfsService
 
 from dagster import (
-    OpExecutionContext,
+    AssetExecutionContext,
     job,
     op,
 )
 
 @op(required_resource_keys={"databricks"})
-def my_databricks_op(context: OpExecutionContext) -> None:
+def my_databricks_op(context: AssetExecutionContext) -> None:
     databricks_api_client = context.resources.databricks.api_client
     dbfs_service = DbfsService(databricks_api_client)
 
@@ -108,14 +108,14 @@ def my_databricks_job():
 from databricks_cli.sdk import JobsService
 
 from dagster import (
+    AssetExecutionContext,
     AssetSelection,
-    OpExecutionContext,
     asset,
     define_asset_job,
 )
 
 @asset(required_resource_keys={"databricks"})
-def my_databricks_table(context: OpExecutionContext) -> None:
+def my_databricks_table(context: AssetExecutionContext) -> None:
     databricks_api_client = context.resources.databricks.api_client
     jobs_service = JobsService(databricks_api_client)
 

--- a/examples/docs_snippets/docs_snippets/concepts/io_management/loading_multiple_upstream_partitions.py
+++ b/examples/docs_snippets/docs_snippets/concepts/io_management/loading_multiple_upstream_partitions.py
@@ -4,9 +4,9 @@ from typing import Dict
 import pandas as pd
 
 from dagster import (
+    AssetExecutionContext,
     DailyPartitionsDefinition,
     HourlyPartitionsDefinition,
-    OpExecutionContext,
     asset,
     materialize,
 )
@@ -18,7 +18,7 @@ daily_partitions = DailyPartitionsDefinition(start_date=f"{start:%Y-%m-%d}")
 
 
 @asset(partitions_def=hourly_partitions)
-def upstream_asset(context: OpExecutionContext) -> pd.DataFrame:
+def upstream_asset(context: AssetExecutionContext) -> pd.DataFrame:
     return pd.DataFrame({"date": [context.partition_key]})
 
 

--- a/examples/docs_snippets/docs_snippets/guides/dagster/migrating_to_python_resources_and_config/migrating_config.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/migrating_to_python_resources_and_config/migrating_config.py
@@ -9,10 +9,10 @@ def upstream_asset() -> int:
 def old_config() -> None:
     # begin_old_config
 
-    from dagster import Definitions, OpExecutionContext, asset
+    from dagster import AssetExecutionContext, Definitions, asset
 
     @asset(config_schema={"conn_string": str, "port": int})
-    def an_asset(context: OpExecutionContext, upstream_asset):
+    def an_asset(context: AssetExecutionContext, upstream_asset):
         assert context.op_config["conn_string"]
         assert context.op_config["port"]
 

--- a/examples/docs_snippets/docs_snippets/guides/dagster/migrating_to_python_resources_and_config/migrating_resources.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/migrating_to_python_resources_and_config/migrating_resources.py
@@ -6,9 +6,9 @@ from dagster import Definitions, define_asset_job
 def initial_code_base() -> Definitions:
     # begin_initial_codebase
     from dagster import (
+        AssetExecutionContext,
         Definitions,
         InitResourceContext,
-        OpExecutionContext,
         asset,
         resource,
     )
@@ -25,11 +25,11 @@ def initial_code_base() -> Definitions:
         return FancyDbResource(context.resource_config["conn_string"])
 
     @asset(required_resource_keys={"fancy_db"})
-    def asset_one(context: OpExecutionContext) -> None:
+    def asset_one(context: AssetExecutionContext) -> None:
         assert context.resources.fancy_db
 
     @asset(required_resource_keys={"fancy_db"})
-    def asset_two(context: OpExecutionContext) -> None:
+    def asset_two(context: AssetExecutionContext) -> None:
         assert context.resources.fancy_db
 
     defs = Definitions(
@@ -76,7 +76,7 @@ def convert_resource() -> Definitions:
 
 def new_style_resource_on_context() -> Definitions:
     # begin_new_style_resource_on_context
-    from dagster import ConfigurableResource, Definitions, OpExecutionContext, asset
+    from dagster import AssetExecutionContext, ConfigurableResource, Definitions, asset
 
     class FancyDbResource(ConfigurableResource):
         conn_string: str
@@ -85,7 +85,7 @@ def new_style_resource_on_context() -> Definitions:
             ...
 
     @asset(required_resource_keys={"fancy_db"})
-    def asset_one(context: OpExecutionContext) -> None:
+    def asset_one(context: AssetExecutionContext) -> None:
         # this still works because the resource is still available on the context
         assert context.resources.fancy_db
 
@@ -109,10 +109,10 @@ def new_style_resource_on_param() -> Definitions:
             ...
 
     # begin_new_style_resource_on_param
-    from dagster import OpExecutionContext, asset
+    from dagster import AssetExecutionContext, asset
 
     @asset
-    def asset_one(context: OpExecutionContext, fancy_db: FancyDbResource) -> None:
+    def asset_one(context: AssetExecutionContext, fancy_db: FancyDbResource) -> None:
         assert fancy_db
 
     # end_new_style_resource_on_param

--- a/examples/docs_snippets/docs_snippets/integrations/databricks/databricks.py
+++ b/examples/docs_snippets/docs_snippets/integrations/databricks/databricks.py
@@ -22,14 +22,14 @@ def scope_define_databricks_custom_asset():
     from databricks_cli.sdk import JobsService
 
     from dagster import (
+        AssetExecutionContext,
         AssetSelection,
-        OpExecutionContext,
         asset,
         define_asset_job,
     )
 
     @asset(required_resource_keys={"databricks"})
-    def my_databricks_table(context: OpExecutionContext) -> None:
+    def my_databricks_table(context: AssetExecutionContext) -> None:
         databricks_api_client = context.resources.databricks.api_client
         jobs_service = JobsService(databricks_api_client)
 
@@ -50,13 +50,13 @@ def scope_define_databricks_custom_op():
     from databricks_cli.sdk import DbfsService
 
     from dagster import (
-        OpExecutionContext,
+        AssetExecutionContext,
         job,
         op,
     )
 
     @op(required_resource_keys={"databricks"})
-    def my_databricks_op(context: OpExecutionContext) -> None:
+    def my_databricks_op(context: AssetExecutionContext) -> None:
         databricks_api_client = context.resources.databricks.api_client
         dbfs_service = DbfsService(databricks_api_client)
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
@@ -12,6 +12,7 @@ from typing import Iterator, List, Mapping, Optional, Sequence, Tuple, TypeVar
 
 from dagster import (
     Any,
+    AssetExecutionContext,
     AssetKey,
     AssetMaterialization,
     AssetObservation,
@@ -39,7 +40,6 @@ from dagster import (
     Map,
     Noneable,
     Nothing,
-    OpExecutionContext,
     Out,
     Output,
     PythonObjectDagsterType,
@@ -729,7 +729,7 @@ def eventually_successful():
     @op(
         required_resource_keys={"retry_count"},
     )
-    def fail(context: OpExecutionContext, depth: int) -> int:
+    def fail(context: AssetExecutionContext, depth: int) -> int:
         if context.resources.retry_count <= depth:
             raise Exception("fail")
 
@@ -1604,31 +1604,31 @@ failure_assets_job = build_assets_job(
 
 
 @asset
-def foo(context: OpExecutionContext):
+def foo(context: AssetExecutionContext):
     assert context.job_def.asset_selection_data is not None
     return 5
 
 
 @asset
-def bar(context: OpExecutionContext):
+def bar(context: AssetExecutionContext):
     assert context.job_def.asset_selection_data is not None
     return 10
 
 
 @asset
-def foo_bar(context: OpExecutionContext, foo, bar):
+def foo_bar(context: AssetExecutionContext, foo, bar):
     assert context.job_def.asset_selection_data is not None
     return foo + bar
 
 
 @asset
-def baz(context: OpExecutionContext, foo_bar):
+def baz(context: AssetExecutionContext, foo_bar):
     assert context.job_def.asset_selection_data is not None
     return foo_bar
 
 
 @asset
-def unconnected(context: OpExecutionContext):
+def unconnected(context: AssetExecutionContext):
     assert context.job_def.asset_selection_data is not None
 
 

--- a/python_modules/dagster/dagster/_config/pythonic_config/attach_other_object_to_context.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/attach_other_object_to_context.py
@@ -16,7 +16,7 @@ class IAttachDifferentObjectToOpContext:
             return context.resource_config["inner_string"]
 
         @asset(required_resource_keys={"my_string"})
-        def my_unconverted_asset(context: OpExecutionContext) -> str:
+        def my_unconverted_asset(context: AssetExecutionContext) -> str:
             return context.resources.my_string
 
     Adapted to a class-style resource, we can ensure our new ConfigurableResource is compatible
@@ -31,7 +31,7 @@ class IAttachDifferentObjectToOpContext:
                 return self.inner_string
 
         @asset(required_resource_keys={"my_string"})
-        def my_unconverted_asset(context: OpExecutionContext) -> str:
+        def my_unconverted_asset(context: AssetExecutionContext) -> str:
             return context.resources.my_string
 
         @asset

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_general_pythonic_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_general_pythonic_resources.py
@@ -7,6 +7,7 @@ from typing import Any, Callable, List, Mapping, Optional
 import mock
 import pytest
 from dagster import (
+    AssetExecutionContext,
     Config,
     ConfigurableIOManagerFactory,
     ConfigurableLegacyIOManagerAdapter,
@@ -18,7 +19,6 @@ from dagster import (
     InitResourceContext,
     IOManager,
     IOManagerDefinition,
-    OpExecutionContext,
     ResourceDependency,
     ResourceParam,
     RunConfig,
@@ -322,7 +322,7 @@ def test_io_manager_adapter():
     executed = {}
 
     @asset
-    def an_asset(context: OpExecutionContext):
+    def an_asset(context: AssetExecutionContext):
         assert context.resources.io_manager.a_config_value == "passed-in-configured"
         executed["yes"] = True
 
@@ -347,7 +347,7 @@ def test_io_manager_factory_class():
     executed = {}
 
     @asset
-    def another_asset(context: OpExecutionContext):
+    def another_asset(context: AssetExecutionContext):
         assert context.resources.io_manager.a_config_value == "passed-in-factory"
         executed["yes"] = True
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
@@ -2,11 +2,11 @@ import re
 
 import pytest
 from dagster import (
+    AssetExecutionContext,
     AssetKey,
     AssetsDefinition,
     DagsterInvalidDefinitionError,
     Definitions,
-    OpExecutionContext,
     ResourceDefinition,
     ScheduleDefinition,
     SourceAsset,
@@ -503,11 +503,11 @@ def test_implicit_global_job_with_job_defined():
 
 def test_implicit_global_job_with_partitioned_asset():
     @asset(partitions_def=DailyPartitionsDefinition(start_date="2022-01-01"))
-    def daily_partition_asset(context: OpExecutionContext):
+    def daily_partition_asset(context: AssetExecutionContext):
         return context.partition_key
 
     @asset(partitions_def=HourlyPartitionsDefinition(start_date="2022-02-02-10:00"))
-    def hourly_partition_asset(context: OpExecutionContext):
+    def hourly_partition_asset(context: AssetExecutionContext):
         return context.partition_key
 
     @asset

--- a/python_modules/dagster/dagster_tests/execution_tests/test_data_versions.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_data_versions.py
@@ -34,7 +34,7 @@ from dagster._core.definitions.events import AssetKey, Output
 from dagster._core.definitions.observe import observe
 from dagster._core.definitions.partition import StaticPartitionsDefinition
 from dagster._core.events import DagsterEventType
-from dagster._core.execution.context.compute import OpExecutionContext
+from dagster._core.execution.context.compute import AssetExecutionContext
 from dagster._core.execution.execute_in_process_result import ExecuteInProcessResult
 from dagster._core.instance_for_test import instance_for_test
 from typing_extensions import Literal
@@ -878,7 +878,7 @@ def test_get_data_provenance_inside_op():
         return Output(1, data_version=DataVersion("foo"))
 
     @asset(config_schema={"check_provenance": Field(bool, default_value=False)})
-    def asset2(context: OpExecutionContext, asset1):
+    def asset2(context: AssetExecutionContext, asset1):
         if context.op_config["check_provenance"]:
             provenance = context.get_asset_provenance(AssetKey("asset2"))
             assert provenance

--- a/python_modules/dagster/dagster_tests/execution_tests/test_execute_job.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_execute_job.py
@@ -1,12 +1,12 @@
 import dagster._check as check
 import pytest
 from dagster import (
+    AssetExecutionContext,
     AssetKey,
     DagsterExecutionStepNotFoundError,
     DagsterInvalidConfigError,
     DagsterInvariantViolationError,
     Field,
-    OpExecutionContext,
     Out,
     Output,
     ReexecutionOptions,
@@ -377,7 +377,7 @@ def echo(x):
 
 
 @op
-def fail_once(context: OpExecutionContext, x):
+def fail_once(context: AssetExecutionContext, x):
     key = context.op_handle.name
     if context.instance.run_storage.get_cursor_values({key}).get(key):
         return x

--- a/python_modules/dagster/dagster_tests/storage_tests/test_upath_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_upath_io_manager.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List, Optional, cast
 import pytest
 from dagster import (
     AllPartitionMapping,
+    AssetExecutionContext,
     AssetIn,
     DagsterType,
     DailyPartitionsDefinition,
@@ -15,7 +16,6 @@ from dagster import (
     InitResourceContext,
     InputContext,
     MetadataValue,
-    OpExecutionContext,
     OutputContext,
     StaticPartitionsDefinition,
     asset,
@@ -168,7 +168,7 @@ def test_upath_io_manager_multiple_time_partitions(
     dummy_io_manager: DummyIOManager,
 ):
     @asset(partitions_def=hourly)
-    def upstream_asset(context: OpExecutionContext) -> str:
+    def upstream_asset(context: AssetExecutionContext) -> str:
         return context.partition_key
 
     @asset(
@@ -190,7 +190,7 @@ def test_upath_io_manager_multiple_static_partitions(dummy_io_manager: DummyIOMa
     upstream_partitions_def = StaticPartitionsDefinition(["A", "B"])
 
     @asset(partitions_def=upstream_partitions_def)
-    def upstream_asset(context: OpExecutionContext) -> str:
+    def upstream_asset(context: AssetExecutionContext) -> str:
         return context.partition_key
 
     @asset(ins={"upstream_asset": AssetIn(partition_mapping=AllPartitionMapping())})
@@ -229,7 +229,7 @@ def test_upath_io_manager_static_partitions_with_dot():
         return TrackingIOManager(base_path=base_path)
 
     @asset(partitions_def=partitions_def)
-    def my_asset(context: OpExecutionContext) -> str:
+    def my_asset(context: AssetExecutionContext) -> str:
         return context.partition_key
 
     my_job = build_assets_job(
@@ -267,7 +267,7 @@ def test_upath_io_manager_with_extension_static_partitions_with_dot():
         return TrackingIOManager(base_path=base_path)
 
     @asset(partitions_def=partitions_def)
-    def my_asset(context: OpExecutionContext) -> str:
+    def my_asset(context: AssetExecutionContext) -> str:
         return context.partition_key
 
     my_job = build_assets_job(
@@ -308,7 +308,7 @@ def test_user_forgot_dict_type_annotation_for_multiple_partitions(
     dummy_io_manager: DummyIOManager,
 ):
     @asset(partitions_def=hourly)
-    def upstream_asset(context: OpExecutionContext) -> str:
+    def upstream_asset(context: AssetExecutionContext) -> str:
         return context.partition_key
 
     @asset(partitions_def=daily)
@@ -333,7 +333,7 @@ def test_skip_type_check_for_multiple_partitions_with_no_type_annotation(
     dummy_io_manager: DummyIOManager,
 ):
     @asset(partitions_def=hourly)
-    def upstream_asset(context: OpExecutionContext) -> str:
+    def upstream_asset(context: AssetExecutionContext) -> str:
         return context.partition_key
 
     @asset(
@@ -357,7 +357,7 @@ def test_skip_type_check_for_multiple_partitions_with_any_type(
     dummy_io_manager: DummyIOManager,
 ):
     @asset(partitions_def=hourly)
-    def upstream_asset(context: OpExecutionContext) -> str:
+    def upstream_asset(context: AssetExecutionContext) -> str:
         return context.partition_key
 
     @asset(


### PR DESCRIPTION
partial revert of fe7c8006ac6199c59b72cfbc37de4b59d9e30a1f

will need #14754, time, and maybe other changes before examples can be upgraded

## How I Tested These Changes

bk

ensure no downloadable examples included