### PR TITLE
[ui] Revert "Propagate changes" in favor of "Materialize changed and missing"

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
@@ -27,7 +27,7 @@ import {ASSET_NODE_CONFIG_FRAGMENT} from './AssetConfig';
 import {MULTIPLE_DEFINITIONS_WARNING} from './AssetDefinedInMultipleReposNotice';
 import {LaunchAssetChoosePartitionsDialog} from './LaunchAssetChoosePartitionsDialog';
 import {partitionDefinitionsEqual} from './MultipartitioningSupport';
-import {isAssetStale} from './Stale';
+import {isAssetMissing, isAssetStale} from './Stale';
 import {AssetKey} from './types';
 import {
   LaunchAssetExecutionAssetNodeFragment,
@@ -135,13 +135,15 @@ function optionsForButton(scope: AssetsInScope, liveDataForStale?: LiveData): La
   });
 
   if (liveDataForStale) {
-    const missingOrStale = assets.filter((a) =>
-      isAssetStale(liveDataForStale[toGraphId(a.assetKey)]),
+    const missingOrStale = assets.filter(
+      (a) =>
+        isAssetMissing(liveDataForStale[toGraphId(a.assetKey)]) ||
+        isAssetStale(liveDataForStale[toGraphId(a.assetKey)]),
     );
 
     options.push({
       assetKeys: missingOrStale.map((a) => a.assetKey),
-      label: `Propagate changes${countOrBlank(missingOrStale)}`,
+      label: `Materialize changed and missing${countOrBlank(missingOrStale)}`,
       hasMaterializePermission,
       icon: <Icon name="changes_present" />,
     });
@@ -209,13 +211,6 @@ export const LaunchAssetExecutionButton: React.FC<{
           position="bottom-right"
           content={
             <Menu>
-              <MenuItem
-                text="Open in launchpad"
-                icon={<Icon name="open_in_new" />}
-                onClick={(e: React.MouseEvent<any>) => {
-                  onClick(firstOption.assetKeys, e, true);
-                }}
-              />
               {options.slice(1).map((option) => (
                 <MenuItem
                   key={option.label}
@@ -225,6 +220,13 @@ export const LaunchAssetExecutionButton: React.FC<{
                   onClick={(e) => onClick(option.assetKeys, e)}
                 />
               ))}
+              <MenuItem
+                text="Open launchpad"
+                icon={<Icon name="open_in_new" />}
+                onClick={(e: React.MouseEvent<any>) => {
+                  onClick(firstOption.assetKeys, e, true);
+                }}
+              />
             </Menu>
           }
         >


### PR DESCRIPTION
## Summary & Motivation

This PR reverts "propagate changes" to "Materialize changed and missing"

It also moves "Open Launchpad" to the bottom and removes the word "in"

<img width="381" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/706f2f1e-4a75-409a-a717-674348bd2200">


## How I Tested These Changes

This is primarily a revert of the last change to 717d640b97de64d3db75343e84d91be6fcdd0ca9, just tested it manually.