### PR TITLE
Gracefully handle unloadable code locations in asset backfill logic

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import time
 from typing import List, Optional, Tuple, cast
@@ -239,7 +240,11 @@ def _execute_backfill_iteration_with_side_effects(graphql_context, backfill_id):
     """
     with get_workspace_process_context(graphql_context.instance) as context:
         backfill = graphql_context.instance.get_backfill(backfill_id)
-        list(execute_asset_backfill_iteration(backfill, context, graphql_context.instance))
+        list(
+            execute_asset_backfill_iteration(
+                backfill, logging.getLogger("fake_logger"), context, graphql_context.instance
+            )
+        )
 
 
 def _mock_asset_backfill_runs(

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
@@ -7,7 +7,6 @@ from dagster._core.definitions.partition import (
     PartitionsSubset,
 )
 from dagster._core.errors import (
-    DagsterAssetBackfillDataLoadError,
     DagsterDefinitionChangedDeserializationError,
 )
 from dagster._core.instance import DynamicPartitionsStore
@@ -210,10 +209,8 @@ class AssetGraphSubset:
             asset_key = AssetKey.from_user_string(key)
 
             if asset_key not in asset_graph.all_asset_keys:
-                raise DagsterAssetBackfillDataLoadError(
-                    f"Asset {key} does not exist. This error may occur when (1) the asset's code"
-                    " location is unloadable or (2) the asset has been removed. When (1) occurs,"
-                    " review the backfill daemon logs to see which code locations are unloadable."
+                raise DagsterDefinitionChangedDeserializationError(
+                    f"Asset {key} existed at storage-time, but no longer does"
                 )
 
             partitions_def = asset_graph.get_partitions_def(asset_key)

--- a/python_modules/dagster/dagster/_core/errors.py
+++ b/python_modules/dagster/dagster/_core/errors.py
@@ -665,7 +665,14 @@ class DagsterUndefinedDataVersionError(DagsterError):
     """
 
 
-class DagsterDefinitionChangedDeserializationError(DagsterError):
+class DagsterAssetBackfillDataLoadError(DagsterError):
+    """Indicates that an asset backfill is now unloadable. May happen when (1) a code location containing
+    targeted assets is unloadable or (2) and asset or an asset's partitions definition has been removed.
+    When (1) occurs, review the backfill daemon logs to see which code locations are unloadable.
+    """
+
+
+class DagsterDefinitionChangedDeserializationError(DagsterAssetBackfillDataLoadError):
     """Indicates that a stored value can't be deserialized because the definition needed to interpret
     it has changed.
     """

--- a/python_modules/dagster/dagster/_core/errors.py
+++ b/python_modules/dagster/dagster/_core/errors.py
@@ -668,11 +668,10 @@ class DagsterUndefinedDataVersionError(DagsterError):
 class DagsterAssetBackfillDataLoadError(DagsterError):
     """Indicates that an asset backfill is now unloadable. May happen when (1) a code location containing
     targeted assets is unloadable or (2) and asset or an asset's partitions definition has been removed.
-    When (1) occurs, review the backfill daemon logs to see which code locations are unloadable.
     """
 
 
-class DagsterDefinitionChangedDeserializationError(DagsterAssetBackfillDataLoadError):
+class DagsterDefinitionChangedDeserializationError(DagsterError):
     """Indicates that a stored value can't be deserialized because the definition needed to interpret
     it has changed.
     """

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -32,7 +32,12 @@ from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
 from dagster._core.definitions.partition import PartitionsSubset
 from dagster._core.definitions.run_request import RunRequest
 from dagster._core.definitions.selector import JobSubsetSelector
