### PR TITLE
[pythonic resources] Improve nested resource evaluation logic

### DIFF
--- a/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
@@ -448,6 +448,8 @@ class AllowDelayedDependencies:
     def _resolve_required_resource_keys(
         self, resource_mapping: Mapping[int, str]
     ) -> AbstractSet[str]:
+        from dagster._core.execution.build_resources import wrap_resource_for_execution
+
         # All dependent resources which are not fully configured
         # must be specified to the Definitions object so that the
         # resource can be configured at runtime by the user
@@ -470,11 +472,13 @@ class AllowDelayedDependencies:
                 _resolve_required_resource_keys_for_resource(v, resource_mapping)
             )
 
-        resources, _ = separate_resource_params(self.__class__, self.__dict__)
+        resources, _ = separate_resource_params(
+            cast(Type[BaseModel], self.__class__), self.__dict__
+        )
         for v in resources.values():
             nested_resource_required_keys.update(
                 _resolve_required_resource_keys_for_resource(
-                    coerce_to_resource(v), resource_mapping
+                    wrap_resource_for_execution(v), resource_mapping
                 )
             )
 
@@ -606,14 +610,6 @@ def is_coercible_to_resource(val: Any) -> TypeGuard[CoercibleToResource]:
     return isinstance(val, (ResourceDefinition, ConfigurableResourceFactory, PartialResource))
 
 
