### PR TITLE
non_arg_deps_rename 2/n - rename parameters in _Asset

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -197,7 +197,7 @@ def asset(
             name=cast(Optional[str], name),  # (mypy bug that it can't infer name is Optional[str])
             key_prefix=key_prefix,
             ins=ins,
-            non_argument_deps=_make_asset_keys(upstream_asset_deps),
+            upstream_assets=_make_asset_keys(upstream_asset_deps),
             metadata=metadata,
             description=description,
             config_schema=config_schema,
@@ -249,7 +249,7 @@ class _Asset:
         name: Optional[str] = None,
         key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
         ins: Optional[Mapping[str, AssetIn]] = None,
-        non_argument_deps: Optional[Set[AssetKey]] = None,
+        upstream_assets: Optional[Set[AssetKey]] = None,
         metadata: Optional[ArbitraryMetadataMapping] = None,
         description: Optional[str] = None,
         config_schema: Optional[UserConfigSchema] = None,
@@ -275,7 +275,7 @@ class _Asset:
             key_prefix = [key_prefix]
         self.key_prefix = key_prefix
         self.ins = ins or {}
-        self.non_argument_deps = non_argument_deps
+        self.upstream_assets = upstream_assets
         self.metadata = metadata
         self.description = description
         self.required_resource_keys = check.opt_set_param(
@@ -313,7 +313,7 @@ class _Asset:
         validate_resource_annotated_function(fn)
         asset_name = self.name or fn.__name__
 
-        asset_ins = build_asset_ins(fn, self.ins or {}, self.non_argument_deps)
+        asset_ins = build_asset_ins(fn, self.ins or {}, self.upstream_assets)
 
         out_asset_key = (
             AssetKey(list(filter(None, [*(self.key_prefix or []), asset_name])))
@@ -547,7 +547,7 @@ def multi_asset(
     def inner(fn: Callable[..., Any]) -> AssetsDefinition:
         op_name = name or fn.__name__
         asset_ins = build_asset_ins(
-            fn, ins or {}, non_argument_deps=_make_asset_keys(upstream_asset_deps)
+            fn, ins or {}, upstream_assets=_make_asset_keys(upstream_asset_deps)
         )
         asset_outs = build_asset_outs(outs)
 
@@ -672,10 +672,10 @@ def multi_asset(
 def build_asset_ins(
     fn: Callable,
     asset_ins: Mapping[str, AssetIn],
-    non_argument_deps: Optional[AbstractSet[AssetKey]],
+    upstream_assets: Optional[AbstractSet[AssetKey]],
 ) -> Mapping[AssetKey, Tuple[str, In]]:
     """Creates a mapping from AssetKey to (name of input, In object)."""
-    non_argument_deps = check.opt_set_param(non_argument_deps, "non_argument_deps", AssetKey)
+    upstream_assets = check.opt_set_param(upstream_assets, "upstream_assets", AssetKey)
 
     params = get_function_params(fn)
     is_context_provided = len(params) > 0 and params[0].name in get_valid_name_permutations(
@@ -733,7 +733,7 @@ def build_asset_ins(
             In(metadata=metadata, input_manager_key=input_manager_key, dagster_type=dagster_type),
         )
 
-    for asset_key in non_argument_deps:
+    for asset_key in upstream_assets:
         stringified_asset_key = "_".join(asset_key.path).replace("-", "_")
         # mypy doesn't realize that Nothing is a valid type here
         ins_by_asset_key[asset_key] = (stringified_asset_key, In(cast(type, Nothing)))


### PR DESCRIPTION
## Summary & Motivation
renames the `non_argument_deps` parameter in `_Asset` to `deps` to align with https://github.com/dagster-io/dagster/pull/14886
## How I Tested These Changes
bk