### PR TITLE
1.4 remove asset methods from OpExecutionContext

### DIFF
--- a/docs/sphinx/sections/api/apidocs/execution.rst
+++ b/docs/sphinx/sections/api/apidocs/execution.rst
@@ -73,6 +73,10 @@ Contexts
   :members:
   :inherited-members:
 
+.. autoclass:: AssetExecutionContext
+  :members:
+  :inherited-members:
+
 .. autofunction:: build_op_context
 
 .. autoclass:: TypeCheckContext

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -14,7 +14,7 @@ from typing import (
 )
 
 import dagster._check as check
-from dagster._annotations import deprecated, experimental, public
+from dagster._annotations import experimental, public
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.data_version import (
     DataProvenance,
@@ -42,7 +42,6 @@ from dagster._core.events import DagsterEvent
 from dagster._core.instance import DagsterInstance
 from dagster._core.log_manager import DagsterLogManager
 from dagster._core.storage.dagster_run import DagsterRun
-from dagster._utils.backcompat import deprecation_warning
 from dagster._utils.forked_pdb import ForkedPdb
 
 from .system import StepExecutionContext
@@ -425,15 +424,15 @@ class OpExecutionContext(AbstractComputeExecutionContext):
         """
         return self._step_execution_context.step.get_mapping_key()
 
-    #############################################################################################
-    # asset related methods that are planned to be made only available on `AssetExecutionContext`
-    #############################################################################################
 
-    @deprecated
+class AssetExecutionContext(OpExecutionContext):
+    """The ``context`` object that can be made available as the first argument to an assets's compute
+    function. Extends what is available on :py:class:`OpExecutionContext` with access to asset related information.
+    """
+
     @public
     @property
     def assets_def(self) -> AssetsDefinition:
-        """DEPRECATED: use :py:func:`AssetExecutionContext.assets_def`."""
         assets_def = self.job_def.asset_layer.assets_def_for_node(self.node_handle)
         if assets_def is None:
             raise DagsterInvalidPropertyError(
@@ -441,21 +440,17 @@ class OpExecutionContext(AbstractComputeExecutionContext):
             )
         return assets_def
 
-    @deprecated
     @public
     @property
     def selected_asset_keys(self) -> AbstractSet[AssetKey]:
-        """DEPRECATED: use :py:func:`AssetExecutionContext.selected_asset_keys`."""
         assets_def = self.job_def.asset_layer.assets_def_for_node(self.node_handle)
         if assets_def is None:
             return set()
         return assets_def.keys
 
-    @deprecated
     @public
     @property
     def selected_output_names(self) -> AbstractSet[str]:
-        """DEPRECATED: use :py:func:`AssetExecutionContext.selected_output_names`."""
         # map selected asset keys to the output names they correspond to
         selected_asset_keys = self.selected_asset_keys
         selected_outputs: Set[str] = set()
@@ -475,10 +470,8 @@ class OpExecutionContext(AbstractComputeExecutionContext):
 
         return selected_outputs
 
-    @deprecated
     @public
     def asset_key_for_output(self, output_name: str = "result") -> AssetKey:
-        """DEPRECATED: use :py:func:`AssetExecutionContext.asset_key_for_output`."""
         asset_output_info = self.job_def.asset_layer.asset_info_for_output(
             node_handle=self.op_handle, output_name=output_name
         )
@@ -487,10 +480,8 @@ class OpExecutionContext(AbstractComputeExecutionContext):
         else:
             return asset_output_info.key
 
-    @deprecated
     @public
     def asset_key_for_input(self, input_name: str) -> AssetKey:
-        """DEPRECATED: use :py:func:`AssetExecutionContext.asset_key_for_input`."""
         key = self.job_def.asset_layer.asset_key_for_input(
             node_handle=self.op_handle, input_name=input_name
         )
@@ -499,65 +490,42 @@ class OpExecutionContext(AbstractComputeExecutionContext):
         else:
             return key
 
-    @deprecated
-    def output_asset_partition_key(self, output_name: str = "result") -> str:
-        deprecation_warning(
-            "OpExecutionContext.output_asset_partition_key",
-            "1.0.0",
-            additional_warn_txt="Use OpExecutionContext.asset_partition_key_for_output instead.",
-        )
-
-        return self.asset_partition_key_for_output(output_name)
-
-    @deprecated
     @public
     def asset_partition_key_for_output(self, output_name: str = "result") -> str:
-        """DEPRECATED: use :py:func:`AssetExecutionContext.asset_partition_key_for_output`."""
+        """Returns the asset partition key for the given output. Defaults to "result", which is the
+        name of the default output.
+        """
         return self._step_execution_context.asset_partition_key_for_output(output_name)
 
-    @deprecated
-    def output_asset_partitions_time_window(self, output_name: str = "result") -> TimeWindow:
-        deprecation_warning(
-            "OpExecutionContext.output_asset_partitions_time_window",
-            "1.0.0",
-            additional_warn_txt=(
-                "Use OpExecutionContext.asset_partitions_time_window_for_output instead."
-            ),
-        )
-
-        return self.asset_partitions_time_window_for_output(output_name)
-
-    @deprecated
     @public
     def asset_partitions_time_window_for_output(self, output_name: str = "result") -> TimeWindow:
-        """DEPRECATED: use :py:func:`AssetExecutionContext.asset_partitions_time_window_for_output`.
+        """The time window for the partitions of the output asset.
+
+        Raises an error if either of the following are true:
+        - The output asset has no partitioning.
+        - The output asset is not partitioned with a TimeWindowPartitionsDefinition or a
+        MultiPartitionsDefinition with one time-partitioned dimension.
         """
         return self._step_execution_context.asset_partitions_time_window_for_output(output_name)
 
-    @deprecated
     @public
     def asset_partition_key_range_for_output(
         self, output_name: str = "result"
     ) -> PartitionKeyRange:
-        """DEPRECATED: use :py:func:`AssetExecutionContext.asset_partition_key_range_for_output`."""
         return self._step_execution_context.asset_partition_key_range_for_output(output_name)
 
-    @deprecated
     @public
     def asset_partition_key_range_for_input(self, input_name: str) -> PartitionKeyRange:
-        """DEPRECATED: use :py:func:`AssetExecutionContext.asset_partition_key_range_for_input`."""
         return self._step_execution_context.asset_partition_key_range_for_input(input_name)
 
-    @deprecated
     @public
     def asset_partition_key_for_input(self, input_name: str) -> str:
-        """DEPRECATED: use :py:func:`AssetExecutionContext.asset_partition_key_for_input`."""
+        """Returns the partition key of the upstream asset corresponding to the given input."""
         return self._step_execution_context.asset_partition_key_for_input(input_name)
 
-    @deprecated
     @public
     def asset_partitions_def_for_output(self, output_name: str = "result") -> PartitionsDefinition:
-        """DEPRECATED: use :py:func:`AssetExecutionContext.asset_partitions_def_for_output`."""
+        """The PartitionsDefinition on the upstream asset corresponding to this input."""
         asset_key = self.asset_key_for_output(output_name)
         result = self._step_execution_context.job_def.asset_layer.partitions_def_for_asset(
             asset_key
@@ -570,10 +538,9 @@ class OpExecutionContext(AbstractComputeExecutionContext):
 
         return result
 
-    @deprecated
     @public
     def asset_partitions_def_for_input(self, input_name: str) -> PartitionsDefinition:
-        """DEPRECATED: use :py:func:`AssetExecutionContext.asset_partitions_def_for_input`."""
+        """The PartitionsDefinition on the upstream asset corresponding to this input."""
         asset_key = self.asset_key_for_input(input_name)
         result = self._step_execution_context.job_def.asset_layer.partitions_def_for_asset(
             asset_key
@@ -586,126 +553,24 @@ class OpExecutionContext(AbstractComputeExecutionContext):
 
         return result
 
-    @deprecated
     @public
     def asset_partition_keys_for_output(self, output_name: str = "result") -> Sequence[str]:
-        """DEPRECATED: use :py:func:`AssetExecutionContext.asset_partition_keys_for_output`."""
+        """Returns a list of the partition keys for the given output."""
         return self.asset_partitions_def_for_output(output_name).get_partition_keys_in_range(
             self._step_execution_context.asset_partition_key_range_for_output(output_name),
             dynamic_partitions_store=self.instance,
         )
-
-    @deprecated
-    @public
-    def asset_partition_keys_for_input(self, input_name: str) -> Sequence[str]:
-        """DEPRECATED: use :py:func:`AssetExecutionContext.asset_partition_keys_for_input`."""
-        return list(
-            self._step_execution_context.asset_partitions_subset_for_input(
-                input_name
-            ).get_partition_keys()
-        )
-
-    @deprecated
-    @public
-    def asset_partitions_time_window_for_input(self, input_name: str = "result") -> TimeWindow:
-        """DEPRECATED: use :py:func:`AssetExecutionContext.asset_partitions_time_window_for_input`.
-        """
-        return self._step_execution_context.asset_partitions_time_window_for_input(input_name)
-
-    @deprecated
-    @public
-    @experimental
-    def get_asset_provenance(self, asset_key: AssetKey) -> Optional[DataProvenance]:
-        """DEPRECATED: use :py:func:`AssetExecutionContext.get_asset_provenance`."""
-        record = self.instance.get_latest_data_version_record(asset_key)
-
-        return (
-            None if record is None else extract_data_provenance_from_entry(record.event_log_entry)
-        )
-
-
-class AssetExecutionContext(OpExecutionContext):
-    """The ``context`` object that can be made available as the first argument to an assets's compute
-    function. Extends what is available on :py:class:`OpExecutionContext` with access to asset related information.
-    """
-
-    @public
-    @property
-    def assets_def(self) -> AssetsDefinition:
-        return super().assets_def
-
-    @public
-    @property
-    def selected_asset_keys(self) -> AbstractSet[AssetKey]:
-        return super().selected_asset_keys
-
-    @public
-    @property
-    def selected_output_names(self) -> AbstractSet[str]:
-        return super().selected_output_names
-
-    @public
-    def asset_key_for_output(self, output_name: str = "result") -> AssetKey:
-        return super().asset_key_for_output(output_name)
-
-    @public
-    def asset_key_for_input(self, input_name: str) -> AssetKey:
-        return super().asset_key_for_input(input_name)
-
-    @public
-    def asset_partition_key_for_output(self, output_name: str = "result") -> str:
-        """Returns the asset partition key for the given output. Defaults to "result", which is the
-        name of the default output.
-        """
-        return super().asset_partition_key_for_output(output_name)
-
-    @public
-    def asset_partitions_time_window_for_output(self, output_name: str = "result") -> TimeWindow:
-        """The time window for the partitions of the output asset.
-
-        Raises an error if either of the following are true:
-        - The output asset has no partitioning.
-        - The output asset is not partitioned with a TimeWindowPartitionsDefinition or a
-        MultiPartitionsDefinition with one time-partitioned dimension.
-        """
-        return super().asset_partitions_time_window_for_output(output_name)
-
-    @public
-    def asset_partition_key_range_for_output(
-        self, output_name: str = "result"
-    ) -> PartitionKeyRange:
-        return super().asset_partition_key_range_for_output(output_name)
-
-    @public
-    def asset_partition_key_range_for_input(self, input_name: str) -> PartitionKeyRange:
-        return super().asset_partition_key_range_for_input(input_name)
-
-    @public
-    def asset_partition_key_for_input(self, input_name: str) -> str:
-        """Returns the partition key of the upstream asset corresponding to the given input."""
-        return super().asset_partition_key_for_input(input_name)
-
-    @public
-    def asset_partitions_def_for_output(self, output_name: str = "result") -> PartitionsDefinition:
-        """The PartitionsDefinition on the upstream asset corresponding to this input."""
-        return super().asset_partitions_def_for_output(output_name)
-
-    @public
-    def asset_partitions_def_for_input(self, input_name: str) -> PartitionsDefinition:
-        """The PartitionsDefinition on the upstream asset corresponding to this input."""
-        return super().asset_partitions_def_for_input(input_name)
-
-    @public
-    def asset_partition_keys_for_output(self, output_name: str = "result") -> Sequence[str]:
-        """Returns a list of the partition keys for the given output."""
-        return super().asset_partition_keys_for_output(output_name)
 
     @public
     def asset_partition_keys_for_input(self, input_name: str) -> Sequence[str]:
         """Returns a list of the partition keys of the upstream asset corresponding to the
         given input.
         """
-        return super().asset_partition_keys_for_input(input_name)
+        return list(
+            self._step_execution_context.asset_partitions_subset_for_input(
+                input_name
+            ).get_partition_keys()
+        )
 
     @public
     def asset_partitions_time_window_for_input(self, input_name: str = "result") -> TimeWindow:
@@ -716,7 +581,7 @@ class AssetExecutionContext(OpExecutionContext):
         - The input asset is not partitioned with a TimeWindowPartitionsDefinition or a
         MultiPartitionsDefinition with one time-partitioned dimension.
         """
-        return super().asset_partitions_time_window_for_input(input_name)
+        return self._step_execution_context.asset_partitions_time_window_for_input(input_name)
 
     @public
     @experimental
@@ -731,7 +596,10 @@ class AssetExecutionContext(OpExecutionContext):
                 materialization of the asset. Returns `None` if the asset was never materialized or
                 the materialization record is too old to contain provenance information.
         """
-        return super().get_asset_provenance(asset_key)
+        record = self.instance.get_latest_data_version_record(asset_key)
+        return (
+            None if record is None else extract_data_provenance_from_entry(record.event_log_entry)
+        )
 
 
 def build_execution_context(

--- a/python_modules/dagster/dagster/_core/execution/context/system.py
+++ b/python_modules/dagster/dagster/_core/execution/context/system.py
@@ -834,14 +834,13 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
 
     @property
     def step_materializes_assets(self) -> bool:
-        step_outputs = self.step.step_outputs
-        if len(step_outputs) == 0:
-            return False
-        else:
+        for output in self.step.step_outputs:
             asset_info = self.job_def.asset_layer.asset_info_for_output(
-                self.node_handle, step_outputs[0].name
+                self.node_handle, output.name
             )
-            return asset_info is not None
+            if asset_info is not None:
+                return True
+        return False
 
     def set_data_version(self, asset_key: AssetKey, data_version: "DataVersion") -> None:
         self._data_version_cache[asset_key] = data_version

--- a/python_modules/dagster/dagster/_core/execution/plan/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/compute.py
@@ -29,7 +29,7 @@ from dagster._core.definitions.asset_layer import AssetLayer
 from dagster._core.definitions.op_definition import OpComputeFunction
 from dagster._core.errors import DagsterExecutionStepExecutionError, DagsterInvariantViolationError
 from dagster._core.events import DagsterEvent
-from dagster._core.execution.context.compute import OpExecutionContext
+from dagster._core.execution.context.compute import build_execution_context
 from dagster._core.execution.context.system import StepExecutionContext
 from dagster._core.system_config.objects import ResolvedRunConfig
 from dagster._utils import iterate_with_context
@@ -135,7 +135,7 @@ def _yield_compute_results(
 ) -> Iterator[OpOutputUnion]:
     check.inst_param(step_context, "step_context", StepExecutionContext)
 
-    context = OpExecutionContext(step_context)
+    context = build_execution_context(step_context)
     user_event_generator = compute_fn(context, inputs)
 
     if isinstance(user_event_generator, Output):


### PR DESCRIPTION
complete the migration of asset related methods off of `OpExecutionContext` on to `AssetExecutionContext`

## How I Tested These Changes

existing coverage