### PR TITLE
[dagster-airflow] remove < 2.6.2 airflow contraint, ignore dynamic task mapping examples

### DIFF
--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_job_factory/test_load_dag_bag.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_job_factory/test_load_dag_bag.py
@@ -94,6 +94,7 @@ test_airflow_example_dags_inputs = [
             "example_complex",
             # can flake due to 502 Server Error: Bad Gateway for url: https://www.httpbin.org/
             "example_http_operator",
+            "example_dynamic_task_mapping_with_no_taskflow_operators",
         ],
     ),
 ]

--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_job_factory/test_load_dag_bag_airflow_2.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_job_factory/test_load_dag_bag_airflow_2.py
@@ -82,6 +82,7 @@ def get_examples_airflow_repo_params():
         # runs slow
         "example_sensors",
         "example_dynamic_task_mapping",
+        "example_dynamic_task_mapping_with_no_taskflow_operators",
     ]
     for job_name in repo.job_names:
         params.append(

--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_pipeline_factory/test_load_dag_bag_airflow_2.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_pipeline_factory/test_load_dag_bag_airflow_2.py
@@ -77,6 +77,7 @@ def get_examples_airflow_repo_params():
         # runs slow
         "example_sensors",
         "example_dynamic_task_mapping",
+        "example_dynamic_task_mapping_with_no_taskflow_operators",
         # wrong state
         "example_short_circuit_operator",
     ]

--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_persistent_db/test_persistent_airflow_2_db.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_persistent_db/test_persistent_airflow_2_db.py
@@ -230,6 +230,7 @@ def get_examples_airflow_repo_params() -> List[ParameterSet]:
         # runs slow
         "example_sensors",
         "example_dynamic_task_mapping",
+        "example_dynamic_task_mapping_with_no_taskflow_operators",
     ]
     for job_name in repo.job_names:
         params.append(

--- a/python_modules/libraries/dagster-airflow/setup.py
+++ b/python_modules/libraries/dagster-airflow/setup.py
@@ -44,8 +44,7 @@ setup(
     extras_require={
         "kubernetes": ["kubernetes>=3.0.0", "cryptography>=2.0.0"],
         "test_airflow_2": [
-            # 2.6.2 breaks how dagster-airflow fetches task instance info
-            "apache-airflow>=2.0.0,<2.6.2",
+            "apache-airflow>=2.0.0",
             "boto3>=1.26.7",
             "kubernetes>=10.0.1",
             "apache-airflow-providers-docker>=3.2.0,<4",


### PR DESCRIPTION
## Summary & Motivation

airflow 2.6.2 added the `example_dynamic_task_mapping_with_no_taskflow_operators` example dag which relies on dynamic task mapping functionality that is not currently supported by dagster-airflow. This PR disables using those examples so that dagster-airflow can still be used with 2.6.2 (although without support of dynamic task mapping)

## How I Tested These Changes
