### PR TITLE
[ui] Show skipped steps as dots at skip-time rather than “unstarted” boxes

### DIFF
--- a/js_modules/dagit/packages/core/src/gantt/GanttChart.tsx
+++ b/js_modules/dagit/packages/core/src/gantt/GanttChart.tsx
@@ -747,7 +747,7 @@ const GanttChartContainer = styled.div`
       border: 1px solid ${Colors.Gray800};
     }
     &.dynamic {
-      filter: brightness(125%);
+      filter: brightness(115%);
     }
 
     ${SpinnerWrapper} {

--- a/js_modules/dagit/packages/core/src/gantt/GanttChartLayout.ts
+++ b/js_modules/dagit/packages/core/src/gantt/GanttChartLayout.ts
@@ -426,9 +426,9 @@ export const adjustLayoutWithRunMetadata = (
     const widthForMs = ({start, end}: {start: number; end?: number}) =>
       Math.max(BOX_DOT_WIDTH_CUTOFF, ((end || nowMs) - start) * scale);
 
-    positionAndSplitBoxes(boxes, metadata, (_box, run) => ({
-      x: run ? xForMs(run.start) : 0,
-      width: run ? widthForMs(run) : BOX_WIDTH,
+    positionAndSplitBoxes(boxes, metadata, (_box, attempt) => ({
+      x: attempt ? xForMs(attempt.start) : 0,
+      width: attempt ? widthForMs(attempt) : BOX_WIDTH,
     }));
 
     positionUntimedBoxes(boxes, xForMs(nowMs) + BOX_SPACING_X);

--- a/js_modules/dagit/packages/core/src/runs/RunMetadataProvider.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunMetadataProvider.tsx
@@ -337,7 +337,18 @@ export function extractMetadataFromLogs(
         attempt.exitState = t.state;
       }
     }
+
+    // If a step is skipped, log an zero-second attempt so that the step is rendered
+    // as a tiny dot on the chart.
+    if (step.transitions.length === 1 && step.state === IStepState.SKIPPED) {
+      step.attempts.push({
+        start: step.transitions[0]!.time,
+        end: step.transitions[0]!.time,
+        exitState: IStepState.SKIPPED,
+      });
+    }
   }
+
   return metadata;
 }
 


### PR DESCRIPTION
## Summary & Motivation

This is a fix for the Gantt chart issue reported in https://github.com/dagster-io/dagster/issues/14898. Right now, Dagit shows skipped boxes and unstarted boxes in the same way -- as gray boxes on the far right of the Gantt timeline.

However, it turns out there are scenarios where a skipped step can have descendant steps that are not skipped. Pushing the box all the way out to the right causes children to be waterfalled out at incorrect times.

This PR updates the rendering of skipped steps so that they appear as dots on the timed Gantt chart at the time they were skipped. In the "untimed" view, they still render as larger gray boxes, which I think is separately useful for debugging.

I also tweaked the brightness of these dynamic ops because it was causing the "running" state to render white instead of purple (too much brightness!)

Before:

(Gray 100px wide boxes push entire graph off to the right)

![image](https://github.com/dagster-io/dagster/assets/1037212/4ced0b36-6731-4a21-a5dc-345555400663)


After:

![image](https://github.com/dagster-io/dagster/assets/1037212/c3a201e5-ac8a-4c2f-8281-5c5b9a9686e1)


Unchanged:

![image](https://github.com/dagster-io/dagster/assets/1037212/dcdf01d8-47c7-4e7a-9d5c-3b0a890c2d2e)


## How I Tested These Changes

I got the repro case debug logs from the user that reported the issue in Slack and was able to verify the fix using dagster debug.