### PR TITLE
[auto-materialize] Fix error when calculating data time of in progress runs

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/data_time.py
+++ b/python_modules/dagster/dagster/_core/definitions/data_time.py
@@ -458,25 +458,26 @@ class CachingDataTimeResolver:
         record: EventLogRecord,
         current_time: Optional[datetime.datetime] = None,
     ) -> Mapping[AssetKey, Optional[datetime.datetime]]:
-        """Method to enable calculating the timestamps of materializations of upstream assets
-        which were relevant to a given AssetMaterialization. These timestamps can be calculated relative
-        to any upstream asset keys.
+        """Method to enable calculating the timestamps of materializations or observations of
+        upstream assets which were relevant to a given AssetMaterialization. These timestamps can
+        be calculated relative to any upstream asset keys.
 
         The heart of this functionality is a recursive method which takes a given asset materialization
         and finds the most recent materialization of each of its parents which happened *before* that
         given materialization event.
         """
-        if record.asset_key is None or record.asset_materialization is None:
+        event = record.asset_materialization or record.asset_observation
+        if record.asset_key is None or event is None:
             raise DagsterInvariantViolationError(
-                "Can only calculate data times for records with a materialization event and an"
-                " asset_key."
+                "Can only calculate data times for records with a materialization / observation "
+                "event and an asset_key."
             )
 
         return self._calculate_data_time_by_key(
             asset_key=record.asset_key,
             record_id=record.storage_id,
             record_timestamp=record.event_log_entry.timestamp,
-            record_tags=make_hashable(record.asset_materialization.tags or {}),
+            record_tags=make_hashable(event.tags or {}),
             current_time=current_time or pendulum.now("UTC"),
         )
 

--- a/python_modules/dagster/dagster/_core/event_api.py
+++ b/python_modules/dagster/dagster/_core/event_api.py
@@ -5,7 +5,7 @@ from typing_extensions import TypeAlias
 
 import dagster._check as check
 from dagster._annotations import PublicAttr
-from dagster._core.definitions.events import AssetKey, AssetMaterialization
+from dagster._core.definitions.events import AssetKey, AssetMaterialization, AssetObservation
 from dagster._core.errors import DagsterInvalidInvocationError
 from dagster._core.events import DagsterEventType
 from dagster._core.events.log import EventLogEntry
@@ -62,6 +62,10 @@ class EventLogRecord(NamedTuple):
     @property
     def asset_materialization(self) -> Optional[AssetMaterialization]:
         return self.event_log_entry.asset_materialization
+
+    @property
+    def asset_observation(self) -> Optional[AssetObservation]:
+        return self.event_log_entry.asset_observation
 
 
 @whitelist_for_serdes

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/active_run_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/active_run_scenarios.py
@@ -6,6 +6,7 @@ from dagster import (
     PartitionKeyRange,
 )
 from dagster._core.definitions.events import AssetKey, AssetMaterialization
+from dagster._core.definitions.freshness_policy import FreshnessPolicy
 from dagster._core.definitions.time_window_partitions import HourlyPartitionsDefinition
 from dagster._core.events import DagsterEvent, StepMaterializationData
 from dagster._core.events.log import EventLogEntry
@@ -15,6 +16,8 @@ from dagster._seven.compat.pendulum import create_pendulum_time
 from .asset_reconciliation_scenario import (
     AssetReconciliationScenario,
     asset_def,
+    observable_source_asset_def,
+    run,
     run_request,
 )
 
@@ -23,10 +26,17 @@ DEFAULT_JOB_NAME = "some_job"
 daily_partitions_def = DailyPartitionsDefinition("2020-01-01")
 hourly_partitions_def = HourlyPartitionsDefinition("2020-01-01-00:00")
 
-assets = [
+partitioned_assets = [
     asset_def("upstream_daily", partitions_def=daily_partitions_def),
     asset_def("downstream_daily", ["upstream_daily"], partitions_def=daily_partitions_def),
     asset_def("downstream_hourly", ["upstream_daily"], partitions_def=hourly_partitions_def),
+]
+
+freshness_with_observable_source_assets = [
+    observable_source_asset_def("observable_source"),
+    asset_def("asset0"),
+    asset_def("asset1", ["observable_source", "asset0"]),
+    asset_def("asset2", ["asset1"], freshness_policy=FreshnessPolicy(maximum_lag_minutes=30)),
 ]
 
 
@@ -52,7 +62,7 @@ def create_materialization_event_log_entry(
 
 active_run_scenarios = {
     "downstream_still_in_progress": AssetReconciliationScenario(
-        assets=assets,
+        assets=partitioned_assets,
         unevaluated_runs=[],
         current_time=create_pendulum_time(year=2020, month=1, day=2, hour=0),
         # manually populate entries here to create an in-progress run for both daily assets
@@ -76,5 +86,26 @@ active_run_scenarios = {
                 PartitionKeyRange(start="2020-01-01-00:00", end="2020-01-01-23:00")
             )
         ],
+    ),
+    "freshness_with_observable_source_still_in_progress": AssetReconciliationScenario(
+        assets=freshness_with_observable_source_assets,
+        unevaluated_runs=[
+            run(["observable_source"], is_observation=True),
+            run(["asset0", "asset1", "asset2"]),
+        ],
+        current_time=create_pendulum_time(year=2020, month=1, day=2, hour=0),
+        # manually populate entries here to create an in-progress run for both downstream assets
+        dagster_runs=[
+            DagsterRun(
+                job_name=DEFAULT_JOB_NAME,
+                run_id="1",
+                status=DagsterRunStatus.STARTED,
+                asset_selection={AssetKey("asset0"), AssetKey("asset1"), AssetKey("asset2")},
+            )
+        ],
+        evaluation_delta=datetime.timedelta(minutes=35),
+        event_log_entries=[],
+        # a run is in progress which will satisfy this policy
+        expected_run_requests=[],
     ),
 }


### PR DESCRIPTION
## Summary & Motivation

https://dagster.slack.com/archives/C02LJ7G0LAZ/p1688653467290869

High level, we were originally assuming that we always start our recursive calls from an asset materialization event, even though this is not the case (and the inner recursion handles asset observations just fine)

## How I Tested These Changes

Reproduced the error with the added test, now it succeeds.
