### PR TITLE
[ui] Don't re-render entire Scheduled list on polling

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/ScheduledRunListRoot.tsx
+++ b/js_modules/dagit/packages/core/src/runs/ScheduledRunListRoot.tsx
@@ -52,7 +52,7 @@ export const ScheduledRunListRoot = () => {
         {tabs}
         <QueryRefreshCountdown refreshState={combinedRefreshState} />
       </Box>
-      <Loading queryResult={queryResult}>
+      <Loading queryResult={queryResult} allowStaleData>
         {(result) => {
           const {repositoriesOrError, instance} = result;
           if (repositoriesOrError.__typename === 'PythonError') {


### PR DESCRIPTION
## Summary & Motivation

Resolves #14826.

Use `allowStaleData` on `ScheduledRunListRoot` to prevent the list from being re-rendered from scratch on polled results.

This resolves the issue where the config dialog for a scheduled run vanishes because the poll reloads the entire view.

## How I Tested These Changes

View `/runs/scheduled`, open a config dialog for one row. Verify that when the polling completes, the page is not re-rendered and the dialog remains open.
