### PR TITLE
[ui] Split AutomaterializeMiddlePanel

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AssetAutomaterializePolicyPage.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AssetAutomaterializePolicyPage.tsx
@@ -63,16 +63,17 @@ export const AssetAutomaterializePolicyPage = ({
   });
 
   const selectedEvaluation = React.useMemo(() => {
-    if (selectedEvaluationId !== undefined) {
-      const found = evaluationsIncludingEmpty.find(
-        (evaluation) => evaluation.evaluationId === selectedEvaluationId,
-      );
-      if (found) {
-        return found;
-      }
+    // If we're looking at the most recent slice and have not selected an evaluation ID,
+    // default to the first item in the list. Otherwise, don't assume that we should
+    // automatically select the first item -- an evaluation on another page might be our
+    // active evaluation ID.
+    if (selectedEvaluationId === undefined && isFirstPage) {
+      return evaluationsIncludingEmpty[0];
     }
-    return evaluationsIncludingEmpty[0];
-  }, [selectedEvaluationId, evaluationsIncludingEmpty]);
+    return evaluationsIncludingEmpty.find(
+      (evaluation) => evaluation.evaluationId === selectedEvaluationId,
+    );
+  }, [selectedEvaluationId, isFirstPage, evaluationsIncludingEmpty]);
 
   const [maxMaterializationsPerMinute, setMaxMaterializationsPerMinute] = React.useState(1);
 
