### PR TITLE
add defs property to SensorEvaluationContext

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -225,7 +225,7 @@ def _create_repository_using_definitions_args(
     resources: Optional[Mapping[str, Any]] = None,
     executor: Optional[Union[ExecutorDefinition, Executor]] = None,
     loggers: Optional[Mapping[str, LoggerDefinition]] = None,
-):
+) -> RepositoryDefinition:
     check.opt_iterable_param(
         assets, "assets", (AssetsDefinition, SourceAsset, CacheableAssetsDefinition)
     )
@@ -401,6 +401,12 @@ class Definitions:
             executor=executor,
             loggers=loggers,
         )
+
+    @staticmethod
+    def from_repository(repo: RepositoryDefinition) -> "Definitions":
+        defs = Definitions()
+        defs._created_pending_or_normal_repo = repo  # noqa: SLF001
+        return defs
 
     @public
     def get_job_def(self, name: str) -> JobDefinition:

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -335,6 +335,19 @@ class SensorEvaluationContext:
     def repository_def(self) -> Optional["RepositoryDefinition"]:
         return self._repository_def
 
+    @public
+    @property
+    def defs(self) -> Optional["Definitions"]:
+        from dagster._core.definitions.definitions_class import Definitions
+
+        if self._repository_def is None:
+            raise DagsterInvariantViolationError(
+                "Attempting to access defs, but no defs or repository was provided when"
+                " constructing the SensorEvaluationContext"
+            )
+
+        return Definitions.from_repository(self._repository_def)
+
     @property
     def log(self) -> logging.Logger:
         if self._logger:

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -172,6 +172,9 @@ def simple_sensor(context):
     if not context.last_completion_time or not int(context.last_completion_time) % 2:
         return SkipReason()
 
+    assert context.defs is not None
+    assert context.defs.get_job_def("the_job") is not None
+
     return RunRequest(run_key=None, run_config={}, tags={})
 
 


### PR DESCRIPTION
## Summary & Motivation

`SensorEvaluationContext` currently exposes a `repository_def` property, but no property that feels relevant in the world of `Definitions`.

This property will make it possible to use definition-level information to make decisions about what computations to request. For example, request all assets whose code versions have changed since their latest materialization.

## How I Tested These Changes
