### PR TITLE
Improve perf for get_partition_keys_in_range

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -177,8 +177,12 @@ class PartitionsDefinition(ABC, Generic[T_str]):
         dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
     ) -> Sequence[T_str]:
         keys_exist = {
-            partition_key_range.start: self.has_partition_key(partition_key_range.start),
-            partition_key_range.end: self.has_partition_key(partition_key_range.end),
+            partition_key_range.start: self.has_partition_key(
+                partition_key_range.start, dynamic_partitions_store=dynamic_partitions_store
+            ),
+            partition_key_range.end: self.has_partition_key(
+                partition_key_range.end, dynamic_partitions_store=dynamic_partitions_store
+            ),
         }
         if not all(keys_exist.values()):
             raise DagsterInvalidInvocationError(

--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -195,6 +195,7 @@ class PartitionsDefinition(ABC, Generic[T_str]):
         if partition_key_range.start == partition_key_range.end:
             return [cast(T_str, partition_key_range.start)]
 
+        # defer this call as it is potentially expensive
         partition_keys = self.get_partition_keys(dynamic_partitions_store=dynamic_partitions_store)
         return partition_keys[
             partition_keys.index(partition_key_range.start) : partition_keys.index(


### PR DESCRIPTION
## Summary & Motivation

Resolves: https://github.com/dagster-io/dagster/issues/14384

Most of the time that we call this, there is only a single partition key in range. In these cases, calling get_partition_keys() is quite wasteful, so we avoid it.

## How I Tested These Changes

Confirmed that get_partition_keys() is no longer called in the materialization flow.
