### PR TITLE
Tweak black config to include docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,14 +16,14 @@
 black:
 	black --fast \
     --extend-exclude="examples/docs_snippets|snapshots" \
-    examples integration_tests helm python_modules .buildkite
+    docs examples integration_tests helm python_modules .buildkite
 	black --fast \
     examples/docs_snippets
 
 check_black:
 	black --check --fast \
     --extend-exclude="examples/docs_snippets|snapshots" \
-    examples integration_tests helm python_modules .buildkite
+    docs examples integration_tests helm python_modules .buildkite
 	black --check --fast \
     examples/docs_snippets
 

--- a/docs/dagit-screenshot/dagit_screenshot/commands/audit.py
+++ b/docs/dagit-screenshot/dagit_screenshot/commands/audit.py
@@ -47,12 +47,11 @@ def audit(
 def _validate_spec(
     spec: ScreenshotSpec, output_root: str, workspace_root: str, verify_outputs: bool
 ) -> SpecAuditResult:
-
     error: Optional[str] = None
 
     try:
         if spec["base_url"].startswith("http://localhost"):
-            if 'workspace' not in spec:
+            if "workspace" not in spec:
                 raise Exception("No workspace defined. Workspace required for local dagit.")
             workspace = spec["workspace"]
             workspace_path = normalize_workspace_path(workspace, workspace_root)
@@ -60,9 +59,7 @@ def _validate_spec(
                 raise Exception(f"No workspace-defining file exists at {workspace_path}.")
 
         if verify_outputs:
-            output_path = normalize_output_path(
-                spec_id_to_relative_path(spec["id"]), output_root
-            )
+            output_path = normalize_output_path(spec_id_to_relative_path(spec["id"]), output_root)
             if not os.path.exists(output_path):
                 raise Exception(f"No screenshot image file exists at {output_path}.")
 

--- a/docs/dagit-screenshot/dagit_screenshot/commands/show.py
+++ b/docs/dagit-screenshot/dagit_screenshot/commands/show.py
@@ -8,5 +8,5 @@ from dagit_screenshot.utils import load_spec_db
 def show(spec_db_path: str, prefix: Optional[str]):
     spec_db = load_spec_db(spec_db_path)
     sorted_db = sorted(spec_db, key=lambda s: s["id"])
-    filtered_db = [ s for s in sorted_db if not prefix or s["id"].startswith(prefix) ]
+    filtered_db = [s for s in sorted_db if not prefix or s["id"].startswith(prefix)]
     print(yaml.dump(filtered_db))  # noqa: T201

--- a/docs/dagit-screenshot/dagit_screenshot/defaults.py
+++ b/docs/dagit-screenshot/dagit_screenshot/defaults.py
@@ -1,15 +1,15 @@
 import os
 
 _dir = os.path.dirname(__file__)
-while not os.path.exists(os.path.join(_dir, '.git')) or os.path.dirname(_dir) == _dir:
+while not os.path.exists(os.path.join(_dir, ".git")) or os.path.dirname(_dir) == _dir:
     _dir = os.path.dirname(_dir)
 _repo_root = os.path.abspath(_dir)
 
 # Root path where captured screenshots are stored.
-DEFAULT_OUTPUT_ROOT = os.path.join(_repo_root, 'docs', 'next', 'public', 'images')
+DEFAULT_OUTPUT_ROOT = os.path.join(_repo_root, "docs", "next", "public", "images")
 
 # Path to a screenshot spec database.
-DEFAULT_SPEC_DB = os.path.join(_repo_root, 'docs', 'screenshots')
+DEFAULT_SPEC_DB = os.path.join(_repo_root, "docs", "screenshots")
 
 # Root path where workspaces are defined.
 DEFAULT_WORKSPACE_ROOT = _repo_root

--- a/docs/dagit-screenshot/setup.py
+++ b/docs/dagit-screenshot/setup.py
@@ -5,7 +5,12 @@ setup(
     version="1!0+dev",
     author_email="hello@elementl.com",
     packages=find_packages(exclude=["dagit_screenshot_tests*"]),  # same as name
-    install_requires=["click>=6", "selenium", "pyyaml", "typing-extensions>=4"],  # external packages as dependencies
+    install_requires=[
+        "click>=6",
+        "selenium",
+        "pyyaml",
+        "typing-extensions>=4",
+    ],  # external packages as dependencies
     author="Elementl",
     license="Apache-2.0",
     description="Utility for taking automated screenshots from dagit",
@@ -21,5 +26,5 @@ setup(
         "console_scripts": [
             "dagit-screenshot = dagit_screenshot.cli:main",
         ]
-    }
+    },
 )

--- a/docs/scripts/pack_json.py
+++ b/docs/scripts/pack_json.py
@@ -75,7 +75,7 @@ def rewrite_relative_links(root: str, file_data: Dict[str, object]) -> None:
 def pack_directory_json(path_to_folder: str):
     root_data: Dict[str, Any] = {}
 
-    for (root, _, files) in os.walk(path_to_folder):
+    for root, _, files in os.walk(path_to_folder):
         for filename in files:
             if filename.endswith(".fjson"):
                 route = extract_route_from_path(path_to_folder, root, filename)


### PR DESCRIPTION
## Summary & Motivation

This tweaks `black` as invoked by `make black` so that it also includes the `docs` folder, which now includes some phyton code.

## How I Tested These Changes

BK
