### PR TITLE
[tox] remove envlist

### DIFF
--- a/docs/tox.ini
+++ b/docs/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = sphinx
 skipsdist = True
 
 [testenv]

--- a/examples/assets_dbt_python/tox.ini
+++ b/examples/assets_dbt_python/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{38, 37}
 skipsdist = true
 
 [testenv]

--- a/examples/assets_modern_data_stack/tox.ini
+++ b/examples/assets_modern_data_stack/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{38, 37}
 skipsdist = true
 
 [testenv]

--- a/examples/assets_pandas_pyspark/tox.ini
+++ b/examples/assets_pandas_pyspark/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{38, 37}
 skipsdist = true
 
 [testenv]

--- a/examples/assets_pandas_type_metadata/tox.ini
+++ b/examples/assets_pandas_type_metadata/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{38, 37}
 skipsdist = true
 
 [testenv]

--- a/examples/assets_smoke_test/tox.ini
+++ b/examples/assets_smoke_test/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{38, 37}
 skipsdist = true
 
 [testenv]

--- a/examples/deploy_docker/tox.ini
+++ b/examples/deploy_docker/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39,38,37,36}-{unix,windows}
 skipsdist = True
 
 [testenv]

--- a/examples/deploy_ecs/tox.ini
+++ b/examples/deploy_ecs/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39,38,37,36}-{unix,windows}
 skipsdist = True
 
 [testenv]

--- a/examples/deploy_k8s/tox.ini
+++ b/examples/deploy_k8s/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39,38,37,36}-{unix,windows}
 skipsdist = True
 
 [testenv]

--- a/examples/development_to_production/tox.ini
+++ b/examples/development_to_production/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39,38,37}-{unix,windows}
 skipsdist = True
 
 [testenv]

--- a/examples/docs_snippets/tox.ini
+++ b/examples/docs_snippets/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39,38,37,36}-{unix,windows}
 skipsdist = true
 
 [testenv]

--- a/examples/feature_graph_backed_assets/tox.ini
+++ b/examples/feature_graph_backed_assets/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39, 38, 37}
 skipsdist = true
 
 [testenv]

--- a/examples/project_fully_featured/tox.ini
+++ b/examples/project_fully_featured/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39,38,37,36}
 skipsdist = true
 
 [testenv]

--- a/examples/with_airflow/tox.ini
+++ b/examples/with_airflow/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39, 38, 37}
 skipsdist = true
 
 [testenv]

--- a/examples/with_great_expectations/tox.ini
+++ b/examples/with_great_expectations/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39, 38, 37}
 skipsdist = true
 
 [testenv]

--- a/examples/with_pyspark/tox.ini
+++ b/examples/with_pyspark/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39, 38, 37}
 skipsdist = true
 
 [testenv]

--- a/examples/with_pyspark_emr/tox.ini
+++ b/examples/with_pyspark_emr/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39, 38, 37}
 skipsdist = true
 
 [testenv]

--- a/examples/with_wandb/tox.ini
+++ b/examples/with_wandb/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{38, 37}
 
 [testenv]
 usedevelop = true

--- a/helm/dagster/schema/tox.ini
+++ b/helm/dagster/schema/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39,38,37,36}-{unix,windows}
 skipsdist = true
 
 [testenv]

--- a/integration_tests/python_modules/dagster-k8s-test-infra/tox.ini
+++ b/integration_tests/python_modules/dagster-k8s-test-infra/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39,38,37,36}-{unix,windows}
 skipsdist = true
 
 [testenv]

--- a/integration_tests/test_suites/backcompat-test-suite/tox.ini
+++ b/integration_tests/test_suites/backcompat-test-suite/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist=py{39,38,37,36}-{unix,windows}-{dagit-latest-release,dagit-earliest-release,user-code-latest-release,user-code-earliest-release}
 skipsdist = True
 
 [testenv]

--- a/integration_tests/test_suites/celery-k8s-test-suite/tox.ini
+++ b/integration_tests/test_suites/celery-k8s-test-suite/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39,38,37,36}-{unix,windows}-{default,markusercodedeploymentsubchart,markdaemon,markredis}
 skipsdist = True
 
 [testenv]

--- a/integration_tests/test_suites/daemon-test-suite/tox.ini
+++ b/integration_tests/test_suites/daemon-test-suite/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39,38,37,36}-{unix,windows}
 skipsdist = True
 
 [testenv]

