### PR TITLE
[auto-materialize] Fix off-by-one error

### DIFF
--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -362,8 +362,8 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
             self.get_observation_record(
                 asset_key=observable_source_asset_key,
                 # we're looking for if a new version exists after `after_cursor`, so we need to know
-                # what the version was before `after_cursor`
-                before_cursor=after_cursor,
+                # what the version was at or before `after_cursor`
+                before_cursor=after_cursor + 1,
             )
             # if the after_cursor is None, then no previous version can exist
             if after_cursor is not None

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/asset_reconciliation_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/asset_reconciliation_scenario.py
@@ -2,7 +2,6 @@ import contextlib
 import datetime
 import itertools
 import os
-import random
 import sys
 from typing import (
     AbstractSet,
@@ -476,9 +475,13 @@ def multi_asset_def(
     return _assets
 
 
-def observable_source_asset_def(key: str, changes: bool = True):
+def observable_source_asset_def(key: str, minutes_to_change: int = 0):
     @observable_source_asset(name=key)
     def _observable():
-        return DataVersion(str(random.random())) if changes else DataVersion("the_version")
+        return (
+            DataVersion(str(pendulum.now().minute // minutes_to_change))
+            if minutes_to_change
+            else DataVersion(str(pendulum.now()))
+        )
 
     return _observable

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/observable_source_asset_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/observable_source_asset_scenarios.py
@@ -1,3 +1,5 @@
+import datetime
+
 from dagster import PartitionKeyRange
 from dagster._seven.compat.pendulum import create_pendulum_time
 
@@ -33,7 +35,12 @@ downstream_of_multiple_observable_source_assets = [
 ]
 
 downstream_of_unchanging_observable_source = [
-    observable_source_asset_def("source_asset1", changes=False),
+    observable_source_asset_def("source_asset1", minutes_to_change=10**100),
+    asset_def("asset1", ["source_asset1"]),
+]
+
+downstream_of_slowly_changing_observable_source = [
+    observable_source_asset_def("source_asset1", minutes_to_change=30),
     asset_def("asset1", ["source_asset1"]),
 ]
 
@@ -152,6 +159,30 @@ observable_source_asset_scenarios = {
             expected_run_requests=[run_request(["asset1"])],
         ),
         unevaluated_runs=[],
+        expected_run_requests=[],
+    ),
+    "slowly_changing_observable_many_observations": AssetReconciliationScenario(
+        assets=downstream_of_slowly_changing_observable_source,
+        cursor_from=AssetReconciliationScenario(
+            assets=downstream_of_slowly_changing_observable_source,
+            unevaluated_runs=[
+                # many observations of the same version
+                run(["source_asset1"], is_observation=True),
+                run(["source_asset1"], is_observation=True),
+                run(["source_asset1"], is_observation=True),
+                run(["source_asset1"], is_observation=True),
+                # an observation of a new version
+                run(["source_asset1"], is_observation=True),
+            ],
+            expected_run_requests=[run_request(["asset1"])],
+            current_time=create_pendulum_time(year=2020, month=1, day=1, hour=1),
+            between_runs_delta=datetime.timedelta(minutes=7),
+        ),
+        current_time=create_pendulum_time(year=2020, month=1, day=1, hour=1, minute=45),
+        unevaluated_runs=[
+            # another observation of the second version
+            run(["source_asset1"], is_observation=True),
+        ],
         expected_run_requests=[],
     ),
 }


### PR DESCRIPTION
## Summary & Motivation

This method returns the storage id of the latest record that has a different data version from what we saw last tick (if such a record exists).

Previously, we would compare the latest available record to the latest record that happened _before_ after_cursor (which will be the last storage id from last tick). However, this misses the correct record in cases where the last storage id from last tick is the record that we saw last tick.

This can happen if no materializations or observations occur in between successive observations of the same version.

## How I Tested These Changes