-from dagster._core.errors import DagsterBackfillFailedError, DagsterInvariantViolationError
+from dagster._core.errors import (
+    DagsterAssetBackfillDataLoadError,
+    DagsterBackfillFailedError,
+    DagsterDefinitionChangedDeserializationError,
+    DagsterInvariantViolationError,
+)
 from dagster._core.event_api import EventRecordsFilter
 from dagster._core.events import DagsterEventType
 from dagster._core.host_representation import (
@@ -420,11 +425,12 @@ def fetch_cancelable_run_ids_for_asset_backfill(instance: DagsterInstance, backf
     return [run.run_id for run in backfill_runs if run.status in CANCELABLE_RUN_STATUSES]
 
 
-def _check_workspace_is_loadable(context: IWorkspace, logger: logging.Logger) -> None:
+def _get_unloadable_location_names(context: IWorkspace, logger: logging.Logger) -> Sequence[str]:
     location_entries_by_name = {
         location_entry.origin.location_name: location_entry
         for location_entry in context.get_workspace_snapshot().values()
     }
+    unloadable_location_names = []
 
     for location_name, location_entry in location_entries_by_name.items():
         if location_entry.load_error:
@@ -432,6 +438,9 @@ def _check_workspace_is_loadable(context: IWorkspace, logger: logging.Logger) ->
                 f"Failure loading location {location_name} due to error:"
                 f" {location_entry.load_error}"
             )
+            unloadable_location_names.append(location_name)
+
+    return unloadable_location_names
 
 
 def execute_asset_backfill_iteration(
@@ -449,15 +458,25 @@ def execute_asset_backfill_iteration(
     from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
 
     workspace_context = workspace_process_context.create_request_context()
-    _check_workspace_is_loadable(workspace_context, logger)
+    unloadable_locations = _get_unloadable_location_names(workspace_context, logger)
     asset_graph = ExternalAssetGraph.from_workspace(workspace_context)
 
     if backfill.serialized_asset_backfill_data is None:
         check.failed("Asset backfill missing serialized_asset_backfill_data")
 
-    asset_backfill_data = AssetBackfillData.from_serialized(
-        backfill.serialized_asset_backfill_data, asset_graph, backfill.backfill_timestamp
-    )
+    try:
+        asset_backfill_data = AssetBackfillData.from_serialized(
+            backfill.serialized_asset_backfill_data, asset_graph, backfill.backfill_timestamp
+        )
+    except DagsterDefinitionChangedDeserializationError as ex:
+        unloadable_locations_error = (
+            "This could be because it's inside a code location that's failing to load:"
+            f" {unloadable_locations}"
+            if unloadable_locations
+            else ""
+        )
+        raise DagsterAssetBackfillDataLoadError(f"{str(ex)}. {unloadable_locations_error}")
+
     backfill_start_time = utc_datetime_from_timestamp(backfill.backfill_timestamp)
 
     instance_queryer = CachingInstanceQueryer(

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -7,7 +7,7 @@ from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
 from dagster._core.definitions.partition import PartitionsSubset
 from dagster._core.errors import (
-    DagsterDefinitionChangedDeserializationError,
+    DagsterAssetBackfillDataLoadError,
 )
 from dagster._core.execution.bulk_actions import BulkActionType
 from dagster._core.host_representation.origin import ExternalPartitionSetOrigin
@@ -156,7 +156,7 @@ class PartitionBackfill(
                     ExternalAssetGraph.from_workspace(workspace),
                     self.backfill_timestamp,
                 )
-            except DagsterDefinitionChangedDeserializationError:
+            except DagsterAssetBackfillDataLoadError:
                 return []
 
             return asset_backfill_data.get_backfill_status_per_asset_key()
@@ -176,7 +176,7 @@ class PartitionBackfill(
                     ExternalAssetGraph.from_workspace(workspace),
                     self.backfill_timestamp,
                 )
-            except DagsterDefinitionChangedDeserializationError:
+            except DagsterAssetBackfillDataLoadError:
                 return None
 
             return asset_backfill_data.get_target_root_partitions_subset()
@@ -194,7 +194,7 @@ class PartitionBackfill(
                     ExternalAssetGraph.from_workspace(workspace),
                     self.backfill_timestamp,
                 )
-            except DagsterDefinitionChangedDeserializationError:
+            except DagsterAssetBackfillDataLoadError:
                 return 0
 
             return asset_backfill_data.get_num_partitions()
@@ -215,7 +215,7 @@ class PartitionBackfill(
                     ExternalAssetGraph.from_workspace(workspace),
                     self.backfill_timestamp,
                 )
-            except DagsterDefinitionChangedDeserializationError:
+            except DagsterAssetBackfillDataLoadError:
                 return None
 
             return asset_backfill_data.get_partition_names()

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -6,9 +6,7 @@ from dagster._core.definitions import AssetKey
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
 from dagster._core.definitions.partition import PartitionsSubset
-from dagster._core.errors import (
-    DagsterAssetBackfillDataLoadError,
-)
+from dagster._core.errors import DagsterDefinitionChangedDeserializationError
 from dagster._core.execution.bulk_actions import BulkActionType
 from dagster._core.host_representation.origin import ExternalPartitionSetOrigin
 from dagster._core.instance import DynamicPartitionsStore
@@ -156,7 +154,7 @@ class PartitionBackfill(
                     ExternalAssetGraph.from_workspace(workspace),
                     self.backfill_timestamp,
                 )
-            except DagsterAssetBackfillDataLoadError:
+            except DagsterDefinitionChangedDeserializationError:
                 return []
 
             return asset_backfill_data.get_backfill_status_per_asset_key()
@@ -176,7 +174,7 @@ class PartitionBackfill(
                     ExternalAssetGraph.from_workspace(workspace),
                     self.backfill_timestamp,
                 )
-            except DagsterAssetBackfillDataLoadError:
+            except DagsterDefinitionChangedDeserializationError:
                 return None
 
             return asset_backfill_data.get_target_root_partitions_subset()
@@ -194,7 +192,7 @@ class PartitionBackfill(
                     ExternalAssetGraph.from_workspace(workspace),
                     self.backfill_timestamp,
                 )
-            except DagsterAssetBackfillDataLoadError:
+            except DagsterDefinitionChangedDeserializationError:
                 return 0
 
             return asset_backfill_data.get_num_partitions()
@@ -215,7 +213,7 @@ class PartitionBackfill(
                     ExternalAssetGraph.from_workspace(workspace),
                     self.backfill_timestamp,
                 )
-            except DagsterAssetBackfillDataLoadError:
+            except DagsterDefinitionChangedDeserializationError:
                 return None
 
             return asset_backfill_data.get_partition_names()

--- a/python_modules/dagster/dagster/_daemon/backfill.py
+++ b/python_modules/dagster/dagster/_daemon/backfill.py
@@ -32,7 +32,7 @@ def execute_backfill_iteration(
         try:
             if backfill.is_asset_backfill:
                 yield from execute_asset_backfill_iteration(
-                    backfill, workspace_process_context, instance
+                    backfill, logger, workspace_process_context, instance
                 )
             else:
                 yield from execute_job_backfill_iteration(

--- a/python_modules/dagster/dagster_tests/daemon_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/conftest.py
@@ -74,3 +74,29 @@ def loadable_target_origin(attribute: Optional[str] = None) -> LoadableTargetOri
         working_directory=os.getcwd(),
         attribute=attribute,
     )
+
+
+def unloadable_target_origin(attribute: Optional[str] = None) -> LoadableTargetOrigin:
+    return LoadableTargetOrigin(
+        executable_path=sys.executable,
+        module_name="dagster_tests.daemon_tests.test_locations.unloadable_location",
+        working_directory=os.getcwd(),
+        attribute=attribute,
+    )
+
+
+def invalid_workspace_load_target(attribute=None):
+    return InProcessTestWorkspaceLoadTarget(
+        InProcessCodeLocationOrigin(
+            loadable_target_origin=unloadable_target_origin(attribute=attribute),
+            location_name="unloadable",
+        )
+    )
+
+
+@pytest.fixture(name="unloadable_location_workspace_context", scope="module")
+def unloadable_location_fixture(instance_module_scoped) -> Iterator[WorkspaceProcessContext]:
+    with create_test_daemon_workspace_context(
+        workspace_load_target=invalid_workspace_load_target(), instance=instance_module_scoped
+    ) as workspace_context:
+        yield workspace_context

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -959,7 +959,9 @@ def test_error_code_location(
 
     assert len(errors) == 1
     assert (
-        "dagster._core.errors.DagsterAssetBackfillDataLoadError: Asset asset_a does not exist."
+        "dagster._core.errors.DagsterAssetBackfillDataLoadError: Asset asset_a existed at"
+        " storage-time, but no longer does. This could be because it's inside a code location"
+        " that's failing to load"
         in errors[0].message
     )
     assert "Failure loading location" in caplog.text

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_locations/unloadable_location.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_locations/unloadable_location.py
@@ -1,0 +1,22 @@
+from dagster import (
+    AssetIn,
+    DailyPartitionsDefinition,
+    Definitions,
+    TimeWindowPartitionMapping,
+    asset,
+)
+
+
+@asset(
+    partitions_def=DailyPartitionsDefinition("2023-01-01"),
+    ins={
+        "error_def_asset": AssetIn(
+            partition_mapping=TimeWindowPartitionMapping(start_offset=-1, end_offset=-1)
+        )
+    },
+)
+def error_def_asset():  # missing error_def_asset param
+    return 1
+
+
+defs = Definitions([error_def_asset])


### PR DESCRIPTION
Certain users are sometimes seeing a mysterious asset backfill deserialization error:
```
2023-06-23 14:45:18 -0700 - dagster.daemon.BackfillDaemon - ERROR - Backfill failed for dummy_backfill: dagster._core.errors.DagsterDefinitionChangedDeserializationError: Asset asset_a had a PartitionsDefinition at storage-time, but no longer does
```

This error can occur in a variety of situations:
- the code location is no longer loadable (i.e. the location now has a definition-time error, or some gRPC error)
- the asset no longer exists in the workspace
- the asset's partitions def has been removed

This PR clarifies the error messaging to be more informative. Now we:
- raise warnings when some code locations cannot load, like we do in the scheduler and sensor daemons. By raising a warning instead of an exception, we allow backfill with loadable code locations to proceed.
- raise a more informative error when a targeted asset does not exist in the workspace

