### PR TITLE
Add schema output to migrate cli

### DIFF
--- a/python_modules/dagster-test/dagster_test/toys/auto_materializing/repo_1.py
+++ b/python_modules/dagster-test/dagster_test/toys/auto_materializing/repo_1.py
@@ -28,22 +28,22 @@ def lazy_downstream_1(lazy_upstream):
 daily_partitions_def = DailyPartitionsDefinition(start_date="2023-02-01")
 
 
-@asset(auto_materialize_policy=AutoMaterializePolicy.eager())
+@asset(auto_materialize_policy=AutoMaterializePolicy.eager(), partitions_def=daily_partitions_def)
 def eager_upstream_partitioned():
     return 3
 
 
-@asset(auto_materialize_policy=AutoMaterializePolicy.eager())
+@asset(auto_materialize_policy=AutoMaterializePolicy.eager(), partitions_def=daily_partitions_def)
 def eager_downstream_1_partitioned(eager_upstream_partitioned):
     return eager_upstream_partitioned + 1
 
 
-@asset(auto_materialize_policy=AutoMaterializePolicy.lazy())
+@asset(auto_materialize_policy=AutoMaterializePolicy.lazy(), partitions_def=daily_partitions_def)
 def lazy_upstream_partitioned():
     return 1
 
 
-@asset(auto_materialize_policy=AutoMaterializePolicy.lazy())
+@asset(auto_materialize_policy=AutoMaterializePolicy.lazy(), partitions_def=daily_partitions_def)
 def lazy_downstream_1_partitioned(lazy_upstream_partitioned):
     return lazy_upstream_partitioned + 1
 

--- a/python_modules/dagster-test/dagster_test/toys/auto_materializing/repo_2.py
+++ b/python_modules/dagster-test/dagster_test/toys/auto_materializing/repo_2.py
@@ -53,20 +53,22 @@ def lazy_downstream_4(lazy_downstream_2, lazy_downstream_3):
 
 daily_partitions_def = DailyPartitionsDefinition(start_date="2023-02-01")
 
-eager_downstream_1_source_partitioned = SourceAsset(AssetKey(["eager_downstream_1_partitioned"]))
+eager_downstream_1_source_partitioned = SourceAsset(
+    AssetKey(["eager_downstream_1_partitioned"]), partitions_def=daily_partitions_def
+)
 
 
-@asset(auto_materialize_policy=AutoMaterializePolicy.eager())
+@asset(partitions_def=daily_partitions_def, auto_materialize_policy=AutoMaterializePolicy.eager())
 def eager_downstream_2_partitioned(eager_downstream_1_partitioned):
     return eager_downstream_1_partitioned + 2
 
 
-@asset(auto_materialize_policy=AutoMaterializePolicy.eager())
+@asset(partitions_def=daily_partitions_def, auto_materialize_policy=AutoMaterializePolicy.eager())
 def eager_downstream_3_partitioned(eager_downstream_1_partitioned):
     return eager_downstream_1_partitioned + 3
 
 
-@asset(auto_materialize_policy=AutoMaterializePolicy.eager())
+@asset(partitions_def=daily_partitions_def, auto_materialize_policy=AutoMaterializePolicy.eager())
 def eager_downstream_4_partitioned(eager_downstream_2_partitioned, eager_downstream_3_partitioned):
     return eager_downstream_2_partitioned + eager_downstream_3_partitioned
 
