### PR TITLE
pin pydantic<2

### DIFF
--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -106,7 +106,7 @@ setup(
         "docstring-parser",
         "universal_pathlib",
         # https://github.com/pydantic/pydantic/issues/5821
-        "pydantic != 1.10.7",
+        "pydantic != 1.10.7,<2.0.0",
     ],
     extras_require={
         "docker": ["docker"],


### PR DESCRIPTION
## Summary

Pins `pydantic<2` (in beta) until we are compatible. Resolves #14647.
