### PR TITLE
migrate examples to AssetExecutionContext

### DIFF
--- a/examples/quickstart_aws/quickstart_aws/assets/hackernews.py
+++ b/examples/quickstart_aws/quickstart_aws/assets/hackernews.py
@@ -5,7 +5,7 @@ from io import BytesIO
 import matplotlib.pyplot as plt
 import pandas as pd
 import requests
-from dagster import MetadataValue, OpExecutionContext, asset
+from dagster import AssetExecutionContext, MetadataValue, asset
 from dagster_aws.s3 import S3Resource
 from wordcloud import STOPWORDS, WordCloud
 
@@ -23,7 +23,7 @@ def hackernews_topstory_ids() -> pd.DataFrame:
 
 @asset(group_name="hackernews", compute_kind="HackerNews API")
 def hackernews_topstories(
-    context: OpExecutionContext, hackernews_topstory_ids: pd.DataFrame
+    context: AssetExecutionContext, hackernews_topstory_ids: pd.DataFrame
 ) -> pd.DataFrame:
     """Get items based on story ids from the HackerNews items endpoint. It may take 1-2 minutes to fetch all 500 items.
 
@@ -53,7 +53,7 @@ def hackernews_topstories(
 
 @asset(group_name="hackernews", compute_kind="Plot")
 def hackernews_topstories_word_cloud(
-    context: OpExecutionContext,
+    context: AssetExecutionContext,
     s3: S3Resource,
     hackernews_topstories: pd.DataFrame,
 ) -> None:

--- a/examples/quickstart_etl/quickstart_etl/assets/hackernews.py
+++ b/examples/quickstart_etl/quickstart_etl/assets/hackernews.py
@@ -5,7 +5,7 @@ from typing import List
 import matplotlib.pyplot as plt
 import pandas as pd
 import requests
-from dagster import MetadataValue, OpExecutionContext, asset
+from dagster import AssetExecutionContext, MetadataValue, asset
 from wordcloud import STOPWORDS, WordCloud
 
 
@@ -22,7 +22,7 @@ def hackernews_topstory_ids() -> List[int]:
 
 @asset(group_name="hackernews", compute_kind="HackerNews API")
 def hackernews_topstories(
-    context: OpExecutionContext, hackernews_topstory_ids: List[int]
+    context: AssetExecutionContext, hackernews_topstory_ids: List[int]
 ) -> pd.DataFrame:
     """Get items based on story ids from the HackerNews items endpoint. It may take 1-2 minutes to fetch all 500 items.
 
