### PR TITLE
[ui] Add "waiting on assets" to auto-materialization

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AutomaterializeMiddlePanelNoPartitions.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AutomaterializeMiddlePanelNoPartitions.tsx
@@ -1,6 +1,8 @@
 import {Box, Colors, Subheading} from '@dagster-io/ui';
 import * as React from 'react';
 
+import {AssetKey} from '../types';
+
 import {AutomaterializeRunTag} from './AutomaterializeRunTag';
 import {ConditionType, ConditionsNoPartitions} from './Conditions';
 import {EvaluationOrEmpty} from './types';
@@ -34,6 +36,19 @@ export const AutomaterializeMiddlePanelNoPartitions = ({
     return <AutomaterializeRunTag runId={runIds[0]!} />;
   };
 
+  const parentOutdatedWaitingOnAssetKeys = React.useMemo(() => {
+    if (!selectedEvaluation?.conditions) {
+      return [];
+    }
+    const waitingOnAssetKeys: AssetKey[] = [];
+    selectedEvaluation.conditions.forEach((condition) => {
+      if (condition.__typename === 'ParentOutdatedAutoMaterializeCondition') {
+        waitingOnAssetKeys.push(...(condition.waitingOnAssetKeys || []));
+      }
+    });
+    return waitingOnAssetKeys;
+  }, [selectedEvaluation]);
+
   return (
     <Box flex={{direction: 'column', grow: 1}}>
       <Box
@@ -48,6 +63,7 @@ export const AutomaterializeMiddlePanelNoPartitions = ({
       <ConditionsNoPartitions
         conditionResults={conditionResults}
         maxMaterializationsPerMinute={maxMaterializationsPerMinute}
+        parentOutdatedWaitingOnAssetKeys={parentOutdatedWaitingOnAssetKeys}
       />
     </Box>
   );

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/GetEvaluationsQuery.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/GetEvaluationsQuery.tsx
@@ -36,5 +36,10 @@ export const GET_EVALUATIONS_QUERY = gql`
         partitionKeys
       }
     }
+    ... on ParentOutdatedAutoMaterializeCondition {
+      waitingOnAssetKeys {
+        path
+      }
+    }
   }
 `;

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/WaitingOnAssetKeysLink.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/WaitingOnAssetKeysLink.tsx
@@ -1,0 +1,139 @@
+import {
+  ButtonLink,
+  Box,
+  Colors,
+  TextInput,
+  Dialog,
+  DialogFooter,
+  Button,
+  NonIdealState,
+} from '@dagster-io/ui';
+import {useVirtualizer} from '@tanstack/react-virtual';
+import * as React from 'react';
+
+import {Container, Inner, Row} from '../../ui/VirtualizedTable';
+import {AssetLink} from '../AssetLink';
+import {AssetKey} from '../types';
+
+interface Props {
+  assetKeys: AssetKey[];
+}
+
+export const WaitingOnAssetKeysLink = ({assetKeys}: Props) => {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const [queryString, setQueryString] = React.useState('');
+  const queryLowercase = queryString.toLocaleLowerCase();
+
+  const count = assetKeys.length;
+
+  const filteredAssetKeys = React.useMemo(() => {
+    if (queryLowercase === '') {
+      return assetKeys;
+    }
+    return assetKeys.filter((assetKey) =>
+      assetKey.path.some((part) => part.toLowerCase().includes(queryLowercase)),
+    );
+  }, [assetKeys, queryLowercase]);
+
+  const label = React.useMemo(
+    () => (count === 1 ? 'Waiting on 1 asset' : `Waiting on ${count} assets`),
+    [count],
+  );
+
+  const content = () => {
+    if (queryString && !filteredAssetKeys.length) {
+      return (
+        <Box padding={32}>
+          <NonIdealState
+            icon="search"
+            title="No matching asset keys"
+            description={
+              <>
+                No matching asset keys for <strong>{queryString}</strong>
+              </>
+            }
+          />
+        </Box>
+      );
+    }
+
+    return <VirtualizedWaitingOnAssetList assetKeys={filteredAssetKeys} />;
+  };
+
+  return (
+    <>
+      <ButtonLink onClick={() => setIsOpen(true)}>{label}</ButtonLink>
+      <Dialog
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        style={{width: '750px', maxWidth: '80vw', minWidth: '500px'}}
+        canOutsideClickClose
+        canEscapeKeyClose
+      >
+        <Box
+          padding={{horizontal: 24, vertical: 16}}
+          flex={{direction: 'row', alignItems: 'center', justifyContent: 'space-between'}}
+          border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+        >
+          <div style={{fontSize: '16px'}}>{count === 1 ? '1 asset' : `${count} assets`}</div>
+          {count > 0 ? (
+            <TextInput
+              icon="search"
+              value={queryString}
+              onChange={(e) => setQueryString(e.target.value)}
+              placeholder="Filter by asset key…"
+              style={{width: '252px'}}
+            />
+          ) : null}
+        </Box>
+        <div style={{height: '272px', overflow: 'hidden'}}>{content()}</div>
+        <DialogFooter topBorder>
+          <Button onClick={() => setIsOpen(false)}>Close</Button>
+        </DialogFooter>
+      </Dialog>
+    </>
+  );
+};
+
+interface VirtualizedWaitingOnAssetListProps {
+  assetKeys: AssetKey[];
+}
+
+const VirtualizedWaitingOnAssetList = ({assetKeys}: VirtualizedWaitingOnAssetListProps) => {
+  const container = React.useRef<HTMLDivElement | null>(null);
+
+  const rowVirtualizer = useVirtualizer({
+    count: assetKeys.length,
+    getScrollElement: () => container.current,
+    estimateSize: () => 40,
+    overscan: 10,
+  });
+
+  const totalHeight = rowVirtualizer.getTotalSize();
+  const items = rowVirtualizer.getVirtualItems();
+
+  return (
+    <Container ref={container} style={{padding: '8px 24px'}}>
+      <Inner $totalHeight={totalHeight}>
+        {items.map(({index, key, size, start}) => {
+          const assetKey = assetKeys[index]!;
+          return (
+            <Row $height={size} $start={start} key={key}>
+              <Box
+                style={{height: '100%'}}
+                flex={{direction: 'row', alignItems: 'center'}}
+                border={
+                  index < assetKeys.length - 1
+                    ? {side: 'bottom', width: 1, color: Colors.KeylineGray}
+                    : null
+                }
+              >
+                <AssetLink path={assetKey.path} icon="asset" />
+              </Box>
+            </Row>
+          );
+        })}
+      </Inner>
+    </Container>
+  );
+};

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/WaitingOnPartitionAssetKeysLink.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/WaitingOnPartitionAssetKeysLink.tsx
@@ -1,0 +1,238 @@
+import {
+  ButtonLink,
+  Box,
+  Colors,
+  TextInput,
+  Dialog,
+  DialogFooter,
+  Button,
+  NonIdealState,
+  Icon,
+} from '@dagster-io/ui';
+import {useVirtualizer} from '@tanstack/react-virtual';
+import * as React from 'react';
+import styled from 'styled-components/macro';
+
+import {Container, Inner, Row} from '../../ui/VirtualizedTable';
+import {AssetLink} from '../AssetLink';
+import {AssetKey} from '../types';
+
+interface Props {
+  assetKeysByPartition: Record<string, AssetKey[]>;
+}
+
+export const WaitingOnPartitionAssetKeysLink = ({assetKeysByPartition}: Props) => {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const [queryString, setQueryString] = React.useState('');
+  const queryLowercase = queryString.toLocaleLowerCase();
+
+  const partitionNames = Object.keys(assetKeysByPartition);
+  const count = partitionNames.length;
+
+  const filteredPartitionNames = React.useMemo(() => {
+    if (queryLowercase === '') {
+      return partitionNames;
+    }
+    return partitionNames.filter((partitionName) =>
+      partitionName.toLowerCase().includes(queryLowercase),
+    );
+  }, [partitionNames, queryLowercase]);
+
+  const label = React.useMemo(() => (count === 1 ? `1 partition` : `${count} partitions`), [count]);
+
+  const content = () => {
+    if (queryString && !filteredPartitionNames.length) {
+      return (
+        <Box padding={32}>
+          <NonIdealState
+            icon="search"
+            title="No matching partitions"
+            description={
+              <>
+                No matching partitions for <strong>{queryString}</strong>
+              </>
+            }
+          />
+        </Box>
+      );
+    }
+
+    const visiblePartitions = {} as Record<string, AssetKey[]>;
+    filteredPartitionNames.forEach((partitionName) => {
+      visiblePartitions[partitionName] = assetKeysByPartition[partitionName]!;
+    });
+
+    return <VirtualizedPartitionsWaitingOnAssetList assetKeysByPartition={visiblePartitions} />;
+  };
+
+  return (
+    <>
+      <ButtonLink onClick={() => setIsOpen(true)}>{label}</ButtonLink>
+      <Dialog
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        style={{width: '750px', maxWidth: '80vw', minWidth: '500px'}}
+        canOutsideClickClose
+        canEscapeKeyClose
+      >
+        <Box
+          padding={{horizontal: 24, vertical: 16}}
+          flex={{direction: 'row', alignItems: 'center', justifyContent: 'space-between'}}
+          border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+        >
+          <div style={{fontSize: '16px'}}>
+            {count === 1 ? '1 partition' : `${count} partitions`}
+          </div>
+          {count > 0 ? (
+            <TextInput
+              icon="search"
+              value={queryString}
+              onChange={(e) => setQueryString(e.target.value)}
+              placeholder="Filter by partition…"
+              style={{width: '252px'}}
+            />
+          ) : null}
+        </Box>
+        <div style={{height: '272px', overflow: 'hidden'}}>{content()}</div>
+        <DialogFooter topBorder>
+          <Button onClick={() => setIsOpen(false)}>Close</Button>
+        </DialogFooter>
+      </Dialog>
+    </>
+  );
+};
+
+interface VirtualizedPartitionsWaitingOnAssetListProps {
+  assetKeysByPartition: Record<string, AssetKey[]>;
+}
+
+type Row =
+  | {
+      type: 'partition-name';
+      partitionName: string;
+      expanded: boolean;
+      assetCount: number;
+    }
+  | {type: 'asset-key'; assetKey: AssetKey};
+
+const VirtualizedPartitionsWaitingOnAssetList = ({
+  assetKeysByPartition,
+}: VirtualizedPartitionsWaitingOnAssetListProps) => {
+  const [expandedPartitions, setExpandedPartitions] = React.useState<Set<string>>(
+    () => new Set([]),
+  );
+  const container = React.useRef<HTMLDivElement | null>(null);
+
+  const allRows = React.useMemo(() => {
+    const rows = [] as Row[];
+    Object.entries(assetKeysByPartition).forEach(([partitionName, assetKeys]) => {
+      const expanded = expandedPartitions.has(partitionName);
+      rows.push({type: 'partition-name', partitionName, expanded, assetCount: assetKeys.length});
+      if (expanded) {
+        const assetRows: Row[] = assetKeys.map((assetKey) => ({type: 'asset-key', assetKey}));
+        rows.push(...assetRows);
+      }
+    });
+    return rows;
+  }, [assetKeysByPartition, expandedPartitions]);
+
+  const rowVirtualizer = useVirtualizer({
+    count: allRows.length,
+    getScrollElement: () => container.current,
+    estimateSize: () => 40,
+    overscan: 10,
+  });
+
+  const onToggle = React.useCallback((partitionName: string) => {
+    setExpandedPartitions((current) => {
+      const copy = new Set(Array.from(current));
+      if (current.has(partitionName)) {
+        copy.delete(partitionName);
+      } else {
+        copy.add(partitionName);
+      }
+      return copy;
+    });
+  }, []);
+
+  const totalHeight = rowVirtualizer.getTotalSize();
+  const items = rowVirtualizer.getVirtualItems();
+
+  return (
+    <Container ref={container} style={{padding: '8px 24px'}}>
+      <Inner $totalHeight={totalHeight}>
+        {items.map(({index, key, size, start}) => {
+          const row = allRows[index]!;
+          return (
+            <Row $height={size} $start={start} key={key}>
+              <Box
+                style={{height: '100%'}}
+                flex={{direction: 'row', alignItems: 'center'}}
+                border={
+                  index < allRows.length - 1
+                    ? {side: 'bottom', width: 1, color: Colors.KeylineGray}
+                    : null
+                }
+              >
+                {row.type === 'partition-name' ? (
+                  <ExpandablePartitionName
+                    partitionName={row.partitionName}
+                    expanded={row.expanded}
+                    assetCount={row.assetCount}
+                    onToggle={onToggle}
+                  />
+                ) : (
+                  <Box padding={{left: 24}}>
+                    <AssetLink path={row.assetKey.path} icon="asset" />
+                  </Box>
+                )}
+              </Box>
+            </Row>
+          );
+        })}
+      </Inner>
+    </Container>
+  );
+};
+
+interface ExpandablePartitionNameProps {
+  partitionName: string;
+  assetCount: number;
+  expanded: boolean;
+  onToggle: (partitionName: string) => void;
+}
+
+const ExpandablePartitionName = ({
+  partitionName,
+  assetCount,
+  expanded,
+  onToggle,
+}: ExpandablePartitionNameProps) => {
+  return (
+    <PartitionNameButton onClick={() => onToggle(partitionName)}>
+      <Icon
+        name="arrow_drop_down"
+        style={{transform: expanded ? 'rotate(0deg)' : 'rotate(-90deg)'}}
+      />
+      <div>{partitionName}</div>
+      <div>{assetCount === 1 ? `(Waiting on 1 asset)` : `Waiting on ${assetCount} assets`}</div>
+    </PartitionNameButton>
+  );
+};
+
+const PartitionNameButton = styled.button`
+  background-color: transparent;
+  cursor: pointer;
+  padding: 0;
+  border: 0;
+  display: flex;
+  height: 100%;
+  width: 100%;
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+
+  :focus {
+    outline: none;
+  }
+`;

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/types/GetEvaluationsQuery.types.ts
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/types/GetEvaluationsQuery.types.ts
@@ -68,6 +68,7 @@ export type GetEvaluationsQuery = {
             | {
                 __typename: 'ParentOutdatedAutoMaterializeCondition';
                 decisionType: Types.AutoMaterializeDecisionType;
+                waitingOnAssetKeys: Array<{__typename: 'AssetKey'; path: Array<string>}> | null;
                 partitionKeysOrError:
                   | {__typename: 'PartitionKeys'; partitionKeys: Array<string>}
                   | {__typename: 'PartitionSubsetDeserializationError'}
@@ -132,6 +133,7 @@ export type AutoMaterializeEvaluationRecordItemFragment = {
     | {
         __typename: 'ParentOutdatedAutoMaterializeCondition';
         decisionType: Types.AutoMaterializeDecisionType;
+        waitingOnAssetKeys: Array<{__typename: 'AssetKey'; path: Array<string>}> | null;
         partitionKeysOrError:
           | {__typename: 'PartitionKeys'; partitionKeys: Array<string>}
           | {__typename: 'PartitionSubsetDeserializationError'}
@@ -188,6 +190,7 @@ export type AutoMateralizeWithConditionFragment_ParentMaterializedAutoMaterializ
 export type AutoMateralizeWithConditionFragment_ParentOutdatedAutoMaterializeCondition_ = {
   __typename: 'ParentOutdatedAutoMaterializeCondition';
   decisionType: Types.AutoMaterializeDecisionType;
+  waitingOnAssetKeys: Array<{__typename: 'AssetKey'; path: Array<string>}> | null;
   partitionKeysOrError:
     | {__typename: 'PartitionKeys'; partitionKeys: Array<string>}
     | {__typename: 'PartitionSubsetDeserializationError'}


### PR DESCRIPTION
## Summary & Motivation

Add "waiting on assets" to the auto-materialization UI, for both non-partitioned and partitioned assets.

- Retrieve `waitingOnAssetKeys` for `ParentOutdatedAutoMaterializeCondition`, to be displayed alongside this condition
- On non-partitioned assets, show a link to open a dialog with the list of awaited asset keys
- On partitioned assets, show a link to open a dialog with a collapsible list of partitions and their awaited keys

Non-partitioned asset:

<img width="1143" alt="Screenshot 2023-07-06 at 8 29 40 PM" src="https://github.com/dagster-io/dagster/assets/2823852/3008b4a9-0399-4a4b-af79-b9dad4c89367">

Partitioned asset:

<img width="1307" alt="Screenshot 2023-07-06 at 9 04 40 PM" src="https://github.com/dagster-io/dagster/assets/2823852/c03eb163-ec70-440e-997b-25e3784d6e93">

## How I Tested These Changes

Kick off some upstream materializations, verify that downstream assets have "skipped" conditions that show the link. Verify that the dialog renders and behaves correctly for each case.
