### PR TITLE
[docs] Dark launch Swiftype search

### DIFF
--- a/docs/next/components/Search.tsx
+++ b/docs/next/components/Search.tsx
@@ -1,4 +1,5 @@
 import {DocSearchModal, useDocSearchKeyboardEvents} from '@docsearch/react';
+import debounce from 'lodash/debounce';
 import Head from 'next/head';
 import Link from 'next/link';
 import {useCallback, useEffect, useRef, useState} from 'react';
@@ -22,9 +23,30 @@ function Hit({hit, children}) {
   return <a onClick={onClick}>{children}</a>;
 }
 
+// Set up docs search dark launch. As the user types into the search dialog input,
+// perform a debounced query to retrieve results.
+const handleDarkSearch = debounce(async (e: InputEvent) => {
+  const node = e.target;
+  if (node instanceof HTMLInputElement && node.closest('.search-container')) {
+    const query = node.value;
+    if (query) {
+      const response = await fetch('/api/search', {
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({query}),
+        method: 'POST',
+      });
+      if (process.env.NODE_ENV === 'development') {
+        const result = await response.json();
+        console.log(result);
+      }
+    }
+  }
+}, 300);
+
 export function Search() {
   const [isOpen, setIsOpen] = useState(false);
   const searchButtonRef = useRef();
+
   const [initialQuery, setInitialQuery] = useState(null);
   const [browserDetected, setBrowserDetected] = useState(false);
   const [actionKey, setActionKey] = useState(ACTION_KEY_DEFAULT);
@@ -52,6 +74,13 @@ export function Search() {
     onInput,
     searchButtonRef,
   });
