### PR TITLE
refactor(dbt): get artifact path from only the target path

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources_v2.py
@@ -863,8 +863,8 @@ class DbtCliTask:
                 if dbt_cli_task.is_successful():
                     run_results = dbt_cli_task.get_artifact("run_results.json")
         """
-        artifact_path = os.path.join(self.project_dir, self.target_path, artifact)
-        with open(artifact_path) as handle:
+        artifact_path = self.target_path.joinpath(artifact)
+        with artifact_path.open() as handle:
             return json.loads(handle.read())
 
 


### PR DESCRIPTION
## Summary & Motivation
As the title. Just removing the confusion, since target path already has the project dir tacked onto its path.

## How I Tested These Changes
pytest
