### PR TITLE
Support partition_key_range for build_op_context, build_asset_context

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -1288,6 +1288,7 @@ def _build_invocation_context_with_included_resources(
             resources_config=context._resources_config,  # noqa: SLF001
             instance=context._instance,  # noqa: SLF001
             partition_key=context._partition_key,  # noqa: SLF001
+            partition_key_range=context._partition_key_range,  # noqa: SLF001
             mapping_key=context._mapping_key,  # noqa: SLF001
             _assets_def=assets_def,
         )

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -263,12 +263,24 @@ class OpExecutionContext(AbstractComputeExecutionContext):
         """
         return self._step_execution_context.partition_key
 
+    @deprecated
     @public
     @property
     def asset_partition_key_range(self) -> PartitionKeyRange:
-        """The asset partition key for the current run.
+        """The range of partition keys for the current run. (DEPRECATED: Use `partition_key_range` instead).
 
-        Raises an error if the current run is not a partitioned run.
+        If run is for a single partition key, return a `PartitionKeyRange` with the same start and
+        end. Raises an error if the current run is not a partitioned run.
+        """
+        return self.partition_key_range
+
+    @public
+    @property
+    def partition_key_range(self) -> PartitionKeyRange:
+        """The range of partition keys for the current run.
+
+        If run is for a single partition key, return a `PartitionKeyRange` with the same start and
+        end. Raises an error if the current run is not a partitioned run.
         """
         return self._step_execution_context.asset_partition_key_range
 


### PR DESCRIPTION
## Summary & Motivation

Fixes #14990.

- Adds `OpExecutionContext.partition_key_range` and deprecates `OpExecutionContext.asset_partition_key_range`
- Fix docstring of `OpExecutionContext.asset_partition_key_range`
- Allows passing `partition_key_range` directly to `build_op_context` and `build_asset_context` (which sets it directly on `UnboundExecutionContext`)-- this allows testing of ops with `partition_key_range`.

I can revert the rename of `asset_partition_key_range` if necessary, but IMO it should be done for consistency with the other partition key methods (`.partition_key` and `.partition_time_window`).

## How I Tested These Changes

Add new unit test.
