### PR TITLE
[docs] - Add Dagster IPs to serverless docs

### DIFF
--- a/docs/content/dagster-cloud/deployment/serverless.mdx
+++ b/docs/content/dagster-cloud/deployment/serverless.mdx
@@ -297,6 +297,32 @@ Unlike Hybrid, Serverless Deployments on Dagster Cloud require direct access to 
 
 ---
 
+## Whitelisting Dagster's IP addresses
+
+To communicate with Dagster Cloud, you may need to whitelist the following static IP addresses:
+
+```plain
+34.216.9.66
+35.162.181.243
+35.83.14.215
+44.230.239.14
+44.240.64.133
+52.34.41.163
+52.36.97.173
+52.37.188.218
+52.38.102.213
+52.39.253.102
+52.40.171.60
+52.89.191.177
+54.201.195.80
+54.68.25.27
+54.71.18.84
+```
+
+**Note**: Additional IP addresses may be added over time. This list was last updated on **June 26, 2023.**
+
+---
+
 ## Run isolation
 
 Dagster Cloud Serverless offers two settings for run isolation: isolated and non-isolated. Non-isolated runs are for iterating quickly and trade off isolation for speed. Isolated runs are for production and compute heavy Assets/Jobs.


### PR DESCRIPTION
## Summary & Motivation

This PR adds Dagster's static IP addresses to the Cloud Serverless docs.

## How I Tested These Changes

:eyes:, local
