### PR TITLE
_core.execution.context.hook: add job_tags property

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/context/hook.py
+++ b/python_modules/dagster/dagster/_core/execution/context/hook.py
@@ -59,12 +59,20 @@ class HookContext:
         self._resources = step_execution_context.scoped_resources_builder.build(
             self._required_resource_keys
         )
+        self._pipeline_execution_context = step_execution_context.plan_data.dagster_run
+
 
     @public
     @property
     def job_name(self) -> str:
         """The name of the job where this hook is being triggered."""
         return self._step_execution_context.job_name
+    
+    @public
+    @property
+    def job_tags(self) -> str:
+        """The tags of the job where this hook is being triggered"""
+        return self._pipeline_execution_context.tags
 
     @public
     @property


### PR DESCRIPTION
## Summary & Motivation
Need to retrieve the tags of a job within a Hook. These tags are created by a Sensor using a RunRequests. It's not possible to use the run_key because these tags are not unique. It's not possible to pass them as a configuration parameter because it adds complexity to the code.

## How I Tested These Changes
Just a simple change without much complexity. Tested locally, no written tests.