### PR TITLE
[ui] Show a tooltip when you hover truncated asset names in DAG #13670

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
@@ -1,9 +1,9 @@
 import {gql} from '@apollo/client';
-import {Colors, Icon, FontFamily, Box, Spinner, Tooltip, Body} from '@dagster-io/ui';
+import {Body, Box, Colors, FontFamily, Icon, Spinner, Tooltip} from '@dagster-io/ui';
 import isEqual from 'lodash/isEqual';
 import React from 'react';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled, {CSSObject} from 'styled-components/macro';
 
 import {withMiddleTruncation} from '../app/Util';
 import {
@@ -58,7 +58,11 @@ export const AssetNode: React.FC<{
             <span style={{marginTop: 1}}>
               <Icon name={isSource ? 'source_asset' : 'asset'} />
             </span>
-            <div style={{overflow: 'hidden', textOverflow: 'ellipsis'}}>
+            <div
+              data-tooltip={displayName}
+              data-tooltip-style={isSource ? NameTooltipStyleSource : NameTooltipStyle}
+              style={{overflow: 'hidden', textOverflow: 'ellipsis'}}
+            >
               {withMiddleTruncation(displayName, {
                 maxLength: ASSET_NODE_NAME_MAX_LENGTH,
               })}
@@ -597,16 +601,39 @@ const AssetNodeBox = styled.div<{$isSource: boolean; $selected: boolean}>`
     }
   }
 `;
+
+/** Keep in sync with DISPLAY_NAME_PX_PER_CHAR */
+const NameCSS: CSSObject = {
+  padding: '3px 6px',
+  color: Colors.Gray800,
+  fontFamily: FontFamily.monospace,
+  fontWeight: 600,
+};
+
+const NameTooltipCSS: CSSObject = {
+  ...NameCSS,
+  top: -9,
+  left: -12,
+  fontSize: 16.8,
+};
+
+const NameTooltipStyle = JSON.stringify({
+  ...NameTooltipCSS,
+  background: Colors.Blue50,
+  border: `1px solid ${Colors.Blue100}`,
+});
+
+const NameTooltipStyleSource = JSON.stringify({
+  ...NameTooltipCSS,
+  background: Colors.Gray100,
+  border: `1px solid ${Colors.Gray200}`,
+});
+
 const Name = styled.div<{$isSource: boolean}>`
-  /** Keep in sync with DISPLAY_NAME_PX_PER_CHAR */
+  ${NameCSS};
   display: flex;
-  padding: 3px 6px;
-  background: ${(p) => (p.$isSource ? Colors.Gray100 : Colors.Blue50)};
-  font-family: ${FontFamily.monospace};
-  border-top-left-radius: 7px;
-  border-top-right-radius: 7px;
-  font-weight: 600;
   gap: 4px;
+  background: ${(p) => (p.$isSource ? Colors.Gray100 : Colors.Blue50)};
 `;
 
 const MinimalAssetNodeContainer = styled(AssetNodeContainer)`


### PR DESCRIPTION
## Summary & Motivation

This is a quick fix for #13670. When you hover over asset names in the full-scale DAG, you get a nice inline expansion of the asset name:

![image](https://github.com/dagster-io/dagster/assets/1037212/5f7b00b9-2e75-4923-bc23-387f00543dbd)

![image](https://github.com/dagster-io/dagster/assets/1037212/9c767608-024f-447f-85f2-45f7bc86f16a)

The rendering of these is slightly different than the existing tooltips in the minified view, but I think that they each make sense and it's probably fine for the styling to be different:

![image](https://github.com/dagster-io/dagster/assets/1037212/de2046f5-ab7c-4e5c-91d9-140c07f2c0a1)


## How I Tested These Changes

Tested in asset graph on both source and non-source assets
