### PR TITLE
Clarify docs for stubbed input

### DIFF
--- a/docs/content/concepts/ops-jobs-graphs/ops.mdx
+++ b/docs/content/concepts/ops-jobs-graphs/ops.mdx
@@ -73,7 +73,7 @@ Both definitions have a few important properties:
 
 #### Inputs
 
-Inputs are passed as arguments to an op's `compute_fn`. The value of an input can be passed from the output of another op, or stubbed (hardcoded) using config.
+Inputs are passed as arguments to an op's `compute_fn`. The value of an input can be passed from the output of another op, or [stubbed (hardcoded) using config](/concepts/io-management/unconnected-inputs#loading-a-built-in-dagster-type-from-config).
 
 The most common way to define inputs is just to add arguments to the decorated function:
 


### PR DESCRIPTION
## Summary & Motivation

Adds a link for stubbed inputs to Ops concept page. Done in response to user request.

See: https://dagster.slack.com/archives/C01U954MEER/p1687944677391479

## How I Tested These Changes

Existing test suite.
