### PR TITLE
feat(dbt): add method to build schedules from dbt selections

### DIFF
--- a/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/schedules/define_schedules.py
+++ b/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/schedules/define_schedules.py
@@ -1,26 +1,17 @@
-from dagster import ScheduleDefinition, define_asset_job
 from dagster_dbt.cli.resources_v2 import DbtManifest
 
 from ..constants import MANIFEST_PATH
 
 manifest = DbtManifest.read(path=MANIFEST_PATH)
 
-daily_dbt_assets_schedule = ScheduleDefinition(
+daily_dbt_assets_schedule = manifest.build_schedule(
+    job_name="all_dbt_assets",
     cron_schedule="0 0 * * *",
-    job=define_asset_job(
-        name="all_dbt_assets",
-        selection=manifest.build_asset_selection(
-            dbt_select="fqn:*",
-        ),
-    ),
+    dbt_select="fqn:*",
 )
 
-hourly_staging_dbt_assets = ScheduleDefinition(
+hourly_staging_dbt_assets = manifest.build_schedule(
+    job_name="staging_dbt_assets",
     cron_schedule="0 * * * *",
-    job=define_asset_job(
-        name="staging_dbt_assets",
-        selection=manifest.build_asset_selection(
-            dbt_select="fqn:staging.*",
-        ),
-    ),
+    dbt_select="fqn:staging.*",
 )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_schedules.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_schedules.py
@@ -1,0 +1,74 @@
+from typing import Mapping, Optional
+
+import pytest
+from dagster import RunConfig
+from dagster._core.definitions.unresolved_asset_job_definition import UnresolvedAssetJobDefinition
+from dagster._utils import file_relative_path
+from dagster_dbt.cli.resources_v2 import DbtManifest, DbtManifestAssetSelection
+
+manifest_path = file_relative_path(__file__, "../sample_manifest.json")
+manifest = DbtManifest.read(path=manifest_path)
+
+
+@pytest.mark.parametrize(
+    [
+        "job_name",
+        "cron_schedule",
+        "dbt_select",
+        "dbt_exclude",
+        "tags",
+        "config",
+        "execution_timezone",
+    ],
+    [
+        (
+            "test_job",
+            "0 0 * * *",
+            "fqn:*",
+            None,
+            None,
+            None,
+            None,
+        ),
+        (
+            "test_job",
+            "0 * * * *",
+            "fqn:*",
+            "fqn:staging.*",
+            {"my": "tag"},
+            RunConfig(ops={"my_op": {"config": "value"}}),
+            "America/Vancouver",
+        ),
+    ],
+)
+def test_dbt_build_schedule(
+    job_name: str,
+    cron_schedule: str,
+    dbt_select: str,
+    dbt_exclude: Optional[str],
+    tags: Optional[Mapping[str, str]],
+    config: Optional[RunConfig],
+    execution_timezone: Optional[str],
+) -> None:
+    test_daily_schedule = manifest.build_schedule(
+        job_name=job_name,
+        cron_schedule=cron_schedule,
+        dbt_select=dbt_select,
+        dbt_exclude=dbt_exclude,
+        tags=tags,
+        config=config,
+        execution_timezone=execution_timezone,
+    )
+
+    assert test_daily_schedule.name == f"{job_name}_schedule"
+    assert test_daily_schedule.job.name == job_name
+    assert test_daily_schedule.execution_timezone == execution_timezone
+
+    job = test_daily_schedule.job
+
+    assert isinstance(job, UnresolvedAssetJobDefinition)
+    assert isinstance(job.selection, DbtManifestAssetSelection)
+    assert job.selection.select == (dbt_select or "fqn:*")
+    assert job.selection.exclude == (dbt_exclude or "")
+    assert job.tags == (tags or {})
+    assert job.config == (config.to_config_dict() if config else None)


### PR DESCRIPTION
## Summary & Motivation

We introduce a `.build_schedule(...)` method on `DbtManifest` to create a schedule given a selection of dbt assets. This way, users are shielded from directly interacting with `define_asset_job` and `ScheduleDefinition`.

The API that we introduce makes the construction of `ScheduleDefinition` for simple cases. But, we should not seek to recreate a parallel API that contains all the `ScheduleDefinition` and `define_asset_job` arguments.

For example, if the user wants to use partition config or yield `RunRequest` and `SkipReason` in their schedule, then they must use the underlying Dagster framework API's (`ScheduleDefinition`, `@schedule`, `define_asset_job`) to accomplish their use cases.

## How I Tested These Changes
pytest