+
+  useEffect(() => {
+    document.addEventListener('input', handleDarkSearch);
+    return () => {
+      document.removeEventListener('input', handleDarkSearch);
+    };
+  }, [isOpen]);
 
   useEffect(() => {
     if (typeof navigator !== 'undefined') {
@@ -116,66 +145,68 @@ export function Search() {
       </button>
       {isOpen &&
         createPortal(
-          <DocSearchModal
-            initialQuery={initialQuery}
-            initialScrollY={window.scrollY}
-            searchParameters={{
-              distinct: 1,
-            }}
-            onClose={onClose}
-            indexName={process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME}
-            apiKey={process.env.NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY}
-            appId={process.env.NEXT_PUBLIC_ALGOLIA_APP_ID}
-            navigator={{
-              navigate({itemUrl}) {
-                setIsOpen(false);
-                window.location.href = itemUrl;
-              },
-            }}
-            hitComponent={Hit}
-            transformItems={(items) => {
-              return items.map((item) => {
-                // We transform the absolute URL into a relative URL to
-                // leverage Next's preloading.
-                const a = document.createElement('a');
-                a.href = item.url;
+          <div className="search-container">
+            <DocSearchModal
+              initialQuery={initialQuery}
+              initialScrollY={window.scrollY}
+              searchParameters={{
+                distinct: 1,
+              }}
+              onClose={onClose}
+              indexName={process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME}
+              apiKey={process.env.NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY}
+              appId={process.env.NEXT_PUBLIC_ALGOLIA_APP_ID}
+              navigator={{
+                navigate({itemUrl}) {
+                  setIsOpen(false);
+                  window.location.href = itemUrl;
+                },
+              }}
+              hitComponent={Hit}
+              transformItems={(items) => {
+                return items.map((item) => {
+                  // We transform the absolute URL into a relative URL to
+                  // leverage Next's preloading.
+                  const a = document.createElement('a');
+                  a.href = item.url;
 
-                const hash = a.hash === '#content-wrapper' ? '' : a.hash;
+                  const hash = a.hash === '#content-wrapper' ? '' : a.hash;
 
-                let url = `${a.pathname}${hash}`;
+                  let url = `${a.pathname}${hash}`;
 
-                // Handle URLs for GitHub Discussions which are external links
-                if (a.pathname.startsWith('/dagster-io/dagster/discussions/')) {
-                  url = a.pathname.replace(
-                    '/dagster-io/dagster/discussions',
-                    'https://github.com/dagster-io/dagster/discussions',
-                  );
-                }
+                  // Handle URLs for GitHub Discussions which are external links
+                  if (a.pathname.startsWith('/dagster-io/dagster/discussions/')) {
+                    url = a.pathname.replace(
+                      '/dagster-io/dagster/discussions',
+                      'https://github.com/dagster-io/dagster/discussions',
+                    );
+                  }
 
-                return {
-                  ...item,
-                  url,
-                };
-              });
-            }}
-            resultsFooterComponent={({state}) => {
-              return (
-                <Link
-                  href={{
-                    pathname: '/searchpage',
-                    query: {query: encodeURIComponent(state.query)},
-                  }}
-                >
-                  <a
-                    onClick={() => setIsOpen(false)}
-                    className="justify-center flex mt-3 text-gray-500"
+                  return {
+                    ...item,
+                    url,
+                  };
+                });
+              }}
+              resultsFooterComponent={({state}) => {
+                return (
+                  <Link
+                    href={{
+                      pathname: '/searchpage',
+                      query: {query: encodeURIComponent(state.query)},
+                    }}
                   >
-                    See all {state.context.nbHits} search results
-                  </a>
-                </Link>
-              );
-            }}
-          />,
+                    <a
+                      onClick={() => setIsOpen(false)}
+                      className="justify-center flex mt-3 text-gray-500"
+                    >
+                      See all {state.context.nbHits} search results
+                    </a>
+                  </Link>
+                );
+              }}
+            />
+          </div>,
           document.body,
         )}
     </>

--- a/docs/next/package.json
+++ b/docs/next/package.json
@@ -33,6 +33,7 @@
     "fast-glob": "^3.2.5",
     "gray-matter": "^4.0.2",
     "image-size": "^0.9.7",
+    "lodash": "^4.17.21",
     "mdast-util-toc": "^5.1.0",
     "new-github-issue-url": "^0.2.1",
     "next": "12",

--- a/docs/next/pages/api/search.ts
+++ b/docs/next/pages/api/search.ts
@@ -1,0 +1,38 @@
+import {NextApiRequest, NextApiResponse} from 'next';
+
+const searchURI = process.env.SWIFTYPE_SEARCH_URI;
+const engineKey = process.env.SWIFTYPE_ENGINE_KEY;
+const maxQueryLength = parseInt(process.env.SWIFTYPE_MAX_QUERY_LENGTH, 10);
+
+export default async function handler(request: NextApiRequest, response: NextApiResponse) {
+  const {method} = request;
+  if (method !== 'POST') {
+    return response.status(400).json({data: 'Invalid request.'});
+  }
+
+  const {body} = request;
+  const query = `${body?.query || ''}`.trim().slice(0, maxQueryLength).toLowerCase();
+
+  if (!query) {
+    return response.status(400).json({data: 'Invalid query.'});
+  }
+
+  const options = {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      engine_key: engineKey,
+      q: query,
+    }),
+  };
+
+  const searchResponse = await fetch(searchURI, options);
+  const searchJSON = await searchResponse.json();
+
+  response.status(200).json({
+    query,
+    records: searchJSON.records,
+  });
+}

--- a/docs/next/yarn.lock
+++ b/docs/next/yarn.lock
@@ -5170,6 +5170,7 @@ __metadata:
     html-react-parser: ^2.0.0
     image-size: ^0.9.7
     jest: ^27.5.1
+    lodash: ^4.17.21
     mdast-util-toc: ^5.1.0
     new-github-issue-url: ^0.2.1
     next: 12


### PR DESCRIPTION
## Summary & Motivation

Begin testing Swiftype search by dark-launching queries, debounced in parallel to the existing search dialog UI. This should allow us to observe search quality without displaying anything new in the UI.

## How I Tested These Changes

In local development and preview deployment, perform a search via the search dialog. Verify that the query is debounced and sent to the `/api/search` serverless function, which proxies to Swiftype. Verify that the resulting records look good in the Network tab, and have no effect on the current UI.