### PR TITLE
Make graphql context test suite fixture class-scoped

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -652,6 +652,9 @@ class SqlEventLogStorage(EventLogStorage):
             if self.has_table("pending_steps"):
                 conn.execute(PendingStepsTable.delete())
 
+        self._wipe_index()
+
+    def _wipe_index(self):
         with self.index_connection() as conn:
             conn.execute(SqlEventLogStorageTable.delete())
             conn.execute(AssetKeyTable.delete())


### PR DESCRIPTION
Summary:
Sharing the context between the same tests in a class (wiping the storage between classes) makes these test suites take ~15 minutes instead of ~25 minutes.

To make the wiping between tests not destructive I had to make the sqlite event log storage wipe semantically similar to the other wipe() methods - deleting the rows in the table but not dropping the schema entirely.

