### PR TITLE
direct execution context cleanup

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
@@ -278,6 +278,10 @@ class DecoratedOpFunction(NamedTuple):
 
     decorated_fn: Callable[..., Any]
 
+    @property
+    def name(self):
+        return self.decorated_fn.__name__
+
     @lru_cache(maxsize=1)
     def has_context_arg(self) -> bool:
         return is_context_provided(get_function_params(self.decorated_fn))

--- a/python_modules/dagster/dagster/_core/definitions/op_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_definition.py
@@ -20,10 +20,9 @@ from typing_extensions import TypeAlias, get_args, get_origin
 import dagster._check as check
 from dagster._annotations import deprecated, deprecated_param, public
 from dagster._config.config_schema import UserConfigSchema
-from dagster._core.decorator_utils import get_function_params
 from dagster._core.definitions.dependency import NodeHandle, NodeInputHandle
 from dagster._core.definitions.node_definition import NodeDefinition
-from dagster._core.definitions.op_invocation import op_invocation_result
+from dagster._core.definitions.op_invocation import direct_invocation_result
 from dagster._core.definitions.policy import RetryPolicy
 from dagster._core.definitions.resource_requirement import (
     InputManagerRequirement,
@@ -442,56 +441,12 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
         return [input_handle]
 
     def __call__(self, *args, **kwargs) -> Any:
-        from ..execution.context.invocation import UnboundOpExecutionContext
         from .composition import is_in_composition
-        from .decorators.op_decorator import DecoratedOpFunction
 
         if is_in_composition():
             return super(OpDefinition, self).__call__(*args, **kwargs)
-        else:
-            if not isinstance(self.compute_fn, DecoratedOpFunction):
-                raise DagsterInvalidInvocationError(
-                    "Attemped to invoke op that was not constructed using the"
-                    " `@op` decorator. Only ops constructed using the"
-                    " `@op` decorator can be directly invoked."
-                )
-            if self.compute_fn.has_context_arg():
-                if len(args) + len(kwargs) == 0:
-                    raise DagsterInvalidInvocationError(
-                        f"Compute function of op '{self.name}' has context argument, but"
-                        " no context was provided when invoking."
-                    )
-                if len(args) > 0:
-                    if args[0] is not None and not isinstance(args[0], UnboundOpExecutionContext):
-                        raise DagsterInvalidInvocationError(
-                            f"Compute function of op '{self.name}' has context argument, "
-                            "but no context was provided when invoking."
-                        )
-                    context = args[0]
-                    return op_invocation_result(self, context, *args[1:], **kwargs)
-                # Context argument is provided under kwargs
-                else:
-                    context_param_name = get_function_params(self.compute_fn.decorated_fn)[0].name
-                    if context_param_name not in kwargs:
-                        raise DagsterInvalidInvocationError(
-                            f"Compute function of op '{self.name}' has context argument "
-                            f"'{context_param_name}', but no value for '{context_param_name}' was "
-                            f"found when invoking. Provided kwargs: {kwargs}"
-                        )
-                    context = cast(UnboundOpExecutionContext, kwargs[context_param_name])
-                    kwargs_sans_context = {
-                        kwarg: val
-                        for kwarg, val in kwargs.items()
-                        if not kwarg == context_param_name
-                    }
-                    return op_invocation_result(self, context, *args, **kwargs_sans_context)
 
-            else:
-                context = None
-                if len(args) > 0 and isinstance(args[0], UnboundOpExecutionContext):
-                    context = cast(UnboundOpExecutionContext, args[0])
-                    args = args[1:]
-                return op_invocation_result(self, context, *args, **kwargs)
+        return direct_invocation_result(self, *args, **kwargs)
 
 
 def _resolve_output_defs_from_outs(

--- a/python_modules/dagster/dagster/_core/definitions/op_invocation.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_invocation.py
@@ -5,7 +5,6 @@ from typing import (
     Dict,
     Mapping,
     NamedTuple,
-    Optional,
     Tuple,
     TypeVar,
     Union,
@@ -30,7 +29,8 @@ from .events import (
 from .output import DynamicOutputDefinition
 
 if TYPE_CHECKING:
-    from ..execution.context.invocation import BoundOpExecutionContext, UnboundOpExecutionContext
+    from ..execution.context.invocation import BoundOpExecutionContext
+    from .assets import AssetsDefinition
     from .composition import PendingNodeInvocation
     from .decorators.op_decorator import DecoratedOpFunction
     from .op_definition import OpDefinition
@@ -98,30 +98,80 @@ def _separate_args_and_kwargs(
     )
 
 
-def op_invocation_result(
-    op_def_or_invocation: Union["OpDefinition", "PendingNodeInvocation[OpDefinition]"],
-    context: Optional["UnboundOpExecutionContext"],
+def direct_invocation_result(
+    def_or_invocation: Union[
+        "OpDefinition", "PendingNodeInvocation[OpDefinition]", "AssetsDefinition"
+    ],
     *args,
     **kwargs,
 ) -> Any:
-    from dagster._core.definitions.decorators.op_decorator import DecoratedOpFunction
-    from dagster._core.execution.context.invocation import build_op_context
-
-    from .composition import PendingNodeInvocation
-
-    op_def = (
-        op_def_or_invocation.node_def
-        if isinstance(op_def_or_invocation, PendingNodeInvocation)
-        else op_def_or_invocation
+    from dagster._config.pythonic_config import Config
+    from dagster._core.execution.context.invocation import (
+        UnboundOpExecutionContext,
+        build_op_context,
     )
+
+    from ..execution.plan.compute_generator import invoke_compute_fn
+    from .assets import AssetsDefinition
+    from .composition import PendingNodeInvocation
+    from .decorators.op_decorator import DecoratedOpFunction
+    from .op_definition import OpDefinition
+
+    if isinstance(def_or_invocation, OpDefinition):
+        op_def = def_or_invocation
+        pending_invocation = None
+        assets_def = None
+    elif isinstance(def_or_invocation, AssetsDefinition):
+        assets_def = def_or_invocation
+        op_def = assets_def.op
+        pending_invocation = None
+    elif isinstance(def_or_invocation, PendingNodeInvocation):
+        pending_invocation = def_or_invocation
+        op_def = def_or_invocation.node_def
+        assets_def = None
+    else:
+        check.failed(f"unexpected direct invocation target {def_or_invocation}")
 
     compute_fn = op_def.compute_fn
     if not isinstance(compute_fn, DecoratedOpFunction):
-        check.failed("op invocation only works with decorated op fns")
+        raise DagsterInvalidInvocationError(
+            "Attempted to directly invoke an op/asset that was not constructed using the `@op` or"
+            " `@asset` decorator. Only decorated functions can be directly invoked."
+        )
 
-    compute_fn = cast(DecoratedOpFunction, compute_fn)
-
-    from ..execution.plan.compute_generator import invoke_compute_fn
+    context = None
+    if compute_fn.has_context_arg():
+        if len(args) + len(kwargs) == 0:
+            raise DagsterInvalidInvocationError(
+                f"Decorated function '{compute_fn.name}' has context argument, but"
+                " no context was provided when invoking."
+            )
+        if len(args) > 0:
+            if args[0] is not None and not isinstance(args[0], UnboundOpExecutionContext):
+                raise DagsterInvalidInvocationError(
+                    f"Decorated function '{compute_fn.name}' has context argument, "
+                    "but no context was provided when invoking."
+                )
+            context = cast(UnboundOpExecutionContext, args[0])
+            # update args to omit context
+            args = args[1:]
+        else:  # context argument is provided under kwargs
+            context_param_name = get_function_params(compute_fn.decorated_fn)[0].name
+            if context_param_name not in kwargs:
+                raise DagsterInvalidInvocationError(
+                    f"Decorated function '{compute_fn.name}' has context argument "
+                    f"'{context_param_name}', but no value for '{context_param_name}' was "
+                    f"found when invoking. Provided kwargs: {kwargs}"
+                )
+            context = cast(UnboundOpExecutionContext, kwargs[context_param_name])
+            # update kwargs to remove context
+            kwargs = {
+                kwarg: val for kwarg, val in kwargs.items() if not kwarg == context_param_name
+            }
+    # allow passing context, even if the function doesn't have an arg for it
+    elif len(args) > 0 and isinstance(args[0], UnboundOpExecutionContext):
+        context = cast(UnboundOpExecutionContext, args[0])
+        args = args[1:]
 
     resource_arg_mapping = {arg.name: arg.name for arg in compute_fn.get_resource_args()}
 
@@ -142,30 +192,17 @@ def op_invocation_result(
     resources_by_param_name = extracted.resources_by_param_name
     config_input = extracted.config_arg
 
-    resources_provided_in_multiple_places = (
-        resources_by_param_name and context and context.resource_keys
-    )
-    if resources_provided_in_multiple_places:
-        raise DagsterInvalidInvocationError("Cannot provide resources in both context and kwargs")
-
-    if resources_by_param_name:
-        context = (context or build_op_context()).replace_resources(resources_by_param_name)
-
-    config_provided_in_multiple_places = config_input and context and context.op_config
-    if config_provided_in_multiple_places:
-        raise DagsterInvalidInvocationError("Cannot provide config in both context and kwargs")
-    if config_input:
-        from dagster._config.pythonic_config import Config
-
-        context = (context or build_op_context()).replace_config(
+    bound_context = (context or build_op_context()).bind(
+        op_def=op_def,
+        pending_invocation=pending_invocation,
+        assets_def=assets_def,
+        resources_from_args=resources_by_param_name,
+        config_from_args=(
             config_input._convert_to_config_dictionary()  # noqa: SLF001
             if isinstance(config_input, Config)
             else config_input
-        )
-
-    _check_invocation_requirements(op_def, context)
-
-    bound_context = (context or build_op_context()).bind(op_def_or_invocation)
+        ),
+    )
 
     input_dict = _resolve_inputs(op_def, input_args, input_kwargs, bound_context)
 
@@ -181,36 +218,6 @@ def op_invocation_result(
     )
 
     return _type_check_output_wrapper(op_def, result, bound_context)
-
-
-def _check_invocation_requirements(
-    op_def: "OpDefinition", context: Optional["UnboundOpExecutionContext"]
-) -> None:
-    """Ensure that provided context fulfills requirements of op definition.
-
-    If no context was provided, then construct an enpty UnboundOpExecutionContext
-    """
-    # Check resource requirements
-    if (
-        op_def.required_resource_keys
-        and cast("DecoratedOpFunction", op_def.compute_fn).has_context_arg()
-        and context is None
-    ):
-        node_label = op_def.node_type_str
-        raise DagsterInvalidInvocationError(
-            f'{node_label} "{op_def.name}" has required resources, but no context was provided.'
-            f" Use the `build_{node_label}_context` function to construct a context with the"
-            " required resources."
-        )
-
-    # Check config requirements
-    if not context and op_def.config_schema.as_field().is_required:
-        node_label = op_def.node_type_str
-        raise DagsterInvalidInvocationError(
-            f'{node_label} "{op_def.name}" has required config schema, but no context was'
-            f" provided. Use the `build_{node_label}_context` function to create a context with"
-            " config."
-        )
 
 
 def _resolve_inputs(

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -234,7 +234,7 @@ class OpExecutionContext(AbstractComputeExecutionContext):
 
     @property
     def op(self) -> Node:
-        """Solid: The current op object.
+        """Node: The object representing the invoked op within the graph.
 
         :meta private:
 

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -1,3 +1,4 @@
+from contextlib import ExitStack
 from typing import (
     AbstractSet,
     Any,
@@ -86,25 +87,22 @@ class UnboundOpExecutionContext(OpExecutionContext):
         self._op_config = op_config
         self._mapping_key = mapping_key
 
-        self._instance_provided = (
-            check.opt_inst_param(instance, "instance", DagsterInstance) is not None
-        )
+        self._exit_stack = ExitStack()
+
         # Construct ephemeral instance if missing
-        self._instance_cm = ephemeral_instance_if_missing(instance)
-        # Pylint can't infer that the ephemeral_instance context manager has an __enter__ method,
-        # so ignore lint error
-        self._instance = self._instance_cm.__enter__()
+        self._instance = self._exit_stack.enter_context(ephemeral_instance_if_missing(instance))
 
         self._resources_config = resources_config
         # Open resource context manager
         self._resources_contain_cm = False
         self._resource_defs = wrap_resources_for_execution(resources_dict)
-        self._resources_cm = build_resources(
-            resources=self._resource_defs,
-            instance=instance,
-            resource_config=resources_config,
+        self._resources = self._exit_stack.enter_context(
+            build_resources(
+                resources=self._resource_defs,
+                instance=instance,
+                resource_config=resources_config,
+            )
         )
-        self._resources = self._resources_cm.__enter__()
         self._resources_contain_cm = isinstance(self._resources, IContainsGenerator)
 
         self._log = initialize_console_manager(None)
@@ -126,14 +124,10 @@ class UnboundOpExecutionContext(OpExecutionContext):
         return self
 
     def __exit__(self, *exc):
-        self._resources_cm.__exit__(*exc)
-        self._instance_cm.__exit__(*exc)
+        self._exit_stack.close()
 
     def __del__(self):
-        if self._resources_contain_cm and not self._cm_scope_entered:
-            self._resources_cm.__exit__(None, None, None)
-        if not self._cm_scope_entered:
-            self._instance_cm.__exit__(None, None, None)
+        self._exit_stack.close()
 
     @property
     def op_config(self) -> Any:
@@ -149,7 +143,7 @@ class UnboundOpExecutionContext(OpExecutionContext):
             raise DagsterInvariantViolationError(
                 "At least one provided resource is a generator, but attempting to access "
                 "resources outside of context manager scope. You can use the following syntax to "
-                "open a context manager: `with build_solid_context(...) as context:`"
+                "open a context manager: `with build_op_context(...) as context:`"
             )
         return self._resources
 
@@ -209,6 +203,10 @@ class UnboundOpExecutionContext(OpExecutionContext):
         raise DagsterInvalidPropertyError(_property_msg("solid_handle", "property"))
 
     @property
+    def op(self) -> JobDefinition:
+        raise DagsterInvalidPropertyError(_property_msg("op", "property"))
+
+    @property
     def solid(self) -> Node:
         raise DagsterInvalidPropertyError(_property_msg("solid", "property"))
 
@@ -258,41 +256,70 @@ class UnboundOpExecutionContext(OpExecutionContext):
 
     def bind(
         self,
-        op_def_or_invocation: Union[OpDefinition, PendingNodeInvocation[OpDefinition]],
+        op_def: OpDefinition,
+        pending_invocation: Optional[PendingNodeInvocation[OpDefinition]],
+        assets_def: Optional[AssetsDefinition],
+        config_from_args: Optional[Mapping[str, Any]],
+        resources_from_args: Optional[Mapping[str, Any]],
     ) -> "BoundOpExecutionContext":
-        op_def = (
-            op_def_or_invocation
-            if isinstance(op_def_or_invocation, OpDefinition)
-            else op_def_or_invocation.node_def
-        )
-
-        _validate_resource_requirements(self._resource_defs, op_def)
-
         from dagster._core.definitions.resource_invocation import resolve_bound_config
 
-        op_config = resolve_bound_config(self.op_config, op_def)
+        if resources_from_args:
+            if self._resource_defs:
+                raise DagsterInvalidInvocationError(
+                    "Cannot provide resources in both context and kwargs"
+                )
+            resource_defs = wrap_resources_for_execution(resources_from_args)
+            # add new resources context to the stack to be cleared on exit
+            resources = self._exit_stack.enter_context(
+                build_resources(resource_defs, self.instance)
+            )
+        elif assets_def and assets_def.resource_defs:
+            for key in sorted(list(assets_def.resource_defs.keys())):
+                if key in self._resource_defs:
+                    raise DagsterInvalidInvocationError(
+                        f"Error when invoking {assets_def!s} resource '{key}' "
+                        "provided on both the definition and invocation context. Please "
+                        "provide on only one or the other."
+                    )
+            resource_defs = wrap_resources_for_execution(
+                {**self._resource_defs, **assets_def.resource_defs}
+            )
+            # add new resources context to the stack to be cleared on exit
+            resources = self._exit_stack.enter_context(
+                build_resources(resource_defs, self.instance, self._resources_config)
+            )
+        else:
+            resources = self.resources
+            resource_defs = self._resource_defs
+
+        _validate_resource_requirements(resource_defs, op_def)
+
+        if self.op_config and config_from_args:
+            raise DagsterInvalidInvocationError("Cannot provide config in both context and kwargs")
+        op_config = resolve_bound_config(config_from_args or self.op_config, op_def)
 
         return BoundOpExecutionContext(
             op_def=op_def,
             op_config=op_config,
-            resources=self.resources,
+            resources=resources,
             resources_config=self._resources_config,
             instance=self.instance,
             log_manager=self.log,
             pdb=self.pdb,
             tags=(
-                op_def_or_invocation.tags
-                if isinstance(op_def_or_invocation, PendingNodeInvocation)
+                pending_invocation.tags
+                if isinstance(pending_invocation, PendingNodeInvocation)
                 else None
             ),
             hook_defs=(
-                op_def_or_invocation.hook_defs
-                if isinstance(op_def_or_invocation, PendingNodeInvocation)
+                pending_invocation.hook_defs
+                if isinstance(pending_invocation, PendingNodeInvocation)
                 else None
             ),
             alias=(
-                op_def_or_invocation.given_alias
-                if isinstance(op_def_or_invocation, PendingNodeInvocation)
+                pending_invocation.given_alias
+                if isinstance(pending_invocation, PendingNodeInvocation)
                 else None
             ),
             user_events=self._user_events,
@@ -300,7 +327,7 @@ class UnboundOpExecutionContext(OpExecutionContext):
             mapping_key=self._mapping_key,
             partition_key=self._partition_key,
             partition_key_range=self._partition_key_range,
-            assets_def=self._assets_def,
+            assets_def=assets_def,
         )
 
     def get_events(self) -> Sequence[UserEvent]:
@@ -347,37 +374,6 @@ class UnboundOpExecutionContext(OpExecutionContext):
 
     def get_mapping_key(self) -> Optional[str]:
         return self._mapping_key
-
-    def replace_resources(self, resources_dict: Mapping[str, Any]) -> "UnboundOpExecutionContext":
-        """Replace the resources of this context.
-
-        This method is intended to be used by the Dagster framework, and should not be called by user code.
-
-        Args:
-            resources (Mapping[str, Any]): The resources to add to the context.
-        """
-        return UnboundOpExecutionContext(
-            op_config=self._op_config,
-            resources_dict=resources_dict,
-            resources_config=self._resources_config,
-            instance=self._instance,
-            partition_key=self._partition_key,
-            partition_key_range=self._partition_key_range,
-            mapping_key=self._mapping_key,
-            assets_def=self._assets_def,
-        )
-
-    def replace_config(self, config: Mapping[str, Any]) -> "UnboundOpExecutionContext":
-        return UnboundOpExecutionContext(
-            op_config=config,
-            resources_dict=self._resource_defs,
-            resources_config=self._resources_config,
-            instance=self._instance,
-            partition_key=self._partition_key,
-            partition_key_range=self._partition_key_range,
-            mapping_key=self._mapping_key,
-            assets_def=self._assets_def,
-        )
 
 
 def _validate_resource_requirements(

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -663,12 +663,6 @@ def test_asset_invocation_resource_errors():
     def asset_uses_resources(context):
         assert context.resources.used == "foo"
 
-    with pytest.raises(
-        DagsterInvalidInvocationError,
-        match='op "asset_uses_resources" has required resources, but no context was provided',
-    ):
-        asset_uses_resources(None)
-
     asset_uses_resources(build_asset_context())
 
     @asset(required_resource_keys={"foo"})

--- a/python_modules/dagster/dagster_tests/core_tests/test_op_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_op_invocation.py
@@ -43,7 +43,7 @@ from dagster._core.errors import (
     DagsterStepOutputNotFoundError,
     DagsterTypeCheckDidNotPass,
 )
-from dagster._core.execution.context.compute import AssetExecutionContext
+from dagster._core.execution.context.compute import AssetExecutionContext, OpExecutionContext
 from dagster._core.execution.context.invocation import build_asset_context
 from dagster._utils.test import wrap_op_in_graph_and_execute
 
@@ -151,28 +151,21 @@ def test_op_invocation_with_resources():
     with pytest.raises(
         DagsterInvalidInvocationError,
         match=(
-            "Compute function of op 'op_requires_resources' has context argument, but no "
+            "Decorated function 'op_requires_resources' has context argument, but no "
             "context was provided when invoking."
         ),
     ):
         op_requires_resources()
 
-    # Ensure that alias is accounted for in error message
+    # alias still refers back to decorated function
     with pytest.raises(
         DagsterInvalidInvocationError,
         match=(
-            "Compute function of op 'aliased_op_requires_resources' has context argument, but no "
+            "Decorated function 'op_requires_resources' has context argument, but no "
             "context was provided when invoking."
         ),
     ):
         op_requires_resources.alias("aliased_op_requires_resources")()
-
-    # Ensure that error is raised when we attempt to invoke with a None context
-    with pytest.raises(
-        DagsterInvalidInvocationError,
-        match='op "op_requires_resources" has required resources, but no context was provided.',
-    ):
-        op_requires_resources(None)
 
     # Ensure that error is raised when we attempt to invoke with a context without the required
     # resource.
@@ -226,17 +219,17 @@ def test_op_invocation_with_config():
     with pytest.raises(
         DagsterInvalidInvocationError,
         match=(
-            "Compute function of op 'op_requires_config' has context argument, but no "
+            "Decorated function 'op_requires_config' has context argument, but no "
             "context was provided when invoking."
         ),
     ):
         op_requires_config()
 
-    # Ensure that alias is accounted for in error message
+    # alias still refers back to decorated function
     with pytest.raises(
         DagsterInvalidInvocationError,
         match=(
-            "Compute function of op 'aliased_op_requires_config' has context argument, but no "
+            "Decorated function 'op_requires_config' has context argument, but no "
             "context was provided when invoking."
         ),
     ):
@@ -244,8 +237,8 @@ def test_op_invocation_with_config():
 
     # Ensure that error is raised when we attempt to invoke with a None context
     with pytest.raises(
-        DagsterInvalidInvocationError,
-        match='op "op_requires_config" has required config schema, but no context was provided.',
+        DagsterInvalidConfigError,
+        match="Error in config for op",
     ):
         op_requires_config(None)
 
@@ -262,7 +255,7 @@ def test_op_invocation_with_config():
     with pytest.raises(
         DagsterInvalidInvocationError,
         match=(
-            "Compute function of op 'configured_op' has context argument, but no "
+            "Decorated function 'op_requires_config' has context argument, but no "
             "context was provided when invoking."
         ),
     ):
@@ -697,19 +690,22 @@ def test_output_sent_multiple_times():
         list(op_yields_twice())
 
 
+_invalid_on_bound = [
+    ("dagster_run", None),
+    ("step_launcher", None),
+    ("job_def", None),
+    ("job_name", None),
+    ("node_handle", None),
+    ("op", None),
+    ("get_step_execution_context", None),
+]
+
+
 @pytest.mark.parametrize(
     "property_or_method_name,val_to_pass",
-    [
-        ("dagster_run", None),
-        ("step_launcher", None),
-        ("job_def", None),
-        ("job_name", None),
-        ("node_handle", None),
-        ("op", None),
-        ("get_step_execution_context", None),
-    ],
+    _invalid_on_bound,
 )
-def test_invalid_properties_on_context(property_or_method_name: str, val_to_pass: object):
+def test_invalid_properties_on_bound_context(property_or_method_name: str, val_to_pass: object):
     @op
     def op_fails_getting_property(context):
         result = getattr(context, property_or_method_name)
@@ -721,7 +717,31 @@ def test_invalid_properties_on_context(property_or_method_name: str, val_to_pass
         )
 
     with pytest.raises(DagsterInvalidPropertyError):
-        op_fails_getting_property(None)
+        op_fails_getting_property(build_op_context())
+
+
+def test_bound_context():
+    @op
+    def access_bound_details(context: OpExecutionContext):
+        assert context.op_def
+
+    access_bound_details(build_op_context())
+
+
+@pytest.mark.parametrize(
+    "property_or_method_name,val_to_pass",
+    [
+        *_invalid_on_bound,
+        ("op_def", None),
+        ("assets_def", None),
+    ],
+)
+def test_invalid_properties_on_unbound_context(property_or_method_name: str, val_to_pass: object):
+    context = build_op_context()
+
+    with pytest.raises(DagsterInvalidPropertyError):
+        result = getattr(context, property_or_method_name)
+        result(val_to_pass) if val_to_pass else result()
 
 
 def test_op_retry_requested():
@@ -1118,7 +1138,7 @@ def test_kwarg_inputs():
 
     with pytest.raises(
         DagsterInvalidInvocationError,
-        match="op 'the_op' has 0 positional inputs, but 1 positional inputs were provided.",
+        match="'the_op' has 0 positional inputs, but 1 positional inputs were provided.",
     ):
         the_op("bar")
 
@@ -1144,7 +1164,7 @@ def test_kwarg_inputs_context():
 
     with pytest.raises(
         DagsterInvalidInvocationError,
-        match="op 'the_op' has 0 positional inputs, but 1 positional inputs were provided.",
+        match="'the_op' has 0 positional inputs, but 1 positional inputs were provided.",
     ):
         the_op(context, "bar")
 


### PR DESCRIPTION
* move more logic to `bind` time, removing the need for various context chaining & argument passing
* refactor direct invocation processing to remove duplication of `context` arg handling 
* drop some error checking on `None` passed for `context` since it gets pretty weird with how config/resources by arg work 

## How I Tested These Changes

existing and updated tests 