### PR TITLE
[ui] Show button to view asset step logs in failed / current run banners

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
@@ -22,7 +22,7 @@ import {TimestampDisplay} from '../schedules/TimestampDisplay';
 import {markdownToPlaintext} from '../ui/markdownToPlaintext';
 
 import {AssetLatestRunSpinner, AssetRunLink} from './AssetRunLinking';
-import {LiveDataForNode} from './Utils';
+import {LiveDataForNode, stepKeyForAsset} from './Utils';
 import {ASSET_NODE_NAME_MAX_LENGTH} from './layout';
 import {AssetNodeFragment} from './types/AssetNode.types';
 
@@ -141,13 +141,6 @@ const AssetNodeStatusRow: React.FC<StatusRowProps> = ({definition, liveData}) =>
   return <AssetNodeStatusBox background={background}>{content}</AssetNodeStatusBox>;
 };
 
-function getStepKey(definition: {opNames: string[]}) {
-  // Used for linking to the run with this step highlighted. We only support highlighting
-  // a single step, so just use the first one.
-  const firstOp = definition.opNames.length ? definition.opNames[0] : null;
-  return firstOp || '';
-}
-
 export function buildAssetNodeStatusContent({
   assetKey,
   definition,
@@ -215,7 +208,7 @@ export function buildAssetNodeStatusContent({
               <AssetRunLink
                 runId={liveData.lastObservation.runId}
                 event={{
-                  stepKey: getStepKey(definition),
+                  stepKey: stepKeyForAsset(definition),
                   timestamp: liveData.lastObservation.timestamp,
                 }}
               >
@@ -340,7 +333,7 @@ export function buildAssetNodeStatusContent({
     <span style={{overflow: 'hidden'}}>
       <AssetRunLink
         runId={lastMaterialization.runId}
-        event={{stepKey: getStepKey(definition), timestamp: lastMaterialization.timestamp}}
+        event={{stepKey: stepKeyForAsset(definition), timestamp: lastMaterialization.timestamp}}
       >
         <TimestampDisplay
           timestamp={Number(lastMaterialization.timestamp) / 1000}

--- a/js_modules/dagit/packages/core/src/asset-graph/SidebarAssetInfo.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/SidebarAssetInfo.tsx
@@ -32,7 +32,13 @@ import {buildRepoAddress} from '../workspace/buildRepoAddress';
 import {RepoAddress} from '../workspace/types';
 import {workspacePathFromAddress} from '../workspace/workspacePath';
 
-import {LiveDataForNode, displayNameForAssetKey, GraphNode, nodeDependsOnSelf} from './Utils';
+import {
+  LiveDataForNode,
+  displayNameForAssetKey,
+  GraphNode,
+  nodeDependsOnSelf,
+  stepKeyForAsset,
+} from './Utils';
 import {SidebarAssetQuery, SidebarAssetQueryVariables} from './types/SidebarAssetInfo.types';
 import {AssetNodeForGraphQueryFragment} from './types/useAssetGraphData.types';
 
@@ -98,6 +104,7 @@ export const SidebarAssetInfo: React.FC<{
         asset={asset}
         assetLastMaterializedAt={lastMaterialization?.timestamp}
         isSourceAsset={definition.isSource}
+        stepKey={stepKeyForAsset(definition)}
         liveData={liveData}
       />
 

--- a/js_modules/dagit/packages/core/src/asset-graph/Utils.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/Utils.tsx
@@ -203,7 +203,7 @@ export const buildLiveDataForNode = (
     lastObservation,
     staleStatus: assetNode.staleStatus,
     staleCauses: assetNode.staleCauses,
-    stepKey: assetNode.opNames[0]!,
+    stepKey: stepKeyForAsset(assetNode),
     freshnessInfo: assetNode.freshnessInfo,
     inProgressRunIds: assetLatestInfo?.inProgressRunIds || [],
     unstartedRunIds: assetLatestInfo?.unstartedRunIds || [],
@@ -218,6 +218,13 @@ export function tokenForAssetKey(key: {path: string[]}) {
 
 export function displayNameForAssetKey(key: {path: string[]}) {
   return key.path.join(' / ');
+}
+
+export function stepKeyForAsset(definition: {opNames: string[]}) {
+  // Used for linking to the run with this step highlighted. We only support highlighting
+  // a single step, so just use the first one.
+  const firstOp = definition.opNames.length ? definition.opNames[0] : null;
+  return firstOp || '';
 }
 
 export const itemWithAssetKey = (key: {path: string[]}) => {

--- a/js_modules/dagit/packages/core/src/assets/AssetSidebarActivitySummary.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetSidebarActivitySummary.tsx
@@ -22,6 +22,7 @@ interface Props {
   asset: SidebarAssetFragment;
   liveData?: LiveDataForNode;
   isSourceAsset: boolean;
+  stepKey: string;
 
   // This timestamp is a "hint", when it changes this component will refetch
   // to retrieve new data. Just don't want to poll the entire table query.
@@ -33,6 +34,7 @@ export const AssetSidebarActivitySummary: React.FC<Props> = ({
   assetLastMaterializedAt,
   isSourceAsset,
   liveData,
+  stepKey,
 }) => {
   const {
     materializations,
@@ -54,24 +56,19 @@ export const AssetSidebarActivitySummary: React.FC<Props> = ({
     refetch();
   }, [assetLastMaterializedAt, refetch]);
 
-  if (loading) {
-    return (
-      <Box padding={{vertical: 20}}>
-        <Spinner purpose="section" />
-      </Box>
-    );
-  }
   return (
     <>
       {!asset.partitionDefinition && (
         <>
           <FailedRunSinceMaterializationBanner
-            run={liveData?.runWhichFailedToMaterialize || null}
+            stepKey={stepKey}
             border={{side: 'top', width: 1, color: Colors.KeylineGray}}
+            run={liveData?.runWhichFailedToMaterialize || null}
           />
           <CurrentRunsBanner
-            liveData={liveData}
+            stepKey={stepKey}
             border={{side: 'top', width: 1, color: Colors.KeylineGray}}
+            liveData={liveData}
           />
         </>
       )}
@@ -109,6 +106,10 @@ export const AssetSidebarActivitySummary: React.FC<Props> = ({
                   liveData={liveData}
                 />
               </div>
+            ) : loading ? (
+              <Box padding={{vertical: 20}}>
+                <Spinner purpose="section" />
+              </Box>
             ) : (
               <Box
                 margin={{horizontal: 24, vertical: 12}}
@@ -126,6 +127,10 @@ export const AssetSidebarActivitySummary: React.FC<Props> = ({
               <div style={{margin: -1, maxWidth: '100%', overflowX: 'auto'}}>
                 <AssetEventSystemTags event={displayedEvent} paddingLeft={24} />
               </div>
+            ) : loading ? (
+              <Box padding={{vertical: 20}}>
+                <Spinner purpose="section" />
+              </Box>
             ) : (
               <Box
                 margin={{horizontal: 24, vertical: 12}}

--- a/js_modules/dagit/packages/core/src/assets/AssetView.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetView.tsx
@@ -189,7 +189,7 @@ export const AssetView: React.FC<Props> = ({assetKey}) => {
     return (
       <AssetEvents
         assetKey={assetKey}
-        assetHasDefinedPartitions={!!definition?.partitionDefinition}
+        assetNode={definition}
         dataRefreshHint={dataRefreshHint}
         params={params}
         paramsTimeWindowOnly={!!params.asOf}

--- a/js_modules/dagit/packages/core/src/assets/CurrentRunsBanner.tsx
+++ b/js_modules/dagit/packages/core/src/assets/CurrentRunsBanner.tsx
@@ -5,46 +5,62 @@ import {Link} from 'react-router-dom';
 
 import {LiveDataForNode} from '../asset-graph/Utils';
 import {titleForRun} from '../runs/RunUtils';
+import {useStepLogs} from '../runs/StepLogsDialog';
 
-export const CurrentRunsBanner: React.FC<{liveData?: LiveDataForNode; border: BorderSetting}> = ({
-  liveData,
-  border,
-}) => {
+export const CurrentRunsBanner: React.FC<{
+  liveData?: LiveDataForNode;
+  border: BorderSetting;
+  stepKey: string;
+}> = ({stepKey, liveData, border}) => {
   const {inProgressRunIds = [], unstartedRunIds = []} = liveData || {};
+  const firstRunId = inProgressRunIds[0] || unstartedRunIds[0];
+  const stepLogs = useStepLogs({runId: firstRunId, stepKeys: [stepKey]});
 
-  if (inProgressRunIds.length === 0 && unstartedRunIds.length === 0) {
-    return null;
-  }
   return (
-    <Box padding={{vertical: 16, left: 24, right: 12}} border={border}>
-      <Alert
-        intent="info"
-        icon={<Spinner purpose="body-text" />}
-        title={
-          <div style={{fontWeight: 400}}>
-            {inProgressRunIds.length > 0 && (
-              <>
-                {inProgressRunIds.map((id) => (
-                  <React.Fragment key={id}>
-                    Run <Link to={`/runs/${id}`}>{titleForRun({id})}</Link>
-                  </React.Fragment>
-                ))}{' '}
-                {inProgressRunIds.length === 1 ? 'is' : 'are'} currently refreshing this asset.
-              </>
-            )}
-            {unstartedRunIds.length > 0 && (
-              <>
-                {unstartedRunIds.map((id) => (
-                  <React.Fragment key={id}>
-                    Run <Link to={`/runs/${id}`}>{titleForRun({id})}</Link>
-                  </React.Fragment>
-                ))}{' '}
-                {unstartedRunIds.length === 1 ? 'has' : 'have'} started and will refresh this asset.
-              </>
-            )}
+    <>
+      {stepLogs.dialog}
+      {firstRunId && (
+        <Box
+          padding={{vertical: 16, left: 24, right: 12}}
+          border={border}
+          flex={{gap: 8, alignItems: 'center'}}
+          style={{width: '100%'}}
+        >
+          <div style={{flex: 1}}>
+            <Alert
+              intent="info"
+              icon={<Spinner purpose="body-text" />}
+              title={
+                <div style={{fontWeight: 400}}>
+                  {inProgressRunIds.length > 0 && (
+                    <>
+                      {inProgressRunIds.map((id) => (
+                        <React.Fragment key={id}>
+                          Run <Link to={`/runs/${id}`}>{titleForRun({id})}</Link>
+                        </React.Fragment>
+                      ))}{' '}
+                      {inProgressRunIds.length === 1 ? 'is' : 'are'} currently refreshing this
+                      asset.
+                    </>
+                  )}
+                  {unstartedRunIds.length > 0 && (
+                    <>
+                      {unstartedRunIds.map((id) => (
+                        <React.Fragment key={id}>
+                          Run <Link to={`/runs/${id}`}>{titleForRun({id})}</Link>
+                        </React.Fragment>
+                      ))}{' '}
+                      {unstartedRunIds.length === 1 ? 'has' : 'have'} started and will refresh this
+                      asset.
+                    </>
+                  )}
+                </div>
+              }
+            />
           </div>
-        }
-      />
-    </Box>
+          {stepLogs.button}
+        </Box>
+      )}
+    </>
   );
 };

--- a/js_modules/dagit/packages/core/src/assets/FailedRunSinceMaterializationBanner.tsx
+++ b/js_modules/dagit/packages/core/src/assets/FailedRunSinceMaterializationBanner.tsx
@@ -5,26 +5,42 @@ import {Link} from 'react-router-dom';
 
 import {AssetLatestInfoRunFragment} from '../asset-graph/types/useLiveDataForAssetKeys.types';
 import {titleForRun} from '../runs/RunUtils';
+import {useStepLogs} from '../runs/StepLogsDialog';
 
 export const FailedRunSinceMaterializationBanner: React.FC<{
   run: AssetLatestInfoRunFragment | null;
   padding?: DirectionalSpacing;
   border?: BorderSetting;
-}> = ({run, border, padding = {vertical: 16, left: 24, right: 12}}) => {
-  if (run) {
-    return (
-      <Box padding={padding} border={border}>
-        <Alert
-          intent="error"
-          title={
-            <div style={{fontWeight: 400}}>
-              Run <Link to={`/runs/${run.id}`}>{titleForRun(run)}</Link> failed to materialize this
-              asset.
-            </div>
-          }
-        />
-      </Box>
-    );
-  }
-  return null;
+  stepKey?: string;
+}> = ({run, stepKey, border, padding = {vertical: 16, left: 24, right: 12}}) => {
+  const stepLogs = useStepLogs({runId: run?.id, stepKeys: stepKey ? [stepKey] : []});
+
+  return (
+    <>
+      {stepLogs.dialog}
+      {run && (
+        <Box
+          padding={padding}
+          border={border}
+          flex={{gap: 8, alignItems: 'center'}}
+          style={{width: '100%'}}
+        >
+          <div style={{flex: 1}}>
+            <Alert
+              intent="error"
+              title={
+                <Box flex={{justifyContent: 'space-between'}}>
+                  <div style={{fontWeight: 400}}>
+                    Run <Link to={`/runs/${run.id}`}>{titleForRun(run)}</Link> failed to materialize
+                    this asset.
+                  </div>
+                </Box>
+              }
+            />
+          </div>
+          {stepLogs.button}
+        </Box>
+      )}
+    </>
+  );
 };

--- a/js_modules/dagit/packages/core/src/assets/LastMaterializationMetadata.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LastMaterializationMetadata.tsx
@@ -1,4 +1,4 @@
-import {Box, Button, Colors, Group, Icon, Mono, NonIdealState, Table} from '@dagster-io/ui';
+import {Box, Colors, Group, Icon, Mono, NonIdealState, Table} from '@dagster-io/ui';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components/macro';
@@ -9,7 +9,7 @@ import {AssetKeyInput} from '../graphql/types';
 import {MetadataEntry} from '../metadata/MetadataEntry';
 import {PipelineReference} from '../pipelines/PipelineReference';
 import {linkToRunEvent, titleForRun} from '../runs/RunUtils';
-import {StepLogsDialog} from '../runs/StepLogsDialog';
+import {useStepLogs} from '../runs/StepLogsDialog';
 import {isThisThingAJob, useRepository} from '../workspace/WorkspaceContext';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
 
@@ -25,137 +25,130 @@ export const LatestMaterializationMetadata: React.FC<{
   latest: AssetObservationFragment | AssetMaterializationFragment | undefined;
   liveData: LiveDataForNode | undefined;
 }> = ({assetKey, latest, liveData}) => {
-  const [showingLogs, setShowingLogs] = React.useState(false);
   const latestRun = latest?.runOrError.__typename === 'Run' ? latest?.runOrError : null;
   const repositoryOrigin = latestRun?.repositoryOrigin;
   const repoAddress = repositoryOrigin
     ? buildRepoAddress(repositoryOrigin.repositoryName, repositoryOrigin.repositoryLocationName)
     : null;
   const repo = useRepository(repoAddress);
-
-  if (!latest) {
-    return (
-      <Box padding={{top: 16, bottom: 32}}>
-        <NonIdealState
-          icon="materialization"
-          title="No metadata"
-          description="No metadata was found for this asset."
-        />
-      </Box>
-    );
-  }
-
   const latestEvent = latest;
   const latestAssetLineage =
-    latestEvent.__typename === 'MaterializationEvent' ? latestEvent?.assetLineage : [];
+    latestEvent?.__typename === 'MaterializationEvent' ? latestEvent?.assetLineage : [];
+
+  const stepLogs = useStepLogs(
+    latestEvent?.stepKey
+      ? {runId: latestEvent.runId, stepKeys: [latestEvent.stepKey]}
+      : {runId: undefined, stepKeys: []},
+  );
 
   return (
-    <MetadataTable>
-      <tbody>
-        <tr>
-          <td>Run</td>
-          <td>
-            {latestRun ? (
-              <div>
-                <Box flex={{direction: 'row', justifyContent: 'space-between'}}>
-                  <Box>
-                    {'Run '}
-                    <Link to={`/runs/${latestEvent.runId}?timestamp=${latestEvent.timestamp}`}>
-                      <Mono>{titleForRun({id: latestEvent.runId})}</Mono>
-                    </Link>
-                  </Box>
-                  {latestEvent.stepKey && (
-                    <>
-                      <StepLogsDialog
-                        runId={latestEvent.runId}
-                        stepKeys={[latestEvent.stepKey]}
-                        isOpen={showingLogs}
-                        onClose={() => setShowingLogs(false)}
-                      />
-                      <Button
-                        small
-                        icon={<Icon name="wysiwyg" />}
-                        onClick={() => setShowingLogs(true)}
-                      >
-                        View logs
-                      </Button>
-                    </>
+    <>
+      {stepLogs.dialog}
+      {latestEvent ? (
+        <MetadataTable>
+          <tbody>
+            <tr>
+              <td>Run</td>
+              <td>
+                {latestRun ? (
+                  <div>
+                    <Box
+                      flex={{
+                        direction: 'row',
+                        justifyContent: 'space-between',
+                        gap: 8,
+                        alignItems: 'flex-start',
+                      }}
+                    >
+                      <Box>
+                        {'Run '}
+                        <Link to={`/runs/${latestEvent.runId}?timestamp=${latestEvent.timestamp}`}>
+                          <Mono>{titleForRun({id: latestEvent.runId})}</Mono>
+                        </Link>
+                      </Box>
+                      {stepLogs.button}
+                    </Box>
+                    {!isHiddenAssetGroupJob(latestRun.pipelineName) && (
+                      <>
+                        <Box padding={{left: 8, top: 4}}>
+                          <PipelineReference
+                            showIcon
+                            pipelineName={latestRun.pipelineName}
+                            pipelineHrefContext={repoAddress || 'repo-unknown'}
+                            snapshotId={latestRun.pipelineSnapshotId}
+                            isJob={isThisThingAJob(repo, latestRun.pipelineName)}
+                          />
+                        </Box>
+                        <Group direction="row" padding={{left: 8}} spacing={8} alignItems="center">
+                          <Icon name="linear_scale" color={Colors.Gray400} />
+                          <Link to={linkToRunEvent(latestRun, latestEvent)}>
+                            {latestEvent.stepKey}
+                          </Link>
+                        </Group>
+                      </>
+                    )}
+                  </div>
+                ) : (
+                  'No materialization events'
+                )}
+              </td>
+            </tr>
+            {latest?.partition ? (
+              <tr>
+                <td>Partition</td>
+                <td>{latest ? latest.partition : 'No materialization events'}</td>
+              </tr>
+            ) : null}
+            <tr>
+              <td>Timestamp</td>
+              <td>
+                <Box flex={{gap: 8, alignItems: 'center'}}>
+                  {latestEvent ? (
+                    <Timestamp timestamp={{ms: Number(latestEvent.timestamp)}} />
+                  ) : (
+                    'No materialization events'
+                  )}
+                  {liveData && (
+                    <StaleReasonsTags assetKey={assetKey} liveData={liveData} include="all" />
                   )}
                 </Box>
-                {!isHiddenAssetGroupJob(latestRun.pipelineName) && (
-                  <>
-                    <Box padding={{left: 8, top: 4}}>
-                      <PipelineReference
-                        showIcon
-                        pipelineName={latestRun.pipelineName}
-                        pipelineHrefContext={repoAddress || 'repo-unknown'}
-                        snapshotId={latestRun.pipelineSnapshotId}
-                        isJob={isThisThingAJob(repo, latestRun.pipelineName)}
-                      />
-                    </Box>
-                    <Group direction="row" padding={{left: 8}} spacing={8} alignItems="center">
-                      <Icon name="linear_scale" color={Colors.Gray400} />
-                      <Link to={linkToRunEvent(latestRun, latestEvent)}>{latestEvent.stepKey}</Link>
-                    </Group>
-                  </>
-                )}
-              </div>
-            ) : (
-              'No materialization events'
-            )}
-          </td>
-          <td />
-        </tr>
-        {latest?.partition ? (
-          <tr>
-            <td>Partition</td>
-            <td>{latest ? latest.partition : 'No materialization events'}</td>
-            <td />
-          </tr>
-        ) : null}
-        <tr>
-          <td>Timestamp</td>
-          <td>
-            <Box flex={{gap: 8, alignItems: 'center'}}>
-              {latestEvent ? (
-                <Timestamp timestamp={{ms: Number(latestEvent.timestamp)}} />
-              ) : (
-                'No materialization events'
-              )}
-              {liveData && (
-                <StaleReasonsTags assetKey={assetKey} liveData={liveData} include="all" />
-              )}
-            </Box>
-          </td>
-          <td />
-        </tr>
-        {latestAssetLineage?.length ? (
-          <tr>
-            <td>Parent assets</td>
-            <td>
-              <AssetLineageElements
-                elements={latestAssetLineage}
-                timestamp={latestEvent.timestamp}
-              />
-            </td>
-            <td />
-          </tr>
-        ) : null}
-        {latestEvent?.metadataEntries.map((entry) => (
-          <tr key={`metadata-${entry.label}`}>
-            <td>{entry.label}</td>
-            <td>
-              <MetadataEntry
-                entry={entry}
-                expandSmallValues={true}
-                repoLocation={repoAddress?.location}
-              />
-            </td>
-            <td>{entry.description}</td>
-          </tr>
-        ))}
-      </tbody>
-    </MetadataTable>
+              </td>
+            </tr>
+            {latestAssetLineage?.length ? (
+              <tr>
+                <td>Parent assets</td>
+                <td>
+                  <AssetLineageElements
+                    elements={latestAssetLineage}
+                    timestamp={latestEvent.timestamp}
+                  />
+                </td>
+              </tr>
+            ) : null}
+            {latestEvent?.metadataEntries.map((entry) => (
+              <tr key={`metadata-${entry.label}`}>
+                <td>{entry.label}</td>
+                <td>
+                  <MetadataEntry
+                    entry={entry}
+                    expandSmallValues={true}
+                    repoLocation={repoAddress?.location}
+                  />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </MetadataTable>
+      ) : (
+        <Box padding={{top: 16, bottom: 32}}>
+          <NonIdealState
+            icon="materialization"
+            title="No metadata"
+            description="No metadata was found for this asset."
+          />
+        </Box>
+      )}
+    </>
   );
 };
 

--- a/js_modules/dagit/packages/core/src/assets/__fixtures__/AssetEventDetail.fixtures.ts
+++ b/js_modules/dagit/packages/core/src/assets/__fixtures__/AssetEventDetail.fixtures.ts
@@ -287,6 +287,7 @@ export const buildAssetPartitionDetailMock = (
       assetNodeOrError: {
         __typename: 'AssetNode',
         id: 'test.py.repo.["asset_1"]',
+        opNames: ['a_different_step'],
         assetMaterializations: [MaterializationEventFull, MaterializationEventOlder],
         assetObservations: [
           BasicObservationEvent,

--- a/js_modules/dagit/packages/core/src/assets/types/AssetPartitionDetail.types.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetPartitionDetail.types.ts
@@ -13,6 +13,7 @@ export type AssetPartitionDetailQuery = {
     | {
         __typename: 'AssetNode';
         id: string;
+        opNames: Array<string>;
         latestRunForPartition: {
           __typename: 'Run';
           id: string;

--- a/js_modules/dagit/packages/core/src/runs/LogsScrollingTable.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogsScrollingTable.tsx
@@ -108,7 +108,7 @@ export const LogsScrollingTable: React.FC<ILogsScrollingTableProps> = (props) =>
   return (
     <ColumnWidthsProvider onWidthsChanged={() => table.current && table.current.didResize()}>
       <Headers />
-      <div style={{flex: 1, minHeight: 0, marginTop: -1}}>
+      <div style={{flex: 1, minHeight: 0, marginTop: -1, position: 'relative'}}>
         <AutoSizer>
           {({width, height}) => (
             <LogsScrollingTableSized
@@ -183,7 +183,8 @@ class LogsScrollingTableSized extends React.Component<ILogsScrollingTableSizedPr
 
     if (
       this.props.focusedTime &&
-      this.props.filteredNodes?.length !== prevProps.filteredNodes?.length
+      (this.props.filteredNodes?.length !== prevProps.filteredNodes?.length ||
+        this.props.focusedTime !== prevProps.focusedTime)
     ) {
       window.requestAnimationFrame(() => {
         this.scrollToTime(this.props.focusedTime);

--- a/js_modules/dagit/packages/core/src/runs/StepLogsDialog.tsx
+++ b/js_modules/dagit/packages/core/src/runs/StepLogsDialog.tsx
@@ -139,9 +139,11 @@ export const StepLogsModalContent: React.FC<{
         filter={filter}
         onSetFilter={setFilter}
       >
-        <Link to={`/runs/${runId}?stepKeys=${stepKeys}`}>
+        <Link to={`/runs/${runId}?stepKeys=${stepKeys}`} style={{marginLeft: 8}}>
           <Box flex={{gap: 4, alignItems: 'center'}}>
-            {!metadata.exitedAt && <Spinner purpose="body-text" />}
+            {!metadata.exitedAt && logType === LogType.structured && (
+              <Spinner purpose="body-text" />
+            )}
             View Run <Mono>{titleForRun({id: runId})}</Mono>
             <Icon name="open_in_new" color={Colors.Link} />
           </Box>


### PR DESCRIPTION
## Summary & Motivation

This PR adds a button to view step logs to both the "Run is currently materializing this asset" and "Run failed to materialize this asset" banners. 

This ended up changing quite a bit of code because we are using the asset.opNames to pre-filter the step logs modal, and the modal must not be conditionally rendered based on whether the banners are visible (to avoid the modal closing as soon as the run finishes.) I improved a few loading states in the asset sidebar - the event loading spinner is shown inside the event section, and the event loading spinner doesn't appear while it's background-refreshing to show a newer event (see last screenshot)

The modal is no longer "locked" to just logs for the selected asset - instead, it scrolls to the selected asset's logs and highlights them in yellow, but shows everything. This is important for "failed to materialize" since the failure may have been upstream.

<img width="665" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/b705408e-bbb4-45cf-90fe-78f997f9b85a">

<img width="1410" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/8a1eb54d-40aa-4c48-948c-4a470330ef69">

<img width="1423" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/831ca1ab-9a36-44c3-a9e3-e17b80e55d19">

<img width="1625" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/1a26e040-de61-425a-9915-a024fbc31dac">

<img width="631" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/aa26067e-760f-4921-b149-085fe5217381">


## How I Tested These Changes

I tested these buttons manually, and verified that if you sit in each modal for a long time / as the run finishes, the modal does not disappear.