### PR TITLE
[dagster-dbt] use deep_merge_dicts to merge "vars" correctly

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources.py
@@ -5,7 +5,7 @@ from dagster import resource
 from dagster._annotations import public
 from dagster._config.pythonic_config import ConfigurableResource, IAttachDifferentObjectToOpContext
 from dagster._core.definitions.resource_definition import dagster_maintained_resource
-from dagster._utils.merger import merge_dicts
+from dagster._utils.merger import deep_merge_dicts
 from pydantic import Field
 
 from ..dbt_resource import DbtClient
@@ -184,7 +184,7 @@ class DbtCliClient(DbtClient):
             if not (k in self.strict_flags and k not in extra_flags)
         }
 
-        return merge_dicts(
+        return deep_merge_dicts(
             default_flags, self._format_params(extra_flags, replace_underscores=True)
         )
 


### PR DESCRIPTION
## Summary & Motivation

Consider the following example:
```python
from dagster import file_relative_path, materialize, DailyPartitionsDefinition
from dagster_dbt import load_assets_from_dbt_project, DbtCliClientResource

DBT_PROJECT_PATH = file_relative_path(__file__, "../my_dbt_project")
DBT_PROFILES_PATH = file_relative_path(__file__, "../my_dbt_project/config")

dbt_assets = load_assets_from_dbt_project(
    project_dir=DBT_PROJECT_PATH,
    profiles_dir=DBT_PROFILES_PATH,
    partitions_def=DailyPartitionsDefinition("2023-06-23"),
    partition_key_to_vars_fn=lambda x: ({"run_date": x}),
)
materialize(
    dbt_assets,
    partition_key="2023-06-23",
    resources={
        "dbt": DbtCliClientResource(
            project_dir=DBT_PROJECT_PATH,
            profiles_dir=DBT_PROFILES_PATH,
            vars={"my_var": "hello"},
        ),
    },
)
```
We have set the resource level configuration equivalent to the dbt cli flag `--vars '{"my_var": "hello"}'`. We expect that the `run_date` property provided by `partition_key_to_vars_fn` will be **added** to this configuration. Unfortunately, in the current implementation, the `vars` property itself is **overwritten** by the return value of `partition_key_to_vars_fn`.

### Actual behavior

This behavior can also be observed in the runtime log output of dagster.

```py
Executing command: dbt --no-use-colors --log-format json run
  --project-dir /workspaces/my_dbt_project
  --profiles-dir /workspaces/my_dbt_project/config
  --vars {"run_date": "2023-06-23"}
```

The `my_var` property has completely disappeared...😢 

### Expected behavior

```py
Executing command: dbt --no-use-colors --log-format json run
  --project-dir /workspaces/my_dbt_project
  --profiles-dir /workspaces/my_dbt_project/config
  --vars {"my_var": "hello", "run_date": "2023-06-23"}
```
I have identified the use of `merge_dicts` at the following code as the root cause:
https://github.com/dagster-io/dagster/blob/13ea0a8ca77ea11071b5955b9de6d563591b2663/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources.py#L187-L189

## How I Tested These Changes

I have modified the python package `dagster_dbt` locally and run the above sample code to verify that it behaves as expected.

Thanks:)