### PR TITLE
change order of apis in partitions api docs

### DIFF
--- a/docs/sphinx/sections/api/apidocs/partitions.rst
+++ b/docs/sphinx/sections/api/apidocs/partitions.rst
@@ -1,23 +1,5 @@
 .. currentmodule:: dagster
 
-Partitioned Config
-==================
-
-.. autoclass:: PartitionedConfig
-
-.. autofunction:: static_partitioned_config
-
-.. autofunction:: dynamic_partitioned_config
-
-.. autofunction:: hourly_partitioned_config
-
-.. autofunction:: daily_partitioned_config
-
-.. autofunction:: weekly_partitioned_config
-
-.. autofunction:: monthly_partitioned_config
-
-
 Partitions Definitions
 ======================
 
@@ -63,3 +45,20 @@ Partition Mapping
 .. autoclass:: LastPartitionMapping
 
 .. autoclass:: StaticPartitionMapping
+
+Partitioned Config
+==================
+
+.. autoclass:: PartitionedConfig
+
+.. autofunction:: static_partitioned_config
+
+.. autofunction:: dynamic_partitioned_config
+
+.. autofunction:: hourly_partitioned_config
+
+.. autofunction:: daily_partitioned_config
+
+.. autofunction:: weekly_partitioned_config
+
+.. autofunction:: monthly_partitioned_config


### PR DESCRIPTION
## Summary & Motivation

PartitionedConfig used to be the only game in town, but with assets and with the new context APIs, it's used much more rarely.  This moves it down to the bottom of the partitions api docs so that PartitionsDefinition can be the star of the show.

## How I Tested These Changes
