### PR TITLE
Vary the target when downloading example projects

### DIFF
--- a/python_modules/dagster/dagster/_cli/project.py
+++ b/python_modules/dagster/dagster/_cli/project.py
@@ -148,13 +148,15 @@ def scaffold_command(name: str):
 )
 def from_example_command(name: Optional[str], example: str):
     name = name or example
-    dir_abspath = os.path.abspath(name)
+    dir_abspath = os.path.abspath(name) + "/"
     if os.path.isdir(dir_abspath) and os.path.exists(dir_abspath):
         click.echo(
             click.style(f"The directory {dir_abspath} already exists. ", fg="red")
             + "\nPlease delete the contents of this path or choose another location."
         )
         sys.exit(1)
+    else:
+        os.mkdir(dir_abspath)
 
     download_example_from_github(dir_abspath, example)
 

--- a/python_modules/dagster/dagster/_generate/download.py
+++ b/python_modules/dagster/dagster/_generate/download.py
@@ -43,12 +43,18 @@ AVAILABLE_EXAMPLES = [
 ]
 
 
-def _get_url_for_version(version: str) -> str:
+def _get_target_for_version(version: str) -> str:
     if version == "1!0+dev":
         target = "master"
     else:
         target = version
-    return f"https://codeload.github.com/dagster-io/dagster/tar.gz/{target}"
+    return target
+
+
+def _get_url_for_version(version: str) -> str:
+    return (
+        f"https://codeload.github.com/dagster-io/dagster/tar.gz/{_get_target_for_version(version)}"
+    )
 
 
 def download_example_from_github(path: str, example: str):
@@ -62,9 +68,9 @@ def download_example_from_github(path: str, example: str):
         )
         sys.exit(1)
 
-    path_to_new_project = os.path.normpath(path)
-    path_to_selected_example = f"dagster-master/examples/{example}"
-
+    path_to_selected_example = (
+        f"dagster-{_get_target_for_version(dagster_version)}/examples/{example}/"
+    )
     click.echo(f"Downloading example '{example}'. This may take a while.")
 
     response = requests.get(_get_url_for_version(dagster_version), stream=True)
@@ -79,7 +85,7 @@ def download_example_from_github(path: str, example: str):
             if _should_skip_file(member.name):
                 continue
 
-            dest = member.name.replace(path_to_selected_example, path_to_new_project)
+            dest = member.name.replace(path_to_selected_example, path)
 
             if member.isdir():
                 os.mkdir(dest)


### PR DESCRIPTION
We recently changed where the download script downloads from:

https://github.com/dagster-io/dagster/pull/14754

Varying the target between "master" for untagged versions and the version for tagged versions.

But we didn't make the same update to our path replacement logic so when running `dagster project from-example --example tutorial` from 1.3.11 or 1.3.12, no files in the downloaded set of files (all begining with `dagster-1.3.11/`) would match our filter for files beginning with `dagster-master`. Consequently, the command would no-op.

This makes a few small tweaks to the script:
1. It varies target between master and the version in both places
2. It updates our filter to include a trailing slash. Otherwise, we get weird interactions if you try to build an example like `tutorial` that is a subset of another example you already have downloaded (like `tutotial_dbt_dagster`.

I tested this by running locally with both a versioned and unversioned dagster.