### PR TITLE
return AssetExecutionContext to type alias of OpExecutionContext

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/plan/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/compute.py
@@ -29,7 +29,7 @@ from dagster._core.definitions.asset_layer import AssetLayer
 from dagster._core.definitions.op_definition import OpComputeFunction
 from dagster._core.errors import DagsterExecutionStepExecutionError, DagsterInvariantViolationError
 from dagster._core.events import DagsterEvent
-from dagster._core.execution.context.compute import build_execution_context
+from dagster._core.execution.context.compute import OpExecutionContext
 from dagster._core.execution.context.system import StepExecutionContext
 from dagster._core.system_config.objects import ResolvedRunConfig
 from dagster._utils import iterate_with_context
@@ -135,7 +135,7 @@ def _yield_compute_results(
 ) -> Iterator[OpOutputUnion]:
     check.inst_param(step_context, "step_context", StepExecutionContext)
 
-    context = build_execution_context(step_context)
+    context = OpExecutionContext(step_context)
     user_event_generator = compute_fn(context, inputs)
 
     if isinstance(user_event_generator, Output):


### PR DESCRIPTION
Conditions like:

* manually constructing `AssetsDefinition` with a manually written `@op`
* `@op`s that make up a graph backed AssetsDefinition

make having different context objects trickier for users than originally antcipated. 

## How I Tested These Changes

existing suite
