### PR TITLE
[telemetry] remove stringify of list of resources that was causing JSON failures

### DIFF
--- a/python_modules/dagster/dagster/_core/telemetry.py
+++ b/python_modules/dagster/dagster/_core/telemetry.py
@@ -562,7 +562,7 @@ def get_resource_stats(external_resources: Sequence["ExternalResource"]) -> Mapp
 
     return {
         "dagster_resources": used_dagster_resources,
-        "has_custom_resources": used_custom_resources,
+        "has_custom_resources": str(used_custom_resources),
     }
 
 

--- a/python_modules/dagster/dagster/_core/telemetry.py
+++ b/python_modules/dagster/dagster/_core/telemetry.py
@@ -545,7 +545,7 @@ def get_stats_from_external_repo(external_repo: "ExternalRepository") -> Mapping
     }
 
 
-def get_resource_stats(external_resources: Sequence["ExternalResource"]) -> Mapping[str, str]:
+def get_resource_stats(external_resources: Sequence["ExternalResource"]) -> Mapping[str, Any]:
     used_dagster_resources = []
     used_custom_resources = False
 
@@ -561,8 +561,8 @@ def get_resource_stats(external_resources: Sequence["ExternalResource"]) -> Mapp
             used_custom_resources = True
 
     return {
-        "dagster_resources": str(used_dagster_resources),
-        "has_custom_resources": str(used_custom_resources),
+        "dagster_resources": used_dagster_resources,
+        "has_custom_resources": used_custom_resources,
     }
 
 

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_telemetry.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_telemetry.py
@@ -394,10 +394,9 @@ def test_get_stats_from_external_repo_resources():
         repository_handle=MagicMock(spec=RepositoryHandle),
     )
     stats = get_stats_from_external_repo(external_repo)
-    assert (
-        stats["dagster_resources"]
-        == "[{'module_name': 'dagster_tests', 'class_name': 'MyResource'}]"
-    )
+    assert stats["dagster_resources"] == [
+        {"module_name": "dagster_tests", "class_name": "MyResource"}
+    ]
     assert stats["has_custom_resources"] == "True"
 
 
@@ -441,10 +440,9 @@ def test_get_stats_from_external_repo_io_managers():
         repository_handle=MagicMock(spec=RepositoryHandle),
     )
     stats = get_stats_from_external_repo(external_repo)
-    assert (
-        stats["dagster_resources"]
-        == "[{'module_name': 'dagster_tests', 'class_name': 'MyIOManager'}]"
-    )
+    assert stats["dagster_resources"] == [
+        {"module_name": "dagster_tests", "class_name": "MyIOManager"}
+    ]
     assert stats["has_custom_resources"] == "True"
 
 
@@ -475,10 +473,9 @@ def test_get_stats_from_external_repo_functional_resources():
         repository_handle=MagicMock(spec=RepositoryHandle),
     )
     stats = get_stats_from_external_repo(external_repo)
-    assert (
-        stats["dagster_resources"]
-        == "[{'module_name': 'dagster_tests', 'class_name': 'my_resource'}]"
-    )
+    assert stats["dagster_resources"] == [
+        {"module_name": "dagster_tests", "class_name": "my_resource"}
+    ]
     assert stats["has_custom_resources"] == "True"
 
 
@@ -509,10 +506,9 @@ def test_get_stats_from_external_repo_functional_io_managers():
         repository_handle=MagicMock(spec=RepositoryHandle),
     )
     stats = get_stats_from_external_repo(external_repo)
-    assert (
-        stats["dagster_resources"]
-        == "[{'module_name': 'dagster_tests', 'class_name': 'my_io_manager'}]"
-    )
+    assert stats["dagster_resources"] == [
+        {"module_name": "dagster_tests", "class_name": "my_io_manager"}
+    ]
     assert stats["has_custom_resources"] == "True"
 
 
@@ -570,13 +566,12 @@ def test_get_stats_from_external_repo_delayed_resource_configuration():
         repository_handle=MagicMock(spec=RepositoryHandle),
     )
     stats = get_stats_from_external_repo(external_repo)
-    assert (
-        stats["dagster_resources"]
-        == "[{'module_name': 'dagster_tests', 'class_name': 'MyIOManager'}, {'module_name':"
-        " 'dagster_tests', 'class_name': 'my_io_manager'}, {'module_name': 'dagster_tests',"
-        " 'class_name': 'my_resource'}, {'module_name': 'dagster_tests', 'class_name':"
-        " 'MyResource'}]"
-    )
+    assert stats["dagster_resources"] == [
+        {"module_name": "dagster_tests", "class_name": "MyIOManager"},
+        {"module_name": "dagster_tests", "class_name": "my_io_manager"},
+        {"module_name": "dagster_tests", "class_name": "my_resource"},
+        {"module_name": "dagster_tests", "class_name": "MyResource"},
+    ]
     assert stats["has_custom_resources"] == "False"
 
 


