### PR TITLE
[ui] Fix issue shift-selecting assets with multi-component asset keys

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
@@ -182,8 +182,8 @@ const AssetGraphExplorerWithData: React.FC<WithDataProps> = ({
         // To better support clicking a bunch of leaves and extending selection, we try to reach
         // the new node from each node in your current selection until we find a path.
         if (e.shiftKey && selectedGraphNodes.length && node) {
-          for (let ii = selectedGraphNodes.length - 1; ii >= 0; ii--) {
-            const from = selectedGraphNodes[ii]!;
+          const reversed = [...selectedGraphNodes].reverse();
+          for (const from of reversed) {
             const tokensInRange = assetKeyTokensInRange({from, to: node, graph: assetGraphData});
             if (tokensInRange.length) {
               tokensToAdd = tokensInRange;


### PR DESCRIPTION
## Summary & Motivation

This is a small fix for a bug raised in https://github.com/dagster-io/dagster/issues/14690. The remaining ideas in the issue will likely get resolved when we add different cursor modes to the asset graph.

The issue was caused by the fact that the "opsInRange" helper was a holdover from an old op graph feature and was using a different stringification method. If your path from asset A -> B included an asset with a multi-component asset key, it was not selected.

## How I Tested These Changes

I think it'd be good to bring more of this under test but right now this page won't mount in jest's test env. I think we could refactor this code so that the "Selection" is managed by a selection object which can be tested separately from the component UI, but I'm not sure it's worth the lift at the moment.