### PR TITLE
Fix perf regression

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -84,6 +84,10 @@ class AssetGraph:
         self._code_versions_by_key = code_versions_by_key
         self._is_observable_by_key = is_observable_by_key
         self._auto_observe_interval_minutes_by_key = auto_observe_interval_minutes_by_key
+        # source assets keys can sometimes appear in the upstream dict
+        self._materializable_asset_keys = (
+            self._asset_dep_graph["upstream"].keys() - self.source_asset_keys
+        )
 
     @property
     def asset_dep_graph(self) -> DependencyGraph[AssetKey]:
@@ -176,12 +180,11 @@ class AssetGraph:
 
     @property
     def all_asset_keys(self) -> AbstractSet[AssetKey]:
-        return self.materializable_asset_keys | self.source_asset_keys
+        return self._asset_dep_graph["upstream"].keys() | self.source_asset_keys
 
     @property
     def materializable_asset_keys(self) -> AbstractSet[AssetKey]:
-        # Source assets keys can sometimes appear in the upstream dict
-        return self._asset_dep_graph["upstream"].keys() - self.source_asset_keys
+        return self._materializable_asset_keys
 
     def get_partitions_def(self, asset_key: AssetKey) -> Optional[PartitionsDefinition]:
         return self._partitions_defs_by_key.get(asset_key)

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -179,12 +179,12 @@ class AssetGraph:
         )
 
     @property
-    def all_asset_keys(self) -> AbstractSet[AssetKey]:
-        return self._asset_dep_graph["upstream"].keys() | self.source_asset_keys
-
-    @property
     def materializable_asset_keys(self) -> AbstractSet[AssetKey]:
         return self._materializable_asset_keys
+
+    @property
+    def all_asset_keys(self) -> AbstractSet[AssetKey]:
+        return self._materializable_asset_keys | self.source_asset_keys
 
     def get_partitions_def(self, asset_key: AssetKey) -> Optional[PartitionsDefinition]:
         return self._partitions_defs_by_key.get(asset_key)

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_reconciliation_sensor_perf.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_reconciliation_sensor_perf.py
@@ -328,7 +328,7 @@ perf_scenarios = [
     PerfScenario(
         snapshot=unpartitioned_2000_assets_2_random_runs,
         n_freshness_policies=0,
-        max_execution_time_seconds=10,
+        max_execution_time_seconds=25,
     ),
     PerfScenario(
         snapshot=unpartitioned_2000_assets_2_random_runs,

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_reconciliation_sensor_perf.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_reconciliation_sensor_perf.py
@@ -328,7 +328,7 @@ perf_scenarios = [
     PerfScenario(
         snapshot=unpartitioned_2000_assets_2_random_runs,
         n_freshness_policies=0,
-        max_execution_time_seconds=25,
+        max_execution_time_seconds=10,
     ),
     PerfScenario(
         snapshot=unpartitioned_2000_assets_2_random_runs,


### PR DESCRIPTION
## Summary & Motivation

We were calling `materializiable_asset_keys` a bunch, causing us to do a set union which seems to be much less efficient on older versions of python. Just calculate this upfront instead

## How I Tested These Changes
