### PR TITLE
Fix docs typo

### DIFF
--- a/docs/content/dagster-cloud/deployment/agents/amazon-ecs/configuration-reference.mdx
+++ b/docs/content/dagster-cloud/deployment/agents/amazon-ecs/configuration-reference.mdx
@@ -290,10 +290,10 @@ user_code_launcher:
   </ReferenceTableItem>
   <ReferenceTableItem
   propertyName="config.server_ecs_tags">
-  Additional ECS tags to include in the service for each code location. If set, must be a list of dictionaries, each with a <code>key</code> key and optional <code>value> key.
+  Additional ECS tags to include in the service for each code location. If set, must be a list of dictionaries, each with a <code>key</code> key and optional <code>value</code> key.
   </ReferenceTableItem>
   <ReferenceTableItem
   propertyName="config.run_ecs_tags">
-  Additional ECS tags to include in the task for each run. If set, must be a list of dictionaries, each with a <code>key</code> key and optional <code>value> key.
+  Additional ECS tags to include in the task for each run. If set, must be a list of dictionaries, each with a <code>key</code> key and optional <code>value</code> key.
   </ReferenceTableItem>
 </ReferenceTable>


### PR DESCRIPTION
Summary:
I made some last minute changes here and foolishly did not check them in the browser. BK seems to be missing syntax errors in the docs site as well, surprisingly.

Test Plan: View the page in the browser

## Summary & Motivation

## How I Tested These Changes
