### PR TITLE
Actually document the GCSComputeLogManager

### DIFF
--- a/docs/content/deployment/dagster-instance.mdx
+++ b/docs/content/deployment/dagster-instance.mdx
@@ -619,35 +619,31 @@ compute_logs:
 The <PyObject module="dagster_gcp.gcs" object="GCSComputeLogManager" /> writes `stdout` and `stderr` to Google Cloud Storage.
 
 ```yaml file=/deploying/dagster_instance/dagster.yaml startafter=start_marker_compute_log_storage_blob endbefore=end_marker_compute_log_storage_blob
-# there are multiple ways to configure the AzureBlobComputeLogManager
+# there are multiple ways to configure the GCSComputeLogManager
 
 # you can set the necessary configuration values directly:
 compute_logs:
-  module: dagster_azure.blob.compute_log_manager
-  class: AzureBlobComputeLogManager
+  module: dagster_gcp.gcs.compute_log_manager
+  class: GCSComputeLogManager
   config:
-    storage_account: mycorp-dagster
-    container: compute-logs
-    secret_key: foo
-    local_dir: /tmp/bar
-    prefix: dagster-test-
+    bucket: "mycorp-dagster-compute-logs"
+    local_dir: "/tmp/bar"
+    prefix: "dagster-test-"
 
 # alternatively, you can obtain any of these config values from environment variables
 compute_logs:
-  module: dagster_azure.blob.compute_log_manager
-  class: AzureBlobComputeLogManager
+  module: dagster_gcp.gcs.compute_log_manager
+  class: GCSComputeLogManager
   config:
-    storage_account:
-      env: MYCORP_DAGSTER_STORAGE_ACCOUNT_NAME
-    container:
-      env: CONTAINER_NAME
-    secret_key:
-      env: SECRET_KEY
+    bucket:
+      env: BUCKET_NAME
     local_dir:
       env: LOCAL_DIR_PATH
     prefix:
       env: DAGSTER_COMPUTE_LOG_PREFIX
 ```
+
+By default this will use credentials from `GOOGLE_APPLICATION_CREDENTIALS`, though the environment variable name can be configured via by configuring `json_credentials_envvar`.
 
 ---
 


### PR DESCRIPTION
## Summary & Motivation

Previously the configuration snippet for the `AzureBlobComputeLogManager` was incorrectly duplicated under the section for the `GCSComputeLogManager`. Replace that snippet with one derived from the docstring for the `GCSComputeLogManager`.

## How I Tested These Changes

Untested.