### PR TITLE
feat(dbt): continue to emit logs that are not valid json

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources_v2.py
@@ -351,13 +351,18 @@ class DbtCliTask:
         """
         for raw_line in self.process.stdout or []:
             log: str = raw_line.decode().strip()
-            event = DbtCliEventMessage.from_log(log=log)
+            try:
+                event = DbtCliEventMessage.from_log(log=log)
 
-            # Re-emit the logs from dbt CLI process into stdout.
-            sys.stdout.write(str(event) + "\n")
-            sys.stdout.flush()
+                # Re-emit the logs from dbt CLI process into stdout.
+                sys.stdout.write(str(event) + "\n")
+                sys.stdout.flush()
 
-            yield event
+                yield event
+            except:
+                # If we can't parse the log, then just emit it as a raw log.
+                sys.stdout.write(log + "\n")
+                sys.stdout.flush()
 
         # Ensure that the dbt CLI process has completed.
         self.process.wait()


### PR DESCRIPTION
## Summary & Motivation
To help the user debug dbt issues due to invalid configuration or run time execution errors that emit non-json logs, just emit the unparsed raw logs. 

## How I Tested These Changes
local
