### PR TITLE
[docs] small io manager docs fixes

### DIFF
--- a/docs/content/concepts/io-management/io-managers.mdx
+++ b/docs/content/concepts/io-management/io-managers.mdx
@@ -76,7 +76,7 @@ Consider the following diagram. In this example, a job has two I/O managers, eac
 
 The default I/O manager, <PyObject module="dagster" object="FilesystemIOManager" />, stores and retrieves values from pickle files in the local filesystem. If a job is invoked via <PyObject object="JobDefinition" method="execute_in_process" />, the default I/O manager is switched to <PyObject module="dagster" object="mem_io_manager"/>, which stores outputs in memory.
 
-Dagster provides out-of-the-box I/O managers for popular storage systems: AWS S3 (<PyObject module="dagster_aws.s3" object="s3_pickle_io_manager" />), Azure Blob Storage (<PyObject module="dagster_azure.adls2" object="adls2_pickle_io_manager" />), GCS (<PyObject module="dagster_gcp.gcs" object="gcs_pickle_io_manager" />), and Snowflake (<PyObject module="dagster_snowflake" object="build_snowflake_io_manager" />) - or you can write your own: either from scratch or by extending the `UPathIOManager` if you want to store data in an `fsspec`-supported filesystem. For a full list of Dagster-provided I/O managers, refer to the [built-in I/O managers list](#built-in-io-managers).
+Dagster provides out-of-the-box I/O managers for popular storage systems: AWS S3 (<PyObject module="dagster_aws.s3" object="s3_pickle_io_manager" />), Azure Blob Storage (<PyObject module="dagster_azure.adls2" object="adls2_pickle_io_manager" />), GCS (<PyObject module="dagster_gcp.gcs" object="gcs_pickle_io_manager" />), and Snowflake (<PyObject module="dagster_snowflake" object="build_snowflake_io_manager" />) - or you can write your own: either from scratch or by extending the `UPathIOManager` if you want to store data in an `fsspec`-supported filesystem. For a full list of Dagster-provided I/O managers, refer to the [built-in I/O managers list](#built-in-io-managers-list).
 
 ### I/O managers are resources
 
@@ -785,7 +785,7 @@ Any entries yielded this way will be attached to the `Handled Output` event for 
 
 Additionally, if the handled output is part of a software-defined asset, these metadata entries will also be attached to the materialization event created for that asset and show up on the Asset Details page for the asset.
 
-## Built-in I/O managers
+## Built-in I/O managers list
 
 | Name                                                                                       | Description                                                                   | Additional Documentation                                                                                               |
 | ------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |

--- a/docs/sphinx/sections/api/apidocs/io-managers.rst
+++ b/docs/sphinx/sections/api/apidocs/io-managers.rst
@@ -37,13 +37,16 @@ Input and Output Contexts
 Built-in IO Managers
 ------------------------
 
-.. autodata:: mem_io_manager
-  :annotation: IOManagerDefinition
-
 .. autodata:: FilesystemIOManager
   :annotation: IOManagerDefinition
 
 .. autodata:: fs_io_manager
+  :annotation: IOManagerDefinition
+
+.. autodata:: InMemoryIOManager
+  :annotation: IOManagerDefinition
+
+.. autodata:: mem_io_manager
   :annotation: IOManagerDefinition
 
 The ``UPathIOManager`` can be used to easily define filesystem-based IO Managers.

--- a/python_modules/dagster/dagster/_core/storage/mem_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/mem_io_manager.py
@@ -6,6 +6,10 @@ from dagster._core.storage.io_manager import IOManager, dagster_maintained_io_ma
 
 
 class InMemoryIOManager(IOManager):
+    """I/O manager that stores and retrieves values in memory. After execution is complete, the values will
+    be garbage-collected. Note that this means that each run will not have access to values from previous runs.
+    """
+
     def __init__(self):
         self.values: Dict[Tuple[object, ...], object] = {}
 


### PR DESCRIPTION
## Summary & Motivation
A collection of small io manager docs fixes that i ran across in OSS support this week. the changes are:
* fix link to the table of built in io managers so that it works (previously there were two sections with the same name, causing the link to direct to the wrong heading)
* add the pythonic IO managers to the API docs page 
* add a comment to the InMemoryIOManager that clarifies that materialized values are garbage-collected after each run

## How I Tested These Changes
