### PR TITLE
DbtCliTask -> DbtCliInvocation

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/__init__.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/__init__.py
@@ -50,7 +50,7 @@ from .asset_decorator import dbt_assets as dbt_assets
 from .cli import (
     DbtCli as DbtCli,
     DbtCliEventMessage as DbtCliEventMessage,
-    DbtCliTask as DbtCliTask,
+    DbtCliInvocation as DbtCliInvocation,
     DbtManifest as DbtManifest,
     DbtManifestAssetSelection as DbtManifestAssetSelection,
 )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/__init__.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/__init__.py
@@ -6,7 +6,7 @@ from .resources import (
 from .resources_v2 import (
     DbtCli as DbtCli,
     DbtCliEventMessage as DbtCliEventMessage,
-    DbtCliTask as DbtCliTask,
+    DbtCliInvocation as DbtCliInvocation,
     DbtManifest as DbtManifest,
     DbtManifestAssetSelection as DbtManifestAssetSelection,
 )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources_v2.py
@@ -683,7 +683,7 @@ class DbtCliEventMessage:
 
 
 @dataclass
-class DbtCliTask:
+class DbtCliInvocation:
     """The representation of an invoked dbt command.
 
     Args:
@@ -709,7 +709,7 @@ class DbtCliTask:
         project_dir: Path,
         target_path: Path,
         raise_on_error: bool,
-    ) -> "DbtCliTask":
+    ) -> "DbtCliInvocation":
         # Attempt to take advantage of partial parsing. If there is a `partial_parse.msgpack` in
         # in the target folder, then copy it to the dynamic target path.
         #
@@ -965,7 +965,7 @@ class DbtCli(ConfigurableResource):
         raise_on_error: bool = True,
         manifest: DbtManifest,
         context: Optional[OpExecutionContext] = None,
-    ) -> DbtCliTask:
+    ) -> DbtCliInvocation:
         """Execute a dbt command.
 
         Args:
@@ -975,7 +975,7 @@ class DbtCli(ConfigurableResource):
             context (Optional[OpExecutionContext]): The execution context.
 
         Returns:
-            DbtCliTask: A task that can be used to retrieve the output of the dbt CLI command.
+            DbtCliInvocation: A task that can be used to retrieve the output of the dbt CLI command.
 
         Examples:
             .. code-block:: python
@@ -1029,7 +1029,7 @@ class DbtCli(ConfigurableResource):
         args = ["dbt"] + self.global_config + args + profile_args + selection_args
         project_dir = Path(self.project_dir).resolve(strict=True)
 
-        return DbtCliTask.run(
+        return DbtCliInvocation.run(
             args=args,
             env=env,
             manifest=manifest,


### PR DESCRIPTION
## Summary & Motivation

This PR renames `DbtCliTask` to `DbtCliInvocation`.  The thinking here is that "task" is a loaded term in orchestration, and it often refers to "something that can be executed" rather than "the result of a particular invocation".

## How I Tested These Changes
