### PR TITLE
remove eager_downstream_2_skipper

### DIFF
--- a/python_modules/dagster-test/dagster_test/toys/auto_materializing/repo_1.py
+++ b/python_modules/dagster-test/dagster_test/toys/auto_materializing/repo_1.py
@@ -1,6 +1,4 @@
-import random
-
-from dagster import AutoMaterializePolicy, SkipReason, asset, repository
+from dagster import AutoMaterializePolicy, asset, repository
 
 
 @asset(auto_materialize_policy=AutoMaterializePolicy.eager())
@@ -23,14 +21,6 @@ def lazy_downstream_1(lazy_upstream):
     return lazy_upstream + 1
 
 
-@asset(auto_materialize_policy=AutoMaterializePolicy.eager())
-def eager_downstream_2_skipper(eager_downstream_1):
-    random.seed(5438790)
-    if random.randint(0, 10) < 8:
-        return SkipReason("Testing")
-    return eager_downstream_1 + 1
-
-
 @repository
 def auto_materialize_repo_1():
     return [
@@ -38,5 +28,4 @@ def auto_materialize_repo_1():
         eager_downstream_1,
         lazy_upstream,
         lazy_downstream_1,
-        eager_downstream_2_skipper,
     ]


### PR DESCRIPTION
slipped through in https://github.com/dagster-io/dagster/pull/14625/files#diff-223f2d9039b8f9b9c111cddee38a9309baa0a5144080c330938b354223098f2d- SkipReasons don't work inside assets