### PR TITLE
[freshness-policies] Prevent "unconverted data" error when upstream partitions definition changes

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/data_time.py
+++ b/python_modules/dagster/dagster/_core/definitions/data_time.py
@@ -108,6 +108,7 @@ class CachingDataTimeResolver:
             partition_key
             for partition_key, new_count in new_partition_counts.items()
             if new_count == total_partition_counts.get(partition_key)
+            and partitions_def.is_valid_partition_key(partition_key)
         }
 
         # there are new materializations, but they don't fill any new partitions


### PR DESCRIPTION
## Summary & Motivation

If an unpartitioned asset is downstream of a partitioned asset, we need to understand what partitions were available at the time the downstream asset was materialized. To do so, we get a count before and after that record's storage id. Previously, we were creating a partitions subset consisting of any of the net-new partitions after the unpartitioned was materialized, but in the following scenario:

1. unpartitioned asset materialized
2. partitioned upstream materialized (hourly partitions)
3. partitioned upstream definition changed

Then some of the net-new partitions would be in the old format. We now filter those out, as we do above in the function.

## How I Tested These Changes
