### PR TITLE
PythonObjectMetadataValue

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -233,6 +233,7 @@ from dagster._core.definitions.metadata import (
     NullMetadataValue as NullMetadataValue,
     PathMetadataValue as PathMetadataValue,
     PythonArtifactMetadataValue as PythonArtifactMetadataValue,
+    PythonObjectMetadataValue as PythonObjectMetadataValue,
     TableMetadataValue as TableMetadataValue,
     TableSchemaMetadataValue as TableSchemaMetadataValue,
     TextMetadataValue as TextMetadataValue,


### PR DESCRIPTION
## Summary & Motivation

This adds the ability to include arbitrary Python objects as metadata on asset and job definitions. This metadata rides along with the definition in the same process, but *does not get serialized when the metadata is serialized*. This means it does not show up in the UI and does not end up in the event log.

The initial use case for this is to allow `DbtManifest` objects to live on the asset definitions that are derived from them. `DbtCli.cli` will be able to access the `DbtManifest` from the context object and thus avoid requiring the user to re-specify it.

## How I Tested These Changes
