### PR TITLE
DagsterInstance.get_latest_materialization_code_versions

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -3,6 +3,7 @@ from abc import ABC, abstractmethod
 from enum import Enum
 from typing import (
     TYPE_CHECKING,
+    Iterable,
     Mapping,
     NamedTuple,
     Optional,
@@ -338,7 +339,7 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
 
     @abstractmethod
     def get_latest_materialization_events(
-        self, asset_keys: Sequence[AssetKey]
+        self, asset_keys: Iterable[AssetKey]
     ) -> Mapping[AssetKey, Optional["EventLogEntry"]]:
         pass
 

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -1202,9 +1202,9 @@ class SqlEventLogStorage(EventLogStorage):
         return [asset_key for asset_key in asset_keys if asset_key]
 
     def get_latest_materialization_events(
-        self, asset_keys: Sequence[AssetKey]
+        self, asset_keys: Iterable[AssetKey]
     ) -> Mapping[AssetKey, Optional[EventLogEntry]]:
-        check.sequence_param(asset_keys, "asset_keys", AssetKey)
+        check.iterable_param(asset_keys, "asset_keys", AssetKey)
         rows = self._fetch_asset_rows(asset_keys=asset_keys)
         return {
             asset_key: event_log_record.event_log_entry if event_log_record is not None else None

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -467,7 +467,7 @@ class LegacyEventLogStorage(EventLogStorage, ConfigurableClass):
         return self._storage.event_log_storage.get_asset_keys(prefix, limit, cursor)
 
     def get_latest_materialization_events(
-        self, asset_keys: Sequence["AssetKey"]
+        self, asset_keys: Iterable["AssetKey"]
     ) -> Mapping["AssetKey", Optional["EventLogEntry"]]:
         return self._storage.event_log_storage.get_latest_materialization_events(asset_keys)
 

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance_data_versions.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance_data_versions.py
@@ -2,6 +2,7 @@ import time
 from hashlib import sha256
 from typing import Any, Union
 
+from dagster import DagsterInstance, asset, materialize
 from dagster._core.definitions.data_version import (
     CODE_VERSION_TAG,
     DATA_VERSION_TAG,
@@ -103,3 +104,27 @@ def test_compute_logical_data_version_unknown_code_version():
 def test_compute_logical_data_version_unknown_dep_version():
     result = compute_logical_data_version("foo", {AssetKey(["alpha"]): UNKNOWN_DATA_VERSION})
     assert result == UNKNOWN_DATA_VERSION
+
+
+def test_get_latest_materialization_code_versions():
+    @asset(code_version="abc")
+    def has_code_version():
+        ...
+
+    @asset
+    def has_no_code_version():
+        ...
+
+    instance = DagsterInstance.ephemeral()
+    materialize([has_code_version, has_no_code_version], instance=instance)
+
+    latest_materialization_code_versions = instance.get_latest_materialization_code_versions(
+        [has_code_version.key, has_no_code_version.key, AssetKey("something_else")]
+    )
+    assert len(latest_materialization_code_versions) == 3
+
+    assert latest_materialization_code_versions[has_code_version.key] == "abc"
+    assert (
+        latest_materialization_code_versions[has_no_code_version.key] is not None
+    )  # auto-generated
+    assert latest_materialization_code_versions[AssetKey("something_else")] is None


### PR DESCRIPTION
## Summary & Motivation

Adds a `DagsterInstance` method that finds the code version assigned to the latest materialization of each of a set of assets.

This will enable users to e.g. write sensors that only request runs for assets whose definition code versions have changed since their latest materialization.

## How I Tested These Changes
