### PR TITLE
fix: Handle multi-dimensional partitions in W&B integration

### DIFF
--- a/python_modules/libraries/dagster-wandb/dagster_wandb/io_manager.py
+++ b/python_modules/libraries/dagster-wandb/dagster_wandb/io_manager.py
@@ -273,8 +273,8 @@ class ArtifactsIOManager(IOManager):
 
                 # We replace the | character with - because it is not allowed in artifact names
                 # The | character is used in multi-dimensional partition keys
-                artifact_name = artifact_name.replace("|", "-" )
-                
+                artifact_name = str(artifact_name).replace("|", "-")
+
                 # Creates an artifact to hold the obj
                 artifact = self.wandb.Artifact(
                     name=artifact_name,

--- a/python_modules/libraries/dagster-wandb/dagster_wandb/io_manager.py
+++ b/python_modules/libraries/dagster-wandb/dagster_wandb/io_manager.py
@@ -271,6 +271,10 @@ class ArtifactsIOManager(IOManager):
                 if context.has_partition_key:
                     artifact_name = f"{artifact_name}.{context.partition_key}"
 
+                # We replace the | character with - because it is not allowed in artifact names
+                # The | character is used in multi-dimensional partition keys
+                artifact_name = artifact_name.replace("|", "-" )
+                
                 # Creates an artifact to hold the obj
                 artifact = self.wandb.Artifact(
                     name=artifact_name,


### PR DESCRIPTION
## Summary & Motivation
A client who uses the W&B integration contacted our customer support regarding an issue with Multi-Partitions.

Dagster, by default, adds a pipe (|) between partitions. However, W&B doesn't permit the usage of pipes in an Artifact name. To resolve this, the present Pull Request replaces all pipe characters with dashes.

## How I Tested These Changes
The modifications were tested and verified locally.