### PR TITLE
Test ParentOutdatedAutoMaterializeCondition

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
@@ -729,7 +729,7 @@ def determine_asset_partitions_to_auto_materialize(
         asset_graph: AssetGraph,
         candidate: AssetKeyPartitionKey,
         parent_partitions_result: ParentsPartitionsResult,
-    ) -> bool:
+    ) -> Tuple[bool, Optional[ParentOutdatedAutoMaterializeCondition]]:
         from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
 
         for parent in parent_partitions_result.parent_partitions:
@@ -740,20 +740,28 @@ def determine_asset_partitions_to_auto_materialize(
                 continue
 
             if not (
-                (
-                    parent in conditions_by_asset_partition
-                    and all(
-                        condition.decision_type == AutoMaterializeDecisionType.MATERIALIZE
-                        for condition in conditions_by_asset_partition[parent]
-                    )
+                parent in conditions_by_asset_partition
+                and all(
+                    condition.decision_type == AutoMaterializeDecisionType.MATERIALIZE
+                    for condition in conditions_by_asset_partition[parent]
                 )
-                # if they don't have the same partitioning, then we can't launch a run that
-                # targets both, so we need to wait until the parent is reconciled before
-                # launching a run for the child
-                and asset_graph.have_same_partitioning(parent.asset_key, candidate.asset_key)
+            ):
+                return False, ParentOutdatedAutoMaterializeCondition(
+                    parent_asset_key=parent.asset_key, parent_will_materialize=False
+                )
+
+            # if they don't have the same partitioning, then we can't launch a run that
+            # targets both, so we need to wait until the parent is reconciled before
+            # launching a run for the child
+            if not (
+                asset_graph.have_same_partitioning(parent.asset_key, candidate.asset_key)
                 and parent.partition_key == candidate.partition_key
             ):
-                return False
+                return False, ParentOutdatedAutoMaterializeCondition(
+                    parent_asset_key=parent.asset_key,
+                    parent_will_materialize=True,
+                    different_partitions=True,
+                )
 
             if isinstance(asset_graph, ExternalAssetGraph):
                 # if the parent is in a different repository, we can't launch a run that targets both,
@@ -761,9 +769,13 @@ def determine_asset_partitions_to_auto_materialize(
                 if asset_graph.get_repository_handle(
                     candidate.asset_key
                 ) is not asset_graph.get_repository_handle(parent.asset_key):
-                    return False
+                    return False, ParentOutdatedAutoMaterializeCondition(
+                        parent_asset_key=parent.asset_key,
+                        parent_will_materialize=True,
+                        different_repositories=True,
+                    )
 
-        return True
+        return True, None
 
     def conditions_for_candidate(
         candidate: AssetKeyPartitionKey,
@@ -850,12 +862,6 @@ def determine_asset_partitions_to_auto_materialize(
                 return all(
                     condition.decision_type == AutoMaterializeDecisionType.MATERIALIZE
                     for condition in unit_conditions
-                )
-            return False
-        else:
-            for candidate in candidates_unit:
-                conditions_by_asset_partition[candidate].add(
-                    ParentOutdatedAutoMaterializeCondition()
                 )
         return False
 

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_condition.py
@@ -1,7 +1,10 @@
 from enum import Enum
-from typing import NamedTuple, Union
+from typing import TYPE_CHECKING, NamedTuple, Optional, Set, Union
 
 from dagster._serdes import whitelist_for_serdes
+
+if TYPE_CHECKING:
+    from dagster import AssetKey
 
 
 @whitelist_for_serdes
@@ -56,9 +59,12 @@ class MissingAutoMaterializeCondition(NamedTuple):
 @whitelist_for_serdes
 class ParentOutdatedAutoMaterializeCondition(NamedTuple):
     """Indicates that this asset should be skipped because one or more of its parents are outdated.
+    This could be because the parent isn't going to run, or it could be that the parent is going to be materialized
+    but in a separate run due to different partitions or repositories.
     """
 
     decision_type: AutoMaterializeDecisionType = AutoMaterializeDecisionType.SKIP
+    asset_keys: Optional[Set["AssetKey"]] = None
 
 
 @whitelist_for_serdes

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_condition.py
@@ -1,10 +1,7 @@
 from enum import Enum
-from typing import TYPE_CHECKING, NamedTuple, Optional, Set, Union
+from typing import NamedTuple, Union
 
 from dagster._serdes import whitelist_for_serdes
-
-if TYPE_CHECKING:
-    from dagster import AssetKey
 
 
 @whitelist_for_serdes
@@ -64,7 +61,6 @@ class ParentOutdatedAutoMaterializeCondition(NamedTuple):
     """
 
     decision_type: AutoMaterializeDecisionType = AutoMaterializeDecisionType.SKIP
-    asset_keys: Optional[Set["AssetKey"]] = None
 
 
 @whitelist_for_serdes

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/auto_materialize_policy_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/auto_materialize_policy_scenarios.py
@@ -12,7 +12,6 @@ from dagster._core.definitions.auto_materialize_condition import (
     ParentOutdatedAutoMaterializeCondition,
 )
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
-from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
 from dagster._seven.compat.pendulum import create_pendulum_time
 
@@ -163,20 +162,8 @@ auto_materialize_policy_scenarios = {
                     PartitionKeyRange(start="2013-01-05-04:00", end="2013-01-07-03:00")
                 )
             },
-            ("daily", "2013-01-05"): {
-                ParentOutdatedAutoMaterializeCondition(
-                    parent_asset_key=AssetKey("hourly"),
-                    parent_will_materialize=True,
-                    different_partitions=True,
-                )
-            },
-            ("daily", "2013-01-06"): {
-                ParentOutdatedAutoMaterializeCondition(
-                    parent_asset_key=AssetKey("hourly"),
-                    parent_will_materialize=True,
-                    different_partitions=True,
-                )
-            },
+            ("daily", "2013-01-05"): {ParentOutdatedAutoMaterializeCondition()},
+            ("daily", "2013-01-06"): {ParentOutdatedAutoMaterializeCondition()},
         },
     ),
     "auto_materialize_policy_with_custom_scope_hourly_to_daily_partitions_never_materialized2": AssetReconciliationScenario(

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/partition_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/partition_scenarios.py
@@ -92,6 +92,16 @@ non_partitioned_after_partitioned = [
     asset_def("asset2", ["asset1"]),
 ]
 
+two_hourly_to_one_daily = [
+    asset_def("hourly_1", partitions_def=hourly_partitions_def),
+    asset_def("hourly_2", partitions_def=hourly_partitions_def),
+    asset_def(
+        "daily",
+        ["hourly_1", "hourly_2"],
+        partitions_def=daily_partitions_def,
+    ),
+]
+
 
 partition_scenarios = {
     "one_asset_one_partition_never_materialized": AssetReconciliationScenario(

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_reconciliation_sensor.py
@@ -33,7 +33,7 @@ def test_reconciliation(scenario):
     instance = DagsterInstance.ephemeral()
     run_requests, _, evaluations = scenario.do_sensor_scenario(instance)
 
-    if scenario.expected_conditions:
+    if scenario.expected_conditions is not None:
         reasons = {
             (
                 AssetKeyPartitionKey(AssetKey.from_coercible(key[0]), key[1])


### PR DESCRIPTION
First pass. I think how we're treating multi assets seems a little shaky- both before and after this diff. Should an asset with no dependencies in a multi asset ever say 'waiting on parent'? I think ideally the evaluations UI would show that the assets are grouped in a single evaluation...

---

Update: just adding a test case