### PR TITLE
[ui] Add experimental feature flag for horizontal asset DAGs

### DIFF
--- a/js_modules/dagit/packages/core/jest/mocks/dagre_layout.worker.ts
+++ b/js_modules/dagit/packages/core/jest/mocks/dagre_layout.worker.ts
@@ -1,11 +1,11 @@
 // eslint-disable-next-line no-restricted-imports
 import {GraphData} from '../../src/asset-graph/Utils';
-import {layoutAssetGraph} from '../../src/asset-graph/layout';
-import {ILayoutOp, layoutOpGraph} from '../../src/graph/layout';
+import {LayoutAssetGraphOptions, layoutAssetGraph} from '../../src/asset-graph/layout';
+import {ILayoutOp, LayoutOpGraphOptions, layoutOpGraph} from '../../src/graph/layout';
 
 type WorkerMessageData =
-  | {type: 'layoutOpGraph'; ops: ILayoutOp[]; parentOp: ILayoutOp}
-  | {type: 'layoutAssetGraph'; graphData: GraphData};
+  | {type: 'layoutOpGraph'; ops: ILayoutOp[]; opts: LayoutOpGraphOptions}
+  | {type: 'layoutAssetGraph'; graphData: GraphData; opts: LayoutAssetGraphOptions};
 
 // eslint-disable-next-line import/no-default-export
 export default class MockWorker {
@@ -14,11 +14,11 @@ export default class MockWorker {
   // mock expects data: { } instead of e: { data: { } }
   postMessage(data: WorkerMessageData) {
     if (data.type === 'layoutOpGraph') {
-      const {ops, parentOp} = data;
-      this.onmessage({data: layoutOpGraph(ops, parentOp)});
+      const {ops, opts} = data;
+      this.onmessage({data: layoutOpGraph(ops, opts)});
     } else if (data.type === 'layoutAssetGraph') {
-      const {graphData} = data;
-      this.onmessage({data: layoutAssetGraph(graphData)});
+      const {graphData, opts} = data;
+      this.onmessage({data: layoutAssetGraph(graphData, opts)});
     }
   }
 }

--- a/js_modules/dagit/packages/core/src/app/Flags.tsx
+++ b/js_modules/dagit/packages/core/src/app/Flags.tsx
@@ -12,6 +12,7 @@ export const FeatureFlag = {
   flagInstanceConcurrencyLimits: 'flagInstanceConcurrencyLimits' as const,
   flagSensorScheduleLogging: 'flagSensorScheduleLogging' as const,
   flagSidebarResources: 'flagSidebarResources' as const,
+  flagHorizontalDAGs: 'flagHorizontalDAGs' as const,
   flagAutoLoadDefaults: 'flagAutoLoadDefaults' as const,
 };
 export type FeatureFlagType = keyof typeof FeatureFlag;

--- a/js_modules/dagit/packages/core/src/app/getVisibleFeatureFlagRows.tsx
+++ b/js_modules/dagit/packages/core/src/app/getVisibleFeatureFlagRows.tsx
@@ -28,4 +28,8 @@ export const getVisibleFeatureFlagRows = () => [
     key: 'Experimental instance-level concurrency limits',
     flagType: FeatureFlag.flagInstanceConcurrencyLimits,
   },
+  {
+    key: 'Experimental horizontal asset DAGs',
+    flagType: FeatureFlag.flagHorizontalDAGs,
+  },
 ];

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
@@ -12,6 +12,7 @@ import without from 'lodash/without';
 import React from 'react';
 import styled from 'styled-components/macro';
 
+import {useFeatureFlags} from '../app/Flags';
 import {QueryRefreshCountdown, QueryRefreshState} from '../app/QueryRefresh';
 import {LaunchAssetExecutionButton} from '../assets/LaunchAssetExecutionButton';
 import {LaunchAssetObservationButton} from '../assets/LaunchAssetObservationButton';
