### PR TITLE
[asset-jobs] Correctly pass resources for hooks into jobs build with define_asset_job

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets_job.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets_job.py
@@ -211,9 +211,7 @@ def build_assets_job(
         graph, assets_defs_by_node_handle, resolved_source_assets, resolved_asset_deps
     )
 
-    all_resource_defs = get_all_resource_defs(
-        assets, resolved_source_assets, hooks or set(), wrapped_resource_defs
-    )
+    all_resource_defs = get_all_resource_defs(assets, resolved_source_assets, wrapped_resource_defs)
 
     if _asset_selection_data:
         original_job = _asset_selection_data.parent_job_def
@@ -315,7 +313,7 @@ def build_source_asset_observation_job(
         graph, assets_defs_by_node_handle, source_assets, resolved_asset_deps
     )
 
-    all_resource_defs = get_all_resource_defs(assets, source_assets, hooks or set(), resource_defs)
+    all_resource_defs = get_all_resource_defs(assets, source_assets, resource_defs)
 
     if _asset_selection_data:
         original_job = _asset_selection_data.parent_job_def
@@ -571,7 +569,6 @@ def _ensure_resources_dont_conflict(
 def check_resources_satisfy_requirements(
     assets: Iterable[AssetsDefinition],
     source_assets: Sequence[SourceAsset],
-    hooks: AbstractSet[HookDefinition],
     resource_defs: Mapping[str, ResourceDefinition],
 ) -> None:
     """Ensures that between the provided resources on an asset and the resource_defs mapping, that all resource requirements are satisfied.
@@ -585,18 +582,15 @@ def check_resources_satisfy_requirements(
         ensure_requirements_satisfied(
             merge_dicts(resource_defs, asset.resource_defs), list(asset.get_resource_requirements())
         )
-    for hook in hooks:
-        ensure_requirements_satisfied(resource_defs, list(hook.get_resource_requirements()))
 
 
 def get_all_resource_defs(
     assets: Iterable[AssetsDefinition],
     source_assets: Sequence[SourceAsset],
-    hooks: AbstractSet[HookDefinition],
     resource_defs: Mapping[str, ResourceDefinition],
 ) -> Mapping[str, ResourceDefinition]:
     # Ensures that no resource keys conflict, and each asset has its resource requirements satisfied.
-    check_resources_satisfy_requirements(assets, source_assets, hooks, resource_defs)
+    check_resources_satisfy_requirements(assets, source_assets, resource_defs)
 
     all_resource_defs = dict(resource_defs)
     all_assets: Sequence[Union[AssetsDefinition, SourceAsset]] = [*assets, *source_assets]

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
@@ -186,7 +186,7 @@ def build_caching_repository_data_from_list(
             assets=assets_defs,
             source_assets=source_assets,
             executor_def=default_executor_def,
-            resource_defs={},  # ????
+            resource_defs=top_level_resources,
         ):
             jobs[job_def.name] = job_def
 
@@ -230,7 +230,9 @@ def build_caching_repository_data_from_list(
     if unresolved_jobs:
         for name, unresolved_job_def in unresolved_jobs.items():
             resolved_job = unresolved_job_def.resolve(
-                asset_graph=asset_graph, default_executor_def=default_executor_def
+                asset_graph=asset_graph,
+                default_executor_def=default_executor_def,
+                resource_defs=top_level_resources,
             )
             jobs[name] = resolved_job
 

--- a/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
         JobDefinition,
         PartitionedConfig,
         PartitionsDefinition,
+        ResourceDefinition,
         SourceAsset,
     )
     from dagster._core.definitions.asset_graph import InternalAssetGraph
@@ -169,7 +170,7 @@ class UnresolvedAssetJobDefinition(
         source_assets: Optional[Sequence["SourceAsset"]] = None,
         default_executor_def: Optional["ExecutorDefinition"] = None,
         asset_graph: Optional["InternalAssetGraph"] = None,
-        resource_defs=None,
+        resource_defs: Optional[Mapping[str, "ResourceDefinition"]] = None,
     ) -> "JobDefinition":
         """Resolve this UnresolvedAssetJobDefinition into a JobDefinition.
 

--- a/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
@@ -169,6 +169,7 @@ class UnresolvedAssetJobDefinition(
         source_assets: Optional[Sequence["SourceAsset"]] = None,
         default_executor_def: Optional["ExecutorDefinition"] = None,
         asset_graph: Optional["InternalAssetGraph"] = None,
+        resource_defs=None,
     ) -> "JobDefinition":
         """Resolve this UnresolvedAssetJobDefinition into a JobDefinition.
 
@@ -244,6 +245,7 @@ class UnresolvedAssetJobDefinition(
             partitions_def=self.partitions_def if self.partitions_def else inferred_partitions_def,
             executor_def=self.executor_def or default_executor_def,
             hooks=self.hooks,
+            resource_defs=resource_defs,
         )
 
 


### PR DESCRIPTION
## Summary & Motivation

As stated in the title -- before, we relied on the fact that assets already have their resources bound to them, meaning they didn't need any additional resources passed in. With hooks, they don't have resources bound to them so we need to pass in the top level resources

## How I Tested These Changes

Added test failed before, passes now