### PR TITLE
Remove old partition mapping methods

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
@@ -4,7 +4,6 @@ from typing import NamedTuple, Optional, cast
 import dagster._check as check
 from dagster._annotations import PublicAttr
 from dagster._core.definitions.partition import PartitionsDefinition, PartitionsSubset
-from dagster._core.definitions.partition_key_range import PartitionKeyRange
 from dagster._core.definitions.partition_mapping import PartitionMapping, UpstreamPartitionsResult
 from dagster._core.definitions.time_window_partitions import (
     TimeWindow,
@@ -112,14 +111,6 @@ class TimeWindowPartitionMapping(
             ),
         )
 
-    def get_upstream_partitions_for_partition_range(
-        self,
-        downstream_partition_key_range: Optional[PartitionKeyRange],
-        downstream_partitions_def: Optional[PartitionsDefinition],
-        upstream_partitions_def: PartitionsDefinition,
-    ) -> PartitionKeyRange:
-        raise NotImplementedError()
-
     def get_upstream_mapped_partitions_result_for_partitions(
         self,
         downstream_partitions_subset: Optional[PartitionsSubset],
@@ -138,28 +129,6 @@ class TimeWindowPartitionMapping(
             self.end_offset,
             current_time=current_time,
         )
-
-    def get_upstream_partitions_for_partitions(
-        self,
-        downstream_partitions_subset: Optional[PartitionsSubset],
-        upstream_partitions_def: PartitionsDefinition,
-        current_time: Optional[datetime] = None,
-        dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
-    ) -> PartitionsSubset:
-        """Returns the partitions in the upstream asset that map to the given downstream partitions.
-
-        Raises an error if upstream partitions do not exist at the given current_time, fetching the
-        current time if not provided.
-        """
-        raise NotImplementedError()
-
-    def get_downstream_partitions_for_partition_range(
-        self,
-        upstream_partition_key_range: PartitionKeyRange,
-        downstream_partitions_def: Optional[PartitionsDefinition],
-        upstream_partitions_def: PartitionsDefinition,
-    ) -> PartitionKeyRange:
-        raise NotImplementedError()
 
     def get_downstream_partitions_for_partitions(
         self,

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
@@ -151,17 +151,7 @@ class TimeWindowPartitionMapping(
         Raises an error if upstream partitions do not exist at the given current_time, fetching the
         current time if not provided.
         """
-        if not isinstance(downstream_partitions_subset, TimeWindowPartitionsSubset):
-            check.failed("downstream_partitions_subset must be a TimeWindowPartitionsSubset")
-
-        return self._map_partitions(
-            downstream_partitions_subset.partitions_def,
-            upstream_partitions_def,
-            downstream_partitions_subset,
-            self.start_offset,
-            self.end_offset,
-            current_time=current_time,
-        ).partitions_subset
+        raise NotImplementedError()
 
     def get_downstream_partitions_for_partition_range(
         self,

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_asset_partition_mappings.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_asset_partition_mappings.py
@@ -761,3 +761,19 @@ def test_multipartitions_def_partition_mapping_infer_multi_to_single_dim():
         resources={"io_manager": IOManagerDefinition.hardcoded_io_manager(MyIOManager())},
         partition_key="a",
     )
+
+
+def test_identity_partition_mapping():
+    xy = StaticPartitionsDefinition(["x", "y"])
+    zx = StaticPartitionsDefinition(["z", "x"])
+
+    result = IdentityPartitionMapping().get_upstream_mapped_partitions_result_for_partitions(
+        zx.empty_subset().with_partition_keys(["z", "x"]), xy
+    )
+    assert result.partitions_subset.get_partition_keys() == set(["x"])
+    assert result.required_but_nonexistent_partition_keys == ["z"]
+
+    result = IdentityPartitionMapping().get_downstream_partitions_for_partitions(
+        zx.empty_subset().with_partition_keys(["z", "x"]), xy
+    )
+    assert result.get_partition_keys() == set(["x"])

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_asset_partition_mappings.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_asset_partition_mappings.py
@@ -1,12 +1,11 @@
 import inspect
+from datetime import datetime
 from typing import Optional
 
-import pendulum
 from dagster import (
     AllPartitionMapping,
     AssetIn,
     AssetMaterialization,
-    AssetOut,
     AssetsDefinition,
     DailyPartitionsDefinition,
     IdentityPartitionMapping,
@@ -16,7 +15,6 @@ from dagster import (
     MultiPartitionKey,
     MultiPartitionsDefinition,
     MultiToSingleDimensionPartitionMapping,
-    Output,
     PartitionsDefinition,
     SourceAsset,
     SpecificPartitionsPartitionMapping,
@@ -28,87 +26,18 @@ from dagster import (
     materialize,
     op,
 )
-from dagster._core.definitions import asset, build_assets_job, multi_asset
+from dagster._core.definitions import asset, build_assets_job
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.events import AssetKey
+from dagster._core.definitions.partition import PartitionsSubset
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
 from dagster._core.definitions.partition_mapping import (
     PartitionMapping,
+    UpstreamPartitionsResult,
     get_builtin_partition_mapping_types,
 )
-from dagster._core.definitions.time_window_partitions import TimeWindow
+from dagster._core.instance import DynamicPartitionsStore
 from dagster._core.test_utils import assert_namedtuple_lists_equal
-from dagster_tests.asset_defs_tests.test_partitioned_assets import (
-    get_downstream_partitions_for_partition_range,
-    get_upstream_partitions_for_partition_range,
-)
-
-
-def test_filter_mapping_partitions_dep():
-    downstream_partitions = ["john", "ringo", "paul", "george"]
-    upstream_partitions = [
-        f"{hemisphere}|{beatle}"
-        for beatle in downstream_partitions
-        for hemisphere in ["southern", "northern"]
-    ]
-    downstream_partitions_def = StaticPartitionsDefinition(downstream_partitions)
-    upstream_partitions_def = StaticPartitionsDefinition(upstream_partitions)
-
-    class HemisphereFilteringPartitionMapping(PartitionMapping):
-        def __init__(self, hemisphere: str):
-            self.hemisphere = hemisphere
-
-        def get_upstream_partitions_for_partition_range(
-            self,
-            downstream_partition_key_range,
-            downstream_partitions_def: Optional[PartitionsDefinition],
-            upstream_partitions_def: PartitionsDefinition,
-        ) -> PartitionKeyRange:
-            assert downstream_partition_key_range is not None
-            return PartitionKeyRange(
-                f"{self.hemisphere}|{downstream_partition_key_range.start}",
-                f"{self.hemisphere}|{downstream_partition_key_range.end}",
-            )
-
-        def get_downstream_partitions_for_partition_range(
-            self,
-            upstream_partition_key_range: PartitionKeyRange,
-            downstream_partitions_def: Optional[PartitionsDefinition],
-            upstream_partitions_def: PartitionsDefinition,
-        ) -> PartitionKeyRange:
-            return PartitionKeyRange(
-                upstream_partition_key_range.start.split("|")[-1],
-                upstream_partition_key_range.end.split("|")[-1],
-            )
-
-    @asset(partitions_def=upstream_partitions_def)
-    def upstream_asset():
-        pass
-
-    @asset(
-        partitions_def=downstream_partitions_def,
-        ins={
-            "upstream_asset": AssetIn(
-                partition_mapping=HemisphereFilteringPartitionMapping("southern")
-            )
-        },
-    )
-    def downstream_asset(upstream_asset):
-        assert upstream_asset
-
-    assert get_upstream_partitions_for_partition_range(
-        downstream_asset,
-        upstream_asset.partitions_def,
-        AssetKey("upstream_asset"),
-        PartitionKeyRange("ringo", "paul"),
-    ) == PartitionKeyRange("southern|ringo", "southern|paul")
-
-    assert get_downstream_partitions_for_partition_range(
-        downstream_asset,
-        upstream_asset,
-        AssetKey("upstream_asset"),
-        PartitionKeyRange("southern|ringo", "southern|paul"),
-    ) == PartitionKeyRange("ringo", "paul")
 
 
 def test_access_partition_keys_from_context_non_identity_partition_mapping():
@@ -120,25 +49,31 @@ def test_access_partition_keys_from_context_non_identity_partition_mapping():
         preceding partition.
         """
 
-        def get_upstream_partitions_for_partition_range(
+        def get_upstream_mapped_partitions_result_for_partitions(
             self,
-            downstream_partition_key_range,
-            downstream_partitions_def: Optional[PartitionsDefinition],
+            downstream_partitions_subset: Optional[PartitionsSubset],
             upstream_partitions_def: PartitionsDefinition,
-        ) -> PartitionKeyRange:
-            assert downstream_partitions_def
+            current_time: Optional[datetime] = None,
+            dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
+        ) -> UpstreamPartitionsResult:
+            assert downstream_partitions_subset
             assert upstream_partitions_def
 
-            assert downstream_partition_key_range is not None
-            start, end = downstream_partition_key_range
-            return PartitionKeyRange(str(max(1, int(start) - 1)), end)
+            partition_keys = list(downstream_partitions_subset.get_partition_keys())
+            return UpstreamPartitionsResult(
+                upstream_partitions_def.empty_subset().with_partition_key_range(
+                    PartitionKeyRange(str(max(1, int(partition_keys[0]) - 1)), partition_keys[-1])
+                ),
+                [],
+            )
 
-        def get_downstream_partitions_for_partition_range(
+        def get_downstream_partitions_for_partitions(
             self,
-            upstream_partition_key_range: PartitionKeyRange,
-            downstream_partitions_def: Optional[PartitionsDefinition],
-            upstream_partitions_def: PartitionsDefinition,
-        ) -> PartitionKeyRange:
+            upstream_partitions_subset: PartitionsSubset,
+            downstream_partitions_def: PartitionsDefinition,
+            current_time: Optional[datetime] = None,
+            dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
+        ) -> PartitionsSubset:
             raise NotImplementedError()
 
     class MyIOManager(IOManager):
@@ -182,187 +117,8 @@ def test_access_partition_keys_from_context_non_identity_partition_mapping():
     )
 
 
-def test_asset_partitions_time_window_non_identity_partition_mapping():
-    upstream_partitions_def = DailyPartitionsDefinition(start_date="2020-01-01")
-    downstream_partitions_def = DailyPartitionsDefinition(start_date="2020-01-01")
-
-    class TrailingWindowPartitionMapping(PartitionMapping):
-        """Maps each downstream partition to two partitions in the upstream asset: itself and the
-        preceding partition.
-        """
-
-        def get_upstream_partitions_for_partition_range(
-            self,
-            downstream_partition_key_range,
-            downstream_partitions_def: Optional[PartitionsDefinition],
-            upstream_partitions_def: PartitionsDefinition,
-        ) -> PartitionKeyRange:
-            del downstream_partitions_def, upstream_partitions_def
-
-            assert downstream_partition_key_range is not None
-            start, end = downstream_partition_key_range
-            assert start == "2020-01-02"
-            assert end == "2020-01-02"
-            return PartitionKeyRange("2020-01-01", "2020-01-02")
-
-        def get_downstream_partitions_for_partition_range(
-            self,
-            upstream_partition_key_range: PartitionKeyRange,
-            downstream_partitions_def: Optional[PartitionsDefinition],
-            upstream_partitions_def: PartitionsDefinition,
-        ) -> PartitionKeyRange:
-            raise NotImplementedError()
-
-    class MyIOManager(IOManager):
-        def handle_output(self, context, obj):
-            assert context.asset_partitions_time_window == TimeWindow(
-                pendulum.parse("2020-01-02"), pendulum.parse("2020-01-03")
-            )
-
-        def load_input(self, context):
-            assert context.asset_partitions_time_window == TimeWindow(
-                pendulum.parse("2020-01-01"), pendulum.parse("2020-01-03")
-            )
-
-    @asset(partitions_def=upstream_partitions_def)
-    def upstream_asset():
-        pass
-
-    @asset(
-        partitions_def=downstream_partitions_def,
-        ins={"upstream_asset": AssetIn(partition_mapping=TrailingWindowPartitionMapping())},
-    )
-    def downstream_asset(upstream_asset):
-        assert upstream_asset is None
-
-    my_job = build_assets_job(
-        "my_job",
-        assets=[upstream_asset, downstream_asset],
-        resource_defs={"io_manager": IOManagerDefinition.hardcoded_io_manager(MyIOManager())},
-    )
-    my_job.execute_in_process(partition_key="2020-01-02")
-
-
-def test_multi_asset_non_identity_partition_mapping():
-    upstream_partitions_def = StaticPartitionsDefinition(["1", "2", "3"])
-    downstream_partitions_def = StaticPartitionsDefinition(["1", "2", "3"])
-
-    class TrailingWindowPartitionMapping(PartitionMapping):
-        """Maps each downstream partition to two partitions in the upstream asset: itself and the
-        preceding partition.
-        """
-
-        def get_upstream_partitions_for_partition_range(
-            self,
-            downstream_partition_key_range,
-            downstream_partitions_def: Optional[PartitionsDefinition],
-            upstream_partitions_def: PartitionsDefinition,
-        ) -> PartitionKeyRange:
-            assert downstream_partitions_def
-            assert upstream_partitions_def
-
-            assert downstream_partition_key_range is not None
-            start, end = downstream_partition_key_range
-            return PartitionKeyRange(str(max(1, int(start) - 1)), end)
-
-        def get_downstream_partitions_for_partition_range(
-            self,
-            upstream_partition_key_range: PartitionKeyRange,
-            downstream_partitions_def: Optional[PartitionsDefinition],
-            upstream_partitions_def: PartitionsDefinition,
-        ) -> PartitionKeyRange:
-            raise NotImplementedError()
-
-    class MyIOManager(IOManager):
-        def handle_output(self, context, obj):
-            assert context.asset_partition_key == "2"
-
-        def load_input(self, context):
-            start, end = context.asset_partition_key_range
-            assert start, end == ("1", "2")
-
-    @multi_asset(
-        outs={
-            "out1": AssetOut(key=AssetKey("upstream_asset_1")),
-            "out2": AssetOut(key=AssetKey("upstream_asset_2")),
-        },
-        partitions_def=upstream_partitions_def,
-    )
-    def upstream_asset(context):
-        assert context.asset_partition_key_for_output("out1") == "2"
-        assert context.asset_partition_key_for_output("out2") == "2"
-        return (Output(1, output_name="out1"), Output(2, output_name="out2"))
-
-    @asset(
-        partitions_def=downstream_partitions_def,
-        ins={"upstream_asset_1": AssetIn(partition_mapping=TrailingWindowPartitionMapping())},
-    )
-    def downstream_asset_1(context, upstream_asset_1):
-        assert context.asset_partition_key_for_output() == "2"
-        assert upstream_asset_1 is None
-
-    @asset(
-        partitions_def=downstream_partitions_def,
-        ins={"upstream_asset_2": AssetIn(partition_mapping=TrailingWindowPartitionMapping())},
-    )
-    def downstream_asset_2(context, upstream_asset_2):
-        assert context.asset_partition_key_for_output() == "2"
-        assert upstream_asset_2 is None
-
-    my_job = build_assets_job(
-        "my_job",
-        assets=[upstream_asset, downstream_asset_1, downstream_asset_2],
-        resource_defs={"io_manager": IOManagerDefinition.hardcoded_io_manager(MyIOManager())},
-    )
-    result = my_job.execute_in_process(partition_key="2")
-    assert_namedtuple_lists_equal(
-        result.asset_materializations_for_node("upstream_asset"),
-        [
-            AssetMaterialization(AssetKey(["upstream_asset_1"]), partition="2"),
-            AssetMaterialization(AssetKey(["upstream_asset_2"]), partition="2"),
-        ],
-        exclude_fields=["tags"],
-    )
-    assert_namedtuple_lists_equal(
-        result.asset_materializations_for_node("downstream_asset_1"),
-        [AssetMaterialization(AssetKey(["downstream_asset_1"]), partition="2")],
-        exclude_fields=["tags"],
-    )
-    assert_namedtuple_lists_equal(
-        result.asset_materializations_for_node("downstream_asset_2"),
-        [AssetMaterialization(AssetKey(["downstream_asset_2"]), partition="2")],
-        exclude_fields=["tags"],
-    )
-
-
 def test_from_graph():
     partitions_def = StaticPartitionsDefinition(["a", "b", "c", "d"])
-
-    class SpecialIdentityPartitionMapping(PartitionMapping):
-        def __init__(self):
-            self.upstream_calls = 0
-            self.downstream_calls = 0
-
-        def get_upstream_partitions_for_partition_range(
-            self,
-            downstream_partition_key_range,
-            downstream_partitions_def: Optional[PartitionsDefinition],
-            upstream_partitions_def: PartitionsDefinition,
-        ) -> PartitionKeyRange:
-            assert downstream_partition_key_range is not None
-            self.upstream_calls += 1
-            return downstream_partition_key_range
-
-        def get_downstream_partitions_for_partition_range(
-            self,
-            upstream_partition_key_range: PartitionKeyRange,
-            downstream_partitions_def: Optional[PartitionsDefinition],
-            upstream_partitions_def: PartitionsDefinition,
-        ) -> PartitionKeyRange:
-            self.downstream_calls += 1
-            return upstream_partition_key_range
-
-    partition_mapping = SpecialIdentityPartitionMapping()
 
     @op
     def my_op(context):
@@ -398,14 +154,12 @@ def test_from_graph():
             AssetsDefinition.from_graph(
                 downstream_asset,
                 partitions_def=partitions_def,
-                partition_mappings={"upstream_asset": partition_mapping},
+                partition_mappings={"upstream_asset": IdentityPartitionMapping()},
             ),
         ],
         resource_defs={"io_manager": IOManagerDefinition.hardcoded_io_manager(MyIOManager())},
     )
     assert my_job.execute_in_process(partition_key="a").success
