### PR TITLE
unexperimentalize DynamicPartitionsDefinition and SensorResult

### DIFF
--- a/docs/content/concepts/partitions-schedules-sensors/partitions.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/partitions.mdx
@@ -132,14 +132,6 @@ result = materialize(
 
 #### Dynamically partitioned assets
 
-<Experimental />
-
-<Note>
-  This feature is <strong>experimental</strong>. Until this feature is marked as
-  stable, further migrations may be required and partition history is not
-  guaranteed to be retained.
-</Note>
-
 Sometimes you don't know the set of partitions ahead of time when you're defining your assets. For example, maybe you want to add a new partition every time a new data file lands in a directory, or every time you want to experiment with a new set of hyperparameters. In these cases, you can use a <PyObject object="DynamicPartitionsDefinition"/>.
 
 The <PyObject object="DynamicPartitionsDefinition" /> class accepts a name argument, representing the name of the partition set:

--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -39,7 +39,6 @@ from dagster._utils import xor
 from dagster._utils.backcompat import (
     canonicalize_backcompat_args,
     deprecation_warning,
-    experimental_arg_warning,
 )
 from dagster._utils.cached_method import cached_method
 
@@ -390,7 +389,7 @@ class DynamicPartitionsDefinition(
     `instance.delete_dynamic_partition` methods.
 
     Args:
-        name (Optional[str]): (Experimental) The name of the partitions definition.
+        name (Optional[str]): The name of the partitions definition.
         partition_fn (Optional[Callable[[Optional[datetime]], Union[Sequence[Partition], Sequence[str]]]]):
             A function that returns the current set of partitions. This argument is deprecated and
             will be removed in 2.0.0.
@@ -417,9 +416,6 @@ class DynamicPartitionsDefinition(
     ):
         partition_fn = check.opt_callable_param(partition_fn, "partition_fn")
         name = check.opt_str_param(name, "name")
-
-        if name:
-            experimental_arg_warning("name", "DynamicPartitionsDefinition.__new__")
 
         if partition_fn:
             deprecation_warning(

--- a/python_modules/dagster/dagster/_core/definitions/run_request.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_request.py
@@ -3,7 +3,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any, Mapping, NamedTuple, Optional, Sequence, Set, Union, cast
 
 import dagster._check as check
-from dagster._annotations import PublicAttr, experimental
+from dagster._annotations import PublicAttr
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.utils import validate_tags
 from dagster._core.instance import DynamicPartitionsStore
@@ -341,7 +341,6 @@ class DagsterRunReaction(
         )
 
 
-@experimental
 class SensorResult(
     NamedTuple(
         "_SensorResult",


### PR DESCRIPTION
## Summary & Motivation

I actually forgot these were experimental until I noticed a user say they're not using them because they're marked as such: https://dagster.slack.com/archives/C01U5LFUZJS/p1685986062633069

A fair number of users rely on this functionality, and it receives few complaints.  Here are the areas where I could imagine changes happening in this realm:
- DynamicPartitionsDefinition names are currently deployment-scoped, like asset keys. This allows dynamically-partitioned pipelines to span code locations. I could also imagine situations where users would want to minimize the opportunity for collisions. Users have not brought this up yet.
- They don't yet work with dynamic mapping. Here's the issue where we're tracking this. I don't anticipate that this would require breaking changes to the above APIs.
- Some users have requested dynamic partition mappings. I don't anticipate that this would require breaking changes to the above APIs.

## How I Tested These Changes
