### PR TITLE
Fix flaky perf regression test

### DIFF
--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_reconciliation_sensor_perf.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_reconciliation_sensor_perf.py
@@ -348,7 +348,7 @@ perf_scenarios = [
     PerfScenario(
         snapshot=all_daily_partitioned_500_assets_2_partition_keys,
         n_freshness_policies=100,
-        max_execution_time_seconds=15,
+        max_execution_time_seconds=25,
     ),
     PerfScenario(
         snapshot=all_hourly_partitioned_100_assets_2_partition_keys,


### PR DESCRIPTION
## Summary & Motivation

A recent change mildly degraded performance for one of these tests (expected), and the limit was not bumped.

## How I Tested These Changes