-    assert partition_mapping.downstream_calls == 0
-    assert partition_mapping.upstream_calls == 2
 
 
 def test_non_partitioned_depends_on_last_partition():

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_static_partition_mapping.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_static_partition_mapping.py
@@ -21,14 +21,14 @@ def test_single_valued_static_mapping():
 
     assert result == DefaultPartitionsSubset(downstream_parts, {"p", "r"})
 
-    result = mapping.get_upstream_partitions_for_partitions(
+    result = mapping.get_upstream_mapped_partitions_result_for_partitions(
         downstream_partitions_subset=downstream_parts.empty_subset().with_partition_keys(
             ["p", "q"]
         ),
         upstream_partitions_def=upstream_parts,
     )
 
-    assert result == DefaultPartitionsSubset(upstream_parts, {"p1", "p2", "p3"})
+    assert result.partitions_subset == DefaultPartitionsSubset(upstream_parts, {"p1", "p2", "p3"})
 
 
 def test_multi_valued_static_mapping():
@@ -44,14 +44,14 @@ def test_multi_valued_static_mapping():
 
     assert result == DefaultPartitionsSubset(downstream_parts, {"p1", "p2", "p3"})
 
-    result = mapping.get_upstream_partitions_for_partitions(
+    result = mapping.get_upstream_mapped_partitions_result_for_partitions(
         downstream_partitions_subset=downstream_parts.empty_subset().with_partition_keys(
             ["p2", "p3", "q"]
         ),
         upstream_partitions_def=upstream_parts,
     )
 
-    assert result == DefaultPartitionsSubset(upstream_parts, {"p", "q1", "q2"})
+    assert result.partitions_subset == DefaultPartitionsSubset(upstream_parts, {"p", "q1", "q2"})
 
 
 def test_error_on_extra_keys_in_mapping():
@@ -69,7 +69,7 @@ def test_error_on_extra_keys_in_mapping():
     with pytest.raises(ValueError, match="OTHER"):
         StaticPartitionMapping(
             {"p": "p", "q": "q", "OTHER": "q"}
-        ).get_upstream_partitions_for_partitions(
+        ).get_upstream_mapped_partitions_result_for_partitions(
             downstream_partitions_subset=downstream_parts.empty_subset(),
             upstream_partitions_def=upstream_parts,
         )

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_time_window_partition_mapping.py
@@ -30,81 +30,104 @@ def test_get_upstream_partitions_for_partition_range_same_partitioning():
     downstream_partitions_def = DailyPartitionsDefinition(start_date="2021-05-05")
     upstream_partitions_def = DailyPartitionsDefinition(start_date="2021-05-05")
     # single partition key
-    result = TimeWindowPartitionMapping().get_upstream_partitions_for_partitions(
+    result = TimeWindowPartitionMapping().get_upstream_mapped_partitions_result_for_partitions(
         subset_with_keys(downstream_partitions_def, ["2021-05-07"]),
         upstream_partitions_def,
     )
-    assert result == upstream_partitions_def.empty_subset().with_partition_keys(["2021-05-07"])
+    assert result.partitions_subset == upstream_partitions_def.empty_subset().with_partition_keys(
+        ["2021-05-07"]
+    )
 
     # range of partition keys
-    result = TimeWindowPartitionMapping().get_upstream_partitions_for_partitions(
+    result = TimeWindowPartitionMapping().get_upstream_mapped_partitions_result_for_partitions(
         subset_with_key_range(downstream_partitions_def, "2021-05-07", "2021-05-09"),
         upstream_partitions_def,
     )
-    assert result == subset_with_key_range(upstream_partitions_def, "2021-05-07", "2021-05-09")
+    assert result.partitions_subset == subset_with_key_range(
+        upstream_partitions_def, "2021-05-07", "2021-05-09"
+    )
 
 
 def test_get_upstream_partitions_for_partition_range_same_partitioning_different_formats():
     downstream_partitions_def = DailyPartitionsDefinition(start_date="2021-05-05")
     upstream_partitions_def = DailyPartitionsDefinition(start_date="2021/05/05", fmt="%Y/%m/%d")
 
-    result = TimeWindowPartitionMapping().get_upstream_partitions_for_partitions(
+    result = TimeWindowPartitionMapping().get_upstream_mapped_partitions_result_for_partitions(
         subset_with_key_range(downstream_partitions_def, "2021-05-07", "2021-05-09"),
         upstream_partitions_def,
     )
-    assert result == subset_with_key_range(upstream_partitions_def, "2021/05/07", "2021/05/09")
-    assert result.get_partition_keys() == upstream_partitions_def.get_partition_keys_in_range(
-        PartitionKeyRange("2021/05/07", "2021/05/09")
+    assert result.partitions_subset == subset_with_key_range(
+        upstream_partitions_def, "2021/05/07", "2021/05/09"
+    )
+    assert (
+        result.partitions_subset.get_partition_keys()
+        == upstream_partitions_def.get_partition_keys_in_range(
+            PartitionKeyRange("2021/05/07", "2021/05/09")
+        )
     )
 
 
 def test_get_upstream_partitions_for_partition_range_hourly_downstream_daily_upstream():
     downstream_partitions_def = HourlyPartitionsDefinition(start_date="2021-05-05-00:00")
     upstream_partitions_def = DailyPartitionsDefinition(start_date="2021-05-05")
-    result = TimeWindowPartitionMapping().get_upstream_partitions_for_partitions(
+    result = TimeWindowPartitionMapping().get_upstream_mapped_partitions_result_for_partitions(
         subset_with_keys(downstream_partitions_def, ["2021-05-07-05:00"]),
         upstream_partitions_def,
     )
-    assert result == upstream_partitions_def.empty_subset().with_partition_keys(["2021-05-07"])
+    assert result.partitions_subset == upstream_partitions_def.empty_subset().with_partition_keys(
+        ["2021-05-07"]
+    )
 
-    result = TimeWindowPartitionMapping().get_upstream_partitions_for_partitions(
+    result = TimeWindowPartitionMapping().get_upstream_mapped_partitions_result_for_partitions(
         subset_with_key_range(downstream_partitions_def, "2021-05-07-05:00", "2021-05-09-09:00"),
         upstream_partitions_def,
     )
-    assert result.get_partition_keys() == upstream_partitions_def.get_partition_keys_in_range(
-        PartitionKeyRange("2021-05-07", "2021-05-09")
+    assert (
+        result.partitions_subset.get_partition_keys()
+        == upstream_partitions_def.get_partition_keys_in_range(
+            PartitionKeyRange("2021-05-07", "2021-05-09")
+        )
     )
 
 
 def test_get_upstream_partitions_for_partition_range_daily_downstream_hourly_upstream():
     downstream_partitions_def = DailyPartitionsDefinition(start_date="2021-05-05")
     upstream_partitions_def = HourlyPartitionsDefinition(start_date="2021-05-05-00:00")
-    result = TimeWindowPartitionMapping().get_upstream_partitions_for_partitions(
+    result = TimeWindowPartitionMapping().get_upstream_mapped_partitions_result_for_partitions(
         subset_with_keys(downstream_partitions_def, ["2021-05-07"]),
         upstream_partitions_def,
     )
-    assert result.get_partition_keys() == upstream_partitions_def.get_partition_keys_in_range(
-        PartitionKeyRange("2021-05-07-00:00", "2021-05-07-23:00")
+    assert (
+        result.partitions_subset.get_partition_keys()
+        == upstream_partitions_def.get_partition_keys_in_range(
+            PartitionKeyRange("2021-05-07-00:00", "2021-05-07-23:00")
+        )
     )
 
-    result = TimeWindowPartitionMapping().get_upstream_partitions_for_partitions(
+    result = TimeWindowPartitionMapping().get_upstream_mapped_partitions_result_for_partitions(
         subset_with_key_range(downstream_partitions_def, "2021-05-07", "2021-05-09"),
         upstream_partitions_def,
     )
-    assert result.get_partition_keys() == upstream_partitions_def.get_partition_keys_in_range(
-        PartitionKeyRange("2021-05-07-00:00", "2021-05-09-23:00")
+    assert (
+        result.partitions_subset.get_partition_keys()
+        == upstream_partitions_def.get_partition_keys_in_range(
+            PartitionKeyRange("2021-05-07-00:00", "2021-05-09-23:00")
+        )
     )
 
 
 def test_get_upstream_partitions_for_partition_range_monthly_downstream_daily_upstream():
     downstream_partitions_def = MonthlyPartitionsDefinition(start_date="2021-05-01")
     upstream_partitions_def = DailyPartitionsDefinition(start_date="2021-05-01")
-    result = TimeWindowPartitionMapping().get_upstream_partitions_for_partitions(
+    result = TimeWindowPartitionMapping().get_upstream_mapped_partitions_result_for_partitions(
         subset_with_key_range(downstream_partitions_def, "2021-05-01", "2021-07-01"),
         upstream_partitions_def,
     )
-    assert result.get_partition_keys() == upstream_partitions_def.get_partition_keys_in_range(
-        PartitionKeyRange("2021-05-01", "2021-07-31")
+    assert (
+        result.partitions_subset.get_partition_keys()
+        == upstream_partitions_def.get_partition_keys_in_range(
+            PartitionKeyRange("2021-05-01", "2021-07-31")
+        )
     )
 
 
@@ -116,12 +139,15 @@ def test_get_upstream_partitions_for_partition_range_twice_daily_downstream_dail
     upstream_partitions_def = TimeWindowPartitionsDefinition(
         cron_schedule="0 0,11 * * *", start=start, fmt="%Y-%m-%d %H:%M"
     )
-    result = TimeWindowPartitionMapping().get_upstream_partitions_for_partitions(
+    result = TimeWindowPartitionMapping().get_upstream_mapped_partitions_result_for_partitions(
         subset_with_key_range(downstream_partitions_def, "2021-05-01", "2021-05-03"),
         upstream_partitions_def,
     )
-    assert result.get_partition_keys() == upstream_partitions_def.get_partition_keys_in_range(
-        PartitionKeyRange("2021-05-01 00:00", "2021-05-03 11:00")
+    assert (
+        result.partitions_subset.get_partition_keys()
+        == upstream_partitions_def.get_partition_keys_in_range(
+            PartitionKeyRange("2021-05-01 00:00", "2021-05-03 11:00")
+        )
     )
 
 
@@ -133,12 +159,15 @@ def test_get_upstream_partitions_for_partition_range_daily_downstream_twice_dail
     upstream_partitions_def = TimeWindowPartitionsDefinition(
         cron_schedule="0 0 * * *", start=start, fmt="%Y-%m-%d"
     )
-    result = TimeWindowPartitionMapping().get_upstream_partitions_for_partitions(
+    result = TimeWindowPartitionMapping().get_upstream_mapped_partitions_result_for_partitions(
         subset_with_key_range(downstream_partitions_def, "2021-05-01 00:00", "2021-05-03 00:00"),
         upstream_partitions_def,
     )
-    assert result.get_partition_keys() == upstream_partitions_def.get_partition_keys_in_range(
-        PartitionKeyRange("2021-05-01", "2021-05-03")
+    assert (
+        result.partitions_subset.get_partition_keys()
+        == upstream_partitions_def.get_partition_keys_in_range(
+            PartitionKeyRange("2021-05-01", "2021-05-03")
+        )
     )
 
 
@@ -150,12 +179,15 @@ def test_get_upstream_partitions_for_partition_range_daily_non_aligned():
     upstream_partitions_def = TimeWindowPartitionsDefinition(
         cron_schedule="0 11 * * *", start=start, fmt="%Y-%m-%d"
     )
-    result = TimeWindowPartitionMapping().get_upstream_partitions_for_partitions(
+    result = TimeWindowPartitionMapping().get_upstream_mapped_partitions_result_for_partitions(
         subset_with_key_range(downstream_partitions_def, "2021-05-02", "2021-05-04"),
         upstream_partitions_def,
     )
-    assert result.get_partition_keys() == upstream_partitions_def.get_partition_keys_in_range(
-        PartitionKeyRange("2021-05-01", "2021-05-04")
+    assert (
+        result.partitions_subset.get_partition_keys()
+        == upstream_partitions_def.get_partition_keys_in_range(
+            PartitionKeyRange("2021-05-01", "2021-05-04")
+        )
     )
 
 
@@ -164,11 +196,11 @@ def test_get_upstream_partitions_for_partition_range_weekly_with_offset():
         start_date="2022-09-04", day_offset=0, hour_offset=10
     )
 
-    result = TimeWindowPartitionMapping().get_upstream_partitions_for_partitions(
+    result = TimeWindowPartitionMapping().get_upstream_mapped_partitions_result_for_partitions(
         subset_with_key_range(partitions_def, "2022-09-11", "2022-09-11"),
         partitions_def,
     )
-    assert result.get_partition_keys() == (
+    assert result.partitions_subset.get_partition_keys() == (
         partitions_def.get_partition_keys_in_range(PartitionKeyRange("2022-09-11", "2022-09-11"))
     )
 
@@ -180,9 +212,9 @@ def test_daily_to_daily_lag():
     mapping = TimeWindowPartitionMapping(start_offset=-1, end_offset=-1)
 
     # single partition key
-    assert mapping.get_upstream_partitions_for_partitions(
+    assert mapping.get_upstream_mapped_partitions_result_for_partitions(
         subset_with_keys(downstream_partitions_def, ["2021-05-07"]), upstream_partitions_def
-    ).get_partition_keys() == ["2021-05-06"]
+    ).partitions_subset.get_partition_keys() == ["2021-05-06"]
 
     assert mapping.get_downstream_partitions_for_partitions(
         subset_with_keys(upstream_partitions_def, ["2021-05-06"]), downstream_partitions_def
@@ -190,17 +222,17 @@ def test_daily_to_daily_lag():
 
     # first partition key
     assert (
-        mapping.get_upstream_partitions_for_partitions(
+        mapping.get_upstream_mapped_partitions_result_for_partitions(
             subset_with_keys(downstream_partitions_def, ["2021-05-05"]), upstream_partitions_def
-        ).get_partition_keys()
+        ).partitions_subset.get_partition_keys()
         == []
     )
 
     # range of partition keys
-    assert mapping.get_upstream_partitions_for_partitions(
+    assert mapping.get_upstream_mapped_partitions_result_for_partitions(
         subset_with_key_range(downstream_partitions_def, "2021-05-07", "2021-05-09"),
         upstream_partitions_def,
-    ).get_partition_keys() == ["2021-05-06", "2021-05-07", "2021-05-08"]
+    ).partitions_subset.get_partition_keys() == ["2021-05-06", "2021-05-07", "2021-05-08"]
 
     assert mapping.get_downstream_partitions_for_partitions(
         subset_with_key_range(downstream_partitions_def, "2021-05-06", "2021-05-08"),
@@ -208,10 +240,10 @@ def test_daily_to_daily_lag():
     ).get_partition_keys() == ["2021-05-07", "2021-05-08", "2021-05-09"]
 
     # range overlaps start
-    assert mapping.get_upstream_partitions_for_partitions(
+    assert mapping.get_upstream_mapped_partitions_result_for_partitions(
         subset_with_key_range(downstream_partitions_def, "2021-05-05", "2021-05-07"),
         upstream_partitions_def,
-    ).get_partition_keys() == ["2021-05-05", "2021-05-06"]
+    ).partitions_subset.get_partition_keys() == ["2021-05-05", "2021-05-06"]
 
 
 def test_daily_to_daily_lag_different_start_date():
@@ -219,9 +251,9 @@ def test_daily_to_daily_lag_different_start_date():
     downstream_partitions_def = DailyPartitionsDefinition(start_date="2021-05-06")
     mapping = TimeWindowPartitionMapping(start_offset=-1, end_offset=-1)
 
-    assert mapping.get_upstream_partitions_for_partitions(
+    assert mapping.get_upstream_mapped_partitions_result_for_partitions(
         subset_with_keys(downstream_partitions_def, ["2021-05-06"]), upstream_partitions_def
-    ).get_partition_keys() == ["2021-05-05"]
+    ).partitions_subset.get_partition_keys() == ["2021-05-05"]
 
     assert mapping.get_downstream_partitions_for_partitions(
         subset_with_keys(upstream_partitions_def, ["2021-05-05"]), downstream_partitions_def
@@ -409,15 +441,6 @@ def test_get_upstream_with_current_time(
 ):
     mapping = TimeWindowPartitionMapping()
 
-    assert (
-        mapping.get_upstream_partitions_for_partitions(
-            subset_with_keys(downstream_partitions_def, downstream_keys),
-            upstream_partitions_def,
-            current_time=current_time,
-        ).get_partition_keys()
-        == expected_upstream_keys
-    )
-
     upstream_partitions_result = mapping.get_upstream_mapped_partitions_result_for_partitions(
         subset_with_keys(downstream_partitions_def, downstream_keys),
         upstream_partitions_def,
@@ -531,16 +554,6 @@ def test_different_start_time_partitions_defs():
     assert upstream_partitions_result.partitions_subset.get_partition_keys() == []
     assert upstream_partitions_result.required_but_nonexistent_partition_keys == ["2023-01-15"]
 
-    assert (
-        TimeWindowPartitionMapping(allow_nonexistent_upstream_partitions=True)
-        .get_upstream_partitions_for_partitions(
-            downstream_partitions_subset=subset_with_keys(jan_start, ["2023-01-15"]),
-            upstream_partitions_def=feb_start,
-        )
-        .get_partition_keys()
-        == []
-    )
-
 
 def test_different_end_time_partitions_defs():
     jan_partitions_def = DailyPartitionsDefinition("2023-01-01", end_date="2023-01-31")
@@ -570,16 +583,6 @@ def test_different_end_time_partitions_defs():
     assert upstream_partitions_result.partitions_subset.get_partition_keys() == []
     assert upstream_partitions_result.required_but_nonexistent_partition_keys == ["2023-02-15"]
 
-    assert (
-        TimeWindowPartitionMapping(allow_nonexistent_upstream_partitions=True)
-        .get_upstream_partitions_for_partitions(
-            downstream_partitions_subset=subset_with_keys(jan_feb_partitions_def, ["2023-02-15"]),
-            upstream_partitions_def=jan_partitions_def,
-        )
-        .get_partition_keys()
-        == []
-    )
-
 
 def test_daily_upstream_of_yearly():
     daily = DailyPartitionsDefinition("2023-01-01")
@@ -592,11 +595,11 @@ def test_daily_upstream_of_yearly():
 
     assert TimeWindowPartitionMapping(
         allow_nonexistent_upstream_partitions=True
-    ).get_upstream_partitions_for_partitions(
+    ).get_upstream_mapped_partitions_result_for_partitions(
         downstream_partitions_subset=subset_with_keys(yearly, ["2023-01-01"]),
         upstream_partitions_def=daily,
         current_time=datetime(2023, 1, 5, 0),
-    ).get_partition_keys() == [
+    ).partitions_subset.get_partition_keys() == [
         "2023-01-01",
         "2023-01-02",
         "2023-01-03",

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
@@ -69,10 +69,10 @@ def get_upstream_partitions_for_partition_range(
         else None
     )
     upstream_partitions_subset = (
-        downstream_partition_mapping.get_upstream_partitions_for_partitions(
+        downstream_partition_mapping.get_upstream_mapped_partitions_result_for_partitions(
             downstream_partitions_subset,
             upstream_partitions_def,
-        )
+        ).partitions_subset
     )
     upstream_key_ranges = upstream_partitions_subset.get_partition_key_ranges()
     check.invariant(len(upstream_key_ranges) == 1)

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
@@ -1,10 +1,9 @@
 from contextlib import contextmanager
-from typing import Iterator, List, Optional, cast
+from typing import Iterator, List, cast
 from unittest import mock
 
 import pytest
 from dagster import (
-    AssetIn,
     AssetKey,
     AssetOut,
     AssetSelection,
@@ -19,9 +18,6 @@ from dagster import (
     EventRecordsFilter,
     FreshnessPolicy,
     Output,
-    PartitionKeyRange,
-    PartitionMapping,
-    PartitionsDefinition,
     RunConfig,
     RunRequest,
     SkipReason,
@@ -1065,43 +1061,15 @@ def test_multi_asset_sensor_all_partitions_materialized():
         asset_sensor(ctx)
 
 
-def test_multi_asset_sensor_custom_partition_mapping():
-    class LastDownstreamPartitionMapping(PartitionMapping):
-        def get_upstream_partitions_for_partition_range(
-            self,
-            downstream_partition_key_range: Optional[PartitionKeyRange],
-            downstream_partitions_def: Optional[PartitionsDefinition],
-            upstream_partitions_def: PartitionsDefinition,
-        ) -> PartitionKeyRange:
-            raise NotImplementedError()
-
-        def get_downstream_partitions_for_partition_range(
-            self,
-            upstream_partition_key_range: PartitionKeyRange,
-            downstream_partitions_def: Optional[PartitionsDefinition],
-            upstream_partitions_def: PartitionsDefinition,
-        ) -> PartitionKeyRange:
-            if not isinstance(downstream_partitions_def, PartitionsDefinition):
-                raise DagsterInvariantViolationError(
-                    "Expected downstream_partitions_def to be a PartitionsDefinition"
-                )
-            first_partition_key = downstream_partitions_def.get_first_partition_key()
-            assert first_partition_key is not None
-            return PartitionKeyRange(first_partition_key, first_partition_key)
-
+def test_multi_asset_sensor_partition_mapping():
     @asset(partitions_def=DailyPartitionsDefinition("2022-07-01"))
     def july_daily_partitions():
         return 1
 
     @asset(
         partitions_def=DailyPartitionsDefinition("2022-08-01"),
-        ins={
-            "upstream": AssetIn(
-                key=july_daily_partitions.key, partition_mapping=LastDownstreamPartitionMapping()
-            )
-        },
     )
-    def downstream_daily_partitions(upstream):
+    def downstream_daily_partitions(july_daily_partitions):
         return 1
 
     @repository
@@ -1118,12 +1086,12 @@ def test_multi_asset_sensor_custom_partition_mapping():
                 to_asset_key=downstream_daily_partitions.key,
                 from_asset_key=july_daily_partitions.key,
             ):
-                assert downstream_partition == "2022-08-01"
+                assert downstream_partition == "2022-08-10"
 
     with instance_for_test() as instance:
         materialize(
             [july_daily_partitions],
-            partition_key="2022-07-10",
+            partition_key="2022-08-10",
             instance=instance,
         )
         ctx = build_multi_asset_sensor_context(

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
@@ -911,35 +911,6 @@ def test_multi_asset_sensor_has_assets():
         passing_sensor(ctx)
 
 
-def test_multi_asset_sensor_invalid_partitions():
-    static_partitions_def = StaticPartitionsDefinition(["a", "b", "c"])
-
-    @asset(partitions_def=static_partitions_def)
-    def static_partitions_asset():
-        return 1
-
-    @asset(partitions_def=DailyPartitionsDefinition("2020-01-01"))
-    def daily_asset():
-        return 1
-
-    @repository
-    def my_repo():
-        return [static_partitions_asset, daily_asset]
-
-    with instance_for_test() as instance:
-        with build_multi_asset_sensor_context(
-            monitored_assets=[static_partitions_asset.key],
-            instance=instance,
-            repository_def=my_repo,
-        ) as context:
-            with pytest.raises(DagsterInvalidInvocationError):
-                context.get_downstream_partition_keys(
-                    "2020-01-01",
-                    to_asset_key=AssetKey("static_partitions_asset"),
-                    from_asset_key=AssetKey("daily_asset"),
-                )
-
-
 def test_partitions_multi_asset_sensor_context():
     daily_partitions_def = DailyPartitionsDefinition("2020-01-01")
 

--- a/python_modules/dagster/dagster_tests/storage_tests/test_fs_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_fs_io_manager.py
@@ -32,6 +32,7 @@ from dagster import (
 from dagster._core.definitions import AssetIn, asset, build_assets_job, multi_asset
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.partition import PartitionsSubset
+from dagster._core.definitions.partition_mapping import UpstreamPartitionsResult
 from dagster._core.definitions.version_strategy import VersionStrategy
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.execution.api import create_execution_plan
@@ -290,14 +291,14 @@ def test_fs_io_manager_partitioned_no_partitions():
         io_manager_def = fs_io_manager.configured({"base_dir": tmpdir_path})
 
         class NoPartitionsPartitionMapping(PartitionMapping):
-            def get_upstream_partitions_for_partitions(
+            def get_upstream_mapped_partitions_result_for_partitions(
                 self,
                 downstream_partitions_subset: Optional[PartitionsSubset],
                 upstream_partitions_def: PartitionsDefinition,
                 current_time: Optional[datetime] = None,
                 dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
-            ) -> PartitionsSubset:
-                return upstream_partitions_def.empty_subset()
+            ) -> UpstreamPartitionsResult:
+                return UpstreamPartitionsResult(upstream_partitions_def.empty_subset(), [])
 
             def get_downstream_partitions_for_partitions(
                 self,
@@ -305,22 +306,6 @@ def test_fs_io_manager_partitioned_no_partitions():
                 downstream_partitions_def,
                 current_time: Optional[datetime] = None,
                 dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
-            ):
-                raise NotImplementedError()
-
-            def get_upstream_partitions_for_partition_range(
-                self,
-                downstream_partition_key_range,
-                downstream_partitions_def,
-                upstream_partitions_def,
-            ):
-                raise NotImplementedError()
-
-            def get_downstream_partitions_for_partition_range(
-                self,
-                upstream_partition_key_range,
-                downstream_partitions_def,
-                upstream_partitions_def,
             ):
                 raise NotImplementedError()
 


### PR DESCRIPTION
This PR refactors built in partition mappings to implement:
- `get_upstream_mapped_partitions_result_for_partitions`
- `get_downstream_partitions_for_partitions`

Removes the following unused APIs:
- `get_upstream_partitions_for_partition_range`
- `get_upstream_partitions_for_partitions`
- `get_downstream_partitions_for_partition_range`

Updates tests:
- Uses the new methods
- Removes some tests for custom partition mappings, since this is no longer supported

This will be a breaking change for anyone that has implemented their own partition mapping. Defining a custom partition mapping has been unsupported since 1.1.7.

Happy to break this down into 2 different PRs if preferred 