### PR TITLE
Pinning Pydantic to < 2.0.0. Fixes #15147

### DIFF
--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -106,7 +106,7 @@ setup(
         "docstring-parser",
         "universal_pathlib",
         # https://github.com/pydantic/pydantic/issues/5821
-        "pydantic != 1.10.7",
+        "pydantic != 1.10.7,<2.0.0",
     ],
     extras_require={
         "docker": ["docker"],


### PR DESCRIPTION
## Summary & Motivation

Fixing #15147 

## How I Tested These Changes

Reinstalled dagster development env from scratch with pin and ran unit tests