### PR TITLE
[ui] Update left panel list for automaterialized asset page

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetView.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetView.tsx
@@ -217,7 +217,12 @@ export const AssetView: React.FC<Props> = ({assetKey}) => {
     if (definitionQueryResult.loading && !definitionQueryResult.previousData) {
       return <AssetLoadingDefinitionState />;
     }
-    return <AssetAutomaterializePolicyPage assetKey={assetKey} />;
+    return (
+      <AssetAutomaterializePolicyPage
+        assetKey={assetKey}
+        assetHasDefinedPartitions={!!definition?.partitionDefinition}
+      />
+    );
   };
 
   return (

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AutomaterializeLeftPanel.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AutomaterializeLeftPanel.tsx
@@ -1,0 +1,169 @@
+import {Box, Caption, Colors, CursorPaginationControls} from '@dagster-io/ui';
+import * as React from 'react';
+import styled from 'styled-components/macro';
+
+import {TimestampDisplay} from '../../schedules/TimestampDisplay';
+import {compactNumber} from '../../ui/formatters';
+
+import {EvaluationCounts} from './EvaluationCounts';
+import {EvaluationOrEmpty} from './types';
+import {AutoMaterializeEvaluationRecordItemFragment} from './types/GetEvaluationsQuery.types';
+import {useEvaluationsQueryResult} from './useEvaluationsQueryResult';
+
+interface Props extends ListProps {
+  evaluations: AutoMaterializeEvaluationRecordItemFragment[];
+  paginationProps: ReturnType<typeof useEvaluationsQueryResult>['paginationProps'];
+}
+
+export const AutomaterializeLeftPanel = ({
+  assetHasDefinedPartitions,
+  evaluations,
+  evaluationsIncludingEmpty,
+  paginationProps,
+  onSelectEvaluation,
+  selectedEvaluation,
+}: Props) => {
+  return (
+    <Box flex={{direction: 'column', grow: 1}} style={{overflowY: 'auto'}}>
+      <AutomaterializeLeftList
+        assetHasDefinedPartitions={assetHasDefinedPartitions}
+        evaluationsIncludingEmpty={evaluationsIncludingEmpty}
+        onSelectEvaluation={onSelectEvaluation}
+        selectedEvaluation={selectedEvaluation}
+      />
+      {evaluations.length ? (
+        <PaginationWrapper>
+          <CursorPaginationControls {...paginationProps} />
+        </PaginationWrapper>
+      ) : null}
+    </Box>
+  );
+};
+
+interface ListProps {
+  assetHasDefinedPartitions: boolean;
+  evaluationsIncludingEmpty: EvaluationOrEmpty[];
+  onSelectEvaluation: (evaluation: EvaluationOrEmpty) => void;
+  selectedEvaluation?: EvaluationOrEmpty;
+}
+
+export const AutomaterializeLeftList = (props: ListProps) => {
+  const {
+    assetHasDefinedPartitions,
+    evaluationsIncludingEmpty,
+    onSelectEvaluation,
+    selectedEvaluation,
+  } = props;
+
+  return (
+    <Box
+      padding={{vertical: 8, horizontal: 12}}
+      style={{flex: 1, minHeight: 0, overflowY: 'auto'}}
+      flex={{grow: 1, direction: 'column'}}
+    >
+      {evaluationsIncludingEmpty.map((evaluation) => {
+        const isSelected = selectedEvaluation?.evaluationId === evaluation.evaluationId;
+        if (evaluation.__typename === 'no_conditions_met') {
+          return (
+            <EvaluationListItem
+              key={`skip-${evaluation.evaluationId}`}
+              onClick={() => {
+                onSelectEvaluation(evaluation);
+              }}
+              $selected={isSelected}
+            >
+              <Box flex={{direction: 'column', gap: 4}} style={{width: '100%'}}>
+                <div>
+                  {evaluation.startTimestamp ? (
+                    evaluation.amount === 1 ? (
+                      '1 evaluation'
+                    ) : (
+                      `${compactNumber(evaluation.amount)} evaluations`
+                    )
+                  ) : (
+                    <>
+                      {evaluation.endTimestamp === 'now' ? (
+                        'Before now'
+                      ) : (
+                        <>
+                          Before <TimestampDisplay timestamp={evaluation.endTimestamp} />
+                        </>
+                      )}
+                    </>
+                  )}
+                </div>
+                <Caption color={isSelected ? Colors.Blue700 : Colors.Gray700}>
+                  No conditions met
+                </Caption>
+              </Box>
+            </EvaluationListItem>
+          );
+        }
+
+        const {numRequested, numSkipped, numDiscarded} = evaluation;
+
+        return (
+          <EvaluationListItem
+            key={`skip-${evaluation.timestamp}`}
+            onClick={() => {
+              onSelectEvaluation(evaluation);
+            }}
+            $selected={isSelected}
+          >
+            <Box flex={{direction: 'column', gap: 4}}>
+              <TimestampDisplay timestamp={evaluation.timestamp} />
+              <EvaluationCounts
+                numRequested={numRequested}
+                numSkipped={numSkipped}
+                numDiscarded={numDiscarded}
+                isPartitionedAsset={assetHasDefinedPartitions}
+                selected={isSelected}
+              />
+            </Box>
+          </EvaluationListItem>
+        );
+      })}
+    </Box>
+  );
+};
+
+const PaginationWrapper = styled.div`
+  position: sticky;
+  bottom: 0;
+  background: ${Colors.White};
+  border-right: 1px solid ${Colors.KeylineGray};
+  box-shadow: inset 0 1px ${Colors.KeylineGray};
+  margin-top: -1px;
+  padding-bottom: 16px;
+  padding-top: 16px;
+  > * {
+    margin-top: 0;
+  }
+`;
+
+interface EvaluationListItemProps {
+  $selected: boolean;
+}
+
+const EvaluationListItem = styled.button<EvaluationListItemProps>`
+  background-color: ${({$selected}) => ($selected ? Colors.Blue50 : Colors.White)};
+  border: none;
+  border-radius: 8px;
+  color: ${({$selected}) => ($selected ? Colors.Blue700 : Colors.Dark)};
+  cursor: pointer;
+  margin: 2px 0;
+  text-align: left;
+  transition: 100ms background-color linear, 100ms color linear;
+  user-select: none;
+
+  &:hover {
+    background-color: ${({$selected}) => ($selected ? Colors.Blue50 : Colors.Gray10)};
+  }
+
+  &:focus,
+  &:active {
+    outline: none;
+  }
+
+  padding: 8px 12px;
+`;

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/EvaluationCounts.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/EvaluationCounts.tsx
@@ -1,0 +1,64 @@
+import {Box, Caption, Colors} from '@dagster-io/ui';
+import * as React from 'react';
+
+import {compactNumber} from '../../ui/formatters';
+
+interface Props {
+  numRequested: number;
+  numSkipped: number;
+  numDiscarded: number;
+  isPartitionedAsset: boolean;
+  selected: boolean;
+}
+
+export const EvaluationCounts = React.memo((props: Props) => {
+  const {numRequested, numSkipped, numDiscarded, isPartitionedAsset, selected} = props;
+
+  const requested =
+    numRequested || isPartitionedAsset ? (
+      <Caption
+        key="requested"
+        color={selected ? Colors.Blue700 : numRequested ? Colors.Green700 : Colors.Gray700}
+      >
+        {isPartitionedAsset ? `${compactNumber(numRequested)} requested` : 'Requested'}
+      </Caption>
+    ) : null;
+
+  const skipped =
+    numSkipped || isPartitionedAsset ? (
+      <Caption
+        key="skipped"
+        color={selected ? Colors.Blue700 : numSkipped ? Colors.Yellow700 : Colors.Gray700}
+      >
+        {isPartitionedAsset ? `${compactNumber(numSkipped)} skipped` : 'Skipped'}
+      </Caption>
+    ) : null;
+
+  const discarded =
+    numDiscarded || isPartitionedAsset ? (
+      <Caption
+        key="discarded"
+        color={selected ? Colors.Blue700 : numDiscarded ? Colors.Red700 : Colors.Gray700}
+      >
+        {isPartitionedAsset ? `${compactNumber(numDiscarded)} discarded` : 'Discarded'}
+      </Caption>
+    ) : null;
+
+  const filtered = [requested, skipped, discarded].filter(
+    (element): element is React.ReactElement => !!element,
+  );
+
+  return (
+    <Box flex={{direction: 'row', gap: 2, alignItems: 'center'}} style={{whiteSpace: 'nowrap'}}>
+      {filtered
+        .map((element, ii) => [
+          element,
+          <Caption key={`spacer-${ii}`} color={selected ? Colors.Blue200 : Colors.Gray200}>
+            /
+          </Caption>,
+        ])
+        .flat()
+        .slice(0, -1)}
+    </Box>
+  );
+});

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/GetEvaluationsQuery.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/GetEvaluationsQuery.tsx
@@ -1,0 +1,32 @@
+import {gql} from '@apollo/client';
+
+export const GET_EVALUATIONS_QUERY = gql`
+  query GetEvaluationsQuery($assetKey: AssetKeyInput!, $limit: Int!, $cursor: String) {
+    autoMaterializeAssetEvaluationsOrError(assetKey: $assetKey, limit: $limit, cursor: $cursor) {
+      ... on AutoMaterializeAssetEvaluationRecords {
+        currentEvaluationId
+        records {
+          id
+          ...AutoMaterializeEvaluationRecordItem
+        }
+      }
+      ... on AutoMaterializeAssetEvaluationNeedsMigrationError {
+        message
+      }
+    }
+  }
+
+  fragment AutoMaterializeEvaluationRecordItem on AutoMaterializeAssetEvaluationRecord {
+    id
+    evaluationId
+    numRequested
+    numSkipped
+    numDiscarded
+    timestamp
+    conditions {
+      ... on AutoMaterializeConditionWithDecisionType {
+        decisionType
+      }
+    }
+  }
+`;

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/__fixtures__/AutoMaterializePolicyPage.fixtures.ts
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/__fixtures__/AutoMaterializePolicyPage.fixtures.ts
@@ -10,17 +10,17 @@ import {
   buildAutoMaterializePolicy,
   buildFreshnessPolicy,
 } from '../../../graphql/types';
+import {GET_POLICY_INFO_QUERY} from '../AssetAutomaterializePolicyPage';
+import {GET_EVALUATIONS_QUERY} from '../GetEvaluationsQuery';
 import {
-  GET_EVALUATIONS_QUERY,
-  GET_POLICY_INFO_QUERY,
-  PAGE_SIZE,
-} from '../AssetAutomaterializePolicyPage';
-import {
-  GetEvaluationsQuery,
-  GetEvaluationsQueryVariables,
   GetPolicyInfoQuery,
   GetPolicyInfoQueryVariables,
 } from '../types/AssetAutomaterializePolicyPage.types';
+import {
+  GetEvaluationsQuery,
+  GetEvaluationsQueryVariables,
+} from '../types/GetEvaluationsQuery.types';
+import {PAGE_SIZE} from '../useEvaluationsQueryResult';
 
 export function buildQueryMock<
   TQuery extends {__typename: 'DagitQuery'},
@@ -74,6 +74,100 @@ export const buildGetPolicyInfoQuery = ({
     variables,
     data,
   });
+};
+
+const ONE_MINUTE = 1000 * 60;
+
+export const buildEvaluationRecordsWithPartitions = () => {
+  const now = Date.now();
+  return [
+    buildAutoMaterializeAssetEvaluationRecord({
+      id: 'g',
+      evaluationId: 27,
+      timestamp: (now - ONE_MINUTE * 6) / 1000,
+      numRequested: 2,
+      numSkipped: 2,
+      numDiscarded: 2,
+    }),
+    buildAutoMaterializeAssetEvaluationRecord({
+      id: 'f',
+      evaluationId: 24,
+      timestamp: (now - ONE_MINUTE * 5) / 1000,
+      numRequested: 2,
+      numSkipped: 2,
+      numDiscarded: 0,
+    }),
+    buildAutoMaterializeAssetEvaluationRecord({
+      id: 'e',
+      evaluationId: 20,
+      timestamp: (now - ONE_MINUTE * 4) / 1000,
+      numRequested: 0,
+      numSkipped: 2410,
+      numDiscarded: 3560,
+    }),
+    buildAutoMaterializeAssetEvaluationRecord({
+      id: 'd',
+      evaluationId: 13,
+      timestamp: (now - ONE_MINUTE * 3) / 1000,
+      numRequested: 2,
+      numSkipped: 0,
+      numDiscarded: 2,
+    }),
+    buildAutoMaterializeAssetEvaluationRecord({
+      id: 'c',
+      timestamp: (now - ONE_MINUTE * 2) / 1000,
+      evaluationId: 12,
+      numRequested: 0,
+      numSkipped: 0,
+      numDiscarded: 2,
+    }),
+    buildAutoMaterializeAssetEvaluationRecord({
+      id: 'b',
+      evaluationId: 4,
+      timestamp: (now - ONE_MINUTE) / 1000,
+      numRequested: 0,
+      numSkipped: 2,
+      numDiscarded: 0,
+    }),
+    buildAutoMaterializeAssetEvaluationRecord({
+      id: 'a',
+      evaluationId: 0,
+      timestamp: now / 1000,
+      numRequested: 2,
+      numSkipped: 0,
+      numDiscarded: 0,
+    }),
+  ];
+};
+
+export const buildEvaluationRecordsWithoutPartitions = () => {
+  const now = Date.now();
+  return [
+    buildAutoMaterializeAssetEvaluationRecord({
+      id: 'g',
+      evaluationId: 27,
+      timestamp: (now - ONE_MINUTE * 6) / 1000,
+      numRequested: 1,
+      numSkipped: 0,
+      numDiscarded: 0,
+    }),
+    buildAutoMaterializeAssetEvaluationRecord({
+      id: 'f',
+      evaluationId: 24,
+      timestamp: (now - ONE_MINUTE * 5) / 1000,
+      numRequested: 0,
+      numSkipped: 1,
+      numDiscarded: 0,
+    }),
+    buildAutoMaterializeAssetEvaluationRecord({
+      id: 'e',
+      evaluationId: 20,
+      timestamp: (now - ONE_MINUTE * 4) / 1000,
+      numRequested: 0,
+      numSkipped: 0,
+      numDiscarded: 1,
+    }),
+  ];
 };
 
 export const Evaluations = {
@@ -140,26 +234,7 @@ export const Evaluations = {
       },
       data: {
         autoMaterializeAssetEvaluationsOrError: buildAutoMaterializeAssetEvaluationRecords({
-          records: [
-            buildAutoMaterializeAssetEvaluationRecord({
-              evaluationId: 0,
-            }),
-            buildAutoMaterializeAssetEvaluationRecord({
-              evaluationId: 1,
-            }),
-            {
-              ...buildAutoMaterializeAssetEvaluationRecord(),
-              evaluationId: 2,
-              numRequested: 0,
-              numSkipped: 5,
-            },
-            buildAutoMaterializeAssetEvaluationRecord({
-              evaluationId: 3,
-            }),
-            buildAutoMaterializeAssetEvaluationRecord({
-              evaluationId: 3,
-            }),
-          ],
+          records: buildEvaluationRecordsWithPartitions(),
         }),
       },
     });

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/__stories__/AutoMaterializePolicyPage.stories.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/__stories__/AutoMaterializePolicyPage.stories.tsx
@@ -20,7 +20,7 @@ export const EmptyState = () => {
         Evaluations.Single(),
       ]}
     >
