### PR TITLE
remove dbt Cloud callout from top of dbt integration page

### DIFF
--- a/docs/content/integrations/dbt.mdx
+++ b/docs/content/integrations/dbt.mdx
@@ -5,11 +5,6 @@ description: Dagster can orchestrate dbt alongside other technologies.
 
 # dbt + Dagster
 
-<Note>
-  Using dbt Cloud? Check out the{" "}
-  <a href="/integrations/dbt-cloud">dbt Cloud with Dagster guide</a>!
-</Note>
-
 Dagster orchestrates dbt alongside other technologies, so you can schedule dbt with Spark, Python, etc. in a single data pipeline.
 
 Dagster's [Software-defined Asset](/concepts/assets/software-defined-assets) approach allows Dagster to understand dbt at the level of individual dbt models. This means that you can:


### PR DESCRIPTION
## Summary & Motivation

Context: https://elementl-workspace.slack.com/archives/C05BF0CSC07/p1688596540672729

## How I Tested These Changes
