### PR TITLE
by->for in DbtManifest methods

### DIFF
--- a/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/jobs/yield_materializations.py
+++ b/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/jobs/yield_materializations.py
@@ -11,7 +11,7 @@ def my_dbt_build_op(dbt: DbtCli):
     for dagster_event in dbt.cli(["build"], manifest=manifest).stream():
         if isinstance(dagster_event, Output):
             yield AssetMaterialization(
-                asset_key=manifest.get_asset_key_by_output_name(dagster_event.output_name),
+                asset_key=manifest.get_asset_key_for_output_name(dagster_event.output_name),
                 metadata=dagster_event.metadata,
             )
         else:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources_v2.py
@@ -245,11 +245,11 @@ class DbtManifest:
             for node in self.node_info_by_dbt_unique_id.values()
         }
 
-    def get_node_info_by_output_name(self, output_name: str) -> Mapping[str, Any]:
+    def get_node_info_for_output_name(self, output_name: str) -> Mapping[str, Any]:
         """Get a dbt node's dictionary representation in the manifest by its Dagster output name."""
         return self.node_info_by_output_name[output_name]
 
-    def get_asset_key_by_output_name(self, output_name: str) -> AssetKey:
+    def get_asset_key_for_output_name(self, output_name: str) -> AssetKey:
         """Return the corresponding dbt node's Dagster asset key for a Dagster output name.
 
         Args:
@@ -258,7 +258,7 @@ class DbtManifest:
         Returns:
             AssetKey: The corresponding dbt node's Dagster asset key.
         """
-        return self.node_info_to_asset_key(self.get_node_info_by_output_name(output_name))
+        return self.node_info_to_asset_key(self.get_node_info_for_output_name(output_name))
 
     def get_asset_key_for_dbt_unique_id(self, unique_id: str) -> AssetKey:
         node_info = self.node_info_by_dbt_unique_id.get(unique_id)
@@ -531,7 +531,7 @@ class DbtManifest:
 
         selected_dbt_resources = []
         for output_name in context.selected_output_names:
-            node_info = self.get_node_info_by_output_name(output_name)
+            node_info = self.get_node_info_for_output_name(output_name)
 
             # Explicitly select a dbt resource by its fully qualified name (FQN).
             # https://docs.getdbt.com/reference/node-selection/methods#the-file-or-fqn-method


### PR DESCRIPTION
## Summary & Motivation

We generally use `by` when we're returning a dictionary and `for` when we're returning a single element from a dictionary.

## How I Tested These Changes