@@ -139,6 +140,7 @@ const AssetGraphExplorerWithData: React.FC<WithDataProps> = ({
   const findAssetLocation = useFindAssetLocation();
   const {layout, loading, async} = useAssetLayout(assetGraphData);
   const viewportEl = React.useRef<SVGViewport>();
+  const {flagHorizontalDAGs} = useFeatureFlags();
 
   const [highlighted, setHighlighted] = React.useState<string | null>(null);
 
@@ -221,7 +223,7 @@ const AssetGraphExplorerWithData: React.FC<WithDataProps> = ({
       onChangeExplorerPath,
       onNavigateToSourceAssetNode,
       findAssetLocation,
-      lastSelectedNode,
+      selectedGraphNodes,
       assetGraphData,
       layout,
     ],
@@ -288,6 +290,7 @@ const AssetGraphExplorerWithData: React.FC<WithDataProps> = ({
           ) : (
             <SVGViewport
               ref={(r) => (viewportEl.current = r || undefined)}
+              defaultZoom={flagHorizontalDAGs ? 'zoom-to-fit-width' : 'zoom-to-fit'}
               interactor={SVGViewport.Interactors.PanAndZoom}
               graphWidth={layout.width}
               graphHeight={layout.height}

--- a/js_modules/dagit/packages/core/src/asset-graph/Utils.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/Utils.tsx
@@ -1,5 +1,6 @@
-import {pathVerticalDiagonal} from '@vx/shape';
+import {pathVerticalDiagonal, pathHorizontalStep} from '@vx/shape';
 
+import {featureEnabled, FeatureFlag} from '../app/Flags';
 import {Maybe, RunStatus, StaleCauseCategory, StaleStatus} from '../graphql/types';
 
 import {
@@ -116,12 +117,20 @@ export const graphHasCycles = (graphData: GraphData) => {
   return hasCycles;
 };
 
-export const buildSVGPath = pathVerticalDiagonal({
-  source: (s: any) => s.source,
-  target: (s: any) => s.target,
-  x: (s: any) => s.x,
-  y: (s: any) => s.y,
-});
+export const buildSVGPath = featureEnabled(FeatureFlag.flagHorizontalDAGs)
+  ? pathHorizontalStep({
+      percent: 0.5,
+      source: (s: any) => s.source,
+      target: (s: any) => s.target,
+      x: (s: any) => s.x,
+      y: (s: any) => s.y,
+    })
+  : pathVerticalDiagonal({
+      source: (s: any) => s.source,
+      target: (s: any) => s.target,
+      x: (s: any) => s.x,
+      y: (s: any) => s.y,
+    });
 
 export interface LiveDataForNode {
   stepKey: string;

--- a/js_modules/dagit/packages/core/src/assets/AssetNodeLineageGraph.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodeLineageGraph.tsx
@@ -60,6 +60,7 @@ export const AssetNodeLineageGraph: React.FC<{
     <SVGViewport
       ref={(r) => (viewportEl.current = r || undefined)}
       interactor={SVGViewport.Interactors.PanAndZoom}
+      defaultZoom="zoom-to-fit"
       graphWidth={layout.width}
       graphHeight={layout.height}
       onDoubleClick={(e) => {

--- a/js_modules/dagit/packages/core/src/graph/OpGraph.tsx
+++ b/js_modules/dagit/packages/core/src/graph/OpGraph.tsx
@@ -200,6 +200,7 @@ export class OpGraph extends React.Component<OpGraphProps> {
         ref={this.viewportEl}
         key={jobName}
         maxZoom={1.2}
+        defaultZoom="zoom-to-fit"
         interactor={interactor || SVGViewport.Interactors.PanAndZoom}
         graphWidth={layout.width}
         graphHeight={layout.height}

--- a/js_modules/dagit/packages/core/src/graph/SVGViewport.tsx
+++ b/js_modules/dagit/packages/core/src/graph/SVGViewport.tsx
@@ -19,6 +19,7 @@ interface SVGViewportProps {
   graphHeight: number;
   graphHasNoMinimumZoom?: boolean;
   interactor: SVGViewportInteractor;
+  defaultZoom: 'zoom-to-fit' | 'zoom-to-fit-width';
   maxZoom: number;
   maxAutocenterZoom: number;
   onClick?: (event: React.MouseEvent<HTMLDivElement>) => void;
@@ -366,7 +367,12 @@ export class SVGViewport extends React.Component<SVGViewportProps, SVGViewportSt
   autocenter(animate = false, scale?: number) {
     const el = this.element.current!;
     const ownerRect = {width: el.clientWidth, height: el.clientHeight};
-    const desiredScale = this.scaleForSVGBounds(this.props.graphWidth, this.props.graphHeight);
+
+    const desiredScale =
+      this.props.defaultZoom === 'zoom-to-fit-width'
+        ? ownerRect.width / this.props.graphWidth
+        : this.scaleForSVGBounds(this.props.graphWidth, this.props.graphHeight);
+
     const minScale = this.getMinZoom();
     const boundedScale =
       scale || Math.max(Math.min(desiredScale, this.props.maxAutocenterZoom), minScale);

--- a/js_modules/dagit/packages/core/src/graph/__stories__/OpGraph.stories.tsx
+++ b/js_modules/dagit/packages/core/src/graph/__stories__/OpGraph.stories.tsx
@@ -105,7 +105,7 @@ export const Basic = () => {
     <OpGraph
       jobName="Test Pipeline"
       ops={ops}
-      layout={getFullOpLayout(ops)}
+      layout={getFullOpLayout(ops, {})}
       interactor={SVGViewport.Interactors.PanAndZoom}
       focusOps={ops.filter((s) => focusOps.includes(s.name))}
       highlightedOps={[]}
@@ -133,7 +133,7 @@ export const FanOut = () => {
     <OpGraph
       jobName="Test Pipeline"
       ops={ops}
-      layout={getFullOpLayout(ops)}
+      layout={getFullOpLayout(ops, {})}
       interactor={SVGViewport.Interactors.PanAndZoom}
       focusOps={ops.filter((s) => focusOps.includes(s.name))}
       highlightedOps={[]}
@@ -158,7 +158,7 @@ export const Tagged = () => {
     <OpGraph
       jobName="Test Pipeline"
       ops={ops}
-      layout={getFullOpLayout(ops)}
+      layout={getFullOpLayout(ops, {})}
       interactor={SVGViewport.Interactors.PanAndZoom}
       focusOps={ops.filter((s) => focusOps.includes(s.name))}
       highlightedOps={[]}
@@ -216,7 +216,7 @@ export const Composite = () => {
       ops={parentOp ? childOps : ops}
       parentOp={parentOp}
       parentHandleID={parentOpName}
-      layout={parentOp ? getFullOpLayout(childOps, parentOp) : getFullOpLayout(ops)}
+      layout={parentOp ? getFullOpLayout(childOps, {parentOp}) : getFullOpLayout(ops, {})}
       interactor={SVGViewport.Interactors.PanAndZoom}
       focusOps={ops.filter((s) => focusOps.includes(s.name))}
       highlightedOps={[]}

--- a/js_modules/dagit/packages/core/src/graph/layout.ts
+++ b/js_modules/dagit/packages/core/src/graph/layout.ts
@@ -113,7 +113,11 @@ function flattenIO(arrays: OpLinkInfo[][]) {
   return Object.values(map);
 }
 
-export function layoutOpGraph(pipelineOps: ILayoutOp[], parentOp?: ILayoutOp): OpGraphLayout {
+export type LayoutOpGraphOptions = {
+  parentOp?: ILayoutOp;
+};
+
+export function layoutOpGraph(pipelineOps: ILayoutOp[], opts: LayoutOpGraphOptions): OpGraphLayout {
   const g = new dagre.graphlib.Graph();
 
   // First, identify how much space we need to pad the DAG by in order to show the
@@ -122,8 +126,9 @@ export function layoutOpGraph(pipelineOps: ILayoutOp[], parentOp?: ILayoutOp): O
   let parentIOPadding = 0;
   let marginy = MARGIN_BASE;
   let marginx = MARGIN_BASE;
-  if (parentOp) {
-    parentIOPadding = Math.max(parentOp.inputs.length, parentOp.outputs.length) * IO_HEIGHT;
+  if (opts.parentOp) {
+    parentIOPadding =
+      Math.max(opts.parentOp.inputs.length, opts.parentOp.outputs.length) * IO_HEIGHT;
     marginx = PARENT_DEFINITION_PADDING + PARENT_INVOCATION_PADDING;
     marginy = marginx + parentIOPadding;
   }
@@ -224,10 +229,10 @@ export function layoutOpGraph(pipelineOps: ILayoutOp[], parentOp?: ILayoutOp): O
     parent: null,
   };
 
-  if (parentOp) {
+  if (opts.parentOp) {
     // Now that we've computed the pipeline layout fully, lay out the
     // composite op around the completed DAG.
-    result.parent = layoutParentGraphOp(result, parentOp, parentIOPadding);
+    result.parent = layoutParentGraphOp(result, opts.parentOp, parentIOPadding);
   }
 
   return result;

--- a/js_modules/dagit/packages/core/src/workers/dagre_layout.worker.ts
+++ b/js_modules/dagit/packages/core/src/workers/dagre_layout.worker.ts
@@ -21,15 +21,15 @@ self.addEventListener('message', (event) => {
   switch (data.type) {
     case 'layoutOpGraph': {
       import('../graph/layout').then(({layoutOpGraph}) => {
-        const {ops, parentOp} = data;
-        self.postMessage(layoutOpGraph(ops, parentOp));
+        const {ops, opts} = data;
+        self.postMessage(layoutOpGraph(ops, opts));
       });
       break;
     }
     case 'layoutAssetGraph': {
       import('../asset-graph/layout').then(({layoutAssetGraph}) => {
-        const {graphData} = data;
-        self.postMessage(layoutAssetGraph(graphData));
+        const {graphData, opts} = data;
+        self.postMessage(layoutAssetGraph(graphData, opts));
       });
     }
   }


### PR DESCRIPTION
## Summary & Motivation

We've talked about doing a horizontal DAG for a while. This PR makes a horizontal rendering available behind a feature flag. It only impacts asset graphs and lineage views, not op jobs. Ops are displayed with "inputs on top / outputs on the bottom", which does not lend itself well to arrows going left <> right. We'd need to more significantly rethink how we render ops to do those horizontally.

- Pro: We can fit more onscreen, since the shape of the nodes mean better packing into the viewport shape.
- Pro: Users with a scrollwheel can use it to navigate better without using the shift key
- Con: Other visualizations (eg: run timeline) show time on the X axis, and this could be confusing.
- Con: The word "Upstream" seems a bit harder to grok when up = left?

This feature flag also changes the default zoom of the asset graph to a "fit-width" behavior. The graph will fit entirely onscreen width-wise but may overflow horizontally. This means that some content may be clipped by default, but you only need the vertical scroll wheel unless you zoom in further. eg: It behaves more like a 'web page'!


<img width="928" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/1703e9f6-5cef-47b3-aba0-4b00f59655bf">


Pics!

<img width="1840" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/282210d3-9732-4764-bea4-6d22717e49dd">
<img width="1840" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/08471424-60c2-494c-b3ea-ee3ff32200c8">


<img width="1840" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/e29c4327-5333-476d-90f6-3f8f1b1903dd">
<img width="1840" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/888a734f-e258-4b52-9460-3f8d8f4efd91">


<img width="1840" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/47839952-3eac-486e-9dea-36a4dbd82b83">
<img width="1840" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/c0f31a2f-5803-489b-89a9-c856ca9937ce">


## How I Tested These Changes

I visually inspected these changes and made sure that there are no regressions when the feature flag is off, for both asset and op jobs. I also tested changing the `ASYNC_LAYOUT_SOLID_COUNT` and verifying that the async web worker version of these code paths works!