-      <AssetAutomaterializePolicyPage assetKey={{path}} />
+      <AssetAutomaterializePolicyPage assetKey={{path}} assetHasDefinedPartitions />
     </MockedProvider>
   );
 };
@@ -34,7 +34,7 @@ export const Errors = () => {
         Evaluations.Errors(path, true),
       ]}
     >
-      <AssetAutomaterializePolicyPage assetKey={{path}} />
+      <AssetAutomaterializePolicyPage assetKey={{path}} assetHasDefinedPartitions />
     </MockedProvider>
   );
 };
@@ -82,7 +82,7 @@ export const Controlled = () => {
               />
             </JoinedButtons>
           </Box>
-          <AssetAutomaterializePolicyPage assetKey={{path}} />
+          <AssetAutomaterializePolicyPage assetKey={{path}} assetHasDefinedPartitions />
         </div>
       </MockedProvider>
     </div>

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/__stories__/AutomaterializeLeftList.stories.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/__stories__/AutomaterializeLeftList.stories.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+
+import {AutomaterializeLeftList} from '../AutomaterializeLeftPanel';
+import {
+  buildEvaluationRecordsWithPartitions,
+  buildEvaluationRecordsWithoutPartitions,
+} from '../__fixtures__/AutoMaterializePolicyPage.fixtures';
+import {getEvaluationsWithEmptyAdded} from '../getEvaluationsWithEmptyAdded';
+import {EvaluationOrEmpty} from '../types';
+
+// eslint-disable-next-line import/no-default-export
+export default {component: AutomaterializeLeftList};
+
+export const WithPartitions = () => {
+  const [selectedEvaluation, setSelectedEvaluation] = React.useState<
+    EvaluationOrEmpty | undefined
+  >();
+
+  const evaluations = buildEvaluationRecordsWithPartitions();
+  const evaluationsWithEmpty = getEvaluationsWithEmptyAdded({
+    evaluations,
+    currentEvaluationId: evaluations[0]!.evaluationId,
+    isLastPage: true,
+    isFirstPage: true,
+    isLoading: false,
+  });
+
+  return (
+    <div style={{width: '320px'}}>
+      <AutomaterializeLeftList
+        assetHasDefinedPartitions
+        evaluationsIncludingEmpty={evaluationsWithEmpty}
+        onSelectEvaluation={(evaluation: EvaluationOrEmpty) => setSelectedEvaluation(evaluation)}
+        selectedEvaluation={selectedEvaluation}
+      />
+    </div>
+  );
+};
+
+export const NoPartitions = () => {
+  const [selectedEvaluation, setSelectedEvaluation] = React.useState<
+    EvaluationOrEmpty | undefined
+  >();
+
+  const evaluations = buildEvaluationRecordsWithoutPartitions();
+  const evaluationsWithEmpty = getEvaluationsWithEmptyAdded({
+    evaluations,
+    currentEvaluationId: evaluations[0]!.evaluationId,
+    isLastPage: true,
+    isFirstPage: true,
+    isLoading: false,
+  });
+
+  return (
+    <div style={{width: '320px'}}>
+      <AutomaterializeLeftList
+        assetHasDefinedPartitions={false}
+        evaluationsIncludingEmpty={evaluationsWithEmpty}
+        onSelectEvaluation={(evaluation: EvaluationOrEmpty) => setSelectedEvaluation(evaluation)}
+        selectedEvaluation={selectedEvaluation}
+      />
+    </div>
+  );
+};

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/__tests__/getEvaluationsWithEmptyAdded.test.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/__tests__/getEvaluationsWithEmptyAdded.test.tsx
@@ -1,5 +1,5 @@
 import {buildAutoMaterializeAssetEvaluationRecord} from '../../../graphql/types';
-import {getEvaluationsWithEmptyAdded} from '../AssetAutomaterializePolicyPage';
+import {getEvaluationsWithEmptyAdded} from '../getEvaluationsWithEmptyAdded';
 
 describe('getEvaluationsWithEmptyAdded', () => {
   it('should return an empty array if isLoading is true', () => {

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/getEvaluationsWithEmptyAdded.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/getEvaluationsWithEmptyAdded.tsx
@@ -1,0 +1,48 @@
+import {AutoMaterializeEvaluationRecordItemFragment} from './types/GetEvaluationsQuery.types';
+
+type Config = {
+  evaluations: AutoMaterializeEvaluationRecordItemFragment[];
+  currentEvaluationId: number | null;
+  isFirstPage: boolean;
+  isLastPage: boolean;
+  isLoading: boolean;
+};
+
+export const getEvaluationsWithEmptyAdded = ({
+  isLoading,
+  currentEvaluationId,
+  evaluations,
+  isFirstPage,
+  isLastPage,
+}: Config) => {
+  if (isLoading || !currentEvaluationId) {
+    return [];
+  }
+  const evalsWithSkips = [];
+  let current = isFirstPage ? currentEvaluationId : evaluations[0]?.evaluationId || 1;
+  evaluations.forEach((evaluation, i) => {
+    const prevEvaluation = evaluations[i - 1];
+    if (evaluation.evaluationId !== current) {
+      evalsWithSkips.push({
+        __typename: 'no_conditions_met' as const,
+        evaluationId: current,
+        amount: current - evaluation.evaluationId,
+        endTimestamp: prevEvaluation?.timestamp ? prevEvaluation?.timestamp - 60 : ('now' as const),
+        startTimestamp: evaluation.timestamp + 60,
+      });
+    }
+    evalsWithSkips.push(evaluation);
+    current = evaluation.evaluationId - 1;
+  });
+  if (isLastPage && current > 0) {
+    const lastEvaluation = evaluations[evaluations.length - 1];
+    evalsWithSkips.push({
+      __typename: 'no_conditions_met' as const,
+      evaluationId: current,
+      amount: current - 0,
+      endTimestamp: lastEvaluation?.timestamp ? lastEvaluation?.timestamp - 60 : ('now' as const),
+      startTimestamp: 0,
+    });
+  }
+  return evalsWithSkips;
+};

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/types.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/types.tsx
@@ -1,0 +1,18 @@
+import {AutoMaterializeEvaluationRecordItemFragment} from './types/GetEvaluationsQuery.types';
+
+export type NoConditionsMetEvaluation = {
+  __typename: 'no_conditions_met';
+  evaluationId: number;
+  amount: number;
+  endTimestamp: number | 'now';
+  startTimestamp: number;
+  numSkipped?: undefined;
+  numRequested?: undefined;
+  numDiscarded?: undefined;
+  numRequests?: undefined;
+  conditions?: undefined;
+};
+
+export type EvaluationOrEmpty =
+  | AutoMaterializeEvaluationRecordItemFragment
+  | NoConditionsMetEvaluation;

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/types/AssetAutomaterializePolicyPage.types.ts
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/types/AssetAutomaterializePolicyPage.types.ts
@@ -2,58 +2,6 @@
 
 import * as Types from '../../../graphql/types';
 
-export type GetEvaluationsQueryVariables = Types.Exact<{
-  assetKey: Types.AssetKeyInput;
-  limit: Types.Scalars['Int'];
-  cursor?: Types.InputMaybe<Types.Scalars['String']>;
-}>;
-
-export type GetEvaluationsQuery = {
-  __typename: 'DagitQuery';
-  autoMaterializeAssetEvaluationsOrError:
-    | {__typename: 'AutoMaterializeAssetEvaluationNeedsMigrationError'; message: string}
-    | {
-        __typename: 'AutoMaterializeAssetEvaluationRecords';
-        currentEvaluationId: number | null;
-        records: Array<{
-          __typename: 'AutoMaterializeAssetEvaluationRecord';
-          id: string;
-          evaluationId: number;
-          numRequested: number;
-          numSkipped: number;
-          numDiscarded: number;
-          timestamp: number;
-          conditions: Array<
-            | {
-                __typename: 'DownstreamFreshnessAutoMaterializeCondition';
-                decisionType: Types.AutoMaterializeDecisionType;
-              }
-            | {
-                __typename: 'FreshnessAutoMaterializeCondition';
-                decisionType: Types.AutoMaterializeDecisionType;
-              }
-            | {
-                __typename: 'MaxMaterializationsExceededAutoMaterializeCondition';
-                decisionType: Types.AutoMaterializeDecisionType;
-              }
-            | {
-                __typename: 'MissingAutoMaterializeCondition';
-                decisionType: Types.AutoMaterializeDecisionType;
-              }
-            | {
-                __typename: 'ParentMaterializedAutoMaterializeCondition';
-                decisionType: Types.AutoMaterializeDecisionType;
-              }
-            | {
-                __typename: 'ParentOutdatedAutoMaterializeCondition';
-                decisionType: Types.AutoMaterializeDecisionType;
-              }
-          >;
-        }>;
-      }
-    | null;
-};
-
 export type GetPolicyInfoQueryVariables = Types.Exact<{
   assetKey: Types.AssetKeyInput;
 }>;

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/types/GetEvaluationsQuery.types.ts
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/types/GetEvaluationsQuery.types.ts
@@ -1,0 +1,91 @@
+// Generated GraphQL types, do not edit manually.
+
+import * as Types from '../../../graphql/types';
+
+export type GetEvaluationsQueryVariables = Types.Exact<{
+  assetKey: Types.AssetKeyInput;
+  limit: Types.Scalars['Int'];
+  cursor?: Types.InputMaybe<Types.Scalars['String']>;
+}>;
+
+export type GetEvaluationsQuery = {
+  __typename: 'DagitQuery';
+  autoMaterializeAssetEvaluationsOrError:
+    | {__typename: 'AutoMaterializeAssetEvaluationNeedsMigrationError'; message: string}
+    | {
+        __typename: 'AutoMaterializeAssetEvaluationRecords';
+        currentEvaluationId: number | null;
+        records: Array<{
+          __typename: 'AutoMaterializeAssetEvaluationRecord';
+          id: string;
+          evaluationId: number;
+          numRequested: number;
+          numSkipped: number;
+          numDiscarded: number;
+          timestamp: number;
+          conditions: Array<
+            | {
+                __typename: 'DownstreamFreshnessAutoMaterializeCondition';
+                decisionType: Types.AutoMaterializeDecisionType;
+              }
+            | {
+                __typename: 'FreshnessAutoMaterializeCondition';
+                decisionType: Types.AutoMaterializeDecisionType;
+              }
+            | {
+                __typename: 'MaxMaterializationsExceededAutoMaterializeCondition';
+                decisionType: Types.AutoMaterializeDecisionType;
+              }
+            | {
+                __typename: 'MissingAutoMaterializeCondition';
+                decisionType: Types.AutoMaterializeDecisionType;
+              }
+            | {
+                __typename: 'ParentMaterializedAutoMaterializeCondition';
+                decisionType: Types.AutoMaterializeDecisionType;
+              }
+            | {
+                __typename: 'ParentOutdatedAutoMaterializeCondition';
+                decisionType: Types.AutoMaterializeDecisionType;
+              }
+          >;
+        }>;
+      }
+    | null;
+};
+
+export type AutoMaterializeEvaluationRecordItemFragment = {
+  __typename: 'AutoMaterializeAssetEvaluationRecord';
+  id: string;
+  evaluationId: number;
+  numRequested: number;
+  numSkipped: number;
+  numDiscarded: number;
+  timestamp: number;
+  conditions: Array<
+    | {
+        __typename: 'DownstreamFreshnessAutoMaterializeCondition';
+        decisionType: Types.AutoMaterializeDecisionType;
+      }
+    | {
+        __typename: 'FreshnessAutoMaterializeCondition';
+        decisionType: Types.AutoMaterializeDecisionType;
+      }
+    | {
+        __typename: 'MaxMaterializationsExceededAutoMaterializeCondition';
+        decisionType: Types.AutoMaterializeDecisionType;
+      }
+    | {
+        __typename: 'MissingAutoMaterializeCondition';
+        decisionType: Types.AutoMaterializeDecisionType;
+      }
+    | {
+        __typename: 'ParentMaterializedAutoMaterializeCondition';
+        decisionType: Types.AutoMaterializeDecisionType;
+      }
+    | {
+        __typename: 'ParentOutdatedAutoMaterializeCondition';
+        decisionType: Types.AutoMaterializeDecisionType;
+      }
+  >;
+};

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/useEvaluationsQueryResult.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/useEvaluationsQueryResult.tsx
@@ -1,0 +1,38 @@
+import {useCursorPaginatedQuery} from '../../runs/useCursorPaginatedQuery';
+import {AssetKey} from '../types';
+
+import {GET_EVALUATIONS_QUERY} from './GetEvaluationsQuery';
+import {GetEvaluationsQuery, GetEvaluationsQueryVariables} from './types/GetEvaluationsQuery.types';
+
+export const PAGE_SIZE = 30;
+
+// This function exists mostly to use the return type later
+export function useEvaluationsQueryResult({assetKey}: {assetKey: AssetKey}) {
+  return useCursorPaginatedQuery<GetEvaluationsQuery, GetEvaluationsQueryVariables>({
+    nextCursorForResult: (data) => {
+      if (
+        data.autoMaterializeAssetEvaluationsOrError?.__typename ===
+        'AutoMaterializeAssetEvaluationRecords'
+      ) {
+        return data.autoMaterializeAssetEvaluationsOrError.records[
+          PAGE_SIZE - 1
+        ]?.evaluationId.toString();
+      }
+      return undefined;
+    },
+    getResultArray: (data) => {
+      if (
+        data?.autoMaterializeAssetEvaluationsOrError?.__typename ===
+        'AutoMaterializeAssetEvaluationRecords'
+      ) {
+        return data.autoMaterializeAssetEvaluationsOrError.records;
+      }
+      return [];
+    },
+    variables: {
+      assetKey,
+    },
+    query: GET_EVALUATIONS_QUERY,
+    pageSize: PAGE_SIZE,
+  });
+}


### PR DESCRIPTION
## Summary & Motivation

Update the left panel on the Auto-materialize page for Assets, to match @braunjj's latest design. I moved the component out to `AutomaterializeLeftPanel` to isolate it a bit more and give it some stories.

I also made some changes to the fixtures, and moved a few other things around as well.

The left list can be seen in this loom: https://www.loom.com/share/6cc9e5d73be149b0be6fd26d71caa918

## How I Tested These Changes

View some auto-materialized assets in the app, verify that the left nav looks and behaves as desired, including for partitioned assets.
