### PR TITLE
Enable to query current status of any partition of an asset

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -493,6 +493,9 @@ from dagster._core.storage.mem_io_manager import (
     mem_io_manager as mem_io_manager,
 )
 from dagster._core.storage.memoizable_io_manager import MemoizableIOManager as MemoizableIOManager
+from dagster._core.storage.partition_status_cache import (
+    AssetPartitionStatus as AssetPartitionStatus,
+)
 from dagster._core.storage.root_input_manager import (
     RootInputManager as RootInputManager,
     RootInputManagerDefinition as RootInputManagerDefinition,

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -35,7 +35,6 @@ from typing_extensions import Protocol, Self, TypeAlias, TypeVar, runtime_checka
 import dagster._check as check
 from dagster._annotations import public
 from dagster._core.definitions.events import AssetKey
-from dagster._core.definitions.partition import PartitionsDefinition
 from dagster._core.errors import (
     DagsterHomeNotSetError,
     DagsterInvalidInvocationError,
@@ -92,6 +91,7 @@ if TYPE_CHECKING:
     from dagster._core.definitions.job_definition import (
         JobDefinition,
     )
+    from dagster._core.definitions.partition import PartitionsDefinition
     from dagster._core.definitions.repository_definition.repository_definition import (
         RepositoryLoadData,
     )
@@ -132,7 +132,10 @@ if TYPE_CHECKING:
         EventLogRecord,
         EventRecordsFilter,
     )
-    from dagster._core.storage.partition_status_cache import AssetStatusCacheValue
+    from dagster._core.storage.partition_status_cache import (
+        AssetPartitionStatus,
+        AssetStatusCacheValue,
+    )
     from dagster._core.storage.root import LocalArtifactStorage
     from dagster._core.storage.runs import RunStorage
     from dagster._core.storage.runs.base import RunGroupInfo
@@ -1783,7 +1786,7 @@ class DagsterInstance(DynamicPartitionsStore):
     @traced
     def get_status_by_partition(
         self, asset_key: AssetKey, partitions_def: PartitionsDefinition, partition_keys: List[str]
-    ) -> Dict:
+    ) -> Mapping[str, AssetPartitionStatus]:
         """Get the current status of provided partition_keys.
 
         Args:
@@ -1796,30 +1799,28 @@ class DagsterInstance(DynamicPartitionsStore):
 
         """
         from dagster._core.storage.partition_status_cache import (
-            PartitionStatus,
+            AssetPartitionStatus,
             get_and_update_asset_status_cache_value,
         )
 
         cached_value = get_and_update_asset_status_cache_value(self, asset_key, partitions_def)
         materialized_partitions = cached_value.deserialize_materialized_partition_subsets(
             partitions_def
-        ).get_partition_keys()
-        failed_partitions = cached_value.deserialize_failed_partition_subsets(
-            partitions_def
-        ).get_partition_keys()
+        )
+        failed_partitions = cached_value.deserialize_failed_partition_subsets(partitions_def)
         in_progress_partitions = cached_value.deserialize_in_progress_partition_subsets(
             partitions_def
-        ).get_partition_keys()
+        )
 
         status_by_partition = {}
 
         for partition_key in partition_keys:
             if partition_key in in_progress_partitions:
-                status_by_partition[partition_key] = PartitionStatus.IN_PROGRESS
+                status_by_partition[partition_key] = AssetPartitionStatus.IN_PROGRESS
             elif partition_key in failed_partitions:
-                status_by_partition[partition_key] = PartitionStatus.FAILED
+                status_by_partition[partition_key] = AssetPartitionStatus.FAILED
             elif partition_key in materialized_partitions:
-                status_by_partition[partition_key] = PartitionStatus.MATERIALIZED
+                status_by_partition[partition_key] = AssetPartitionStatus.MATERIALIZED
             else:
                 status_by_partition[partition_key] = None
 

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -56,10 +56,6 @@ from dagster._core.storage.dagster_run import (
     RunsFilter,
     TagBucket,
 )
