### PR TITLE
[ui] Use engines field to force Node >= 18.x

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagit_ui.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagit_ui.py
@@ -30,9 +30,9 @@ def build_dagit_ui_steps() -> List[CommandStep]:
         CommandStepBuilder(":typescript: dagit-ui")
         .run(
             "cd js_modules/dagit",
-            # Explicitly install Node 16.x because BK is otherwise running 12.x.
+            # Explicitly install Node 20.x because BK is otherwise running 12.x.
             # Todo: Fix BK images to use newer Node versions, remove this.
-            "curl -sL https://deb.nodesource.com/setup_16.x | bash -",
+            "curl -sL https://deb.nodesource.com/setup_20.x | bash -",
             "apt-get -yqq --no-install-recommends install nodejs",
             "tox -vv -e py310",
         )

--- a/js_modules/dagit/package.json
+++ b/js_modules/dagit/package.json
@@ -15,5 +15,8 @@
       "packages/*"
     ]
   },
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "packageManager": "yarn@3.3.0"
 }

--- a/js_modules/dagit/packages/app/package.json
+++ b/js_modules/dagit/packages/app/package.json
@@ -4,6 +4,14 @@
   "private": true,
   "description": "Dagit Application Shell",
   "license": "Apache-2.0",
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "lint": "eslint src/ --ext=.tsx,.ts,.js --fix -c .eslintrc.js",
+    "test": "react-scripts test",
+    "ts": "tsc -p .",
+    "analyze": "webpack-bundle-analyzer 'build/bundle-stats.json'"
+  },
   "dependencies": {
     "@apollo/client": "3.7.13",
     "@blueprintjs/core": "^4.17.8",
@@ -42,13 +50,8 @@
     "webpack": "^5.0.0",
     "webpack-bundle-analyzer": "^4.7.0"
   },
-  "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "lint": "eslint src/ --ext=.tsx,.ts,.js --fix -c .eslintrc.js",
-    "test": "react-scripts test",
-    "ts": "tsc -p .",
-    "analyze": "webpack-bundle-analyzer 'build/bundle-stats.json'"
+  "engines": {
+    "node": ">=18.0.0"
   },
   "browserslist": {
     "production": [

--- a/js_modules/dagit/packages/core/package.json
+++ b/js_modules/dagit/packages/core/package.json
@@ -159,6 +159,9 @@
     "typescript": "5.0.2",
     "webpack": "^5.0.0"
   },
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "resolutions": {
     "@testing-library/dom": "^9.3.0",
     "@testing-library/user-event": "^14.4.3"

--- a/js_modules/dagit/packages/eslint-config/package.json
+++ b/js_modules/dagit/packages/eslint-config/package.json
@@ -32,5 +32,8 @@
     "prettier": "2.2.1",
     "ts-jest": "^28.0.3",
     "typescript": "5.0.2"
+  },
+  "engines": {
+    "node": ">=18.0.0"
   }
 }

--- a/js_modules/dagit/packages/ui/package.json
+++ b/js_modules/dagit/packages/ui/package.json
@@ -99,6 +99,9 @@
     "typescript": "5.0.2",
     "webpack": "^5.0.0"
   },
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "resolutions": {
     "@testing-library/dom": "^9.3.0",
     "@testing-library/user-event": "^14.4.3"


### PR DESCRIPTION
## Summary & Motivation

Use the `engines` field in our package.jsons to force Node >= 18 usage.

## How I Tested These Changes
