### PR TITLE
add indirect execution context access

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -1,4 +1,6 @@
 from abc import ABC, ABCMeta, abstractmethod
+from contextlib import contextmanager
+from contextvars import ContextVar
 from inspect import _empty as EmptyAnnotation
 from typing import (
     AbstractSet,
@@ -48,6 +50,7 @@ from dagster._core.events import DagsterEvent
 from dagster._core.instance import DagsterInstance
 from dagster._core.log_manager import DagsterLogManager
 from dagster._core.storage.dagster_run import DagsterRun
+from dagster._utils.cached_method import cached_method
 from dagster._utils.forked_pdb import ForkedPdb
 from dagster._utils.warnings import (
     deprecation_warning,
@@ -1334,15 +1337,34 @@ class OpExecutionContext(AbstractComputeExecutionContext, metaclass=OpExecutionC
     def set_requires_typed_event_stream(self, *, error_message: Optional[str] = None) -> None:
         self._step_execution_context.set_requires_typed_event_stream(error_message=error_message)
 
+    @staticmethod
+    def get() -> "OpExecutionContext":
+        ctx = _current_asset_execution_context.get()
+        if ctx is None:
+            raise DagsterInvariantViolationError("No current OpExecutionContext in scope.")
+        return ctx.get_op_execution_context()
+
 
 class AssetExecutionContext(OpExecutionContext):
     def __init__(self, step_execution_context: StepExecutionContext):
         super().__init__(step_execution_context=step_execution_context)
 
+    @staticmethod
+    def get() -> "AssetExecutionContext":
+        ctx = _current_asset_execution_context.get()
+        if ctx is None:
+            raise DagsterInvariantViolationError("No current AssetExecutionContext in scope.")
+        return ctx
 
-def build_execution_context(
+    @cached_method
+    def get_op_execution_context(self) -> "OpExecutionContext":
+        return OpExecutionContext(self._step_execution_context)
+
+
+@contextmanager
+def enter_execution_context(
     step_context: StepExecutionContext,
-) -> Union[OpExecutionContext, AssetExecutionContext]:
+) -> Iterator[Union[OpExecutionContext, AssetExecutionContext]]:
     """Get the correct context based on the type of step (op or asset) and the user provided context
     type annotation. Follows these rules.
 
@@ -1393,16 +1415,30 @@ def build_execution_context(
             " OpExecutionContext, or left blank."
         )
 
-    if context_annotation is EmptyAnnotation:
-        # if no type hint has been given, default to:
-        # * AssetExecutionContext for sda steps not in graph-backed assets, and asset_checks
-        # * OpExecutionContext for non sda steps
-        # * OpExecutionContext for ops in graph-backed assets
-        if is_asset_check:
-            return AssetExecutionContext(step_context)
-        if is_op_in_graph_asset or not is_sda_step:
-            return OpExecutionContext(step_context)
-        return AssetExecutionContext(step_context)
-    if context_annotation is AssetExecutionContext:
-        return AssetExecutionContext(step_context)
-    return OpExecutionContext(step_context)
+    # Structured assuming upcoming changes to make AssetExecutionContext contain an OpExecutionContext
+    asset_ctx = AssetExecutionContext(step_context)
+    asset_token = _current_asset_execution_context.set(asset_ctx)
+
+    try:
+        if context_annotation is EmptyAnnotation:
+            # if no type hint has been given, default to:
+            # * AssetExecutionContext for sda steps not in graph-backed assets, and asset_checks
+            # * OpExecutionContext for non sda steps
+            # * OpExecutionContext for ops in graph-backed assets
+            if is_asset_check:
+                yield asset_ctx
+            elif is_op_in_graph_asset or not is_sda_step:
+                yield asset_ctx.get_op_execution_context()
+            else:
+                yield asset_ctx
+        elif context_annotation is AssetExecutionContext:
+            yield asset_ctx
+        else:
+            yield asset_ctx.get_op_execution_context()
+    finally:
+        _current_asset_execution_context.reset(asset_token)
+
+
+_current_asset_execution_context: ContextVar[Optional[AssetExecutionContext]] = ContextVar(
+    "_current_asset_execution_context", default=None
+)


### PR DESCRIPTION
adds a means to get the current op/asset execution context via a function call, setup using a `ContextVar`. Exposed as `OpExecutionContext.get()` & `AssetExecutionContext.get()`



## How I Tested These Changes

added test