### PR TITLE
Pin tests to dbt-core 1.5.1

### DIFF
--- a/python_modules/libraries/dagster-dbt/tox.ini
+++ b/python_modules/libraries/dagster-dbt/tox.ini
@@ -12,7 +12,7 @@ deps =
   dbt_13X: dbt-duckdb==1.3.*
   dbt_14X: dbt-core==1.4.*
   dbt_14X: dbt-duckdb==1.4.*
-  dbt_15X: dbt-core==1.5.*
+  dbt_15X: dbt-core==1.5.1
   dbt_15X: dbt-duckdb==1.5.*
   -e .[test]
 allowlist_externals =

--- a/python_modules/libraries/dagster-dbt/tox.ini
+++ b/python_modules/libraries/dagster-dbt/tox.ini
@@ -12,8 +12,8 @@ deps =
   dbt_13X: dbt-duckdb==1.3.*
   dbt_14X: dbt-core==1.4.*
   dbt_14X: dbt-duckdb==1.4.*
-  dbt_15X: dbt-core==1.5.1
-  dbt_15X: dbt-duckdb==1.5.*
+  dbt_15X: dbt-core<=1.5.1
+  dbt_15X: dbt-duckdb<=1.5.1
   -e .[test]
 allowlist_externals =
   /bin/bash


### PR DESCRIPTION
dbt-core 1.5.2 breaks our 1.5.x tests.

For now, pinning. @OwenKephart can you get a fix up when you get a chance?
