### PR TITLE
[tsconfig] Allow unreachable code from typescript linter 

### DIFF
--- a/docs/next/tsconfig.json
+++ b/docs/next/tsconfig.json
@@ -11,6 +11,7 @@
     "module": "esnext",
     "moduleResolution": "node",
     "resolveJsonModule": true,
+    "allowUnreachableCode": true,
     "isolatedModules": true,
     "jsx": "preserve",
     "baseUrl": ".",

--- a/js_modules/dagit/packages/app/tsconfig.json
+++ b/js_modules/dagit/packages/app/tsconfig.json
@@ -13,6 +13,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
+    "allowUnreachableCode": true,
     "noImplicitReturns": true,
     "noImplicitThis": true,
     "noImplicitAny": true,
@@ -23,7 +24,5 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }

--- a/js_modules/dagit/packages/core/tsconfig.json
+++ b/js_modules/dagit/packages/core/tsconfig.json
@@ -13,6 +13,7 @@
     "forceConsistentCasingInFileNames": true,
     "noImplicitReturns": true,
     "noUncheckedIndexedAccess": true,
+    "allowUnreachableCode": true,
     "allowSyntheticDefaultImports": true,
     "types": ["jest", "node"],
     "skipLibCheck": true,

--- a/js_modules/dagit/packages/ui/tsconfig.json
+++ b/js_modules/dagit/packages/ui/tsconfig.json
@@ -13,6 +13,7 @@
     "noImplicitReturns": true,
     "noUncheckedIndexedAccess": true,
     "allowSyntheticDefaultImports": true,
+    "allowUnreachableCode": true,
     "types": ["jest", "node"],
     "skipLibCheck": true,
     "esModuleInterop": true,


### PR DESCRIPTION
The typescript linter has a fixer that deletes unreachable code and it does so even if theres a syntax error.
Lets disable this rule on the typescript linter and rely on eslint reporting these errors.

Eslint doesn't have an autofixer so it won't disappear your code.

#### Test Plan

Make sure eslint reports unreachable code:

![Screenshot 2023-07-07 at 3 18 11 PM](https://github.com/dagster-io/internal/assets/2286579/dc5f5562-5de3-4e09-a7db-324649d60654)
