### PR TITLE
[ui] Refactor error handling in spanTextToSelectionsOrError, show alert on other callsite

### DIFF
--- a/js_modules/dagit/packages/core/src/partitions/DimensionRangeInput.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/DimensionRangeInput.tsx
@@ -5,7 +5,7 @@ import {showCustomAlert} from '../app/CustomAlertProvider';
 import {testId} from '../testing/testId';
 import {ClearButton} from '../ui/ClearButton';
 
-import {partitionsToText, spanTextToSelections} from './SpanRepresentation';
+import {partitionsToText, spanTextToSelectionsOrError} from './SpanRepresentation';
 
 export const DimensionRangeInput: React.FC<{
   value: string[];
@@ -28,11 +28,12 @@ export const DimensionRangeInput: React.FC<{
   }, [partitionKeys, isTimeseries]);
 
   const tryCommit = (e: React.SyntheticEvent<HTMLInputElement>) => {
-    try {
-      onChange(spanTextToSelections(partitionKeys, valueString).selectedKeys);
-    } catch (err: any) {
+    const selections = spanTextToSelectionsOrError(partitionKeys, valueString);
+    if (selections instanceof Error) {
       e.preventDefault();
-      showCustomAlert({body: err.message});
+      showCustomAlert({body: selections.message});
+    } else {
+      onChange(selections.selectedKeys);
     }
   };
 

--- a/js_modules/dagit/packages/core/src/partitions/SpanRepresentation.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/SpanRepresentation.tsx
@@ -41,11 +41,11 @@ export function allPartitionsRange({
   };
 }
 
-export function spanTextToSelections(
+export function spanTextToSelectionsOrError(
   allPartitionKeys: string[],
   text: string,
   skipPartitionKeyValidation?: boolean, // This is used by Dynamic Partitions as a workaround to be able to select a newly added partition before the partition health data is refetched
-): Omit<PartitionDimensionSelection, 'dimension'> {
+): Error | Omit<PartitionDimensionSelection, 'dimension'> {
   const terms = text.split(',').map((s) => s.trim());
   const result: Omit<PartitionDimensionSelection, 'dimension'> = {
     selectedKeys: [],
@@ -62,7 +62,7 @@ export function spanTextToSelections(
       const allStartIdx = allPartitionKeys.indexOf(start!);
       const allEndIdx = allPartitionKeys.indexOf(end!);
       if (allStartIdx === -1 || allEndIdx === -1) {
-        throw new Error(`Could not find partitions for provided range: ${start}...${end}`);
+        return new Error(`Could not find partitions for provided range: ${start}...${end}`);
       }
       result.selectedKeys.push(...allPartitionKeys.slice(allStartIdx, allEndIdx + 1));
       result.selectedRanges.push({
@@ -99,7 +99,7 @@ export function spanTextToSelections(
     } else {
       const idx = allPartitionKeys.indexOf(term);
       if (idx === -1 && !skipPartitionKeyValidation) {
-        throw new Error(`Could not find partition: ${term}`);
+        return new Error(`Could not find partition: ${term}`);
       }
       result.selectedKeys.push(term);
       result.selectedRanges.push({

--- a/js_modules/dagit/packages/core/src/partitions/__tests__/SpanRepresentation.test.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/__tests__/SpanRepresentation.test.tsx
@@ -3,7 +3,7 @@ import {
   assembleIntoSpans,
   partitionsToText,
   stringForSpan,
-  spanTextToSelections,
+  spanTextToSelectionsOrError,
 } from '../SpanRepresentation';
 
 const MOCK_PARTITION_STATES = {
@@ -57,9 +57,12 @@ describe('SpanRepresentation', () => {
     });
   });
 
-  describe('textToPartitions', () => {
+  describe('spanTextToSelectionsOrError', () => {
     it('should parse a single value', () => {
-      const result = spanTextToSelections(MOCK_PARTITIONS, '2022-01-01');
+      const result = spanTextToSelectionsOrError(MOCK_PARTITIONS, '2022-01-01');
+      if (result instanceof Error) {
+        throw result;
+      }
       expect(result.selectedKeys).toEqual(['2022-01-01']);
       expect(result.selectedRanges).toEqual([
         {
@@ -69,8 +72,13 @@ describe('SpanRepresentation', () => {
       ]);
     });
     it('should parse comma-separated values', () => {
-      const result = spanTextToSelections(MOCK_PARTITIONS, '2022-01-01, 2022-01-02,2022-01-03');
-
+      const result = spanTextToSelectionsOrError(
+        MOCK_PARTITIONS,
+        '2022-01-01, 2022-01-02,2022-01-03',
+      );
+      if (result instanceof Error) {
+        throw result;
+      }
       expect(result.selectedKeys).toEqual(['2022-01-01', '2022-01-02', '2022-01-03']);
       expect(result.selectedRanges).toEqual([
         {
@@ -88,17 +96,23 @@ describe('SpanRepresentation', () => {
       ]);
     });
     it('should parse spans using the [...] syntax', () => {
-      const result = spanTextToSelections(MOCK_PARTITIONS, '[2022-01-01...2022-01-03]');
+      const result = spanTextToSelectionsOrError(MOCK_PARTITIONS, '[2022-01-01...2022-01-03]');
+      if (result instanceof Error) {
+        throw result;
+      }
       expect(result.selectedKeys).toEqual(['2022-01-01', '2022-01-02', '2022-01-03']);
       expect(result.selectedRanges).toEqual([
         {start: {idx: 0, key: '2022-01-01'}, end: {idx: 2, key: '2022-01-03'}},
       ]);
     });
     it('should parse a multi-span string', () => {
-      const result = spanTextToSelections(
+      const result = spanTextToSelectionsOrError(
         MOCK_PARTITIONS,
         '[2022-01-01...2022-01-03],2022-01-05,[2022-01-06...2022-01-07]',
       );
+      if (result instanceof Error) {
+        throw result;
+      }
       expect(result.selectedKeys).toEqual([
         '2022-01-01',
         '2022-01-02',
@@ -123,7 +137,9 @@ describe('SpanRepresentation', () => {
       ]);
     });
     it('should throw an exception if the string is invalid', () => {
-      expect(() => spanTextToSelections(MOCK_PARTITIONS, '[1980-01-01]')).toThrow();
+      expect(spanTextToSelectionsOrError(MOCK_PARTITIONS, '[1980-01-01]') instanceof Error).toEqual(
+        true,
+      );
     });
   });
 


### PR DESCRIPTION
## Summary & Motivation

This is a fix for the error reported in https://elementl-workspace.slack.com/archives/C03CCE471E0/p1687272525520469

The `spanTextToSelections` method was designed to throw exceptions when the text is invalid, but the error case is a standard-but-non-ideal case, and the error should always be handled by the caller.  To make it easier to enforce this in Typescript I converted it to return the Error.

## How I Tested These Changes

I was able to reproduce the error in the report by visiting the partition page and then changing the URL to reference a partition that does not exist:

http://localhost:3000/assets/yoyoyoyoyo?view=partitions&default_range=doesnotexist

This would crash the page previously because the selection tries to set initial state from the URL and fails. I updated this use of `spanTextToSelections` to display an error the way the other callsites do. It's admittedly a /bit/ odd to show an error alert from a hook, but this one just runs the relevant initialize method once so the alert appears once and not again.