### PR TITLE
feat(dbt): allow `DbtManifest` to be created from `os.PathLike`

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources_v2.py
@@ -78,11 +78,11 @@ class DbtManifest:
     raw_manifest: Mapping[str, Any]
 
     @classmethod
-    def read(cls, path: str) -> "DbtManifest":
+    def read(cls, path: Union[str, os.PathLike]) -> "DbtManifest":
         """Read the file path to a dbt manifest and create a DbtManifest object.
 
         Args:
-            path(str): The path to the dbt manifest.json file.
+            path(Union[str, os.PathLike]): The path to the dbt manifest.json file.
 
         Returns:
             DbtManifest: A DbtManifest object.
@@ -884,7 +884,7 @@ class DbtCli(ConfigurableResource):
     """A resource used to execute dbt CLI commands.
 
     Attributes:
-        project_dir (Path): The path to the dbt project directory. This directory should contain a
+        project_dir (str): The path to the dbt project directory. This directory should contain a
             `dbt_project.yml`. See https://docs.getdbt.com/reference/dbt_project.yml for more
             information.
         global_config_flags (List[str]): A list of global flags configuration to pass to the dbt CLI

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_asset_selection.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_asset_selection.py
@@ -1,13 +1,13 @@
+from pathlib import Path
 from typing import Optional, Set
 
 import pytest
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.events import AssetKey
-from dagster._utils import file_relative_path
 from dagster_dbt.asset_decorator import dbt_assets
 from dagster_dbt.cli.resources_v2 import DbtManifest
 
-manifest_path = file_relative_path(__file__, "../sample_manifest.json")
+manifest_path = Path(__file__).parent.joinpath("..", "sample_manifest.json")
 manifest = DbtManifest.read(path=manifest_path)
 
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_resources_v2.py
@@ -18,7 +18,7 @@ from ..conftest import TEST_PROJECT_DIR
 pytest.importorskip("dbt.version", minversion="1.4")
 
 
-manifest_path = f"{TEST_PROJECT_DIR}/manifest.json"
+manifest_path = Path(TEST_PROJECT_DIR).joinpath("manifest.json")
 manifest = DbtManifest.read(path=manifest_path)
 
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_schedules.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_schedules.py
@@ -1,12 +1,12 @@
+from pathlib import Path
 from typing import Mapping, Optional
 
 import pytest
 from dagster import RunConfig
 from dagster._core.definitions.unresolved_asset_job_definition import UnresolvedAssetJobDefinition
-from dagster._utils import file_relative_path
 from dagster_dbt.cli.resources_v2 import DbtManifest, DbtManifestAssetSelection
 
-manifest_path = file_relative_path(__file__, "../sample_manifest.json")
+manifest_path = Path(__file__).parent.joinpath("..", "sample_manifest.json")
 manifest = DbtManifest.read(path=manifest_path)
 
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_decorator.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import AbstractSet, Any, Mapping, Optional
 
 import pytest
@@ -7,17 +8,16 @@ from dagster import (
     DailyPartitionsDefinition,
     FreshnessPolicy,
     PartitionsDefinition,
-    file_relative_path,
 )
 from dagster._core.definitions.utils import DEFAULT_IO_MANAGER_KEY
 from dagster_dbt.asset_decorator import dbt_assets
 from dagster_dbt.cli import DbtManifest
 
-manifest_path = file_relative_path(__file__, "sample_manifest.json")
+manifest_path = Path(__file__).parent.joinpath("sample_manifest.json")
 manifest = DbtManifest.read(path=manifest_path)
 
-test_dagster_metadata_manifest_path = file_relative_path(
-    __file__, "dbt_projects/test_dagster_metadata/manifest.json"
+test_dagster_metadata_manifest_path = Path(__file__).parent.joinpath(
+    "dbt_projects", "test_dagster_metadata", "manifest.json"
 )
 test_dagster_metadata_manifest = DbtManifest.read(path=test_dagster_metadata_manifest_path)
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_dependencies.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_dependencies.py
@@ -1,15 +1,16 @@
+from pathlib import Path
+
 import pytest
 from dagster import (
     AssetKey,
     asset,
-    file_relative_path,
 )
 from dagster._core.errors import DagsterInvalidInvocationError
 from dagster_dbt.asset_decorator import dbt_assets
 from dagster_dbt.cli import DbtManifest
 
 test_dagster_metadata_manifest = DbtManifest.read(
-    path=file_relative_path(__file__, "dbt_projects/test_dagster_metadata/manifest.json")
+    path=Path(__file__).parent.joinpath("dbt_projects", "test_dagster_metadata", "manifest.json")
 )
 
 


### PR DESCRIPTION
## Summary & Motivation
This is needed to divest from `file_relative_path` in the dbt scaffold.

## How I Tested These Changes
pytest
