### PR TITLE
Fix Button loading prop + topBorder on CustomConfirmationDialog

### DIFF
--- a/js_modules/dagit/packages/core/src/app/CustomConfirmationProvider.tsx
+++ b/js_modules/dagit/packages/core/src/app/CustomConfirmationProvider.tsx
@@ -31,7 +31,7 @@ const ConfirmationDialog: React.FC<ConfirmationDialogProps> = ({
   return (
     <Dialog icon={title ? icon ?? 'info' : icon} onClose={onClose} title={title} isOpen={open}>
       <DialogBody>{description}</DialogBody>
-      <DialogFooter>
+      <DialogFooter topBorder>
         <Button onClick={onClose}>Cancel</Button>
         <Button onClick={onSubmit} intent={intent}>
           {buttonText}

--- a/js_modules/dagit/packages/ui/src/components/Button.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Button.tsx
@@ -96,14 +96,11 @@ export const Button = React.forwardRef(
     const {children, icon, intent, loading, outlined, rightIcon, ...rest} = props;
 
     let iconOrSpinner = icon;
-    let rightIconOrSpinner = rightIcon;
+    const rightIconOrSpinner = rightIcon;
 
     if (loading) {
       const spinnerColor = intentToSpinnerColor(intent, outlined);
-      iconOrSpinner = rightIcon ? icon : <Spinner purpose="body-text" fillColor={spinnerColor} />;
-      rightIconOrSpinner = rightIcon ? (
-        <Spinner purpose="body-text" fillColor={spinnerColor} />
-      ) : null;
+      iconOrSpinner = <Spinner purpose="body-text" fillColor={spinnerColor} />;
     }
 
     return (

--- a/js_modules/dagit/packages/ui/src/components/Button.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Button.tsx
@@ -100,9 +100,10 @@ export const Button = React.forwardRef(
 
     if (loading) {
       const spinnerColor = intentToSpinnerColor(intent, outlined);
-      iconOrSpinner = icon ? <Spinner purpose="body-text" fillColor={spinnerColor} /> : icon;
-      rightIconOrSpinner =
-        rightIcon && !icon ? <Spinner purpose="body-text" fillColor={spinnerColor} /> : rightIcon;
+      iconOrSpinner = rightIcon ? null : <Spinner purpose="body-text" fillColor={spinnerColor} />;
+      rightIconOrSpinner = rightIcon ? (
+        <Spinner purpose="body-text" fillColor={spinnerColor} />
+      ) : null;
     }
 
     return (

--- a/js_modules/dagit/packages/ui/src/components/Button.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Button.tsx
@@ -100,7 +100,7 @@ export const Button = React.forwardRef(
 
     if (loading) {
       const spinnerColor = intentToSpinnerColor(intent, outlined);
-      iconOrSpinner = rightIcon ? null : <Spinner purpose="body-text" fillColor={spinnerColor} />;
+      iconOrSpinner = rightIcon ? icon : <Spinner purpose="body-text" fillColor={spinnerColor} />;
       rightIconOrSpinner = rightIcon ? (
         <Spinner purpose="body-text" fillColor={spinnerColor} />
       ) : null;

--- a/js_modules/dagit/packages/ui/src/components/Button.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Button.tsx
@@ -96,7 +96,6 @@ export const Button = React.forwardRef(
     const {children, icon, intent, loading, outlined, rightIcon, ...rest} = props;
 
     let iconOrSpinner = icon;
-    const rightIconOrSpinner = rightIcon;
 
     if (loading) {
       const spinnerColor = intentToSpinnerColor(intent, outlined);
@@ -107,7 +106,7 @@ export const Button = React.forwardRef(
       <BaseButton
         {...rest}
         icon={iconOrSpinner}
-        rightIcon={rightIconOrSpinner}
+        rightIcon={rightIcon}
         loading={loading}
         fillColor={intentToFillColor(intent, outlined)}
         textColor={intentToTextColor(intent, outlined)}

--- a/js_modules/dagit/packages/ui/src/components/__stories__/Button.stories.tsx
+++ b/js_modules/dagit/packages/ui/src/components/__stories__/Button.stories.tsx
@@ -1,6 +1,7 @@
 import {Meta} from '@storybook/react';
 import * as React from 'react';
 
+import {Box} from '../Box';
 import {Button, JoinedButtons} from '../Button';
 import {Group} from '../Group';
 import {Icon} from '../Icon';
@@ -170,3 +171,19 @@ export const Joined = () => {
     </Group>
   );
 };
+
+export function LoadingStates() {
+  return (
+    <Box flex={{direction: 'row', gap: 12}}>
+      <Button loading={true} icon={<Icon name="wysiwyg" />}>
+        Test
+      </Button>
+      <Button loading={true} icon={<Icon name="close" />} rightIcon={<Icon name="cached" />}>
+        Test
+      </Button>
+      <Button loading={true} rightIcon={<Icon name="wysiwyg" />}>
+        Test
+      </Button>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary & Motivation
fix button `loading` prop

## How I Tested These Changes

storybook:
<img width="360" alt="Screen Shot 2023-06-23 at 11 08 28 AM" src="https://github.com/dagster-io/dagster/assets/2286579/fcb5e85a-6cbc-4429-87b1-d749ae6e9d9d">
