### PR TITLE
[pythonic resources] Error if extra params passed to Config or ConfigurableResources

### DIFF
--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_general_pythonic_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_general_pythonic_resources.py
@@ -1082,3 +1082,11 @@ def test_telemetry_dagster_resource():
             return True
 
     assert MyResource(my_value="foo")._is_dagster_maintained()  # noqa: SLF001
+
+
+def test_err_extra_params() -> None:
+    class MyResource(ConfigurableResource):
+        my_value: str
+
+    with pytest.raises(ValidationError):
+        MyResource(my_value="foo", extra_param="bar")


### PR DESCRIPTION
## Summary

Introduces the pydantic extra param "forbidden" flag and ensures that extra values are passed through to Pydantic so an error is thrown in the case that extra params are passed to the constructor of a Config or ConfigurableResouce class

## Test Plan

Unit test.
