### PR TITLE
[ui] Auto-materialization: Repair "Before" item in left list

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AssetAutomaterializePolicyPage.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AssetAutomaterializePolicyPage.tsx
@@ -63,7 +63,7 @@ export const AssetAutomaterializePolicyPage = ({
   });
 
   const selectedEvaluation = React.useMemo(() => {
-    if (selectedEvaluationId) {
+    if (selectedEvaluationId !== undefined) {
       const found = evaluationsIncludingEmpty.find(
         (evaluation) => evaluation.evaluationId === selectedEvaluationId,
       );

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/__tests__/getEvaluationsWithEmptyAdded.test.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/__tests__/getEvaluationsWithEmptyAdded.test.tsx
@@ -1,5 +1,6 @@
 import {buildAutoMaterializeAssetEvaluationRecord} from '../../../graphql/types';
 import {getEvaluationsWithEmptyAdded} from '../getEvaluationsWithEmptyAdded';
+import {AutoMaterializeEvaluationRecordItemFragment} from '../types/GetEvaluationsQuery.types';
 
 describe('getEvaluationsWithEmptyAdded', () => {
   it('should return an empty array if isLoading is true', () => {
@@ -33,6 +34,50 @@ describe('getEvaluationsWithEmptyAdded', () => {
     });
 
     expect(actual).toEqual([]);
+  });
+
+  it('should return "no conditions met" before NOW if no evaluations yet', () => {
+    const evaluations: AutoMaterializeEvaluationRecordItemFragment[] = [];
+
+    const actual = getEvaluationsWithEmptyAdded({
+      evaluations,
+      currentEvaluationId: null,
+      isFirstPage: true,
+      isLastPage: true,
+      isLoading: false,
+    });
+
+    expect(actual).toEqual([
+      {
+        __typename: 'no_conditions_met',
+        evaluationId: 1,
+        amount: 1,
+        startTimestamp: 0,
+        endTimestamp: 'now',
+      },
+    ]);
+  });
+
+  it('should return "no conditions met" before [time] if no evaluations yet', () => {
+    const evaluations: AutoMaterializeEvaluationRecordItemFragment[] = [];
+
+    const actual = getEvaluationsWithEmptyAdded({
+      evaluations,
+      currentEvaluationId: null,
+      isFirstPage: true,
+      isLastPage: true,
+      isLoading: false,
+    });
+
+    expect(actual).toEqual([
+      {
+        __typename: 'no_conditions_met',
+        evaluationId: 1,
+        amount: 1,
+        startTimestamp: 0,
+        endTimestamp: 'now',
+      },
+    ]);
   });
 
   it(
@@ -128,6 +173,13 @@ describe('getEvaluationsWithEmptyAdded', () => {
         startTimestamp: evaluations[1]!.timestamp + 60,
       },
       evaluations[1],
+      {
+        __typename: 'no_conditions_met',
+        evaluationId: 0,
+        amount: 0,
+        endTimestamp: evaluations[1]!.timestamp - 60,
+        startTimestamp: 0,
+      },
     ]);
   });
 });

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/getEvaluationsWithEmptyAdded.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/getEvaluationsWithEmptyAdded.tsx
@@ -15,11 +15,17 @@ export const getEvaluationsWithEmptyAdded = ({
   isFirstPage,
   isLastPage,
 }: Config) => {
-  if (isLoading || !currentEvaluationId) {
+  if (isLoading) {
     return [];
   }
+
   const evalsWithSkips = [];
-  let current = isFirstPage ? currentEvaluationId : evaluations[0]?.evaluationId || 1;
+
+  let current =
+    isFirstPage && currentEvaluationId !== null
+      ? currentEvaluationId
+      : evaluations[0]?.evaluationId || 1;
+
   evaluations.forEach((evaluation, i) => {
     const prevEvaluation = evaluations[i - 1];
     if (evaluation.evaluationId !== current) {
@@ -34,15 +40,17 @@ export const getEvaluationsWithEmptyAdded = ({
     evalsWithSkips.push(evaluation);
     current = evaluation.evaluationId - 1;
   });
-  if (isLastPage && current > 0) {
+
+  if (isLastPage) {
     const lastEvaluation = evaluations[evaluations.length - 1];
     evalsWithSkips.push({
       __typename: 'no_conditions_met' as const,
       evaluationId: current,
-      amount: current - 0,
+      amount: current,
       endTimestamp: lastEvaluation?.timestamp ? lastEvaluation?.timestamp - 60 : ('now' as const),
       startTimestamp: 0,
     });
   }
+
   return evalsWithSkips;
 };

--- a/js_modules/dagit/packages/core/src/ui/Filters/__tests__/useTimeRangeFilter.test.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Filters/__tests__/useTimeRangeFilter.test.tsx
@@ -6,7 +6,6 @@ import userEvent from '@testing-library/user-event';
 import moment from 'moment-timezone';
 import React from 'react';
 
-import {browserTimezone} from '../../../app/time/browserTimezone';
 import {
   calculateTimeRanges,
   useTimeRangeFilter,
@@ -73,7 +72,7 @@ describe('useTimeRangeFilter', () => {
     });
     filter = result.current;
 
-    const {timeRanges} = calculateTimeRanges(browserTimezone());
+    const {timeRanges} = calculateTimeRanges('UTC');
     expect(filter.state).toEqual(timeRanges.YESTERDAY.range);
   });
 });


### PR DESCRIPTION
## Summary & Motivation

When no auto-materialize evaluations have taken place yet, make sure to show the empty state item in the left list.

Additionally, on the last page of left list items, ensure that the "Before [date]" list item always appears at the end.

<img width="1438" alt="Screenshot 2023-07-06 at 9 57 57 AM" src="https://github.com/dagster-io/dagster/assets/2823852/2ab0eceb-d436-45b7-a848-a22623e31259">
<img width="1442" alt="Screenshot 2023-07-06 at 9 43 42 AM" src="https://github.com/dagster-io/dagster/assets/2823852/54b58a52-5541-4ed7-9f44-897ac0baa5d3">


## How I Tested These Changes

Jest. Wipe out Dagster data, view auto-materialize page for a handful of assets. Verify that the "Before now" item appears. Enable auto-materialization, then verify that the "Before [...]" item appears at the end of the list.
