### PR TITLE
[ui] Fix auto-materialize conditions for non-partitioned asset

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AutomaterializeMiddlePanel.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AutomaterializeMiddlePanel.tsx
@@ -97,9 +97,12 @@ export const AutomaterializeMiddlePanel = ({
     ) as Record<ConditionType, string[]>;
   }, [selectedEvaluation]);
 
-  const conditionResults = React.useMemo(() => new Set(Object.keys(conditionToPartitions)), [
-    conditionToPartitions,
-  ]);
+  const conditionResults = React.useMemo(() => {
+    if (assetHasDefinedPartitions) {
+      return new Set(Object.keys(conditionToPartitions));
+    }
+    return new Set(selectedEvaluation?.conditions?.map((condition) => condition.__typename) || []);
+  }, [assetHasDefinedPartitions, conditionToPartitions, selectedEvaluation]);
 
   if (loading && !data) {
     return (


### PR DESCRIPTION
## Summary & Motivation

When determining the set of materialization conditions, I accidentally changed things only to regard conditions that affected some set of partition keys. This broke non-partitioned assets. Fix the issue by using all conditions in the non-partitioned asset.

<img width="1198" alt="Screenshot 2023-07-06 at 10 42 09 AM" src="https://github.com/dagster-io/dagster/assets/2823852/fcb3f86f-562a-47b4-924b-8ed73a00f39d">
<img width="1183" alt="Screenshot 2023-07-06 at 10 41 57 AM" src="https://github.com/dagster-io/dagster/assets/2823852/b3325a93-d100-4e7f-ad81-c3f787a27a7d">


## How I Tested These Changes

View non-partitioned asset, verify that when the missing materialization condition is present, it is correctly checked in the UI. Verify that partitioned assets are the same as before.
