### PR TITLE
build_asset_context

### DIFF
--- a/docs/sphinx/sections/api/apidocs/execution.rst
+++ b/docs/sphinx/sections/api/apidocs/execution.rst
@@ -79,6 +79,8 @@ Contexts
 
 .. autofunction:: build_op_context
 
+.. autofunction:: build_asset_context
+
 .. autoclass:: TypeCheckContext
   :members:
   :inherited-members:

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -429,7 +429,10 @@ from dagster._core.execution.context.input import (
     InputContext as InputContext,
     build_input_context as build_input_context,
 )
-from dagster._core.execution.context.invocation import build_op_context as build_op_context
+from dagster._core.execution.context.invocation import (
+    build_asset_context as build_asset_context,
+    build_op_context as build_op_context,
+)
 from dagster._core.execution.context.logger import InitLoggerContext as InitLoggerContext
 from dagster._core.execution.context.output import (
     OutputContext as OutputContext,

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -684,12 +684,13 @@ def build_op_context(
     Args:
         resources (Optional[Dict[str, Any]]): The resources to provide to the context. These can be
             either values or resource definitions.
-        config (Optional[Any]): The op config to provide to the context.
+        op_config (Optional[Mapping[str, Any]]): The config to provide to the op.
+        resources_config (Optional[Mapping[str, Any]]): The config to provide to the resources.
         instance (Optional[DagsterInstance]): The dagster instance configured for the context.
             Defaults to DagsterInstance.ephemeral().
+        partition_key (Optional[str]): String value representing partition key to execute with.
         mapping_key (Optional[str]): A key representing the mapping key from an upstream dynamic
             output. Can be accessed using ``context.get_mapping_key()``.
-        partition_key (Optional[str]): String value representing partition key to execute with.
         _assets_def (Optional[AssetsDefinition]): Internal argument that populates the op's assets
             definition, not meant to be populated by users.
 
@@ -719,4 +720,45 @@ def build_op_context(
         partition_key=check.opt_str_param(partition_key, "partition_key"),
         mapping_key=check.opt_str_param(mapping_key, "mapping_key"),
         assets_def=check.opt_inst_param(_assets_def, "_assets_def", AssetsDefinition),
+    )
+
+
+def build_asset_context(
+    resources: Optional[Mapping[str, Any]] = None,
+    resources_config: Optional[Mapping[str, Any]] = None,
+    asset_config: Optional[Mapping[str, Any]] = None,
+    instance: Optional[DagsterInstance] = None,
+    partition_key: Optional[str] = None,
+):
+    """Builds asset execution context from provided parameters.
+
+    ``build_asset_context`` can be used as either a function or context manager. If there is a
+    provided resource that is a context manager, then ``build_asset_context`` must be used as a
+    context manager. This function can be used to provide the context argument when directly
+    invoking an asset.
+
+    Args:
+        resources (Optional[Dict[str, Any]]): The resources to provide to the context. These can be
+            either values or resource definitions.
+        resources_config (Optional[Mapping[str, Any]]): The config to provide to the resources.
+        asset_config (Optional[Mapping[str, Any]]): The config to provide to the asset.
+        instance (Optional[DagsterInstance]): The dagster instance configured for the context.
+            Defaults to DagsterInstance.ephemeral().
+        partition_key (Optional[str]): String value representing partition key to execute with.
+
+    Examples:
+        .. code-block:: python
+
+            context = build_asset_context()
+            asset_to_invoke(context)
+
+            with build_asset_context(resources={"foo": context_manager_resource}) as context:
+                asset_to_invoke(context)
+    """
+    return build_op_context(
+        op_config=asset_config,
+        resources=resources,
+        resources_config=resources_config,
+        partition_key=partition_key,
+        instance=instance,
     )

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -20,7 +20,7 @@ from dagster import (
     Out,
     Output,
     ResourceDefinition,
-    build_op_context,
+    build_asset_context,
     define_asset_job,
     fs_io_manager,
     graph,
@@ -586,7 +586,9 @@ def test_asset_invocation_resource_overrides():
         assert context.resources.foo == "foo_resource"
         assert context.resources.bar == "bar_resource"
 
-    asset_reqs_resources(build_op_context(resources={"foo": "foo_resource", "bar": "bar_resource"}))
+    asset_reqs_resources(
+        build_asset_context(resources={"foo": "foo_resource", "bar": "bar_resource"})
+    )
 
     @asset(
         resource_defs={
@@ -602,7 +604,7 @@ def test_asset_invocation_resource_overrides():
         DagsterInvalidInvocationError,
         match="resource 'foo' provided on both the definition and invocation context.",
     ):
-        asset_resource_overrides(build_op_context(resources={"foo": "override_foo"}))
+        asset_resource_overrides(build_asset_context(resources={"foo": "override_foo"}))
 
 
 def test_asset_invocation_resource_errors():
@@ -622,7 +624,7 @@ def test_asset_invocation_resource_errors():
     ):
         asset_uses_resources(None)
 
-    asset_uses_resources(build_op_context())
+    asset_uses_resources(build_asset_context())
 
     @asset(required_resource_keys={"foo"})
     def required_key_not_provided(_):
@@ -634,7 +636,7 @@ def test_asset_invocation_resource_errors():
             "resource with key 'foo' required by op 'required_key_not_provided' was not provided."
         ),
     ):
-        required_key_not_provided(build_op_context())
+        required_key_not_provided(build_asset_context())
 
 
 def test_multi_asset_resources_execution():

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
@@ -22,7 +22,7 @@ from dagster import (
     String,
     TimeWindowPartitionMapping,
     _check as check,
-    build_op_context,
+    build_asset_context,
     graph_asset,
     graph_multi_asset,
     io_manager,
@@ -556,7 +556,7 @@ def test_invoking_asset_with_context():
         assert isinstance(context, OpExecutionContext)
         return arg1
 
-    ctx = build_op_context()
+    ctx = build_asset_context()
     out = asset_with_context(ctx, 1)
     assert out == 1
 
@@ -607,8 +607,8 @@ def test_kwargs_with_context():
     assert len(my_asset.op.output_defs) == 1
     assert len(my_asset.op.input_defs) == 1
     assert AssetKey("upstream") in my_asset.keys_by_input_name.values()
-    assert my_asset(build_op_context(), upstream=5) == 7
-    assert my_asset.op(build_op_context(), upstream=5) == 7
+    assert my_asset(build_asset_context(), upstream=5) == 7
+    assert my_asset.op(build_asset_context(), upstream=5) == 7
 
     @asset
     def upstream():
@@ -648,8 +648,8 @@ def test_kwargs_multi_asset_with_context():
     assert len(my_asset.op.output_defs) == 1
     assert len(my_asset.op.input_defs) == 1
     assert AssetKey("upstream") in my_asset.keys_by_input_name.values()
-    assert my_asset(build_op_context(), upstream=5) == (7,)
-    assert my_asset.op(build_op_context(), upstream=5) == (7,)
+    assert my_asset(build_asset_context(), upstream=5) == (7,)
+    assert my_asset.op(build_asset_context(), upstream=5) == (7,)
 
     @asset
     def upstream():

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
@@ -19,7 +19,7 @@ from dagster import (
     PartitionsDefinition,
     SourceAsset,
     StaticPartitionsDefinition,
-    build_op_context,
+    build_asset_context,
     daily_partitioned_config,
     define_asset_job,
     hourly_partitioned_config,
@@ -207,7 +207,7 @@ def test_access_partition_keys_from_context_direct_invocation():
     def partitioned_asset(context):
         assert context.asset_partition_key_for_output() == "a"
 
-    context = build_op_context(partition_key="a")
+    context = build_asset_context(partition_key="a")
 
     # check unbound context
     assert context.asset_partition_key_for_output() == "a"
@@ -223,7 +223,7 @@ def test_access_partition_keys_from_context_direct_invocation():
         ):
             context.asset_partition_key_for_output()
 
-    context = build_op_context()
+    context = build_asset_context()
     non_partitioned_asset(context)
 
 


### PR DESCRIPTION
adds `build_asset_context` for creating test contexts with assets

Under the hood theres no material difference since there is only one underlying type for execution contexts.

Try to clean up what arguments are available 

## How I Tested These Changes

change asset usages of `build_op_context` over in various tests