### PR TITLE
Fetch AssetRecords all at once in CachingStaleStatusResolver

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -211,8 +211,18 @@ class AssetGraph:
         return self._asset_dep_graph["downstream"][asset_key]
 
     def get_parents(self, asset_key: AssetKey) -> AbstractSet[AssetKey]:
-        """Returns all assets that the given asset depends on."""
-        return self._asset_dep_graph["upstream"][asset_key]
+        """Returns all first-order dependencies of an asset."""
+        return self._asset_dep_graph["upstream"].get(asset_key) or set()
+
+    def get_ancestors(
+        self, asset_key: AssetKey, include_self: bool = False
+    ) -> AbstractSet[AssetKey]:
+        """Returns all nth-order dependencies of an asset."""
+        ancestors = {asset_key} if include_self else set()
+        parents = self.get_parents(asset_key) - {asset_key}  # remove self-dependencies
+        return ancestors.union(
+            *[self.get_ancestors(parent, include_self=True) for parent in parents]
+        )
 
     def get_children_partitions(
         self,


### PR DESCRIPTION
## Summary & Motivation

See https://elementl-workspace.slack.com/archives/C03CCE471E0/p1687988463503799

This changes the `CachingStaleStatusResolver` to fetch and cache all `AssetRecord` objects for the asset graph in one shot. This prevents one-query-per-asset, which can be prohibitively expensive in large asset graphs.

I am not sure if it is best to fetch _all_ the records in every case though-- one alternative possibility is to use a counter in the resolver, and do solo queries until some threshold N has been crossed, at which point we fetch them all.

The major wrinkle in the implementation here is that source assets can't be handled with `AssetRecord`, because the `AssetRecord` contains the last materialization but not the last observation. In theory this could also pose a problem for materializabele assets if someone is manually yielding observations for them with `DataVersion`, but I doubt this is happening anywhere. Regardless we should start including the most recent observation on the `AssetRecord`.

## How I Tested These Changes

Existing test suite.