### PR DESCRIPTION
## Summary & Motivation
dagster v 1.3.10 introduced a telemetry error with the new resources telemetry https://github.com/dagster-io/dagster/pull/14615

the resulting telemetry string was improperly formatted, causing the JSON parsing to fail

Example of a bad string

```
'{"dagster_resources": "[{"module_name": "dagster_gcp_pandas", "class_name": "BigQueryPandasIOManager"}, {"module_name": "dagster", "class_name": "FilesystemIOManager"}]", "has_custom_resources": "False"}'
the "[ and ]" characters caused the failure, and replacing them with [ and ] makes the JSON parsing work.
```

Example of the fixed string

```
'{"dagster_resources": [{"module_name": "dagster_gcp_pandas", "class_name": "BigQueryPandasIOManager"}, {"module_name": "dagster", "class_name": "FilesystemIOManager"}], "has_custom_resources": "False"}'
```

This PR doesn't stringify the list of resource metadata, so it shouldn't cause the json parsing issue anymore

## How I Tested These Changes

Saved the following telemetry event in a file. The event was generated by running `project_fully_featured` and capturing telemetry locally
```
{"action": "update_repo_stats", "client_time": "2023-07-10 16:29:18.240028", "event_id": "b165a662-cadc-4675-bc9a-6cfd2da08e2c", "elapsed_time": "", "instance_id": "8f2f3c13-4efd-4974-bde7-fa5c432c30d6", "metadata": {"dagster_resources": [{"module_name": "dagster_dbt", "class_name": "DbtCliClientResource"}], "has_custom_resources": "True", "num_pipelines_in_repo": "4", "num_schedules_in_repo": "1", "num_sensors_in_repo": "2", "num_assets_in_repo": "12", "num_source_assets_in_repo": "0", "num_partitioned_assets_in_repo": "3", "num_dynamic_partitioned_assets_in_repo": "0", "num_multi_partitioned_assets_in_repo": "0", "num_assets_with_freshness_policies_in_repo": "0", "num_assets_with_eager_auto_materialize_policies_in_repo": "0", "num_assets_with_lazy_auto_materialize_policies_in_repo": "0", "num_observable_source_assets_in_repo": "0", "num_dbt_assets_in_repo": "3", "num_assets_with_code_versions_in_repo": "3", "num_asset_reconciliation_sensors_in_repo": "0", "source": "dagit", "pipeline_name_hash": "", "repo_hash": "f17e9128abe12b4ff329425c469a7c5abc06bace32a2237848bc3a71cf9ef808", "location_name_hash": "b0f61aa60e1bed5c1d1e8794b103bfc05f0117110133cbd2b4a27aa873b0da2e"}, "python_version": "3.9.10", "dagster_version": "1!0+dev", "os_desc": "macOS-13.1-x86_64-i386-64bit", "os_platform": "Darwin", "run_storage_id": "", "is_known_ci_env": false}
```

then opened that file, and did the relevant portions of the `telemetry_events_snowflake` [job](https://github.com/dagster-io/internal/blob/master/python_modules/purina/purina/jobs/telemetry_infra/s3_to_snowflake.py) in purina. Specifically, reading the entire event as json, pulling out the metadata, replacing the ' with " in the metadata, and dumping it back to a string. then I ran a `json.loads` on the new metadata object to replicate the `PARSE_JSON` command in the Snowflake query to confirm that the new metadata could be read as json

```python
import json

with open("sample_telem.txt") as f:
    telem_string = f.read()

    # event is read as json https://github.com/dagster-io/internal/blob/master/python_modules/purina/purina/jobs/telemetry_infra/utils.py#L120 
    telem_json = json.loads(telem_string)

    # metadata is pulled out https://github.com/dagster-io/internal/blob/master/python_modules/purina/purina/jobs/telemetry_infra/utils.py#L63
    metadata = telem_json["metadata"]

   # in this case, since the metadata is fixed, we can skip the condition here https://github.com/dagster-io/internal/blob/master/python_modules/purina/purina/jobs/telemetry_infra/utils.py#L72

    # and go straight to the quote replacement https://github.com/dagster-io/internal/blob/master/python_modules/purina/purina/jobs/telemetry_infra/utils.py#L79
    formatted_json = json.dumps(metadata).replace("'", '"')

    # to mimic the PARSE_JSON in this query https://github.com/dagster-io/internal/blob/master/python_modules/purina/purina/jobs/telemetry_infra/s3_to_snowflake.py#L61
    json.loads(formatted_json)

```


