### PR TITLE
dagit -> dagster-webserver docstring and comment renames

### DIFF
--- a/python_modules/dagster-webserver/dagster_webserver/cli.py
+++ b/python_modules/dagster-webserver/dagster_webserver/cli.py
@@ -186,7 +186,7 @@ def dagster_webserver(
         logger=logger,
     ) as instance:
         # Allow the instance components to change behavior in the context of a long running server process
-        instance.optimize_for_dagster_webserver(db_statement_timeout, db_pool_recycle)
+        instance.optimize_for_webserver(db_statement_timeout, db_pool_recycle)
 
         with get_workspace_process_context_from_kwargs(
             instance,

--- a/python_modules/dagster-webserver/dagster_webserver/cli.py
+++ b/python_modules/dagster-webserver/dagster_webserver/cli.py
@@ -186,7 +186,7 @@ def dagster_webserver(
         logger=logger,
     ) as instance:
         # Allow the instance components to change behavior in the context of a long running server process
-        instance.optimize_for_dagit(db_statement_timeout, db_pool_recycle)
+        instance.optimize_for_dagster_webserver(db_statement_timeout, db_pool_recycle)
 
         with get_workspace_process_context_from_kwargs(
             instance,

--- a/python_modules/dagster/dagster/_cli/api.py
+++ b/python_modules/dagster/dagster/_cli/api.py
@@ -509,7 +509,7 @@ def _execute_step_command_body(
     help=(
         "Wait until the first LoadRepositories call to actually load the repositories, instead of"
         " waiting to load them when the server is launched. Useful for surfacing errors when the"
-        " server is managed directly from Dagit"
+        " server is managed directly from the Dagster UI."
     ),
     envvar="DAGSTER_LAZY_LOAD_USER_CODE",
 )

--- a/python_modules/dagster/dagster/_cli/asset.py
+++ b/python_modules/dagster/dagster/_cli/asset.py
@@ -166,7 +166,7 @@ def asset_wipe_command(key, **cli_args):
 @click.option("--all", is_flag=True, help="Wipe partitions status cache of all asset keys")
 @click.option("--noprompt", is_flag=True)
 def asset_wipe_cache_command(key, **cli_args):
-    r"""Clears the asset partitions status cache, which is used by Dagit to load partition
+    r"""Clears the asset partitions status cache, which is used by the webserver to load partition
     pages more quickly. The cache will be rebuilt the next time the partition pages are loaded,
     if caching is enabled.
 

--- a/python_modules/dagster/dagster/_cli/debug.py
+++ b/python_modules/dagster/dagster/_cli/debug.py
@@ -38,8 +38,8 @@ def debug_cli():
     This can be used to send a file to someone like the Dagster team who doesn't have direct access
     to your instance to allow them to view the events and details of a specific run.
 
-    Debug files can be viewed using `dagit-debug` cli.
-    Debug files can also be downloaded from dagit.
+    Debug files can be viewed using `dagster-webserver-debug` cli.
+    Debug files can also be downloaded from the Dagster UI.
     """
 
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
@@ -984,7 +984,7 @@ def build_asset_reconciliation_sensor(
         minimum_interval_seconds (Optional[int]): The minimum amount of time that should elapse between sensor invocations.
         description (Optional[str]): A description for the sensor.
         default_status (DefaultSensorStatus): Whether the sensor starts as running or not. The default
-            status can be overridden from Dagit or via the GraphQL API.
+            status can be overridden from the Dagster UI or via the GraphQL API.
         run_tags (Optional[Mapping[str, str]): Dictionary of tags to pass to the RunRequests launched by this sensor
 
     Returns:

--- a/python_modules/dagster/dagster/_core/definitions/asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_sensor_definition.py
@@ -64,7 +64,7 @@ class AssetSensorDefinition(SensorDefinition):
         jobs (Optional[Sequence[Union[GraphDefinition, JobDefinition, UnresolvedAssetJobDefinition]]]):
             (experimental) A list of jobs to be executed when the sensor fires.
         default_status (DefaultSensorStatus): Whether the sensor starts as running or not. The default
-            status can be overridden from Dagit or via the GraphQL API.
+            status can be overridden from the Dagster UI or via the GraphQL API.
     """
 
     def __init__(

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -1011,8 +1011,8 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
             # materialize the unselected asset.
             #
             # Thus, we include unselected assets that may be accidentally materialized in
-            # keys_by_output_name and asset_deps so that Dagit can populate an warning when this
-            # occurs. This is the same behavior as multi-asset subsetting.
+            # keys_by_output_name and asset_deps so that tee webserver can populate an warning when
+            # this occurs. This is the same behavior as multi-asset subsetting.
 
             subsetted_asset_deps = {
                 out_asset_key: set(self._keys_by_input_name.values())

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -1011,7 +1011,7 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
             # materialize the unselected asset.
             #
             # Thus, we include unselected assets that may be accidentally materialized in
-            # keys_by_output_name and asset_deps so that tee webserver can populate an warning when
+            # keys_by_output_name and asset_deps so that the webserver can populate an warning when
             # this occurs. This is the same behavior as multi-asset subsetting.
 
             subsetted_asset_deps = {

--- a/python_modules/dagster/dagster/_core/definitions/configurable.py
+++ b/python_modules/dagster/dagster/_core/definitions/configurable.py
@@ -79,7 +79,7 @@ class AnonymousConfigurableDefinition(ConfigurableDefinition):
         object.
 
         Using ``configured`` may result in config values being displayed in
-        Dagit, so it is not recommended to use this API with sensitive values,
+        the Dagster UI, so it is not recommended to use this API with sensitive values,
         such as secrets.
 
         Args:
@@ -124,7 +124,7 @@ class NamedConfigurableDefinition(ConfigurableDefinition):
         object.
 
         Using ``configured`` may result in config values being displayed in
-        Dagit, so it is not recommended to use this API with sensitive values,
+        the Dagster UI, so it is not recommended to use this API with sensitive values,
         such as secrets.
 
         Args:
@@ -264,7 +264,7 @@ def configured(
     * :py:class:`ResourceDefinition`
     * :py:class:`OpDefinition`
 
-    Using ``configured`` may result in config values being displayed in Dagit,
+    Using ``configured`` may result in config values being displayed in the Dagster UI,
     so it is not recommended to use this API with sensitive values, such as
     secrets.
 

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -146,7 +146,7 @@ def asset(
             storing the output of the op as an asset,  and for loading it in
             downstream ops. Only one of io_manager_def and io_manager_key can be provided.
         compute_kind (Optional[str]): A string to represent the kind of computation that produces
-            the asset, e.g. "dbt" or "spark". It will be displayed in Dagit as a badge on the asset.
+            the asset, e.g. "dbt" or "spark". It will be displayed in the Dagster UI as a badge on the asset.
         dagster_type (Optional[DagsterType]): Allows specifying type validation functions that
             will be executed on the output of the decorated function after it runs.
         partitions_def (Optional[PartitionsDefinition]): Defines the set of partition keys that
@@ -448,7 +448,7 @@ def multi_asset(
             if it does not. If not set, Dagster will accept any config provided for the op.
         required_resource_keys (Optional[Set[str]]): Set of resource handles required by the underlying op.
         compute_kind (Optional[str]): A string to represent the kind of computation that produces
-            the asset, e.g. "dbt" or "spark". It will be displayed in Dagit as a badge on the asset.
+            the asset, e.g. "dbt" or "spark". It will be displayed in the Dagster UI as a badge on the asset.
         internal_asset_deps (Optional[Mapping[str, Set[AssetKey]]]): By default, it is assumed
             that all assets produced by a multi_asset depend on all assets that are consumed by that
             multi asset. If this default is not correct, you pass in a map of output names to a

--- a/python_modules/dagster/dagster/_core/definitions/decorators/job_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/job_decorator.py
@@ -178,7 +178,7 @@ def job(
 
             If a dictionary is provided, then it must conform to the standard config schema, and
             it will be used as the job's run config for the job whenever the job is executed.
-            The values provided will be viewable and editable in the Dagit playground, so be
+            The values provided will be viewable and editable in the Dagster UI, so be
             careful with secrets.
 
             If a :py:class:`RunConfig` object is provided, then it will be used directly as the run config
@@ -191,14 +191,14 @@ def job(
             If a :py:class:`PartitionedConfig` object is provided, then it defines a discrete set of config
             values that can parameterize the job, as well as a function for mapping those
             values to the base config. The values provided will be viewable and editable in the
-            Dagit playground, so be careful with secrets.
+            Dagster UI, so be careful with secrets.
         tags (Optional[Dict[str, Any]]):
             Arbitrary information that will be attached to the execution of the Job.
             Values that are not strings will be json encoded and must meet the criteria that
             `json.loads(json.dumps(value)) == value`.  These tag values may be overwritten by tag
             values provided at invocation time.
         metadata (Optional[Dict[str, RawMetadataValue]]):
-            Arbitrary information that will be attached to the JobDefinition and be viewable in Dagit.
+            Arbitrary information that will be attached to the JobDefinition and be viewable in the Dagster UI.
             Keys must be strings, and values must be python primitive types or one of the provided
             MetadataValue types
         logger_defs (Optional[Dict[str, LoggerDefinition]]):

--- a/python_modules/dagster/dagster/_core/definitions/decorators/schedule_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/schedule_decorator.py
@@ -96,7 +96,7 @@ def schedule(
         job (Optional[Union[GraphDefinition, JobDefinition, UnresolvedAssetJobDefinition]]): The job
             that should execute when this schedule runs.
         default_status (DefaultScheduleStatus): Whether the schedule starts as running or not. The default
-            status can be overridden from Dagit or via the GraphQL API.
+            status can be overridden from the Dagster UI or via the GraphQL API.
         required_resource_keys (Optional[Set[str]]): The set of resource keys required by the schedule.
     """
 

--- a/python_modules/dagster/dagster/_core/definitions/decorators/sensor_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/sensor_decorator.py
@@ -61,7 +61,7 @@ def sensor(
         jobs (Optional[Sequence[Union[GraphDefinition, JobDefinition, UnresolvedAssetJobDefinition]]]):
             (experimental) A list of jobs to be executed when the sensor fires.
         default_status (DefaultSensorStatus): Whether the sensor starts as running or not. The default
-            status can be overridden from Dagit or via the GraphQL API.
+            status can be overridden from the Dagster UI or via the GraphQL API.
         asset_selection (AssetSelection): (Experimental) an asset selection to launch a run for if
             the sensor condition is met. This can be provided instead of specifying a job.
     """
@@ -128,7 +128,7 @@ def asset_sensor(
         jobs (Optional[Sequence[Union[GraphDefinition, JobDefinition, UnresolvedAssetJobDefinition]]]):
             (experimental) A list of jobs to be executed when the sensor fires.
         default_status (DefaultSensorStatus): Whether the sensor starts as running or not. The default
-            status can be overridden from Dagit or via the GraphQL API.
+            status can be overridden from the Dagster UI or via the GraphQL API.
 
 
     Example:
@@ -246,7 +246,7 @@ def multi_asset_sensor(
         jobs (Optional[Sequence[Union[GraphDefinition, JobDefinition, UnresolvedAssetJobDefinition]]]):
             (experimental) A list of jobs to be executed when the sensor fires.
         default_status (DefaultSensorStatus): Whether the sensor starts as running or not. The default
-            status can be overridden from Dagit or via the GraphQL API.
+            status can be overridden from the Dagster UI or via the GraphQL API.
         request_assets (Optional[AssetSelection]): (Experimental) an asset selection to launch a run
             for if the sensor condition is met. This can be provided instead of specifying a job.
     """

--- a/python_modules/dagster/dagster/_core/definitions/events.py
+++ b/python_modules/dagster/dagster/_core/definitions/events.py
@@ -476,7 +476,7 @@ class AssetMaterialization(
     framework.
 
     Op authors should use these events to organize metadata about the side effects of their
-    computations, enabling tooling like the Assets dashboard in Dagit.
+    computations, enabling tooling like the Assets dashboard in the Dagster UI.
 
     Args:
         asset_key (Union[str, List[str], AssetKey]): A key to identify the materialized asset across

--- a/python_modules/dagster/dagster/_core/definitions/executor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/executor_definition.py
@@ -162,7 +162,7 @@ class ExecutorDefinition(NamedConfigurableDefinition):
         object.
 
         Using ``configured`` may result in config values being displayed in
-        Dagit, so it is not recommended to use this API with sensitive values,
+        the Dagster UI, so it is not recommended to use this API with sensitive values,
         such as secrets.
 
         Args:
@@ -445,8 +445,8 @@ def _check_intra_process_job(job: IJob) -> None:
             f' "{job.get_definition().name}" that is not reconstructable. Job must be loaded in a'
             " way that allows dagster to reconstruct them in a new process. This means: \n  *"
             " using the file, module, or repository.yaml arguments of"
-            " dagit/dagster-graphql/dagster\n  * loading the job through the reconstructable()"
-            " function\n"
+            " dagster-webserver/dagster-graphql/dagster\n  * loading the job through the"
+            " reconstructable() function\n"
         )
 
 

--- a/python_modules/dagster/dagster/_core/definitions/executor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/executor_definition.py
@@ -444,7 +444,7 @@ def _check_intra_process_job(job: IJob) -> None:
             "You have attempted to use an executor that uses multiple processes with the job"
             f' "{job.get_definition().name}" that is not reconstructable. Job must be loaded in a'
             " way that allows dagster to reconstruct them in a new process. This means: \n  *"
-            " using the file, module, or repository.yaml arguments of"
+            " using the file, module, or workspace.yaml arguments of"
             " dagster-webserver/dagster-graphql/dagster\n  * loading the job through the"
             " reconstructable() function\n"
         )

--- a/python_modules/dagster/dagster/_core/definitions/freshness_policy_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_policy_sensor_definition.py
@@ -196,7 +196,7 @@ class FreshnessPolicySensorDefinition(SensorDefinition):
             between sensor evaluations.
         description (Optional[str]): A human-readable description of the sensor.
         default_status (DefaultSensorStatus): Whether the sensor starts as running or not. The default
-            status can be overridden from Dagit or via the GraphQL API.
+            status can be overridden from the Dagster UI or via the GraphQL API.
     """
 
     def __init__(
@@ -366,7 +366,7 @@ def freshness_policy_sensor(
             between sensor evaluations.
         description (Optional[str]): A human-readable description of the sensor.
         default_status (DefaultSensorStatus): Whether the sensor starts as running or not. The default
-            status can be overridden from Dagit or via the GraphQL API.
+            status can be overridden from the Dagster UI or via the GraphQL API.
     """
 
     def inner(fn: Callable[..., None]) -> FreshnessPolicySensorDefinition:

--- a/python_modules/dagster/dagster/_core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/graph_definition.py
@@ -592,7 +592,7 @@ class GraphDefinition(NodeDefinition):
 
                 If a dictionary is provided, then it must conform to the standard config schema, and
                 it will be used as the job's run config for the job whenever the job is executed.
-                The values provided will be viewable and editable in the Dagit playground, so be
+                The values provided will be viewable and editable in the Dagster UI, so be
                 careful with secrets.
 
                 If a :py:class:`ConfigMapping` object is provided, then the schema for the job's run config is
@@ -602,14 +602,14 @@ class GraphDefinition(NodeDefinition):
                 If a :py:class:`PartitionedConfig` object is provided, then it defines a discrete set of config
                 values that can parameterize the job, as well as a function for mapping those
                 values to the base config. The values provided will be viewable and editable in the
-                Dagit playground, so be careful with secrets.
+                Dagster UI, so be careful with secrets.
             tags (Optional[Mapping[str, Any]]):
                 Arbitrary information that will be attached to the execution of the Job.
                 Values that are not strings will be json encoded and must meet the criteria that
                 `json.loads(json.dumps(value)) == value`.  These tag values may be overwritten by tag
                 values provided at invocation time.
             metadata (Optional[Mapping[str, RawMetadataValue]]):
-                Arbitrary information that will be attached to the JobDefinition and be viewable in Dagit.
+                Arbitrary information that will be attached to the JobDefinition and be viewable in the Dagster UI.
                 Keys must be strings, and values must be python primitive types or one of the provided
                 MetadataValue types
             logger_defs (Optional[Mapping[str, LoggerDefinition]]):

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -806,7 +806,7 @@ class JobDefinition(IHasInternalInit):
             sub_graph = get_graph_subset(self.graph, op_selection)
 
             # if explicit config was passed the config_mapping that resolves the defaults implicitly is
-            # very unlikely to work. The job will still present the default config in dagit.
+            # very unlikely to work. The job will still present the default config in the Dagster UI.
             config = (
                 None
                 if self.run_config is not None

--- a/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
@@ -140,7 +140,7 @@ def normalize_metadata_value(raw_value: RawMetadataValue) -> "MetadataValue[Any]
 
 class MetadataValue(ABC, Generic[T_Packable]):
     """Utility class to wrap metadata values passed into Dagster events so that they can be
-    displayed in Dagit and other tooling.
+    displayed in the Dagster UI and other tooling.
 
     .. code-block:: python
 
@@ -974,7 +974,7 @@ class MetadataEntry(
     .. note:: This class is no longer usable in any Dagster API, and will be completely removed in 2.0.
 
     Lists of objects of this type can be passed as arguments to Dagster events and will be displayed
-    in Dagit and other tooling.
+    in the Dagster UI and other tooling.
 
     Should be yielded from within an IO manager to append metadata for a given input/output event.
     For other event types, passing a dict with `MetadataValue` values to the `metadata` argument
@@ -984,7 +984,7 @@ class MetadataEntry(
         label (str): Short display label for this metadata entry.
         description (Optional[str]): A human-readable description of this metadata entry.
         value (MetadataValue): Typed metadata entry data. The different types allow
-            for customized display in tools like dagit.
+            for customized display in tools like the Dagster UI.
     """
 
     def __new__(

--- a/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
@@ -1080,7 +1080,7 @@ class MultiAssetSensorDefinition(SensorDefinition):
         jobs (Optional[Sequence[Union[GraphDefinition, JobDefinition, UnresolvedAssetJobDefinition]]]):
             (experimental) A list of jobs to be executed when the sensor fires.
         default_status (DefaultSensorStatus): Whether the sensor starts as running or not. The default
-            status can be overridden from Dagit or via the GraphQL API.
+            status can be overridden from the Dagster UI or via the GraphQL API.
         request_assets (Optional[AssetSelection]): (Experimental) an asset selection to launch a run
             for if the sensor condition is met. This can be provided instead of specifying a job.
     """

--- a/python_modules/dagster/dagster/_core/definitions/multi_dimensional_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_dimensional_partitions.py
@@ -477,7 +477,7 @@ class MultiPartitionsDefinition(PartitionsDefinition[MultiPartitionKey]):
     ) -> int:
         # Static partitions definitions can contain duplicate keys (will throw error in 1.3.0)
         # In the meantime, relying on get_num_partitions to handle duplicates to display
-        # correct counts in Dagit
+        # correct counts in the Dagster UI.
         dimension_counts = [
             dim.partitions_def.get_num_partitions(
                 current_time=current_time, dynamic_partitions_store=dynamic_partitions_store

--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -63,9 +63,9 @@ T_PartitionsDefinition = TypeVar(
     covariant=True,
 )
 
-# Dagit selects partition ranges following the format '2022-01-13...2022-01-14'
+# In the Dagster UI users can select partition ranges following the format '2022-01-13...2022-01-14'
 # "..." is an invalid substring in partition keys
-# The other escape characters are characters that may not display in Dagit
+# The other escape characters are characters that may not display in the Dagster UI.
 INVALID_PARTITION_SUBSTRINGS = ["...", "\a", "\b", "\f", "\n", "\r", "\t", "\v", "\0"]
 
 
@@ -343,7 +343,7 @@ class StaticPartitionsDefinition(PartitionsDefinition[str]):
     ) -> int:
         # We don't currently throw an error when a duplicate partition key is defined
         # in a static partitions definition, though we will at 1.3.0.
-        # This ensures that partition counts are correct in Dagit.
+        # This ensures that partition counts are correct in the Dagster UI.
         return len(set(self.get_partition_keys(current_time, dynamic_partitions_store)))
 
 
@@ -485,8 +485,8 @@ class DynamicPartitionsDefinition(
             if dynamic_partitions_store is None:
                 check.failed(
                     "The instance is not available to load partitions. You may be seeing this error"
-                    " when using dynamic partitions with a version of dagit or dagster-cloud that"
-                    " is older than 1.1.18."
+                    " when using dynamic partitions with a version of dagster-webserver or"
+                    " dagster-cloud that is older than 1.1.18."
                 )
 
             return dynamic_partitions_store.get_dynamic_partitions(
@@ -505,8 +505,8 @@ class DynamicPartitionsDefinition(
             if dynamic_partitions_store is None:
                 check.failed(
                     "The instance is not available to load partitions. You may be seeing this error"
-                    " when using dynamic partitions with a version of dagit or dagster-cloud that"
-                    " is older than 1.1.18."
+                    " when using dynamic partitions with a version of dagster-webserver or"
+                    " dagster-cloud that is older than 1.1.18."
                 )
 
             return dynamic_partitions_store.has_dynamic_partition(
@@ -716,7 +716,7 @@ def static_partitioned_config(
     change over time, the list of valid partition keys does not.
 
     This has performance advantages over `dynamic_partitioned_config` in terms of loading different
-    partition views in Dagit.
+    partition views in the Dagster UI.
 
     The decorated function takes in a partition key and returns a valid run config for a particular
     target job.

--- a/python_modules/dagster/dagster/_core/definitions/run_request.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_request.py
@@ -33,7 +33,7 @@ class SkipReason(NamedTuple("_SkipReason", [("skip_message", PublicAttr[Optional
     why no runs were requested.
 
     Attributes:
-        skip_message (Optional[str]): A message displayed in dagit for why this evaluation resulted
+        skip_message (Optional[str]): A message displayed in the Dagster UI for why this evaluation resulted
             in no requested runs.
     """
 

--- a/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
@@ -437,7 +437,7 @@ def run_failure_sensor(
             monitored by this failure sensor. Defaults to None, which means the alert will be sent
             when any job in the repository fails.
         default_status (DefaultSensorStatus): Whether the sensor starts as running or not. The default
-            status can be overridden from Dagit or via the GraphQL API.
+            status can be overridden from the Dagster UI or via the GraphQL API.
         request_job (Optional[Union[GraphDefinition, JobDefinition, UnresolvedAssetJob]]): The job a RunRequest should
             execute if yielded from the sensor.
         request_jobs (Optional[Sequence[Union[GraphDefinition, JobDefinition, UnresolvedAssetJob]]]): (experimental)
@@ -509,7 +509,7 @@ class RunStatusSensorDefinition(SensorDefinition):
             Dagster instance. If set to True, an error will be raised if you also specify
             monitored_jobs or job_selection. Defaults to False.
         default_status (DefaultSensorStatus): Whether the sensor starts as running or not. The default
-            status can be overridden from Dagit or via the GraphQL API.
+            status can be overridden from the Dagster UI or via the GraphQL API.
         request_job (Optional[Union[GraphDefinition, JobDefinition]]): The job a RunRequest should
             execute if yielded from the sensor.
         request_jobs (Optional[Sequence[Union[GraphDefinition, JobDefinition]]]): (experimental)
@@ -895,7 +895,7 @@ def run_status_sensor(
             monitored by this sensor. Defaults to None, which means the alert will be sent when
             any job in the repository matches the requested run_status.
         default_status (DefaultSensorStatus): Whether the sensor starts as running or not. The default
-            status can be overridden from Dagit or via the GraphQL API.
+            status can be overridden from the Dagster UI or via the GraphQL API.
         request_job (Optional[Union[GraphDefinition, JobDefinition, UnresolvedAssetJobDefinition]]): The job that should be
             executed if a RunRequest is yielded from the sensor.
         request_jobs (Optional[Sequence[Union[GraphDefinition, JobDefinition, UnresolvedAssetJobDefinition]]]): (experimental)

--- a/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
@@ -506,7 +506,7 @@ class ScheduleDefinition(IHasInternalInit):
         job (Optional[Union[GraphDefinition, JobDefinition]]): The job that should execute when this
             schedule runs.
         default_status (DefaultScheduleStatus): Whether the schedule starts as running or not. The default
-            status can be overridden from Dagit or via the GraphQL API.
+            status can be overridden from the Dagster UI or via the GraphQL API.
         required_resource_keys (Optional[Set[str]]): The set of resource keys required by the schedule.
     """
 

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -472,7 +472,7 @@ class SensorDefinition(IHasInternalInit):
         job (Optional[GraphDefinition, JobDefinition, UnresolvedAssetJob]): The job to execute when this sensor fires.
         jobs (Optional[Sequence[GraphDefinition, JobDefinition, UnresolvedAssetJob]]): (experimental) A list of jobs to execute when this sensor fires.
         default_status (DefaultSensorStatus): Whether the sensor starts as running or not. The default
-            status can be overridden from Dagit or via the GraphQL API.
+            status can be overridden from the Dagster UI or via the GraphQL API.
         asset_selection (AssetSelection): (Experimental) an asset selection to launch a run for if
             the sensor condition is met. This can be provided instead of specifying a job.
     """

--- a/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
@@ -294,7 +294,7 @@ def define_asset_job(
 
             If a dictionary is provided, then it must conform to the standard config schema, and
             it will be used as the job's run config for the job whenever the job is executed.
-            The values provided will be viewable and editable in the Dagit playground, so be
+            The values provided will be viewable and editable in the Dagster UI, so be
             careful with secrets.
 
             If a :py:class:`ConfigMapping` object is provided, then the schema for the job's run config is

--- a/python_modules/dagster/dagster/_core/events/__init__.py
+++ b/python_modules/dagster/dagster/_core/events/__init__.py
@@ -88,12 +88,12 @@ class DagsterEventType(str, Enum):
     STEP_SKIPPED = "STEP_SKIPPED"
 
     # The process carrying out step execution is starting/started. Shown as a
-    # marker start/end in Dagit
+    # marker start/end in the Dagster UI.
     STEP_WORKER_STARTING = "STEP_WORKER_STARTING"
     STEP_WORKER_STARTED = "STEP_WORKER_STARTED"
 
     # Resource initialization for execution has started/succeede/failed. Shown
-    # as a marker start/end in Dagit
+    # as a marker start/end in the Dagster UI.
     RESOURCE_INIT_STARTED = "RESOURCE_INIT_STARTED"
     RESOURCE_INIT_SUCCESS = "RESOURCE_INIT_SUCCESS"
     RESOURCE_INIT_FAILURE = "RESOURCE_INIT_FAILURE"
@@ -106,7 +106,7 @@ class DagsterEventType(str, Enum):
     ASSET_OBSERVATION = "ASSET_OBSERVATION"
     STEP_EXPECTATION_RESULT = "STEP_EXPECTATION_RESULT"
 
-    # We want to display RUN_* events in dagit and in our LogManager output, but in order to
+    # We want to display RUN_* events in the Dagster UI and in our LogManager output, but in order to
     # support backcompat for our storage layer, we need to keep the persisted value to be strings
     # of the form "PIPELINE_*".  We may have user code that pass in the DagsterEventType
     # enum values into storage APIs (like get_event_records, which takes in an EventRecordsFilter).

--- a/python_modules/dagster/dagster/_core/host_representation/__init__.py
+++ b/python_modules/dagster/dagster/_core/host_representation/__init__.py
@@ -1,4 +1,4 @@
-"""This subpackage contains all classes that host processes (e.g. dagit)
+"""This subpackage contains all classes that host processes (e.g. dagster-webserver)
 use to manipulate and represent definitions that are resident
 in user processes and containers.  e.g. ExternalPipeline.
 

--- a/python_modules/dagster/dagster/_core/host_representation/external.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external.py
@@ -79,7 +79,7 @@ if TYPE_CHECKING:
 
 class ExternalRepository:
     """ExternalRepository is a object that represents a loaded repository definition that
-    is resident in another process or container. Host processes such as dagit use
+    is resident in another process or container. Host processes such as dagster-webserver use
     objects such as these to interact with user-defined artifacts.
     """
 
@@ -288,7 +288,7 @@ class ExternalRepository:
 
 class ExternalJob(RepresentedJob):
     """ExternalJob is a object that represents a loaded job definition that
-    is resident in another process or container. Host processes such as dagit use
+    is resident in another process or container. Host processes such as dagster-webserver use
     objects such as these to interact with user-defined artifacts.
     """
 

--- a/python_modules/dagster/dagster/_core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external_data.py
@@ -467,7 +467,7 @@ class ExternalTargetData(
 class ExternalSensorMetadata(
     NamedTuple("_ExternalSensorMetadata", [("asset_keys", Optional[Sequence[AssetKey]])])
 ):
-    """Stores additional sensor metadata which is available on the Dagit frontend."""
+    """Stores additional sensor metadata which is available in the Dagster UI."""
 
     def __new__(cls, asset_keys: Optional[Sequence[AssetKey]] = None):
         return super(ExternalSensorMetadata, cls).__new__(
@@ -1743,7 +1743,7 @@ def external_dynamic_partitions_definition_from_def(
     check.inst_param(partitions_def, "partitions_def", DynamicPartitionsDefinition)
     if partitions_def.name is None:
         raise DagsterInvalidDefinitionError(
-            "Dagit does not support dynamic partitions definitions without a name parameter."
+            "Dagster does not support dynamic partitions definitions without a name parameter."
         )
     return ExternalDynamicPartitionsDefinitionData(name=partitions_def.name)
 

--- a/python_modules/dagster/dagster/_core/host_representation/origin.py
+++ b/python_modules/dagster/dagster/_core/host_representation/origin.py
@@ -162,7 +162,7 @@ class InProcessCodeLocationOrigin(
     CodeLocationOrigin,
 ):
     """Identifies a repository location constructed in the same process. Primarily
-    used in tests, since Dagster system processes like Dagit and the daemon do not
+    used in tests, since Dagster system processes like the webserver and daemon do not
     load user code in the same process.
     """
 
@@ -263,7 +263,7 @@ class ManagedGrpcPythonEnvCodeLocationOrigin(
         self,
         instance: "DagsterInstance",
     ) -> Iterator["GrpcServerCodeLocation"]:
-        from dagster._core.workspace.context import DAGIT_GRPC_SERVER_HEARTBEAT_TTL
+        from dagster._core.workspace.context import WEBSERVER_GRPC_SERVER_HEARTBEAT_TTL
 
         from .code_location import GrpcServerCodeLocation
         from .grpc_server_registry import GrpcServerRegistry
@@ -271,7 +271,7 @@ class ManagedGrpcPythonEnvCodeLocationOrigin(
         with GrpcServerRegistry(
             instance_ref=instance.get_ref(),
             reload_interval=0,
-            heartbeat_ttl=DAGIT_GRPC_SERVER_HEARTBEAT_TTL,
+            heartbeat_ttl=WEBSERVER_GRPC_SERVER_HEARTBEAT_TTL,
             startup_timeout=(
                 instance.code_server_process_startup_timeout
                 if instance

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -891,15 +891,15 @@ class DagsterInstance(DynamicPartitionsStore):
             self._schedule_storage.upgrade()  # type: ignore  # (possible none)
             self._schedule_storage.migrate(print_fn)  # type: ignore  # (possible none)
 
-    def optimize_for_dagit(self, statement_timeout: int, pool_recycle: int) -> None:
+    def optimize_for_dagster_webserver(self, statement_timeout: int, pool_recycle: int) -> None:
         if self._schedule_storage:
-            self._schedule_storage.optimize_for_dagit(
+            self._schedule_storage.optimize_for_webserver(
                 statement_timeout=statement_timeout, pool_recycle=pool_recycle
             )
-        self._run_storage.optimize_for_dagit(
+        self._run_storage.optimize_for_webserver(
             statement_timeout=statement_timeout, pool_recycle=pool_recycle
         )
-        self._event_storage.optimize_for_dagit(
+        self._event_storage.optimize_for_webserver(
             statement_timeout=statement_timeout, pool_recycle=pool_recycle
         )
 

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -891,7 +891,7 @@ class DagsterInstance(DynamicPartitionsStore):
             self._schedule_storage.upgrade()  # type: ignore  # (possible none)
             self._schedule_storage.migrate(print_fn)  # type: ignore  # (possible none)
 
-    def optimize_for_dagster_webserver(self, statement_timeout: int, pool_recycle: int) -> None:
+    def optimize_for_webserver(self, statement_timeout: int, pool_recycle: int) -> None:
         if self._schedule_storage:
             self._schedule_storage.optimize_for_webserver(
                 statement_timeout=statement_timeout, pool_recycle=pool_recycle

--- a/python_modules/dagster/dagster/_core/snap/__init__.py
+++ b/python_modules/dagster/dagster/_core/snap/__init__.py
@@ -9,7 +9,7 @@ This will have a number of uses, but the most immediately germane are:
 will enable, in the short term, for the user to be able to go to a historical
 run and view the meta information at that point in time.
 2) Access metadata about dagster artifiacts that are resident in an external
-process or container. For example, dagit uses these classes load and represent
+process or container. For example, dagster-webserver uses these classes to load and represent
 metadata from user repositories that reside in different processes.
 
 There are a few varietals of classes:
@@ -24,7 +24,7 @@ snapshot data for fast access.
 3) "Active Data". These classes are serializable but not meant to be persisted.
 For example we do not persist preset configuration blocks since config
 can contain sensitive information. However this information needs to be
-communicated between user repositories and host processes such as dagit.
+communicated between user repositories and host processes such as dagster-webserver.
 
 """
 

--- a/python_modules/dagster/dagster/_core/storage/base_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/base_storage.py
@@ -12,7 +12,7 @@ class DagsterStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
     events, and schedule/sensor state.
 
     Users should not directly instantiate concrete subclasses of this class; they are instantiated
-    by internal machinery when ``dagit`` and ``dagster-daemon`` load, based on the values in the
+    by internal machinery when ``dagster-webserver`` and ``dagster-daemon`` load, based on the values in the
     ``dagster.yaml`` file in ``$DAGSTER_HOME``. Configuration of concrete subclasses of this class
     should be done by setting values in that file.
     """

--- a/python_modules/dagster/dagster/_core/storage/captured_log_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/captured_log_manager.py
@@ -24,7 +24,7 @@ class CapturedLogContext(
     )
 ):
     """Object representing the context in which logs are captured.  Can be used by external logging
-    sidecar implementations to point dagit to an external url to view compute logs instead of a
+    sidecar implementations to point the Dagster UI to an external url to view compute logs instead of a
     Dagster-managed location.
     """
 

--- a/python_modules/dagster/dagster/_core/storage/compute_log_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/compute_log_manager.py
@@ -178,7 +178,7 @@ class ComputeLogManager(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
 
     @abstractmethod
     def on_subscribe(self, subscription: "ComputeLogSubscription") -> None:
-        """Hook for managing streaming subscriptions for log data from `dagit`.
+        """Hook for managing streaming subscriptions for log data from `dagster-webserver`.
 
         Args:
             subscription (ComputeLogSubscription): subscription object which manages when to send

--- a/python_modules/dagster/dagster/_core/storage/dagster_run.py
+++ b/python_modules/dagster/dagster/_core/storage/dagster_run.py
@@ -377,7 +377,7 @@ class DagsterRun(
         repository_tags = {}
         if self.external_job_origin:
             # tag the run with a label containing the repository name / location name, to allow for
-            # per-repository filtering of runs from dagit.
+            # per-repository filtering of runs from the Dagster UI.
             repository_tags[
                 REPOSITORY_LABEL_TAG
             ] = self.external_job_origin.external_repository_origin.get_label()

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -145,7 +145,7 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
     :py:class:`~dagster._core.storage.event_log.SqlEventLogStorage`.
 
     Users should not directly instantiate concrete subclasses of this class; they are instantiated
-    by internal machinery when ``dagit`` and ``dagster-graphql`` load, based on the values in the
+    by internal machinery when ``dagster-webserver`` and ``dagster-graphql`` load, based on the values in the
     ``dagster.yaml`` file in ``$DAGSTER_HOME``. Configuration of concrete subclasses of this class
     should be done by setting values in that file.
     """
@@ -256,8 +256,8 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
     def dispose(self) -> None:
         """Explicit lifecycle management."""
 
-    def optimize_for_dagit(self, statement_timeout: int, pool_recycle: int) -> None:
-        """Allows for optimizing database connection / use in the context of a long lived dagit process.
+    def optimize_for_webserver(self, statement_timeout: int, pool_recycle: int) -> None:
+        """Allows for optimizing database connection / use in the context of a long lived webserver process.
         """
 
     @abstractmethod

--- a/python_modules/dagster/dagster/_core/storage/event_log/in_memory.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/in_memory.py
@@ -20,7 +20,7 @@ from .sql_event_log import SqlEventLogStorage
 class InMemoryEventLogStorage(SqlEventLogStorage, ConfigurableClass):
     """In memory only event log storage. Used by ephemeral DagsterInstance or for testing purposes.
 
-    WARNING: Dagit and other core functionality will not work if this is used on a real DagsterInstance
+    WARNING: The Dagster UI and other core functionality will not work if this is used on a real DagsterInstance
     """
 
     def __init__(self, inst_data: Optional[ConfigurableClassData] = None, preload=None):

--- a/python_modules/dagster/dagster/_core/storage/event_log/schema.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/schema.py
@@ -31,7 +31,7 @@ SecondaryIndexMigrationTable = db.Table(
 # used to determine if an asset exists (last materialization timestamp > wipe timestamp).
 # This column is used nowhere else, and as of AssetObservation creation, we want to extend
 # this functionality to ensure that assets with observation OR materialization timestamp
-# > wipe timestamp display in Dagit.
+# > wipe timestamp display in the Dagster UI.
 
 # As of the following PR, we update last_materialization_timestamp to store the timestamp
 # of the latest asset observation or materialization that has occurred.

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -210,7 +210,7 @@ class SqlEventLogStorage(EventLogStorage):
         # This column is used nowhere else, and as of AssetObservation/AssetMaterializationPlanned
         # event creation, we want to extend this functionality to ensure that assets with any event
         # (observation, materialization, or materialization planned) yielded with timestamp
-        # > wipe timestamp display in Dagit.
+        # > wipe timestamp display in the Dagster UI.
 
         # As of the following PRs, we update last_materialization_timestamp to store the timestamp
         # of the latest asset observation, materialization, or materialization_planned that has occurred.

--- a/python_modules/dagster/dagster/_core/storage/event_log/sqlite/consolidated_sqlite_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sqlite/consolidated_sqlite_event_log.py
@@ -35,7 +35,7 @@ class ConsolidatedSqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
     """SQLite-backed consolidated event log storage intended for test cases only.
 
     Users should not directly instantiate this class; it is instantiated by internal machinery when
-    ``dagit`` and ``dagster-graphql`` load, based on the values in the ``dagster.yaml`` file in
+    ``dagster-webserver`` and ``dagster-graphql`` load, based on the values in the ``dagster.yaml`` file in
     ``$DAGSTER_HOME``. Configuration of this class should be done by setting values in that file.
 
     To explicitly specify the consolidated SQLite for event log storage, you can add a block such as

--- a/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
@@ -59,7 +59,7 @@ class SqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
     """SQLite-backed event log storage.
 
     Users should not directly instantiate this class; it is instantiated by internal machinery when
-    ``dagit`` and ``dagster-graphql`` load, based on the values in the ``dagster.yaml`` file in
+    ``dagster-webserver`` and ``dagster-graphql`` load, based on the values in the ``dagster.yaml`` file insqliteve
     ``$DAGSTER_HOME``. Configuration of this class should be done by setting values in that file.
 
     This is the default event log storage when none is specified in the ``dagster.yaml``.
@@ -176,7 +176,7 @@ class SqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
                 break
             except (db_exc.DatabaseError, sqlite3.DatabaseError, sqlite3.OperationalError) as exc:
                 # This is SQLite-specific handling for concurrency issues that can arise when
-                # multiple processes (e.g. the dagit process and user code process) contend with
+                # multiple processes (e.g. the dagster-webserver process and user code process) contend with
                 # each other to init the db. When we hit the following errors, we know that another
                 # process is on the case and we should retry.
                 err_msg = str(exc)

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -300,8 +300,8 @@ class LegacyRunStorage(RunStorage, ConfigurableClass):
     def dispose(self) -> None:
         return self._storage.run_storage.dispose()
 
-    def optimize_for_dagit(self, statement_timeout: int, pool_recycle: int) -> None:
-        return self._storage.run_storage.optimize_for_dagit(statement_timeout, pool_recycle)
+    def optimize_for_webserver(self, statement_timeout: int, pool_recycle: int) -> None:
+        return self._storage.run_storage.optimize_for_webserver(statement_timeout, pool_recycle)
 
     def add_daemon_heartbeat(self, daemon_heartbeat: "DaemonHeartbeat") -> None:
         return self._storage.run_storage.add_daemon_heartbeat(daemon_heartbeat)
@@ -432,8 +432,10 @@ class LegacyEventLogStorage(EventLogStorage, ConfigurableClass):
     def dispose(self) -> None:
         return self._storage.event_log_storage.dispose()
 
-    def optimize_for_dagit(self, statement_timeout: int, pool_recycle: int) -> None:
-        return self._storage.event_log_storage.optimize_for_dagit(statement_timeout, pool_recycle)
+    def optimize_for_webserver(self, statement_timeout: int, pool_recycle: int) -> None:
+        return self._storage.event_log_storage.optimize_for_webserver(
+            statement_timeout, pool_recycle
+        )
 
     def get_event_records(
         self,
@@ -730,8 +732,10 @@ class LegacyScheduleStorage(ScheduleStorage, ConfigurableClass):
     def optimize(self, print_fn: Optional[PrintFn] = None, force_rebuild_all: bool = False) -> None:
         return self._storage.schedule_storage.optimize(print_fn, force_rebuild_all)
 
-    def optimize_for_dagit(self, statement_timeout: int, pool_recycle: int) -> None:
-        return self._storage.schedule_storage.optimize_for_dagit(statement_timeout, pool_recycle)
+    def optimize_for_webserver(self, statement_timeout: int, pool_recycle: int) -> None:
+        return self._storage.schedule_storage.optimize_for_webserver(
+            statement_timeout, pool_recycle
+        )
 
     def dispose(self) -> None:
         return self._storage.schedule_storage.dispose()

--- a/python_modules/dagster/dagster/_core/storage/runs/base.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/base.py
@@ -37,7 +37,7 @@ class RunStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance], DaemonCursorSto
     :py:class:`~dagster._core.storage.runs.SqlRunStorage`.
 
     Users should not directly instantiate concrete subclasses of this class; they are instantiated
-    by internal machinery when ``dagit`` and ``dagster-graphql`` load, based on the values in the
+    by internal machinery when ``dagster-webserver`` and ``dagster-graphql`` load, based on the values in the
     ``dagster.yaml`` file in ``$DAGSTER_HOME``. Configuration of concrete subclasses of this class
     should be done by setting values in that file.
     """
@@ -351,8 +351,8 @@ class RunStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance], DaemonCursorSto
     def dispose(self) -> None:
         """Explicit lifecycle management."""
 
-    def optimize_for_dagit(self, statement_timeout: int, pool_recycle: int) -> None:
-        """Allows for optimizing database connection / use in the context of a long lived dagit process.
+    def optimize_for_webserver(self, statement_timeout: int, pool_recycle: int) -> None:
+        """Allows for optimizing database connection / use in the context of a long lived webserver process.
         """
 
     # Daemon Heartbeat Storage

--- a/python_modules/dagster/dagster/_core/storage/runs/in_memory.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/in_memory.py
@@ -17,7 +17,7 @@ from .sql_run_storage import SqlRunStorage
 class InMemoryRunStorage(SqlRunStorage):
     """In memory only run storage. Used by ephemeral DagsterInstance or for testing purposes.
 
-    WARNING: Dagit and other core functionality will not work if this is used on a real DagsterInstance
+    WARNING: The Dagster UI and other core functionality will not work if this is used on a real DagsterInstance
     """
 
     def __init__(self, preload: Optional[Sequence[DebugRunPayload]] = None):

--- a/python_modules/dagster/dagster/_core/storage/runs/sqlite/sqlite_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sqlite/sqlite_run_storage.py
@@ -38,7 +38,7 @@ class SqliteRunStorage(SqlRunStorage, ConfigurableClass):
     """SQLite-backed run storage.
 
     Users should not directly instantiate this class; it is instantiated by internal machinery when
-    ``dagit`` and ``dagster-graphql`` load, based on the values in the ``dagster.yaml`` file in
+    ``dagster-webserver`` and ``dagster-graphql`` load, based on the values in the ``dagster.yaml`` file in
     ``$DAGSTER_HOME``. Configuration of this class should be done by setting values in that file.
 
     This is the default run storage when none is specified in the ``dagster.yaml``.

--- a/python_modules/dagster/dagster/_core/storage/schedules/base.py
+++ b/python_modules/dagster/dagster/_core/storage/schedules/base.py
@@ -179,8 +179,8 @@ class ScheduleStorage(abc.ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
     def optimize(self, print_fn: Optional[PrintFn] = None, force_rebuild_all: bool = False) -> None:
         """Call this method to run any optional data migrations for optimized reads."""
 
-    def optimize_for_dagit(self, statement_timeout: int, pool_recycle: int) -> None:
-        """Allows for optimizing database connection / use in the context of a long lived dagit process.
+    def optimize_for_webserver(self, statement_timeout: int, pool_recycle: int) -> None:
+        """Allows for optimizing database connection / use in the context of a long lived webserver process.
         """
 
     def alembic_version(self) -> Optional[AlembicVersion]:

--- a/python_modules/dagster/dagster/_core/storage/sqlite_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/sqlite_storage.py
@@ -42,7 +42,7 @@ class DagsterSqliteStorage(DagsterStorage, ConfigurableClass):
     """SQLite-backed run storage.
 
     Users should not directly instantiate this class; it is instantiated by internal machinery when
-    ``dagit`` and ``dagster-graphql`` load, based on the values in the ``dagster.yaml`` file in
+    ``dagster-webserver`` and ``dagster-graphql`` load, based on the values in the ``dagster.yaml`` file in
     ``$DAGSTER_HOME``. Configuration of this class should be done by setting values in that file.
 
     This is the default run storage when none is specified in the ``dagster.yaml``.

--- a/python_modules/dagster/dagster/_core/workspace/context.py
+++ b/python_modules/dagster/dagster/_core/workspace/context.py
@@ -66,7 +66,7 @@ if TYPE_CHECKING:
 
 T = TypeVar("T")
 
-DAGIT_GRPC_SERVER_HEARTBEAT_TTL = 45
+WEBSERVER_GRPC_SERVER_HEARTBEAT_TTL = 45
 
 
 class BaseWorkspaceRequestContext(IWorkspace):
@@ -380,13 +380,13 @@ class WorkspaceRequestContext(BaseWorkspaceRequestContext):
     @property
     def source(self) -> Optional[object]:
         """The source of the request this WorkspaceRequestContext originated from.
-        For example in Dagit this object represents the web request.
+        For example in the webserver this object represents the web request.
         """
         return self._source
 
 
 class IWorkspaceProcessContext(ABC):
-    """Class that stores process-scoped information about a dagit session.
+    """Class that stores process-scoped information about a webserver session.
     In most cases, you will want to create a `BaseWorkspaceRequestContext` to create a request-scoped
     object.
     """
@@ -488,7 +488,7 @@ class WorkspaceProcessContext(IWorkspaceProcessContext):
                 GrpcServerRegistry(
                     instance_ref=self._instance.get_ref(),
                     reload_interval=0,
-                    heartbeat_ttl=DAGIT_GRPC_SERVER_HEARTBEAT_TTL,
+                    heartbeat_ttl=WEBSERVER_GRPC_SERVER_HEARTBEAT_TTL,
                     startup_timeout=instance.code_server_process_startup_timeout,
                     log_level=code_server_log_level,
                     wait_for_processes_on_shutdown=instance.wait_for_local_code_server_processes_on_shutdown,
@@ -735,7 +735,7 @@ class WorkspaceProcessContext(IWorkspaceProcessContext):
             self.refresh_code_location(event.location_name)
 
     def refresh_code_location(self, name: str) -> None:
-        # This method reloads Dagit's copy of the code from the remote gRPC server without
+        # This method reloads the webserver's copy of the code from the remote gRPC server without
         # restarting it, and returns a new request context created from the updated process context
         new = self._load_location(self._location_entry_dict[name].origin, reload=False)
         with self._lock:

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -380,7 +380,7 @@ def execute_sensor_iteration(
                 logger.warning(
                     f"Sensor {sensor_name} was started from a location "
                     f"{location_name} that can no longer be found in the workspace. "
-                    "You can turn off this sensor in the Dagit UI from the Status tab."
+                    "You can turn off this sensor in the Dagster UI from the Status tab."
                 )
             elif not check.not_none(  # checked above
                 workspace_snapshot[location_name].code_location
@@ -388,13 +388,13 @@ def execute_sensor_iteration(
                 logger.warning(
                     f"Could not find repository {repo_name} in location {location_name} to "
                     + f"run sensor {sensor_name}. If this repository no longer exists, you can "
-                    + "turn off the sensor in the Dagit UI from the Status tab.",
+                    + "turn off the sensor in the Dagster UI from the Status tab.",
                 )
             else:
                 logger.warning(
                     (
                         f"Could not find sensor {sensor_name} in repository {repo_name}. If this "
-                        "sensor no longer exists, you can turn it off in the Dagit UI from the "
+                        "sensor no longer exists, you can turn it off in the Dagster UI from the "
                         "Status tab."
                     ),
                 )

--- a/python_modules/dagster/dagster/_daemon/workspace.py
+++ b/python_modules/dagster/dagster/_daemon/workspace.py
@@ -99,7 +99,7 @@ class BaseDaemonWorkspace(IWorkspace):
 class DaemonIterationWorkspace(BaseDaemonWorkspace):
     """A copy of the main workspace's locations that can be called from a background thread
     in a daemon without worrying that the main thread will clean up the locations underneath us.
-    Analagous to WorkspaceRequestContext in Dagit.
+    Analagous to WorkspaceRequestContext in the webserver.
 
     Daemons that call this should be careful to set cleanup_locations=False when calling cleanup
     on the parent workspace that get_workspace_copy_for_iteration() was called on to create

--- a/python_modules/dagster/dagster/_grpc/__init__.py
+++ b/python_modules/dagster/dagster/_grpc/__init__.py
@@ -5,7 +5,7 @@ locally (over UDS on MacOS and Unix, and over a local port on Windows) and when 
 remote Dagster user proceses (e.g., containers).
 
 The GRPC layer is not intended to supplant the dagster-graphql layer, which should still be used to
-drive web frontends like dagit.
+drive web frontends like the Dagster UI.
 """
 
 from .client import (

--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -255,7 +255,7 @@ class DagsterApiServer(DagsterApiServicer):
         self._container_context = check.opt_dict_param(container_context, "container_context")
 
         # When will this be set in a gRPC server?
-        #  - When running `dagster dev` (or `dagit`) in the gRPC server subprocesses that are spun up
+        #  - When running `dagster dev` (or `dagster-webserver`) in the gRPC server subprocesses that are spun up
         #  - When running code in Dagster Cloud on 1.1 or later
         # When will it not be set?
         #  - When running your own grpc server with `dagster api grpc`

--- a/python_modules/dagster/dagster/_scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/_scheduler/scheduler.py
@@ -283,7 +283,7 @@ def launch_scheduled_runs(
                 logger.warning(
                     f"Schedule {schedule_name} was started from a location "
                     f"{code_location_name} that can no longer be found in the workspace. You can "
-                    "turn off this schedule in the Dagit UI from the Status tab."
+                    "turn off this schedule in the Dagster UI from the Status tab."
                 )
             elif not check.not_none(  # checked in case above
                 workspace_snapshot[code_location_origin.location_name].code_location
@@ -291,14 +291,14 @@ def launch_scheduled_runs(
                 logger.warning(
                     f"Could not find repository {repo_name} in location {code_location_name} to "
                     + f"run schedule {schedule_name}. If this repository no longer exists, you can "
-                    + "turn off the schedule in the Dagit UI from the Status tab.",
+                    + "turn off the schedule in the Dagster UI from the Status tab.",
                 )
             else:
                 logger.warning(
                     (
                         f"Could not find schedule {schedule_name} in repository {repo_name}. If"
-                        " this schedule no longer exists, you can turn it off in the Dagit UI from"
-                        " the Status tab."
+                        " this schedule no longer exists, you can turn it off in the Dagster UI"
+                        " from the Status tab."
                     ),
                 )
 

--- a/python_modules/dagster/dagster/_utils/alert.py
+++ b/python_modules/dagster/dagster/_utils/alert.py
@@ -86,7 +86,7 @@ def make_email_on_run_failure_sensor(
     smtp_type: str = "SSL",
     smtp_port: Optional[int] = None,
     name: Optional[str] = None,
-    dagit_base_url: Optional[str] = None,
+    webserver_base_url: Optional[str] = None,
     monitored_jobs: Optional[
         Sequence[
             Union[
@@ -128,7 +128,7 @@ def make_email_on_run_failure_sensor(
         smtp_type (str): The protocol; either "SSL" or "STARTTLS". Defaults to SSL.
         smtp_port (Optional[int]): The SMTP port. Defaults to 465 for SSL, 587 for STARTTLS.
         name: (Optional[str]): The name of the sensor. Defaults to "email_on_job_failure".
-        dagit_base_url: (Optional[str]): The base url of your Dagit instance. Specify this to allow
+        webserver_base_url: (Optional[str]): The base url of your dagster-webserver instance. Specify this to allow
             messages to include deeplinks to the failed run.
         monitored_jobs (Optional[List[Union[JobDefinition, GraphDefinition, JobDefinition, RepositorySelector, JobSelector]]]):
             The jobs that will be monitored by this failure sensor. Defaults to None, which means the alert will
@@ -141,7 +141,7 @@ def make_email_on_run_failure_sensor(
             (deprecated in favor of monitored_jobs) The jobs that will be monitored by this failure
             sensor. Defaults to None, which means the alert will be sent when any job in the repository fails.
         default_status (DefaultSensorStatus): Whether the sensor starts as running or not. The default
-            status can be overridden from Dagit or via the GraphQL API.
+            status can be overridden from the Dagster UI or via the GraphQL API.
 
     Examples:
         .. code-block:: python
@@ -170,7 +170,7 @@ def make_email_on_run_failure_sensor(
                 email_to=["xxx@example.com"],
                 email_body_fn=my_message_fn,
                 email_subject_fn=lambda _: "Dagster Alert",
-                dagit_base_url="http://mycoolsite.com",
+                webserver_base_url="http://mycoolsite.com",
             )
 
 
@@ -192,10 +192,10 @@ def make_email_on_run_failure_sensor(
     )
     def email_on_run_failure(context: RunFailureSensorContext):
         email_body = email_body_fn(context)
-        if dagit_base_url:
+        if webserver_base_url:
             email_body += (
-                f'<p><a href="{dagit_base_url}/runs/{context.dagster_run.run_id}">View in'
-                " Dagit</a></p>"
+                f'<p><a href="{webserver_base_url}/runs/{context.dagster_run.run_id}">View in'
+                " the Dagster UI</a></p>"
             )
 
         message = EMAIL_MESSAGE.format(

--- a/python_modules/dagster/dagster/_utils/forked_pdb.py
+++ b/python_modules/dagster/dagster/_utils/forked_pdb.py
@@ -20,7 +20,7 @@ class ForkedPdb(pdb.Pdb):
 
             # some other complicated stuff
 
-    You can initiate pipeline execution via dagit and use the pdb debugger to examine/step through
+    You can initiate pipeline execution via the webserver and use the pdb debugger to examine/step through
     execution at the breakpoint.
     """
 

--- a/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_type_printer.py
+++ b/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_type_printer.py
@@ -244,8 +244,8 @@ def define_solid_for_test_type(name, config):
     return a_op
 
 
-# launch in dagit with this command:
-# dagit -f test_type_printer.py -n define_test_type_pipeline
+# launch in UI with this command:
+# dagster dev -f test_type_printer.py -n define_test_type_pipeline
 def define_test_type_pipeline():
     return GraphDefinition(
         name="test_type_pipeline",

--- a/python_modules/dagster/dagster_tests/storage_tests/test_captured_log_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_captured_log_manager.py
@@ -33,8 +33,7 @@ class TestLocalCapturedLogManager(TestCapturedLogManager):
 
 class ExternalTestComputeLogManager(NoOpComputeLogManager):
     """Test compute log manager that does not actually capture logs, but generates an external url
-    to be shown within Dagit
-    .
+    to be shown within the Dagster UI.
     """
 
     @classmethod

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -1524,7 +1524,7 @@ class TestEventLogStorage:
         event_list = []
 
         # Direct end_watch emulates behavior of clean up on exception downstream
-        # of the subscription in the dagit webserver.
+        # of the subscription in the webserver.
         storage.watch(err_run_id, None, _unsub)
 
         # Other active watches should proceed correctly.

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/event_log/event_log.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/event_log/event_log.py
@@ -91,7 +91,7 @@ class MySQLEventLogStorage(SqlEventLogStorage, ConfigurableClass):
             SqlEventLogStorageMetadata.create_all(conn)
             stamp_alembic_rev(mysql_alembic_config(__file__), conn)
 
-    def optimize_for_dagit(self, statement_timeout: int, pool_recycle: int) -> None:
+    def optimize_for_webserver(self, statement_timeout: int, pool_recycle: int) -> None:
         # When running in dagit, hold an open connection
         # https://github.com/dagster-io/dagster/issues/3719
         self._engine = create_engine(

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/run_storage/run_storage.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/run_storage/run_storage.py
@@ -90,7 +90,7 @@ class MySQLRunStorage(SqlRunStorage, ConfigurableClass):
             RunStorageSqlMetadata.create_all(conn)
             stamp_alembic_rev(mysql_alembic_config(__file__), conn)
 
-    def optimize_for_dagit(self, statement_timeout: int, pool_recycle: int) -> None:
+    def optimize_for_webserver(self, statement_timeout: int, pool_recycle: int) -> None:
         # When running in dagit, hold 1 open connection
         # https://github.com/dagster-io/dagster/issues/3719
         self._engine = create_engine(

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/schedule_storage/schedule_storage.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/schedule_storage/schedule_storage.py
@@ -79,7 +79,7 @@ class MySQLScheduleStorage(SqlScheduleStorage, ConfigurableClass):
         self.migrate()
         self.optimize()
 
-    def optimize_for_dagit(self, statement_timeout: int, pool_recycle: int) -> None:
+    def optimize_for_webserver(self, statement_timeout: int, pool_recycle: int) -> None:
         # When running in dagit, hold an open connection
         # https://github.com/dagster-io/dagster/issues/3719
         self._engine = create_engine(

--- a/python_modules/libraries/dagster-mysql/dagster_mysql_tests/test_instance.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql_tests/test_instance.py
@@ -133,7 +133,7 @@ def test_statement_timeouts(conn_string):
     port = parse_result.port
 
     with instance_for_test(overrides=yaml.safe_load(full_mysql_config(hostname, port))) as instance:
-        instance.optimize_for_dagit(statement_timeout=500, pool_recycle=-1)  # 500ms
+        instance.optimize_for_dagster_webserver(statement_timeout=500, pool_recycle=-1)  # 500ms
 
         # ensure migration error is not raised by being up to date
         instance.upgrade()

--- a/python_modules/libraries/dagster-mysql/dagster_mysql_tests/test_instance.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql_tests/test_instance.py
@@ -133,7 +133,7 @@ def test_statement_timeouts(conn_string):
     port = parse_result.port
 
     with instance_for_test(overrides=yaml.safe_load(full_mysql_config(hostname, port))) as instance:
-        instance.optimize_for_dagster_webserver(statement_timeout=500, pool_recycle=-1)  # 500ms
+        instance.optimize_for_webserver(statement_timeout=500, pool_recycle=-1)  # 500ms
 
         # ensure migration error is not raised by being up to date
         instance.upgrade()

--- a/python_modules/libraries/dagster-mysql/dagster_mysql_tests/test_wait_timeout.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql_tests/test_wait_timeout.py
@@ -7,7 +7,7 @@ from dagster_mysql.run_storage import MySQLRunStorage
 
 def retry_connect(conn_string: str, num_retries: int = 5, pool_recycle=-1):
     storage = MySQLRunStorage.create_clean_storage(conn_string)
-    storage.optimize_for_dagit(-1, pool_recycle=pool_recycle)
+    storage.optimize_for_webserver(-1, pool_recycle=pool_recycle)
 
     with storage.connect() as conn:
         conn.execute(db.text("SET SESSION wait_timeout = 2;"))

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
@@ -112,7 +112,7 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
                 SqlEventLogStorageMetadata.create_all(conn)
                 stamp_alembic_rev(pg_alembic_config(__file__), conn)
 
-    def optimize_for_dagit(self, statement_timeout: int, pool_recycle: int) -> None:
+    def optimize_for_webserver(self, statement_timeout: int, pool_recycle: int) -> None:
         # When running in dagit, hold an open connection and set statement_timeout
         existing_options = self._engine.url.query.get("options")
         timeout_option = pg_statement_timeout(statement_timeout)

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/run_storage/run_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/run_storage/run_storage.py
@@ -106,7 +106,7 @@ class PostgresRunStorage(SqlRunStorage, ConfigurableClass):
                 # This revision may be shared by any other dagster storage classes using the same DB
                 stamp_alembic_rev(pg_alembic_config(__file__), conn)
 
-    def optimize_for_dagit(self, statement_timeout: int, pool_recycle: int) -> None:
+    def optimize_for_webserver(self, statement_timeout: int, pool_recycle: int) -> None:
         # When running in dagit, hold 1 open connection and set statement_timeout
         existing_options = self._engine.url.query.get("options")
         timeout_option = pg_statement_timeout(statement_timeout)

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/schedule_storage/schedule_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/schedule_storage/schedule_storage.py
@@ -95,7 +95,7 @@ class PostgresScheduleStorage(SqlScheduleStorage, ConfigurableClass):
         self.migrate()
         self.optimize()
 
-    def optimize_for_dagit(self, statement_timeout: int, pool_recycle: int) -> None:
+    def optimize_for_webserver(self, statement_timeout: int, pool_recycle: int) -> None:
         # When running in dagit, hold an open connection and set statement_timeout
         existing_options = self._engine.url.query.get("options")
         timeout_option = pg_statement_timeout(statement_timeout)

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_instance.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_instance.py
@@ -203,7 +203,7 @@ def test_connection_leak(hostname, conn_string):
 
 def test_statement_timeouts(hostname):
     with instance_for_test(overrides=yaml.safe_load(full_pg_config(hostname))) as instance:
-        instance.optimize_for_dagit(statement_timeout=500, pool_recycle=-1)  # 500ms
+        instance.optimize_for_dagster_webserver(statement_timeout=500, pool_recycle=-1)  # 500ms
 
         # ensure migration error is not raised by being up to date
         instance.upgrade()
@@ -315,7 +315,7 @@ def test_configured_other_schema(hostname):
         instance.get_runs()
         instance.all_asset_keys()
         instance.all_instigator_state()
-        instance.optimize_for_dagit(statement_timeout=100, pool_recycle=100)
+        instance.optimize_for_dagster_webserver(statement_timeout=100, pool_recycle=100)
         instance.get_runs()
         instance.all_asset_keys()
         instance.all_instigator_state()

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_instance.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_instance.py
@@ -203,7 +203,7 @@ def test_connection_leak(hostname, conn_string):
 
 def test_statement_timeouts(hostname):
     with instance_for_test(overrides=yaml.safe_load(full_pg_config(hostname))) as instance:
-        instance.optimize_for_dagster_webserver(statement_timeout=500, pool_recycle=-1)  # 500ms
+        instance.optimize_for_webserver(statement_timeout=500, pool_recycle=-1)  # 500ms
 
         # ensure migration error is not raised by being up to date
         instance.upgrade()
@@ -315,7 +315,7 @@ def test_configured_other_schema(hostname):
         instance.get_runs()
         instance.all_asset_keys()
         instance.all_instigator_state()
-        instance.optimize_for_dagster_webserver(statement_timeout=100, pool_recycle=100)
+        instance.optimize_for_webserver(statement_timeout=100, pool_recycle=100)
         instance.get_runs()
         instance.all_asset_keys()
         instance.all_instigator_state()


### PR DESCRIPTION
## Summary & Motivation

Renames "dagit" to "dagster-webserver", "Dagster UI", or "webserver" depending on context in comments and docstrings.

## How I Tested These Changes

Existing test suite.