### PR TITLE
[dagster-dbt] fix failing tests

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_selection.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_selection.py
@@ -5,6 +5,7 @@ import dagster._check as check
 from dagster import AssetKey, AssetSelection
 from dagster._annotations import experimental
 from dagster._core.definitions.asset_graph import AssetGraph
+from dagster._utils.backcompat import deprecation_warning
 
 from dagster_dbt.asset_utils import (
     default_asset_key_fn,
@@ -90,6 +91,10 @@ class DbtManifestAssetSelection(AssetSelection):
 
         self.state_path = check.opt_str_param(state_path, "state_path")
         if self.state_path:
+            deprecation_warning(
+                "The state_path argument to DbtManifestAssetSelection",
+                "1.4.0",
+            )
             check.param_invariant(
                 self.manifest_json_path is not None,
                 "state_path",

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_resources.py
@@ -50,10 +50,22 @@ def test_ls(test_project_dir, dbt_config_dir):
 
     context = get_dbt_solid_context(test_project_dir, dbt_config_dir)
     dbt_result = my_dbt_solid(context)
-    # slightly different output formats between dbt versions result in raw log output shifting
-    expected_results = 25
-    raw_lines = len(dbt_result.raw_output.split("\n\n"))
-    assert raw_lines == expected_results or raw_lines == expected_results + 2
+    for expected_element in [
+        "ephem1",
+        "ephem2",
+        "subdir.least_caloric",
+        "sort_by_calories",
+        "sort_cold_cereals_by_calories",
+        "sort_hot_cereals_by_calories",
+        # snapshot
+        "sort_snapshot.orders_snapshot",
+        # tests
+        "accepted_values_sort_by_calories_type__H__C",
+        "not_null_sort_by_calories_carbo",
+    ]:
+        assert (
+            f"dagster_dbt_test_project.{expected_element}" in dbt_result.raw_output
+        ), dbt_result.raw_output
 
 
 def test_ls_resource_type(test_project_dir, dbt_config_dir):
@@ -63,10 +75,21 @@ def test_ls_resource_type(test_project_dir, dbt_config_dir):
 
     context = get_dbt_solid_context(test_project_dir, dbt_config_dir)
     dbt_result = my_dbt_solid(context)
-    # slightly different output formats between dbt versions result in raw log output shifting
-    expected_results = 6
-    raw_lines = len(dbt_result.raw_output.split("\n\n"))
-    assert raw_lines == expected_results or raw_lines == expected_results + 2
+    for expected_element in [
+        "ephem1",
+        "ephem2",
+        "subdir.least_caloric",
+        "sort_by_calories",
+        "sort_cold_cereals_by_calories",
+        "sort_hot_cereals_by_calories",
+    ]:
+        assert (
+            f"dagster_dbt_test_project.{expected_element}" in dbt_result.raw_output
+        ), dbt_result.raw_output
+
+    # should not include snapshots or tests
+    assert "dagster_dbt_test_project.sort_snapshot.orders_snapshot" not in dbt_result.raw_output
+    assert "dagster_dbt_test_project.not_null_sort_by_calories_carbo" not in dbt_result.raw_output
 
 
 def test_test(dbt_seed, test_project_dir, dbt_config_dir):

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_selection.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_selection.py
@@ -101,6 +101,7 @@ def test_dbt_asset_selection(select, exclude, expected_asset_names):
     assert expected_keys == actual_keys
 
 
+@pytest.mark.skip("Using state with the DbtManifestAssetSelection is deprecated")
 def test_dbt_asset_selection_with_state():
     """Changes from previous state to sample_manifest.json.
 

--- a/python_modules/libraries/dagster-dbt/tox.ini
+++ b/python_modules/libraries/dagster-dbt/tox.ini
@@ -12,8 +12,8 @@ deps =
   dbt_13X: dbt-duckdb==1.3.*
   dbt_14X: dbt-core==1.4.*
   dbt_14X: dbt-duckdb==1.4.*
-  dbt_15X: dbt-core<=1.5.1
-  dbt_15X: dbt-duckdb<=1.5.1
+  dbt_15X: dbt-core==1.5.*
+  dbt_15X: dbt-duckdb==1.5.*
   -e .[test]
 allowlist_externals =
   /bin/bash


### PR DESCRIPTION
## Summary & Motivation

Followup to the pinning required for dbt-core==1.5.2

Three things:

0. Unpin the dependencies
1. Deprecate the use of the state parameter in DbtManifestAssetSelection (this is experimental, and we don't have high confidence that supporting state like this is a good idea)
2. Update the test_ls* tests to be less brittle. We don't have a consistent structured format to compare against (and different versions would end up producing different numbers of lines), so instead we just do a spot check that all the things we expect to be in the output are, and that nothing we don't expect to be in the output is.

## How I Tested These Changes
