### PR TITLE
dagster-webserver gql renames

### DIFF
--- a/js_modules/dagit/packages/core/src/app/types/Permissions.types.ts
+++ b/js_modules/dagit/packages/core/src/app/types/Permissions.types.ts
@@ -5,7 +5,7 @@ import * as Types from '../../graphql/types';
 export type PermissionsQueryVariables = Types.Exact<{[key: string]: never}>;
 
 export type PermissionsQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   unscopedPermissions: Array<{
     __typename: 'Permission';
     permission: string;

--- a/js_modules/dagit/packages/core/src/app/types/Telemetry.types.ts
+++ b/js_modules/dagit/packages/core/src/app/types/Telemetry.types.ts
@@ -10,7 +10,7 @@ export type LogTelemetryMutationVariables = Types.Exact<{
 }>;
 
 export type LogTelemetryMutation = {
-  __typename: 'DagitMutation';
+  __typename: 'Mutation';
   logTelemetry:
     | {__typename: 'LogTelemetrySuccess'; action: string}
     | {

--- a/js_modules/dagit/packages/core/src/asset-graph/__stories__/SidebarAssetInfo.stories.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/__stories__/SidebarAssetInfo.stories.tsx
@@ -61,7 +61,7 @@ const buildSidebarQueryMock = (
   },
   result: {
     data: {
-      __typename: 'DagitQuery',
+      __typename: 'Query',
       assetNodeOrError: {
         __typename: 'AssetNode',
         id: 'test.py.repo.["asset1"]',
@@ -135,7 +135,7 @@ const EventsMock: MockedResponse<AssetEventsQuery> = {
   },
   result: {
     data: {
-      __typename: 'DagitQuery',
+      __typename: 'Query',
       assetOrError: {
         __typename: 'Asset',
         key: MockAssetKey,

--- a/js_modules/dagit/packages/core/src/asset-graph/__tests__/AssetRunLogObserver.test.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/__tests__/AssetRunLogObserver.test.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 
 import {
   buildAssetKey,
-  buildDagitSubscription,
+  buildSubscription,
   buildMaterializationEvent,
   buildPipelineRunLogsSubscriptionSuccess,
 } from '../../graphql/types';
@@ -22,7 +22,7 @@ const SubscriptionMock: MockedResponse<AssetLiveRunLogsSubscription> = {
     variables: {runId: '12345'},
   },
   result: jest.fn(() => ({
-    data: buildDagitSubscription({
+    data: buildSubscription({
       pipelineRunLogs: buildPipelineRunLogsSubscriptionSuccess({
         messages: [
           buildMaterializationEvent({

--- a/js_modules/dagit/packages/core/src/asset-graph/types/AssetGraphJobSidebar.types.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/types/AssetGraphJobSidebar.types.ts
@@ -7,7 +7,7 @@ export type AssetGraphSidebarQueryVariables = Types.Exact<{
 }>;
 
 export type AssetGraphSidebarQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   pipelineSnapshotOrError:
     | {__typename: 'PipelineNotFoundError'; message: string}
     | {

--- a/js_modules/dagit/packages/core/src/asset-graph/types/AssetRunLogObserver.types.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/types/AssetRunLogObserver.types.ts
@@ -7,7 +7,7 @@ export type AssetLiveRunLogsSubscriptionVariables = Types.Exact<{
 }>;
 
 export type AssetLiveRunLogsSubscription = {
-  __typename: 'DagitSubscription';
+  __typename: 'Subscription';
   pipelineRunLogs:
     | {__typename: 'PipelineRunLogsSubscriptionFailure'}
     | {

--- a/js_modules/dagit/packages/core/src/asset-graph/types/SidebarAssetInfo.types.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/types/SidebarAssetInfo.types.ts
@@ -15543,7 +15543,7 @@ export type SidebarAssetQueryVariables = Types.Exact<{
 }>;
 
 export type SidebarAssetQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   assetNodeOrError:
     | {
         __typename: 'AssetNode';

--- a/js_modules/dagit/packages/core/src/asset-graph/types/useAssetGraphData.types.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/types/useAssetGraphData.types.ts
@@ -8,7 +8,7 @@ export type AssetGraphQueryVariables = Types.Exact<{
 }>;
 
 export type AssetGraphQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   assetNodes: Array<{
     __typename: 'AssetNode';
     id: string;

--- a/js_modules/dagit/packages/core/src/asset-graph/types/useFindAssetLocation.types.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/types/useFindAssetLocation.types.ts
@@ -7,7 +7,7 @@ export type AssetForNavigationQueryVariables = Types.Exact<{
 }>;
 
 export type AssetForNavigationQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   assetOrError:
     | {
         __typename: 'Asset';

--- a/js_modules/dagit/packages/core/src/asset-graph/types/useLiveDataForAssetKeys.types.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/types/useLiveDataForAssetKeys.types.ts
@@ -27,7 +27,7 @@ export type AssetGraphLiveQueryVariables = Types.Exact<{
 }>;
 
 export type AssetGraphLiveQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   assetNodes: Array<{
     __typename: 'AssetNode';
     id: string;

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/__fixtures__/AutoMaterializePolicyPage.fixtures.ts
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/__fixtures__/AutoMaterializePolicyPage.fixtures.ts
@@ -26,7 +26,7 @@ import {
 import {PAGE_SIZE} from '../useEvaluationsQueryResult';
 
 export function buildQueryMock<
-  TQuery extends {__typename: 'DagitQuery'},
+  TQuery extends {__typename: 'Query'},
   TVariables extends Record<string, any>
 >({
   query,
@@ -44,7 +44,7 @@ export function buildQueryMock<
     },
     result: {
       data: {
-        __typename: 'DagitQuery',
+        __typename: 'Query',
         ...data,
       } as TQuery,
     },

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/__fixtures__/AutomaterializeRequestedPartitionsLink.fixtures.ts
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/__fixtures__/AutomaterializeRequestedPartitionsLink.fixtures.ts
@@ -35,7 +35,7 @@ export const buildRunStatusAndPartitionKeyQuery = (
     },
     result: {
       data: {
-        __typename: 'DagitQuery',
+        __typename: 'Query',
         runsOrError: buildRuns({
           results: runIds.map((runId, ii) => {
             return buildRun({

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/__fixtures__/RunStatusOnlyQuery.fixtures.ts
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/__fixtures__/RunStatusOnlyQuery.fixtures.ts
@@ -18,7 +18,7 @@ export const buildRunStatusOnlyQuery = (
     },
     result: {
       data: {
-        __typename: 'DagitQuery',
+        __typename: 'Query',
         runOrError: buildRun({
           id: runId,
           status,

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/types/AutomaterializeRequestedPartitionsLink.types.ts
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/types/AutomaterializeRequestedPartitionsLink.types.ts
@@ -7,7 +7,7 @@ export type RunStatusAndPartitionKeyQueryVariables = Types.Exact<{
 }>;
 
 export type RunStatusAndPartitionKeyQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   runsOrError:
     | {__typename: 'InvalidPipelineRunsFilterError'; message: string}
     | {

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/types/AutomaterializeRightPanel.types.ts
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/types/AutomaterializeRightPanel.types.ts
@@ -7,7 +7,7 @@ export type GetPolicyInfoQueryVariables = Types.Exact<{
 }>;
 
 export type GetPolicyInfoQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   assetNodeOrError:
     | {
         __typename: 'AssetNode';

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/types/AutomaterializeRunTag.types.ts
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/types/AutomaterializeRunTag.types.ts
@@ -7,7 +7,7 @@ export type RunStatusOnlyQueryVariables = Types.Exact<{
 }>;
 
 export type RunStatusOnlyQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   runOrError:
     | {__typename: 'PythonError'}
     | {__typename: 'Run'; id: string; status: Types.RunStatus}

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/types/GetEvaluationsQuery.types.ts
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/types/GetEvaluationsQuery.types.ts
@@ -9,7 +9,7 @@ export type GetEvaluationsQueryVariables = Types.Exact<{
 }>;
 
 export type GetEvaluationsQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   autoMaterializeAssetEvaluationsOrError:
     | {__typename: 'AutoMaterializeAssetEvaluationNeedsMigrationError'; message: string}
     | {

--- a/js_modules/dagit/packages/core/src/assets/__fixtures__/AssetEventDetail.fixtures.ts
+++ b/js_modules/dagit/packages/core/src/assets/__fixtures__/AssetEventDetail.fixtures.ts
@@ -220,7 +220,7 @@ export const MaterializationUpstreamDataFullMock: MockedResponse<AssetMaterializ
   },
   result: {
     data: {
-      __typename: 'DagitQuery',
+      __typename: 'Query',
       assetNodeOrError: {
         __typename: 'AssetNode',
         id: 'test.py.repo.["asset_1"]',
@@ -263,7 +263,7 @@ export const MaterializationUpstreamDataEmptyMock: MockedResponse<AssetMateriali
   },
   result: {
     data: {
-      __typename: 'DagitQuery',
+      __typename: 'Query',
       assetNodeOrError: {
         __typename: 'AssetNode',
         id: 'test.py.repo.["asset_1"]',
@@ -283,7 +283,7 @@ export const buildAssetPartitionDetailMock = (
   },
   result: {
     data: {
-      __typename: 'DagitQuery',
+      __typename: 'Query',
       assetNodeOrError: {
         __typename: 'AssetNode',
         id: 'test.py.repo.["asset_1"]',

--- a/js_modules/dagit/packages/core/src/assets/__fixtures__/AssetJobPartitionSetsQuery.fixtures.tsx
+++ b/js_modules/dagit/packages/core/src/assets/__fixtures__/AssetJobPartitionSetsQuery.fixtures.tsx
@@ -10,7 +10,7 @@ export const ReleasesWorkspace: MockedResponse<AssetJobPartitionSetsQuery> = {
   },
   result: {
     data: {
-      __typename: 'DagitQuery',
+      __typename: 'Query',
       partitionSetsOrError: {
         __typename: 'PartitionSets',
         results: [

--- a/js_modules/dagit/packages/core/src/assets/__fixtures__/AssetTables.fixtures.ts
+++ b/js_modules/dagit/packages/core/src/assets/__fixtures__/AssetTables.fixtures.ts
@@ -26,7 +26,7 @@ export const AssetCatalogGroupTableMock: MockedResponse<AssetCatalogGroupTableQu
   },
   result: {
     data: {
-      __typename: 'DagitQuery',
+      __typename: 'Query',
       assetNodes: [],
     },
   },
@@ -39,7 +39,7 @@ export const SingleAssetQueryTrafficDashboard: MockedResponse<SingleNonSdaAssetQ
   },
   result: {
     data: {
-      __typename: 'DagitQuery',
+      __typename: 'Query',
       assetOrError: {
         id: '["dashboards", "traffic_dashboard"]',
         assetMaterializations: [
@@ -73,7 +73,7 @@ export const SingleAssetQueryMaterializedWithLatestRun: MockedResponse<AssetGrap
   },
   result: {
     data: {
-      __typename: 'DagitQuery',
+      __typename: 'Query',
       assetNodes: [
         {
           id: 'test.py.repo.["good_asset"]',
@@ -133,7 +133,7 @@ export const SingleAssetQueryMaterializedStaleAndLate: MockedResponse<AssetGraph
   },
   result: {
     data: {
-      __typename: 'DagitQuery',
+      __typename: 'Query',
       assetNodes: [
         {
           id: 'test.py.repo.["late_asset"]',
@@ -189,7 +189,7 @@ export const SingleAssetQueryLastRunFailed: MockedResponse<AssetGraphLiveQuery> 
   },
   result: {
     data: {
-      __typename: 'DagitQuery',
+      __typename: 'Query',
       assetNodes: [
         {
           id: 'test.py.repo.["run_failing_asset"]',
@@ -332,7 +332,7 @@ export const AssetCatalogTableMock: MockedResponse<AssetCatalogTableQuery> = {
   },
   result: {
     data: {
-      __typename: 'DagitQuery',
+      __typename: 'Query',
       assetsOrError: {
         __typename: 'AssetConnection',
         nodes: AssetCatalogTableMockAssets,

--- a/js_modules/dagit/packages/core/src/assets/__fixtures__/AssetViewDefinition.fixtures.ts
+++ b/js_modules/dagit/packages/core/src/assets/__fixtures__/AssetViewDefinition.fixtures.ts
@@ -14,7 +14,7 @@ export const AssetGraphEmpty: MockedResponse<AssetGraphQuery> = {
   },
   result: {
     data: {
-      __typename: 'DagitQuery',
+      __typename: 'Query',
       assetNodes: [],
     },
   },
@@ -29,7 +29,7 @@ export const AssetViewDefinitionNonSDA: MockedResponse<AssetViewDefinitionQuery>
   },
   result: {
     data: {
-      __typename: 'DagitQuery',
+      __typename: 'Query',
       assetOrError: {
         id: '["non_sda_asset"]',
         key: {
@@ -58,7 +58,7 @@ export const AssetViewDefinitionSourceAsset: MockedResponse<AssetViewDefinitionQ
   },
   result: {
     data: {
-      __typename: 'DagitQuery',
+      __typename: 'Query',
       assetOrError: {
         id: 'test.py.repo.["observable_source_asset"]',
         key: {
@@ -124,7 +124,7 @@ export const AssetViewDefinitionSDA: MockedResponse<AssetViewDefinitionQuery> = 
   },
   result: {
     data: {
-      __typename: 'DagitQuery',
+      __typename: 'Query',
       assetOrError: {
         id: 'test.py.repo.["sda_asset"]',
         key: {

--- a/js_modules/dagit/packages/core/src/assets/__fixtures__/LaunchAssetChoosePartitionsQuery.fixtures.tsx
+++ b/js_modules/dagit/packages/core/src/assets/__fixtures__/LaunchAssetChoosePartitionsQuery.fixtures.tsx
@@ -16,7 +16,7 @@ export const ReleasesWorkspace: MockedResponse<LaunchAssetWarningsQuery> = {
   },
   result: {
     data: {
-      __typename: 'DagitQuery',
+      __typename: 'Query',
       assetNodes: [],
       instance: buildInstance({
         daemonHealth: buildDaemonHealth({

--- a/js_modules/dagit/packages/core/src/assets/__fixtures__/LaunchAssetExecutionButton.fixtures.ts
+++ b/js_modules/dagit/packages/core/src/assets/__fixtures__/LaunchAssetExecutionButton.fixtures.ts
@@ -199,7 +199,7 @@ export const buildLaunchAssetWarningsMock = (
   },
   result: {
     data: {
-      __typename: 'DagitQuery',
+      __typename: 'Query',
       assetNodes: [],
       instance: buildInstance({
         daemonHealth: buildDaemonHealth({
@@ -227,7 +227,7 @@ export const PartitionHealthAssetDailyMock: MockedResponse<PartitionHealthQuery>
   },
   result: {
     data: {
-      __typename: 'DagitQuery',
+      __typename: 'Query',
       assetNodeOrError: {
         id: 'test.py.repo.["asset_daily"]',
         partitionKeysByDimension: [
@@ -300,7 +300,7 @@ export const PartitionHealthAssetWeeklyMock: MockedResponse<PartitionHealthQuery
   },
   result: {
     data: {
-      __typename: 'DagitQuery',
+      __typename: 'Query',
       assetNodeOrError: {
         id: 'test.py.repo.["asset_weekly"]',
         partitionKeysByDimension: [
@@ -336,7 +336,7 @@ export const PartitionHealthAssetWeeklyRootMock: MockedResponse<PartitionHealthQ
   },
   result: {
     data: {
-      __typename: 'DagitQuery',
+      __typename: 'Query',
       assetNodeOrError: {
         id: 'test.py.repo.["asset_weekly_root"]',
         partitionKeysByDimension: [
@@ -372,7 +372,7 @@ export const LaunchAssetLoaderResourceJob7Mock: MockedResponse<LaunchAssetLoader
   },
   result: {
     data: {
-      __typename: 'DagitQuery',
+      __typename: 'Query',
       partitionSetsOrError: {
         results: [
           {
@@ -477,7 +477,7 @@ export const LaunchAssetLoaderResourceJob8Mock: MockedResponse<LaunchAssetLoader
   },
   result: {
     data: {
-      __typename: 'DagitQuery',
+      __typename: 'Query',
       partitionSetsOrError: {
         results: [
           {
@@ -582,7 +582,7 @@ export const LaunchAssetLoaderResourceMyAssetJobMock: MockedResponse<LaunchAsset
   },
   result: {
     data: {
-      __typename: 'DagitQuery',
+      __typename: 'Query',
       partitionSetsOrError: {
         results: [
           {
@@ -617,7 +617,7 @@ export const LaunchAssetLoaderAssetDailyWeeklyMock: MockedResponse<LaunchAssetLo
   },
   result: {
     data: {
-      __typename: 'DagitQuery',
+      __typename: 'Query',
       assetNodes: [
         {
           ...ASSET_DAILY,
@@ -686,7 +686,7 @@ export const LaunchAssetCheckUpstreamWeeklyRootMock: MockedResponse<LaunchAssetC
   },
   result: {
     data: {
-      __typename: 'DagitQuery',
+      __typename: 'Query',
       assetNodes: [
         {
           id: 'test.py.repo.["asset_weekly_root"]',
@@ -728,7 +728,7 @@ export function buildConfigPartitionSelectionLatestPartitionMock(
     },
     result: {
       data: {
-        __typename: 'DagitQuery',
+        __typename: 'Query',
         partitionSetOrError: {
           __typename: 'PartitionSet',
           id: '5b10aae97b738c48a4262b1eca530f89b13e9afc',
@@ -946,7 +946,7 @@ export function buildLaunchAssetLoaderMock(
     },
     result: {
       data: {
-        __typename: 'DagitQuery',
+        __typename: 'Query',
         assetNodeDefinitionCollisions: [],
         assetNodes: LOADER_RESULTS.filter((a) =>
           assetKeys.some((k) => tokenForAssetKey(k) === tokenForAssetKey(a.assetKey)),
@@ -966,7 +966,7 @@ export function buildExpectedLaunchBackfillMutation(
     },
     result: jest.fn(() => ({
       data: {
-        __typename: 'DagitMutation',
+        __typename: 'Mutation',
         launchPartitionBackfill: {__typename: 'LaunchBackfillSuccess', backfillId: 'backfillid'},
       },
     })),
@@ -983,7 +983,7 @@ export function buildExpectedLaunchSingleRunMutation(
     },
     result: jest.fn(() => ({
       data: {
-        __typename: 'DagitMutation',
+        __typename: 'Mutation',
         launchPipelineExecution: {
           __typename: 'LaunchRunSuccess',
           run: {

--- a/js_modules/dagit/packages/core/src/assets/__fixtures__/LaunchAssetLoaderQuery.fixtures.tsx
+++ b/js_modules/dagit/packages/core/src/assets/__fixtures__/LaunchAssetLoaderQuery.fixtures.tsx
@@ -273,7 +273,7 @@ export const ReleasesWorkspace: MockedResponse<LaunchAssetLoaderQuery> = {
   },
   result: {
     data: {
-      __typename: 'DagitQuery' as const,
+      __typename: 'Query' as const,
       assetNodes: assetNodes as any[],
       assetNodeDefinitionCollisions: [],
     },

--- a/js_modules/dagit/packages/core/src/assets/__fixtures__/PartitionHealthQuery.fixtures.tsx
+++ b/js_modules/dagit/packages/core/src/assets/__fixtures__/PartitionHealthQuery.fixtures.tsx
@@ -23,7 +23,7 @@ export const buildPartitionHealthMock = (
   },
   result: {
     data: {
-      __typename: 'DagitQuery',
+      __typename: 'Query',
       assetNodeOrError: buildAssetNode({
         id: `assets_dynamic_partitions.__repository__.["${assetKey}"]`,
         partitionKeysByDimension: [

--- a/js_modules/dagit/packages/core/src/assets/__fixtures__/PartitionHealthSummary.fixtures.ts
+++ b/js_modules/dagit/packages/core/src/assets/__fixtures__/PartitionHealthSummary.fixtures.ts
@@ -38,7 +38,7 @@ export const SingleDimensionTimePartitionHealthQuery: MockedResponse<PartitionHe
   },
   result: {
     data: {
-      __typename: 'DagitQuery',
+      __typename: 'Query',
       assetNodeOrError: {
         id: 'test.py.repo.["yoyoyoyoyo"]',
         partitionKeysByDimension: [
@@ -1582,7 +1582,7 @@ export const SingleDimensionStaticPartitionHealthQuery: MockedResponse<Partition
   },
   result: {
     data: {
-      __typename: 'DagitQuery',
+      __typename: 'Query',
       assetNodeOrError: {
         id: 'test.py.repo.["single_dimension_static"]',
         partitionKeysByDimension: [
@@ -1612,7 +1612,7 @@ export const MultiDimensionStaticPartitionHealthQuery: MockedResponse<PartitionH
   },
   result: {
     data: {
-      __typename: 'DagitQuery',
+      __typename: 'Query',
       assetNodeOrError: {
         id: 'test.py.repo.["multi_dimension_static"]',
         partitionKeysByDimension: [
@@ -1686,7 +1686,7 @@ export const MultiDimensionTimeFirstPartitionHealthQuery: MockedResponse<Partiti
 
   result: {
     data: {
-      __typename: 'DagitQuery',
+      __typename: 'Query',
       assetNodeOrError: {
         id: 'test.py.repo.["multi_dimension_time_first"]',
         partitionKeysByDimension: [
@@ -1852,7 +1852,7 @@ export const MultiDimensionTimeSecondPartitionHealthQuery: MockedResponse<Partit
   },
   result: {
     data: {
-      __typename: 'DagitQuery',
+      __typename: 'Query',
       assetNodeOrError: {
         id: 'test.py.repo.["multi_dimension_time_second"]',
         partitionKeysByDimension: [

--- a/js_modules/dagit/packages/core/src/assets/__fixtures__/RunningBackfillsNoticeQuery.fixture.tsx
+++ b/js_modules/dagit/packages/core/src/assets/__fixtures__/RunningBackfillsNoticeQuery.fixture.tsx
@@ -10,7 +10,7 @@ export const NoRunningBackfills: MockedResponse<RunningBackfillsNoticeQuery> = {
   },
   result: {
     data: {
-      __typename: 'DagitQuery',
+      __typename: 'Query',
       partitionBackfillsOrError: {
         __typename: 'PartitionBackfills',
         results: [],

--- a/js_modules/dagit/packages/core/src/assets/__tests__/usePartitionHealthData.test.tsx
+++ b/js_modules/dagit/packages/core/src/assets/__tests__/usePartitionHealthData.test.tsx
@@ -29,7 +29,7 @@ const DIMENSION_ONE_KEYS = [
 const DIMENSION_TWO_KEYS = ['TN', 'CA', 'VA', 'NY', 'MN'];
 
 const NO_DIMENSIONAL_ASSET: PartitionHealthQuery = {
-  __typename: 'DagitQuery',
+  __typename: 'Query',
   assetNodeOrError: {
     __typename: 'AssetNode',
     id: '1234',
@@ -44,7 +44,7 @@ const NO_DIMENSIONAL_ASSET: PartitionHealthQuery = {
 };
 
 const ONE_DIMENSIONAL_ASSET: PartitionHealthQuery = {
-  __typename: 'DagitQuery',
+  __typename: 'Query',
   assetNodeOrError: {
     __typename: 'AssetNode',
     id: '1234',
@@ -81,7 +81,7 @@ const ONE_DIMENSIONAL_ASSET: PartitionHealthQuery = {
 };
 
 const TWO_DIMENSIONAL_ASSET: PartitionHealthQuery = {
-  __typename: 'DagitQuery',
+  __typename: 'Query',
   assetNodeOrError: {
     __typename: 'AssetNode',
     id: '1234',
@@ -161,7 +161,7 @@ const TWO_DIMENSIONAL_ASSET: PartitionHealthQuery = {
 };
 
 const TWO_DIMENSIONAL_ASSET_BOTH_STATIC: PartitionHealthQuery = {
-  __typename: 'DagitQuery',
+  __typename: 'Query',
   assetNodeOrError: {
     __typename: 'AssetNode',
     id: '1234',
@@ -215,7 +215,7 @@ const TWO_DIMENSIONAL_ASSET_BOTH_STATIC: PartitionHealthQuery = {
 };
 
 const TWO_DIMENSIONAL_ASSET_EMPTY: PartitionHealthQuery = {
-  __typename: 'DagitQuery',
+  __typename: 'Query',
   assetNodeOrError: {
     __typename: 'AssetNode',
     id: '1234',

--- a/js_modules/dagit/packages/core/src/assets/types/AssetDefinedInMultipleReposNotice.types.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetDefinedInMultipleReposNotice.types.ts
@@ -7,7 +7,7 @@ export type AssetDefinitionCollisionQueryVariables = Types.Exact<{
 }>;
 
 export type AssetDefinitionCollisionQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   assetNodeDefinitionCollisions: Array<{
     __typename: 'AssetNodeDefinitionCollision';
     assetKey: {__typename: 'AssetKey'; path: Array<string>};

--- a/js_modules/dagit/packages/core/src/assets/types/AssetGroupRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetGroupRoot.types.ts
@@ -7,7 +7,7 @@ export type AssetGroupMetadataQueryVariables = Types.Exact<{
 }>;
 
 export type AssetGroupMetadataQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   assetNodes: Array<{
     __typename: 'AssetNode';
     id: string;

--- a/js_modules/dagit/packages/core/src/assets/types/AssetMaterializationUpstreamData.types.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetMaterializationUpstreamData.types.ts
@@ -8,7 +8,7 @@ export type AssetMaterializationUpstreamQueryVariables = Types.Exact<{
 }>;
 
 export type AssetMaterializationUpstreamQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   assetNodeOrError:
     | {
         __typename: 'AssetNode';

--- a/js_modules/dagit/packages/core/src/assets/types/AssetPartitionDetail.types.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetPartitionDetail.types.ts
@@ -8,7 +8,7 @@ export type AssetPartitionDetailQueryVariables = Types.Exact<{
 }>;
 
 export type AssetPartitionDetailQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   assetNodeOrError:
     | {
         __typename: 'AssetNode';

--- a/js_modules/dagit/packages/core/src/assets/types/AssetView.types.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetView.types.ts
@@ -7,7 +7,7 @@ export type AssetViewDefinitionQueryVariables = Types.Exact<{
 }>;
 
 export type AssetViewDefinitionQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   assetOrError:
     | {
         __typename: 'Asset';

--- a/js_modules/dagit/packages/core/src/assets/types/AssetWipeDialog.types.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetWipeDialog.types.ts
@@ -7,7 +7,7 @@ export type AssetWipeMutationVariables = Types.Exact<{
 }>;
 
 export type AssetWipeMutation = {
-  __typename: 'DagitMutation';
+  __typename: 'Mutation';
   wipeAssets:
     | {__typename: 'AssetNotFoundError'}
     | {

--- a/js_modules/dagit/packages/core/src/assets/types/AssetsCatalogRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetsCatalogRoot.types.ts
@@ -7,7 +7,7 @@ export type AssetsCatalogRootQueryVariables = Types.Exact<{
 }>;
 
 export type AssetsCatalogRootQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   assetOrError:
     | {__typename: 'Asset'; id: string; key: {__typename: 'AssetKey'; path: Array<string>}}
     | {__typename: 'AssetNotFoundError'};

--- a/js_modules/dagit/packages/core/src/assets/types/AssetsCatalogTable.types.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetsCatalogTable.types.ts
@@ -5,7 +5,7 @@ import * as Types from '../../graphql/types';
 export type AssetCatalogTableQueryVariables = Types.Exact<{[key: string]: never}>;
 
 export type AssetCatalogTableQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   assetsOrError:
     | {
         __typename: 'AssetConnection';
@@ -50,7 +50,7 @@ export type AssetCatalogGroupTableQueryVariables = Types.Exact<{
 }>;
 
 export type AssetCatalogGroupTableQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   assetNodes: Array<{
     __typename: 'AssetNode';
     id: string;

--- a/js_modules/dagit/packages/core/src/assets/types/AutomaterializeDaemonStatusTag.types.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AutomaterializeDaemonStatusTag.types.ts
@@ -5,7 +5,7 @@ import * as Types from '../../graphql/types';
 export type GetAutoMaterializePausedQueryVariables = Types.Exact<{[key: string]: never}>;
 
 export type GetAutoMaterializePausedQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   instance: {__typename: 'Instance'; id: string; autoMaterializePaused: boolean};
 };
 
@@ -14,6 +14,6 @@ export type SetAutoMaterializePausedMutationVariables = Types.Exact<{
 }>;
 
 export type SetAutoMaterializePausedMutation = {
-  __typename: 'DagitMutation';
+  __typename: 'Mutation';
   setAutoMaterializePaused: boolean;
 };

--- a/js_modules/dagit/packages/core/src/assets/types/LaunchAssetChoosePartitionsDialog.types.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/LaunchAssetChoosePartitionsDialog.types.ts
@@ -7,7 +7,7 @@ export type LaunchAssetWarningsQueryVariables = Types.Exact<{
 }>;
 
 export type LaunchAssetWarningsQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   assetNodes: Array<{
     __typename: 'AssetNode';
     id: string;

--- a/js_modules/dagit/packages/core/src/assets/types/LaunchAssetExecutionButton.types.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/LaunchAssetExecutionButton.types.ts
@@ -602,7 +602,7 @@ export type LaunchAssetLoaderQueryVariables = Types.Exact<{
 }>;
 
 export type LaunchAssetLoaderQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   assetNodes: Array<{
     __typename: 'AssetNode';
     id: string;
@@ -1208,7 +1208,7 @@ export type LaunchAssetLoaderResourceQueryVariables = Types.Exact<{
 }>;
 
 export type LaunchAssetLoaderResourceQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   partitionSetsOrError:
     | {
         __typename: 'PartitionSets';
@@ -1796,7 +1796,7 @@ export type LaunchAssetCheckUpstreamQueryVariables = Types.Exact<{
 }>;
 
 export type LaunchAssetCheckUpstreamQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   assetNodes: Array<{
     __typename: 'AssetNode';
     id: string;

--- a/js_modules/dagit/packages/core/src/assets/types/RunningBackfillsNotice.types.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/RunningBackfillsNotice.types.ts
@@ -5,7 +5,7 @@ import * as Types from '../../graphql/types';
 export type RunningBackfillsNoticeQueryVariables = Types.Exact<{[key: string]: never}>;
 
 export type RunningBackfillsNoticeQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   partitionBackfillsOrError:
     | {
         __typename: 'PartitionBackfills';

--- a/js_modules/dagit/packages/core/src/assets/types/usePartitionHealthData.types.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/usePartitionHealthData.types.ts
@@ -7,7 +7,7 @@ export type PartitionHealthQueryVariables = Types.Exact<{
 }>;
 
 export type PartitionHealthQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   assetNodeOrError:
     | {
         __typename: 'AssetNode';

--- a/js_modules/dagit/packages/core/src/assets/types/usePartitionNameForPipeline.types.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/usePartitionNameForPipeline.types.ts
@@ -9,7 +9,7 @@ export type AssetJobPartitionSetsQueryVariables = Types.Exact<{
 }>;
 
 export type AssetJobPartitionSetsQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   partitionSetsOrError:
     | {
         __typename: 'PartitionSets';

--- a/js_modules/dagit/packages/core/src/assets/types/useRecentAssetEvents.types.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/useRecentAssetEvents.types.ts
@@ -277,7 +277,7 @@ export type AssetEventsQueryVariables = Types.Exact<{
 }>;
 
 export type AssetEventsQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   assetOrError:
     | {
         __typename: 'Asset';

--- a/js_modules/dagit/packages/core/src/gantt/__stories__/GanttChart.stories.tsx
+++ b/js_modules/dagit/packages/core/src/gantt/__stories__/GanttChart.stories.tsx
@@ -22,7 +22,7 @@ const runGroupMock: MockedResponse<RunGroupPanelQuery, RunGroupPanelQueryVariabl
   },
   result: {
     data: {
-      __typename: 'DagitQuery',
+      __typename: 'Query',
       runGroupOrError: buildRunGroup({
         rootRunId: 'r1',
         runs: [

--- a/js_modules/dagit/packages/core/src/gantt/types/RunGroupPanel.types.ts
+++ b/js_modules/dagit/packages/core/src/gantt/types/RunGroupPanel.types.ts
@@ -7,7 +7,7 @@ export type RunGroupPanelQueryVariables = Types.Exact<{
 }>;
 
 export type RunGroupPanelQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   runGroupOrError:
     | {
         __typename: 'PythonError';

--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -1,9 +1,3 @@
-schema {
-  query: DagitQuery
-  mutation: DagitMutation
-  subscription: DagitSubscription
-}
-
 type ComputeLogFile {
   path: String!
   data: String
@@ -2833,7 +2827,7 @@ type UsedSolid {
   invocations: [NodeInvocationSite!]!
 }
 
-type DagitQuery {
+type Query {
   version: String!
   repositoriesOrError(repositorySelector: RepositorySelector): RepositoriesOrError!
   repositoryOrError(repositorySelector: RepositorySelector!): RepositoryOrError!
@@ -3130,7 +3124,7 @@ type AutoMaterializeAssetEvaluationNeedsMigrationError implements Error {
   message: String!
 }
 
-type DagitMutation {
+type Mutation {
   launchPipelineExecution(executionParams: ExecutionParams!): LaunchRunResult!
   launchRun(executionParams: ExecutionParams!): LaunchRunResult!
   launchPipelineReexecution(
@@ -3237,7 +3231,7 @@ type AddDynamicPartitionSuccess {
   partitionKey: String!
 }
 
-type DagitSubscription {
+type Subscription {
   pipelineRunLogs(runId: ID!, cursor: String): PipelineRunLogsSubscriptionPayload!
   computeLogs(runId: ID!, stepKey: String!, ioType: ComputeIOType!, cursor: String): ComputeLogFile!
   capturedLogs(logKey: [String!]!, cursor: String): CapturedLogs!

--- a/js_modules/dagit/packages/core/src/graphql/types.ts
+++ b/js_modules/dagit/packages/core/src/graphql/types.ts
@@ -547,416 +547,6 @@ export type DaemonStatus = {
   required: Scalars['Boolean'];
 };
 
-export type DagitMutation = {
-  __typename: 'DagitMutation';
-  addDynamicPartition: AddDynamicPartitionResult;
-  cancelPartitionBackfill: CancelBackfillResult;
-  deletePipelineRun: DeletePipelineRunResult;
-  deleteRun: DeletePipelineRunResult;
-  freeConcurrencySlotsForRun: Scalars['Boolean'];
-  launchPartitionBackfill: LaunchBackfillResult;
-  launchPipelineExecution: LaunchRunResult;
-  launchPipelineReexecution: LaunchRunReexecutionResult;
-  launchRun: LaunchRunResult;
-  launchRunReexecution: LaunchRunReexecutionResult;
-  logTelemetry: LogTelemetryMutationResult;
-  reloadRepositoryLocation: ReloadRepositoryLocationMutationResult;
-  reloadWorkspace: ReloadWorkspaceMutationResult;
-  resumePartitionBackfill: ResumeBackfillResult;
-  scheduleDryRun: ScheduleDryRunResult;
-  sensorDryRun: SensorDryRunResult;
-  setAutoMaterializePaused: Scalars['Boolean'];
-  setConcurrencyLimit: Scalars['Boolean'];
-  setNuxSeen: Scalars['Boolean'];
-  setSensorCursor: SensorOrError;
-  shutdownRepositoryLocation: ShutdownRepositoryLocationMutationResult;
-  startSchedule: ScheduleMutationResult;
-  startSensor: SensorOrError;
-  stopRunningSchedule: ScheduleMutationResult;
-  stopSensor: StopSensorMutationResultOrError;
-  terminatePipelineExecution: TerminateRunResult;
-  terminateRun: TerminateRunResult;
-  wipeAssets: AssetWipeMutationResult;
-};
-
-export type DagitMutationAddDynamicPartitionArgs = {
-  partitionKey: Scalars['String'];
-  partitionsDefName: Scalars['String'];
-  repositorySelector: RepositorySelector;
-};
-
-export type DagitMutationCancelPartitionBackfillArgs = {
-  backfillId: Scalars['String'];
-};
-
-export type DagitMutationDeletePipelineRunArgs = {
-  runId: Scalars['String'];
-};
-
-export type DagitMutationDeleteRunArgs = {
-  runId: Scalars['String'];
-};
-
-export type DagitMutationFreeConcurrencySlotsForRunArgs = {
-  runId: Scalars['String'];
-};
-
-export type DagitMutationLaunchPartitionBackfillArgs = {
-  backfillParams: LaunchBackfillParams;
-};
-
-export type DagitMutationLaunchPipelineExecutionArgs = {
-  executionParams: ExecutionParams;
-};
-
-export type DagitMutationLaunchPipelineReexecutionArgs = {
-  executionParams?: InputMaybe<ExecutionParams>;
-  reexecutionParams?: InputMaybe<ReexecutionParams>;
-};
-
-export type DagitMutationLaunchRunArgs = {
-  executionParams: ExecutionParams;
-};
-
-export type DagitMutationLaunchRunReexecutionArgs = {
-  executionParams?: InputMaybe<ExecutionParams>;
-  reexecutionParams?: InputMaybe<ReexecutionParams>;
-};
-
-export type DagitMutationLogTelemetryArgs = {
-  action: Scalars['String'];
-  clientId: Scalars['String'];
-  clientTime: Scalars['String'];
-  metadata: Scalars['String'];
-};
-
-export type DagitMutationReloadRepositoryLocationArgs = {
-  repositoryLocationName: Scalars['String'];
-};
-
-export type DagitMutationResumePartitionBackfillArgs = {
-  backfillId: Scalars['String'];
-};
-
-export type DagitMutationScheduleDryRunArgs = {
-  selectorData: ScheduleSelector;
-  timestamp?: InputMaybe<Scalars['Float']>;
-};
-
-export type DagitMutationSensorDryRunArgs = {
-  cursor?: InputMaybe<Scalars['String']>;
-  selectorData: SensorSelector;
-};
-
-export type DagitMutationSetAutoMaterializePausedArgs = {
-  paused: Scalars['Boolean'];
-};
-
-export type DagitMutationSetConcurrencyLimitArgs = {
-  concurrencyKey: Scalars['String'];
-  limit: Scalars['Int'];
-};
-
-export type DagitMutationSetSensorCursorArgs = {
-  cursor?: InputMaybe<Scalars['String']>;
-  sensorSelector: SensorSelector;
-};
-
-export type DagitMutationShutdownRepositoryLocationArgs = {
-  repositoryLocationName: Scalars['String'];
-};
-
-export type DagitMutationStartScheduleArgs = {
-  scheduleSelector: ScheduleSelector;
-};
-
-export type DagitMutationStartSensorArgs = {
-  sensorSelector: SensorSelector;
-};
-
-export type DagitMutationStopRunningScheduleArgs = {
-  scheduleOriginId: Scalars['String'];
-  scheduleSelectorId: Scalars['String'];
-};
-
-export type DagitMutationStopSensorArgs = {
-  jobOriginId: Scalars['String'];
-  jobSelectorId: Scalars['String'];
-};
-
-export type DagitMutationTerminatePipelineExecutionArgs = {
-  runId: Scalars['String'];
-  terminatePolicy?: InputMaybe<TerminateRunPolicy>;
-};
-
-export type DagitMutationTerminateRunArgs = {
-  runId: Scalars['String'];
-  terminatePolicy?: InputMaybe<TerminateRunPolicy>;
-};
-
-export type DagitMutationWipeAssetsArgs = {
-  assetKeys: Array<AssetKeyInput>;
-};
-
-export type DagitQuery = {
-  __typename: 'DagitQuery';
-  allTopLevelResourceDetailsOrError: ResourcesOrError;
-  assetNodeDefinitionCollisions: Array<AssetNodeDefinitionCollision>;
-  assetNodeOrError: AssetNodeOrError;
-  assetNodes: Array<AssetNode>;
-  assetOrError: AssetOrError;
-  assetsLatestInfo: Array<AssetLatestInfo>;
-  assetsOrError: AssetsOrError;
-  autoMaterializeAssetEvaluationsOrError: Maybe<AutoMaterializeAssetEvaluationRecordsOrError>;
-  capturedLogs: CapturedLogs;
-  capturedLogsMetadata: CapturedLogsMetadata;
-  executionPlanOrError: ExecutionPlanOrError;
-  graphOrError: GraphOrError;
-  instance: Instance;
-  instigationStateOrError: InstigationStateOrError;
-  isPipelineConfigValid: PipelineConfigValidationResult;
-  locationStatusesOrError: WorkspaceLocationStatusEntriesOrError;
-  logsForRun: EventConnectionOrError;
-  partitionBackfillOrError: PartitionBackfillOrError;
-  partitionBackfillsOrError: PartitionBackfillsOrError;
-  partitionSetOrError: PartitionSetOrError;
-  partitionSetsOrError: PartitionSetsOrError;
-  permissions: Array<Permission>;
-  pipelineOrError: PipelineOrError;
-  pipelineRunOrError: RunOrError;
-  pipelineRunsOrError: RunsOrError;
-  pipelineSnapshotOrError: PipelineSnapshotOrError;
-  repositoriesOrError: RepositoriesOrError;
-  repositoryOrError: RepositoryOrError;
-  runConfigSchemaOrError: RunConfigSchemaOrError;
-  runGroupOrError: RunGroupOrError;
-  runGroupsOrError: RunGroupsOrError;
-  runOrError: RunOrError;
-  runTagKeysOrError: Maybe<RunTagKeysOrError>;
-  runTagsOrError: Maybe<RunTagsOrError>;
-  runsOrError: RunsOrError;
-  scheduleOrError: ScheduleOrError;
-  scheduler: SchedulerOrError;
-  schedulesOrError: SchedulesOrError;
-  sensorOrError: SensorOrError;
-  sensorsOrError: SensorsOrError;
-  shouldShowNux: Scalars['Boolean'];
-  test: Maybe<TestFields>;
-  topLevelResourceDetailsOrError: ResourceDetailsOrError;
-  unloadableInstigationStatesOrError: InstigationStatesOrError;
-  utilizedEnvVarsOrError: EnvVarWithConsumersOrError;
-  version: Scalars['String'];
-  workspaceOrError: WorkspaceOrError;
-};
-
-export type DagitQueryAllTopLevelResourceDetailsOrErrorArgs = {
-  repositorySelector: RepositorySelector;
-};
-
-export type DagitQueryAssetNodeDefinitionCollisionsArgs = {
-  assetKeys?: InputMaybe<Array<AssetKeyInput>>;
-};
-
-export type DagitQueryAssetNodeOrErrorArgs = {
-  assetKey: AssetKeyInput;
-};
-
-export type DagitQueryAssetNodesArgs = {
-  assetKeys?: InputMaybe<Array<AssetKeyInput>>;
-  group?: InputMaybe<AssetGroupSelector>;
-  loadMaterializations?: InputMaybe<Scalars['Boolean']>;
-  pipeline?: InputMaybe<PipelineSelector>;
-};
-
-export type DagitQueryAssetOrErrorArgs = {
-  assetKey: AssetKeyInput;
-};
-
-export type DagitQueryAssetsLatestInfoArgs = {
-  assetKeys: Array<AssetKeyInput>;
-};
-
-export type DagitQueryAssetsOrErrorArgs = {
-  cursor?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  prefix?: InputMaybe<Array<Scalars['String']>>;
-};
-
-export type DagitQueryAutoMaterializeAssetEvaluationsOrErrorArgs = {
-  assetKey: AssetKeyInput;
-  cursor?: InputMaybe<Scalars['String']>;
-  limit: Scalars['Int'];
-};
-
-export type DagitQueryCapturedLogsArgs = {
-  cursor?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  logKey: Array<Scalars['String']>;
-};
-
-export type DagitQueryCapturedLogsMetadataArgs = {
-  logKey: Array<Scalars['String']>;
-};
-
-export type DagitQueryExecutionPlanOrErrorArgs = {
-  mode: Scalars['String'];
-  pipeline: PipelineSelector;
-  runConfigData?: InputMaybe<Scalars['RunConfigData']>;
-};
-
-export type DagitQueryGraphOrErrorArgs = {
-  selector?: InputMaybe<GraphSelector>;
-};
-
-export type DagitQueryInstigationStateOrErrorArgs = {
-  instigationSelector: InstigationSelector;
-};
-
-export type DagitQueryIsPipelineConfigValidArgs = {
-  mode: Scalars['String'];
-  pipeline: PipelineSelector;
-  runConfigData?: InputMaybe<Scalars['RunConfigData']>;
-};
-
-export type DagitQueryLogsForRunArgs = {
-  afterCursor?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  runId: Scalars['ID'];
-};
-
-export type DagitQueryPartitionBackfillOrErrorArgs = {
-  backfillId: Scalars['String'];
-};
-
-export type DagitQueryPartitionBackfillsOrErrorArgs = {
-  cursor?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  status?: InputMaybe<BulkActionStatus>;
-};
-
-export type DagitQueryPartitionSetOrErrorArgs = {
-  partitionSetName?: InputMaybe<Scalars['String']>;
-  repositorySelector: RepositorySelector;
-};
-
-export type DagitQueryPartitionSetsOrErrorArgs = {
-  pipelineName: Scalars['String'];
-  repositorySelector: RepositorySelector;
-};
-
-export type DagitQueryPipelineOrErrorArgs = {
-  params: PipelineSelector;
-};
-
-export type DagitQueryPipelineRunOrErrorArgs = {
-  runId: Scalars['ID'];
-};
-
-export type DagitQueryPipelineRunsOrErrorArgs = {
-  cursor?: InputMaybe<Scalars['String']>;
-  filter?: InputMaybe<RunsFilter>;
-  limit?: InputMaybe<Scalars['Int']>;
-};
-
-export type DagitQueryPipelineSnapshotOrErrorArgs = {
-  activePipelineSelector?: InputMaybe<PipelineSelector>;
-  snapshotId?: InputMaybe<Scalars['String']>;
-};
-
-export type DagitQueryRepositoriesOrErrorArgs = {
-  repositorySelector?: InputMaybe<RepositorySelector>;
-};
-
-export type DagitQueryRepositoryOrErrorArgs = {
-  repositorySelector: RepositorySelector;
-};
-
-export type DagitQueryRunConfigSchemaOrErrorArgs = {
-  mode?: InputMaybe<Scalars['String']>;
-  selector: PipelineSelector;
-};
-
-export type DagitQueryRunGroupOrErrorArgs = {
-  runId: Scalars['ID'];
-};
-
-export type DagitQueryRunGroupsOrErrorArgs = {
-  cursor?: InputMaybe<Scalars['String']>;
-  filter?: InputMaybe<RunsFilter>;
-  limit?: InputMaybe<Scalars['Int']>;
-};
-
-export type DagitQueryRunOrErrorArgs = {
-  runId: Scalars['ID'];
-};
-
-export type DagitQueryRunTagsOrErrorArgs = {
-  limit?: InputMaybe<Scalars['Int']>;
-  tagKeys?: InputMaybe<Array<Scalars['String']>>;
-  valuePrefix?: InputMaybe<Scalars['String']>;
-};
-
-export type DagitQueryRunsOrErrorArgs = {
-  cursor?: InputMaybe<Scalars['String']>;
-  filter?: InputMaybe<RunsFilter>;
-  limit?: InputMaybe<Scalars['Int']>;
-};
-
-export type DagitQueryScheduleOrErrorArgs = {
-  scheduleSelector: ScheduleSelector;
-};
-
-export type DagitQuerySchedulesOrErrorArgs = {
-  repositorySelector: RepositorySelector;
-  scheduleStatus?: InputMaybe<InstigationStatus>;
-};
-
-export type DagitQuerySensorOrErrorArgs = {
-  sensorSelector: SensorSelector;
-};
-
-export type DagitQuerySensorsOrErrorArgs = {
-  repositorySelector: RepositorySelector;
-  sensorStatus?: InputMaybe<InstigationStatus>;
-};
-
-export type DagitQueryTopLevelResourceDetailsOrErrorArgs = {
-  resourceSelector: ResourceSelector;
-};
-
-export type DagitQueryUnloadableInstigationStatesOrErrorArgs = {
-  instigationType?: InputMaybe<InstigationType>;
-};
-
-export type DagitQueryUtilizedEnvVarsOrErrorArgs = {
-  repositorySelector: RepositorySelector;
-};
-
-export type DagitSubscription = {
-  __typename: 'DagitSubscription';
-  capturedLogs: CapturedLogs;
-  computeLogs: ComputeLogFile;
-  locationStateChangeEvents: LocationStateChangeSubscription;
-  pipelineRunLogs: PipelineRunLogsSubscriptionPayload;
-};
-
-export type DagitSubscriptionCapturedLogsArgs = {
-  cursor?: InputMaybe<Scalars['String']>;
-  logKey: Array<Scalars['String']>;
-};
-
-export type DagitSubscriptionComputeLogsArgs = {
-  cursor?: InputMaybe<Scalars['String']>;
-  ioType: ComputeIoType;
-  runId: Scalars['ID'];
-  stepKey: Scalars['String'];
-};
-
-export type DagitSubscriptionPipelineRunLogsArgs = {
-  cursor?: InputMaybe<Scalars['String']>;
-  runId: Scalars['ID'];
-};
-
 export enum DagsterEventType {
   ALERT_FAILURE = 'ALERT_FAILURE',
   ALERT_START = 'ALERT_START',
@@ -2251,6 +1841,157 @@ export type MultiPartitionStatuses = {
   ranges: Array<MaterializedPartitionRangeStatuses2D>;
 };
 
+export type Mutation = {
+  __typename: 'Mutation';
+  addDynamicPartition: AddDynamicPartitionResult;
+  cancelPartitionBackfill: CancelBackfillResult;
+  deletePipelineRun: DeletePipelineRunResult;
+  deleteRun: DeletePipelineRunResult;
+  freeConcurrencySlotsForRun: Scalars['Boolean'];
+  launchPartitionBackfill: LaunchBackfillResult;
+  launchPipelineExecution: LaunchRunResult;
+  launchPipelineReexecution: LaunchRunReexecutionResult;
+  launchRun: LaunchRunResult;
+  launchRunReexecution: LaunchRunReexecutionResult;
+  logTelemetry: LogTelemetryMutationResult;
+  reloadRepositoryLocation: ReloadRepositoryLocationMutationResult;
+  reloadWorkspace: ReloadWorkspaceMutationResult;
+  resumePartitionBackfill: ResumeBackfillResult;
+  scheduleDryRun: ScheduleDryRunResult;
+  sensorDryRun: SensorDryRunResult;
+  setAutoMaterializePaused: Scalars['Boolean'];
+  setConcurrencyLimit: Scalars['Boolean'];
+  setNuxSeen: Scalars['Boolean'];
+  setSensorCursor: SensorOrError;
+  shutdownRepositoryLocation: ShutdownRepositoryLocationMutationResult;
+  startSchedule: ScheduleMutationResult;
+  startSensor: SensorOrError;
+  stopRunningSchedule: ScheduleMutationResult;
+  stopSensor: StopSensorMutationResultOrError;
+  terminatePipelineExecution: TerminateRunResult;
+  terminateRun: TerminateRunResult;
+  wipeAssets: AssetWipeMutationResult;
+};
+
+export type MutationAddDynamicPartitionArgs = {
+  partitionKey: Scalars['String'];
+  partitionsDefName: Scalars['String'];
+  repositorySelector: RepositorySelector;
+};
+
+export type MutationCancelPartitionBackfillArgs = {
+  backfillId: Scalars['String'];
+};
+
+export type MutationDeletePipelineRunArgs = {
+  runId: Scalars['String'];
+};
+
+export type MutationDeleteRunArgs = {
+  runId: Scalars['String'];
+};
+
+export type MutationFreeConcurrencySlotsForRunArgs = {
+  runId: Scalars['String'];
+};
+
+export type MutationLaunchPartitionBackfillArgs = {
+  backfillParams: LaunchBackfillParams;
+};
+
+export type MutationLaunchPipelineExecutionArgs = {
+  executionParams: ExecutionParams;
+};
+
+export type MutationLaunchPipelineReexecutionArgs = {
+  executionParams?: InputMaybe<ExecutionParams>;
+  reexecutionParams?: InputMaybe<ReexecutionParams>;
+};
+
+export type MutationLaunchRunArgs = {
+  executionParams: ExecutionParams;
+};
+
+export type MutationLaunchRunReexecutionArgs = {
+  executionParams?: InputMaybe<ExecutionParams>;
+  reexecutionParams?: InputMaybe<ReexecutionParams>;
+};
+
+export type MutationLogTelemetryArgs = {
+  action: Scalars['String'];
+  clientId: Scalars['String'];
+  clientTime: Scalars['String'];
+  metadata: Scalars['String'];
+};
+
+export type MutationReloadRepositoryLocationArgs = {
+  repositoryLocationName: Scalars['String'];
+};
+
+export type MutationResumePartitionBackfillArgs = {
+  backfillId: Scalars['String'];
+};
+
+export type MutationScheduleDryRunArgs = {
+  selectorData: ScheduleSelector;
+  timestamp?: InputMaybe<Scalars['Float']>;
+};
+
+export type MutationSensorDryRunArgs = {
+  cursor?: InputMaybe<Scalars['String']>;
+  selectorData: SensorSelector;
+};
+
+export type MutationSetAutoMaterializePausedArgs = {
+  paused: Scalars['Boolean'];
+};
+
+export type MutationSetConcurrencyLimitArgs = {
+  concurrencyKey: Scalars['String'];
+  limit: Scalars['Int'];
+};
+
+export type MutationSetSensorCursorArgs = {
+  cursor?: InputMaybe<Scalars['String']>;
+  sensorSelector: SensorSelector;
+};
+
+export type MutationShutdownRepositoryLocationArgs = {
+  repositoryLocationName: Scalars['String'];
+};
+
+export type MutationStartScheduleArgs = {
+  scheduleSelector: ScheduleSelector;
+};
+
+export type MutationStartSensorArgs = {
+  sensorSelector: SensorSelector;
+};
+
+export type MutationStopRunningScheduleArgs = {
+  scheduleOriginId: Scalars['String'];
+  scheduleSelectorId: Scalars['String'];
+};
+
+export type MutationStopSensorArgs = {
+  jobOriginId: Scalars['String'];
+  jobSelectorId: Scalars['String'];
+};
+
+export type MutationTerminatePipelineExecutionArgs = {
+  runId: Scalars['String'];
+  terminatePolicy?: InputMaybe<TerminateRunPolicy>;
+};
+
+export type MutationTerminateRunArgs = {
+  runId: Scalars['String'];
+  terminatePolicy?: InputMaybe<TerminateRunPolicy>;
+};
+
+export type MutationWipeAssetsArgs = {
+  assetKeys: Array<AssetKeyInput>;
+};
+
 export type NestedResourceEntry = {
   __typename: 'NestedResourceEntry';
   name: Scalars['String'];
@@ -2914,6 +2655,240 @@ export type PythonError = Error & {
   errorChain: Array<ErrorChainLink>;
   message: Scalars['String'];
   stack: Array<Scalars['String']>;
+};
+
+export type Query = {
+  __typename: 'Query';
+  allTopLevelResourceDetailsOrError: ResourcesOrError;
+  assetNodeDefinitionCollisions: Array<AssetNodeDefinitionCollision>;
+  assetNodeOrError: AssetNodeOrError;
+  assetNodes: Array<AssetNode>;
+  assetOrError: AssetOrError;
+  assetsLatestInfo: Array<AssetLatestInfo>;
+  assetsOrError: AssetsOrError;
+  autoMaterializeAssetEvaluationsOrError: Maybe<AutoMaterializeAssetEvaluationRecordsOrError>;
+  capturedLogs: CapturedLogs;
+  capturedLogsMetadata: CapturedLogsMetadata;
+  executionPlanOrError: ExecutionPlanOrError;
+  graphOrError: GraphOrError;
+  instance: Instance;
+  instigationStateOrError: InstigationStateOrError;
+  isPipelineConfigValid: PipelineConfigValidationResult;
+  locationStatusesOrError: WorkspaceLocationStatusEntriesOrError;
+  logsForRun: EventConnectionOrError;
+  partitionBackfillOrError: PartitionBackfillOrError;
+  partitionBackfillsOrError: PartitionBackfillsOrError;
+  partitionSetOrError: PartitionSetOrError;
+  partitionSetsOrError: PartitionSetsOrError;
+  permissions: Array<Permission>;
+  pipelineOrError: PipelineOrError;
+  pipelineRunOrError: RunOrError;
+  pipelineRunsOrError: RunsOrError;
+  pipelineSnapshotOrError: PipelineSnapshotOrError;
+  repositoriesOrError: RepositoriesOrError;
+  repositoryOrError: RepositoryOrError;
+  runConfigSchemaOrError: RunConfigSchemaOrError;
+  runGroupOrError: RunGroupOrError;
+  runGroupsOrError: RunGroupsOrError;
+  runOrError: RunOrError;
+  runTagKeysOrError: Maybe<RunTagKeysOrError>;
+  runTagsOrError: Maybe<RunTagsOrError>;
+  runsOrError: RunsOrError;
+  scheduleOrError: ScheduleOrError;
+  scheduler: SchedulerOrError;
+  schedulesOrError: SchedulesOrError;
+  sensorOrError: SensorOrError;
+  sensorsOrError: SensorsOrError;
+  shouldShowNux: Scalars['Boolean'];
+  test: Maybe<TestFields>;
+  topLevelResourceDetailsOrError: ResourceDetailsOrError;
+  unloadableInstigationStatesOrError: InstigationStatesOrError;
+  utilizedEnvVarsOrError: EnvVarWithConsumersOrError;
+  version: Scalars['String'];
+  workspaceOrError: WorkspaceOrError;
+};
+
+export type QueryAllTopLevelResourceDetailsOrErrorArgs = {
+  repositorySelector: RepositorySelector;
+};
+
+export type QueryAssetNodeDefinitionCollisionsArgs = {
+  assetKeys?: InputMaybe<Array<AssetKeyInput>>;
+};
+
+export type QueryAssetNodeOrErrorArgs = {
+  assetKey: AssetKeyInput;
+};
+
+export type QueryAssetNodesArgs = {
+  assetKeys?: InputMaybe<Array<AssetKeyInput>>;
+  group?: InputMaybe<AssetGroupSelector>;
+  loadMaterializations?: InputMaybe<Scalars['Boolean']>;
+  pipeline?: InputMaybe<PipelineSelector>;
+};
+
+export type QueryAssetOrErrorArgs = {
+  assetKey: AssetKeyInput;
+};
+
+export type QueryAssetsLatestInfoArgs = {
+  assetKeys: Array<AssetKeyInput>;
+};
+
+export type QueryAssetsOrErrorArgs = {
+  cursor?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  prefix?: InputMaybe<Array<Scalars['String']>>;
+};
+
+export type QueryAutoMaterializeAssetEvaluationsOrErrorArgs = {
+  assetKey: AssetKeyInput;
+  cursor?: InputMaybe<Scalars['String']>;
+  limit: Scalars['Int'];
+};
+
+export type QueryCapturedLogsArgs = {
+  cursor?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  logKey: Array<Scalars['String']>;
+};
+
+export type QueryCapturedLogsMetadataArgs = {
+  logKey: Array<Scalars['String']>;
+};
+
+export type QueryExecutionPlanOrErrorArgs = {
+  mode: Scalars['String'];
+  pipeline: PipelineSelector;
+  runConfigData?: InputMaybe<Scalars['RunConfigData']>;
+};
+
+export type QueryGraphOrErrorArgs = {
+  selector?: InputMaybe<GraphSelector>;
+};
+
+export type QueryInstigationStateOrErrorArgs = {
+  instigationSelector: InstigationSelector;
+};
+
+export type QueryIsPipelineConfigValidArgs = {
+  mode: Scalars['String'];
+  pipeline: PipelineSelector;
+  runConfigData?: InputMaybe<Scalars['RunConfigData']>;
+};
+
+export type QueryLogsForRunArgs = {
+  afterCursor?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  runId: Scalars['ID'];
+};
+
+export type QueryPartitionBackfillOrErrorArgs = {
+  backfillId: Scalars['String'];
+};
+
+export type QueryPartitionBackfillsOrErrorArgs = {
+  cursor?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  status?: InputMaybe<BulkActionStatus>;
+};
+
+export type QueryPartitionSetOrErrorArgs = {
+  partitionSetName?: InputMaybe<Scalars['String']>;
+  repositorySelector: RepositorySelector;
+};
+
+export type QueryPartitionSetsOrErrorArgs = {
+  pipelineName: Scalars['String'];
+  repositorySelector: RepositorySelector;
+};
+
+export type QueryPipelineOrErrorArgs = {
+  params: PipelineSelector;
+};
+
+export type QueryPipelineRunOrErrorArgs = {
+  runId: Scalars['ID'];
+};
+
+export type QueryPipelineRunsOrErrorArgs = {
+  cursor?: InputMaybe<Scalars['String']>;
+  filter?: InputMaybe<RunsFilter>;
+  limit?: InputMaybe<Scalars['Int']>;
+};
+
+export type QueryPipelineSnapshotOrErrorArgs = {
+  activePipelineSelector?: InputMaybe<PipelineSelector>;
+  snapshotId?: InputMaybe<Scalars['String']>;
+};
+
+export type QueryRepositoriesOrErrorArgs = {
+  repositorySelector?: InputMaybe<RepositorySelector>;
+};
+
+export type QueryRepositoryOrErrorArgs = {
+  repositorySelector: RepositorySelector;
+};
+
+export type QueryRunConfigSchemaOrErrorArgs = {
+  mode?: InputMaybe<Scalars['String']>;
+  selector: PipelineSelector;
+};
+
+export type QueryRunGroupOrErrorArgs = {
+  runId: Scalars['ID'];
+};
+
+export type QueryRunGroupsOrErrorArgs = {
+  cursor?: InputMaybe<Scalars['String']>;
+  filter?: InputMaybe<RunsFilter>;
+  limit?: InputMaybe<Scalars['Int']>;
+};
+
+export type QueryRunOrErrorArgs = {
+  runId: Scalars['ID'];
+};
+
+export type QueryRunTagsOrErrorArgs = {
+  limit?: InputMaybe<Scalars['Int']>;
+  tagKeys?: InputMaybe<Array<Scalars['String']>>;
+  valuePrefix?: InputMaybe<Scalars['String']>;
+};
+
+export type QueryRunsOrErrorArgs = {
+  cursor?: InputMaybe<Scalars['String']>;
+  filter?: InputMaybe<RunsFilter>;
+  limit?: InputMaybe<Scalars['Int']>;
+};
+
+export type QueryScheduleOrErrorArgs = {
+  scheduleSelector: ScheduleSelector;
+};
+
+export type QuerySchedulesOrErrorArgs = {
+  repositorySelector: RepositorySelector;
+  scheduleStatus?: InputMaybe<InstigationStatus>;
+};
+
+export type QuerySensorOrErrorArgs = {
+  sensorSelector: SensorSelector;
+};
+
+export type QuerySensorsOrErrorArgs = {
+  repositorySelector: RepositorySelector;
+  sensorStatus?: InputMaybe<InstigationStatus>;
+};
+
+export type QueryTopLevelResourceDetailsOrErrorArgs = {
+  resourceSelector: ResourceSelector;
+};
+
+export type QueryUnloadableInstigationStatesOrErrorArgs = {
+  instigationType?: InputMaybe<InstigationType>;
+};
+
+export type QueryUtilizedEnvVarsOrErrorArgs = {
+  repositorySelector: RepositorySelector;
 };
 
 export type ReexecutionParams = {
@@ -3891,6 +3866,31 @@ export type StopSensorMutationResultOrError =
   | PythonError
   | StopSensorMutationResult
   | UnauthorizedError;
+
+export type Subscription = {
+  __typename: 'Subscription';
+  capturedLogs: CapturedLogs;
+  computeLogs: ComputeLogFile;
+  locationStateChangeEvents: LocationStateChangeSubscription;
+  pipelineRunLogs: PipelineRunLogsSubscriptionPayload;
+};
+
+export type SubscriptionCapturedLogsArgs = {
+  cursor?: InputMaybe<Scalars['String']>;
+  logKey: Array<Scalars['String']>;
+};
+
+export type SubscriptionComputeLogsArgs = {
+  cursor?: InputMaybe<Scalars['String']>;
+  ioType: ComputeIoType;
+  runId: Scalars['ID'];
+  stepKey: Scalars['String'];
+};
+
+export type SubscriptionPipelineRunLogsArgs = {
+  cursor?: InputMaybe<Scalars['String']>;
+  runId: Scalars['ID'];
+};
 
 export type Table = {
   __typename: 'Table';
@@ -5174,477 +5174,6 @@ export const buildDaemonStatus = (
         ? overrides.lastHeartbeatTime!
         : 8.69,
     required: overrides && overrides.hasOwnProperty('required') ? overrides.required! : false,
-  };
-};
-
-export const buildDagitMutation = (
-  overrides?: Partial<DagitMutation>,
-  _relationshipsToOmit: Set<string> = new Set(),
-): {__typename: 'DagitMutation'} & DagitMutation => {
-  const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
-  relationshipsToOmit.add('DagitMutation');
-  return {
-    __typename: 'DagitMutation',
-    addDynamicPartition:
-      overrides && overrides.hasOwnProperty('addDynamicPartition')
-        ? overrides.addDynamicPartition!
-        : relationshipsToOmit.has('AddDynamicPartitionSuccess')
-        ? ({} as AddDynamicPartitionSuccess)
-        : buildAddDynamicPartitionSuccess({}, relationshipsToOmit),
-    cancelPartitionBackfill:
-      overrides && overrides.hasOwnProperty('cancelPartitionBackfill')
-        ? overrides.cancelPartitionBackfill!
-        : relationshipsToOmit.has('CancelBackfillSuccess')
-        ? ({} as CancelBackfillSuccess)
-        : buildCancelBackfillSuccess({}, relationshipsToOmit),
-    deletePipelineRun:
-      overrides && overrides.hasOwnProperty('deletePipelineRun')
-        ? overrides.deletePipelineRun!
-        : relationshipsToOmit.has('DeletePipelineRunSuccess')
-        ? ({} as DeletePipelineRunSuccess)
-        : buildDeletePipelineRunSuccess({}, relationshipsToOmit),
-    deleteRun:
-      overrides && overrides.hasOwnProperty('deleteRun')
-        ? overrides.deleteRun!
-        : relationshipsToOmit.has('DeletePipelineRunSuccess')
-        ? ({} as DeletePipelineRunSuccess)
-        : buildDeletePipelineRunSuccess({}, relationshipsToOmit),
-    freeConcurrencySlotsForRun:
-      overrides && overrides.hasOwnProperty('freeConcurrencySlotsForRun')
-        ? overrides.freeConcurrencySlotsForRun!
-        : false,
-    launchPartitionBackfill:
-      overrides && overrides.hasOwnProperty('launchPartitionBackfill')
-        ? overrides.launchPartitionBackfill!
-        : relationshipsToOmit.has('ConflictingExecutionParamsError')
-        ? ({} as ConflictingExecutionParamsError)
-        : buildConflictingExecutionParamsError({}, relationshipsToOmit),
-    launchPipelineExecution:
-      overrides && overrides.hasOwnProperty('launchPipelineExecution')
-        ? overrides.launchPipelineExecution!
-        : relationshipsToOmit.has('ConflictingExecutionParamsError')
-        ? ({} as ConflictingExecutionParamsError)
-        : buildConflictingExecutionParamsError({}, relationshipsToOmit),
-    launchPipelineReexecution:
-      overrides && overrides.hasOwnProperty('launchPipelineReexecution')
-        ? overrides.launchPipelineReexecution!
-        : relationshipsToOmit.has('ConflictingExecutionParamsError')
-        ? ({} as ConflictingExecutionParamsError)
-        : buildConflictingExecutionParamsError({}, relationshipsToOmit),
-    launchRun:
-      overrides && overrides.hasOwnProperty('launchRun')
-        ? overrides.launchRun!
-        : relationshipsToOmit.has('ConflictingExecutionParamsError')
-        ? ({} as ConflictingExecutionParamsError)
-        : buildConflictingExecutionParamsError({}, relationshipsToOmit),
-    launchRunReexecution:
-      overrides && overrides.hasOwnProperty('launchRunReexecution')
-        ? overrides.launchRunReexecution!
-        : relationshipsToOmit.has('ConflictingExecutionParamsError')
-        ? ({} as ConflictingExecutionParamsError)
-        : buildConflictingExecutionParamsError({}, relationshipsToOmit),
-    logTelemetry:
-      overrides && overrides.hasOwnProperty('logTelemetry')
-        ? overrides.logTelemetry!
-        : relationshipsToOmit.has('LogTelemetrySuccess')
-        ? ({} as LogTelemetrySuccess)
-        : buildLogTelemetrySuccess({}, relationshipsToOmit),
-    reloadRepositoryLocation:
-      overrides && overrides.hasOwnProperty('reloadRepositoryLocation')
-        ? overrides.reloadRepositoryLocation!
-        : relationshipsToOmit.has('PythonError')
-        ? ({} as PythonError)
-        : buildPythonError({}, relationshipsToOmit),
-    reloadWorkspace:
-      overrides && overrides.hasOwnProperty('reloadWorkspace')
-        ? overrides.reloadWorkspace!
-        : relationshipsToOmit.has('PythonError')
-        ? ({} as PythonError)
-        : buildPythonError({}, relationshipsToOmit),
-    resumePartitionBackfill:
-      overrides && overrides.hasOwnProperty('resumePartitionBackfill')
-        ? overrides.resumePartitionBackfill!
-        : relationshipsToOmit.has('PythonError')
-        ? ({} as PythonError)
-        : buildPythonError({}, relationshipsToOmit),
-    scheduleDryRun:
-      overrides && overrides.hasOwnProperty('scheduleDryRun')
-        ? overrides.scheduleDryRun!
-        : relationshipsToOmit.has('DryRunInstigationTick')
-        ? ({} as DryRunInstigationTick)
-        : buildDryRunInstigationTick({}, relationshipsToOmit),
-    sensorDryRun:
-      overrides && overrides.hasOwnProperty('sensorDryRun')
-        ? overrides.sensorDryRun!
-        : relationshipsToOmit.has('DryRunInstigationTick')
-        ? ({} as DryRunInstigationTick)
-        : buildDryRunInstigationTick({}, relationshipsToOmit),
-    setAutoMaterializePaused:
-      overrides && overrides.hasOwnProperty('setAutoMaterializePaused')
-        ? overrides.setAutoMaterializePaused!
-        : true,
-    setConcurrencyLimit:
-      overrides && overrides.hasOwnProperty('setConcurrencyLimit')
-        ? overrides.setConcurrencyLimit!
-        : true,
-    setNuxSeen: overrides && overrides.hasOwnProperty('setNuxSeen') ? overrides.setNuxSeen! : true,
-    setSensorCursor:
-      overrides && overrides.hasOwnProperty('setSensorCursor')
-        ? overrides.setSensorCursor!
-        : relationshipsToOmit.has('PythonError')
-        ? ({} as PythonError)
-        : buildPythonError({}, relationshipsToOmit),
-    shutdownRepositoryLocation:
-      overrides && overrides.hasOwnProperty('shutdownRepositoryLocation')
-        ? overrides.shutdownRepositoryLocation!
-        : relationshipsToOmit.has('PythonError')
-        ? ({} as PythonError)
-        : buildPythonError({}, relationshipsToOmit),
-    startSchedule:
-      overrides && overrides.hasOwnProperty('startSchedule')
-        ? overrides.startSchedule!
-        : relationshipsToOmit.has('PythonError')
-        ? ({} as PythonError)
-        : buildPythonError({}, relationshipsToOmit),
-    startSensor:
-      overrides && overrides.hasOwnProperty('startSensor')
-        ? overrides.startSensor!
-        : relationshipsToOmit.has('PythonError')
-        ? ({} as PythonError)
-        : buildPythonError({}, relationshipsToOmit),
-    stopRunningSchedule:
-      overrides && overrides.hasOwnProperty('stopRunningSchedule')
-        ? overrides.stopRunningSchedule!
-        : relationshipsToOmit.has('PythonError')
-        ? ({} as PythonError)
-        : buildPythonError({}, relationshipsToOmit),
-    stopSensor:
-      overrides && overrides.hasOwnProperty('stopSensor')
-        ? overrides.stopSensor!
-        : relationshipsToOmit.has('PythonError')
-        ? ({} as PythonError)
-        : buildPythonError({}, relationshipsToOmit),
-    terminatePipelineExecution:
-      overrides && overrides.hasOwnProperty('terminatePipelineExecution')
-        ? overrides.terminatePipelineExecution!
-        : relationshipsToOmit.has('PythonError')
-        ? ({} as PythonError)
-        : buildPythonError({}, relationshipsToOmit),
-    terminateRun:
-      overrides && overrides.hasOwnProperty('terminateRun')
-        ? overrides.terminateRun!
-        : relationshipsToOmit.has('PythonError')
-        ? ({} as PythonError)
-        : buildPythonError({}, relationshipsToOmit),
-    wipeAssets:
-      overrides && overrides.hasOwnProperty('wipeAssets')
-        ? overrides.wipeAssets!
-        : relationshipsToOmit.has('AssetNotFoundError')
-        ? ({} as AssetNotFoundError)
-        : buildAssetNotFoundError({}, relationshipsToOmit),
-  };
-};
-
-export const buildDagitQuery = (
-  overrides?: Partial<DagitQuery>,
-  _relationshipsToOmit: Set<string> = new Set(),
-): {__typename: 'DagitQuery'} & DagitQuery => {
-  const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
-  relationshipsToOmit.add('DagitQuery');
-  return {
-    __typename: 'DagitQuery',
-    allTopLevelResourceDetailsOrError:
-      overrides && overrides.hasOwnProperty('allTopLevelResourceDetailsOrError')
-        ? overrides.allTopLevelResourceDetailsOrError!
-        : relationshipsToOmit.has('PythonError')
-        ? ({} as PythonError)
-        : buildPythonError({}, relationshipsToOmit),
-    assetNodeDefinitionCollisions:
-      overrides && overrides.hasOwnProperty('assetNodeDefinitionCollisions')
-        ? overrides.assetNodeDefinitionCollisions!
-        : [],
-    assetNodeOrError:
-      overrides && overrides.hasOwnProperty('assetNodeOrError')
-        ? overrides.assetNodeOrError!
-        : relationshipsToOmit.has('AssetNode')
-        ? ({} as AssetNode)
-        : buildAssetNode({}, relationshipsToOmit),
-    assetNodes: overrides && overrides.hasOwnProperty('assetNodes') ? overrides.assetNodes! : [],
-    assetOrError:
-      overrides && overrides.hasOwnProperty('assetOrError')
-        ? overrides.assetOrError!
-        : relationshipsToOmit.has('Asset')
-        ? ({} as Asset)
-        : buildAsset({}, relationshipsToOmit),
-    assetsLatestInfo:
-      overrides && overrides.hasOwnProperty('assetsLatestInfo') ? overrides.assetsLatestInfo! : [],
-    assetsOrError:
-      overrides && overrides.hasOwnProperty('assetsOrError')
-        ? overrides.assetsOrError!
-        : relationshipsToOmit.has('AssetConnection')
-        ? ({} as AssetConnection)
-        : buildAssetConnection({}, relationshipsToOmit),
-    autoMaterializeAssetEvaluationsOrError:
-      overrides && overrides.hasOwnProperty('autoMaterializeAssetEvaluationsOrError')
-        ? overrides.autoMaterializeAssetEvaluationsOrError!
-        : relationshipsToOmit.has('AutoMaterializeAssetEvaluationNeedsMigrationError')
-        ? ({} as AutoMaterializeAssetEvaluationNeedsMigrationError)
-        : buildAutoMaterializeAssetEvaluationNeedsMigrationError({}, relationshipsToOmit),
-    capturedLogs:
-      overrides && overrides.hasOwnProperty('capturedLogs')
-        ? overrides.capturedLogs!
-        : relationshipsToOmit.has('CapturedLogs')
-        ? ({} as CapturedLogs)
-        : buildCapturedLogs({}, relationshipsToOmit),
-    capturedLogsMetadata:
-      overrides && overrides.hasOwnProperty('capturedLogsMetadata')
-        ? overrides.capturedLogsMetadata!
-        : relationshipsToOmit.has('CapturedLogsMetadata')
-        ? ({} as CapturedLogsMetadata)
-        : buildCapturedLogsMetadata({}, relationshipsToOmit),
-    executionPlanOrError:
-      overrides && overrides.hasOwnProperty('executionPlanOrError')
-        ? overrides.executionPlanOrError!
-        : relationshipsToOmit.has('ExecutionPlan')
-        ? ({} as ExecutionPlan)
-        : buildExecutionPlan({}, relationshipsToOmit),
-    graphOrError:
-      overrides && overrides.hasOwnProperty('graphOrError')
-        ? overrides.graphOrError!
-        : relationshipsToOmit.has('Graph')
-        ? ({} as Graph)
-        : buildGraph({}, relationshipsToOmit),
-    instance:
-      overrides && overrides.hasOwnProperty('instance')
-        ? overrides.instance!
-        : relationshipsToOmit.has('Instance')
-        ? ({} as Instance)
-        : buildInstance({}, relationshipsToOmit),
-    instigationStateOrError:
-      overrides && overrides.hasOwnProperty('instigationStateOrError')
-        ? overrides.instigationStateOrError!
-        : relationshipsToOmit.has('InstigationState')
-        ? ({} as InstigationState)
-        : buildInstigationState({}, relationshipsToOmit),
-    isPipelineConfigValid:
-      overrides && overrides.hasOwnProperty('isPipelineConfigValid')
-        ? overrides.isPipelineConfigValid!
-        : relationshipsToOmit.has('InvalidSubsetError')
-        ? ({} as InvalidSubsetError)
-        : buildInvalidSubsetError({}, relationshipsToOmit),
-    locationStatusesOrError:
-      overrides && overrides.hasOwnProperty('locationStatusesOrError')
-        ? overrides.locationStatusesOrError!
-        : relationshipsToOmit.has('PythonError')
-        ? ({} as PythonError)
-        : buildPythonError({}, relationshipsToOmit),
-    logsForRun:
-      overrides && overrides.hasOwnProperty('logsForRun')
-        ? overrides.logsForRun!
-        : relationshipsToOmit.has('EventConnection')
-        ? ({} as EventConnection)
-        : buildEventConnection({}, relationshipsToOmit),
-    partitionBackfillOrError:
-      overrides && overrides.hasOwnProperty('partitionBackfillOrError')
-        ? overrides.partitionBackfillOrError!
-        : relationshipsToOmit.has('BackfillNotFoundError')
-        ? ({} as BackfillNotFoundError)
-        : buildBackfillNotFoundError({}, relationshipsToOmit),
-    partitionBackfillsOrError:
-      overrides && overrides.hasOwnProperty('partitionBackfillsOrError')
-        ? overrides.partitionBackfillsOrError!
-        : relationshipsToOmit.has('PartitionBackfills')
-        ? ({} as PartitionBackfills)
-        : buildPartitionBackfills({}, relationshipsToOmit),
-    partitionSetOrError:
-      overrides && overrides.hasOwnProperty('partitionSetOrError')
-        ? overrides.partitionSetOrError!
-        : relationshipsToOmit.has('PartitionSet')
-        ? ({} as PartitionSet)
-        : buildPartitionSet({}, relationshipsToOmit),
-    partitionSetsOrError:
-      overrides && overrides.hasOwnProperty('partitionSetsOrError')
-        ? overrides.partitionSetsOrError!
-        : relationshipsToOmit.has('PartitionSets')
-        ? ({} as PartitionSets)
-        : buildPartitionSets({}, relationshipsToOmit),
-    permissions: overrides && overrides.hasOwnProperty('permissions') ? overrides.permissions! : [],
-    pipelineOrError:
-      overrides && overrides.hasOwnProperty('pipelineOrError')
-        ? overrides.pipelineOrError!
-        : relationshipsToOmit.has('InvalidSubsetError')
-        ? ({} as InvalidSubsetError)
-        : buildInvalidSubsetError({}, relationshipsToOmit),
-    pipelineRunOrError:
-      overrides && overrides.hasOwnProperty('pipelineRunOrError')
-        ? overrides.pipelineRunOrError!
-        : relationshipsToOmit.has('PythonError')
-        ? ({} as PythonError)
-        : buildPythonError({}, relationshipsToOmit),
-    pipelineRunsOrError:
-      overrides && overrides.hasOwnProperty('pipelineRunsOrError')
-        ? overrides.pipelineRunsOrError!
-        : relationshipsToOmit.has('InvalidPipelineRunsFilterError')
-        ? ({} as InvalidPipelineRunsFilterError)
-        : buildInvalidPipelineRunsFilterError({}, relationshipsToOmit),
-    pipelineSnapshotOrError:
-      overrides && overrides.hasOwnProperty('pipelineSnapshotOrError')
-        ? overrides.pipelineSnapshotOrError!
-        : relationshipsToOmit.has('PipelineNotFoundError')
-        ? ({} as PipelineNotFoundError)
-        : buildPipelineNotFoundError({}, relationshipsToOmit),
-    repositoriesOrError:
-      overrides && overrides.hasOwnProperty('repositoriesOrError')
-        ? overrides.repositoriesOrError!
-        : relationshipsToOmit.has('PythonError')
-        ? ({} as PythonError)
-        : buildPythonError({}, relationshipsToOmit),
-    repositoryOrError:
-      overrides && overrides.hasOwnProperty('repositoryOrError')
-        ? overrides.repositoryOrError!
-        : relationshipsToOmit.has('PythonError')
-        ? ({} as PythonError)
-        : buildPythonError({}, relationshipsToOmit),
-    runConfigSchemaOrError:
-      overrides && overrides.hasOwnProperty('runConfigSchemaOrError')
-        ? overrides.runConfigSchemaOrError!
-        : relationshipsToOmit.has('InvalidSubsetError')
-        ? ({} as InvalidSubsetError)
-        : buildInvalidSubsetError({}, relationshipsToOmit),
-    runGroupOrError:
-      overrides && overrides.hasOwnProperty('runGroupOrError')
-        ? overrides.runGroupOrError!
-        : relationshipsToOmit.has('PythonError')
-        ? ({} as PythonError)
-        : buildPythonError({}, relationshipsToOmit),
-    runGroupsOrError:
-      overrides && overrides.hasOwnProperty('runGroupsOrError')
-        ? overrides.runGroupsOrError!
-        : relationshipsToOmit.has('RunGroupsOrError')
-        ? ({} as RunGroupsOrError)
-        : buildRunGroupsOrError({}, relationshipsToOmit),
-    runOrError:
-      overrides && overrides.hasOwnProperty('runOrError')
-        ? overrides.runOrError!
-        : relationshipsToOmit.has('PythonError')
-        ? ({} as PythonError)
-        : buildPythonError({}, relationshipsToOmit),
-    runTagKeysOrError:
-      overrides && overrides.hasOwnProperty('runTagKeysOrError')
-        ? overrides.runTagKeysOrError!
-        : relationshipsToOmit.has('PythonError')
-        ? ({} as PythonError)
-        : buildPythonError({}, relationshipsToOmit),
-    runTagsOrError:
-      overrides && overrides.hasOwnProperty('runTagsOrError')
-        ? overrides.runTagsOrError!
-        : relationshipsToOmit.has('PythonError')
-        ? ({} as PythonError)
-        : buildPythonError({}, relationshipsToOmit),
-    runsOrError:
-      overrides && overrides.hasOwnProperty('runsOrError')
-        ? overrides.runsOrError!
-        : relationshipsToOmit.has('InvalidPipelineRunsFilterError')
-        ? ({} as InvalidPipelineRunsFilterError)
-        : buildInvalidPipelineRunsFilterError({}, relationshipsToOmit),
-    scheduleOrError:
-      overrides && overrides.hasOwnProperty('scheduleOrError')
-        ? overrides.scheduleOrError!
-        : relationshipsToOmit.has('PythonError')
-        ? ({} as PythonError)
-        : buildPythonError({}, relationshipsToOmit),
-    scheduler:
-      overrides && overrides.hasOwnProperty('scheduler')
-        ? overrides.scheduler!
-        : relationshipsToOmit.has('PythonError')
-        ? ({} as PythonError)
-        : buildPythonError({}, relationshipsToOmit),
-    schedulesOrError:
-      overrides && overrides.hasOwnProperty('schedulesOrError')
-        ? overrides.schedulesOrError!
-        : relationshipsToOmit.has('PythonError')
-        ? ({} as PythonError)
-        : buildPythonError({}, relationshipsToOmit),
-    sensorOrError:
-      overrides && overrides.hasOwnProperty('sensorOrError')
-        ? overrides.sensorOrError!
-        : relationshipsToOmit.has('PythonError')
-        ? ({} as PythonError)
-        : buildPythonError({}, relationshipsToOmit),
-    sensorsOrError:
-      overrides && overrides.hasOwnProperty('sensorsOrError')
-        ? overrides.sensorsOrError!
-        : relationshipsToOmit.has('PythonError')
-        ? ({} as PythonError)
-        : buildPythonError({}, relationshipsToOmit),
-    shouldShowNux:
-      overrides && overrides.hasOwnProperty('shouldShowNux') ? overrides.shouldShowNux! : true,
-    test:
-      overrides && overrides.hasOwnProperty('test')
-        ? overrides.test!
-        : relationshipsToOmit.has('TestFields')
-        ? ({} as TestFields)
-        : buildTestFields({}, relationshipsToOmit),
-    topLevelResourceDetailsOrError:
-      overrides && overrides.hasOwnProperty('topLevelResourceDetailsOrError')
-        ? overrides.topLevelResourceDetailsOrError!
-        : relationshipsToOmit.has('PythonError')
-        ? ({} as PythonError)
-        : buildPythonError({}, relationshipsToOmit),
-    unloadableInstigationStatesOrError:
-      overrides && overrides.hasOwnProperty('unloadableInstigationStatesOrError')
-        ? overrides.unloadableInstigationStatesOrError!
-        : relationshipsToOmit.has('InstigationStates')
-        ? ({} as InstigationStates)
-        : buildInstigationStates({}, relationshipsToOmit),
-    utilizedEnvVarsOrError:
-      overrides && overrides.hasOwnProperty('utilizedEnvVarsOrError')
-        ? overrides.utilizedEnvVarsOrError!
-        : relationshipsToOmit.has('EnvVarWithConsumersList')
-        ? ({} as EnvVarWithConsumersList)
-        : buildEnvVarWithConsumersList({}, relationshipsToOmit),
-    version: overrides && overrides.hasOwnProperty('version') ? overrides.version! : 'sed',
-    workspaceOrError:
-      overrides && overrides.hasOwnProperty('workspaceOrError')
-        ? overrides.workspaceOrError!
-        : relationshipsToOmit.has('PythonError')
-        ? ({} as PythonError)
-        : buildPythonError({}, relationshipsToOmit),
-  };
-};
-
-export const buildDagitSubscription = (
-  overrides?: Partial<DagitSubscription>,
-  _relationshipsToOmit: Set<string> = new Set(),
-): {__typename: 'DagitSubscription'} & DagitSubscription => {
-  const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
-  relationshipsToOmit.add('DagitSubscription');
-  return {
-    __typename: 'DagitSubscription',
-    capturedLogs:
-      overrides && overrides.hasOwnProperty('capturedLogs')
-        ? overrides.capturedLogs!
-        : relationshipsToOmit.has('CapturedLogs')
-        ? ({} as CapturedLogs)
-        : buildCapturedLogs({}, relationshipsToOmit),
-    computeLogs:
-      overrides && overrides.hasOwnProperty('computeLogs')
-        ? overrides.computeLogs!
-        : relationshipsToOmit.has('ComputeLogFile')
-        ? ({} as ComputeLogFile)
-        : buildComputeLogFile({}, relationshipsToOmit),
-    locationStateChangeEvents:
-      overrides && overrides.hasOwnProperty('locationStateChangeEvents')
-        ? overrides.locationStateChangeEvents!
-        : relationshipsToOmit.has('LocationStateChangeSubscription')
-        ? ({} as LocationStateChangeSubscription)
-        : buildLocationStateChangeSubscription({}, relationshipsToOmit),
-    pipelineRunLogs:
-      overrides && overrides.hasOwnProperty('pipelineRunLogs')
-        ? overrides.pipelineRunLogs!
-        : relationshipsToOmit.has('PipelineRunLogsSubscriptionFailure')
-        ? ({} as PipelineRunLogsSubscriptionFailure)
-        : buildPipelineRunLogsSubscriptionFailure({}, relationshipsToOmit),
   };
 };
 
@@ -8184,6 +7713,174 @@ export const buildMultiPartitionStatuses = (
   };
 };
 
+export const buildMutation = (
+  overrides?: Partial<Mutation>,
+  _relationshipsToOmit: Set<string> = new Set(),
+): {__typename: 'Mutation'} & Mutation => {
+  const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
+  relationshipsToOmit.add('Mutation');
+  return {
+    __typename: 'Mutation',
+    addDynamicPartition:
+      overrides && overrides.hasOwnProperty('addDynamicPartition')
+        ? overrides.addDynamicPartition!
+        : relationshipsToOmit.has('AddDynamicPartitionSuccess')
+        ? ({} as AddDynamicPartitionSuccess)
+        : buildAddDynamicPartitionSuccess({}, relationshipsToOmit),
+    cancelPartitionBackfill:
+      overrides && overrides.hasOwnProperty('cancelPartitionBackfill')
+        ? overrides.cancelPartitionBackfill!
+        : relationshipsToOmit.has('CancelBackfillSuccess')
+        ? ({} as CancelBackfillSuccess)
+        : buildCancelBackfillSuccess({}, relationshipsToOmit),
+    deletePipelineRun:
+      overrides && overrides.hasOwnProperty('deletePipelineRun')
+        ? overrides.deletePipelineRun!
+        : relationshipsToOmit.has('DeletePipelineRunSuccess')
+        ? ({} as DeletePipelineRunSuccess)
+        : buildDeletePipelineRunSuccess({}, relationshipsToOmit),
+    deleteRun:
+      overrides && overrides.hasOwnProperty('deleteRun')
+        ? overrides.deleteRun!
+        : relationshipsToOmit.has('DeletePipelineRunSuccess')
+        ? ({} as DeletePipelineRunSuccess)
+        : buildDeletePipelineRunSuccess({}, relationshipsToOmit),
+    freeConcurrencySlotsForRun:
+      overrides && overrides.hasOwnProperty('freeConcurrencySlotsForRun')
+        ? overrides.freeConcurrencySlotsForRun!
+        : false,
+    launchPartitionBackfill:
+      overrides && overrides.hasOwnProperty('launchPartitionBackfill')
+        ? overrides.launchPartitionBackfill!
+        : relationshipsToOmit.has('ConflictingExecutionParamsError')
+        ? ({} as ConflictingExecutionParamsError)
+        : buildConflictingExecutionParamsError({}, relationshipsToOmit),
+    launchPipelineExecution:
+      overrides && overrides.hasOwnProperty('launchPipelineExecution')
+        ? overrides.launchPipelineExecution!
+        : relationshipsToOmit.has('ConflictingExecutionParamsError')
+        ? ({} as ConflictingExecutionParamsError)
+        : buildConflictingExecutionParamsError({}, relationshipsToOmit),
+    launchPipelineReexecution:
+      overrides && overrides.hasOwnProperty('launchPipelineReexecution')
+        ? overrides.launchPipelineReexecution!
+        : relationshipsToOmit.has('ConflictingExecutionParamsError')
+        ? ({} as ConflictingExecutionParamsError)
+        : buildConflictingExecutionParamsError({}, relationshipsToOmit),
+    launchRun:
+      overrides && overrides.hasOwnProperty('launchRun')
+        ? overrides.launchRun!
+        : relationshipsToOmit.has('ConflictingExecutionParamsError')
+        ? ({} as ConflictingExecutionParamsError)
+        : buildConflictingExecutionParamsError({}, relationshipsToOmit),
+    launchRunReexecution:
+      overrides && overrides.hasOwnProperty('launchRunReexecution')
+        ? overrides.launchRunReexecution!
+        : relationshipsToOmit.has('ConflictingExecutionParamsError')
+        ? ({} as ConflictingExecutionParamsError)
+        : buildConflictingExecutionParamsError({}, relationshipsToOmit),
+    logTelemetry:
+      overrides && overrides.hasOwnProperty('logTelemetry')
+        ? overrides.logTelemetry!
+        : relationshipsToOmit.has('LogTelemetrySuccess')
+        ? ({} as LogTelemetrySuccess)
+        : buildLogTelemetrySuccess({}, relationshipsToOmit),
+    reloadRepositoryLocation:
+      overrides && overrides.hasOwnProperty('reloadRepositoryLocation')
+        ? overrides.reloadRepositoryLocation!
+        : relationshipsToOmit.has('PythonError')
+        ? ({} as PythonError)
+        : buildPythonError({}, relationshipsToOmit),
+    reloadWorkspace:
+      overrides && overrides.hasOwnProperty('reloadWorkspace')
+        ? overrides.reloadWorkspace!
+        : relationshipsToOmit.has('PythonError')
+        ? ({} as PythonError)
+        : buildPythonError({}, relationshipsToOmit),
+    resumePartitionBackfill:
+      overrides && overrides.hasOwnProperty('resumePartitionBackfill')
+        ? overrides.resumePartitionBackfill!
+        : relationshipsToOmit.has('PythonError')
+        ? ({} as PythonError)
+        : buildPythonError({}, relationshipsToOmit),
+    scheduleDryRun:
+      overrides && overrides.hasOwnProperty('scheduleDryRun')
+        ? overrides.scheduleDryRun!
+        : relationshipsToOmit.has('DryRunInstigationTick')
+        ? ({} as DryRunInstigationTick)
+        : buildDryRunInstigationTick({}, relationshipsToOmit),
+    sensorDryRun:
+      overrides && overrides.hasOwnProperty('sensorDryRun')
+        ? overrides.sensorDryRun!
+        : relationshipsToOmit.has('DryRunInstigationTick')
+        ? ({} as DryRunInstigationTick)
+        : buildDryRunInstigationTick({}, relationshipsToOmit),
+    setAutoMaterializePaused:
+      overrides && overrides.hasOwnProperty('setAutoMaterializePaused')
+        ? overrides.setAutoMaterializePaused!
+        : true,
+    setConcurrencyLimit:
+      overrides && overrides.hasOwnProperty('setConcurrencyLimit')
+        ? overrides.setConcurrencyLimit!
+        : false,
+    setNuxSeen: overrides && overrides.hasOwnProperty('setNuxSeen') ? overrides.setNuxSeen! : true,
+    setSensorCursor:
+      overrides && overrides.hasOwnProperty('setSensorCursor')
+        ? overrides.setSensorCursor!
+        : relationshipsToOmit.has('PythonError')
+        ? ({} as PythonError)
+        : buildPythonError({}, relationshipsToOmit),
+    shutdownRepositoryLocation:
+      overrides && overrides.hasOwnProperty('shutdownRepositoryLocation')
+        ? overrides.shutdownRepositoryLocation!
+        : relationshipsToOmit.has('PythonError')
+        ? ({} as PythonError)
+        : buildPythonError({}, relationshipsToOmit),
+    startSchedule:
+      overrides && overrides.hasOwnProperty('startSchedule')
+        ? overrides.startSchedule!
+        : relationshipsToOmit.has('PythonError')
+        ? ({} as PythonError)
+        : buildPythonError({}, relationshipsToOmit),
+    startSensor:
+      overrides && overrides.hasOwnProperty('startSensor')
+        ? overrides.startSensor!
+        : relationshipsToOmit.has('PythonError')
+        ? ({} as PythonError)
+        : buildPythonError({}, relationshipsToOmit),
+    stopRunningSchedule:
+      overrides && overrides.hasOwnProperty('stopRunningSchedule')
+        ? overrides.stopRunningSchedule!
+        : relationshipsToOmit.has('PythonError')
+        ? ({} as PythonError)
+        : buildPythonError({}, relationshipsToOmit),
+    stopSensor:
+      overrides && overrides.hasOwnProperty('stopSensor')
+        ? overrides.stopSensor!
+        : relationshipsToOmit.has('PythonError')
+        ? ({} as PythonError)
+        : buildPythonError({}, relationshipsToOmit),
+    terminatePipelineExecution:
+      overrides && overrides.hasOwnProperty('terminatePipelineExecution')
+        ? overrides.terminatePipelineExecution!
+        : relationshipsToOmit.has('PythonError')
+        ? ({} as PythonError)
+        : buildPythonError({}, relationshipsToOmit),
+    terminateRun:
+      overrides && overrides.hasOwnProperty('terminateRun')
+        ? overrides.terminateRun!
+        : relationshipsToOmit.has('PythonError')
+        ? ({} as PythonError)
+        : buildPythonError({}, relationshipsToOmit),
+    wipeAssets:
+      overrides && overrides.hasOwnProperty('wipeAssets')
+        ? overrides.wipeAssets!
+        : relationshipsToOmit.has('AssetNotFoundError')
+        ? ({} as AssetNotFoundError)
+        : buildAssetNotFoundError({}, relationshipsToOmit),
+  };
+};
+
 export const buildNestedResourceEntry = (
   overrides?: Partial<NestedResourceEntry>,
   _relationshipsToOmit: Set<string> = new Set(),
@@ -9564,6 +9261,274 @@ export const buildPythonError = (
     errorChain: overrides && overrides.hasOwnProperty('errorChain') ? overrides.errorChain! : [],
     message: overrides && overrides.hasOwnProperty('message') ? overrides.message! : 'veritatis',
     stack: overrides && overrides.hasOwnProperty('stack') ? overrides.stack! : [],
+  };
+};
+
+export const buildQuery = (
+  overrides?: Partial<Query>,
+  _relationshipsToOmit: Set<string> = new Set(),
+): {__typename: 'Query'} & Query => {
+  const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
+  relationshipsToOmit.add('Query');
+  return {
+    __typename: 'Query',
+    allTopLevelResourceDetailsOrError:
+      overrides && overrides.hasOwnProperty('allTopLevelResourceDetailsOrError')
+        ? overrides.allTopLevelResourceDetailsOrError!
+        : relationshipsToOmit.has('PythonError')
+        ? ({} as PythonError)
+        : buildPythonError({}, relationshipsToOmit),
+    assetNodeDefinitionCollisions:
+      overrides && overrides.hasOwnProperty('assetNodeDefinitionCollisions')
+        ? overrides.assetNodeDefinitionCollisions!
+        : [],
+    assetNodeOrError:
+      overrides && overrides.hasOwnProperty('assetNodeOrError')
+        ? overrides.assetNodeOrError!
+        : relationshipsToOmit.has('AssetNode')
+        ? ({} as AssetNode)
+        : buildAssetNode({}, relationshipsToOmit),
+    assetNodes: overrides && overrides.hasOwnProperty('assetNodes') ? overrides.assetNodes! : [],
+    assetOrError:
+      overrides && overrides.hasOwnProperty('assetOrError')
+        ? overrides.assetOrError!
+        : relationshipsToOmit.has('Asset')
+        ? ({} as Asset)
+        : buildAsset({}, relationshipsToOmit),
+    assetsLatestInfo:
+      overrides && overrides.hasOwnProperty('assetsLatestInfo') ? overrides.assetsLatestInfo! : [],
+    assetsOrError:
+      overrides && overrides.hasOwnProperty('assetsOrError')
+        ? overrides.assetsOrError!
+        : relationshipsToOmit.has('AssetConnection')
+        ? ({} as AssetConnection)
+        : buildAssetConnection({}, relationshipsToOmit),
+    autoMaterializeAssetEvaluationsOrError:
+      overrides && overrides.hasOwnProperty('autoMaterializeAssetEvaluationsOrError')
+        ? overrides.autoMaterializeAssetEvaluationsOrError!
+        : relationshipsToOmit.has('AutoMaterializeAssetEvaluationNeedsMigrationError')
+        ? ({} as AutoMaterializeAssetEvaluationNeedsMigrationError)
+        : buildAutoMaterializeAssetEvaluationNeedsMigrationError({}, relationshipsToOmit),
+    capturedLogs:
+      overrides && overrides.hasOwnProperty('capturedLogs')
+        ? overrides.capturedLogs!
+        : relationshipsToOmit.has('CapturedLogs')
+        ? ({} as CapturedLogs)
+        : buildCapturedLogs({}, relationshipsToOmit),
+    capturedLogsMetadata:
+      overrides && overrides.hasOwnProperty('capturedLogsMetadata')
+        ? overrides.capturedLogsMetadata!
+        : relationshipsToOmit.has('CapturedLogsMetadata')
+        ? ({} as CapturedLogsMetadata)
+        : buildCapturedLogsMetadata({}, relationshipsToOmit),
+    executionPlanOrError:
+      overrides && overrides.hasOwnProperty('executionPlanOrError')
+        ? overrides.executionPlanOrError!
+        : relationshipsToOmit.has('ExecutionPlan')
+        ? ({} as ExecutionPlan)
+        : buildExecutionPlan({}, relationshipsToOmit),
+    graphOrError:
+      overrides && overrides.hasOwnProperty('graphOrError')
+        ? overrides.graphOrError!
+        : relationshipsToOmit.has('Graph')
+        ? ({} as Graph)
+        : buildGraph({}, relationshipsToOmit),
+    instance:
+      overrides && overrides.hasOwnProperty('instance')
+        ? overrides.instance!
+        : relationshipsToOmit.has('Instance')
+        ? ({} as Instance)
+        : buildInstance({}, relationshipsToOmit),
+    instigationStateOrError:
+      overrides && overrides.hasOwnProperty('instigationStateOrError')
+        ? overrides.instigationStateOrError!
+        : relationshipsToOmit.has('InstigationState')
+        ? ({} as InstigationState)
+        : buildInstigationState({}, relationshipsToOmit),
+    isPipelineConfigValid:
+      overrides && overrides.hasOwnProperty('isPipelineConfigValid')
+        ? overrides.isPipelineConfigValid!
+        : relationshipsToOmit.has('InvalidSubsetError')
+        ? ({} as InvalidSubsetError)
+        : buildInvalidSubsetError({}, relationshipsToOmit),
+    locationStatusesOrError:
+      overrides && overrides.hasOwnProperty('locationStatusesOrError')
+        ? overrides.locationStatusesOrError!
+        : relationshipsToOmit.has('PythonError')
+        ? ({} as PythonError)
+        : buildPythonError({}, relationshipsToOmit),
+    logsForRun:
+      overrides && overrides.hasOwnProperty('logsForRun')
+        ? overrides.logsForRun!
+        : relationshipsToOmit.has('EventConnection')
+        ? ({} as EventConnection)
+        : buildEventConnection({}, relationshipsToOmit),
+    partitionBackfillOrError:
+      overrides && overrides.hasOwnProperty('partitionBackfillOrError')
+        ? overrides.partitionBackfillOrError!
+        : relationshipsToOmit.has('BackfillNotFoundError')
+        ? ({} as BackfillNotFoundError)
+        : buildBackfillNotFoundError({}, relationshipsToOmit),
+    partitionBackfillsOrError:
+      overrides && overrides.hasOwnProperty('partitionBackfillsOrError')
+        ? overrides.partitionBackfillsOrError!
+        : relationshipsToOmit.has('PartitionBackfills')
+        ? ({} as PartitionBackfills)
+        : buildPartitionBackfills({}, relationshipsToOmit),
+    partitionSetOrError:
+      overrides && overrides.hasOwnProperty('partitionSetOrError')
+        ? overrides.partitionSetOrError!
+        : relationshipsToOmit.has('PartitionSet')
+        ? ({} as PartitionSet)
+        : buildPartitionSet({}, relationshipsToOmit),
+    partitionSetsOrError:
+      overrides && overrides.hasOwnProperty('partitionSetsOrError')
+        ? overrides.partitionSetsOrError!
+        : relationshipsToOmit.has('PartitionSets')
+        ? ({} as PartitionSets)
+        : buildPartitionSets({}, relationshipsToOmit),
+    permissions: overrides && overrides.hasOwnProperty('permissions') ? overrides.permissions! : [],
+    pipelineOrError:
+      overrides && overrides.hasOwnProperty('pipelineOrError')
+        ? overrides.pipelineOrError!
+        : relationshipsToOmit.has('InvalidSubsetError')
+        ? ({} as InvalidSubsetError)
+        : buildInvalidSubsetError({}, relationshipsToOmit),
+    pipelineRunOrError:
+      overrides && overrides.hasOwnProperty('pipelineRunOrError')
+        ? overrides.pipelineRunOrError!
+        : relationshipsToOmit.has('PythonError')
+        ? ({} as PythonError)
+        : buildPythonError({}, relationshipsToOmit),
+    pipelineRunsOrError:
+      overrides && overrides.hasOwnProperty('pipelineRunsOrError')
+        ? overrides.pipelineRunsOrError!
+        : relationshipsToOmit.has('InvalidPipelineRunsFilterError')
+        ? ({} as InvalidPipelineRunsFilterError)
+        : buildInvalidPipelineRunsFilterError({}, relationshipsToOmit),
+    pipelineSnapshotOrError:
+      overrides && overrides.hasOwnProperty('pipelineSnapshotOrError')
+        ? overrides.pipelineSnapshotOrError!
+        : relationshipsToOmit.has('PipelineNotFoundError')
+        ? ({} as PipelineNotFoundError)
+        : buildPipelineNotFoundError({}, relationshipsToOmit),
+    repositoriesOrError:
+      overrides && overrides.hasOwnProperty('repositoriesOrError')
+        ? overrides.repositoriesOrError!
+        : relationshipsToOmit.has('PythonError')
+        ? ({} as PythonError)
+        : buildPythonError({}, relationshipsToOmit),
+    repositoryOrError:
+      overrides && overrides.hasOwnProperty('repositoryOrError')
+        ? overrides.repositoryOrError!
+        : relationshipsToOmit.has('PythonError')
+        ? ({} as PythonError)
+        : buildPythonError({}, relationshipsToOmit),
+    runConfigSchemaOrError:
+      overrides && overrides.hasOwnProperty('runConfigSchemaOrError')
+        ? overrides.runConfigSchemaOrError!
+        : relationshipsToOmit.has('InvalidSubsetError')
+        ? ({} as InvalidSubsetError)
+        : buildInvalidSubsetError({}, relationshipsToOmit),
+    runGroupOrError:
+      overrides && overrides.hasOwnProperty('runGroupOrError')
+        ? overrides.runGroupOrError!
+        : relationshipsToOmit.has('PythonError')
+        ? ({} as PythonError)
+        : buildPythonError({}, relationshipsToOmit),
+    runGroupsOrError:
+      overrides && overrides.hasOwnProperty('runGroupsOrError')
+        ? overrides.runGroupsOrError!
+        : relationshipsToOmit.has('RunGroupsOrError')
+        ? ({} as RunGroupsOrError)
+        : buildRunGroupsOrError({}, relationshipsToOmit),
+    runOrError:
+      overrides && overrides.hasOwnProperty('runOrError')
+        ? overrides.runOrError!
+        : relationshipsToOmit.has('PythonError')
+        ? ({} as PythonError)
+        : buildPythonError({}, relationshipsToOmit),
+    runTagKeysOrError:
+      overrides && overrides.hasOwnProperty('runTagKeysOrError')
+        ? overrides.runTagKeysOrError!
+        : relationshipsToOmit.has('PythonError')
+        ? ({} as PythonError)
+        : buildPythonError({}, relationshipsToOmit),
+    runTagsOrError:
+      overrides && overrides.hasOwnProperty('runTagsOrError')
+        ? overrides.runTagsOrError!
+        : relationshipsToOmit.has('PythonError')
+        ? ({} as PythonError)
+        : buildPythonError({}, relationshipsToOmit),
+    runsOrError:
+      overrides && overrides.hasOwnProperty('runsOrError')
+        ? overrides.runsOrError!
+        : relationshipsToOmit.has('InvalidPipelineRunsFilterError')
+        ? ({} as InvalidPipelineRunsFilterError)
+        : buildInvalidPipelineRunsFilterError({}, relationshipsToOmit),
+    scheduleOrError:
+      overrides && overrides.hasOwnProperty('scheduleOrError')
+        ? overrides.scheduleOrError!
+        : relationshipsToOmit.has('PythonError')
+        ? ({} as PythonError)
+        : buildPythonError({}, relationshipsToOmit),
+    scheduler:
+      overrides && overrides.hasOwnProperty('scheduler')
+        ? overrides.scheduler!
+        : relationshipsToOmit.has('PythonError')
+        ? ({} as PythonError)
+        : buildPythonError({}, relationshipsToOmit),
+    schedulesOrError:
+      overrides && overrides.hasOwnProperty('schedulesOrError')
+        ? overrides.schedulesOrError!
+        : relationshipsToOmit.has('PythonError')
+        ? ({} as PythonError)
+        : buildPythonError({}, relationshipsToOmit),
+    sensorOrError:
+      overrides && overrides.hasOwnProperty('sensorOrError')
+        ? overrides.sensorOrError!
+        : relationshipsToOmit.has('PythonError')
+        ? ({} as PythonError)
+        : buildPythonError({}, relationshipsToOmit),
+    sensorsOrError:
+      overrides && overrides.hasOwnProperty('sensorsOrError')
+        ? overrides.sensorsOrError!
+        : relationshipsToOmit.has('PythonError')
+        ? ({} as PythonError)
+        : buildPythonError({}, relationshipsToOmit),
+    shouldShowNux:
+      overrides && overrides.hasOwnProperty('shouldShowNux') ? overrides.shouldShowNux! : false,
+    test:
+      overrides && overrides.hasOwnProperty('test')
+        ? overrides.test!
+        : relationshipsToOmit.has('TestFields')
+        ? ({} as TestFields)
+        : buildTestFields({}, relationshipsToOmit),
+    topLevelResourceDetailsOrError:
+      overrides && overrides.hasOwnProperty('topLevelResourceDetailsOrError')
+        ? overrides.topLevelResourceDetailsOrError!
+        : relationshipsToOmit.has('PythonError')
+        ? ({} as PythonError)
+        : buildPythonError({}, relationshipsToOmit),
+    unloadableInstigationStatesOrError:
+      overrides && overrides.hasOwnProperty('unloadableInstigationStatesOrError')
+        ? overrides.unloadableInstigationStatesOrError!
+        : relationshipsToOmit.has('InstigationStates')
+        ? ({} as InstigationStates)
+        : buildInstigationStates({}, relationshipsToOmit),
+    utilizedEnvVarsOrError:
+      overrides && overrides.hasOwnProperty('utilizedEnvVarsOrError')
+        ? overrides.utilizedEnvVarsOrError!
+        : relationshipsToOmit.has('EnvVarWithConsumersList')
+        ? ({} as EnvVarWithConsumersList)
+        : buildEnvVarWithConsumersList({}, relationshipsToOmit),
+    version: overrides && overrides.hasOwnProperty('version') ? overrides.version! : 'et',
+    workspaceOrError:
+      overrides && overrides.hasOwnProperty('workspaceOrError')
+        ? overrides.workspaceOrError!
+        : relationshipsToOmit.has('PythonError')
+        ? ({} as PythonError)
+        : buildPythonError({}, relationshipsToOmit),
   };
 };
 
@@ -11537,6 +11502,41 @@ export const buildStopSensorMutationResult = (
         : relationshipsToOmit.has('InstigationState')
         ? ({} as InstigationState)
         : buildInstigationState({}, relationshipsToOmit),
+  };
+};
+
+export const buildSubscription = (
+  overrides?: Partial<Subscription>,
+  _relationshipsToOmit: Set<string> = new Set(),
+): {__typename: 'Subscription'} & Subscription => {
+  const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
+  relationshipsToOmit.add('Subscription');
+  return {
+    __typename: 'Subscription',
+    capturedLogs:
+      overrides && overrides.hasOwnProperty('capturedLogs')
+        ? overrides.capturedLogs!
+        : relationshipsToOmit.has('CapturedLogs')
+        ? ({} as CapturedLogs)
+        : buildCapturedLogs({}, relationshipsToOmit),
+    computeLogs:
+      overrides && overrides.hasOwnProperty('computeLogs')
+        ? overrides.computeLogs!
+        : relationshipsToOmit.has('ComputeLogFile')
+        ? ({} as ComputeLogFile)
+        : buildComputeLogFile({}, relationshipsToOmit),
+    locationStateChangeEvents:
+      overrides && overrides.hasOwnProperty('locationStateChangeEvents')
+        ? overrides.locationStateChangeEvents!
+        : relationshipsToOmit.has('LocationStateChangeSubscription')
+        ? ({} as LocationStateChangeSubscription)
+        : buildLocationStateChangeSubscription({}, relationshipsToOmit),
+    pipelineRunLogs:
+      overrides && overrides.hasOwnProperty('pipelineRunLogs')
+        ? overrides.pipelineRunLogs!
+        : relationshipsToOmit.has('PipelineRunLogsSubscriptionFailure')
+        ? ({} as PipelineRunLogsSubscriptionFailure)
+        : buildPipelineRunLogsSubscriptionFailure({}, relationshipsToOmit),
   };
 };
 

--- a/js_modules/dagit/packages/core/src/instance/__fixtures__/BackfillTable.fixtures.ts
+++ b/js_modules/dagit/packages/core/src/instance/__fixtures__/BackfillTable.fixtures.ts
@@ -60,7 +60,7 @@ export const BackfillTableFragmentRequested2000AssetsPureStatus: MockedResponse<
   },
   result: {
     data: {
-      __typename: 'DagitQuery',
+      __typename: 'Query',
       partitionBackfillOrError: buildPartitionBackfill({
         id: 'qtpussca',
         isAssetBackfill: true,
@@ -127,7 +127,7 @@ export const BackfillTableFragmentCancelledAssetsPartitionSetStatus: MockedRespo
   },
   result: {
     data: {
-      __typename: 'DagitQuery',
+      __typename: 'Query',
       partitionBackfillOrError: buildPartitionBackfill({
         id: 'tclwoggv',
         partitionStatusCounts: [
@@ -172,7 +172,7 @@ export const BackfillTableFragmentFailedErrorStatus: MockedResponse<SingleBackfi
   },
   result: {
     data: {
-      __typename: 'DagitQuery',
+      __typename: 'Query',
       partitionBackfillOrError: buildPartitionBackfill({
         id: 'sjqzcfhe',
         partitionStatuses: buildPartitionStatuses({
@@ -244,7 +244,7 @@ export const BackfillTableFragmentCompletedAssetJobStatus: MockedResponse<Single
   },
   result: {
     data: {
-      __typename: 'DagitQuery',
+      __typename: 'Query',
       partitionBackfillOrError: {
         id: 'pwgcpiwc',
         partitionStatuses: {
@@ -370,7 +370,7 @@ export const BackfillTableFragmentCompletedOpJobStatus: MockedResponse<SingleBac
   },
   result: {
     data: {
-      __typename: 'DagitQuery',
+      __typename: 'Query',
       partitionBackfillOrError: buildPartitionBackfill({
         id: 'pqdiepuf',
         isAssetBackfill: true,

--- a/js_modules/dagit/packages/core/src/instance/__tests__/DaemonList.test.tsx
+++ b/js_modules/dagit/packages/core/src/instance/__tests__/DaemonList.test.tsx
@@ -53,7 +53,7 @@ function autoMaterializePausedMock(paused: boolean): MockedResponse<GetAutoMater
     result: jest.fn(() => {
       return {
         data: {
-          __typename: 'DagitQuery',
+          __typename: 'Query',
           instance: buildInstance({
             autoMaterializePaused: paused,
           }),

--- a/js_modules/dagit/packages/core/src/instance/backfill/__fixtures__/buildBackfillDetails.ts
+++ b/js_modules/dagit/packages/core/src/instance/backfill/__fixtures__/buildBackfillDetails.ts
@@ -15,7 +15,7 @@ export function buildBackfillDetailsQuery(
     },
     result: {
       data: {
-        __typename: 'DagitQuery',
+        __typename: 'Query',
         partitionBackfillOrError: buildPartitionBackfill(partitionBackfill),
       },
     },

--- a/js_modules/dagit/packages/core/src/instance/backfill/__tests__/BackfillPage.test.tsx
+++ b/js_modules/dagit/packages/core/src/instance/backfill/__tests__/BackfillPage.test.tsx
@@ -33,7 +33,7 @@ const mocks = [
       variables: {backfillId: mockBackfillId},
     },
     result: {
-      __typename: 'CloudDagitQuery',
+      __typename: 'CloudQuery',
       data: {
         partitionBackfillOrError: buildPartitionBackfill({
           assetBackfillData: buildAssetBackfillData({
@@ -102,7 +102,7 @@ describe('BackfillPage', () => {
         },
         result: {
           data: {
-            __typename: 'CloudDagitQuery',
+            __typename: 'CloudQuery',
             partitionBackfillOrError: buildPythonError({
               message: 'An error occurred',
             }),

--- a/js_modules/dagit/packages/core/src/instance/backfill/types/BackfillPage.types.ts
+++ b/js_modules/dagit/packages/core/src/instance/backfill/types/BackfillPage.types.ts
@@ -7,7 +7,7 @@ export type BackfillStatusesByAssetQueryVariables = Types.Exact<{
 }>;
 
 export type BackfillStatusesByAssetQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   partitionBackfillOrError:
     | {__typename: 'BackfillNotFoundError'; message: string}
     | {

--- a/js_modules/dagit/packages/core/src/instance/types/BackfillRow.types.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/BackfillRow.types.ts
@@ -7,7 +7,7 @@ export type SingleBackfillCountsQueryVariables = Types.Exact<{
 }>;
 
 export type SingleBackfillCountsQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   partitionBackfillOrError:
     | {__typename: 'BackfillNotFoundError'}
     | {
@@ -27,7 +27,7 @@ export type SingleBackfillQueryVariables = Types.Exact<{
 }>;
 
 export type SingleBackfillQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   partitionBackfillOrError:
     | {__typename: 'BackfillNotFoundError'}
     | {

--- a/js_modules/dagit/packages/core/src/instance/types/BackfillTerminationDialog.types.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/BackfillTerminationDialog.types.ts
@@ -7,7 +7,7 @@ export type CancelBackfillMutationVariables = Types.Exact<{
 }>;
 
 export type CancelBackfillMutation = {
-  __typename: 'DagitMutation';
+  __typename: 'Mutation';
   cancelPartitionBackfill:
     | {__typename: 'CancelBackfillSuccess'; backfillId: string}
     | {

--- a/js_modules/dagit/packages/core/src/instance/types/BackfillUtils.types.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/BackfillUtils.types.ts
@@ -7,7 +7,7 @@ export type ResumeBackfillMutationVariables = Types.Exact<{
 }>;
 
 export type ResumeBackfillMutation = {
-  __typename: 'DagitMutation';
+  __typename: 'Mutation';
   resumePartitionBackfill:
     | {
         __typename: 'PythonError';
@@ -28,7 +28,7 @@ export type LaunchPartitionBackfillMutationVariables = Types.Exact<{
 }>;
 
 export type LaunchPartitionBackfillMutation = {
-  __typename: 'DagitMutation';
+  __typename: 'Mutation';
   launchPartitionBackfill:
     | {__typename: 'ConflictingExecutionParamsError'; message: string}
     | {__typename: 'InvalidOutputError'; stepKey: string; invalidOutputName: string}

--- a/js_modules/dagit/packages/core/src/instance/types/InstanceBackfills.types.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/InstanceBackfills.types.ts
@@ -5,7 +5,7 @@ import * as Types from '../../graphql/types';
 export type InstanceHealthForBackfillsQueryVariables = Types.Exact<{[key: string]: never}>;
 
 export type InstanceHealthForBackfillsQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   instance: {
     __typename: 'Instance';
     id: string;
@@ -41,7 +41,7 @@ export type InstanceBackfillsQueryVariables = Types.Exact<{
 }>;
 
 export type InstanceBackfillsQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   partitionBackfillsOrError:
     | {
         __typename: 'PartitionBackfills';

--- a/js_modules/dagit/packages/core/src/instance/types/InstanceConcurrency.types.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/InstanceConcurrency.types.ts
@@ -13,7 +13,7 @@ export type ConcurrencyLimitFragment = {
 export type InstanceConcurrencyLimitsQueryVariables = Types.Exact<{[key: string]: never}>;
 
 export type InstanceConcurrencyLimitsQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   instance: {
     __typename: 'Instance';
     id: string;
@@ -32,17 +32,14 @@ export type SetConcurrencyLimitMutationVariables = Types.Exact<{
   limit: Types.Scalars['Int'];
 }>;
 
-export type SetConcurrencyLimitMutation = {
-  __typename: 'DagitMutation';
-  setConcurrencyLimit: boolean;
-};
+export type SetConcurrencyLimitMutation = {__typename: 'Mutation'; setConcurrencyLimit: boolean};
 
 export type FreeConcurrencySlotsForRunMutationVariables = Types.Exact<{
   runId: Types.Scalars['String'];
 }>;
 
 export type FreeConcurrencySlotsForRunMutation = {
-  __typename: 'DagitMutation';
+  __typename: 'Mutation';
   freeConcurrencySlotsForRun: boolean;
 };
 
@@ -52,7 +49,7 @@ export type RunsForConcurrencyKeyQueryVariables = Types.Exact<{
 }>;
 
 export type RunsForConcurrencyKeyQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   pipelineRunsOrError:
     | {__typename: 'InvalidPipelineRunsFilterError'}
     | {

--- a/js_modules/dagit/packages/core/src/instance/types/InstanceConfig.types.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/InstanceConfig.types.ts
@@ -5,7 +5,7 @@ import * as Types from '../../graphql/types';
 export type InstanceConfigQueryVariables = Types.Exact<{[key: string]: never}>;
 
 export type InstanceConfigQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   version: string;
   instance: {__typename: 'Instance'; id: string; info: string | null};
 };

--- a/js_modules/dagit/packages/core/src/instance/types/InstanceHealthPage.types.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/InstanceHealthPage.types.ts
@@ -5,7 +5,7 @@ import * as Types from '../../graphql/types';
 export type InstanceHealthQueryVariables = Types.Exact<{[key: string]: never}>;
 
 export type InstanceHealthQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   instance: {
     __typename: 'Instance';
     id: string;

--- a/js_modules/dagit/packages/core/src/instance/types/JobMenu.types.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/JobMenu.types.ts
@@ -7,7 +7,7 @@ export type RunReExecutionQueryVariables = Types.Exact<{
 }>;
 
 export type RunReExecutionQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   pipelineRunOrError:
     | {__typename: 'PythonError'}
     | {

--- a/js_modules/dagit/packages/core/src/instance/types/StepSummaryForRun.types.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/StepSummaryForRun.types.ts
@@ -7,7 +7,7 @@ export type StepSummaryForRunQueryVariables = Types.Exact<{
 }>;
 
 export type StepSummaryForRunQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   pipelineRunOrError:
     | {__typename: 'PythonError'}
     | {

--- a/js_modules/dagit/packages/core/src/instance/types/useCanSeeConfig.types.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/useCanSeeConfig.types.ts
@@ -5,6 +5,6 @@ import * as Types from '../../graphql/types';
 export type InstanceConfigHasInfoQueryVariables = Types.Exact<{[key: string]: never}>;
 
 export type InstanceConfigHasInfoQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   instance: {__typename: 'Instance'; id: string; hasInfo: boolean};
 };

--- a/js_modules/dagit/packages/core/src/instance/types/useDaemonStatus.types.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/useDaemonStatus.types.ts
@@ -5,7 +5,7 @@ import * as Types from '../../graphql/types';
 export type InstanceWarningQueryVariables = Types.Exact<{[key: string]: never}>;
 
 export type InstanceWarningQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   instance: {
     __typename: 'Instance';
     id: string;

--- a/js_modules/dagit/packages/core/src/instance/types/useSupportsCapturedLogs.types.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/useSupportsCapturedLogs.types.ts
@@ -5,6 +5,6 @@ import * as Types from '../../graphql/types';
 export type InstanceSupportsCapturedLogsQueryVariables = Types.Exact<{[key: string]: never}>;
 
 export type InstanceSupportsCapturedLogsQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   instance: {__typename: 'Instance'; id: string; hasCapturedLogManager: boolean};
 };

--- a/js_modules/dagit/packages/core/src/instigation/types/InstigationTick.types.ts
+++ b/js_modules/dagit/packages/core/src/instigation/types/InstigationTick.types.ts
@@ -27,7 +27,7 @@ export type LaunchedRunListQueryVariables = Types.Exact<{
 }>;
 
 export type LaunchedRunListQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   pipelineRunsOrError:
     | {__typename: 'InvalidPipelineRunsFilterError'; message: string}
     | {

--- a/js_modules/dagit/packages/core/src/instigation/types/TickDetailsDialog.types.ts
+++ b/js_modules/dagit/packages/core/src/instigation/types/TickDetailsDialog.types.ts
@@ -8,7 +8,7 @@ export type SelectedTickQueryVariables = Types.Exact<{
 }>;
 
 export type SelectedTickQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   instigationStateOrError:
     | {
         __typename: 'InstigationState';

--- a/js_modules/dagit/packages/core/src/instigation/types/TickHistory.types.ts
+++ b/js_modules/dagit/packages/core/src/instigation/types/TickHistory.types.ts
@@ -11,7 +11,7 @@ export type TickHistoryQueryVariables = Types.Exact<{
 }>;
 
 export type TickHistoryQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   instigationStateOrError:
     | {
         __typename: 'InstigationState';

--- a/js_modules/dagit/packages/core/src/launchpad/types/ConfigEditorConfigPicker.types.ts
+++ b/js_modules/dagit/packages/core/src/launchpad/types/ConfigEditorConfigPicker.types.ts
@@ -9,7 +9,7 @@ export type ConfigPartitionsQueryVariables = Types.Exact<{
 }>;
 
 export type ConfigPartitionsQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   partitionSetOrError:
     | {
         __typename: 'PartitionSet';
@@ -49,7 +49,7 @@ export type ConfigPartitionSelectionQueryVariables = Types.Exact<{
 }>;
 
 export type ConfigPartitionSelectionQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   partitionSetOrError:
     | {
         __typename: 'PartitionSet';

--- a/js_modules/dagit/packages/core/src/launchpad/types/LaunchpadAllowedRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/launchpad/types/LaunchpadAllowedRoot.types.ts
@@ -9,7 +9,7 @@ export type LaunchpadRootQueryVariables = Types.Exact<{
 }>;
 
 export type LaunchpadRootQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   pipelineOrError:
     | {__typename: 'InvalidSubsetError'}
     | {

--- a/js_modules/dagit/packages/core/src/launchpad/types/LaunchpadSession.types.ts
+++ b/js_modules/dagit/packages/core/src/launchpad/types/LaunchpadSession.types.ts
@@ -9,7 +9,7 @@ export type PreviewConfigQueryVariables = Types.Exact<{
 }>;
 
 export type PreviewConfigQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   isPipelineConfigValid:
     | {__typename: 'InvalidSubsetError'; message: string}
     | {__typename: 'PipelineConfigValidationValid'}
@@ -125,7 +125,7 @@ export type PipelineExecutionConfigSchemaQueryVariables = Types.Exact<{
 }>;
 
 export type PipelineExecutionConfigSchemaQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   runConfigSchemaOrError:
     | {__typename: 'InvalidSubsetError'}
     | {__typename: 'ModeNotFoundError'; message: string}

--- a/js_modules/dagit/packages/core/src/launchpad/types/LaunchpadSetupFromRunRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/launchpad/types/LaunchpadSetupFromRunRoot.types.ts
@@ -7,7 +7,7 @@ export type ConfigForRunQueryVariables = Types.Exact<{
 }>;
 
 export type ConfigForRunQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   runOrError:
     | {
         __typename: 'PythonError';

--- a/js_modules/dagit/packages/core/src/launchpad/types/OpSelector.types.ts
+++ b/js_modules/dagit/packages/core/src/launchpad/types/OpSelector.types.ts
@@ -8,7 +8,7 @@ export type OpSelectorQueryVariables = Types.Exact<{
 }>;
 
 export type OpSelectorQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   pipelineOrError:
     | {__typename: 'InvalidSubsetError'; message: string}
     | {

--- a/js_modules/dagit/packages/core/src/nav/__fixtures__/LeftNavRepositorySection.fixtures.tsx
+++ b/js_modules/dagit/packages/core/src/nav/__fixtures__/LeftNavRepositorySection.fixtures.tsx
@@ -46,7 +46,7 @@ export const buildWorkspaceQueryWithZeroLocations = (): MockedResponse<RootWorks
     },
     result: {
       data: {
-        __typename: 'DagitQuery',
+        __typename: 'Query',
         workspaceOrError: buildWorkspace({
           locationEntries: [],
         }),
@@ -63,7 +63,7 @@ export const buildWorkspaceQueryWithOneLocation = (): MockedResponse<RootWorkspa
     },
     result: {
       data: {
-        __typename: 'DagitQuery',
+        __typename: 'Query',
         workspaceOrError: buildWorkspace({
           locationEntries: [
             buildWorkspaceLocationEntry({
@@ -92,7 +92,7 @@ export const buildWorkspaceQueryWithThreeLocations = (): MockedResponse<RootWork
     },
     result: {
       data: {
-        __typename: 'DagitQuery',
+        __typename: 'Query',
         workspaceOrError: buildWorkspace({
           locationEntries: [
             buildWorkspaceLocationEntry({
@@ -146,7 +146,7 @@ export const buildWorkspaceQueryWithOneLocationAndAssetGroup = (): MockedRespons
     },
     result: {
       data: {
-        __typename: 'DagitQuery',
+        __typename: 'Query',
         workspaceOrError: buildWorkspace({
           locationEntries: [
             buildWorkspaceLocationEntry({

--- a/js_modules/dagit/packages/core/src/nav/__fixtures__/ReloadRepositoryLocationButton.fixtures.tsx
+++ b/js_modules/dagit/packages/core/src/nav/__fixtures__/ReloadRepositoryLocationButton.fixtures.tsx
@@ -11,7 +11,7 @@ export const buildPermissionsQuery = (canReload: boolean): MockedResponse<Permis
     },
     result: {
       data: {
-        __typename: 'DagitQuery',
+        __typename: 'Query',
         unscopedPermissions: [],
         workspaceOrError: buildWorkspace({
           locationEntries: [

--- a/js_modules/dagit/packages/core/src/nav/__fixtures__/useDaemonStatus.fixtures.tsx
+++ b/js_modules/dagit/packages/core/src/nav/__fixtures__/useDaemonStatus.fixtures.tsx
@@ -63,7 +63,7 @@ export const buildWorkspaceQueryWithNoSchedulesOrSensors = (): MockedResponse<Ro
     },
     result: {
       data: {
-        __typename: 'DagitQuery',
+        __typename: 'Query',
         workspaceOrError: buildWorkspace({
           locationEntries: [
             buildWorkspaceLocationEntry({
@@ -96,7 +96,7 @@ export const buildWorkspaceQueryWithScheduleAndSensor = ({
     },
     result: {
       data: {
-        __typename: 'DagitQuery',
+        __typename: 'Query',
         workspaceOrError: buildWorkspace({
           locationEntries: [
             buildWorkspaceLocationEntry({
@@ -134,7 +134,7 @@ export const buildInstanceWarningQuery = (
     },
     result: {
       data: {
-        __typename: 'DagitQuery',
+        __typename: 'Query',
         instance: buildInstance({
           daemonHealth: buildDaemonHealth({
             id: 'daemon-health',

--- a/js_modules/dagit/packages/core/src/nav/__tests__/VersionNumber.test.tsx
+++ b/js_modules/dagit/packages/core/src/nav/__tests__/VersionNumber.test.tsx
@@ -15,7 +15,7 @@ describe('VersionNumber', () => {
       },
       result: {
         data: {
-          __typename: 'DagitQuery',
+          __typename: 'Query',
           version: '1.2.34',
         },
       },

--- a/js_modules/dagit/packages/core/src/nav/types/JobMetadata.types.ts
+++ b/js_modules/dagit/packages/core/src/nav/types/JobMetadata.types.ts
@@ -8,7 +8,7 @@ export type JobMetadataQueryVariables = Types.Exact<{
 }>;
 
 export type JobMetadataQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   pipelineOrError:
     | {__typename: 'InvalidSubsetError'}
     | {

--- a/js_modules/dagit/packages/core/src/nav/types/LatestRunTag.types.ts
+++ b/js_modules/dagit/packages/core/src/nav/types/LatestRunTag.types.ts
@@ -7,7 +7,7 @@ export type LatestRunTagQueryVariables = Types.Exact<{
 }>;
 
 export type LatestRunTagQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   pipelineRunsOrError:
     | {__typename: 'InvalidPipelineRunsFilterError'}
     | {__typename: 'PythonError'}

--- a/js_modules/dagit/packages/core/src/nav/types/RepositoryLocationStateObserver.types.ts
+++ b/js_modules/dagit/packages/core/src/nav/types/RepositoryLocationStateObserver.types.ts
@@ -5,7 +5,7 @@ import * as Types from '../../graphql/types';
 export type LocationStateChangeSubscriptionVariables = Types.Exact<{[key: string]: never}>;
 
 export type LocationStateChangeSubscription = {
-  __typename: 'DagitSubscription';
+  __typename: 'Subscription';
   locationStateChangeEvents: {
     __typename: 'LocationStateChangeSubscription';
     event: {

--- a/js_modules/dagit/packages/core/src/nav/types/VersionNumber.types.ts
+++ b/js_modules/dagit/packages/core/src/nav/types/VersionNumber.types.ts
@@ -4,4 +4,4 @@ import * as Types from '../../graphql/types';
 
 export type VersionNumberQueryVariables = Types.Exact<{[key: string]: never}>;
 
-export type VersionNumberQuery = {__typename: 'DagitQuery'; version: string};
+export type VersionNumberQuery = {__typename: 'Query'; version: string};

--- a/js_modules/dagit/packages/core/src/nav/types/useCodeLocationsStatus.types.ts
+++ b/js_modules/dagit/packages/core/src/nav/types/useCodeLocationsStatus.types.ts
@@ -5,7 +5,7 @@ import * as Types from '../../graphql/types';
 export type CodeLocationStatusQueryVariables = Types.Exact<{[key: string]: never}>;
 
 export type CodeLocationStatusQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   locationStatusesOrError:
     | {__typename: 'PythonError'}
     | {

--- a/js_modules/dagit/packages/core/src/nav/types/useRepositoryLocationReload.types.ts
+++ b/js_modules/dagit/packages/core/src/nav/types/useRepositoryLocationReload.types.ts
@@ -5,7 +5,7 @@ import * as Types from '../../graphql/types';
 export type RepositoryLocationStatusQueryVariables = Types.Exact<{[key: string]: never}>;
 
 export type RepositoryLocationStatusQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   workspaceOrError:
     | {
         __typename: 'PythonError';
@@ -53,7 +53,7 @@ export type RepositoryLocationStatusQuery = {
 export type ReloadWorkspaceMutationVariables = Types.Exact<{[key: string]: never}>;
 
 export type ReloadWorkspaceMutation = {
-  __typename: 'DagitMutation';
+  __typename: 'Mutation';
   reloadWorkspace:
     | {
         __typename: 'PythonError';
@@ -105,7 +105,7 @@ export type ReloadRepositoryLocationMutationVariables = Types.Exact<{
 }>;
 
 export type ReloadRepositoryLocationMutation = {
-  __typename: 'DagitMutation';
+  __typename: 'Mutation';
   reloadRepositoryLocation:
     | {
         __typename: 'PythonError';

--- a/js_modules/dagit/packages/core/src/ops/types/OpDetailsRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/ops/types/OpDetailsRoot.types.ts
@@ -8,7 +8,7 @@ export type UsedSolidDetailsQueryVariables = Types.Exact<{
 }>;
 
 export type UsedSolidDetailsQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   repositoryOrError:
     | {__typename: 'PythonError'}
     | {

--- a/js_modules/dagit/packages/core/src/ops/types/OpsRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/ops/types/OpsRoot.types.ts
@@ -7,7 +7,7 @@ export type OpsRootQueryVariables = Types.Exact<{
 }>;
 
 export type OpsRootQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   repositoryOrError:
     | {__typename: 'PythonError'}
     | {

--- a/js_modules/dagit/packages/core/src/overview/types/OverviewJobsRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/overview/types/OverviewJobsRoot.types.ts
@@ -5,7 +5,7 @@ import * as Types from '../../graphql/types';
 export type OverviewJobsQueryVariables = Types.Exact<{[key: string]: never}>;
 
 export type OverviewJobsQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   workspaceOrError:
     | {
         __typename: 'PythonError';

--- a/js_modules/dagit/packages/core/src/overview/types/OverviewResourcesRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/overview/types/OverviewResourcesRoot.types.ts
@@ -5,7 +5,7 @@ import * as Types from '../../graphql/types';
 export type OverviewResourcesQueryVariables = Types.Exact<{[key: string]: never}>;
 
 export type OverviewResourcesQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   workspaceOrError:
     | {
         __typename: 'PythonError';

--- a/js_modules/dagit/packages/core/src/overview/types/OverviewSchedulesRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/overview/types/OverviewSchedulesRoot.types.ts
@@ -5,7 +5,7 @@ import * as Types from '../../graphql/types';
 export type OverviewSchedulesQueryVariables = Types.Exact<{[key: string]: never}>;
 
 export type OverviewSchedulesQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   workspaceOrError:
     | {
         __typename: 'PythonError';
@@ -99,7 +99,7 @@ export type OverviewSchedulesQuery = {
 export type UnloadableSchedulesQueryVariables = Types.Exact<{[key: string]: never}>;
 
 export type UnloadableSchedulesQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   unloadableInstigationStatesOrError:
     | {
         __typename: 'InstigationStates';

--- a/js_modules/dagit/packages/core/src/overview/types/OverviewSensorsRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/overview/types/OverviewSensorsRoot.types.ts
@@ -5,7 +5,7 @@ import * as Types from '../../graphql/types';
 export type OverviewSensorsQueryVariables = Types.Exact<{[key: string]: never}>;
 
 export type OverviewSensorsQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   workspaceOrError:
     | {
         __typename: 'PythonError';
@@ -100,7 +100,7 @@ export type OverviewSensorsQuery = {
 export type UnloadableSensorsQueryVariables = Types.Exact<{[key: string]: never}>;
 
 export type UnloadableSensorsQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   unloadableInstigationStatesOrError:
     | {
         __typename: 'InstigationStates';

--- a/js_modules/dagit/packages/core/src/partitions/__fixtures__/CreatePartitionDialog.fixture.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/__fixtures__/CreatePartitionDialog.fixture.tsx
@@ -27,7 +27,7 @@ export function buildCreatePartitionFixture({
     },
     result: jest.fn(() => ({
       data: {
-        __typename: 'DagitMutation',
+        __typename: 'Mutation',
         addDynamicPartition: {
           __typename: 'AddDynamicPartitionSuccess',
           partitionsDefName: partitionKey,
@@ -52,7 +52,7 @@ export function buildCreatePartitionMutation({
     },
     result: jest.fn(() => ({
       data: {
-        __typename: 'DagitMutation',
+        __typename: 'Mutation',
         addDynamicPartition: data,
       },
     })),

--- a/js_modules/dagit/packages/core/src/partitions/types/BackfillSelector.types.ts
+++ b/js_modules/dagit/packages/core/src/partitions/types/BackfillSelector.types.ts
@@ -7,7 +7,7 @@ export type BackfillSelectorQueryVariables = Types.Exact<{
 }>;
 
 export type BackfillSelectorQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   pipelineSnapshotOrError:
     | {__typename: 'PipelineNotFoundError'}
     | {

--- a/js_modules/dagit/packages/core/src/partitions/types/CreatePartitionDialog.types.ts
+++ b/js_modules/dagit/packages/core/src/partitions/types/CreatePartitionDialog.types.ts
@@ -9,7 +9,7 @@ export type AddDynamicPartitionMutationVariables = Types.Exact<{
 }>;
 
 export type AddDynamicPartitionMutation = {
-  __typename: 'DagitMutation';
+  __typename: 'Mutation';
   addDynamicPartition:
     | {__typename: 'AddDynamicPartitionSuccess'; partitionsDefName: string; partitionKey: string}
     | {__typename: 'DuplicateDynamicPartitionError'}

--- a/js_modules/dagit/packages/core/src/partitions/types/JobBackfillsTable.types.ts
+++ b/js_modules/dagit/packages/core/src/partitions/types/JobBackfillsTable.types.ts
@@ -10,7 +10,7 @@ export type JobBackfillsQueryVariables = Types.Exact<{
 }>;
 
 export type JobBackfillsQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   partitionSetOrError:
     | {
         __typename: 'PartitionSet';

--- a/js_modules/dagit/packages/core/src/partitions/types/OpJobPartitionsView.types.ts
+++ b/js_modules/dagit/packages/core/src/partitions/types/OpJobPartitionsView.types.ts
@@ -8,7 +8,7 @@ export type PartitionsStatusQueryVariables = Types.Exact<{
 }>;
 
 export type PartitionsStatusQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   partitionSetOrError:
     | {
         __typename: 'PartitionSet';

--- a/js_modules/dagit/packages/core/src/partitions/types/PartitionRunList.types.ts
+++ b/js_modules/dagit/packages/core/src/partitions/types/PartitionRunList.types.ts
@@ -7,7 +7,7 @@ export type PartitionRunListQueryVariables = Types.Exact<{
 }>;
 
 export type PartitionRunListQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   pipelineRunsOrError:
     | {__typename: 'InvalidPipelineRunsFilterError'; message: string}
     | {

--- a/js_modules/dagit/packages/core/src/partitions/types/PartitionStepStatus.types.ts
+++ b/js_modules/dagit/packages/core/src/partitions/types/PartitionStepStatus.types.ts
@@ -7,7 +7,7 @@ export type PartitionStepStatusPipelineQueryVariables = Types.Exact<{
 }>;
 
 export type PartitionStepStatusPipelineQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   pipelineSnapshotOrError:
     | {__typename: 'PipelineNotFoundError'}
     | {

--- a/js_modules/dagit/packages/core/src/partitions/types/usePartitionStepQuery.types.ts
+++ b/js_modules/dagit/packages/core/src/partitions/types/usePartitionStepQuery.types.ts
@@ -9,7 +9,7 @@ export type PartitionStepLoaderQueryVariables = Types.Exact<{
 }>;
 
 export type PartitionStepLoaderQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   pipelineRunsOrError:
     | {__typename: 'InvalidPipelineRunsFilterError'; message: string}
     | {

--- a/js_modules/dagit/packages/core/src/pipelines/types/PipelineExplorerRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/pipelines/types/PipelineExplorerRoot.types.ts
@@ -10,7 +10,7 @@ export type PipelineExplorerRootQueryVariables = Types.Exact<{
 }>;
 
 export type PipelineExplorerRootQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   pipelineSnapshotOrError:
     | {__typename: 'PipelineNotFoundError'; message: string}
     | {

--- a/js_modules/dagit/packages/core/src/pipelines/types/PipelineRunsRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/pipelines/types/PipelineRunsRoot.types.ts
@@ -9,7 +9,7 @@ export type PipelineRunsRootQueryVariables = Types.Exact<{
 }>;
 
 export type PipelineRunsRootQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   pipelineRunsOrError:
     | {__typename: 'InvalidPipelineRunsFilterError'; message: string}
     | {

--- a/js_modules/dagit/packages/core/src/pipelines/types/SidebarOp.types.ts
+++ b/js_modules/dagit/packages/core/src/pipelines/types/SidebarOp.types.ts
@@ -3885,7 +3885,7 @@ export type SidebarPipelineOpQueryVariables = Types.Exact<{
 }>;
 
 export type SidebarPipelineOpQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   pipelineOrError:
     | {__typename: 'InvalidSubsetError'}
     | {
@@ -4682,7 +4682,7 @@ export type SidebarGraphOpQueryVariables = Types.Exact<{
 }>;
 
 export type SidebarGraphOpQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   graphOrError:
     | {
         __typename: 'Graph';

--- a/js_modules/dagit/packages/core/src/pipelines/types/SidebarOpExecutionGraphs.types.ts
+++ b/js_modules/dagit/packages/core/src/pipelines/types/SidebarOpExecutionGraphs.types.ts
@@ -8,7 +8,7 @@ export type SidebarOpGraphsQueryVariables = Types.Exact<{
 }>;
 
 export type SidebarOpGraphsQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   pipelineOrError:
     | {__typename: 'InvalidSubsetError'}
     | {

--- a/js_modules/dagit/packages/core/src/resources/types/ResourceRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/resources/types/ResourceRoot.types.ts
@@ -59,7 +59,7 @@ export type ResourceRootQueryVariables = Types.Exact<{
 }>;
 
 export type ResourceRootQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   topLevelResourceDetailsOrError:
     | {
         __typename: 'PythonError';

--- a/js_modules/dagit/packages/core/src/resources/types/WorkspaceResourcesRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/resources/types/WorkspaceResourcesRoot.types.ts
@@ -17,7 +17,7 @@ export type WorkspaceResourcesQueryVariables = Types.Exact<{
 }>;
 
 export type WorkspaceResourcesQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   repositoryOrError:
     | {
         __typename: 'PythonError';

--- a/js_modules/dagit/packages/core/src/runs/__fixtures__/RunsFilterInput.fixtures.tsx
+++ b/js_modules/dagit/packages/core/src/runs/__fixtures__/RunsFilterInput.fixtures.tsx
@@ -15,7 +15,7 @@ export const buildWorkspaceContextMockedResponse = (
   },
   result: {
     data: {
-      __typename: 'DagitQuery',
+      __typename: 'Query',
       workspaceOrError,
     },
   },
@@ -32,7 +32,7 @@ export function buildRunTagValuesQueryMockedResponse(
     },
     result: {
       data: {
-        __typename: 'DagitQuery',
+        __typename: 'Query',
         runTagsOrError: buildRunTags({
           tags: [
             buildPipelineTagAndValues({

--- a/js_modules/dagit/packages/core/src/runs/__tests__/ReexecutionDialog.test.tsx
+++ b/js_modules/dagit/packages/core/src/runs/__tests__/ReexecutionDialog.test.tsx
@@ -18,7 +18,7 @@ const buildLaunchPipelineReexecutionSuccessMock = (
   },
   result: {
     data: {
-      __typename: 'DagitMutation',
+      __typename: 'Mutation',
       launchPipelineReexecution: {
         __typename: 'LaunchRunSuccess',
         run: {
@@ -42,7 +42,7 @@ const buildLaunchPipelineReexecutionErrorMock = (
   },
   result: {
     data: {
-      __typename: 'DagitMutation',
+      __typename: 'Mutation',
       launchPipelineReexecution: {
         __typename: 'PythonError',
         errorChain: [],

--- a/js_modules/dagit/packages/core/src/runs/__tests__/RunFilterInput.test.tsx
+++ b/js_modules/dagit/packages/core/src/runs/__tests__/RunFilterInput.test.tsx
@@ -36,7 +36,7 @@ const runTagKeysMock: MockedResponse<RunTagKeysQuery> = {
   },
   result: {
     data: {
-      __typename: 'DagitQuery',
+      __typename: 'Query',
       runTagKeysOrError: buildRunTagKeys({
         keys: [DagsterTag.Partition, DagsterTag.PartitionSet],
       }),

--- a/js_modules/dagit/packages/core/src/runs/__tests__/types/RunActionButtonsTestQuery.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/__tests__/types/RunActionButtonsTestQuery.types.ts
@@ -5,7 +5,7 @@ import * as Types from '../../../graphql/types';
 export type RunActionButtonsTestQueryVariables = Types.Exact<{[key: string]: never}>;
 
 export type RunActionButtonsTestQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   pipelineRunOrError:
     | {__typename: 'PythonError'}
     | {

--- a/js_modules/dagit/packages/core/src/runs/types/CapturedLogPanel.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/CapturedLogPanel.types.ts
@@ -8,7 +8,7 @@ export type CapturedLogsSubscriptionVariables = Types.Exact<{
 }>;
 
 export type CapturedLogsSubscription = {
-  __typename: 'DagitSubscription';
+  __typename: 'Subscription';
   capturedLogs: {
     __typename: 'CapturedLogs';
     stdout: string | null;
@@ -29,7 +29,7 @@ export type CapturedLogsMetadataQueryVariables = Types.Exact<{
 }>;
 
 export type CapturedLogsMetadataQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   capturedLogsMetadata: {
     __typename: 'CapturedLogsMetadata';
     stdoutDownloadUrl: string | null;
@@ -46,7 +46,7 @@ export type CapturedLogsQueryVariables = Types.Exact<{
 }>;
 
 export type CapturedLogsQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   capturedLogs: {
     __typename: 'CapturedLogs';
     stdout: string | null;

--- a/js_modules/dagit/packages/core/src/runs/types/LogsProvider.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/LogsProvider.types.ts
@@ -8,7 +8,7 @@ export type PipelineRunLogsSubscriptionVariables = Types.Exact<{
 }>;
 
 export type PipelineRunLogsSubscription = {
-  __typename: 'DagitSubscription';
+  __typename: 'Subscription';
   pipelineRunLogs:
     | {
         __typename: 'PipelineRunLogsSubscriptionFailure';
@@ -4880,7 +4880,7 @@ export type RunLogsQueryVariables = Types.Exact<{
 }>;
 
 export type RunLogsQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   pipelineRunOrError:
     | {__typename: 'PythonError'}
     | {__typename: 'Run'; id: string; status: Types.RunStatus; canTerminate: boolean}

--- a/js_modules/dagit/packages/core/src/runs/types/RunActionsMenu.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunActionsMenu.types.ts
@@ -7,7 +7,7 @@ export type PipelineEnvironmentQueryVariables = Types.Exact<{
 }>;
 
 export type PipelineEnvironmentQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   pipelineRunOrError:
     | {__typename: 'PythonError'}
     | {

--- a/js_modules/dagit/packages/core/src/runs/types/RunListTabs.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunListTabs.types.ts
@@ -8,7 +8,7 @@ export type RunTabsCountQueryVariables = Types.Exact<{
 }>;
 
 export type RunTabsCountQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   queuedCount:
     | {__typename: 'InvalidPipelineRunsFilterError'}
     | {__typename: 'PythonError'}

--- a/js_modules/dagit/packages/core/src/runs/types/RunRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunRoot.types.ts
@@ -7,7 +7,7 @@ export type RunRootQueryVariables = Types.Exact<{
 }>;
 
 export type RunRootQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   pipelineRunOrError:
     | {__typename: 'PythonError'}
     | {

--- a/js_modules/dagit/packages/core/src/runs/types/RunStats.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunStats.types.ts
@@ -7,7 +7,7 @@ export type RunStatsQueryVariables = Types.Exact<{
 }>;
 
 export type RunStatsQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   pipelineRunOrError:
     | {
         __typename: 'PythonError';

--- a/js_modules/dagit/packages/core/src/runs/types/RunUtils.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunUtils.types.ts
@@ -7,7 +7,7 @@ export type LaunchPipelineExecutionMutationVariables = Types.Exact<{
 }>;
 
 export type LaunchPipelineExecutionMutation = {
-  __typename: 'DagitMutation';
+  __typename: 'Mutation';
   launchPipelineExecution:
     | {__typename: 'ConflictingExecutionParamsError'}
     | {__typename: 'InvalidOutputError'}
@@ -47,7 +47,7 @@ export type DeleteMutationVariables = Types.Exact<{
 }>;
 
 export type DeleteMutation = {
-  __typename: 'DagitMutation';
+  __typename: 'Mutation';
   deletePipelineRun:
     | {__typename: 'DeletePipelineRunSuccess'}
     | {
@@ -70,7 +70,7 @@ export type TerminateMutationVariables = Types.Exact<{
 }>;
 
 export type TerminateMutation = {
-  __typename: 'DagitMutation';
+  __typename: 'Mutation';
   terminatePipelineExecution:
     | {
         __typename: 'PythonError';
@@ -97,7 +97,7 @@ export type LaunchPipelineReexecutionMutationVariables = Types.Exact<{
 }>;
 
 export type LaunchPipelineReexecutionMutation = {
-  __typename: 'DagitMutation';
+  __typename: 'Mutation';
   launchPipelineReexecution:
     | {__typename: 'ConflictingExecutionParamsError'}
     | {__typename: 'InvalidOutputError'}

--- a/js_modules/dagit/packages/core/src/runs/types/RunsFilterInput.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunsFilterInput.types.ts
@@ -5,7 +5,7 @@ import * as Types from '../../graphql/types';
 export type RunTagKeysQueryVariables = Types.Exact<{[key: string]: never}>;
 
 export type RunTagKeysQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   runTagKeysOrError:
     | {__typename: 'PythonError'}
     | {__typename: 'RunTagKeys'; keys: Array<string>}
@@ -17,7 +17,7 @@ export type RunTagValuesQueryVariables = Types.Exact<{
 }>;
 
 export type RunTagValuesQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   runTagsOrError:
     | {__typename: 'PythonError'}
     | {

--- a/js_modules/dagit/packages/core/src/runs/types/RunsRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunsRoot.types.ts
@@ -9,7 +9,7 @@ export type RunsRootQueryVariables = Types.Exact<{
 }>;
 
 export type RunsRootQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   pipelineRunsOrError:
     | {__typename: 'InvalidPipelineRunsFilterError'; message: string}
     | {
@@ -57,7 +57,7 @@ export type RunsRootQuery = {
 export type QueueDaemonStatusQueryVariables = Types.Exact<{[key: string]: never}>;
 
 export type QueueDaemonStatusQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   instance: {
     __typename: 'Instance';
     id: string;

--- a/js_modules/dagit/packages/core/src/runs/types/ScheduledRunListRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/ScheduledRunListRoot.types.ts
@@ -5,7 +5,7 @@ import * as Types from '../../graphql/types';
 export type ScheduledRunsListQueryVariables = Types.Exact<{[key: string]: never}>;
 
 export type ScheduledRunsListQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   instance: {
     __typename: 'Instance';
     id: string;

--- a/js_modules/dagit/packages/core/src/runs/types/useComputeLogs.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/useComputeLogs.types.ts
@@ -10,7 +10,7 @@ export type ComputeLogsSubscriptionVariables = Types.Exact<{
 }>;
 
 export type ComputeLogsSubscription = {
-  __typename: 'DagitSubscription';
+  __typename: 'Subscription';
   computeLogs: {
     __typename: 'ComputeLogFile';
     path: string;

--- a/js_modules/dagit/packages/core/src/runs/types/useRunsForTimeline.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/useRunsForTimeline.types.ts
@@ -10,7 +10,7 @@ export type RunTimelineQueryVariables = Types.Exact<{
 }>;
 
 export type RunTimelineQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   unterminated:
     | {__typename: 'InvalidPipelineRunsFilterError'}
     | {__typename: 'PythonError'}

--- a/js_modules/dagit/packages/core/src/schedules/__fixtures__/ScheduleState.fixtures.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/__fixtures__/ScheduleState.fixtures.tsx
@@ -64,7 +64,7 @@ export const buildStartAlaskaSuccess = (delay = 0): MockedResponse<StartThisSche
     },
     result: {
       data: {
-        __typename: 'DagitMutation',
+        __typename: 'Mutation',
         startSchedule: buildScheduleStateResult({
           scheduleState: buildInstigationState({
             status: InstigationStatus.RUNNING,
@@ -90,7 +90,7 @@ export const buildStartColoradoSuccess = (delay = 0): MockedResponse<StartThisSc
     },
     result: {
       data: {
-        __typename: 'DagitMutation',
+        __typename: 'Mutation',
         startSchedule: buildScheduleStateResult({
           scheduleState: buildInstigationState({
             status: InstigationStatus.RUNNING,
@@ -116,7 +116,7 @@ export const buildStartColoradoError = (delay = 0): MockedResponse<StartThisSche
     },
     result: {
       data: {
-        __typename: 'DagitMutation',
+        __typename: 'Mutation',
         startSchedule: buildUnauthorizedError({
           message: 'lol u cannot',
         }),
@@ -137,7 +137,7 @@ export const buildStopDelawareSuccess = (delay = 0): MockedResponse<StopSchedule
     },
     result: {
       data: {
-        __typename: 'DagitMutation',
+        __typename: 'Mutation',
         stopRunningSchedule: buildScheduleStateResult({
           scheduleState: buildInstigationState({
             status: InstigationStatus.STOPPED,
@@ -160,7 +160,7 @@ export const buildStopHawaiiSuccess = (delay = 0): MockedResponse<StopScheduleMu
     },
     result: {
       data: {
-        __typename: 'DagitMutation',
+        __typename: 'Mutation',
         stopRunningSchedule: buildScheduleStateResult({
           scheduleState: buildInstigationState({
             status: InstigationStatus.STOPPED,
@@ -183,7 +183,7 @@ export const buildStopHawaiiError = (delay = 0): MockedResponse<StopScheduleMuta
     },
     result: {
       data: {
-        __typename: 'DagitMutation',
+        __typename: 'Mutation',
         stopRunningSchedule: buildUnauthorizedError({
           message: 'lol u cannot',
         }),

--- a/js_modules/dagit/packages/core/src/schedules/types/ScheduleMutations.types.ts
+++ b/js_modules/dagit/packages/core/src/schedules/types/ScheduleMutations.types.ts
@@ -7,7 +7,7 @@ export type StartThisScheduleMutationVariables = Types.Exact<{
 }>;
 
 export type StartThisScheduleMutation = {
-  __typename: 'DagitMutation';
+  __typename: 'Mutation';
   startSchedule:
     | {
         __typename: 'PythonError';
@@ -37,7 +37,7 @@ export type StopScheduleMutationVariables = Types.Exact<{
 }>;
 
 export type StopScheduleMutation = {
-  __typename: 'DagitMutation';
+  __typename: 'Mutation';
   stopRunningSchedule:
     | {
         __typename: 'PythonError';

--- a/js_modules/dagit/packages/core/src/schedules/types/SchedulePartitionStatus.types.ts
+++ b/js_modules/dagit/packages/core/src/schedules/types/SchedulePartitionStatus.types.ts
@@ -7,7 +7,7 @@ export type SchedulePartitionStatusQueryVariables = Types.Exact<{
 }>;
 
 export type SchedulePartitionStatusQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   scheduleOrError:
     | {__typename: 'PythonError'}
     | {

--- a/js_modules/dagit/packages/core/src/schedules/types/ScheduleRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/schedules/types/ScheduleRoot.types.ts
@@ -7,7 +7,7 @@ export type ScheduleRootQueryVariables = Types.Exact<{
 }>;
 
 export type ScheduleRootQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   scheduleOrError:
     | {
         __typename: 'PythonError';
@@ -117,7 +117,7 @@ export type PreviousRunsForScheduleQueryVariables = Types.Exact<{
 }>;
 
 export type PreviousRunsForScheduleQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   pipelineRunsOrError:
     | {__typename: 'InvalidPipelineRunsFilterError'; message: string}
     | {__typename: 'PythonError'; message: string}

--- a/js_modules/dagit/packages/core/src/schedules/types/SchedulesNextTicks.types.ts
+++ b/js_modules/dagit/packages/core/src/schedules/types/SchedulesNextTicks.types.ts
@@ -44,7 +44,7 @@ export type ScheduleTickConfigQueryVariables = Types.Exact<{
 }>;
 
 export type ScheduleTickConfigQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   scheduleOrError:
     | {__typename: 'PythonError'}
     | {

--- a/js_modules/dagit/packages/core/src/search/__fixtures__/Search.fixtures.tsx
+++ b/js_modules/dagit/packages/core/src/search/__fixtures__/Search.fixtures.tsx
@@ -26,7 +26,7 @@ export const buildPrimarySearch = (delay = 0): MockedResponse<SearchPrimaryQuery
     },
     result: {
       data: {
-        __typename: 'DagitQuery',
+        __typename: 'Query',
         workspaceOrError: buildWorkspace({
           locationEntries: [
             buildWorkspaceLocationEntry({
@@ -84,7 +84,7 @@ export const buildPrimarySearchStatic = (delay = 0): MockedResponse<SearchPrimar
     },
     result: {
       data: {
-        __typename: 'DagitQuery',
+        __typename: 'Query',
         workspaceOrError: buildWorkspace({
           locationEntries: [
             buildWorkspaceLocationEntry({
@@ -158,7 +158,7 @@ export const buildSecondarySearch = (
     },
     result: {
       data: {
-        __typename: 'DagitQuery',
+        __typename: 'Query',
         assetsOrError: buildAssetConnection({
           // This array manually builds up `Asset` objects because it is too expensive
           // to run the builders for many thousands of objects.
@@ -192,7 +192,7 @@ export const buildSecondarySearchStatic = (delay = 0): MockedResponse<SearchSeco
     },
     result: {
       data: {
-        __typename: 'DagitQuery',
+        __typename: 'Query',
         assetsOrError: buildAssetConnection({
           nodes: [
             buildAsset({

--- a/js_modules/dagit/packages/core/src/search/types/useGlobalSearch.types.ts
+++ b/js_modules/dagit/packages/core/src/search/types/useGlobalSearch.types.ts
@@ -5,7 +5,7 @@ import * as Types from '../../graphql/types';
 export type SearchPrimaryQueryVariables = Types.Exact<{[key: string]: never}>;
 
 export type SearchPrimaryQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   workspaceOrError:
     | {
         __typename: 'PythonError';
@@ -59,7 +59,7 @@ export type SearchPrimaryQuery = {
 export type SearchSecondaryQueryVariables = Types.Exact<{[key: string]: never}>;
 
 export type SearchSecondaryQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   assetsOrError:
     | {
         __typename: 'AssetConnection';

--- a/js_modules/dagit/packages/core/src/sensors/__fixtures__/SensorState.fixtures.tsx
+++ b/js_modules/dagit/packages/core/src/sensors/__fixtures__/SensorState.fixtures.tsx
@@ -65,7 +65,7 @@ export const buildStartKansasSuccess = (delay = 0): MockedResponse<StartSensorMu
     },
     result: {
       data: {
-        __typename: 'DagitMutation',
+        __typename: 'Mutation',
         startSensor: buildSensor({
           sensorState: buildInstigationState({
             status: InstigationStatus.RUNNING,
@@ -91,7 +91,7 @@ export const buildStartLouisianaSuccess = (delay = 0): MockedResponse<StartSenso
     },
     result: {
       data: {
-        __typename: 'DagitMutation',
+        __typename: 'Mutation',
         startSensor: buildSensor({
           sensorState: buildInstigationState({
             status: InstigationStatus.RUNNING,
@@ -117,7 +117,7 @@ export const buildStartLouisianaError = (delay = 0): MockedResponse<StartSensorM
     },
     result: {
       data: {
-        __typename: 'DagitMutation',
+        __typename: 'Mutation',
         startSensor: buildUnauthorizedError({
           message: 'lol u cannot',
         }),
@@ -138,7 +138,7 @@ export const buildStopMinnesotaSuccess = (delay = 0): MockedResponse<StopRunning
     },
     result: {
       data: {
-        __typename: 'DagitMutation',
+        __typename: 'Mutation',
         stopSensor: buildStopSensorMutationResult({
           instigationState: buildInstigationState({
             status: InstigationStatus.STOPPED,
@@ -161,7 +161,7 @@ export const buildStopOregonSuccess = (delay = 0): MockedResponse<StopRunningSen
     },
     result: {
       data: {
-        __typename: 'DagitMutation',
+        __typename: 'Mutation',
         stopSensor: buildStopSensorMutationResult({
           instigationState: buildInstigationState({
             status: InstigationStatus.STOPPED,
@@ -184,7 +184,7 @@ export const buildStopOregonError = (delay = 0): MockedResponse<StopRunningSenso
     },
     result: {
       data: {
-        __typename: 'DagitMutation',
+        __typename: 'Mutation',
         stopSensor: buildUnauthorizedError({
           message: 'lol u cannot',
         }),

--- a/js_modules/dagit/packages/core/src/sensors/types/EditCursorDialog.types.ts
+++ b/js_modules/dagit/packages/core/src/sensors/types/EditCursorDialog.types.ts
@@ -8,7 +8,7 @@ export type SetSensorCursorMutationVariables = Types.Exact<{
 }>;
 
 export type SetSensorCursorMutation = {
-  __typename: 'DagitMutation';
+  __typename: 'Mutation';
   setSensorCursor:
     | {
         __typename: 'PythonError';

--- a/js_modules/dagit/packages/core/src/sensors/types/SensorMutations.types.ts
+++ b/js_modules/dagit/packages/core/src/sensors/types/SensorMutations.types.ts
@@ -7,7 +7,7 @@ export type StartSensorMutationVariables = Types.Exact<{
 }>;
 
 export type StartSensorMutation = {
-  __typename: 'DagitMutation';
+  __typename: 'Mutation';
   startSensor:
     | {
         __typename: 'PythonError';
@@ -34,7 +34,7 @@ export type StopRunningSensorMutationVariables = Types.Exact<{
 }>;
 
 export type StopRunningSensorMutation = {
-  __typename: 'DagitMutation';
+  __typename: 'Mutation';
   stopSensor:
     | {
         __typename: 'PythonError';

--- a/js_modules/dagit/packages/core/src/sensors/types/SensorPreviousRuns.types.ts
+++ b/js_modules/dagit/packages/core/src/sensors/types/SensorPreviousRuns.types.ts
@@ -8,7 +8,7 @@ export type PreviousRunsForSensorQueryVariables = Types.Exact<{
 }>;
 
 export type PreviousRunsForSensorQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   pipelineRunsOrError:
     | {__typename: 'InvalidPipelineRunsFilterError'}
     | {__typename: 'PythonError'}

--- a/js_modules/dagit/packages/core/src/sensors/types/SensorRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/sensors/types/SensorRoot.types.ts
@@ -7,7 +7,7 @@ export type SensorRootQueryVariables = Types.Exact<{
 }>;
 
 export type SensorRootQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   sensorOrError:
     | {
         __typename: 'PythonError';

--- a/js_modules/dagit/packages/core/src/snapshots/types/SnapshotNav.types.ts
+++ b/js_modules/dagit/packages/core/src/snapshots/types/SnapshotNav.types.ts
@@ -7,7 +7,7 @@ export type SnapshotQueryVariables = Types.Exact<{
 }>;
 
 export type SnapshotQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   pipelineSnapshotOrError:
     | {__typename: 'PipelineNotFoundError'}
     | {__typename: 'PipelineSnapshot'; id: string; parentSnapshotId: string | null}

--- a/js_modules/dagit/packages/core/src/testing/__tests__/ApolloTestProvider.test.tsx
+++ b/js_modules/dagit/packages/core/src/testing/__tests__/ApolloTestProvider.test.tsx
@@ -35,9 +35,9 @@ describe('ApolloTestProvider', () => {
     expect(result.length).toBe(1);
   });
 
-  it('allows overriding with mocked `DagitQuery` values', async () => {
+  it('allows overriding with mocked `Query` values', async () => {
     const mocks = {
-      DagitQuery: () => ({
+      Query: () => ({
         version: () => '1234',
       }),
     };

--- a/js_modules/dagit/packages/core/src/testing/defaultMocks.ts
+++ b/js_modules/dagit/packages/core/src/testing/defaultMocks.ts
@@ -42,7 +42,7 @@ export const defaultMocks = {
     solids: () => [...new Array(2)],
     modes: () => [...new Array(1)],
   }),
-  DagitQuery: () => ({
+  Query: () => ({
     version: () => 'x.y.z',
   }),
   Repository: () => ({

--- a/js_modules/dagit/packages/core/src/ticks/__fixtures__/EvaluateScheduleDialog.fixtures.tsx
+++ b/js_modules/dagit/packages/core/src/ticks/__fixtures__/EvaluateScheduleDialog.fixtures.tsx
@@ -25,7 +25,7 @@ export const GetScheduleQueryMock: MockedResponse<GetScheduleQuery> = {
   },
   result: {
     data: {
-      __typename: 'DagitQuery',
+      __typename: 'Query',
       scheduleOrError: buildSchedule({
         id: 'foo',
         name: 'configurable_job_schedule',
@@ -36,7 +36,7 @@ export const GetScheduleQueryMock: MockedResponse<GetScheduleQuery> = {
 };
 
 export const scheduleDryWithWithRunRequest = {
-  __typename: 'DagitMutation' as const,
+  __typename: 'Mutation' as const,
   scheduleDryRun: buildDryRunInstigationTick({
     timestamp: 1674950400,
     evaluationResult: buildTickEvaluation({
@@ -101,7 +101,7 @@ export const ScheduleDryRunMutationError: MockedResponse<ScheduleDryRunMutation>
   },
   result: {
     data: {
-      __typename: 'DagitMutation',
+      __typename: 'Mutation',
       scheduleDryRun: buildDryRunInstigationTick({
         timestamp: null,
         evaluationResult: buildTickEvaluation({
@@ -151,7 +151,7 @@ export const ScheduleDryRunMutationSkipped: MockedResponse<ScheduleDryRunMutatio
   },
   result: {
     data: {
-      __typename: 'DagitMutation',
+      __typename: 'Mutation',
       scheduleDryRun: buildDryRunInstigationTick({
         timestamp: null,
         evaluationResult: buildTickEvaluation({

--- a/js_modules/dagit/packages/core/src/ticks/__fixtures__/SensorDryRunDialog.fixtures.tsx
+++ b/js_modules/dagit/packages/core/src/ticks/__fixtures__/SensorDryRunDialog.fixtures.tsx
@@ -62,7 +62,7 @@ export const SensorDryRunMutationRunRequests: MockedResponse<SensorDryRunMutatio
   },
   result: {
     data: {
-      __typename: 'DagitMutation',
+      __typename: 'Mutation',
       sensorDryRun: buildDryRunInstigationTick({
         evaluationResult: buildTickEvaluation({
           cursor: 'a new cursor',
@@ -88,7 +88,7 @@ export const SensorDryRunMutationError: MockedResponse<SensorDryRunMutation> = {
   },
   result: {
     data: {
-      __typename: 'DagitMutation',
+      __typename: 'Mutation',
       sensorDryRun: buildDryRunInstigationTick({
         evaluationResult: buildTickEvaluation({
           error: buildPythonError({
@@ -135,7 +135,7 @@ export const SensorDryRunMutationSkipped: MockedResponse<SensorDryRunMutation> =
   },
   result: {
     data: {
-      __typename: 'DagitMutation',
+      __typename: 'Mutation',
       sensorDryRun: buildDryRunInstigationTick({
         evaluationResult: buildTickEvaluation({
           cursor: '',
@@ -163,7 +163,7 @@ export const PersistCursorValueMock: MockedResponse<SetSensorCursorMutation> = {
   },
   result: {
     data: {
-      __typename: 'DagitMutation',
+      __typename: 'Mutation',
       setSensorCursor: buildSensor({
         id: '8c8110e095e45239948246b18f9c66def47a2a11',
         sensorState: buildInstigationState({

--- a/js_modules/dagit/packages/core/src/ticks/types/EvaluateScheduleDialog.types.ts
+++ b/js_modules/dagit/packages/core/src/ticks/types/EvaluateScheduleDialog.types.ts
@@ -10,7 +10,7 @@ export type GetScheduleQueryVariables = Types.Exact<{
 }>;
 
 export type GetScheduleQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   scheduleOrError:
     | {__typename: 'PythonError'; message: string; stack: Array<string>}
     | {__typename: 'Schedule'; id: string; name: string; potentialTickTimestamps: Array<number>}
@@ -23,7 +23,7 @@ export type ScheduleDryRunMutationVariables = Types.Exact<{
 }>;
 
 export type ScheduleDryRunMutation = {
-  __typename: 'DagitMutation';
+  __typename: 'Mutation';
   scheduleDryRun:
     | {
         __typename: 'DryRunInstigationTick';

--- a/js_modules/dagit/packages/core/src/ticks/types/SensorDryRunDialog.types.ts
+++ b/js_modules/dagit/packages/core/src/ticks/types/SensorDryRunDialog.types.ts
@@ -8,7 +8,7 @@ export type SensorDryRunMutationVariables = Types.Exact<{
 }>;
 
 export type SensorDryRunMutation = {
-  __typename: 'DagitMutation';
+  __typename: 'Mutation';
   sensorDryRun:
     | {
         __typename: 'DryRunInstigationTick';

--- a/js_modules/dagit/packages/core/src/ticks/types/TickLogDialog.types.ts
+++ b/js_modules/dagit/packages/core/src/ticks/types/TickLogDialog.types.ts
@@ -8,7 +8,7 @@ export type TickLogEventsQueryVariables = Types.Exact<{
 }>;
 
 export type TickLogEventsQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   instigationStateOrError:
     | {
         __typename: 'InstigationState';

--- a/js_modules/dagit/packages/core/src/typeexplorer/types/TypeExplorerContainer.types.ts
+++ b/js_modules/dagit/packages/core/src/typeexplorer/types/TypeExplorerContainer.types.ts
@@ -8,7 +8,7 @@ export type TypeExplorerContainerQueryVariables = Types.Exact<{
 }>;
 
 export type TypeExplorerContainerQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   pipelineOrError:
     | {__typename: 'InvalidSubsetError'}
     | {

--- a/js_modules/dagit/packages/core/src/typeexplorer/types/TypeListContainer.types.ts
+++ b/js_modules/dagit/packages/core/src/typeexplorer/types/TypeListContainer.types.ts
@@ -7,7 +7,7 @@ export type TypeListContainerQueryVariables = Types.Exact<{
 }>;
 
 export type TypeListContainerQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   pipelineOrError:
     | {__typename: 'InvalidSubsetError'}
     | {

--- a/js_modules/dagit/packages/core/src/workspace/types/GraphRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/GraphRoot.types.ts
@@ -9,7 +9,7 @@ export type GraphExplorerRootQueryVariables = Types.Exact<{
 }>;
 
 export type GraphExplorerRootQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   graphOrError:
     | {
         __typename: 'Graph';

--- a/js_modules/dagit/packages/core/src/workspace/types/VirtualizedAssetRow.types.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/VirtualizedAssetRow.types.ts
@@ -7,7 +7,7 @@ export type SingleNonSdaAssetQueryVariables = Types.Exact<{
 }>;
 
 export type SingleNonSdaAssetQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   assetOrError:
     | {
         __typename: 'Asset';

--- a/js_modules/dagit/packages/core/src/workspace/types/VirtualizedGraphTable.types.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/VirtualizedGraphTable.types.ts
@@ -7,7 +7,7 @@ export type SingleGraphQueryVariables = Types.Exact<{
 }>;
 
 export type SingleGraphQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   graphOrError:
     | {__typename: 'Graph'; id: string; name: string; description: string | null}
     | {__typename: 'GraphNotFoundError'}

--- a/js_modules/dagit/packages/core/src/workspace/types/VirtualizedJobRow.types.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/VirtualizedJobRow.types.ts
@@ -7,7 +7,7 @@ export type SingleJobQueryVariables = Types.Exact<{
 }>;
 
 export type SingleJobQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   pipelineOrError:
     | {__typename: 'InvalidSubsetError'}
     | {

--- a/js_modules/dagit/packages/core/src/workspace/types/VirtualizedScheduleRow.types.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/VirtualizedScheduleRow.types.ts
@@ -7,7 +7,7 @@ export type SingleScheduleQueryVariables = Types.Exact<{
 }>;
 
 export type SingleScheduleQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   scheduleOrError:
     | {__typename: 'PythonError'}
     | {

--- a/js_modules/dagit/packages/core/src/workspace/types/VirtualizedSensorRow.types.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/VirtualizedSensorRow.types.ts
@@ -7,7 +7,7 @@ export type SingleSensorQueryVariables = Types.Exact<{
 }>;
 
 export type SingleSensorQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   sensorOrError:
     | {__typename: 'PythonError'}
     | {

--- a/js_modules/dagit/packages/core/src/workspace/types/WorkspaceAssetsRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/WorkspaceAssetsRoot.types.ts
@@ -7,7 +7,7 @@ export type WorkspaceAssetsQueryVariables = Types.Exact<{
 }>;
 
 export type WorkspaceAssetsQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   repositoryOrError:
     | {
         __typename: 'PythonError';

--- a/js_modules/dagit/packages/core/src/workspace/types/WorkspaceContext.types.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/WorkspaceContext.types.ts
@@ -5,7 +5,7 @@ import * as Types from '../../graphql/types';
 export type RootWorkspaceQueryVariables = Types.Exact<{[key: string]: never}>;
 
 export type RootWorkspaceQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   workspaceOrError:
     | {
         __typename: 'PythonError';

--- a/js_modules/dagit/packages/core/src/workspace/types/WorkspaceGraphsRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/WorkspaceGraphsRoot.types.ts
@@ -7,7 +7,7 @@ export type WorkspaceGraphsQueryVariables = Types.Exact<{
 }>;
 
 export type WorkspaceGraphsQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   repositoryOrError:
     | {
         __typename: 'PythonError';

--- a/js_modules/dagit/packages/core/src/workspace/types/WorkspaceJobsRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/WorkspaceJobsRoot.types.ts
@@ -7,7 +7,7 @@ export type WorkspaceJobsQueryVariables = Types.Exact<{
 }>;
 
 export type WorkspaceJobsQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   repositoryOrError:
     | {
         __typename: 'PythonError';

--- a/js_modules/dagit/packages/core/src/workspace/types/WorkspaceSchedulesRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/WorkspaceSchedulesRoot.types.ts
@@ -7,7 +7,7 @@ export type WorkspaceSchedulesQueryVariables = Types.Exact<{
 }>;
 
 export type WorkspaceSchedulesQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   repositoryOrError:
     | {
         __typename: 'PythonError';

--- a/js_modules/dagit/packages/core/src/workspace/types/WorkspaceSensorsRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/WorkspaceSensorsRoot.types.ts
@@ -7,7 +7,7 @@ export type WorkspaceSensorsQueryVariables = Types.Exact<{
 }>;
 
 export type WorkspaceSensorsQuery = {
-  __typename: 'DagitQuery';
+  __typename: 'Query';
   repositoryOrError:
     | {
         __typename: 'PythonError';

--- a/python_modules/dagster-graphql/dagster_graphql/schema/__init__.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/__init__.py
@@ -1,8 +1,8 @@
 import graphene
 
-from .roots.mutation import GrapheneDagitMutation
-from .roots.query import GrapheneDagitQuery
-from .roots.subscription import GrapheneDagitSubscription
+from .roots.mutation import GrapheneMutation
+from .roots.query import GrapheneQuery
+from .roots.subscription import GrapheneSubscription
 
 
 def types():
@@ -70,8 +70,8 @@ def types():
 
 def create_schema() -> graphene.Schema:
     return graphene.Schema(
-        query=GrapheneDagitQuery,
-        mutation=GrapheneDagitMutation,
-        subscription=GrapheneDagitSubscription,
+        query=GrapheneQuery,
+        mutation=GrapheneMutation,
+        subscription=GrapheneSubscription,
         types=types(),
     )

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/mutation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/mutation.py
@@ -748,11 +748,11 @@ class GrapheneFreeConcurrencySlotsForRunMutation(graphene.Mutation):
         return True
 
 
-class GrapheneDagitMutation(graphene.ObjectType):
+class GrapheneMutation(graphene.ObjectType):
     """The root for all mutations to modify data in your Dagster instance."""
 
     class Meta:
-        name = "DagitMutation"
+        name = "Mutation"
 
     launchPipelineExecution = GrapheneLaunchRunMutation.Field()
     launchRun = GrapheneLaunchRunMutation.Field()

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -151,11 +151,11 @@ from .execution_plan import GrapheneExecutionPlanOrError
 from .pipeline import GrapheneGraphOrError, GraphenePipelineOrError
 
 
-class GrapheneDagitQuery(graphene.ObjectType):
+class GrapheneQuery(graphene.ObjectType):
     """The root for all queries to retrieve data from the Dagster instance."""
 
     class Meta:
-        name = "DagitQuery"
+        name = "Query"
 
     version = graphene.Field(
         graphene.NonNull(graphene.String),

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/subscription.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/subscription.py
@@ -8,11 +8,11 @@ from ..pipelines.subscription import GraphenePipelineRunLogsSubscriptionPayload
 from ..util import ResolveInfo, non_null_list
 
 
-class GrapheneDagitSubscription(graphene.ObjectType):
+class GrapheneSubscription(graphene.ObjectType):
     """The root for all subscriptions to retrieve real-time data from the Dagster instance."""
 
     class Meta:
-        name = "DagitSubscription"
+        name = "Subscription"
 
     pipelineRunLogs = graphene.Field(
         graphene.NonNull(GraphenePipelineRunLogsSubscriptionPayload),

--- a/python_modules/dagster-webserver/dagster_webserver_tests/webserver/test_app.py
+++ b/python_modules/dagster-webserver/dagster_webserver_tests/webserver/test_app.py
@@ -88,7 +88,7 @@ def test_graphql_get(instance, test_client: TestClient):
         params={"query": "{__typename}"},
     )
     assert response.status_code == 200, response.text
-    assert response.json() == {"data": {"__typename": "DagitQuery"}}
+    assert response.json() == {"data": {"__typename": "Query"}}
 
     # missing
     response = test_client.get("/graphql")
@@ -133,7 +133,7 @@ def test_graphql_post(test_client: TestClient):
         params={"query": "{__typename}"},
     )
     assert response.status_code == 200, response.text
-    assert response.json() == {"data": {"__typename": "DagitQuery"}}
+    assert response.json() == {"data": {"__typename": "Query"}}
 
     # missing
     response = test_client.post("/graphql")
@@ -173,7 +173,7 @@ def test_graphql_post(test_client: TestClient):
         headers={"Content-type": "application/graphql"},
     )
     assert response.status_code == 200, response.text
-    assert response.json() == {"data": {"__typename": "DagitQuery"}}
+    assert response.json() == {"data": {"__typename": "Query"}}
 
     # non existent field
     response = test_client.post(


### PR DESCRIPTION
## Summary & Motivation

Internal companion PR: https://github.com/dagster-io/internal/pull/6052

- Rename root types of GQL schema by stripping the `Dagit` prefix.

## How I Tested These Changes

Existing test suite.