### PR TITLE
[ui] Prevent Zoom slider and buttons from closing right panel

### DIFF
--- a/js_modules/dagit/packages/core/src/graph/SVGViewport.tsx
+++ b/js_modules/dagit/packages/core/src/graph/SVGViewport.tsx
@@ -161,7 +161,15 @@ const PanAndZoomInteractor: SVGViewportInteractor = {
 
   render(viewport: SVGViewport) {
     return (
-      <ZoomSliderContainer id="zoom-slider-container">
+      <ZoomSliderContainer
+        id="zoom-slider-container"
+        onClick={(e: React.MouseEvent) => {
+          // Disallow click event from being handled by SVGViewport container, to avoid
+          // zoom button/slider mouse events from being treated as "background" clicks
+          // on the SVG display.
+          e.stopPropagation();
+        }}
+      >
         <WheelInstructionTooltip />
         <Box flex={{direction: 'column', alignItems: 'center'}}>
           <IconButton


### PR DESCRIPTION
## Summary & Motivation

Resolves #14861.

Prevent zoom button/slider clicks from propagating to the `SVGViewport` container, so that they don't get treated as "background" clicks on the SVG display. This is because "background" clicks will unselect the DAG nodes, hiding the right panel. Instead, we want to maintain the node selection even as we zoom in and out.

https://github.com/dagster-io/dagster/assets/2823852/09257616-8c41-44d9-9329-63cdc9a32d19

## How I Tested These Changes

View an asset DAG.

- Click on a node, verify that it is highlighted and shows the right panel.
- Click off of it on the background of the DAG display, verify that the panel disappears.
- Click on the node again, then use the zoom buttons and slider to verify correct zooming behavior, and that the right panel remains open and the node remains highlighted.
