### PR TITLE
[Runs] Pass timezone to timerange filter

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/RunsFilterInput.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunsFilterInput.tsx
@@ -10,7 +10,6 @@ import memoize from 'lodash/memoize';
 import qs from 'qs';
 import * as React from 'react';
 
-import {TimeContext} from '../app/time/TimeContext';
 import {__ASSET_JOB_PREFIX} from '../asset-graph/Utils';
 import {RunsFilter, RunStatus} from '../graphql/types';
 import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
@@ -406,10 +405,6 @@ export const useRunsFilterInput = ({tokens, onChange, enabledFilters}: RunsFilte
     },
   });
 
-  const {
-    timezone: [timezone],
-  } = React.useContext(TimeContext);
-
   const {button, activeFiltersJsx} = useFilters({
     filters: [
       !enabledFilters || enabledFilters?.includes('status') ? statusFilter : null,
@@ -471,7 +466,6 @@ export const useRunsFilterInput = ({tokens, onChange, enabledFilters}: RunsFilte
       useTimeRangeFilter({
         name: 'Created date',
         icon: 'date',
-        timezone,
         initialState: React.useMemo(() => {
           const before = tokens.find((token) => token.token === 'created_date_before');
           const after = tokens.find((token) => token.token === 'created_date_after');

--- a/js_modules/dagit/packages/core/src/runs/RunsFilterInput.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunsFilterInput.tsx
@@ -10,6 +10,7 @@ import memoize from 'lodash/memoize';
 import qs from 'qs';
 import * as React from 'react';
 
+import {TimeContext} from '../app/time/TimeContext';
 import {__ASSET_JOB_PREFIX} from '../asset-graph/Utils';
 import {RunsFilter, RunStatus} from '../graphql/types';
 import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
@@ -405,6 +406,10 @@ export const useRunsFilterInput = ({tokens, onChange, enabledFilters}: RunsFilte
     },
   });
 
+  const {
+    timezone: [timezone],
+  } = React.useContext(TimeContext);
+
   const {button, activeFiltersJsx} = useFilters({
     filters: [
       !enabledFilters || enabledFilters?.includes('status') ? statusFilter : null,
@@ -466,7 +471,7 @@ export const useRunsFilterInput = ({tokens, onChange, enabledFilters}: RunsFilte
       useTimeRangeFilter({
         name: 'Created date',
         icon: 'date',
-        timezone: 'UTC',
+        timezone,
         initialState: React.useMemo(() => {
           const before = tokens.find((token) => token.token === 'created_date_before');
           const after = tokens.find((token) => token.token === 'created_date_after');

--- a/js_modules/dagit/packages/core/src/ui/Filters/__stories__/useFilters.stories.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Filters/__stories__/useFilters.stories.tsx
@@ -84,7 +84,6 @@ const TestComponent: React.FC = () => {
   const timeRangeFilter = useTimeRangeFilter({
     name: 'Timestamp',
     icon: 'date',
-    timezone: 'UTC',
   });
 
   const filters = React.useMemo(() => [userFilter, deploymentFilter, timeRangeFilter, testFilter], [

--- a/js_modules/dagit/packages/core/src/ui/Filters/__tests__/useTimeRangeFilter.test.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Filters/__tests__/useTimeRangeFilter.test.tsx
@@ -26,7 +26,6 @@ jest.mock('react-dates', () => {
 const mockFilterProps = {
   name: 'Test Filter',
   icon: 'date' as IconName,
-  timezone: 'UTC',
   initialState: [null, null] as TimeRangeState,
 };
 

--- a/js_modules/dagit/packages/core/src/ui/Filters/useTimeRangeFilter.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Filters/useTimeRangeFilter.tsx
@@ -67,10 +67,12 @@ type Args = {
 export function useTimeRangeFilter({
   name,
   icon,
-  timezone,
+  timezone: _timezone,
   initialState,
   onStateChanged,
 }: Args): TimeRangeFilter {
+  const timezone =
+    _timezone === 'Automatic' ? Intl.DateTimeFormat().resolvedOptions().timeZone : _timezone;
   const [state, setState] = React.useState<TimeRangeState>(initialState || [null, null]);
   React.useEffect(() => {
     onStateChanged?.(state);
@@ -178,8 +180,7 @@ export function ActiveFilterState({
         year: 'numeric',
         month: 'numeric',
         day: 'numeric',
-        timeZone:
-          timezone === 'Automatic' ? Intl.DateTimeFormat().resolvedOptions().timeZone : timezone,
+        timeZone: timezone,
       }),
     [timezone],
   );

--- a/js_modules/dagit/packages/core/src/ui/Filters/useTimeRangeFilter.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Filters/useTimeRangeFilter.tsx
@@ -7,6 +7,7 @@ import {DateRangePicker} from 'react-dates';
 import styled from 'styled-components/macro';
 
 import {TimeContext} from '../../app/time/TimeContext';
+import {browserTimezone} from '../../app/time/browserTimezone';
 import {useUpdatingRef} from '../../hooks/useUpdatingRef';
 
 import {FilterObject, FilterTag, FilterTagHighlightedText} from './useFilter';
@@ -73,8 +74,7 @@ export function useTimeRangeFilter({
   const {
     timezone: [_timezone],
   } = React.useContext(TimeContext);
-  const timezone =
-    _timezone === 'Automatic' ? Intl.DateTimeFormat().resolvedOptions().timeZone : _timezone;
+  const timezone = _timezone === 'Automatic' ? browserTimezone() : _timezone;
   const [state, setState] = React.useState<TimeRangeState>(initialState || [null, null]);
   React.useEffect(() => {
     onStateChanged?.(state);

--- a/js_modules/dagit/packages/core/src/ui/Filters/useTimeRangeFilter.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Filters/useTimeRangeFilter.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import {DateRangePicker} from 'react-dates';
 import styled from 'styled-components/macro';
 
+import {TimeContext} from '../../app/time/TimeContext';
 import {useUpdatingRef} from '../../hooks/useUpdatingRef';
 
 import {FilterObject, FilterTag, FilterTagHighlightedText} from './useFilter';
@@ -60,17 +61,18 @@ type TimeRangeKey = keyof ReturnType<typeof calculateTimeRanges>['timeRanges'];
 type Args = {
   name: string;
   icon: IconName;
-  timezone: string;
   initialState?: TimeRangeState;
   onStateChanged?: (state: TimeRangeState) => void;
 };
 export function useTimeRangeFilter({
   name,
   icon,
-  timezone: _timezone,
   initialState,
   onStateChanged,
 }: Args): TimeRangeFilter {
+  const {
+    timezone: [_timezone],
+  } = React.useContext(TimeContext);
   const timezone =
     _timezone === 'Automatic' ? Intl.DateTimeFormat().resolvedOptions().timeZone : _timezone;
   const [state, setState] = React.useState<TimeRangeState>(initialState || [null, null]);


### PR DESCRIPTION
## Summary & Motivation
As titled

## How I Tested These Changes

Loaded the Runs page and checked the timestamp when selecting "Today" that its correctly the start of "today" in my timezone (eg: the time is 00:00:00):
<img width="471" alt="Screenshot 2023-06-28 at 1 44 20 PM" src="https://github.com/dagster-io/dagster/assets/2286579/8eedf810-e184-437b-bc98-af58c1d6d588">

