### PR TITLE
Make AssetSelection.from_coercible accept Sequences

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -1,3 +1,4 @@
+import collections.abc
 import operator
 from abc import ABC, abstractmethod
 from functools import reduce
@@ -275,11 +276,13 @@ class AssetSelection(ABC):
             return cls._selection_from_string(selection)
         elif isinstance(selection, AssetSelection):
             return selection
-        elif isinstance(selection, list) and all(isinstance(el, str) for el in selection):
+        elif isinstance(selection, collections.abc.Sequence) and all(
+            isinstance(el, str) for el in selection
+        ):
             return reduce(
                 operator.or_, [cls._selection_from_string(cast(str, s)) for s in selection]
             )
-        elif isinstance(selection, list) and all(
+        elif isinstance(selection, collections.abc.Sequence) and all(
             isinstance(el, (AssetsDefinition, SourceAsset)) for el in selection
         ):
             return AssetSelection.keys(
@@ -291,7 +294,9 @@ class AssetSelection(ABC):
                     )
                 )
             )
-        elif isinstance(selection, list) and all(isinstance(el, AssetKey) for el in selection):
+        elif isinstance(selection, collections.abc.Sequence) and all(
+            isinstance(el, AssetKey) for el in selection
+        ):
             return cls.keys(*cast(Sequence[AssetKey], selection))
         else:
             check.failed(

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
@@ -339,3 +339,18 @@ def test_from_coercible_multi_asset():
         AssetSelection.from_coercible([my_multi_asset]).resolve([my_multi_asset, other_asset])
         == my_multi_asset.keys
     )
+
+
+def test_from_coercible_tuple():
+    @asset
+    def foo():
+        ...
+
+    @asset
+    def bar():
+        ...
+
+    assert AssetSelection.from_coercible((foo, bar)).resolve([foo, bar]) == {
+        AssetKey("foo"),
+        AssetKey("bar"),
+    }


### PR DESCRIPTION
## Summary & Motivation

The type hint allows any sequence, but the code explicitly checked for lists.

Resolves: https://github.com/dagster-io/dagster/issues/14772

## How I Tested These Changes

Added test failed before, passes now.