### PR TITLE
Fixup setting repository credentials in task defn

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/container_context.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/container_context.py
@@ -284,7 +284,9 @@ class EcsContainerContext(
             ),
             server_ecs_tags=check.opt_sequence_param(server_ecs_tags, "server_ecs_tags"),
             run_ecs_tags=check.opt_sequence_param(run_ecs_tags, "run_tags"),
-            repository_credentials=check.opt_str_param(repository_credentials, "repository_credentials"),
+            repository_credentials=check.opt_str_param(
+                repository_credentials, "repository_credentials"
+            ),
         )
 
     def merge(self, other: "EcsContainerContext") -> "EcsContainerContext":
@@ -339,7 +341,7 @@ class EcsContainerContext(
                     volumes=run_launcher.volumes,
                     run_sidecar_containers=run_launcher.run_sidecar_containers,
                     run_ecs_tags=run_launcher.run_ecs_tags,
-                    repository_credentials=run_launcher.repository_credentials
+                    repository_credentials=run_launcher.repository_credentials,
                 )
             )
 

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -214,7 +214,7 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
         return self.task_definition_dict.get("volumes")
 
     @property
-    def repository_credentials(self) -> Optional[Sequence[Mapping[str, Any]]]:
+    def repository_credentials(self) -> Optional[str]:
         if not self.task_definition_dict:
             return None
         return self.task_definition_dict.get("repository_credentials")

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -79,7 +79,6 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
         run_task_kwargs: Optional[Mapping[str, Any]] = None,
         run_resources: Optional[Dict[str, Any]] = None,
         run_ecs_tags: Optional[List[Dict[str, Optional[str]]]] = None,
-        repository_credentials: Optional[str] = None,
     ):
         self._inst_data = inst_data
         self.ecs = boto3.client("ecs")
@@ -110,10 +109,6 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
             self.task_definition_dict = task_definition or {}
 
         self.container_name = container_name
-
-        self.repository_credentials = check.opt_str_param(
-            repository_credentials, "repository_credentials"
-        )
 
         self.secrets = check.opt_list_param(secrets, "secrets")
 
@@ -217,6 +212,12 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
         if not self.task_definition_dict:
             return None
         return self.task_definition_dict.get("volumes")
+
+    @property
+    def repository_credentials(self) -> Optional[Sequence[Mapping[str, Any]]]:
+        if not self.task_definition_dict:
+            return None
+        return self.task_definition_dict.get("repository_credentials")
 
     @property
     def run_sidecar_containers(self) -> Optional[Sequence[Mapping[str, Any]]]:

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -111,8 +111,10 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
 
         self.container_name = container_name
 
-        self.repository_credentials = check.opt_str_param(repository_credentials, "repository_credentials")
-        
+        self.repository_credentials = check.opt_str_param(
+            repository_credentials, "repository_credentials"
+        )
+
         self.secrets = check.opt_list_param(secrets, "secrets")
 
         self.env_vars = check.opt_list_param(env_vars, "env_vars")

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/tasks.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/tasks.py
@@ -99,7 +99,15 @@ class DagsterEcsTaskDefinitionConfig(
                     ({"secrets": self.secrets} if self.secrets else {}),
                     ({"environment": self.environment} if self.environment else {}),
                     ({"mountPoints": self.mount_points} if self.mount_points else {}),
-                    ({"repositoryCredentials": { "credentialsParameter": self.repository_credentials }} if self.repository_credentials else {}),
+                    (
+                        {
+                            "repositoryCredentials": {
+                                "credentialsParameter": self.repository_credentials
+                            }
+                        }
+                        if self.repository_credentials
+                        else {}
+                    ),
                 ),
                 *self.sidecars,
             ],
@@ -161,7 +169,9 @@ class DagsterEcsTaskDefinitionConfig(
             runtime_platform=task_definition_dict.get("runtimePlatform"),
             mount_points=container_definition.get("mountPoints"),
             volumes=task_definition_dict.get("volumes"),
-            repository_credentials=container_definition.get("repositoryCredentials", {}).get("credentialsParameter"),
+            repository_credentials=container_definition.get("repositoryCredentials", {}).get(
+                "credentialsParameter"
+            ),
         )
 
 
@@ -244,7 +254,11 @@ def get_task_definition_dict_from_current_task(
         "image": image,
         "entryPoint": [],
         "command": command if command else [],
-        **({"repositoryCredentials": {"credentialsParameter": repository_credentials} } if repository_credentials else {}),
+        **(
+            {"repositoryCredentials": {"credentialsParameter": repository_credentials}}
+            if repository_credentials
+            else {}
+        ),
         **({"secrets": secrets} if secrets else {}),
         **({} if include_sidecars else {"dependsOn": []}),
     }

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
@@ -685,7 +685,7 @@ def test_launching_with_task_definition_dict(ecs, instance_cm, run, workspace, j
         }
     ]
 
-    repository_credentials = ("fake-secret-arn",)
+    repository_credentials = "fake-secret-arn"
 
     # You can provide a family or a task definition ARN
     with instance_cm(

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
@@ -685,7 +685,7 @@ def test_launching_with_task_definition_dict(ecs, instance_cm, run, workspace, j
         }
     ]
 
-    repository_credentials = "fake-secret-arn",
+    repository_credentials = ("fake-secret-arn",)
 
     # You can provide a family or a task definition ARN
     with instance_cm(
@@ -741,7 +741,10 @@ def test_launching_with_task_definition_dict(ecs, instance_cm, run, workspace, j
         container_definition = task_definition["containerDefinitions"][0]
         assert container_definition["mountPoints"] == mount_points
 
-        assert container_definition["repositoryCredentials"]["credentialsParameter"] == repository_credentials
+        assert (
+            container_definition["repositoryCredentials"]["credentialsParameter"]
+            == repository_credentials
+        )
 
         assert [container["name"] for container in task_definition["containerDefinitions"]] == [
             container_name,
@@ -981,7 +984,10 @@ def test_launch_run_with_container_context(
 
     assert container_definition["mountPoints"] == container_context_config["ecs"]["mount_points"]
 
-    assert container_definition["repositoryCredentials"]["credentialsParameter"] == container_context_config["ecs"]["repository_credentials"]
+    assert (
+        container_definition["repositoryCredentials"]["credentialsParameter"]
+        == container_context_config["ecs"]["repository_credentials"]
+    )
 
     sidecar_container = task_definition["containerDefinitions"][1]
     assert sidecar_container["name"] == "busyrun"


### PR DESCRIPTION
The original PR correctly set and tested repository credentials that
were passed via container context.

But things weren't quite right when passing a task definition dict. This
updates the test and implementation to pull repository credentials off
of the task definition dict much like we do for volumes and other
similar customizable config.