### PR TITLE
[dbt tutorial] use vanilla jaffle shop in first section

### DIFF
--- a/docs/content/integrations/dbt/using-dbt-with-dagster.mdx
+++ b/docs/content/integrations/dbt/using-dbt-with-dagster.mdx
@@ -32,6 +32,8 @@ By the end of this tutorial, you will:
 
 To complete this tutorial, you'll need:
 
+- **To have [git](https://en.wikipedia.org/wiki/Git) installed**. If it's not installed already (find out by typing `git` in your terminal), you can install it using the [intructions on the git website](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git).
+
 - **To install dbt, Dagster, and the Dagster webserver/UI**. Run the following to install everything using pip:
 
   ```shell
@@ -39,28 +41,6 @@ To complete this tutorial, you'll need:
   ```
 
   Refer to the [dbt](https://docs.getdbt.com/dbt-cli/install/overview) and [Dagster](/getting-started/install) installation docs for more info.
-
-- **To download the [`tutorial_dbt_dagster`](https://github.com/dagster-io/dagster/tree/master/examples/tutorial_dbt_dagster) Dagster example.** We'll walk you through this in the first step. This example includes:
-
-  - **dbt's example [jaffle shop project](https://github.com/dbt-labs/jaffle_shop).** You can follow along using a different dbt project, but you won't be able to use the code examples in this tutorial as-is.
-
-  - **A blank template version of the tutorial project**, which you can use to follow along with the tutorial.
-
-  - **A finished version of the tutorial project,** which you can use to check out the final version of the work you'll do in the tutorial.
-
-  - **Dependencies for the following libraries**:
-
-    - **dagster-dbt.** This library allows you to integrate dbt with Dagster.
-
-    - **dbt-duckdb.** This tutorial uses [DuckDB](https://docs.getdbt.com/reference/warehouse-profiles/duckdb-profile) as the database backing dbt.
-
-    - **dagster-duckdb.** This library provides a resource that enables the materialization of Dagster assets as DuckDB tables.
-
-    - **dagster-duckdb-pandas.** This library allows you to store pandas DataFrames in DuckDB.
-
-    - **pandas.** This tutorial uses [pandas](https://pandas.pydata.org/docs/index.html) to fetch raw data.
-
-    - **plotly.** This tutorial uses [plotly](https://plotly.com/python/) to create a histogram asset.
 
 ---
 

--- a/docs/content/integrations/dbt/using-dbt-with-dagster/set-up-dbt-project.mdx
+++ b/docs/content/integrations/dbt/using-dbt-with-dagster/set-up-dbt-project.mdx
@@ -11,62 +11,53 @@ description: Dagster can orchestrate dbt alongside other technologies.
   tutorial.
 </Note>
 
-First, you'll download Dagster's `tutorial_dbt_dagster` example and configure the dbt project it contains. This example uses dbt's [jaffle shop project](https://github.com/dbt-labs/jaffle_shop), but you can follow along with a different project as well.
+The first part of this tutorial doesn't involve Dagster at all. You'll get a dbt project running on your computer.
 
 In this part, you'll:
 
-- [Download the `tutorial_dbt_dagster` example](#step-1-download-the-tutorial_dbt_dagster-example)
-- [Create a profile](#step-2-create-a-profile)
-- [Configure dbt model data sources](#step-3-configure-dbt-model-data-sources)
+- [Download a dbt project](#step-1-download-the-sample-dbt-project)
+- [Configure your dbt project to run with DuckDB](#step-2-configure-your-dbt-project-to-run-with-duckdb)
+- [Build your dbt project](#step-3-build-your-dbt-project)
 
 ---
 
-## Step 1: Download the tutorial_dbt_dagster example
+## Step 1: Download the sample dbt project
 
-Let's get started by downloading the [`tutorial_dbt_dagster` example](https://github.com/dagster-io/dagster/tree/master/examples/tutorial_dbt_dagster).
+Let's get started by downloading a sample dbt project. We'll use the standard dbt [Jaffle Shop](https://github.com/dbt-labs/jaffle_shop) example.
 
-1. In the terminal, run the following to download the example:
+1. First, create a folder that will ultimately contain both your dbt project and Dagster code.
 
-   ```shell
-   dagster project from-example --name tutorial_dbt_dagster --example tutorial_dbt_dagster
+  ```shell
+   mkdir tutorial-dbt-dagster
    ```
 
-2. Navigate into the `tutorial_dbt_dagster` folder:
+2. Then, navigate into that folder:
 
    ```shell
-   cd tutorial_dbt_dagster
+   cd tutorial-dbt-dagster
    ```
 
-3. Run the following to install the project's dependencies:
+3. Finally, download the sample dbt project into that folder.
 
    ```shell
-   pip install -e ".[dev]"
+   git clone https://github.com/dbt-labs/jaffle_shop.git
    ```
 
 ---
 
-## Step 2: Create a profile
+## Step 2: Configure your dbt project to run with DuckDB
 
-<Note>
-  We assume you use DuckDB as your data warehouse in order to run the tutorial
-  entirely locally. If you plan on using a different data warehouse in
-  production, that's totally fine: Dagster can orchestrate dbt regardless of
-  what profile is configured. For example, we support dbt profiles for{" "}
-  <a href="https://docs.getdbt.com/reference/warehouse-setups/bigquery-setup">
-    BigQuery
-  </a>
-  , <a href="https://docs.getdbt.com/reference/warehouse-setups/redshift-setup">
-    Redshift
-  </a>, <a href="https://docs.getdbt.com/reference/warehouse-setups/snowflake-setup">
-    Snowflake
-  </a>, and more.
-</Note>
+Running dbt requires a data warehouse to store the tables that are created from the dbt models. For our data warehouse, we'll use DuckDB, because setting it up doesn't require any long-running services or external infrastructure.
 
-In this step, you'll add a profile to the dbt project. Profiles in dbt allow you to connect dbt to a database - in this case, that's DuckDB.
+You'll set up dbt to work with DuckDB by configuring a dbt [profile](https://docs.getdbt.com/docs/core/connect-data-platform/connection-profiles):
 
-1. Open the `profiles.yml` file, located in `/tutorial_template/jaffle_shop/config`.
+1. Navigate into the `jaffle_shop` folder, which was created when you downloaded the project, inside your `tutorial-dbt-dagster` folder:
 
-2. Add the following code to the file:
+  ```shell
+  cd jaffle_shop
+  ```
+
+2. In this folder, with your text editor of choice, create a file named `profiles.yml` and add the following code to it:
 
    ```yaml
    jaffle_shop:
@@ -80,46 +71,15 @@ In this step, you'll add a profile to the dbt project. Profiles in dbt allow you
 
 ---
 
-## Step 3: Configure dbt model data sources
+## Step 3: Build your dbt project
 
-Next, you'll tell the dbt models where their source data will be located. There isn't any data yet - we'll create Dagster assets that fetch and provide data to the dbt models later in the tutorial.
+With the profile configured above, your dbt project should now be usable. To test it out, run:
 
-In dbt, [sources are declared](https://docs.getdbt.com/docs/building-a-dbt-project/using-sources#declaring-a-source) using `sources.yml` files. We've provided this file for you in `/tutorial_template/jaffle_shop/models`, which defines the location of tables containing source data:
-
-```yaml
-version: 2
-
-sources:
-  - name: jaffle_shop
-    tables:
-      - name: orders_raw
-      - name: customers_raw
+```shell
+dbt build
 ```
 
-The Dagster assets you build in [part three of this tutorial](/integrations/dbt/using-dbt-with-dagster/upstream-assets) will create `orders_raw` and `customers_raw` tables when materialized. To have the models select data from these tables, you'll need to update the models.
-
-In `/tutorial_template/jaffle_shop/models`, update the `stg_customers.sql` and `stg_orders.sql` models to use the [`{{ source()}}` function](https://docs.getdbt.com/reference/dbt-jinja-functions/source). This function tells the dbt model to select data from the defined source. In this example, that's the `customers_raw` and `orders_raw` tables in the DuckDB database:.
-
-1. In `stg_customers.sql`, replace its contents with the following:
-
-   ```sql
-   select
-       id as customer_id,
-       first_name,
-       last_name
-   from {{ source('jaffle_shop', 'customers_raw') }}
-   ```
-
-2. In `stg_orders.sql`, replace its contents with the following:
-
-   ```sql
-   select
-       id as order_id,
-       user_id as customer_id,
-       order_date,
-       status
-   from {{ source('jaffle_shop', 'orders_raw') }}
-   ```
+This will run all the models, seeds, and snapshots in the project and store a set of tables in your DuckDB database.
 
 ---
 


### PR DESCRIPTION
## Summary & Motivation

This PR is not independently mergeable, because downstream sections in the tutorial need to be updated to be consistent here.

Prior to this PR, the dbt tutorial asks the user to download a tutorial-specific scaffold that includes both a dbt project and an accompany Dagster project.  This PR updates the first section of the dbt tutorial to instead start with the vanilla dbt jaffle shop project, and doesn't scaffold any Dagster code.  The idea of this change is that separating the dbt setup steps from the Dagster setup steps will make it easier for users to learn how to set up Dagster with an existing dbt project.  I.e. they can essentially skip this section if they already have a working dbt project.

The followup tutorial work depends on @rexledesma adding `dagster-dbt project scaffold`, which the second section of the tutorial can then take advantage of.

## How I Tested These Changes