--- a/integration_tests/test_suites/k8s-test-suite/tox.ini
+++ b/integration_tests/test_suites/k8s-test-suite/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39,38,37,36}-{unix,windows}-{default,subchart}
 skipsdist = True
 
 [testenv]

--- a/js_modules/dagit/tox.ini
+++ b/js_modules/dagit/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py310
 skipsdist = True
 
 [testenv]

--- a/python_modules/automation/tox.ini
+++ b/python_modules/automation/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39,38,37,36}-{unix,windows}
 skipsdist = true
 
 [testenv]

--- a/python_modules/dagit/tox.ini
+++ b/python_modules/dagit/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39,38,37,36}-{unix,windows}
 skipsdist = true
 
 [testenv]

--- a/python_modules/dagster-graphql/tox.ini
+++ b/python_modules/dagster-graphql/tox.ini
@@ -1,9 +1,4 @@
 [tox]
-envlist =
-  py{39,38,37,36}-{unix,windows}-{not_graphql_context_test_suite,sqlite_instance_multi_location,sqlite_instance_managed_grpc_env,sqlite_instance_deployed_grpc_env,graphql_python_client}
-  py{39,38,37,36}-{unix,windows}-postgres-{graphql_context_variants,instance_multi_location,instance_managed_grpc_env,instance_deployed_grpc_env}
-
-
 skipsdist = true
 
 [testenv]

--- a/python_modules/dagster-test/tox.ini
+++ b/python_modules/dagster-test/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39,38,37,36}-{unix,windows}
 skipsdist = true
 
 [testenv]

--- a/python_modules/dagster/tox.ini
+++ b/python_modules/dagster/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39,38,37,36}-{unix,windows}-{api_tests,cli_tests,core_tests,definitions_tests_old_pendulum,daemon_sensor_tests,daemon_tests,general_tests,general_tests_old_protobuf,scheduler_tests,scheduler_tests_old_pendulum}
 skipsdist = True
 
 [testenv]

--- a/python_modules/libraries/dagster-airbyte/tox.ini
+++ b/python_modules/libraries/dagster-airbyte/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{38,37,36}-{unix,windows}-{unit,integration}
 skipsdist = true
 
 [testenv]

--- a/python_modules/libraries/dagster-airflow/tox.ini
+++ b/python_modules/libraries/dagster-airflow/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39,38,37,36}-{unix,windows}-{default,localdb,persistentdb}-airflow{1,2}
 skipsdist = true
 
 [testenv]

--- a/python_modules/libraries/dagster-aws/tox.ini
+++ b/python_modules/libraries/dagster-aws/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39,38,37,36}-{unix,windows}
 skipsdist = true
 
 [testenv]

--- a/python_modules/libraries/dagster-azure/tox.ini
+++ b/python_modules/libraries/dagster-azure/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39,38,37,36}-{unix,windows}
 skipsdist = true
 
 [testenv]

--- a/python_modules/libraries/dagster-celery-docker/tox.ini
+++ b/python_modules/libraries/dagster-celery-docker/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39,38,37,36}-{unix,windows}
 skipsdist = true
 
 [testenv]

--- a/python_modules/libraries/dagster-celery-k8s/tox.ini
+++ b/python_modules/libraries/dagster-celery-k8s/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39,38,37,36}-{unix,windows}
 skipsdist = true
 
 [testenv]

--- a/python_modules/libraries/dagster-celery/tox.ini
+++ b/python_modules/libraries/dagster-celery/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39,38,37,36}-{unix,windows}
 skipsdist = true
 
 [testenv]

--- a/python_modules/libraries/dagster-census/tox.ini
+++ b/python_modules/libraries/dagster-census/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39,38,37,36}-{unix,windows}
 skipsdist = true
 
 [testenv]

--- a/python_modules/libraries/dagster-dask/tox.ini
+++ b/python_modules/libraries/dagster-dask/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39,38,37,36}-{unix,windows}
 skipsdist = true
 
 [testenv]

--- a/python_modules/libraries/dagster-databricks/tox.ini
+++ b/python_modules/libraries/dagster-databricks/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39,38,37,36}-{unix,windows}
 skipsdist = true
 
 [testenv]

