### PR TITLE
[ui] Fix asset stale causes to a popover, stop truncating the list

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/Stale.tsx
+++ b/js_modules/dagit/packages/core/src/assets/Stale.tsx
@@ -16,6 +16,7 @@ import React from 'react';
 import {Link} from 'react-router-dom';
 
 import {displayNameForAssetKey, LiveDataForNode} from '../asset-graph/Utils';
+import {AssetNodeKeyFragment} from '../asset-graph/types/AssetNode.types';
 import {AssetKeyInput, StaleCauseCategory, StaleStatus} from '../graphql/types';
 
 import {assetDetailsPathForKey} from './assetDetailsPathForKey';
@@ -147,19 +148,36 @@ const StaleCausesSummary: React.FC<{causes: LiveDataForNode['staleCauses']}> = (
           <Link to={assetDetailsPathForKey(cause.key)}>
             <CaptionMono>{displayNameForAssetKey(cause.key)}</CaptionMono>
           </Link>
-          {cause.dependency ? (
-            <Caption>
-              {` ${cause.reason} (`}
-              <Link to={assetDetailsPathForKey(cause.dependency)}>
-                {displayNameForAssetKey(cause.dependency)}
-              </Link>
-              )
-            </Caption>
-          ) : (
-            <Caption>{` ${cause.reason}`}</Caption>
-          )}
+          <StaleReason reason={cause.reason} dependency={cause.dependency} />
         </Box>
       ))}
     </Box>
   </Box>
 );
+
+const StaleReason: React.FC<{reason: string; dependency: AssetNodeKeyFragment | null}> = ({
+  reason,
+  dependency,
+}) => {
+  if (!dependency) {
+    return <Caption>{` ${reason}`}</Caption>;
+  }
+
+  const dependencyName = displayNameForAssetKey(dependency);
+  const dependencyPythonName = dependencyName.replace(/ /g, '');
+  if (reason.endsWith(`${dependencyPythonName}`)) {
+    const reasonUpToDep = reason.slice(0, -dependencyPythonName.length);
+    return (
+      <Caption>
+        {` ${reasonUpToDep}`}
+        <Link to={assetDetailsPathForKey(dependency)}>{dependencyName}</Link>
+      </Caption>
+    );
+  }
+
+  return (
+    <Caption>
+      {` ${reason} `}(<Link to={assetDetailsPathForKey(dependency)}>{dependencyName}</Link>)
+    </Caption>
+  );
+};


### PR DESCRIPTION
## Summary & Motivation

Resolves #14654

This PR switches the on-hover display of stale causes from a Tooltip to a Popover, which allows you to move the mouse into the overlay without it closing. We already use this on the run timeline to show a list of runs on hover.

This new rendering style means that the list can scroll when there are many stale causes and we can also linkify the references to other assets (they now link to those asset's detail pages). 

![image](https://github.com/dagster-io/dagster/assets/1037212/b03dec56-9be3-40b2-ab50-380c30a82487)

Note: These new ones are slightly larger, primarily because I made the styling match the padding, etc. of the run timeline popover:
![image](https://github.com/dagster-io/dagster/assets/1037212/32716b9c-8d77-48b4-a61d-bab80a82b92a)
![image](https://github.com/dagster-io/dagster/assets/1037212/e3af24a3-7b15-48c8-9577-41c8ecf6295a)

## How I Tested These Changes

I tested these changes manually by viewing stale causes overlaid on the asset DAG and overlaid via the Stale tag in the asset catalog / asset details pages. I used a hack to give myself many stale causes to ensure that the max-height and scrolling behavior works as expected.