@@ -110,9 +111,8 @@ export const AssetAutomaterializePolicyPage = ({
             <AutomaterializeMiddlePanel
               assetKey={assetKey}
               assetHasDefinedPartitions={assetHasDefinedPartitions}
-              key={selectedEvaluation?.evaluationId || ''}
+              selectedEvaluationId={selectedEvaluationId}
               maxMaterializationsPerMinute={maxMaterializationsPerMinute}
-              selectedEvaluation={selectedEvaluation}
             />
           </Box>
         </Box>

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AutomaterializeMiddlePanel.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AutomaterializeMiddlePanel.tsx
@@ -1,108 +1,44 @@
 import {useQuery} from '@apollo/client';
-import {Box, Colors, Subheading, Icon, NonIdealState} from '@dagster-io/ui';
+import {Box, Colors, NonIdealState, Subheading} from '@dagster-io/ui';
 import * as React from 'react';
-import styled from 'styled-components/macro';
 
 import {ErrorWrapper} from '../../app/PythonErrorInfo';
 import {AssetKey} from '../types';
 
-import {AutomaterializeRequestedPartitionsLink} from './AutomaterializeRequestedPartitionsLink';
-import {AutomaterializeRunTag} from './AutomaterializeRunTag';
+import {AutomaterializeMiddlePanelNoPartitions} from './AutomaterializeMiddlePanelNoPartitions';
+import {AutomaterializeMiddlePanelWithPartitions} from './AutomaterializeMiddlePanelWithPartitions';
 import {GET_EVALUATIONS_QUERY} from './GetEvaluationsQuery';
 import {EvaluationOrEmpty} from './types';
-import {
-  AutoMateralizeWithConditionFragment,
-  GetEvaluationsQuery,
-  GetEvaluationsQueryVariables,
-} from './types/GetEvaluationsQuery.types';
-
-const isRequestCondition = (
-  condition: AutoMateralizeWithConditionFragment,
-): condition is AutoMateralizeWithConditionFragment => {
-  switch (condition.__typename) {
-    case 'MissingAutoMaterializeCondition':
-    case 'DownstreamFreshnessAutoMaterializeCondition':
-    case 'FreshnessAutoMaterializeCondition':
-    case 'ParentMaterializedAutoMaterializeCondition':
-      return true;
-    default:
-      return false;
-  }
-};
-
-type ConditionType = AutoMateralizeWithConditionFragment['__typename'];
-
-const extractRequestedPartitionKeys = (conditions: AutoMateralizeWithConditionFragment[]) => {
-  let requested: string[] = [];
-  let skippedOrDiscarded: string[] = [];
-
-  conditions.forEach((condition) => {
-    const didRequest = isRequestCondition(condition);
-    const partitionKeys =
-      condition.partitionKeysOrError?.__typename === 'PartitionKeys'
-        ? condition.partitionKeysOrError.partitionKeys
-        : [];
-    if (didRequest) {
-      requested = requested.concat(partitionKeys);
-    } else {
-      skippedOrDiscarded = skippedOrDiscarded.concat(partitionKeys);
-    }
-  });
-
-  const skippedOrDiscardedSet = new Set(skippedOrDiscarded);
-  return new Set(requested.filter((partitionKey) => !skippedOrDiscardedSet.has(partitionKey)));
-};
+import {GetEvaluationsQuery, GetEvaluationsQueryVariables} from './types/GetEvaluationsQuery.types';
 
 interface Props {
   assetKey: AssetKey;
   assetHasDefinedPartitions: boolean;
-  selectedEvaluation?: EvaluationOrEmpty;
   maxMaterializationsPerMinute: number;
+  selectedEvaluationId: number | undefined;
 }
 
-export const AutomaterializeMiddlePanel = ({
-  assetKey,
-  assetHasDefinedPartitions,
-  selectedEvaluation,
-  maxMaterializationsPerMinute,
-}: Props) => {
+export const AutomaterializeMiddlePanel = (props: Props) => {
+  const {
+    assetKey,
+    assetHasDefinedPartitions,
+    maxMaterializationsPerMinute,
+    selectedEvaluationId,
+  } = props;
+
+  // We receive the selected evaluation ID and retrieve it here because the middle panel
+  // may be displaying an evaluation that was not retrieved at the page level for the
+  // left panel, e.g. as we paginate away from it, we don't want to lose it.
   const {data, loading, error} = useQuery<GetEvaluationsQuery, GetEvaluationsQueryVariables>(
     GET_EVALUATIONS_QUERY,
     {
       variables: {
         assetKey,
-        cursor: selectedEvaluation?.evaluationId
-          ? (selectedEvaluation.evaluationId + 1).toString()
-          : undefined,
+        cursor: selectedEvaluationId ? `${selectedEvaluationId + 1}` : undefined,
         limit: 2,
       },
     },
   );
-
-  const conditionToPartitions: Record<ConditionType, string[]> = React.useMemo(() => {
-    const conditions = selectedEvaluation?.conditions;
-    if (!conditions?.length) {
-      return {} as Record<ConditionType, string[]>;
-    }
-    return Object.fromEntries(
-      conditions
-        .map((condition) => {
-          const {__typename, partitionKeysOrError} = condition;
-          if (partitionKeysOrError?.__typename === 'PartitionKeys') {
-            return [__typename, partitionKeysOrError.partitionKeys];
-          }
-          return null;
-        })
-        .filter((entryOrNull): entryOrNull is [ConditionType, string[]] => !!entryOrNull),
-    ) as Record<ConditionType, string[]>;
-  }, [selectedEvaluation]);
-
-  const conditionResults = React.useMemo(() => {
-    if (assetHasDefinedPartitions) {
-      return new Set(Object.keys(conditionToPartitions));
-    }
-    return new Set(selectedEvaluation?.conditions?.map((condition) => condition.__typename) || []);
-  }, [assetHasDefinedPartitions, conditionToPartitions, selectedEvaluation]);
 
   if (loading && !data) {
     return (
@@ -146,207 +82,40 @@ export const AutomaterializeMiddlePanel = ({
     );
   }
 
-  const headerRight = () => {
-    const runIds =
-      selectedEvaluation?.__typename === 'AutoMaterializeAssetEvaluationRecord'
-        ? selectedEvaluation.runIds
-        : [];
-    const count = runIds.length;
+  const evaluations = data?.autoMaterializeAssetEvaluationsOrError?.records || [];
+  const findSelectedEvaluation = (): EvaluationOrEmpty => {
+    const found = evaluations.find(
+      (evaluation) => evaluation.evaluationId === selectedEvaluationId,
+    );
 
-    if (count === 0 || !selectedEvaluation?.conditions) {
-      return null;
+    if (found) {
+      return found;
     }
 
-    const {conditions} = selectedEvaluation;
-    if (assetHasDefinedPartitions) {
-      const partitionKeys = extractRequestedPartitionKeys(conditions);
-      return (
-        <AutomaterializeRequestedPartitionsLink
-          runIds={runIds}
-          partitionKeys={Array.from(partitionKeys)}
-        />
-      );
-    }
-
-    return <AutomaterializeRunTag runId={runIds[0]!} />;
+    return {
+      __typename: 'no_conditions_met',
+      evaluationId: 0,
+      amount: 0,
+      endTimestamp: 0,
+      startTimestamp: 0,
+    };
   };
 
-  return (
-    <Box flex={{direction: 'column', grow: 1}}>
-      <Box
-        style={{flex: '0 0 48px'}}
-        padding={{horizontal: 16}}
-        border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
-        flex={{alignItems: 'center', justifyContent: 'space-between'}}
-      >
-        <Subheading>Result</Subheading>
-        <div>{headerRight()}</div>
-      </Box>
-      <CollapsibleSection header="Materialization conditions met">
-        <Box flex={{direction: 'column', gap: 8}}>
-          <Condition
-            text="Materialization is missing"
-            met={conditionResults.has('MissingAutoMaterializeCondition')}
-            type="materialization"
-            assetHasDefinedPartitions={assetHasDefinedPartitions}
-            partitionKeys={conditionToPartitions['MissingAutoMaterializeCondition']}
-          />
-          <Condition
-            text="Upstream data has changed since latest materialization"
-            met={conditionResults.has('ParentMaterializedAutoMaterializeCondition')}
-            type="materialization"
-            assetHasDefinedPartitions={assetHasDefinedPartitions}
-            partitionKeys={conditionToPartitions['ParentMaterializedAutoMaterializeCondition']}
-          />
-          <Condition
-            text="Required to meet this asset's freshness policy"
-            met={conditionResults.has('FreshnessAutoMaterializeCondition')}
-            type="materialization"
-            assetHasDefinedPartitions={assetHasDefinedPartitions}
-            partitionKeys={conditionToPartitions['FreshnessAutoMaterializeCondition']}
-          />
-          <Condition
-            text="Required to meet a downstream freshness policy"
-            met={conditionResults.has('DownstreamFreshnessAutoMaterializeCondition')}
-            type="materialization"
-            assetHasDefinedPartitions={assetHasDefinedPartitions}
-            partitionKeys={conditionToPartitions['DownstreamFreshnessAutoMaterializeCondition']}
-          />
-        </Box>
-      </CollapsibleSection>
-      <CollapsibleSection header="Skip conditions met">
-        <Condition
-          text="Waiting on upstream data"
-          met={conditionResults.has('ParentOutdatedAutoMaterializeCondition')}
-          type="skip"
-          assetHasDefinedPartitions={assetHasDefinedPartitions}
-          partitionKeys={conditionToPartitions['ParentOutdatedAutoMaterializeCondition']}
-        />
-      </CollapsibleSection>
-      <CollapsibleSection header="Discard conditions met">
-        <Condition
-          text={`Exceeds ${
-            maxMaterializationsPerMinute === 1
-              ? '1 materialization'
-              : `${maxMaterializationsPerMinute} materializations`
-          } per minute`}
-          met={conditionResults.has('MaxMaterializationsExceededAutoMaterializeCondition')}
-          type="discard"
-          assetHasDefinedPartitions={assetHasDefinedPartitions}
-          partitionKeys={
-            conditionToPartitions['MaxMaterializationsExceededAutoMaterializeCondition']
-          }
-        />
-      </CollapsibleSection>
-    </Box>
-  );
-};
+  const selectedEvaluation = findSelectedEvaluation();
 
-const CollapsibleSection = ({
-  header,
-  headerRightSide,
-  children,
-}: {
-  header: React.ReactNode;
-  headerRightSide?: React.ReactNode;
-  children: React.ReactNode;
-}) => {
-  const [isCollapsed, setIsCollapsed] = React.useState(false);
+  if (assetHasDefinedPartitions) {
+    return (
+      <AutomaterializeMiddlePanelWithPartitions
+        selectedEvaluation={selectedEvaluation}
+        maxMaterializationsPerMinute={maxMaterializationsPerMinute}
+      />
+    );
+  }
 
   return (
-    <Box
-      flex={{direction: 'column'}}
-      border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
-    >
-      <SectionHeader onClick={() => setIsCollapsed(!isCollapsed)}>
-        <Box
-          flex={{
-            justifyContent: 'space-between',
-            gap: 12,
-            grow: 1,
-          }}
-          padding={{vertical: 8, horizontal: 16}}
-          border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
-        >
-          <CenterAlignedRow flex={{gap: 4, grow: 1}}>
-            <Icon
-              name="arrow_drop_down"
-              style={{transform: isCollapsed ? 'rotate(-90deg)' : 'rotate(0deg)'}}
-            />
-            <Subheading>{header}</Subheading>
-          </CenterAlignedRow>
-          {headerRightSide}
-        </Box>
-      </SectionHeader>
-      {isCollapsed ? null : <Box padding={{vertical: 12, left: 32, right: 16}}>{children}</Box>}
-    </Box>
-  );
-};
-
-const Condition = ({
-  text,
-  met,
-  type,
-  partitionKeys,
-  assetHasDefinedPartitions,
-}: {
-  text: React.ReactNode;
-  met: boolean;
-  details?: React.ReactNode;
-  type: 'materialization' | 'skip' | 'discard';
-  partitionKeys: string[] | undefined;
-  assetHasDefinedPartitions: boolean;
-}) => {
-  const activeColor = React.useMemo(() => {
-    switch (type) {
-      case 'skip':
-        return Colors.Yellow700;
-      case 'discard':
-        return Colors.Red700;
-      default:
-        return Colors.Green700;
-    }
-  }, [type]);
-
-  return (
-    <CenterAlignedRow flex={{justifyContent: 'space-between'}}>
-      <CenterAlignedRow flex={{gap: 8}}>
-        <Icon name={met ? 'done' : 'close'} color={met ? activeColor : Colors.Gray400} />
-        <div style={{color: met ? activeColor : undefined}}>{text}</div>
-      </CenterAlignedRow>
-      {assetHasDefinedPartitions ? (
-        partitionKeys?.length ? (
-          <AutomaterializeRequestedPartitionsLink partitionKeys={partitionKeys} />
-        ) : (
-          <div style={{color: Colors.Gray400}}>&ndash;</div>
-        )
-      ) : null}
-    </CenterAlignedRow>
-  );
-};
-
-const CenterAlignedRow = React.forwardRef((props: React.ComponentProps<typeof Box>, ref) => {
-  return (
-    <Box
-      {...props}
-      ref={ref}
-      flex={{
-        direction: 'row',
-        alignItems: 'center',
-        ...(props.flex || {}),
-      }}
+    <AutomaterializeMiddlePanelNoPartitions
+      selectedEvaluation={selectedEvaluation}
+      maxMaterializationsPerMinute={maxMaterializationsPerMinute}
     />
   );
-});
-
-const SectionHeader = styled.button`
-  background-color: ${Colors.White};
-  border: 0;
-  cursor: pointer;
-  padding: 0;
-  margin: 0;
-
-  :focus {
-    outline: none;
-  }
-`;
+};

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AutomaterializeMiddlePanelNoPartitions.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AutomaterializeMiddlePanelNoPartitions.tsx
@@ -1,0 +1,54 @@
+import {Box, Colors, Subheading} from '@dagster-io/ui';
+import * as React from 'react';
+
+import {AutomaterializeRunTag} from './AutomaterializeRunTag';
+import {ConditionType, ConditionsNoPartitions} from './Conditions';
+import {EvaluationOrEmpty} from './types';
+
+interface Props {
+  selectedEvaluation?: EvaluationOrEmpty;
+  maxMaterializationsPerMinute: number;
+}
+
+export const AutomaterializeMiddlePanelNoPartitions = ({
+  selectedEvaluation,
+  maxMaterializationsPerMinute,
+}: Props) => {
+  const conditionResults = React.useMemo(() => {
+    return new Set(
+      (selectedEvaluation?.conditions || []).map((condition) => condition.__typename),
+    ) as Set<ConditionType>;
+  }, [selectedEvaluation]);
+
+  const headerRight = () => {
+    const runIds =
+      selectedEvaluation?.__typename === 'AutoMaterializeAssetEvaluationRecord'
+        ? selectedEvaluation.runIds
+        : [];
+    const count = runIds.length;
+
+    if (count === 0 || !selectedEvaluation?.conditions) {
+      return null;
+    }
+
+    return <AutomaterializeRunTag runId={runIds[0]!} />;
+  };
+
+  return (
+    <Box flex={{direction: 'column', grow: 1}}>
+      <Box
+        style={{flex: '0 0 48px'}}
+        padding={{horizontal: 16}}
+        border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+        flex={{alignItems: 'center', justifyContent: 'space-between'}}
+      >
+        <Subheading>Result</Subheading>
+        <div>{headerRight()}</div>
+      </Box>
+      <ConditionsNoPartitions
+        conditionResults={conditionResults}
+        maxMaterializationsPerMinute={maxMaterializationsPerMinute}
+      />
+    </Box>
+  );
+};

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AutomaterializeMiddlePanelWithPartitions.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AutomaterializeMiddlePanelWithPartitions.tsx
@@ -1,0 +1,115 @@
+import {Box, Colors, Subheading} from '@dagster-io/ui';
+import * as React from 'react';
+
+import {AutomaterializeRequestedPartitionsLink} from './AutomaterializeRequestedPartitionsLink';
+import {ConditionType, ConditionsWithPartitions} from './Conditions';
+import {EvaluationOrEmpty} from './types';
+import {AutoMateralizeWithConditionFragment} from './types/GetEvaluationsQuery.types';
+
+const isRequestCondition = (
+  condition: AutoMateralizeWithConditionFragment,
+): condition is AutoMateralizeWithConditionFragment => {
+  switch (condition.__typename) {
+    case 'MissingAutoMaterializeCondition':
+    case 'DownstreamFreshnessAutoMaterializeCondition':
+    case 'FreshnessAutoMaterializeCondition':
+    case 'ParentMaterializedAutoMaterializeCondition':
+      return true;
+    default:
+      return false;
+  }
+};
+
+const extractRequestedPartitionKeys = (conditions: AutoMateralizeWithConditionFragment[]) => {
+  let requested: string[] = [];
+  let skippedOrDiscarded: string[] = [];
+
+  conditions.forEach((condition) => {
+    const didRequest = isRequestCondition(condition);
+    const partitionKeys =
+      condition.partitionKeysOrError?.__typename === 'PartitionKeys'
+        ? condition.partitionKeysOrError.partitionKeys
+        : [];
+    if (didRequest) {
+      requested = requested.concat(partitionKeys);
+    } else {
+      skippedOrDiscarded = skippedOrDiscarded.concat(partitionKeys);
+    }
+  });
+
+  const skippedOrDiscardedSet = new Set(skippedOrDiscarded);
+  return new Set(requested.filter((partitionKey) => !skippedOrDiscardedSet.has(partitionKey)));
+};
+
+interface Props {
+  selectedEvaluation?: EvaluationOrEmpty;
+  maxMaterializationsPerMinute: number;
+}
+
+export const AutomaterializeMiddlePanelWithPartitions = ({
+  selectedEvaluation,
+  maxMaterializationsPerMinute,
+}: Props) => {
+  const conditionToPartitions: Record<ConditionType, string[]> = React.useMemo(() => {
+    const conditions = selectedEvaluation?.conditions;
+    if (!conditions?.length) {
+      return {} as Record<ConditionType, string[]>;
+    }
+    return Object.fromEntries(
+      conditions
+        .map((condition) => {
+          const {__typename, partitionKeysOrError} = condition;
+          if (partitionKeysOrError?.__typename === 'PartitionKeys') {
+            return [__typename, partitionKeysOrError.partitionKeys];
+          }
+          return null;
+        })
+        .filter((entryOrNull): entryOrNull is [ConditionType, string[]] => !!entryOrNull),
+    ) as Record<ConditionType, string[]>;
+  }, [selectedEvaluation]);
+
+  const conditionResults = React.useMemo(
+    () => new Set(Object.keys(conditionToPartitions)) as Set<ConditionType>,
+    [conditionToPartitions],
+  );
+
+  const headerRight = () => {
+    const runIds =
+      selectedEvaluation?.__typename === 'AutoMaterializeAssetEvaluationRecord'
+        ? selectedEvaluation.runIds
+        : [];
+    const count = runIds.length;
+
+    if (count === 0 || !selectedEvaluation?.conditions) {
+      return null;
+    }
+
+    const {conditions} = selectedEvaluation;
+    const partitionKeys = extractRequestedPartitionKeys(conditions);
+    return (
+      <AutomaterializeRequestedPartitionsLink
+        runIds={runIds}
+        partitionKeys={Array.from(partitionKeys)}
+      />
+    );
+  };
+
+  return (
+    <Box flex={{direction: 'column', grow: 1}}>
+      <Box
+        style={{flex: '0 0 48px'}}
+        padding={{horizontal: 16}}
+        border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+        flex={{alignItems: 'center', justifyContent: 'space-between'}}
+      >
+        <Subheading>Result</Subheading>
+        <div>{headerRight()}</div>
+      </Box>
+      <ConditionsWithPartitions
+        conditionResults={conditionResults}
+        conditionToPartitions={conditionToPartitions}
+        maxMaterializationsPerMinute={maxMaterializationsPerMinute}
+      />
+    </Box>
+  );
+};

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/CollapsibleSection.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/CollapsibleSection.tsx
@@ -1,0 +1,53 @@
+import {Box, Colors, Icon, Subheading} from '@dagster-io/ui';
+import * as React from 'react';
+import styled from 'styled-components/macro';
+
+interface Props {
+  header: React.ReactNode;
+  headerRightSide?: React.ReactNode;
+  children: React.ReactNode;
+}
+
+export const CollapsibleSection = ({header, headerRightSide, children}: Props) => {
+  const [isCollapsed, setIsCollapsed] = React.useState(false);
+  return (
+    <Box
+      flex={{direction: 'column'}}
+      border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+    >
+      <SectionHeader onClick={() => setIsCollapsed(!isCollapsed)}>
+        <Box
+          flex={{
+            justifyContent: 'space-between',
+            gap: 12,
+            grow: 1,
+          }}
+          padding={{vertical: 8, horizontal: 16}}
+          border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+        >
+          <Box flex={{direction: 'row', alignItems: 'center', gap: 4, grow: 1}}>
+            <Icon
+              name="arrow_drop_down"
+              style={{transform: isCollapsed ? 'rotate(-90deg)' : 'rotate(0deg)'}}
+            />
+            <Subheading>{header}</Subheading>
+          </Box>
+          {headerRightSide}
+        </Box>
+      </SectionHeader>
+      {isCollapsed ? null : <Box padding={{vertical: 12, left: 32, right: 16}}>{children}</Box>}
+    </Box>
+  );
+};
+
+const SectionHeader = styled.button`
+  background-color: ${Colors.White};
+  border: 0;
+  cursor: pointer;
+  padding: 0;
+  margin: 0;
+
+  :focus {
+    outline: none;
+  }
+`;

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/Conditions.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/Conditions.tsx
@@ -1,0 +1,177 @@
+import {Colors, Box, Icon} from '@dagster-io/ui';
+import * as React from 'react';
+
+import {AutomaterializeRequestedPartitionsLink} from './AutomaterializeRequestedPartitionsLink';
+import {CollapsibleSection} from './CollapsibleSection';
+import {AutoMateralizeWithConditionFragment} from './types/GetEvaluationsQuery.types';
+
+export type ConditionType = AutoMateralizeWithConditionFragment['__typename'];
+
+interface ConditionProps {
+  text: React.ReactNode;
+  met: boolean;
+  type: 'materialization' | 'skip' | 'discard';
+  rightElement?: React.ReactNode;
+}
+
+const Condition = ({text, met, type, rightElement}: ConditionProps) => {
+  const activeColor = React.useMemo(() => {
+    switch (type) {
+      case 'skip':
+        return Colors.Yellow700;
+      case 'discard':
+        return Colors.Red700;
+      default:
+        return Colors.Green700;
+    }
+  }, [type]);
+
+  return (
+    <Box flex={{direction: 'row', alignItems: 'center', justifyContent: 'space-between'}}>
+      <Box flex={{direction: 'row', alignItems: 'center', gap: 8}}>
+        <Icon name={met ? 'done' : 'close'} color={met ? activeColor : Colors.Gray400} />
+        <div style={{color: met ? activeColor : undefined}}>{text}</div>
+      </Box>
+      {rightElement}
+    </Box>
+  );
+};
+
+interface ConditionsWithPartitionsProps extends ConditionsProps {
+  conditionToPartitions: Record<ConditionType, string[]>;
+}
+
+export const ConditionsWithPartitions = ({
+  conditionResults,
+  conditionToPartitions,
+  maxMaterializationsPerMinute,
+}: ConditionsWithPartitionsProps) => {
+  const buildRightElement = (partitionKeys: string[]) => {
+    if (partitionKeys?.length) {
+      return <AutomaterializeRequestedPartitionsLink partitionKeys={partitionKeys} />;
+    }
+    return <div style={{color: Colors.Gray400}}>&ndash;</div>;
+  };
+
+  return (
+    <>
+      <CollapsibleSection header="Materialization conditions met">
+        <Box flex={{direction: 'column', gap: 8}}>
+          <Condition
+            text="Materialization is missing"
+            met={conditionResults.has('MissingAutoMaterializeCondition')}
+            type="materialization"
+            rightElement={buildRightElement(
+              conditionToPartitions['MissingAutoMaterializeCondition'],
+            )}
+          />
+          <Condition
+            text="Upstream data has changed since latest materialization"
+            met={conditionResults.has('ParentMaterializedAutoMaterializeCondition')}
+            type="materialization"
+            rightElement={buildRightElement(
+              conditionToPartitions['ParentMaterializedAutoMaterializeCondition'],
+            )}
+          />
+          <Condition
+            text="Required to meet this asset's freshness policy"
+            met={conditionResults.has('FreshnessAutoMaterializeCondition')}
+            type="materialization"
+            rightElement={buildRightElement(
+              conditionToPartitions['FreshnessAutoMaterializeCondition'],
+            )}
+          />
+          <Condition
+            text="Required to meet a downstream freshness policy"
+            met={conditionResults.has('DownstreamFreshnessAutoMaterializeCondition')}
+            type="materialization"
+            rightElement={buildRightElement(
+              conditionToPartitions['DownstreamFreshnessAutoMaterializeCondition'],
+            )}
+          />
+        </Box>
+      </CollapsibleSection>
+      <CollapsibleSection header="Skip conditions met">
+        <Condition
+          text="Waiting on upstream data"
+          met={conditionResults.has('ParentOutdatedAutoMaterializeCondition')}
+          type="skip"
+          rightElement={buildRightElement(
+            conditionToPartitions['ParentOutdatedAutoMaterializeCondition'],
+          )}
+        />
+      </CollapsibleSection>
+      <CollapsibleSection header="Discard conditions met">
+        <Condition
+          text={`Exceeds ${
+            maxMaterializationsPerMinute === 1
+              ? '1 materialization'
+              : `${maxMaterializationsPerMinute} materializations`
+          } per minute`}
+          met={conditionResults.has('MaxMaterializationsExceededAutoMaterializeCondition')}
+          type="discard"
+          rightElement={buildRightElement(
+            conditionToPartitions['MaxMaterializationsExceededAutoMaterializeCondition'],
+          )}
+        />
+      </CollapsibleSection>
+    </>
+  );
+};
+
+interface ConditionsProps {
+  conditionResults: Set<ConditionType>;
+  maxMaterializationsPerMinute: number;
+}
+
+export const ConditionsNoPartitions = ({
+  conditionResults,
+  maxMaterializationsPerMinute,
+}: ConditionsProps) => {
+  return (
+    <>
+      <CollapsibleSection header="Materialization conditions met">
+        <Box flex={{direction: 'column', gap: 8}}>
+          <Condition
+            text="Materialization is missing"
+            met={conditionResults.has('MissingAutoMaterializeCondition')}
+            type="materialization"
+          />
+          <Condition
+            text="Upstream data has changed since latest materialization"
+            met={conditionResults.has('ParentMaterializedAutoMaterializeCondition')}
+            type="materialization"
+          />
+          <Condition
+            text="Required to meet this asset's freshness policy"
+            met={conditionResults.has('FreshnessAutoMaterializeCondition')}
+            type="materialization"
+          />
+          <Condition
+            text="Required to meet a downstream freshness policy"
+            met={conditionResults.has('DownstreamFreshnessAutoMaterializeCondition')}
+            type="materialization"
+          />
+        </Box>
+      </CollapsibleSection>
+      <CollapsibleSection header="Skip conditions met">
+        <Condition
+          text="Waiting on upstream data"
+          met={conditionResults.has('ParentOutdatedAutoMaterializeCondition')}
+          type="skip"
+        />
+      </CollapsibleSection>
+      <CollapsibleSection header="Discard conditions met">
+        <Condition
+          text={`Exceeds ${
+            maxMaterializationsPerMinute === 1
+              ? '1 materialization'
+              : `${maxMaterializationsPerMinute} materializations`
+          } per minute`}
+          met={conditionResults.has('MaxMaterializationsExceededAutoMaterializeCondition')}
+          type="discard"
+        />
+      </CollapsibleSection>
+    </>
+  );
+};

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/__stories__/AutomaterializeMiddlePanelNoPartitions.stories.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/__stories__/AutomaterializeMiddlePanelNoPartitions.stories.tsx
@@ -2,33 +2,17 @@ import {MockedProvider} from '@apollo/client/testing';
 import * as React from 'react';
 
 import {RunStatus} from '../../../graphql/types';
-import {AutomaterializeMiddlePanel} from '../AutomaterializeMiddlePanel';
+import {AutomaterializeMiddlePanelNoPartitions} from '../AutomaterializeMiddlePanelNoPartitions';
 import {
   Evaluations,
   SINGLE_MATERIALIZE_RECORD_NO_PARTITIONS,
-  SINGLE_MATERIALIZE_RECORD_WITH_PARTITIONS,
 } from '../__fixtures__/AutoMaterializePolicyPage.fixtures';
 import {buildRunStatusOnlyQuery} from '../__fixtures__/RunStatusOnlyQuery.fixtures';
 
 // eslint-disable-next-line import/no-default-export
-export default {component: AutomaterializeMiddlePanel};
+export default {component: AutomaterializeMiddlePanelNoPartitions};
 
 const path = ['test'];
-
-export const WithPartitions = () => {
-  return (
-    <MockedProvider mocks={[Evaluations.Single(path)]}>
-      <div style={{width: '800px'}}>
-        <AutomaterializeMiddlePanel
-          assetKey={{path}}
-          assetHasDefinedPartitions
-          maxMaterializationsPerMinute={1}
-          selectedEvaluation={SINGLE_MATERIALIZE_RECORD_WITH_PARTITIONS}
-        />
-      </div>
-    </MockedProvider>
-  );
-};
 
 export const WithoutPartitions = () => {
   return (
@@ -36,9 +20,7 @@ export const WithoutPartitions = () => {
       mocks={[Evaluations.Single(path), buildRunStatusOnlyQuery('abcdef12', RunStatus.STARTED)]}
     >
       <div style={{width: '800px'}}>
-        <AutomaterializeMiddlePanel
-          assetKey={{path}}
-          assetHasDefinedPartitions={false}
+        <AutomaterializeMiddlePanelNoPartitions
           maxMaterializationsPerMinute={1}
           selectedEvaluation={SINGLE_MATERIALIZE_RECORD_NO_PARTITIONS}
         />

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/__stories__/AutomaterializeMiddlePanelWithPartitions.stories.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/__stories__/AutomaterializeMiddlePanelWithPartitions.stories.tsx
@@ -1,0 +1,30 @@
+import {MockedProvider} from '@apollo/client/testing';
+import * as React from 'react';
+
+import {RunStatus} from '../../../graphql/types';
+import {AutomaterializeMiddlePanelWithPartitions} from '../AutomaterializeMiddlePanelWithPartitions';
+import {
+  Evaluations,
+  SINGLE_MATERIALIZE_RECORD_WITH_PARTITIONS,
+} from '../__fixtures__/AutoMaterializePolicyPage.fixtures';
+import {buildRunStatusOnlyQuery} from '../__fixtures__/RunStatusOnlyQuery.fixtures';
+
+// eslint-disable-next-line import/no-default-export
+export default {component: AutomaterializeMiddlePanelWithPartitions};
+
+const path = ['test'];
+
+export const WithPartitions = () => {
+  return (
+    <MockedProvider
+      mocks={[Evaluations.Single(path), buildRunStatusOnlyQuery('abcdef12', RunStatus.STARTED)]}
+    >
+      <div style={{width: '800px'}}>
+        <AutomaterializeMiddlePanelWithPartitions
+          maxMaterializationsPerMinute={1}
+          selectedEvaluation={SINGLE_MATERIALIZE_RECORD_WITH_PARTITIONS}
+        />
+      </div>
+    </MockedProvider>
+  );
+};

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/getEvaluationsWithEmptyAdded.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/getEvaluationsWithEmptyAdded.tsx
@@ -1,3 +1,4 @@
+import {EvaluationOrEmpty} from './types';
 import {AutoMaterializeEvaluationRecordItemFragment} from './types/GetEvaluationsQuery.types';
 
 type Config = {
@@ -14,7 +15,7 @@ export const getEvaluationsWithEmptyAdded = ({
   evaluations,
   isFirstPage,
   isLastPage,
-}: Config) => {
+}: Config): EvaluationOrEmpty[] => {
   if (isLoading) {
     return [];
   }


### PR DESCRIPTION
## Summary & Motivation

Split the auto-materialize middle panel component for the partitioned and non-partitioned cases. There are some shared pieces, but enough differences at this point that it's a bit simpler to treat them separately.

## How I Tested These Changes

View partitioned and non-partitioned assets' auto-materialization pages. Verify that they render correctly.
