### PR TITLE
[ui] Use compact formatter for auto-materialize evaluation count

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetView.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetView.tsx
@@ -213,7 +213,7 @@ export const AssetView: React.FC<Props> = ({assetKey}) => {
     );
   };
 
-  const renderAutomaterializePolicyTab = () => {
+  const renderAutomaterializeHistoryTab = () => {
     if (definitionQueryResult.loading && !definitionQueryResult.previousData) {
       return <AssetLoadingDefinitionState />;
     }
@@ -310,7 +310,7 @@ export const AssetView: React.FC<Props> = ({assetKey}) => {
         ) : selectedTab === 'plots' ? (
           renderPlotsTab()
         ) : selectedTab === 'auto-materialize-history' ? (
-          renderAutomaterializePolicyTab()
+          renderAutomaterializeHistoryTab()
         ) : (
           <span />
         )}

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AssetAutomaterializePolicyPage.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AssetAutomaterializePolicyPage.tsx
@@ -2,6 +2,7 @@ import {gql, useQuery} from '@apollo/client';
 import {
   Body,
   Box,
+  Caption,
   Colors,
   CursorPaginationControls,
   ExternalAnchorButton,
@@ -23,6 +24,7 @@ import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../../app/QueryRefresh
 import {useQueryPersistedState} from '../../hooks/useQueryPersistedState';
 import {useCursorPaginatedQuery} from '../../runs/useCursorPaginatedQuery';
 import {TimestampDisplay} from '../../schedules/TimestampDisplay';
+import {compactNumber} from '../../ui/formatters';
 import {
   AutomaterializePolicyTag,
   automaterializePolicyDescription,
@@ -276,22 +278,25 @@ function LeftPanel({
                   style={{width: '100%'}}
                 >
                   <div>No materialization conditions met </div>
-                  <div>
+                  <Caption>
                     {evaluation.startTimestamp ? (
-                      <>
-                        {evaluation.amount} evaluation{evaluation.amount === 1 ? '' : 's'}
-                      </>
+                      evaluation.amount === 1 ? (
+                        '1 evaluation'
+                      ) : (
+                        `${compactNumber(evaluation.amount)} evaluations`
+                      )
                     ) : (
                       <>
-                        {'Before'}{' '}
                         {evaluation.endTimestamp === 'now' ? (
-                          'now'
+                          'Before now'
                         ) : (
-                          <TimestampDisplay timestamp={evaluation.endTimestamp} />
+                          <>
+                            Before <TimestampDisplay timestamp={evaluation.endTimestamp} />
+                          </>
                         )}
                       </>
                     )}
-                  </div>
+                  </Caption>
                 </Box>
               </EvaluationRow>
             );
@@ -312,10 +317,11 @@ function LeftPanel({
                   style={{width: '100%'}}
                 >
                   <div style={{color: Colors.Yellow700}}>
-                    {evaluation.numSkipped} materialization{evaluation.numSkipped === 1 ? '' : 's'}{' '}
-                    skipped{' '}
+                    {compactNumber(evaluation.numSkipped)} skipped
                   </div>
-                  <TimestampDisplay timestamp={evaluation.timestamp} />
+                  <Caption>
+                    <TimestampDisplay timestamp={evaluation.timestamp} />
+                  </Caption>
                 </Box>
               </EvaluationRow>
             );
@@ -334,11 +340,10 @@ function LeftPanel({
               >
                 <Icon name="done" color={Colors.Blue700} />
                 <Box flex={{direction: 'column', gap: 4}} style={{width: '100%'}}>
-                  <div>
-                    {evaluation.numRequested} run{evaluation.numRequested === 1 ? '' : 's'}{' '}
-                    requested
-                  </div>
-                  <TimestampDisplay timestamp={evaluation.timestamp} />
+                  <div>{compactNumber(evaluation.numRequested)} requested</div>
+                  <Caption>
+                    <TimestampDisplay timestamp={evaluation.timestamp} />
+                  </Caption>
                 </Box>
               </Box>
             </EvaluationRow>
@@ -718,7 +723,7 @@ const CollapsibleSection = ({
         >
           <Icon
             name="arrow_drop_down"
-            style={{transform: isCollapsed ? 'rotate(180deg)' : 'rotate(0deg)'}}
+            style={{transform: isCollapsed ? 'rotate(-90deg)' : 'rotate(0deg)'}}
           />
           <Subheading>{header}</Subheading>
         </CenterAlignedRow>

--- a/js_modules/dagit/packages/core/src/assets/AutomaterializeDaemonStatusTag.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutomaterializeDaemonStatusTag.tsx
@@ -10,23 +10,24 @@ import {
   SetAutoMaterializePausedMutationVariables,
 } from './types/AutomaterializeDaemonStatusTag.types';
 
-export const AutomaterializeDaemonStatusTag: React.FC = () => {
+export const AutomaterializeDaemonStatusTag = () => {
   const {paused} = useAutomaterializeDaemonStatus();
 
   return (
-    <Link to="/health">
-      {paused ? (
-        <Tooltip content="Auto-materializing is paused. New materializations will not be triggered by auto-materialization policies.">
-          <Tag icon="toggle_off" intent="warning">
-            Auto-materialize
-          </Tag>
-        </Tooltip>
-      ) : (
-        <Tag icon="toggle_on" intent="success">
-          Auto-materialize
+    <Tooltip
+      content={
+        paused
+          ? 'Auto-materializing is paused. New materializations will not be triggered by auto-materialization policies.'
+          : ''
+      }
+      canShow={paused}
+    >
+      <Link to="/health" style={{outline: 'none'}}>
+        <Tag icon={paused ? 'toggle_off' : 'toggle_on'} intent={paused ? 'warning' : 'success'}>
+          {paused ? 'Auto-materialize off' : 'Auto-materialize on'}
         </Tag>
-      )}
-    </Link>
+      </Link>
+    </Tooltip>
   );
 };
 


### PR DESCRIPTION
## Summary & Motivation

Use the compact number formatter for materialization counts on the Auto-materialize history page. Additionally:

- Add 'on' and 'off' to the auto-materialize status tag in the header and tidy up the tag link
- Use `Caption` text for secondary text in materialization list items
- Just show "requested", "skipped" etc instead of "materializion skipped"
- Rotate collapse icon to match other use cases

Compact number, caption text:
<img width="309" alt="Screenshot 2023-06-12 at 2 17 29 PM" src="https://github.com/dagster-io/dagster/assets/2823852/d7cfd4fd-d538-436a-89c5-0a24952d5f7f">

Labels:
<img width="300" alt="Screenshot 2023-06-14 at 9 23 37 AM" src="https://github.com/dagster-io/dagster/assets/2823852/eb96ed39-fbfe-4e1a-8577-eab0c0f4a2b0">

Tag:
<img width="157" alt="Screenshot 2023-06-14 at 9 23 25 AM" src="https://github.com/dagster-io/dagster/assets/2823852/a279b1ca-3079-409d-926d-f57329d59cb4">


## How I Tested These Changes

Storybook example. View http://localhost:3000/assets/eager_downstream_1?view=auto-materialize-history with auto-materialize on and off, verify correct list rendering, tag rendering, etc.
