### PR TITLE
[ui] Fix op selection for run log filter

### DIFF
--- a/js_modules/dagit/packages/core/src/app/GraphQueryImpl.ts
+++ b/js_modules/dagit/packages/core/src/app/GraphQueryImpl.ts
@@ -106,31 +106,27 @@ export function filterByQuery<T extends GraphQueryItem>(items: T[], query: strin
     if (!parts) {
       continue;
     }
-    const [, parentsClause, itemName, descendentsClause] = parts;
+    const [, parentsClause = '', itemName = '', descendentsClause = ''] = parts;
 
-    const itemsMatching = itemName
-      ? items.filter((s) => {
-          if (isPlannedDynamicStep(itemName.replace(/\"/g, ''))) {
-            // When unresolved dynamic step (i.e ends with `[?]`) is selected, match all dynamic steps
-            return s.name.startsWith(dynamicKeyWithoutIndex(itemName.replace(/\"/g, '')));
-          } else {
-            return /\".*\"/.test(itemName)
-              ? s.name === itemName.replace(/\"/g, '')
-              : s.name.includes(itemName);
-          }
-        })
-      : [];
-
-    if (parentsClause && descendentsClause) {
-      for (const item of itemsMatching) {
-        const upDepth = expansionDepthForClause(parentsClause);
-        const downDepth = expansionDepthForClause(descendentsClause);
-
-        focus.add(item);
-        results.add(item);
-        traverser.fetchUpstream(item, upDepth).forEach((other) => results.add(other));
-        traverser.fetchDownstream(item, downDepth).forEach((other) => results.add(other));
+    const itemsMatching = items.filter((s) => {
+      if (isPlannedDynamicStep(itemName.replace(/\"/g, ''))) {
+        // When unresolved dynamic step (i.e ends with `[?]`) is selected, match all dynamic steps
+        return s.name.startsWith(dynamicKeyWithoutIndex(itemName.replace(/\"/g, '')));
+      } else {
+        return /\".*\"/.test(itemName)
+          ? s.name === itemName.replace(/\"/g, '')
+          : s.name.includes(itemName);
       }
+    });
+
+    for (const item of itemsMatching) {
+      const upDepth = expansionDepthForClause(parentsClause);
+      const downDepth = expansionDepthForClause(descendentsClause);
+
+      focus.add(item);
+      results.add(item);
+      traverser.fetchUpstream(item, upDepth).forEach((other) => results.add(other));
+      traverser.fetchDownstream(item, downDepth).forEach((other) => results.add(other));
     }
   }
 


### PR DESCRIPTION
## Summary & Motivation

Bug: Clicking on an op name in the Gantt chart does not correctly filter the run logs. Instead, the run logs appear to have no matches.

While updating `GraphQueryImpl` to use stricter array indexing, I didn't correctly handle the search behavior for matching items. Instead of insisting that the regex parts be truthy, I should have set empty string defaults to appease TypeScript.

## How I Tested These Changes

View a run, click on an op. Verify that the relevant steps appear filtered correctly in the run log table.
