### PR TITLE
[bug] Fix issue with offsetted TimeWindowPartitionMappings

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
@@ -125,8 +125,8 @@ class TimeWindowPartitionMapping(
             downstream_partitions_subset.partitions_def,
             upstream_partitions_def,
             downstream_partitions_subset,
-            self.start_offset,
-            self.end_offset,
+            start_offset=self.start_offset,
+            end_offset=self.end_offset,
             current_time=current_time,
         )
 
@@ -146,8 +146,8 @@ class TimeWindowPartitionMapping(
             upstream_partitions_subset.partitions_def,
             downstream_partitions_def,
             upstream_partitions_subset,
-            -self.start_offset,
-            -self.end_offset,
+            end_offset=-self.start_offset,
+            start_offset=-self.end_offset,
             current_time=current_time,
         ).partitions_subset
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_time_window_partition_mapping.py
@@ -260,6 +260,30 @@ def test_daily_to_daily_lag_different_start_date():
     ).get_partition_keys() == ["2021-05-06"]
 
 
+def test_daily_to_daily_many_to_one():
+    upstream_partitions_def = DailyPartitionsDefinition(start_date="2021-05-05")
+    downstream_partitions_def = DailyPartitionsDefinition(start_date="2021-05-06")
+    mapping = TimeWindowPartitionMapping(start_offset=-1)
+
+    """
+    assert mapping.get_upstream_partitions_for_partitions(
+        subset_with_keys(downstream_partitions_def, ["2022-07-04"]), upstream_partitions_def
+    ).get_partition_keys() == ["2022-07-03", "2022-07-04"]
+    """
+    assert mapping.get_downstream_partitions_for_partitions(
+        subset_with_keys(upstream_partitions_def, ["2022-07-03", "2022-07-04"]),
+        downstream_partitions_def,
+    ).get_partition_keys() == ["2022-07-03", "2022-07-04", "2022-07-05"]
+
+    assert mapping.get_downstream_partitions_for_partitions(
+        subset_with_keys(upstream_partitions_def, ["2022-07-03"]), downstream_partitions_def
+    ).get_partition_keys() == ["2022-07-03", "2022-07-04"]
+
+    assert mapping.get_downstream_partitions_for_partitions(
+        subset_with_keys(upstream_partitions_def, ["2022-07-04"]), downstream_partitions_def
+    ).get_partition_keys() == ["2022-07-04", "2022-07-05"]
+
+
 @pytest.mark.parametrize(
     "upstream_partitions_def,downstream_partitions_def,upstream_keys,expected_downstream_keys,current_time",
     [

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_time_window_partition_mapping.py
@@ -265,14 +265,14 @@ def test_daily_to_daily_many_to_one():
     downstream_partitions_def = DailyPartitionsDefinition(start_date="2021-05-06")
     mapping = TimeWindowPartitionMapping(start_offset=-1)
 
-    assert mapping.get_upstream_partitions_for_partitions(
+    assert mapping.get_upstream_mapped_partitions_result_for_partitions(
         subset_with_keys(downstream_partitions_def, ["2022-07-04"]), upstream_partitions_def
-    ).get_partition_keys() == ["2022-07-03", "2022-07-04"]
+    ).partitions_subset.get_partition_keys() == ["2022-07-03", "2022-07-04"]
 
-    assert mapping.get_upstream_partitions_for_partitions(
+    assert mapping.get_upstream_mapped_partitions_result_for_partitions(
         subset_with_keys(downstream_partitions_def, ["2022-07-04", "2022-07-05"]),
         upstream_partitions_def,
-    ).get_partition_keys() == ["2022-07-03", "2022-07-04", "2022-07-05"]
+    ).partitions_subset.get_partition_keys() == ["2022-07-03", "2022-07-04", "2022-07-05"]
 
     assert mapping.get_downstream_partitions_for_partitions(
         subset_with_keys(upstream_partitions_def, ["2022-07-03", "2022-07-04"]),

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_time_window_partition_mapping.py
@@ -265,11 +265,15 @@ def test_daily_to_daily_many_to_one():
     downstream_partitions_def = DailyPartitionsDefinition(start_date="2021-05-06")
     mapping = TimeWindowPartitionMapping(start_offset=-1)
 
-    """
     assert mapping.get_upstream_partitions_for_partitions(
         subset_with_keys(downstream_partitions_def, ["2022-07-04"]), upstream_partitions_def
     ).get_partition_keys() == ["2022-07-03", "2022-07-04"]
-    """
+
+    assert mapping.get_upstream_partitions_for_partitions(
+        subset_with_keys(downstream_partitions_def, ["2022-07-04", "2022-07-05"]),
+        upstream_partitions_def,
+    ).get_partition_keys() == ["2022-07-03", "2022-07-04", "2022-07-05"]
+
     assert mapping.get_downstream_partitions_for_partitions(
         subset_with_keys(upstream_partitions_def, ["2022-07-03", "2022-07-04"]),
         downstream_partitions_def,


### PR DESCRIPTION
## Summary & Motivation

Added test, and it failed. Now it passes

Likely avoided detection as we rarely call `get_downstream_partitions_for_partitions` (basically only in the AutoMaterialize world as far as I'm aware)

## How I Tested These Changes
