### PR TITLE
[docs] Add robots.txt

### DIFF
--- a/docs/next/public/robots.txt
+++ b/docs/next/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Sitemap: https://docs.dagster.io/sitemap.xml


### PR DESCRIPTION
## Summary & Motivation

We don't currently have a robots.txt file on the Docs site indicating the presence of our sitemap, so it seems like we may as well go ahead and add it.

## How I Tested These Changes

`yarn start`, verify that `robots.txt` can be loaded in the browser.
