### PR TITLE
Support @asset(key=...) and AssetKey(...).with_prefix(...)

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -37,7 +37,7 @@ from ..asset_out import AssetOut
 from ..assets import AssetsDefinition
 from ..decorators.graph_decorator import graph
 from ..decorators.op_decorator import _Op
-from ..events import AssetKey, CoercibleToAssetKeyPrefix
+from ..events import AssetKey, CoercibleToAssetKey, CoercibleToAssetKeyPrefix
 from ..input import In
 from ..output import GraphOut, Out
 from ..partition import PartitionsDefinition
@@ -77,6 +77,7 @@ def asset(
     auto_materialize_policy: Optional[AutoMaterializePolicy] = ...,
     retry_policy: Optional[RetryPolicy] = ...,
     code_version: Optional[str] = ...,
+    key: Optional[CoercibleToAssetKey] = None,
 ) -> Callable[[Callable[..., Any]], AssetsDefinition]:
     ...
 
@@ -105,6 +106,7 @@ def asset(
     auto_materialize_policy: Optional[AutoMaterializePolicy] = None,
     retry_policy: Optional[RetryPolicy] = None,
     code_version: Optional[str] = None,
+    key: Optional[CoercibleToAssetKey] = None,
 ) -> Union[AssetsDefinition, Callable[[Callable[..., Any]], AssetsDefinition]]:
     """Create a definition for how to compute an asset.
 
@@ -202,6 +204,7 @@ def asset(
             auto_materialize_policy=auto_materialize_policy,
             retry_policy=retry_policy,
             code_version=code_version,
+            key=key,
         )
 
     if compute_fn is not None:
@@ -253,6 +256,7 @@ class _Asset:
         auto_materialize_policy: Optional[AutoMaterializePolicy] = None,
         retry_policy: Optional[RetryPolicy] = None,
         code_version: Optional[str] = None,
+        key: Optional[CoercibleToAssetKey] = None,
     ):
         self.name = name
 
@@ -281,6 +285,14 @@ class _Asset:
         self.auto_materialize_policy = auto_materialize_policy
         self.code_version = code_version
 
+        if (name or key_prefix) and key:
+            raise DagsterInvalidDefinitionError(
+                "Cannot specify a name or key prefix for an asset when the key argument is"
+                " provided."
+            )
+
+        self.key = AssetKey.from_coercible(key) if key is not None else None
+
     def __call__(self, fn: Callable) -> AssetsDefinition:
         from dagster._config.pythonic_config import (
             validate_resource_annotated_function,
@@ -292,7 +304,11 @@ class _Asset:
 
         asset_ins = build_asset_ins(fn, self.ins or {}, self.non_argument_deps)
 
-        out_asset_key = AssetKey(list(filter(None, [*(self.key_prefix or []), asset_name])))
+        out_asset_key = (
+            AssetKey(list(filter(None, [*(self.key_prefix or []), asset_name])))
+            if not self.key
+            else self.key
+        )
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=ExperimentalWarning)
 

--- a/python_modules/dagster/dagster/_core/definitions/events.py
+++ b/python_modules/dagster/dagster/_core/definitions/events.py
@@ -176,6 +176,10 @@ class AssetKey(NamedTuple("_AssetKey", [("path", PublicAttr[Sequence[str]])])):
     def has_prefix(self, prefix: Sequence[str]) -> bool:
         return len(self.path) >= len(prefix) and self.path[: len(prefix)] == prefix
 
+    def with_prefix(self, prefix: "CoercibleToAssetKeyPrefix") -> "AssetKey":
+        prefix = key_prefix_from_coercible(prefix)
+        return AssetKey(list(prefix) + list(self.path))
+
 
 class AssetKeyPartitionKey(NamedTuple):
     """An AssetKey with an (optional) partition key. Refers either to a non-partitioned asset or a

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -1476,3 +1476,13 @@ def test_asset_takes_bare_resource():
     defs = Definitions(assets=[blah])
     defs.get_implicit_global_asset_job_def().execute_in_process()
     assert executed["yes"]
+
+
+def test_asset_key_with_prefix():
+    assert AssetKey("foo").with_prefix("prefix") == AssetKey(["prefix", "foo"])
+    assert AssetKey("foo").with_prefix(["prefix_one", "prefix_two"]) == AssetKey(
+        ["prefix_one", "prefix_two", "foo"]
+    )
+
+    with pytest.raises(CheckError):
+        AssetKey("foo").with_prefix(1)

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
@@ -1124,3 +1124,52 @@ def test_multi_asset_with_auto_materialize_policy():
         AssetKey("o2"): AutoMaterializePolicy.eager(),
         AssetKey("o3"): AutoMaterializePolicy.lazy(),
     }
+
+
+@pytest.mark.parametrize(
+    "key,expected_key",
+    [
+        (
+            AssetKey(["this", "is", "a", "prefix", "the_asset"]),
+            AssetKey(["this", "is", "a", "prefix", "the_asset"]),
+        ),
+        ("the_asset", AssetKey(["the_asset"])),
+        (["prefix", "the_asset"], AssetKey(["prefix", "the_asset"])),
+        (("prefix", "the_asset"), AssetKey(["prefix", "the_asset"])),
+    ],
+)
+def test_asset_key_provided(key, expected_key):
+    @asset(key=key)
+    def foo():
+        return 1
+
+    assert foo.key == expected_key
+
+
+def test_error_on_asset_key_provided():
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match="key argument is provided",
+    ):
+
+        @asset(key="the_asset", key_prefix="foo")
+        def one():
+            ...
+
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match="key argument is provided",
+    ):
+
+        @asset(key="the_asset", name="foo")
+        def two():
+            ...
+
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match="key argument is provided",
+    ):
+
+        @asset(key="the_asset", name="foo", key_prefix="bar")
+        def three():
+            ...


### PR DESCRIPTION
This PR enables two new asset key behaviors in order to support dbt dependencies work.

**Defining an asset key via `@asset(key=["prefix", "name"])`**
- This will support defining assets upstream of dbt assets by doing something like `@asset(key=manifest.get_asset_key_for_source("raw_data")`
- This is more straightforward than `@asset(name="name", prefix="prefix")`.

**Adds a `with_prefix(...)` method to `AssetKey`**
- This will support dbt behaviors like `AssetIn(key=manifest.get_asset_key_for_model(...).with_prefix("prefix"))`. Currently we throw an error when both a key and a key prefix are provided.

Adds tests for these two new functionalities.

