### PR TITLE
[refactor] Clean up should_reconcile logic

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -39,7 +39,6 @@ from .time_window_partitions import (
     TimeWindowPartitionsDefinition,
     get_time_partition_key,
     get_time_partitions_def,
-    has_one_dimension_time_window_partitioning,
 )
 
 if TYPE_CHECKING:
@@ -703,9 +702,8 @@ class ToposortedPriorityQueue:
 
         partitions_def = self._asset_graph.get_partitions_def(asset_key)
         if self._asset_graph.has_self_dependency(asset_key):
-            if partitions_def is None or not has_one_dimension_time_window_partitioning(
-                partitions_def
-            ):
+            time_partitions_def = get_time_partitions_def(partitions_def)
+            if time_partitions_def is None:
                 check.failed(
                     "Assets with self-dependencies must have time-window partitions, but"
                     f" {asset_key} does not."
@@ -714,7 +712,7 @@ class ToposortedPriorityQueue:
             # sort self dependencies from oldest to newest, as older partitions must exist before
             # new ones can execute
             partition_sort_key = _sort_key_for_time_window_partition(
-                get_time_partitions_def(partitions_def),
+                time_partitions_def,
                 get_time_partition_key(partitions_def, asset_partition.partition_key),
             )
         elif isinstance(partitions_def, TimeWindowPartitionsDefinition):

--- a/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
@@ -617,7 +617,6 @@ def determine_asset_partitions_to_auto_materialize(
     Mapping[AssetKey, AbstractSet[str]],
     Optional[int],
 ]:
-    defaultdict(set)
     evaluation_time = instance_queryer.evaluation_time
 
     (
@@ -681,7 +680,8 @@ def determine_asset_partitions_to_auto_materialize(
     )
 
     def get_unresolved_parent_asset_keys(candidate: AssetKeyPartitionKey) -> AbstractSet[AssetKey]:
-        """Returns the set of parent asset keys which will be unresolved when this candidate is materialized.
+        """Returns the set of parent asset keys which would be unresolved if this candidate were
+        materialize this tick.
         """
         from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
@@ -705,7 +705,7 @@ def determine_asset_partitions_to_auto_materialize(
                     and (
                         not isinstance(asset_graph, ExternalAssetGraph)
                         or asset_graph.get_repository_handle(candidate.asset_key)
-                        != asset_graph.get_repository_handle(parent.asset_key)
+                        == asset_graph.get_repository_handle(parent.asset_key)
                     )
                 )
                 and

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_condition.py
@@ -1,7 +1,6 @@
 from enum import Enum
-from typing import NamedTuple, Optional, Sequence, Union
+from typing import NamedTuple, Union
 
-from dagster._core.definitions.events import AssetKey
 from dagster._serdes import whitelist_for_serdes
 
 
@@ -62,7 +61,6 @@ class ParentOutdatedAutoMaterializeCondition(NamedTuple):
     """
 
     decision_type: AutoMaterializeDecisionType = AutoMaterializeDecisionType.SKIP
-    parent_asset_keys: Optional[Sequence[AssetKey]] = None
 
 
 @whitelist_for_serdes

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_condition.py
@@ -1,6 +1,7 @@
 from enum import Enum
-from typing import NamedTuple, Union
+from typing import NamedTuple, Optional, Sequence, Union
 
+from dagster._core.definitions.events import AssetKey
 from dagster._serdes import whitelist_for_serdes
 
 
@@ -61,6 +62,7 @@ class ParentOutdatedAutoMaterializeCondition(NamedTuple):
     """
 
     decision_type: AutoMaterializeDecisionType = AutoMaterializeDecisionType.SKIP
+    parent_asset_keys: Optional[Sequence[AssetKey]] = None
 
 
 @whitelist_for_serdes

--- a/python_modules/dagster/dagster/_core/definitions/partitioned_schedule.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitioned_schedule.py
@@ -46,7 +46,7 @@ class UnresolvedPartitionedAssetScheduleDefinition(NamedTuple):
             )
 
         partitions_def = _check_valid_schedule_partitions_def(partitions_def)
-        time_partitions_def = get_time_partitions_def(partitions_def)
+        time_partitions_def = check.not_none(get_time_partitions_def(partitions_def))
 
         return ScheduleDefinition(
             job=resolved_job,
@@ -145,7 +145,7 @@ def build_schedule_from_partitioned_job(
             check.failed("The provided job is not partitioned")
 
         partitions_def = _check_valid_schedule_partitions_def(partitions_def)
-        time_partitions_def = get_time_partitions_def(partitions_def)
+        time_partitions_def = check.not_none(get_time_partitions_def(partitions_def))
 
         return schedule(
             cron_schedule=time_partitions_def.get_cron_schedule(

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -1802,21 +1802,24 @@ def has_one_dimension_time_window_partitioning(
 
 def get_time_partitions_def(
     partitions_def: Optional[PartitionsDefinition],
-) -> TimeWindowPartitionsDefinition:
+) -> Optional[TimeWindowPartitionsDefinition]:
+    """For a given PartitionsDefinition, return the associated TimeWindowPartitionsDefinition if it
+    exists.
+    """
     from .multi_dimensional_partitions import MultiPartitionsDefinition
 
     if partitions_def is None:
-        check.failed("Cannot get time partitions def from None object")
+        return None
     elif isinstance(partitions_def, TimeWindowPartitionsDefinition):
         return partitions_def
-    elif isinstance(partitions_def, MultiPartitionsDefinition):
+    elif isinstance(
+        partitions_def, MultiPartitionsDefinition
+    ) and has_one_dimension_time_window_partitioning(partitions_def):
         return cast(
             TimeWindowPartitionsDefinition, partitions_def.time_window_dimension.partitions_def
         )
     else:
-        check.failed(
-            f"Cannot return time partitions def from non-time partitions def {partitions_def}"
-        )
+        return None
 
 
 def get_time_partition_key(

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/auto_materialize_policy_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/auto_materialize_policy_scenarios.py
@@ -162,8 +162,14 @@ auto_materialize_policy_scenarios = {
                     PartitionKeyRange(start="2013-01-05-04:00", end="2013-01-07-03:00")
                 )
             },
-            ("daily", "2013-01-05"): {ParentOutdatedAutoMaterializeCondition()},
-            ("daily", "2013-01-06"): {ParentOutdatedAutoMaterializeCondition()},
+            ("daily", "2013-01-05"): {
+                ParentOutdatedAutoMaterializeCondition(),
+                MissingAutoMaterializeCondition(),
+            },
+            ("daily", "2013-01-06"): {
+                ParentOutdatedAutoMaterializeCondition(),
+                MissingAutoMaterializeCondition(),
+            },
         },
     ),
     "auto_materialize_policy_with_custom_scope_hourly_to_daily_partitions_never_materialized2": AssetReconciliationScenario(


### PR DESCRIPTION
## Summary & Motivation

This was becoming quite a mess, with different bits of logic placed somewhat at random throughout these functions.

For the most part, this is a no-op in terms of functionality (just clearing the way to make adjustments easier in the future), but the one small change is that now when an asset is missing and one of its parents are updated, it gets both of those conditions associated with it, rather than one.

## How I Tested These Changes
