### PR TITLE
[ui] Clean up config editor hints on blur/navigation

### DIFF
--- a/js_modules/dagit/packages/ui/src/components/ConfigEditor.tsx
+++ b/js_modules/dagit/packages/ui/src/components/ConfigEditor.tsx
@@ -157,7 +157,6 @@ export class ConfigEditor extends React.Component<ConfigEditorProps> {
               },
               hintOptions: {
                 completeSingle: false,
-                closeOnUnfocus: false,
                 schema: this.props.configSchema,
               },
               keyMap: 'sublime',


### PR DESCRIPTION
## Summary & Motivation

Resolves #14726.

Our ConfigEditor CodeMirror has `closeOnUnfocus: false` in its configuration, and has had it for almost five years. It's not really clear why from the original PR (https://github.com/dagster-io/dagster/pull/282) but it is preventing the hint popover from being removed from the DOM when the user navigates away from the Launchpad with the popover open. The result is the bug described in the issue, where the popover persists after launching a run.

Removing this line allows the hint popover to be removed on any blur behavior, which seems more correct than the current behavior in general.

## How I Tested These Changes

View Launchpad.

- Open the hint popover with Ctrl+Space within the config, verify that hints appear.
- Choose a hint, verify that it behaves properly, adding text to the editor and disappearing.
- Open the hint popover, click outside the editor. Verify that the hints disappear correctly.
- Open the hint popover, click to another tab. Verify that the hints do not persist in the DOM.
- Open the hint popover, launch run. Verify that the hints do not persist in the DOM.
