### PR TITLE
[pythonic config] Add basic support for fixed-length Tuples

### DIFF
--- a/python_modules/dagster/dagster/_config/pythonic_config/config.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/config.py
@@ -7,6 +7,7 @@ from typing import (
     Mapping,
     Optional,
     Set,
+    Tuple,
     Type,
     cast,
 )
@@ -238,6 +239,8 @@ class Config(MakeConfigCacheable, metaclass=BaseConfigMeta):
                     **nested_values,
                     discriminator_key: discriminated_value,
                 }
+            elif field and safe_is_subclass(field.annotation, Tuple):
+                modified_data[key] = list(value) if value is not None else None
             else:
                 if field and safe_is_subclass(field.annotation, Config) and isinstance(value, dict):
                     modified_data[key] = field.annotation._get_non_default_public_field_values_cls(  # noqa: SLF001
@@ -353,6 +356,8 @@ def _config_value_to_dict_representation(field: Optional[ModelFieldCompat], valu
             return {k: v for k, v in value._convert_to_config_dictionary().items()}  # noqa: SLF001
     elif isinstance(value, Enum):
         return value.name
+    elif isinstance(value, Tuple):
+        return [_config_value_to_dict_representation(None, v) for v in value]
 
     return value
 

--- a/python_modules/dagster/dagster/_config/pythonic_config/conversion_utils.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/conversion_utils.py
@@ -6,6 +6,7 @@ from typing import (
     List,
     Mapping,
     Optional,
+    Tuple,
     Type,
     TypeVar,
     Union,
@@ -18,6 +19,7 @@ from dagster import (
 )
 from dagster._config.config_type import (
     Array,
+    ConfigAnyInstance as DagsterAny,
     ConfigType,
     Noneable,
 )
@@ -190,6 +192,8 @@ def _config_type_for_type_on_pydantic_field(
     if safe_is_subclass(get_origin(potential_dagster_type), List):
         list_inner_type = get_args(potential_dagster_type)[0]
         return Array(_config_type_for_type_on_pydantic_field(list_inner_type))
+    elif safe_is_subclass(get_origin(potential_dagster_type), Tuple):
+        return Array(Noneable(DagsterAny))
     elif is_optional(potential_dagster_type):
         optional_inner_type = next(
             arg for arg in get_args(potential_dagster_type) if arg is not type(None)

--- a/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_pythonic_config_types.py
+++ b/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_pythonic_config_types.py
@@ -1002,6 +1002,11 @@ def test_tuple_nested() -> None:
     with pytest.raises(ValidationError):
         a_job.execute_in_process({"ops": {"a_struct_config_op": {"config": {"a_tuple": [1, 2]}}}})
 
+    with pytest.raises(ValidationError):
+        a_job.execute_in_process(
+            {"ops": {"a_struct_config_op": {"config": {"a_tuple": [1, [2, "foo", "bar"]]}}}}
+        )
+
 
 def test_optional_tuple() -> None:
     class AnOpConfig(Config):


### PR DESCRIPTION
## Summary

Adds basic support for tuples in the Pythonic config system. This converts to the underlying Array Dagster type for the purposes of the launchpad.

```python
class AnOpConfig(Config):
    a_tuple: Tuple[int, int, str]

@op
def a_struct_config_op(config: AnOpConfig):
    assert config.a_tuple == (1, 2, "test")


a_struct_config_op(AnOpConfig(a_tuple=(1, 2, "test")))
```

A stacked change will enable this to work for variable-size tuples (w/ ellipses)

## Test Plan

New unit tests, tested locally in launchpad.


