### PR TITLE
DbtCli.global_config -> global_config_flags

### DIFF
--- a/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/__init__.py
+++ b/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/__init__.py
@@ -13,7 +13,7 @@ defs = Definitions(
     resources={
         "dbt": DbtCli(
             project_dir=DBT_PROJECT_DIR,
-            global_config=["--no-use-colors"],
+            global_config_flags=["--no-use-colors"],
             profile="jaffle_shop",
             target="dev",
         ),

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources_v2.py
@@ -887,7 +887,7 @@ class DbtCli(ConfigurableResource):
         project_dir (Path): The path to the dbt project directory. This directory should contain a
             `dbt_project.yml`. See https://docs.getdbt.com/reference/dbt_project.yml for more
             information.
-        global_config (List[str]): A list of global flags configuration to pass to the dbt CLI
+        global_config_flags (List[str]): A list of global flags configuration to pass to the dbt CLI
             invocation. See https://docs.getdbt.com/reference/global-configs for a full list of
             configuration.
         profile (Optional[str]): The profile from your dbt `profiles.yml` to use for execution. See
@@ -904,7 +904,7 @@ class DbtCli(ConfigurableResource):
 
             dbt = DbtCli(
                 project_dir="/path/to/dbt/project",
-                global_config=["--no-use-colors"],
+                global_config_flags=["--no-use-colors"],
                 profile="jaffle_shop",
                 target="dev",
             )
@@ -918,7 +918,7 @@ class DbtCli(ConfigurableResource):
             " information."
         ),
     )
-    global_config: List[str] = Field(
+    global_config_flags: List[str] = Field(
         default=[],
         description=(
             "A list of global flags configuration to pass to the dbt CLI invocation. See"
@@ -1026,7 +1026,7 @@ class DbtCli(ConfigurableResource):
         if self.target:
             profile_args += ["--target", self.target]
 
-        args = ["dbt"] + self.global_config + args + profile_args + selection_args
+        args = ["dbt"] + self.global_config_flags + args + profile_args + selection_args
         project_dir = Path(self.project_dir).resolve(strict=True)
 
         return DbtCliTask.run(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_resources_v2.py
@@ -22,15 +22,15 @@ manifest_path = f"{TEST_PROJECT_DIR}/manifest.json"
 manifest = DbtManifest.read(path=manifest_path)
 
 
-@pytest.mark.parametrize("global_config", [[], ["--debug"]])
+@pytest.mark.parametrize("global_config_flags", [[], ["--debug"]])
 @pytest.mark.parametrize("command", ["run", "parse"])
-def test_dbt_cli(global_config: List[str], command: str) -> None:
-    dbt = DbtCli(project_dir=TEST_PROJECT_DIR, global_config=global_config)
+def test_dbt_cli(global_config_flags: List[str], command: str) -> None:
+    dbt = DbtCli(project_dir=TEST_PROJECT_DIR, global_config_flags=global_config_flags)
     dbt_cli_task = dbt.cli([command], manifest=manifest)
 
     dbt_cli_task.wait()
 
-    assert dbt_cli_task.process.args == ["dbt", *global_config, command]
+    assert dbt_cli_task.process.args == ["dbt", *global_config_flags, command]
     assert dbt_cli_task.is_successful()
     assert dbt_cli_task.process.returncode == 0
 


### PR DESCRIPTION
## Summary & Motivation

I'm aiming to remove the experimental label from DbtCli, which will allow me to start switching over the tutorial. As a precursor to this, I did a final review of the API. The only thing that came up was that I found the name `global_config` to be a tiny bit confusing - I thought it make accept a dictionary of config key value pairs, when in fact it accepts a list of command line flags.  If I understand correctly from the [dbt documentation](https://docs.getdbt.com/reference/global-configs/command-line-flags), flags are one way to set dbt global config, and this particular API sets flags.

## How I Tested These Changes
