### PR TITLE
Fix typo in dagster-duckdb-polars tests

### DIFF
--- a/python_modules/libraries/dagster-duckdb-polars/setup.py
+++ b/python_modules/libraries/dagster-duckdb-polars/setup.py
@@ -22,7 +22,7 @@ setup(
     author_email="hello@elementl.com",
     license="Apache-2.0",
     description="Package for storing Polars DataFrames in DuckDB.",
-    url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-duckb-polars",
+    url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-duckdb-polars",
     classifiers=[
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",


### PR DESCRIPTION
## Summary & Motivation

This fixes a typo in the URL that points to `dagster-duckdb-polars`.

## How I Tested These Changes