@@ -52,7 +52,7 @@ def hackernews_topstories(
 
 @asset(group_name="hackernews", compute_kind="Plot")
 def hackernews_topstories_word_cloud(
-    context: OpExecutionContext, hackernews_topstories: pd.DataFrame
+    context: AssetExecutionContext, hackernews_topstories: pd.DataFrame
 ) -> bytes:
     """Exploratory analysis: Generate a word cloud from the current top 500 HackerNews top stories.
     Embed the plot into a Markdown metadata for quick view.

--- a/examples/quickstart_gcp/quickstart_gcp/assets/hackernews.py
+++ b/examples/quickstart_gcp/quickstart_gcp/assets/hackernews.py
@@ -4,7 +4,7 @@ from io import BytesIO
 import matplotlib.pyplot as plt
 import pandas as pd
 import requests
-from dagster import MetadataValue, OpExecutionContext, asset
+from dagster import AssetExecutionContext, MetadataValue, asset
 from wordcloud import STOPWORDS, WordCloud
 
 
@@ -21,7 +21,7 @@ def hackernews_topstory_ids() -> pd.DataFrame:
 
 @asset(group_name="hackernews", compute_kind="HackerNews API")
 def hackernews_topstories(
-    context: OpExecutionContext, hackernews_topstory_ids: pd.DataFrame
+    context: AssetExecutionContext, hackernews_topstory_ids: pd.DataFrame
 ) -> pd.DataFrame:
     """Get items based on story ids from the HackerNews items endpoint. It may take 1-2 minutes to fetch all 500 items.
 
@@ -54,7 +54,7 @@ def hackernews_topstories(
 
 @asset(group_name="hackernews", compute_kind="Plot")
 def hackernews_topstories_word_cloud(
-    context: OpExecutionContext, hackernews_topstories: pd.DataFrame
+    context: AssetExecutionContext, hackernews_topstories: pd.DataFrame
 ) -> None:
     """Exploratory analysis: Generate a word cloud from the current top 500 HackerNews top stories.
     Embed the plot into a Markdown metadata for quick view.

--- a/examples/quickstart_snowflake/quickstart_snowflake/assets/hackernews.py
+++ b/examples/quickstart_snowflake/quickstart_snowflake/assets/hackernews.py
@@ -4,7 +4,7 @@ from io import BytesIO
 import matplotlib.pyplot as plt
 import pandas as pd
 import requests
-from dagster import MetadataValue, OpExecutionContext, asset
+from dagster import AssetExecutionContext, MetadataValue, asset
 from wordcloud import STOPWORDS, WordCloud
 
 
@@ -21,7 +21,7 @@ def hackernews_topstory_ids() -> pd.DataFrame:
 
 @asset(group_name="hackernews", compute_kind="HackerNews API")
 def hackernews_topstories(
-    context: OpExecutionContext, hackernews_topstory_ids: pd.DataFrame
+    context: AssetExecutionContext, hackernews_topstory_ids: pd.DataFrame
 ) -> pd.DataFrame:
     """Get items based on story ids from the HackerNews items endpoint. It may take 1-2 minutes to fetch all 500 items.
 
@@ -51,7 +51,7 @@ def hackernews_topstories(
 
 @asset(group_name="hackernews", compute_kind="Plot")
 def hackernews_topstories_word_cloud(
-    context: OpExecutionContext, hackernews_topstories: pd.DataFrame
+    context: AssetExecutionContext, hackernews_topstories: pd.DataFrame
 ) -> None:
     """Exploratory analysis: Generate a word cloud from the current top 500 HackerNews top stories.
     Embed the plot into a Markdown metadata for quick view.

--- a/examples/with_wandb/with_wandb/assets/advanced_example.py
+++ b/examples/with_wandb/with_wandb/assets/advanced_example.py
@@ -1,5 +1,5 @@
 import wandb
-from dagster import AssetIn, OpExecutionContext, asset
+from dagster import AssetExecutionContext, AssetIn, asset
 from dagster_wandb import WandbArtifactConfiguration
 
 wandb_artifact_configuration: WandbArtifactConfiguration = {
@@ -79,11 +79,11 @@ def write_advanced_artifact() -> wandb.wandb_sdk.wandb_artifacts.Artifact:
     },
     output_required=False,
 )
-def get_table(context: OpExecutionContext, table: wandb.Table) -> None:
+def get_table(context: AssetExecutionContext, table: wandb.Table) -> None:
     """Example that reads a W&B Table contained in an Artifact.
 
     Args:
-        context (OpExecutionContext): Dagster execution context
+        context (AssetExecutionContext): Dagster execution context
         table (wandb.Table): Table contained in our downloaded Artifact
 
     Here, we use the integration to read the W&B Table object created in the previous asset.
@@ -108,11 +108,11 @@ def get_table(context: OpExecutionContext, table: wandb.Table) -> None:
     },
     output_required=False,
 )
-def get_path(context: OpExecutionContext, path: str) -> None:
+def get_path(context: AssetExecutionContext, path: str) -> None:
     """Example that gets the local path of a file contained in an Artifact.
 
     Args:
-        context (OpExecutionContext): Dagster execution context
+        context (AssetExecutionContext): Dagster execution context
         path (str): Path in the local filesystem of the downloaded file
 
     Here, we use the integration to collect the local of the file added through the 'add_dirs' in
@@ -133,12 +133,12 @@ def get_path(context: OpExecutionContext, path: str) -> None:
     output_required=False,
 )
 def get_artifact(
-    context: OpExecutionContext, artifact: wandb.wandb_sdk.wandb_artifacts.Artifact
+    context: AssetExecutionContext, artifact: wandb.wandb_sdk.wandb_artifacts.Artifact
 ) -> None:
     """Example that gets the entire Artifact object.
 
     Args:
-        context (OpExecutionContext): Dagster execution context
+        context (AssetExecutionContext): Dagster execution context
         artifact (wandb.wandb_sdk.wandb_artifacts.Artifact): Downloaded Artifact object
 
     Here, we use the integration to collect the entire W&B Artifact object created from in first

--- a/examples/with_wandb/with_wandb/assets/custom_serialization_example.py
+++ b/examples/with_wandb/with_wandb/assets/custom_serialization_example.py
@@ -1,6 +1,6 @@
 import numpy
 import onnxruntime as rt
-from dagster import AssetIn, AssetOut, OpExecutionContext, asset, multi_asset
+from dagster import AssetExecutionContext, AssetIn, AssetOut, asset, multi_asset
 from skl2onnx import convert_sklearn
 from skl2onnx.common.data_types import FloatTensorType
 from sklearn.datasets import load_iris
@@ -36,7 +36,7 @@ def create_model_serialized_with_joblib():
         }
     },
 )
-def use_model_serialized_with_joblib(context: OpExecutionContext, my_joblib_serialized_model):
+def use_model_serialized_with_joblib(context: AssetExecutionContext, my_joblib_serialized_model):
     inference_result = my_joblib_serialized_model(1, 2)
     context.log.info(inference_result)  # Prints: 3
     return inference_result

--- a/examples/with_wandb/with_wandb/assets/model_registry_example.py
+++ b/examples/with_wandb/with_wandb/assets/model_registry_example.py
@@ -1,5 +1,5 @@
 import wandb
-from dagster import AssetIn, OpExecutionContext, asset
+from dagster import AssetExecutionContext, AssetIn, asset
 
 MODEL_NAME = "my_model"
 
@@ -29,12 +29,12 @@ def write_model() -> wandb.wandb_sdk.wandb_artifacts.Artifact:
     config_schema={"model_registry": str},
 )
 def promote_best_model_to_production(
-    context: OpExecutionContext, artifact: wandb.wandb_sdk.wandb_artifacts.Artifact
+    context: AssetExecutionContext, artifact: wandb.wandb_sdk.wandb_artifacts.Artifact
 ):
     """Example that links a model stored in a W&B Artifact to the Model Registry.
 
     Args:
-        context (OpExecutionContext): Dagster execution context
+        context (AssetExecutionContext): Dagster execution context
         artifact (wandb.wandb_sdk.wandb_artifacts.Artifact): Downloaded Artifact object
     """
     # In a real scenario you would evaluate model performance


### PR DESCRIPTION
follow-up to #14760 for examples that require `AssetExecutionContext` to be published first

## How I Tested These Changes

bk
#14770
