### PR TITLE
Add utility to parse string into MultiPartitionKey

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/multi_dimensional_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_dimensional_partitions.py
@@ -3,7 +3,6 @@ import itertools
 from datetime import datetime
 from functools import reduce
 from typing import (
-    TYPE_CHECKING,
     Dict,
     Iterable,
     List,
@@ -40,8 +39,6 @@ from .partition import (
 )
 from .time_window_partitions import TimeWindow, TimeWindowPartitionsDefinition
 
-if TYPE_CHECKING:
-    from dagster import MultiPartitionsDefinition
 INVALID_STATIC_PARTITIONS_KEY_CHARACTERS = set(["|", ",", "[", "]"])
 
 MULTIPARTITION_KEY_DELIMITER = "|"

--- a/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
+++ b/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
@@ -266,7 +266,6 @@ def test_multi_partitions() -> None:
 
     def config_fn(partition_key: str):
         mpk = MultiPartitionKey.from_str(partition_key, multi_partition_def)
-        print(mpk.keys_by_dimension)
         return {
             "ops": {
                 "my_op": {
@@ -292,9 +291,6 @@ def test_multi_partitions() -> None:
     assert job_def.partitioned_config.get_run_config_for_partition_key(str(partition_keys[0])) == {
         "ops": {"my_op": {"config": {"date": "2020-02-25", "client": "foo"}}}
     }
-    # assert job_def.partitioned_config.get_run_config_for_partition_key(partition_keys[1]) == {
-    #     "ops": {"my_op": {"config": {"date": "2020-02-26"}}}
-    # }
 
 
 def test_partitions():

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_multi_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_multi_partitions.py
@@ -214,6 +214,31 @@ def test_multipartitions_subset_serialization():
     ).get_partition_keys() == set(partition_keys)
 
 
+def test_parse_multi_partition_key() -> None:
+    partitions1 = StaticPartitionsDefinition(["a", "b", "c"])
+    partitions2 = StaticPartitionsDefinition(["x", "y", "z"])
+    composite = MultiPartitionsDefinition({"abc": partitions1, "xyz": partitions2})
+
+    assert MultiPartitionKey.from_str("a|x", composite) == MultiPartitionKey(
+        {"abc": "a", "xyz": "x"}
+    )
+    assert MultiPartitionKey.from_str("c|z", composite) == MultiPartitionKey(
+        {"abc": "c", "xyz": "z"}
+    )
+
+
+def test_parse_multi_partition_key_errs() -> None:
+    partitions1 = StaticPartitionsDefinition(["a", "b", "c"])
+    partitions2 = StaticPartitionsDefinition(["x", "y", "z"])
+    composite = MultiPartitionsDefinition({"abc": partitions1, "xyz": partitions2})
+
+    with pytest.raises(DagsterInvalidDefinitionError):
+        MultiPartitionKey.from_str("a", composite)
+
+    with pytest.raises(DagsterInvalidDefinitionError):
+        MultiPartitionKey.from_str("a|b|z", composite)
+
+
 def test_multipartitions_subset_equality():
     assert multipartitions_def.empty_subset().with_partition_keys(
         [


### PR DESCRIPTION
## Summary

Adds a user-facing utility to parse a partition key back into a `MultiPartitionKey`, useful in cases such as the `run_config_for_partition_key_fn` which have the `MultiPartitionKey` casted back to a raw string.

```python
partitions1 = StaticPartitionsDefinition(["a", "b", "c"])
partitions2 = StaticPartitionsDefinition(["x", "y", "z"])
composite = MultiPartitionsDefinition({"abc": partitions1, "xyz": partitions2})

mpk = MultiPartitionKey(
    {"abc": "a", "xyz": "x"}
)
mpk_str = str(mpk) # "a|x"

assert MultiPartitionKey.from_str(mpk_str, composite) == mpk
```

## Test Plan

New unit tests.