--- a/python_modules/libraries/dagster-datadog/tox.ini
+++ b/python_modules/libraries/dagster-datadog/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39,38,37,36}-{unix,windows}
 skipsdist = true
 
 [testenv]

--- a/python_modules/libraries/dagster-datahub/tox.ini
+++ b/python_modules/libraries/dagster-datahub/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39,38,37,36}-{unix,windows}
 skipsdist = true
 
 [testenv]

--- a/python_modules/libraries/dagster-dbt/tox.ini
+++ b/python_modules/libraries/dagster-dbt/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39,38,37,36}-{unix,windows}-{dbt_13X,dbt_14X,dbt_15X}
 skipsdist = true
 
 [testenv]

--- a/python_modules/libraries/dagster-docker/tox.ini
+++ b/python_modules/libraries/dagster-docker/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39,38,37,36}-{unix,windows}
 skipsdist = true
 
 [testenv]

--- a/python_modules/libraries/dagster-duckdb-pandas/tox.ini
+++ b/python_modules/libraries/dagster-duckdb-pandas/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39,38,37}-{unix,windows}
 skipsdist = true
 
 [testenv]

--- a/python_modules/libraries/dagster-duckdb-polars/tox.ini
+++ b/python_modules/libraries/dagster-duckdb-polars/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39,38,37}-{unix,windows},mypy
 skipsdist = true
 
 [testenv]

--- a/python_modules/libraries/dagster-duckdb-pyspark/tox.ini
+++ b/python_modules/libraries/dagster-duckdb-pyspark/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39,38,37}-{unix,windows}
 skipsdist = true
 
 [testenv]

--- a/python_modules/libraries/dagster-duckdb/tox.ini
+++ b/python_modules/libraries/dagster-duckdb/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39,38,37}-{unix,windows}
 skipsdist = true
 
 [testenv]

--- a/python_modules/libraries/dagster-fivetran/tox.ini
+++ b/python_modules/libraries/dagster-fivetran/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39,38,37,36}-{unix,windows}
 skipsdist = true
 
 [testenv]

--- a/python_modules/libraries/dagster-gcp-pandas/tox.ini
+++ b/python_modules/libraries/dagster-gcp-pandas/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39,38,37}-{unix,windows},mypy
 skipsdist = true
 
 [testenv]

--- a/python_modules/libraries/dagster-gcp-pyspark/tox.ini
+++ b/python_modules/libraries/dagster-gcp-pyspark/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{310,39,38,37}-{unix,windows}
 
 [testenv]
 usedevelop = true

--- a/python_modules/libraries/dagster-gcp/tox.ini
+++ b/python_modules/libraries/dagster-gcp/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39,38,37,36}-{unix,windows}
 skipsdist = true
 
 [testenv]

--- a/python_modules/libraries/dagster-ge/tox.ini
+++ b/python_modules/libraries/dagster-ge/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39,38,37,36}-{unix,windows}
 skipsdist = true
 
 [testenv]

--- a/python_modules/libraries/dagster-github/tox.ini
+++ b/python_modules/libraries/dagster-github/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39,38,37,36}-{unix,windows}
 skipsdist = true
 
 [testenv]

--- a/python_modules/libraries/dagster-k8s/tox.ini
+++ b/python_modules/libraries/dagster-k8s/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{39,38,37,36}-{unix,windows}-{default,old_kubernetes}
+envlist = {default,old_kubernetes}
 skipsdist = true
 
 [testenv]

--- a/python_modules/libraries/dagster-managed-elements/tox.ini
+++ b/python_modules/libraries/dagster-managed-elements/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{38,37,36}-{unix,windows}
 skipsdist = true
 
 [testenv]

--- a/python_modules/libraries/dagster-mlflow/tox.ini
+++ b/python_modules/libraries/dagster-mlflow/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39,38,37,36}-{unix,windows}
 skipsdist = true
 
 [testenv]

--- a/python_modules/libraries/dagster-msteams/tox.ini
+++ b/python_modules/libraries/dagster-msteams/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39,38,37,36}-{unix,windows}
 skipsdist = true
 
 [testenv]

--- a/python_modules/libraries/dagster-mysql/tox.ini
+++ b/python_modules/libraries/dagster-mysql/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39,38,37,36}-{unix,windows}
 skipsdist = true
 
 [testenv]

