### PR TITLE
[ui] Add optional EmptyState to RunTable

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/RunTable.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTable.tsx
@@ -55,6 +55,7 @@ interface RunTableProps {
   belowActionBarComponents?: React.ReactNode;
   hideCreatedBy?: boolean;
   additionalActionsForRun?: (run: RunTableRunFragment) => JSX.Element[];
+  emptyState?: () => React.ReactNode;
 }
 
 export const RunTable = (props: RunTableProps) => {
@@ -66,6 +67,7 @@ export const RunTable = (props: RunTableProps) => {
     actionBarComponents,
     belowActionBarComponents,
     hideCreatedBy,
+    emptyState,
   } = props;
   const allIds = runs.map((r) => r.id);
 
@@ -77,7 +79,11 @@ export const RunTable = (props: RunTableProps) => {
 
   function content() {
     if (runs.length === 0) {
-      const anyFilter = Object.keys(filter || {}).length;
+      const anyFilter = !!Object.keys(filter || {}).length;
+      if (emptyState) {
+        return <>{emptyState()}</>;
+      }
+
       return (
         <div>
           <Box margin={{vertical: 32}}>


### PR DESCRIPTION
## Summary & Motivation

In https://github.com/dagster-io/dagster/pull/14843, I didn't handle the case where the user has set filters on the view. While fixing this, I noticed that the empty state could prevent the filters from rendering at all, since they're part of `RunTable`.

To resolve this, add an optional `emptyState` prop to `RunTable` so that an empty state can be defined by the component that uses `RunTable`.

Then, check for the presence of any filters to determine exactly what copy to show the user in the empty state case.

<img width="1244" alt="Screenshot 2023-06-21 at 10 52 31 AM" src="https://github.com/dagster-io/dagster/assets/2823852/12390821-70ca-4387-a7b1-655da2e63214">

## How I Tested These Changes

View asset jobs and op jobs with and without filters. Verify that the correct empty states appear, and that their buttons navigate to the correct place.

View global Runs view, use filters to get to an empty state. Verify that it renders correctly, even though this RunTable has no custom empty state defined.
