### PR TITLE
Fix typo in dagster_aws S3 resources

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/resources.py
@@ -12,7 +12,7 @@ T = TypeVar("T")
 
 class ResourceWithS3Configuration(ConfigurableResource):
     use_unsigned_session: bool = Field(
-        default=False, description="Specifiesw whether to use an unsigned S3 session."
+        default=False, description="Specifies whether to use an unsigned S3 session."
     )
     region_name: Optional[str] = Field(
         default=None, description="Specifies a custom region for the S3 session."


### PR DESCRIPTION
## Summary & Motivation
Small typo in https://docs.dagster.io/_apidocs/libraries/dagster-aws#dagster_aws.s3.s3_resource
<img width="928" alt="image" src="https://github.com/dagster-io/dagster/assets/29241719/47bd7dab-92e5-413a-a65c-f54699fa2e06">

## How I Tested These Changes
```
cd docs
make next-watch-build
```