### PR TITLE
non_argument_deps rename - update tests to use deps instead of non_argument_deps

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
@@ -1588,12 +1588,12 @@ def asset_1():
     yield Output(3)
 
 
-@asset(non_argument_deps={AssetKey("asset_1")})
+@asset(deps=[AssetKey("asset_1")])
 def asset_2():
     raise Exception("foo")
 
 
-@asset(non_argument_deps={AssetKey("asset_2")})
+@asset(deps=[AssetKey("asset_2")])
 def asset_3():
     yield Output(7)
 
@@ -1675,7 +1675,7 @@ def untyped_asset(typed_asset):
     return typed_asset
 
 
-@asset(non_argument_deps={AssetKey("diamond_source")})
+@asset(deps=[AssetKey("diamond_source")])
 def fresh_diamond_top():
     return 1
 

--- a/python_modules/dagster-test/dagster_test/toys/big_honkin_asset_graph.py
+++ b/python_modules/dagster-test/dagster_test/toys/big_honkin_asset_graph.py
@@ -11,11 +11,11 @@ def generate_big_honkin_assets() -> List[AssetsDefinition]:
     assets = []
 
     for i in range(N_ASSETS):
-        non_argument_deps = {
+        non_argument_deps = [
             AssetKey(f"asset_{j}") for j in random.sample(range(i), min(i, random.randint(0, 3)))
-        }
+        ]
 
-        @asset(name=f"asset_{i}", non_argument_deps=non_argument_deps)
+        @asset(name=f"asset_{i}", deps=non_argument_deps)
         def some_asset():
             pass
 

--- a/python_modules/dagster-test/dagster_test/toys/data_versions.py
+++ b/python_modules/dagster-test/dagster_test/toys/data_versions.py
@@ -24,29 +24,29 @@ def observable_same_version():
 non_observable_source = SourceAsset("non_observable_source")
 
 
-@asset(code_version="1", non_argument_deps={"observable_different_version"})
+@asset(code_version="1", deps=[observable_different_version])
 def has_code_version1(context):
     ...
 
 
-@asset(code_version="1", non_argument_deps={"observable_same_version"})
+@asset(code_version="1", deps=[observable_same_version])
 def has_code_version2():
     ...
 
 
 @asset(
-    non_argument_deps={
-        "observable_different_version",
-        "observable_same_version",
-        "non_observable_source",
-    },
+    deps=[
+        observable_different_version,
+        observable_same_version,
+        non_observable_source,
+    ],
     code_version="1",
 )
 def has_code_version_multiple_deps():
     ...
 
 
-@asset(code_version="1", non_argument_deps={"has_code_version1"})
+@asset(code_version="1", deps=[has_code_version1])
 def downstream_of_code_versioned():
     ...
 
@@ -56,7 +56,7 @@ def root_asset_no_code_version(context):
     return 100
 
 
-@asset(non_argument_deps={"root_asset_no_code_version"})
+@asset(deps=[root_asset_no_code_version])
 def downstream_of_no_code_version():
     ...
 
@@ -66,13 +66,13 @@ def downstream_of_no_code_version():
         "code_versioned_multi_asset1": AssetOut(code_version="1"),
         "code_versioned_multi_asset2": AssetOut(code_version="3"),
     },
-    non_argument_deps={"downstream_of_no_code_version"},
+    deps=[downstream_of_no_code_version],
 )
 def code_versioned_multi_asset():
     yield Output(None, "code_versioned_multi_asset1")
     yield Output(None, "code_versioned_multi_asset2")
 
 
-@asset(non_argument_deps={"code_versioned_multi_asset2"})
+@asset(deps=["code_versioned_multi_asset2"])
 def downstream_of_code_versioned_multi_asset():
     ...

--- a/python_modules/dagster-test/dagster_test/toys/partitioned_assets/hourly_partitions_to_daily.py
+++ b/python_modules/dagster-test/dagster_test/toys/partitioned_assets/hourly_partitions_to_daily.py
@@ -14,6 +14,6 @@ def hourly_asset2() -> None:
     ...
 
 
-@asset(partitions_def=daily_partitions_def, non_argument_deps={"hourly_asset1", "hourly_asset2"})
+@asset(partitions_def=daily_partitions_def, deps=[hourly_asset1, hourly_asset2])
 def daily_asset() -> None:
     ...

--- a/python_modules/dagster/dagster/_core/definitions/materialize.py
+++ b/python_modules/dagster/dagster/_core/definitions/materialize.py
@@ -36,7 +36,7 @@ def materialize(
         assets (Sequence[Union[AssetsDefinition, SourceAsset]]):
             The assets to materialize.
 
-            Unless you're using `non_argument_deps`, you must also include all assets that are
+            Unless you're using `deps` or `non_argument_deps`, you must also include all assets that are
             upstream of the assets that you want to materialize. This is because those upstream
             asset definitions have information that is needed to load their contents while
             materializing the downstream assets.

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
@@ -382,7 +382,7 @@ def test_get_non_source_roots_missing_source():
     def foo():
         pass
 
-    @asset(non_argument_deps={"this_source_is_fake", "source_asset"})
+    @asset(deps=["this_source_is_fake", "source_asset"])
     def bar(foo):
         pass
 
@@ -400,7 +400,7 @@ def test_partitioned_source_asset():
         partitions_def=partitions_def,
     )
 
