### PR TITLE
[Tabs component] Set background color on icons

### DIFF
--- a/js_modules/dagit/packages/ui/src/components/Tabs.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Tabs.tsx
@@ -69,7 +69,7 @@ export const tabCSS = css<TabStyleProps>`
   }
 
   & ${IconWrapper} {
-    color: ${({selected, disabled}) =>
+    background: ${({selected, disabled}) =>
       selected ? Colors.Blue500 : disabled ? Colors.Gray300 : ''};
   }
 


### PR DESCRIPTION
## Summary & Motivation

Our Icons use a combination of background color + mask so this should be background color.
## How I Tested These Changes
storybook:
<img width="506" alt="Screenshot 2023-06-28 at 3 19 10 PM" src="https://github.com/dagster-io/dagster/assets/2286579/e31afa3a-64ac-4633-87c8-693e91f244d2">
