### PR TITLE
Add `Title`

### DIFF
--- a/js_modules/dagit/packages/ui/src/components/Text.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Text.tsx
@@ -7,7 +7,7 @@ interface TextProps {
   color?: string;
 }
 
-export const BigHeading = styled.span<TextProps>`
+export const Title = styled.span<TextProps>`
   ${({color}) => (color ? `color: ${color};` : null)}
   font-size: 24px;
   font-weight: 600;

--- a/js_modules/dagit/packages/ui/src/components/Text.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Text.tsx
@@ -7,6 +7,14 @@ interface TextProps {
   color?: string;
 }
 
+export const BigHeading = styled.span<TextProps>`
+  ${({color}) => (color ? `color: ${color};` : null)}
+  font-size: 24px;
+  font-weight: 600;
+  line-height: 29px;
+  -webkit-font-smoothing: antialiased;
+`;
+
 export const Heading = styled.span<TextProps>`
   ${({color}) => (color ? `color: ${color};` : null)}
   font-size: 18px;


### PR DESCRIPTION
## Summary & Motivation

Adds a new heading type "Title". Ideally we'd rename our headings to be like Heading1, Heading2, etc, but it's something we can do down the line with a regex rename when we have spare cycles.

## How I Tested These Changes

Figma spec for the new header text:

<img width="138" alt="Screenshot 2023-06-27 at 11 03 28 AM" src="https://github.com/dagster-io/dagster/assets/2286579/0bd2a531-dfe8-4d8c-9066-bf2e646c7043">