-from dagster._core.storage.partition_status_cache import (
-    PartitionStatus,
-    get_and_update_asset_status_cache_value,
-)
 from dagster._core.storage.tags import (
     ASSET_PARTITION_RANGE_END_TAG,
     ASSET_PARTITION_RANGE_START_TAG,
@@ -1799,6 +1795,11 @@ class DagsterInstance(DynamicPartitionsStore):
             Dict: status for each partition key
 
         """
+        from dagster._core.storage.partition_status_cache import (
+            PartitionStatus,
+            get_and_update_asset_status_cache_value,
+        )
+
         cached_value = get_and_update_asset_status_cache_value(self, asset_key, partitions_def)
         materialized_partitions = cached_value.deserialize_materialized_partition_subsets(
             partitions_def

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -1800,6 +1800,7 @@ class DagsterInstance(DynamicPartitionsStore):
         """
         from dagster._core.storage.partition_status_cache import (
             AssetPartitionStatus,
+            AssetStatusCacheValue,
             get_and_update_asset_status_cache_value,
         )
 

--- a/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
+++ b/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
@@ -1,5 +1,5 @@
 from typing import Dict, List, NamedTuple, Optional, Sequence, Set, Tuple
-
+from enum import Enum
 from dagster import (
     AssetKey,
     DagsterEventType,
@@ -36,6 +36,14 @@ CACHEABLE_PARTITION_TYPES = (
     StaticPartitionsDefinition,
     DynamicPartitionsDefinition,
 )
+
+
+class PartitionStatus(Enum):
+    """The status of partition."""
+
+    MATERIALIZED = "MATERIALIZED"
+    IN_PROGRESS = "IN_PROGRESS"
+    FAILED = "FAILED"
 
 
 def is_cacheable_partition_type(partitions_def: PartitionsDefinition) -> bool:

--- a/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
+++ b/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
@@ -39,8 +39,8 @@ CACHEABLE_PARTITION_TYPES = (
 )
 
 
-class PartitionStatus(Enum):
-    """The status of partition."""
+class AssetPartitionStatus(Enum):
+    """The status of asset partition."""
 
     MATERIALIZED = "MATERIALIZED"
     IN_PROGRESS = "IN_PROGRESS"

--- a/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
+++ b/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
@@ -1,5 +1,6 @@
-from typing import Dict, List, NamedTuple, Optional, Sequence, Set, Tuple
 from enum import Enum
+from typing import Dict, List, NamedTuple, Optional, Sequence, Set, Tuple
+
 from dagster import (
     AssetKey,
     DagsterEventType,

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
@@ -16,6 +16,7 @@ from dagster import (
     job,
     op,
     reconstructable,
+    PartitionKeyRange,
 )
 from dagster._check import CheckError
 from dagster._cli.utils import get_instance_for_cli
@@ -36,7 +37,7 @@ from dagster._core.snap import (
     create_job_snapshot_id,
     snapshot_from_execution_plan,
 )
-from dagster._core.storage.partition_status_cache import PartitionStatus
+from dagster._core.storage.partition_status_cache import AssetPartitionStatus
 from dagster._core.storage.sqlite_storage import (
     _event_logs_directory,
     _runs_directory,
@@ -725,14 +726,14 @@ def test_configurable_class_missing_methods():
 @patch("dagster._core.storage.partition_status_cache.get_and_update_asset_status_cache_value")
 def test_get_status_by_partition(mock_get_and_update):
     mock_cached_value = MagicMock()
-    mock_cached_value.deserialize_materialized_partition_subsets.return_value.get_partition_keys.return_value = [
+    mock_cached_value.deserialize_materialized_partition_subsets.return_value = [
         "2023-06-01",
         "2023-06-02",
     ]
-    mock_cached_value.deserialize_failed_partition_subsets.return_value.get_partition_keys.return_value = [
+    mock_cached_value.deserialize_failed_partition_subsets.return_value= [
         "2023-06-15"
     ]
-    mock_cached_value.deserialize_in_progress_partition_subsets.return_value.get_partition_keys.return_value = [
+    mock_cached_value.deserialize_in_progress_partition_subsets.return_value = [
         "2023-07-01"
     ]
     mock_get_and_update.return_value = mock_cached_value
@@ -742,4 +743,4 @@ def test_get_status_by_partition(mock_get_and_update):
             DailyPartitionsDefinition(start_date="2023-06-01"),
             ["2023-07-01"],
         )
-        assert partition_status == {"2023-07-01": PartitionStatus.IN_PROGRESS}
+        assert partition_status == {"2023-07-01": AssetPartitionStatus.IN_PROGRESS}

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
@@ -16,7 +16,6 @@ from dagster import (
     job,
     op,
     reconstructable,
-    PartitionKeyRange,
 )
 from dagster._check import CheckError
 from dagster._cli.utils import get_instance_for_cli
@@ -730,12 +729,8 @@ def test_get_status_by_partition(mock_get_and_update):
         "2023-06-01",
         "2023-06-02",
     ]
-    mock_cached_value.deserialize_failed_partition_subsets.return_value= [
-        "2023-06-15"
-    ]
-    mock_cached_value.deserialize_in_progress_partition_subsets.return_value = [
-        "2023-07-01"
-    ]
+    mock_cached_value.deserialize_failed_partition_subsets.return_value = ["2023-06-15"]
+    mock_cached_value.deserialize_in_progress_partition_subsets.return_value = ["2023-07-01"]
     mock_get_and_update.return_value = mock_cached_value
     with instance_for_test() as instance:
         partition_status = instance.get_status_by_partition(

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
@@ -36,7 +36,10 @@ from dagster._core.snap import (
     create_job_snapshot_id,
     snapshot_from_execution_plan,
 )
-from dagster._core.storage.partition_status_cache import AssetPartitionStatus
+from dagster._core.storage.partition_status_cache import (
+    AssetPartitionStatus,
+    AssetStatusCacheValue,
+)
 from dagster._core.storage.sqlite_storage import (
     _event_logs_directory,
     _runs_directory,
@@ -724,7 +727,7 @@ def test_configurable_class_missing_methods():
 
 @patch("dagster._core.storage.partition_status_cache.get_and_update_asset_status_cache_value")
 def test_get_status_by_partition(mock_get_and_update):
-    mock_cached_value = MagicMock()
+    mock_cached_value = MagicMock(spec=AssetStatusCacheValue)
     mock_cached_value.deserialize_materialized_partition_subsets.return_value = [
         "2023-06-01",
         "2023-06-02",

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
@@ -2,10 +2,13 @@ import os
 import re
 import tempfile
 from typing import Any, Mapping, Optional
+from unittest.mock import MagicMock, patch
 
 import pytest
 import yaml
 from dagster import (
+    AssetKey,
+    DailyPartitionsDefinition,
     _check as check,
     _seven,
     asset,
@@ -33,6 +36,7 @@ from dagster._core.snap import (
     create_job_snapshot_id,
     snapshot_from_execution_plan,
 )
+from dagster._core.storage.partition_status_cache import PartitionStatus
 from dagster._core.storage.sqlite_storage import (
     _event_logs_directory,
     _runs_directory,
@@ -716,3 +720,26 @@ def test_configurable_class_missing_methods():
             }
         ) as instance:
             print(instance.run_launcher)  # noqa: T201
+
+
+@patch("dagster._core.storage.partition_status_cache.get_and_update_asset_status_cache_value")
+def test_get_status_by_partition(mock_get_and_update):
+    mock_cached_value = MagicMock()
+    mock_cached_value.deserialize_materialized_partition_subsets.return_value.get_partition_keys.return_value = [
+        "2023-06-01",
+        "2023-06-02",
+    ]
+    mock_cached_value.deserialize_failed_partition_subsets.return_value.get_partition_keys.return_value = [
+        "2023-06-15"
+    ]
+    mock_cached_value.deserialize_in_progress_partition_subsets.return_value.get_partition_keys.return_value = [
+        "2023-07-01"
+    ]
+    mock_get_and_update.return_value = mock_cached_value
+    with instance_for_test() as instance:
+        partition_status = instance.get_status_by_partition(
+            AssetKey("test-asset"),
+            DailyPartitionsDefinition(start_date="2023-06-01"),
+            ["2023-07-01"],
+        )
+        assert partition_status == {"2023-07-01": PartitionStatus.IN_PROGRESS}


### PR DESCRIPTION
## Summary & Motivation
https://github.com/dagster-io/dagster/issues/14988

## How I Tested These Changes

- Unittest is included in the PR. 

- Test with local dagster:

1. create a simple daily partitioned asset with only one op included:

```python
@op(ins={"start": In(Nothing)}, out={"result": Out(Nothing)})
def op1(context: OpExecutionContext):
    status = context.instance.get_status_by_partition(context.assets_def.asset_key, context.assets_def.partitions_def, ["2023-06-22","2023-06-24"])
    time.sleep(1)
```

2. Randomly materialize and fail some partitions.
3. Put a debug point on line `status = ...`, then materilize a random partition. Replace the partition key values in the list with any partition(s).  Check the value of `status`, and the values are as expected.