--- a/python_modules/libraries/dagster-pagerduty/tox.ini
+++ b/python_modules/libraries/dagster-pagerduty/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39,38,37,36}-{unix,windows}
 skipsdist = true
 
 [testenv]

--- a/python_modules/libraries/dagster-pandas/tox.ini
+++ b/python_modules/libraries/dagster-pandas/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39,38,37,36}-{unix,windows}
 skipsdist = true
 
 [testenv]

--- a/python_modules/libraries/dagster-pandera/tox.ini
+++ b/python_modules/libraries/dagster-pandera/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39,38,37}-{unix,windows}
 skipsdist = true
 
 [testenv]

--- a/python_modules/libraries/dagster-papertrail/tox.ini
+++ b/python_modules/libraries/dagster-papertrail/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39,38,37,36}-{unix,windows}
 skipsdist = true
 
 [testenv]

--- a/python_modules/libraries/dagster-postgres/tox.ini
+++ b/python_modules/libraries/dagster-postgres/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39,38,37,36}-{unix,windows}
 skipsdist = true
 
 [testenv]

--- a/python_modules/libraries/dagster-prometheus/tox.ini
+++ b/python_modules/libraries/dagster-prometheus/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39,38,37,36}-{unix,windows}
 skipsdist = true
 
 [testenv]

--- a/python_modules/libraries/dagster-pyspark/tox.ini
+++ b/python_modules/libraries/dagster-pyspark/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39,38,37,36}-{unix,windows}
 skipsdist = true
 
 [testenv]

--- a/python_modules/libraries/dagster-shell/tox.ini
+++ b/python_modules/libraries/dagster-shell/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39,38,37,36}-{unix,windows}
 skipsdist = true
 
 [testenv]

--- a/python_modules/libraries/dagster-slack/tox.ini
+++ b/python_modules/libraries/dagster-slack/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39,38,37,36}-{unix,windows}
 skipsdist = true
 
 [testenv]

--- a/python_modules/libraries/dagster-snowflake-pandas/tox.ini
+++ b/python_modules/libraries/dagster-snowflake-pandas/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{38,37,36}-{unix,windows}
 skipsdist = true
 
 [testenv]

--- a/python_modules/libraries/dagster-snowflake-pyspark/tox.ini
+++ b/python_modules/libraries/dagster-snowflake-pyspark/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{38,37,36}-{unix,windows}
 skipsdist = true
 
 [testenv]

--- a/python_modules/libraries/dagster-snowflake/tox.ini
+++ b/python_modules/libraries/dagster-snowflake/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39,38,37,36}-{unix,windows}
 skipsdist = true
 
 [testenv]

--- a/python_modules/libraries/dagster-spark/tox.ini
+++ b/python_modules/libraries/dagster-spark/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39,38,37,36}-{unix,windows}
 skipsdist = true
 
 [testenv]

--- a/python_modules/libraries/dagster-ssh/tox.ini
+++ b/python_modules/libraries/dagster-ssh/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39,38,37,36}-{unix,windows}
 skipsdist = true
 
 [testenv]

--- a/python_modules/libraries/dagster-twilio/tox.ini
+++ b/python_modules/libraries/dagster-twilio/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{39,38,37,36}-{unix,windows}
 skipsdist = true
 
 [testenv]

--- a/python_modules/libraries/dagster-wandb/tox.ini
+++ b/python_modules/libraries/dagster-wandb/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{310,39,38,37}-{unix,windows}
 
 [testenv]
 usedevelop = true

--- a/python_modules/libraries/dagstermill/tox.ini
+++ b/python_modules/libraries/dagstermill/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{39,38,37,36}-{papermill1,papermill2}-{unix,windows}
+envlist = {papermill1,papermill2}
 skipsdist = true
 
 [testenv]

--- a/scripts/templates_create_dagster_package/tox.ini.tmpl
+++ b/scripts/templates_create_dagster_package/tox.ini.tmpl
@@ -1,5 +1,4 @@
 [tox]
-envlist = py{310,39,38,37}-{unix,windows}
 
 [testenv]
 usedevelop = true


### PR DESCRIPTION
Why I think we should remove these
* the vast majority are out of sync with the versions actively under test
* all this does is provide a set of environments to test by default when invoking `tox` which i dont believe is a workflow anyone does  ( https://tox.wiki/en/latest/config.html#envlist )

## How I Tested These Changes

bk