### PR TITLE
Avoid creation of local directories by the GCS IO Manager

### DIFF
--- a/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/io_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/io_manager.py
@@ -58,6 +58,10 @@ class PickledObjectGCSIOManager(UPathIOManager):
     def _uri_for_path(self, path: UPath) -> str:
         return f"gs://{self.bucket}/{path}"
 
+    def make_directory(self, path: UPath) -> None:
+        # It is not necessary to create directories in GCP
+        return None
+
     def load_from_path(self, context: InputContext, path: UPath) -> Any:
         bytes_obj = self.bucket_obj.blob(str(path)).download_as_bytes()
         return pickle.loads(bytes_obj)


### PR DESCRIPTION
## Summary & Motivation

Prior to this change the underlying behaviour from the base `UPathIOManager` would be invoked when the user had configured the use of a GCS IO Manager. This would mostly result in the (perhaps innocuous) creation of local directories, however when running on a filesystem where the user does not have write access it would cause `IOError`s that would cause job runs to fail.

This change copies the approach taken in the AWS S3 IO Manager, as (just like S3) GCS doesn't really have the concept of directories and there is no need to try to create them (either locally or in the remote store).

## How I Tested These Changes

Validated by applying this fix on top of 1.3.12 and running with that in our cluster.

~Are there any unit tests I should be adding to?~