### PR TITLE
Databricks dynamic partitions fix

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/context/system.py
+++ b/python_modules/dagster/dagster/_core/execution/context/system.py
@@ -1006,6 +1006,9 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
         else:
             return None
 
+    def partitions_def_for_output(self, output_name: str) -> Optional[PartitionsDefinition]:
+        return self._partitions_def_for_output(output_name)
+
     def has_asset_partitions_for_output(self, output_name: str) -> bool:
         return self._partitions_def_for_output(output_name) is not None
 

--- a/python_modules/dagster/dagster/_core/execution/plan/external_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/external_step.py
@@ -237,6 +237,10 @@ def run_step_from_ref(
     check.inst_param(instance, "instance", DagsterInstance)
     step_context = step_run_ref_to_step_context(step_run_ref, instance)
 
+    # Note: This is a patch that enables using DynamicPartitionsDefinitions with step launchers in the specific case where:
+    # 1. The external step operates on a single dynamic partition.
+    # 2. No dynamic partitions are added in this external step.
+    # A more complete solution would require including all dynamic partitions on the StepRunRef object.
     if step_context.has_partition_key:
         partitions_def = next(
             step_context.partitions_def_for_output(output_name=output_name)

--- a/python_modules/dagster/dagster/_core/execution/plan/external_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/external_step.py
@@ -11,6 +11,7 @@ from dagster._core.code_pointer import FileCodePointer, ModuleCodePointer
 from dagster._core.definitions.reconstruct import ReconstructableJob, ReconstructableRepository
 from dagster._core.definitions.resource_definition import dagster_maintained_resource, resource
 from dagster._core.definitions.step_launcher import StepLauncher, StepRunRef
+from dagster._core.definitions.partition import DynamicPartitionsDefinition
 from dagster._core.errors import raise_execution_interrupts
 from dagster._core.events import DagsterEvent
 from dagster._core.events.log import EventLogEntry
@@ -22,6 +23,7 @@ from dagster._core.execution.plan.state import KnownExecutionState
 from dagster._core.instance import DagsterInstance
 from dagster._core.storage.file_manager import LocalFileHandle, LocalFileManager
 from dagster._serdes import deserialize_value
+
 
 PICKLED_EVENTS_FILE_NAME = "events.pkl"
 PICKLED_STEP_RUN_REF_FILE_NAME = "step_run_ref.pkl"
@@ -235,6 +237,22 @@ def run_step_from_ref(
 ) -> Iterator[DagsterEvent]:
     check.inst_param(instance, "instance", DagsterInstance)
     step_context = step_run_ref_to_step_context(step_run_ref, instance)
+
+    if step_context.has_partition_key:
+        partitions_def = next(
+            step_context._partitions_def_for_output(output_name=output_name)
+            for output_name in step_context.op_def.output_dict.keys()
+        )
+
+        # If we deal with DynamicPartitions, add the relevant partition to the remote instance
+        if (
+            isinstance(partitions_def, DynamicPartitionsDefinition) and
+            partitions_def.name is not None
+        ):
+            step_context.instance.add_dynamic_partitions(
+                partitions_def_name=partitions_def.name,
+                partition_keys=[step_context.partition_key]
+            )
 
     # The step should be forced to run locally with respect to the remote process that this step
     # context is being deserialized in


### PR DESCRIPTION
Proposed fix by @OwenKephart, to fix this issue: #14987 

Additionally, I added a wrapper method in python_modules/dagster/dagster/_core/execution/context/system.py so that we do not access the private method directly. If you have a better naming for it, or any other proposed ideas feel free to add / change them.
