### PR TITLE
[graphql] support async resolvers

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -3315,6 +3315,7 @@ type CapturedLogsMetadata {
 
 type TestFields {
   alwaysException: String
+  asyncString: String
 }
 
 union AutoMaterializeAssetEvaluationRecordsOrError =

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -4334,6 +4334,7 @@ export type TerminateRunsResultOrError = PythonError | TerminateRunsResult;
 export type TestFields = {
   __typename: 'TestFields';
   alwaysException: Maybe<Scalars['String']>;
+  asyncString: Maybe<Scalars['String']>;
 };
 
 export type TextMetadataEntry = MetadataEntry & {
@@ -12761,6 +12762,8 @@ export const buildTestFields = (
       overrides && overrides.hasOwnProperty('alwaysException')
         ? overrides.alwaysException!
         : 'quibusdam',
+    asyncString:
+      overrides && overrides.hasOwnProperty('asyncString') ? overrides.asyncString! : 'non',
   };
 };
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/test.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/test.py
@@ -1,4 +1,8 @@
+import asyncio
+
 import graphene
+
+_STATE = {}
 
 
 class GrapheneTestFields(graphene.ObjectType):
@@ -6,6 +10,18 @@ class GrapheneTestFields(graphene.ObjectType):
         name = "TestFields"
 
     alwaysException = graphene.String()
+    asyncString = graphene.String()
 
     def resolve_alwaysException(self, _):
         raise Exception("as advertised")
+
+    async def resolve_asyncString(self, _):
+        msg = "slept"
+        if _STATE.get("sleeping"):
+            msg += " concurrently"
+        else:
+            _STATE["sleeping"] = True
+
+        await asyncio.sleep(0)
+        _STATE["sleeping"] = False
+        return msg

--- a/python_modules/dagster-webserver/dagster_webserver/graphql.py
+++ b/python_modules/dagster-webserver/dagster_webserver/graphql.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from asyncio import Task, get_event_loop
+from asyncio import Task, get_event_loop, run
 from enum import Enum
 from typing import (
     TYPE_CHECKING,
@@ -236,15 +236,23 @@ class GraphQLServer(ABC):
         variables: Optional[Dict[str, Any]],
         operation_name: Optional[str],
     ) -> ExecutionResult:
-        # use run_in_threadpool since underlying schema is sync
-        return await run_in_threadpool(
-            self._graphql_schema.execute,
-            query,
-            variables=variables,
-            operation_name=operation_name,
-            context=self.make_request_context(request),
-            middleware=self._graphql_middleware,
-        )
+        # run each query in a separate thread, as much of the schema is sync/blocking
+        # use execute_async to allow async resolvers to facilitate dataloader pattern
+
+        request_context = self.make_request_context(request)
+
+        def _graphql_request():
+            return run(
+                self._graphql_schema.execute_async(
+                    query,
+                    variables=variables,
+                    operation_name=operation_name,
+                    context=request_context,
+                    middleware=self._graphql_middleware,
+                )
+            )
+
+        return await run_in_threadpool(_graphql_request)
 
     async def execute_graphql_subscription(
         self,

--- a/python_modules/dagster-webserver/dagster_webserver_tests/webserver/test_app.py
+++ b/python_modules/dagster-webserver/dagster_webserver_tests/webserver/test_app.py
@@ -278,3 +278,14 @@ def test_download_compute(instance, test_client: TestClient):
 
     response = test_client.get(f"/download/{run_id}/jonx/stdout")
     assert response.status_code == 404
+
+
+def test_async(test_client: TestClient):
+    response = test_client.post(
+        "/graphql",
+        params={"query": "{test{one: asyncString, two: asyncString}}"},
+    )
+    assert response.status_code == 200, response.text
+    result = response.json()
+    assert result["data"]["test"]["one"] == "slept", result
+    assert result["data"]["test"]["two"] == "slept concurrently", result


### PR DESCRIPTION
changes how the root graphql execution is invoked to support `async` resolvers, unlocking the ability to use something like DataLoader https://docs.graphene-python.org/en/latest/execution/dataloader/ to effectively batch request instead of issuing them serially. 

## How I Tested These Changes

added test

did some quick py-spy profiling to make sure nothing stood out 