@@ -74,17 +76,18 @@ def eager_downstream_4_partitioned(eager_downstream_2_partitioned, eager_downstr
 lazy_downstream_1_source_partitioned = SourceAsset(AssetKey(["lazy_downstream_1_partitioned"]))
 
 
-@asset(auto_materialize_policy=AutoMaterializePolicy.lazy())
+@asset(partitions_def=daily_partitions_def, auto_materialize_policy=AutoMaterializePolicy.lazy())
 def lazy_downstream_2_partitioned(lazy_downstream_1_partitioned):
     return lazy_downstream_1_partitioned + 2
 
 
-@asset(auto_materialize_policy=AutoMaterializePolicy.lazy())
+@asset(partitions_def=daily_partitions_def, auto_materialize_policy=AutoMaterializePolicy.lazy())
 def lazy_downstream_3_partitioned(lazy_downstream_1_partitioned):
     return lazy_downstream_1_partitioned + 3
 
 
 @asset(
+    partitions_def=daily_partitions_def,
     auto_materialize_policy=AutoMaterializePolicy.lazy(),
     freshness_policy=FreshnessPolicy(maximum_lag_minutes=5),
 )

--- a/python_modules/dagster/dagster/_cli/instance.py
+++ b/python_modules/dagster/dagster/_cli/instance.py
@@ -52,12 +52,16 @@ def migrate_command():
         click.echo("\nInstance configuration:\n-----------------------")
         click.echo(instance.info_str())
 
-        click.echo("\nStorage schema state before migration:\n---------------------")
+        click.echo(
+            "\nStorage schema state before migration:\n--------------------------------------"
+        )
         click.echo(instance.schema_str())
+
+        click.echo("\nRunning migration:\n------------------")
 
         instance.upgrade(click.echo)
 
-        click.echo("\nStorage schema state after migration:\n---------------------")
+        click.echo("\nStorage schema state after migration:\n-------------------------------------")
         click.echo(instance.schema_str())
 
 

--- a/python_modules/dagster/dagster/_cli/instance.py
+++ b/python_modules/dagster/dagster/_cli/instance.py
@@ -49,9 +49,16 @@ def migrate_command():
 
         click.echo(f"$DAGSTER_HOME: {home}\n")
 
+        click.echo("\nInstance configuration:\n-----------------------")
+        click.echo(instance.info_str())
+
+        click.echo("\nStorage schema state before migration:\n---------------------")
+        click.echo(instance.schema_str())
+
         instance.upgrade(click.echo)
 
-        click.echo(instance.info_str())
+        click.echo("\nStorage schema state after migration:\n---------------------")
+        click.echo(instance.schema_str())
 
 
 @instance_cli.command(name="reindex", help="Rebuild index over historical runs for performance.")


### PR DESCRIPTION
New output:

```
> dagster instance migrate
$DAGSTER_HOME: /Users/johann/code/assets-playground


Instance configuration:
-----------------------
local_artifact_storage:
  module: dagster._core.storage.root
  class: LocalArtifactStorage
  config:
    base_dir: /Users/johann/code/assets-playground
run_storage:
  module: dagster_postgres.run_storage
  class: PostgresRunStorage
  config:
    postgres_db:
      db_name: postgres
      hostname: localhost
      password: ''
      port: 9367
      username: postgres
event_log_storage:
  module: dagster_postgres.event_log
  class: PostgresEventLogStorage
  config:
    postgres_db:
      db_name: postgres
      hostname: localhost
      password: ''
      port: 9367
      username: postgres
compute_logs: NoneType
schedule_storage:
  module: dagster_postgres.schedule_storage
  class: PostgresScheduleStorage
  config:
    postgres_db:
      db_name: postgres
      hostname: localhost
      password: ''
      port: 9367
      username: postgres
scheduler:
  module: dagster._core.scheduler
  class: DagsterDaemonScheduler
  config: {}
run_coordinator: NoneType
run_launcher:
  module: dagster
  class: DefaultRunLauncher
  config: {}
auto_materialize:
  minimum_interval_seconds: 5


Storage schema state before migration:
----------------------------------------
schema:
  event_log_storage:
    current: d3a4c9e87af3
    latest: 5771160a95ad
  run_storage:
    current: d3a4c9e87af3
    latest: 5771160a95ad
  schedule_storage:
    current: d3a4c9e87af3
    latest: 5771160a95ad

Running migration:
-------------------
Updating run storage...
Skipping already applied data migration: run_partitions
Skipping already applied data migration: run_repo_label_tags
Skipping already applied data migration: bulk_action_types
Updating event storage...
Skipping already applied data migration: asset_key_index_columns
Updating schedule storage...
Skipping already applied migration: schedule_jobs_selector_id

Storage schema state after migration:
--------------------------------------
schema:
  event_log_storage:
    current: 5771160a95ad
    latest: 5771160a95ad
  run_storage:
    current: 5771160a95ad
    latest: 5771160a95ad
  schedule_storage:
    current: 5771160a95ad
    latest: 5771160a95ad
```