-    @asset(partitions_def=partitions_def, non_argument_deps={"partitioned_source"})
+    @asset(partitions_def=partitions_def, deps=["partitioned_source"])
     def downstream_of_partitioned_source():
         pass
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_external_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_external_asset_graph.py
@@ -52,7 +52,7 @@ def downstream(asset1):
 downstream_defs = Definitions(assets=[asset1_source, downstream])
 
 
-@asset(non_argument_deps={"asset1"})
+@asset(deps=[asset1])
 def downstream_non_arg_dep():
     ...
 
@@ -66,7 +66,7 @@ partitioned_source = SourceAsset(
 
 @asset(
     partitions_def=DailyPartitionsDefinition(start_date="2022-01-01"),
-    non_argument_deps={"partitioned_source"},
+    deps=[partitioned_source],
     auto_materialize_policy=AutoMaterializePolicy(
         on_missing=True,
         for_freshness=True,

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_resolved_asset_deps.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_resolved_asset_deps.py
@@ -39,7 +39,7 @@ def test_input_has_asset_key():
     def asset1():
         ...
 
-    @asset(non_argument_deps={AssetKey(["b", "asset1"])})
+    @asset(deps=[AssetKey(["b", "asset1"])])
     def asset2():
         ...
 
@@ -47,15 +47,13 @@ def test_input_has_asset_key():
 
 
 def test_upstream_same_name_as_asset():
-    @asset(non_argument_deps={AssetKey("asset1")}, key_prefix="b")
+    @asset(deps=[AssetKey("asset1")], key_prefix="b")
     def asset1():
         ...
 
     assert len(resolve_assets_def_deps([asset1], [])) == 0
 
-    @multi_asset(
-        outs={"asset1": AssetOut(key_prefix="b")}, non_argument_deps={AssetKey(["a", "asset1"])}
-    )
+    @multi_asset(outs={"asset1": AssetOut(key_prefix="b")}, deps=[AssetKey(["a", "asset1"])])
     def multi_asset1():
         ...
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_source_asset_observation_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_source_asset_observation_job.py
@@ -98,7 +98,7 @@ def test_mixed_source_asset_observation_job():
     def foo(_context) -> DataVersion:
         return DataVersion("alpha")
 
-    @asset(non_argument_deps={"foo"})
+    @asset(deps=["foo"])
     def bar(context):
         return 1
 

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/assets.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/assets.py
@@ -11,7 +11,7 @@ def asset_with_prefix() -> None:
     ...
 
 
-@asset(non_argument_deps={"asset1"})
+@asset(deps=[asset1])
 def downstream_asset() -> None:
     ...
 

--- a/python_modules/dagster/dagster_tests/core_tests/test_data_time.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_data_time.py
@@ -79,7 +79,7 @@ def test_calculate_data_time_unpartitioned(ignore_asset_tags, runs_to_expected_d
         return 1
 
     @multi_asset(
-        non_argument_deps={AssetKey("a")},
+        deps=[AssetKey("a")],
         outs={
             "b": AssetOut(is_required=False),
             "c": AssetOut(is_required=False),
@@ -96,11 +96,11 @@ def test_calculate_data_time_unpartitioned(ignore_asset_tags, runs_to_expected_d
         for output_name in sorted(context.selected_output_names):
             yield Output(output_name, output_name)
 
-    @asset(non_argument_deps={AssetKey("c")})
+    @asset(deps=[AssetKey("c")])
     def e():
         return 1
 
-    @asset(non_argument_deps={AssetKey("d")})
+    @asset(deps=[AssetKey("d")])
     def f():
         return 1
 
@@ -170,7 +170,7 @@ def partitioned_asset():
     pass
 
 
-@asset(non_argument_deps={AssetKey("partitioned_asset")})
+@asset(deps=[AssetKey("partitioned_asset")])
 def unpartitioned_asset():
     pass
 
@@ -299,22 +299,22 @@ def sB():
     return DataVersion(str(random.random()))
 
 
-@asset(non_argument_deps={"sA"})
+@asset(deps=[sA])
 def A():
     pass
 
 
-@asset(non_argument_deps={"sB"})
+@asset(deps=[sB])
 def B():
     pass
 
 
-@asset(non_argument_deps={"B"})
+@asset(deps=[B])
 def B2():
     pass
 
 
-@asset(non_argument_deps={"sA", "sB"})
+@asset(deps=[sA, sB])
 def AB():
     pass
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/asset_reconciliation_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/asset_reconciliation_scenario.py
@@ -424,10 +424,10 @@ def asset_def(
     auto_materialize_policy: Optional[AutoMaterializePolicy] = None,
 ) -> AssetsDefinition:
     if deps is None:
-        non_argument_deps = set()
+        non_argument_deps = None
         ins = None
     elif isinstance(deps, list):
-        non_argument_deps = set(deps)
+        non_argument_deps = deps
         ins = None
     else:
         non_argument_deps = None
@@ -439,7 +439,7 @@ def asset_def(
     @asset(
         name=key,
         partitions_def=partitions_def,
-        non_argument_deps=non_argument_deps,
+        deps=non_argument_deps,
         ins=ins,
         config_schema={"fail": Field(bool, default_value=False)},
         freshness_policy=freshness_policy,
@@ -461,13 +461,13 @@ def multi_asset_def(
     freshness_policies: Optional[Mapping[str, FreshnessPolicy]] = None,
 ) -> AssetsDefinition:
     if deps is None:
-        non_argument_deps = set()
+        non_argument_deps = None
         internal_asset_deps = None
     elif isinstance(deps, list):
-        non_argument_deps = set(deps)
+        non_argument_deps = deps
         internal_asset_deps = None
     else:
-        non_argument_deps = set().union(*deps.values()) - set(deps.keys())
+        non_argument_deps = list(set().union(*deps.values()) - set(deps.keys()))
         internal_asset_deps = {k: {AssetKey(vv) for vv in v} for k, v in deps.items()}
 
     @multi_asset(
@@ -479,7 +479,7 @@ def multi_asset_def(
             for key in keys
         },
         name="_".join(keys),
-        non_argument_deps=non_argument_deps,
+        deps=non_argument_deps,
         internal_asset_deps=internal_asset_deps,
         can_subset=can_subset,
     )

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_reconciliation_sensor_perf.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_reconciliation_sensor_perf.py
@@ -90,10 +90,10 @@ class RandomAssets(NamedTuple):
                 )
                 for i in range(self.n_assets)
             },
-            non_argument_deps={
+            deps=[
                 *(f"root_{i}" for i in range(self.n_roots)),
                 *(f"source_{i}" for i in range(self.n_sources)),
-            },
+            ],
             internal_asset_deps=deps,
             can_subset=True,
             partitions_def=self.asset_partitions_def,

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_dynamic_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_dynamic_partitions.py
@@ -87,7 +87,7 @@ def test_dynamic_partitioned_asset_dep():
     def asset1():
         pass
 
-    @asset(partitions_def=partitions_def, non_argument_deps={"asset1"})
+    @asset(partitions_def=partitions_def, deps=[asset1])
     def asset2(context):
         assert context.partition_key == "apple"
         assert context.asset_key_for_output() == "apple"

--- a/python_modules/dagster/dagster_tests/execution_tests/test_data_versions.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_data_versions.py
@@ -289,10 +289,10 @@ def test_source_asset_versioned_asset():
     assert_same_versions(mat1, mat2, "abc")
 
 
-def test_source_asset_non_versioned_asset_non_argument_deps():
+def test_source_asset_non_versioned_asset_deps():
     source1 = SourceAsset("source1")
 
-    @asset(non_argument_deps={"source1"})
+    @asset(deps=[source1])
     def asset1():
         ...
 

--- a/python_modules/dagster/dagster_tests/storage_tests/test_fs_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_fs_io_manager.py
@@ -455,7 +455,7 @@ def test_fs_io_manager_none():
         def asset1() -> None:
             pass
 
-        @asset(non_argument_deps={"asset1"})
+        @asset(deps=[asset1])
         def asset2() -> None:
             pass
 

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_io_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_io_manager.py
@@ -232,7 +232,7 @@ def test_nothing(mock_s3_bucket):
     def asset1() -> None:
         ...
 
-    @asset(non_argument_deps={"asset1"})
+    @asset(deps=[asset1])
     def asset2() -> None:
         ...
 

--- a/python_modules/libraries/dagster-azure/dagster_azure_tests/adls2_tests/test_io_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure_tests/adls2_tests/test_io_manager.py
@@ -340,7 +340,7 @@ def test_nothing():
     def asset1() -> None:
         ...
 
-    @asset(non_argument_deps={"asset1"})
+    @asset(deps=[asset1])
     def asset2() -> None:
         ...
 
@@ -368,7 +368,7 @@ def test_nothing_pythonic() -> None:
     def asset1() -> None:
         ...
 
-    @asset(non_argument_deps={"asset1"})
+    @asset(deps=[asset1])
     def asset2() -> None:
         ...
 

--- a/python_modules/libraries/dagster-gcp/dagster_gcp_tests/gcs_tests/test_io_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp_tests/gcs_tests/test_io_manager.py
@@ -248,7 +248,7 @@ def test_nothing(gcs_bucket):
     def asset1() -> None:
         ...
 
-    @asset(non_argument_deps={"asset1"})
+    @asset(deps=[asset1])
     def asset2() -> None:
         ...
 
@@ -326,7 +326,7 @@ def test_nothing_pythonic_io_manager(gcs_bucket):
     def asset1() -> None:
         ...
 
-    @asset(non_argument_deps={"asset1"})
+    @asset(deps=[asset1])
     def asset2() -> None:
         ...
 


### PR DESCRIPTION
## Summary & Motivation
Updates tests and the toys repo to use `deps` instead of `non_argument_deps`

## How I Tested These Changes
