### PR TITLE
dagster-dbt docs, move to DbtCli and move profiles.yml to root of project

### DIFF
--- a/docs/content/integrations/dbt/reference.mdx
+++ b/docs/content/integrations/dbt/reference.mdx
@@ -94,12 +94,7 @@ DBT_TARGET = "hive" if os.getenv("EXECUTION_ENV") == "prod" else "duckdb"
 
 dbt_assets = with_resources(
     load_assets_from_dbt_project(DBT_PROJECT_PATH),
-    {
-        "dbt": DbtCli(
-            project_dir=DBT_PROJECT_PATH,
-            target=DBT_TARGET,
-        )
-    },
+    {"dbt": DbtCli(project_dir=DBT_PROJECT_PATH, target=DBT_TARGET)},
 )
 ```
 
@@ -311,9 +306,7 @@ from dagster import with_resources
 dbt_assets = with_resources(
     load_assets_from_dbt_project(...),
     {
-        "dbt": DbtCli(
-            project_dir="path/to/dbt_project",
-        ),
+        "dbt": DbtCli(project_dir="path/to/dbt_project"),
         "pandas_df_manager": PandasIOManager(connection_str=...),
     },
 )

--- a/docs/content/integrations/dbt/reference.mdx
+++ b/docs/content/integrations/dbt/reference.mdx
@@ -66,7 +66,7 @@ If you make any changes to your dbt project that change the structure of the pro
 
 ---
 
-## Using the DbtCliClientResource for dbt CLI commands
+## Using the DbtCli for dbt CLI commands
 
 <Note>
   Check out{" "}
@@ -76,16 +76,16 @@ If you make any changes to your dbt project that change the structure of the pro
   to see this concept in context.
 </Note>
 
-Assets loaded from dbt require a dbt resource, which is responsible for firing off dbt CLI commands. The `dagster-dbt` integration provides the <PyObject module="dagster_dbt" object="DbtCliClientResource" /> for this purpose. This resource can be configured with CLI flags that are passed into every dbt invocation.
+Assets loaded from dbt require a dbt resource, which is responsible for firing off dbt CLI commands. The `dagster-dbt` integration provides the <PyObject module="dagster_dbt" object="DbtCli" /> for this purpose. This resource can be configured with CLI flags that are passed into every dbt invocation.
 
-The most important flag to set is the `project_dir` flag, which points Dagster at the directory of your dbt project. You can also use the `target` flag to point at an explicit dbt [target](https://docs.getdbt.com/reference/dbt-jinja-functions/target). For a full list of configuration options, refer to the <PyObject module="dagster_dbt" object="DbtCliClientResource" /> API docs.
+The most important flag to set is the `project_dir` flag, which points Dagster at the directory of your dbt project. You can also use the `target` flag to point at an explicit dbt [target](https://docs.getdbt.com/reference/dbt-jinja-functions/target). For a full list of configuration options, refer to the <PyObject module="dagster_dbt" object="DbtCli" /> API docs.
 
 You can configure this resource and add it to your dbt assets by doing the following:
 
 ```python startafter=start_dbt_cli_resource endbefore=end_dbt_cli_resource file=/integrations/dbt/dbt.py dedent=4
 import os
 
-from dagster_dbt import DbtCliClientResource, load_assets_from_dbt_project
+from dagster_dbt import DbtCli, load_assets_from_dbt_project
 
 from dagster import with_resources
 