-def coerce_to_resource(
-    coercible_to_resource: CoercibleToResource,
-) -> ResourceDefinition:
-    from dagster._core.execution.build_resources import wrap_resources_for_execution
-
-    return wrap_resources_for_execution({"test": coercible_to_resource})["test"]
-
-
 class ConfigurableResourceFactoryResourceDefinition(ResourceDefinition, AllowDelayedDependencies):
     def __init__(
         self,
@@ -622,7 +618,7 @@ class ConfigurableResourceFactoryResourceDefinition(ResourceDefinition, AllowDel
         config_schema: Any,
         description: Optional[str],
         resolve_resource_keys: Callable[[Mapping[int, str]], AbstractSet[str]],
-        nested_resources: Mapping[str, CoercibleToResource],
+        nested_resources: Mapping[str, Any],
         dagster_maintained: bool = False,
     ):
         super().__init__(
@@ -642,7 +638,7 @@ class ConfigurableResourceFactoryResourceDefinition(ResourceDefinition, AllowDel
     @property
     def nested_resources(
         self,
-    ) -> Mapping[str, CoercibleToResource]:
+    ) -> Mapping[str, Any]:
         return self._nested_resources
 
     def _resolve_required_resource_keys(
@@ -662,7 +658,7 @@ class ConfigurableIOManagerFactoryResourceDefinition(IOManagerDefinition, AllowD
         config_schema: Any,
         description: Optional[str],
         resolve_resource_keys: Callable[[Mapping[int, str]], AbstractSet[str]],
-        nested_resources: Mapping[str, CoercibleToResource],
+        nested_resources: Mapping[str, Any],
         input_config_schema: Optional[Union[CoercableToConfigSchema, Type[Config]]] = None,
         output_config_schema: Optional[Union[CoercableToConfigSchema, Type[Config]]] = None,
         dagster_maintained: bool = False,
@@ -696,7 +692,7 @@ class ConfigurableIOManagerFactoryResourceDefinition(IOManagerDefinition, AllowD
     @property
     def nested_resources(
         self,
-    ) -> Mapping[str, CoercibleToResource]:
+    ) -> Mapping[str, Any]:
         return self._nested_resources
 
     def _resolve_required_resource_keys(
@@ -706,11 +702,11 @@ class ConfigurableIOManagerFactoryResourceDefinition(IOManagerDefinition, AllowD
 
 
 class ConfigurableResourceFactoryState(NamedTuple):
-    nested_partial_resources: Mapping[str, CoercibleToResource]
+    nested_partial_resources: Mapping[str, Any]
     resolved_config_dict: Dict[str, Any]
     config_schema: DefinitionConfigSchema
     schema: DagsterField
-    nested_resources: Dict[str, CoercibleToResource]
+    nested_resources: Dict[str, Any]
     resource_context: Optional[InitResourceContext]
 
 
@@ -863,7 +859,7 @@ class ConfigurableResourceFactory(
     @property
     def nested_resources(
         self,
-    ) -> Mapping[str, CoercibleToResource]:
+    ) -> Mapping[str, Any]:
         return self._nested_resources
 
     @classmethod
@@ -899,6 +895,8 @@ class ConfigurableResourceFactory(
 
         Returns a new instance of the resource.
         """
+        from dagster._core.execution.build_resources import wrap_resource_for_execution
+
         partial_resources_to_update: Dict[str, Any] = {}
         if self._nested_partial_resources:
             context_with_mapping = cast(
@@ -923,7 +921,7 @@ class ConfigurableResourceFactory(
             resources_to_update, _ = separate_resource_params(self.__class__, self.__dict__)
             resources_to_update = {
                 attr_name: _call_resource_fn_with_default(
-                    stack, coerce_to_resource(resource), context
+                    stack, wrap_resource_for_execution(resource), context
                 )
                 for attr_name, resource in resources_to_update.items()
                 if attr_name not in partial_resources_to_update
@@ -1121,7 +1119,9 @@ class ConfigurableResource(ConfigurableResourceFactory[TResValue]):
 
 
 def _is_fully_configured(resource: CoercibleToResource) -> bool:
-    actual_resource = coerce_to_resource(resource)
+    from dagster._core.execution.build_resources import wrap_resource_for_execution
+
+    actual_resource = wrap_resource_for_execution(resource)
     res = (
         validate_config(
             actual_resource.config_schema.config_type,
@@ -1136,11 +1136,11 @@ def _is_fully_configured(resource: CoercibleToResource) -> bool:
 
 
 class PartialResourceState(NamedTuple):
-    nested_partial_resources: Dict[str, CoercibleToResource]
+    nested_partial_resources: Dict[str, Any]
     config_schema: DagsterField
     resource_fn: Callable[[InitResourceContext], Any]
     description: Optional[str]
-    nested_resources: Dict[str, CoercibleToResource]
+    nested_resources: Dict[str, Any]
 
 
 class PartialResource(Generic[TResValue], AllowDelayedDependencies, MakeConfigCacheable):
@@ -1180,13 +1180,13 @@ class PartialResource(Generic[TResValue], AllowDelayedDependencies, MakeConfigCa
     @property
     def _nested_partial_resources(
         self,
-    ) -> Mapping[str, CoercibleToResource]:
+    ) -> Mapping[str, Any]:
         return self._state__internal__.nested_partial_resources
 
     @property
     def nested_resources(
         self,
-    ) -> Mapping[str, CoercibleToResource]:
+    ) -> Mapping[str, Any]:
         return self._state__internal__.nested_resources
 
     @cached_method
@@ -1774,7 +1774,7 @@ def infer_schema_from_config_class(
 
 
 class SeparatedResourceParams(NamedTuple):
-    resources: Dict[str, CoercibleToResource]
+    resources: Dict[str, Any]
     non_resources: Dict[str, Any]
 
 
@@ -1831,14 +1831,14 @@ def _call_resource_fn_with_default(
             )
         context = context.replace_config(cast(dict, evr.value)["config"])
 
-    is_fn_generator = inspect.isgenerator(obj.resource_fn) or isinstance(
-        obj.resource_fn, contextlib.ContextDecorator
-    )
-    if has_at_least_one_parameter(obj.resource_fn):  # type: ignore[unreachable]
+    if has_at_least_one_parameter(obj.resource_fn):
         result = cast(ResourceFunctionWithContext, obj.resource_fn)(context)
     else:
         result = cast(ResourceFunctionWithoutContext, obj.resource_fn)()
 
+    is_fn_generator = inspect.isgenerator(obj.resource_fn) or isinstance(
+        obj.resource_fn, contextlib.ContextDecorator
+    )
     if is_fn_generator:
         return stack.enter_context(cast(contextlib.AbstractContextManager, result))
     else:

--- a/python_modules/dagster/dagster/_config/pythonic_config/typing_utils.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/typing_utils.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING, Any, Generic, Optional, Type, TypeVar, Union, 
 
 import pydantic
 from pydantic import Field
-from typing_extensions import dataclass_transform, get_origin
+from typing_extensions import Annotated, dataclass_transform, get_origin
 
 from dagster._core.errors import DagsterInvalidDagsterTypeInPythonicConfigDefinitionError
 
@@ -110,7 +110,7 @@ class BaseResourceMeta(BaseConfigMeta):
                     # arg = get_args(annotations[field])[0]
                     # If so, we treat it as a Union of a PartialResource and a Resource
                     # for Pydantic's sake.
-                    annotations[field] = Any
+                    annotations[field] = Annotated[Any, "resource_dependency"]
                 elif safe_is_subclass(
                     annotations[field], LateBoundTypesForResourceTypeChecking.get_resource_type()
                 ):
@@ -118,8 +118,12 @@ class BaseResourceMeta(BaseConfigMeta):
                     # and a Resource for Pydantic's sake, so that a user can pass in a partially
                     # configured resource.
                     base = annotations[field]
-                    annotations[field] = Union[
-                        LateBoundTypesForResourceTypeChecking.get_partial_resource_type(base), base
+                    annotations[field] = Annotated[
+                        Union[
+                            LateBoundTypesForResourceTypeChecking.get_partial_resource_type(base),
+                            base,
+                        ],
+                        "resource_dependency",
                     ]
 
         namespaces["__annotations__"] = annotations

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
@@ -18,7 +18,6 @@ from dagster._config.pythonic_config import (
     ConfigurableIOManagerFactoryResourceDefinition,
     ConfigurableResourceFactoryResourceDefinition,
     ResourceWithKeyMapping,
-    coerce_to_resource,
 )
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.assets_job import (
@@ -67,6 +66,8 @@ def _env_vars_from_resource_defaults(resource_def: ResourceDefinition) -> Set[st
     resource's default config. This is used to extract environment variables from the top-level
     resources in a Definitions object.
     """
+    from dagster._core.execution.build_resources import wrap_resource_for_execution
+
     config_schema_default = cast(
         Mapping[str, Any],
         json.loads(resource_def.config_schema.default_value_as_json_str)
@@ -86,7 +87,7 @@ def _env_vars_from_resource_defaults(resource_def: ResourceDefinition) -> Set[st
         nested_resources = resource_def.inner_resource.nested_resources
         for nested_resource in nested_resources.values():
             env_vars = env_vars.union(
-                _env_vars_from_resource_defaults(coerce_to_resource(nested_resource))
+                _env_vars_from_resource_defaults(wrap_resource_for_execution(nested_resource))
             )
 
     return env_vars

--- a/python_modules/dagster/dagster/_core/execution/build_resources.py
+++ b/python_modules/dagster/dagster/_core/execution/build_resources.py
@@ -115,22 +115,26 @@ def build_resources(
 def wrap_resources_for_execution(
     resources: Optional[Mapping[str, Any]] = None
 ) -> Dict[str, ResourceDefinition]:
+    return (
+        {
+            resource_key: wrap_resource_for_execution(resource)
+            for resource_key, resource in resources.items()
+        }
+        if resources
+        else {}
+    )
+
+
+def wrap_resource_for_execution(resource: Any) -> ResourceDefinition:
     from dagster._config.pythonic_config import ConfigurableResourceFactory, PartialResource
 
-    resources = check.opt_mapping_param(resources, "resources", key_type=str)
-    resource_defs = {}
     # Wrap instantiated resource values in a resource definition.
     # If an instantiated IO manager is provided, wrap it in an IO manager definition.
-    for resource_key, resource in resources.items():
-        # Wrap instantiated resource values in a resource definition.
-        # If an instantiated IO manager is provided, wrap it in an IO manager definition.
-        if isinstance(resource, (ConfigurableResourceFactory, PartialResource)):
-            resource_defs[resource_key] = resource.get_resource_definition()
-        elif isinstance(resource, ResourceDefinition):
-            resource_defs[resource_key] = resource
-        elif isinstance(resource, IOManager):
-            resource_defs[resource_key] = IOManagerDefinition.hardcoded_io_manager(resource)
-        else:
-            resource_defs[resource_key] = ResourceDefinition.hardcoded_resource(resource)
-
-    return resource_defs
+    if isinstance(resource, (ConfigurableResourceFactory, PartialResource)):
+        return resource.get_resource_definition()
+    elif isinstance(resource, ResourceDefinition):
+        return resource
+    elif isinstance(resource, IOManager):
+        return IOManagerDefinition.hardcoded_io_manager(resource)
+    else:
+        return ResourceDefinition.hardcoded_resource(resource)

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_nesting.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_nesting.py
@@ -1,0 +1,458 @@
+import json
+from abc import ABC, abstractmethod
+from typing import Any, Callable
+
+import pytest
+from dagster import (
+    ConfigurableResource,
+    Definitions,
+    Field,
+    ResourceDependency,
+    ResourceParam,
+    asset,
+    resource,
+)
+from dagster._check import CheckError
+from dagster._config.pythonic_config import ConfigurableResourceFactory
+
+
+def test_nested_resources():
+    out_txt = []
+
+    class Writer(ConfigurableResource, ABC):
+        @abstractmethod
+        def output(self, text: str) -> None:
+            pass
+
+    class WriterResource(Writer):
+        def output(self, text: str) -> None:
+            out_txt.append(text)
+
+    class PrefixedWriterResource(Writer):
+        prefix: str
+
+        def output(self, text: str) -> None:
+            out_txt.append(f"{self.prefix}{text}")
+
+    class JsonWriterResource(
+        Writer,
+    ):
+        base_writer: Writer
+        indent: int
+
+        def output(self, obj: Any) -> None:
+            self.base_writer.output(json.dumps(obj, indent=self.indent))
+
+    @asset
+    def hello_world_asset(writer: JsonWriterResource):
+        writer.output({"hello": "world"})
+
+    # Construct a resource that is needed by another resource
+    writer_resource = WriterResource()
+    json_writer_resource = JsonWriterResource(indent=2, base_writer=writer_resource)
+
+    assert (
+        Definitions(
+            assets=[hello_world_asset],
+            resources={
+                "writer": json_writer_resource,
+            },
+        )
+        .get_implicit_global_asset_job_def()
+        .execute_in_process()
+        .success
+    )
+
+    assert out_txt == ['{\n  "hello": "world"\n}']
+
+    # Do it again, with a different nested resource
+    out_txt.clear()
+    prefixed_writer_resource = PrefixedWriterResource(prefix="greeting: ")
+    prefixed_json_writer_resource = JsonWriterResource(
+        indent=2, base_writer=prefixed_writer_resource
+    )
+
+    assert (
+        Definitions(
+            assets=[hello_world_asset],
+            resources={
+                "writer": prefixed_json_writer_resource,
+            },
+        )
+        .get_implicit_global_asset_job_def()
+        .execute_in_process()
+        .success
+    )
+
+    assert out_txt == ['greeting: {\n  "hello": "world"\n}']
+
+
+def test_nested_resources_multiuse():
+    class AWSCredentialsResource(ConfigurableResource):
+        username: str
+        password: str
+
+    class S3Resource(ConfigurableResource):
+        aws_credentials: AWSCredentialsResource
+        bucket_name: str
+
+    class EC2Resource(ConfigurableResource):
+        aws_credentials: AWSCredentialsResource
+
+    completed = {}
+
+    @asset
+    def my_asset(s3: S3Resource, ec2: EC2Resource):
+        assert s3.aws_credentials.username == "foo"
+        assert s3.aws_credentials.password == "bar"
+        assert s3.bucket_name == "my_bucket"
+
+        assert ec2.aws_credentials.username == "foo"
+        assert ec2.aws_credentials.password == "bar"
+
+        completed["yes"] = True
+
+    aws_credentials = AWSCredentialsResource(username="foo", password="bar")
+    defs = Definitions(
+        assets=[my_asset],
+        resources={
+            "s3": S3Resource(bucket_name="my_bucket", aws_credentials=aws_credentials),
+            "ec2": EC2Resource(aws_credentials=aws_credentials),
+        },
+    )
+
+    assert defs.get_implicit_global_asset_job_def().execute_in_process().success
+    assert completed["yes"]
+
+
+def test_nested_resources_runtime_config():
+    class AWSCredentialsResource(ConfigurableResource):
+        username: str
+        password: str
+
+    class S3Resource(ConfigurableResource):
+        aws_credentials: AWSCredentialsResource
+        bucket_name: str
+
+    class EC2Resource(ConfigurableResource):
+        aws_credentials: AWSCredentialsResource
+
+    completed = {}
+
+    @asset
+    def my_asset(s3: S3Resource, ec2: EC2Resource):
+        assert s3.aws_credentials.username == "foo"
+        assert s3.aws_credentials.password == "bar"
+        assert s3.bucket_name == "my_bucket"
+
+        assert ec2.aws_credentials.username == "foo"
+        assert ec2.aws_credentials.password == "bar"
+
+        completed["yes"] = True
+
+    aws_credentials = AWSCredentialsResource.configure_at_launch()
+    defs = Definitions(
+        assets=[my_asset],
+        resources={
+            "aws_credentials": aws_credentials,
+            "s3": S3Resource(bucket_name="my_bucket", aws_credentials=aws_credentials),
+            "ec2": EC2Resource(aws_credentials=aws_credentials),
+        },
+    )
+
+    assert (
+        defs.get_implicit_global_asset_job_def()
+        .execute_in_process(
+            {
+                "resources": {
+                    "aws_credentials": {
+                        "config": {
+                            "username": "foo",
+                            "password": "bar",
+                        }
+                    }
+                }
+            }
+        )
+        .success
+    )
+    assert completed["yes"]
+
+
+def test_nested_resources_runtime_config_complex():
+    class CredentialsResource(ConfigurableResource):
+        username: str
+        password: str
+
+    class DBConfigResource(ConfigurableResource):
+        creds: CredentialsResource
+        host: str
+        database: str
+
+    class DBResource(ConfigurableResource):
+        config: DBConfigResource
+
+    completed = {}
+
+    @asset
+    def my_asset(db: DBResource):
+        assert db.config.creds.username == "foo"
+        assert db.config.creds.password == "bar"
+        assert db.config.host == "localhost"
+        assert db.config.database == "my_db"
+        completed["yes"] = True
+
+    credentials = CredentialsResource.configure_at_launch()
+    db_config = DBConfigResource.configure_at_launch(creds=credentials)
+    db = DBResource(config=db_config)
+
+    defs = Definitions(
+        assets=[my_asset],
+        resources={
+            "credentials": credentials,
+            "db_config": db_config,
+            "db": db,
+        },
+    )
+
+    assert (
+        defs.get_implicit_global_asset_job_def()
+        .execute_in_process(
+            {
+                "resources": {
+                    "credentials": {
+                        "config": {
+                            "username": "foo",
+                            "password": "bar",
+                        }
+                    },
+                    "db_config": {
+                        "config": {
+                            "host": "localhost",
+                            "database": "my_db",
+                        }
+                    },
+                }
+            }
+        )
+        .success
+    )
+    assert completed["yes"]
+
+    credentials = CredentialsResource.configure_at_launch()
+    db_config = DBConfigResource(creds=credentials, host="localhost", database="my_db")
+    db = DBResource(config=db_config)
+
+    defs = Definitions(
+        assets=[my_asset],
+        resources={
+            "credentials": credentials,
+            "db": db,
+        },
+    )
+
+    assert (
+        defs.get_implicit_global_asset_job_def()
+        .execute_in_process(
+            {
+                "resources": {
+                    "credentials": {
+                        "config": {
+                            "username": "foo",
+                            "password": "bar",
+                        }
+                    },
+                }
+            }
+        )
+        .success
+    )
+    assert completed["yes"]
+
+
+def test_nested_function_resource():
+    out_txt = []
+
+    @resource
+    def writer_resource(context):
+        def output(text: str) -> None:
+            out_txt.append(text)
+
+        return output
+
+    class PostfixWriterResource(ConfigurableResourceFactory[Callable[[str], None]]):
+        writer: ResourceDependency[Callable[[str], None]]
+        postfix: str
+
+        def create_resource(self, context) -> Callable[[str], None]:
+            def output(text: str):
+                self.writer(f"{text}{self.postfix}")
+
+            return output
+
+    @asset
+    def my_asset(writer: ResourceParam[Callable[[str], None]]):
+        writer("foo")
+        writer("bar")
+
+    defs = Definitions(
+        assets=[my_asset],
+        resources={
+            "writer": PostfixWriterResource(writer=writer_resource, postfix="!"),
+        },
+    )
+
+    assert defs.get_implicit_global_asset_job_def().execute_in_process().success
+    assert out_txt == ["foo!", "bar!"]
+
+
+def test_nested_function_resource_configured():
+    out_txt = []
+
+    @resource(config_schema={"prefix": Field(str, default_value="")})
+    def writer_resource(context):
+        prefix = context.resource_config["prefix"]
+
+        def output(text: str) -> None:
+            out_txt.append(f"{prefix}{text}")
+
+        return output
+
+    class PostfixWriterResource(ConfigurableResourceFactory[Callable[[str], None]]):
+        writer: ResourceDependency[Callable[[str], None]]
+        postfix: str
+
+        def create_resource(self, context) -> Callable[[str], None]:
+            def output(text: str):
+                self.writer(f"{text}{self.postfix}")
+
+            return output
+
+    @asset
+    def my_asset(writer: ResourceParam[Callable[[str], None]]):
+        writer("foo")
+        writer("bar")
+
+    defs = Definitions(
+        assets=[my_asset],
+        resources={
+            "writer": PostfixWriterResource(writer=writer_resource, postfix="!"),
+        },
+    )
+
+    assert defs.get_implicit_global_asset_job_def().execute_in_process().success
+    assert out_txt == ["foo!", "bar!"]
+
+    out_txt.clear()
+
+    defs = Definitions(
+        assets=[my_asset],
+        resources={
+            "writer": PostfixWriterResource(
+                writer=writer_resource.configured({"prefix": "msg: "}), postfix="!"
+            ),
+        },
+    )
+
+    assert defs.get_implicit_global_asset_job_def().execute_in_process().success
+    assert out_txt == ["msg: foo!", "msg: bar!"]
+
+
+def test_nested_function_resource_runtime_config():
+    out_txt = []
+
+    @resource(config_schema={"prefix": str})
+    def writer_resource(context):
+        prefix = context.resource_config["prefix"]
+
+        def output(text: str) -> None:
+            out_txt.append(f"{prefix}{text}")
+
+        return output
+
+    class PostfixWriterResource(ConfigurableResourceFactory[Callable[[str], None]]):
+        writer: ResourceDependency[Callable[[str], None]]
+        postfix: str
+
+        def create_resource(self, context) -> Callable[[str], None]:
+            def output(text: str):
+                self.writer(f"{text}{self.postfix}")
+
+            return output
+
+    @asset
+    def my_asset(writer: ResourceParam[Callable[[str], None]]):
+        writer("foo")
+        writer("bar")
+
+    with pytest.raises(
+        CheckError,
+        match="Any partially configured, nested resources must be provided to Definitions",
+    ):
+        # errors b/c writer_resource is not configured
+        # and not provided as a top-level resource to Definitions
+        defs = Definitions(
+            assets=[my_asset],
+            resources={
+                "writer": PostfixWriterResource(writer=writer_resource, postfix="!"),
+            },
+        )
+
+    defs = Definitions(
+        assets=[my_asset],
+        resources={
+            "base_writer": writer_resource,
+            "writer": PostfixWriterResource(writer=writer_resource, postfix="!"),
+        },
+    )
+
+    assert (
+        defs.get_implicit_global_asset_job_def()
+        .execute_in_process(
+            {
+                "resources": {
+                    "base_writer": {
+                        "config": {
+                            "prefix": "msg: ",
+                        },
+                    },
+                },
+            }
+        )
+        .success
+    )
+    assert out_txt == ["msg: foo!", "msg: bar!"]
+
+
+def test_nested_resource_raw_value() -> None:
+    class MyResourceWithDep(ConfigurableResource):
+        a_string: ResourceDependency[str]
+
+    @resource
+    def string_resource(context) -> str:
+        return "foo"
+
+    executed = {}
+
+    @asset
+    def my_asset(my_resource: MyResourceWithDep):
+        assert my_resource.a_string == "foo"
+        executed["yes"] = True
+
+    defs = Definitions(
+        assets=[my_asset],
+        resources={
+            "my_resource": MyResourceWithDep(a_string=string_resource),
+        },
+    )
+    assert defs.get_implicit_global_asset_job_def().execute_in_process().success
+    assert executed["yes"]
+
+    executed.clear()
+
+    defs = Definitions(
+        assets=[my_asset],
+        resources={"my_resource": MyResourceWithDep(a_string="foo")},
+    )
+    assert defs.get_implicit_global_asset_job_def().execute_in_process().success
+    assert executed["yes"]


### PR DESCRIPTION
## Summary

This PR attempts to address a couple shortcomings with the Pythonic resource system which are exposed in #14751. 

First, the logic to determine whether a field on a resource represents a nested resource or a config field is not a good heuristic currently. Right now, the check only assesses whether the value is a resource type - but this fails in the case that a user wants to provide a raw value (ie an instance of `IOManager`). This PR updates this check to inspect the annotation on the field, and treat it as a resource only if the annotation indicates as much.

Second, the initialization logic for nested resources (`coerce_to_resource`) doesn't properly handle raw values such as a plain `IOManager`. This PR updates the logic in `coerce_to_resource` to call out to `wrap_resources_for_execution`, which can successfully deal with these cases.

## Example

The following resource previously would not accept a raw `IOManager` as input, only a resource which produces one:
```python
class MyResourceNeedsIOManager(ConfigurableIOManager):
    base_io_manager: ResourceDependency[IOManager]


@io_manager
def my_io_manager(context) -> IOManager:
    pass

# previously OK, since my_io_manager is a resource
MyResourceNeedsIOManager(base_io_manager=my_io_manager)


class MyIOManager(IOManager):
    pass

# previously errors, since MyIOManager is not a resource
MyResourceNeedsIOManager(base_io_manager=MyIOManager())
```

The new code will coerce `MyIOManager` to a resource by wrapping it, since it is annotated as a `ResourceDependency`. This gives the user more flexibility when specifying resource-resource dependencies to input raw values or mocks.

## Test Plan

Existing unit tests succeed. New unit tests of nesting behavior with raw values (such as an IOManager).