### PR TITLE
Unpack abritrary number of values

### DIFF
--- a/examples/assets_dbt_python/setup.py
+++ b/examples/assets_dbt_python/setup.py
@@ -23,6 +23,7 @@ setup(
         "dagster-duckdb-pandas",
         # packaging v22 has build compatibility issues with dbt as of 2022-12-07
         "packaging<22.0",
+        "croniter<1.4.0",  # https://github.com/dagster-io/dagster/pull/14811
     ],
     extras_require={"dev": ["dagit", "pytest"]},
 )

--- a/examples/assets_modern_data_stack/setup.py
+++ b/examples/assets_modern_data_stack/setup.py
@@ -17,6 +17,7 @@ setup(
         "dbt-core",
         "dbt-postgres",
         "packaging<22.0",  # match dbt-core's requirement to workaround a resolution issue
+        "croniter<1.4.0",  # https://github.com/dagster-io/dagster/pull/14811
     ],
     extras_require={"dev": ["dagit", "pytest"]},
 )

--- a/examples/quickstart_aws/setup.py
+++ b/examples/quickstart_aws/setup.py
@@ -12,6 +12,7 @@ setup(
         "textblob",
         "tweepy",
         "wordcloud",
+        "croniter<1.4.0",  # https://github.com/dagster-io/dagster/pull/14811
     ],
     extras_require={"dev": ["dagit", "pytest"]},
 )

--- a/examples/quickstart_etl/setup.py
+++ b/examples/quickstart_etl/setup.py
@@ -12,6 +12,7 @@ setup(
         "textblob",
         "tweepy",
         "wordcloud",
+        "croniter<1.4.0",  # https://github.com/dagster-io/dagster/pull/14811
     ],
     extras_require={"dev": ["dagit", "pytest"]},
 )

--- a/examples/quickstart_gcp/setup.py
+++ b/examples/quickstart_gcp/setup.py
@@ -16,6 +16,7 @@ setup(
         "wordcloud",
         "pandas_gbq",
         "google-auth",
+        "croniter<1.4.0",  # https://github.com/dagster-io/dagster/pull/14811
     ],
     extras_require={"dev": ["dagit", "pytest"]},
 )

--- a/examples/quickstart_snowflake/setup.py
+++ b/examples/quickstart_snowflake/setup.py
@@ -16,6 +16,7 @@ setup(
         "textblob",
         "tweepy",
         "wordcloud",
+        "croniter<1.4.0",  # https://github.com/dagster-io/dagster/pull/14811
     ],
     extras_require={"dev": ["dagit", "pytest"]},
 )

--- a/python_modules/dagster/dagster/_utils/schedules.py
+++ b/python_modules/dagster/dagster/_utils/schedules.py
@@ -32,7 +32,9 @@ def _exact_match(cron_expression: str, dt: datetime.datetime) -> bool:
 def is_valid_cron_string(cron_string: str) -> bool:
     if not CroniterShim.is_valid(cron_string):
         return False
-    expanded, _ = CroniterShim.expand(cron_string)
+    # Croniter < 1.4 returns 2 items
+    # Croniter >= 1.4 returns 3 items
+    expanded, *_ = CroniterShim.expand(cron_string)
     # dagster only recognizes cron strings that resolve to 5 parts (e.g. not seconds resolution)
     return len(expanded) == 5
 
@@ -58,7 +60,9 @@ def cron_string_iterator(
     utc_datetime = pytz.utc.localize(datetime.datetime.utcfromtimestamp(start_timestamp))
     start_datetime = utc_datetime.astimezone(pytz.timezone(timezone_str))
 
-    cron_parts, nth_weekday_of_month = CroniterShim.expand(cron_string)
+    # Croniter < 1.4 returns 2 items
+    # Croniter >= 1.4 returns 3 items
+    cron_parts, nth_weekday_of_month, *_ = CroniterShim.expand(cron_string)
 
     is_numeric = [len(part) == 1 and part[0] != "*" for part in cron_parts]
     is_wildcard = [len(part) == 1 and part[0] == "*" for part in cron_parts]
@@ -176,7 +180,9 @@ def reverse_cron_string_iterator(
     # and matches the cron schedule
     next_date = date_iter.get_next(datetime.datetime)
 
-    cron_parts, _ = CroniterShim.expand(cron_string)
+    # Croniter < 1.4 returns 2 items
+    # Croniter >= 1.4 returns 3 items
+    cron_parts, *_ = CroniterShim.expand(cron_string)
 
     is_numeric = [len(part) == 1 and part[0] != "*" for part in cron_parts]
     is_wildcard = [len(part) == 1 and part[0] == "*" for part in cron_parts]

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -80,7 +80,7 @@ setup(
         # core (not explicitly expressed atm)
         # pin around issues in specific versions of alembic that broke our migrations
         "alembic>=1.2.1,!=1.6.3,!=1.7.0,!=1.11.0",
-        "croniter>=0.3.34",
+        "croniter>=0.3.34,<1.4.0",
         f"grpcio>={GRPC_VERSION_FLOOR},<{GRPC_VERSION_CAP}; python_version<'3.11'",
         f"grpcio>={GRPC_VERSION_FLOOR}; python_version>='3.11'",
         f"grpcio-health-checking>={GRPC_VERSION_FLOOR},<{GRPC_VERSION_CAP}; python_version<'3.11'",

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -80,7 +80,7 @@ setup(
         # core (not explicitly expressed atm)
         # pin around issues in specific versions of alembic that broke our migrations
         "alembic>=1.2.1,!=1.6.3,!=1.7.0,!=1.11.0",
-        "croniter>=0.3.34,<1.4.0",
+        "croniter>=0.3.34",
         f"grpcio>={GRPC_VERSION_FLOOR},<{GRPC_VERSION_CAP}; python_version<'3.11'",
         f"grpcio>={GRPC_VERSION_FLOOR}; python_version>='3.11'",
         f"grpcio-health-checking>={GRPC_VERSION_FLOOR},<{GRPC_VERSION_CAP}; python_version<'3.11'",


### PR DESCRIPTION
Croniter < 1.4 returns 2 items
Croniter >= 1.4 returns 3 items

Continue to unpack what we need and throw away the rest. This will break if they ever change their API to return items in a different order.

https://github.com/kiorky/croniter/commit/09e51e13aae39640bc200ddb8a1dbb4a7423d29f