@@ -95,7 +95,7 @@ DBT_TARGET = "hive" if os.getenv("EXECUTION_ENV") == "prod" else "duckdb"
 dbt_assets = with_resources(
     load_assets_from_dbt_project(DBT_PROJECT_PATH),
     {
-        "dbt": DbtCliClientResource(
+        "dbt": DbtCli(
             project_dir=DBT_PROJECT_PATH,
             target=DBT_TARGET,
         )
@@ -304,14 +304,14 @@ class PandasIOManager(ConfigurableIOManager):
 Once the I/O manager is defined, you can supply it like any other resource when calling <PyObject object="with_resources"/> :
 
 ```python startafter=start_input_manager_resources endbefore=end_input_manager_resources file=/integrations/dbt/dbt.py dedent=4
-from dagster_dbt import DbtCliClientResource, load_assets_from_dbt_project
+from dagster_dbt import DbtCli, load_assets_from_dbt_project
 
 from dagster import with_resources
 
 dbt_assets = with_resources(
     load_assets_from_dbt_project(...),
     {
-        "dbt": DbtCliClientResource(
+        "dbt": DbtCli(
             project_dir="path/to/dbt_project",
         ),
         "pandas_df_manager": PandasIOManager(connection_str=...),

--- a/docs/content/integrations/dbt/using-dbt-with-dagster/downstream-assets.mdx
+++ b/docs/content/integrations/dbt/using-dbt-with-dagster/downstream-assets.mdx
@@ -93,9 +93,7 @@ def orders_raw() -> pd.DataFrame:
 DBT_PROJECT_PATH = file_relative_path(__file__, "../../jaffle_shop")
 DBT_PROFILES = file_relative_path(__file__, "../../jaffle_shop/config")
 
-dbt_assets = load_assets_from_dbt_project(
-    project_dir=DBT_PROJECT_PATH, profiles_dir=DBT_PROFILES, key_prefix=["jaffle_shop"]
-)
+dbt_assets = load_assets_from_dbt_project(project_dir=DBT_PROJECT_PATH, key_prefix=["jaffle_shop"])
 
 
 @asset(ins={"customers": AssetIn(key_prefix=["jaffle_shop"])})

--- a/docs/content/integrations/dbt/using-dbt-with-dagster/load-dbt-models.mdx
+++ b/docs/content/integrations/dbt/using-dbt-with-dagster/load-dbt-models.mdx
@@ -36,11 +36,8 @@ from dagster import file_relative_path
 
 
 DBT_PROJECT_PATH = file_relative_path(__file__, "../../jaffle_shop")
-DBT_PROFILES = file_relative_path(__file__, "../../jaffle_shop/config")
 
-dbt_assets = load_assets_from_dbt_project(
-    project_dir=DBT_PROJECT_PATH, profiles_dir=DBT_PROFILES, key_prefix=["jaffle_shop"]
-)
+dbt_assets = load_assets_from_dbt_project(project_dir=DBT_PROJECT_PATH, key_prefix=["jaffle_shop"])
 ```
 
 Let's discuss what this example is doing, specifically the <PyObject module="dagster_dbt" object="load_assets_from_dbt_project" /> function. This function loads dbt models into Dagster as assets, creating one Dagster asset for each model.
@@ -64,7 +61,6 @@ When invoked, this function:
 Let's take a look at the arguments we've supplied:
 
 - `project_dir`, which is the path to the dbt project
-- `profiles_dir`, which is the path to the dbt project's connection profiles
 - `key_prefix`, which is a prefix to apply to all models in the dbt project
 
 ---
@@ -82,16 +78,11 @@ import os
 
 from dagster_dbt import DbtCli
 from tutorial_dbt_dagster import assets
-from tutorial_dbt_dagster.assets import DBT_PROFILES, DBT_PROJECT_PATH
+from tutorial_dbt_dagster.assets import DBT_PROJECT_PATH
 
 from dagster import Definitions, load_assets_from_modules
 
-resources = {
-    "dbt": DbtCli(
-        project_dir=DBT_PROJECT_PATH,
-        profiles_dir=DBT_PROFILES,
-    ),
-}
+resources = {"dbt": DbtCli(project_dir=DBT_PROJECT_PATH)}
 
 defs = Definitions(assets=load_assets_from_modules([assets]), resources=resources)
 ```

--- a/docs/content/integrations/dbt/using-dbt-with-dagster/load-dbt-models.mdx
+++ b/docs/content/integrations/dbt/using-dbt-with-dagster/load-dbt-models.mdx
@@ -73,21 +73,21 @@ Let's take a look at the arguments we've supplied:
 
 Next, you'll define the code location for your Dagster project. A [code location](/concepts/code-locations), created using the <PyObject object="Definitions" /> object, is a collection of definitions in a Dagster project, such as assets, resources, and so on.
 
-Assets loaded from dbt require a dbt resource, which is responsible for firing off dbt CLI commands. Using the <PyObject module="dagster_dbt" object="DbtCliClientResource" /> resource, we can supply a dbt resource to the dbt project.
+Assets loaded from dbt require a dbt resource, which is responsible for firing off dbt CLI commands. Using the <PyObject module="dagster_dbt" object="DbtCli" /> resource, we can supply a dbt resource to the dbt project.
 
 Open the `__init__.py` file, located in `/tutorial_template/tutorial_dbt_dagster`, and add the following code:
 
 ```python
 import os
 
-from dagster_dbt import DbtCliClientResource
+from dagster_dbt import DbtCli
 from tutorial_dbt_dagster import assets
 from tutorial_dbt_dagster.assets import DBT_PROFILES, DBT_PROJECT_PATH
 
 from dagster import Definitions, load_assets_from_modules
 
 resources = {
-    "dbt": DbtCliClientResource(
+    "dbt": DbtCli(
         project_dir=DBT_PROJECT_PATH,
         profiles_dir=DBT_PROFILES,
     ),
@@ -98,7 +98,7 @@ defs = Definitions(assets=load_assets_from_modules([assets]), resources=resource
 
 Let's take a look at what's happening here:
 
-- In the `resources` key, we've provided configuration info for the <PyObject module="dagster_dbt" object="DbtCliClientResource" /> resource.
+- In the `resources` key, we've provided configuration info for the <PyObject module="dagster_dbt" object="DbtCli" /> resource.
 - Added all assets in the assets module and the resources mapped to the `resources` key to the <PyObject object="Definitions" /> object. This supplies the resource we created to our assets.
 - Using <PyObject object="load_assets_from_modules" />, we've added all assets in the `assets` module as definitions. This approach allows any new assets we created to be automatically included in the code location instead of needing to manually add them one by one.
 

--- a/docs/content/integrations/dbt/using-dbt-with-dagster/upstream-assets.mdx
+++ b/docs/content/integrations/dbt/using-dbt-with-dagster/upstream-assets.mdx
@@ -105,7 +105,7 @@ In `/tutorial_template/tutorial_dbt_dagster/__init__.py`, replace its contents w
 ```python
 import os
 
-from dagster_dbt import DbtCliClientResource
+from dagster_dbt import DbtCli
 from tutorial_dbt_dagster import assets
 from tutorial_dbt_dagster.assets import DBT_PROFILES, DBT_PROJECT_PATH
 
@@ -115,7 +115,7 @@ from dagster import Definitions, load_assets_from_modules
 
 
 resources = {
-    "dbt": DbtCliClientResource(
+    "dbt": DbtCli(
         project_dir=DBT_PROJECT_PATH,
         profiles_dir=DBT_PROFILES,
     ),

--- a/examples/docs_snippets/docs_snippets/integrations/dbt/dbt.py
+++ b/examples/docs_snippets/docs_snippets/integrations/dbt/dbt.py
@@ -35,12 +35,7 @@ def scope_dbt_cli_resource_config():
 
     dbt_assets = with_resources(
         load_assets_from_dbt_project(DBT_PROJECT_PATH),
-        {
-            "dbt": DbtCli(
-                project_dir=DBT_PROJECT_PATH,
-                target=DBT_TARGET,
-            )
-        },
+        {"dbt": DbtCli(project_dir=DBT_PROJECT_PATH, target=DBT_TARGET)},
     )
     # end_dbt_cli_resource
 
@@ -130,9 +125,7 @@ def scope_input_manager_resources():
     dbt_assets = with_resources(
         load_assets_from_dbt_project(...),
         {
-            "dbt": DbtCli(
-                project_dir="path/to/dbt_project",
-            ),
+            "dbt": DbtCli(project_dir="path/to/dbt_project"),
             "pandas_df_manager": PandasIOManager(connection_str=...),
         },
     )

--- a/examples/docs_snippets/docs_snippets/integrations/dbt/dbt.py
+++ b/examples/docs_snippets/docs_snippets/integrations/dbt/dbt.py
@@ -26,7 +26,7 @@ def scope_dbt_cli_resource_config():
     # start_dbt_cli_resource
     import os
 
-    from dagster_dbt import DbtCliClientResource, load_assets_from_dbt_project
+    from dagster_dbt import DbtCli, load_assets_from_dbt_project
 
     from dagster import with_resources
 
@@ -36,7 +36,7 @@ def scope_dbt_cli_resource_config():
     dbt_assets = with_resources(
         load_assets_from_dbt_project(DBT_PROJECT_PATH),
         {
-            "dbt": DbtCliClientResource(
+            "dbt": DbtCli(
                 project_dir=DBT_PROJECT_PATH,
                 target=DBT_TARGET,
             )
@@ -123,14 +123,14 @@ def scope_input_manager_resources():
             pass
 
     # start_input_manager_resources
-    from dagster_dbt import DbtCliClientResource, load_assets_from_dbt_project
+    from dagster_dbt import DbtCli, load_assets_from_dbt_project
 
     from dagster import with_resources
 
     dbt_assets = with_resources(
         load_assets_from_dbt_project(...),
         {
-            "dbt": DbtCliClientResource(
+            "dbt": DbtCli(
                 project_dir="path/to/dbt_project",
             ),
             "pandas_df_manager": PandasIOManager(connection_str=...),

--- a/examples/tutorial_dbt_dagster/tutorial_finished/tutorial_dbt_dagster/__init__.py
+++ b/examples/tutorial_dbt_dagster/tutorial_finished/tutorial_dbt_dagster/__init__.py
@@ -5,13 +5,10 @@ from dagster_dbt import DbtCli
 from dagster_duckdb_pandas import DuckDBPandasIOManager
 
 from tutorial_dbt_dagster import assets
-from tutorial_dbt_dagster.assets import DBT_PROFILES, DBT_PROJECT_PATH
+from tutorial_dbt_dagster.assets import DBT_PROJECT_PATH
 
 resources = {
-    "dbt": DbtCli(
-        project_dir=DBT_PROJECT_PATH,
-        profiles_dir=DBT_PROFILES,
-    ),
+    "dbt": DbtCli(project_dir=DBT_PROJECT_PATH),
     "io_manager": DuckDBPandasIOManager(database=os.path.join(DBT_PROJECT_PATH, "tutorial.duckdb")),
 }
 

--- a/examples/tutorial_dbt_dagster/tutorial_finished/tutorial_dbt_dagster/__init__.py
+++ b/examples/tutorial_dbt_dagster/tutorial_finished/tutorial_dbt_dagster/__init__.py
@@ -1,14 +1,14 @@
 import os
 
 from dagster import Definitions, load_assets_from_modules
-from dagster_dbt import DbtCliClientResource
+from dagster_dbt import DbtCli
 from dagster_duckdb_pandas import DuckDBPandasIOManager
 
 from tutorial_dbt_dagster import assets
 from tutorial_dbt_dagster.assets import DBT_PROFILES, DBT_PROJECT_PATH
 
 resources = {
-    "dbt": DbtCliClientResource(
+    "dbt": DbtCli(
         project_dir=DBT_PROJECT_PATH,
         profiles_dir=DBT_PROFILES,
     ),

--- a/examples/tutorial_dbt_dagster/tutorial_finished/tutorial_dbt_dagster/assets/__init__.py
+++ b/examples/tutorial_dbt_dagster/tutorial_finished/tutorial_dbt_dagster/assets/__init__.py
@@ -17,13 +17,10 @@ def orders_raw() -> pd.DataFrame:
 
 
 DBT_PROJECT_PATH = file_relative_path(__file__, "../../jaffle_shop")
-DBT_PROFILES = file_relative_path(__file__, "../../jaffle_shop/config")
 
 # if larger project use load_assets_from_dbt_manifest
 # dbt_assets = load_assets_from_dbt_manifest(json.load(DBT_PROJECT_PATH + "manifest.json", encoding="utf8"))
-dbt_assets = load_assets_from_dbt_project(
-    project_dir=DBT_PROJECT_PATH, profiles_dir=DBT_PROFILES, key_prefix=["jaffle_shop"]
-)
+dbt_assets = load_assets_from_dbt_project(project_dir=DBT_PROJECT_PATH, key_prefix=["jaffle_shop"])
 
 
 @asset(ins={"customers": AssetIn(key_prefix=["jaffle_shop"])})


### PR DESCRIPTION
## Summary & Motivation

This makes the dbt docs and tutorial a little cleaner

Depends on unexperimentalizing the DbtCli: https://github.com/dagster-io/dagster/pull/15068

## How I Tested These Changes
