### PR TITLE
[ui] Fix run table headers for `hideCreatedBy` case

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/RunTable.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTable.tsx
@@ -156,6 +156,7 @@ export const RunTable = (props: RunTableProps) => {
                 additionalActionsForRun={props.additionalActionsForRun}
                 onToggleChecked={onToggleFactory(run.id)}
                 isHighlighted={highlightedIds && highlightedIds.includes(run.id)}
+                hideCreatedBy={hideCreatedBy}
               />
             ))}
           </tbody>


### PR DESCRIPTION
## Summary & Motivation

The `hideCreatedBy` prop wasn't being passed along to `RunRow`, so `RunTable` usage that should hide that column was instead showing the column.

## How I Tested These Changes

View a schedule with some past runs, verify that the run rows no longer include the "Created by" column.
