### PR TITLE
with @dbt_assets, pass manifest through context

### DIFF
--- a/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/build.py
+++ b/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/build.py
@@ -8,4 +8,4 @@ manifest = DbtManifest.read(path=MANIFEST_PATH)
 
 @dbt_assets(manifest=manifest)
 def my_dbt_assets(context: OpExecutionContext, dbt: DbtCli):
-    yield from dbt.cli(["build"], manifest=manifest, context=context).stream()
+    yield from dbt.cli(["build"], context=context).stream()

--- a/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/customize_asset_keys.py
+++ b/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/customize_asset_keys.py
@@ -17,4 +17,4 @@ manifest = CustomizedDbtManifest.read(path=MANIFEST_PATH)
 
 @dbt_assets(manifest=manifest)
 def my_dbt_assets(context: OpExecutionContext, dbt: DbtCli):
-    yield from dbt.cli(["build"], manifest=manifest, context=context).stream()
+    yield from dbt.cli(["build"], context=context).stream()

--- a/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/customize_description.py
+++ b/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/customize_description.py
@@ -27,4 +27,4 @@ manifest = CustomizedDbtManifest.read(path=MANIFEST_PATH)
 
 @dbt_assets(manifest=manifest)
 def my_dbt_assets(context: OpExecutionContext, dbt: DbtCli):
-    yield from dbt.cli(["build"], manifest=manifest, context=context).stream()
+    yield from dbt.cli(["build"], context=context).stream()

--- a/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/dependencies.py
+++ b/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/dependencies.py
@@ -32,7 +32,7 @@ def clients_data(context):
 
 @dbt_assets(manifest=manifest)
 def my_dbt_assets(context: OpExecutionContext, dbt: DbtCli):
-    yield from dbt.cli(["build"], manifest=manifest, context=context).stream()
+    yield from dbt.cli(["build"], context=context).stream()
 
 
 @asset(non_argument_deps={manifest.get_asset_key_for_model("customers")})

--- a/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/partitions.py
+++ b/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/partitions.py
@@ -12,7 +12,7 @@ manifest = DbtManifest.read(path=MANIFEST_PATH)
 
 @dbt_assets(manifest=manifest, select=DBT_SELECT_SEED)
 def dbt_seed_assets(context: OpExecutionContext, dbt: DbtCli):
-    yield from dbt.cli(["seed"], manifest=manifest, context=context).stream()
+    yield from dbt.cli(["seed"], context=context).stream()
 
 
 @dbt_assets(
@@ -24,4 +24,4 @@ def dbt_daily_assets(context: OpExecutionContext, dbt: DbtCli):
     dbt_vars = {"date": context.partition_key}
     dbt_args = ["run", "--vars", json.dumps(dbt_vars)]
 
-    yield from dbt.cli(dbt_args, manifest=manifest, context=context).stream()
+    yield from dbt.cli(dbt_args, context=context).stream()

--- a/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/runtime_metadata.py
+++ b/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/runtime_metadata.py
@@ -9,7 +9,7 @@ manifest = DbtManifest.read(path=MANIFEST_PATH)
 
 @dbt_assets(manifest=manifest)
 def my_dbt_assets(context: OpExecutionContext, dbt: DbtCli):
-    for event in dbt.cli(["build"], manifest=manifest, context=context).stream_raw_events():
+    for event in dbt.cli(["build"], context=context).stream_raw_events():
         for dagster_event in event.to_default_asset_events(manifest=manifest):
             if isinstance(dagster_event, Output):
                 event_node_info = event.raw_event["data"]["node_info"]

--- a/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/seed_run_test.py
+++ b/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/seed_run_test.py
@@ -15,4 +15,4 @@ def my_dbt_assets(context: OpExecutionContext, dbt: DbtCli):
     ]
 
     for dbt_command in dbt_commands:
-        yield from dbt.cli(dbt_command, manifest=manifest, context=context).stream()
+        yield from dbt.cli(dbt_command, context=context).stream()

--- a/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/separate_asset_defs.py
+++ b/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/separate_asset_defs.py
@@ -8,7 +8,7 @@ manifest = DbtManifest.read(path=MANIFEST_PATH)
 
 @dbt_assets(manifest=manifest, select="resource_type:seed")
 def dbt_seed_assets(context: OpExecutionContext, dbt: DbtCli):
-    yield from dbt.cli(["seed"], manifest=manifest, context=context).stream()
+    yield from dbt.cli(["seed"], context=context).stream()
 
 
 @dbt_assets(manifest=manifest, select="fqn:staging.*")
@@ -19,7 +19,7 @@ def dbt_staging_assets(context: OpExecutionContext, dbt: DbtCli):
     ]
 
     for dbt_command in dbt_commands:
-        yield from dbt.cli(dbt_command, manifest=manifest, context=context).stream()
+        yield from dbt.cli(dbt_command, context=context).stream()
 
 
 @dbt_assets(manifest=manifest, select="fqn:customers fqn:orders")
@@ -30,4 +30,4 @@ def my_dbt_assets(context: OpExecutionContext, dbt: DbtCli):
     ]
 
     for dbt_command in dbt_commands:
-        yield from dbt.cli(dbt_command, manifest=manifest, context=context).stream()
+        yield from dbt.cli(dbt_command, context=context).stream()

--- a/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/use_artifacts.py
+++ b/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/use_artifacts.py
@@ -11,7 +11,7 @@ manifest = DbtManifest.read(path=MANIFEST_PATH)
 
 @dbt_assets(manifest=manifest)
 def my_dbt_assets(context: OpExecutionContext, dbt: DbtCli):
-    dbt_build = dbt.cli(["build"], manifest=manifest, context=context)
+    dbt_build = dbt.cli(["build"], context=context)
 
     yield from dbt_build.stream()
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
@@ -42,7 +42,7 @@ def dbt_assets(
 
             @dbt_assets(manifest=manifest)
             def my_dbt_assets(context: OpExecutionContext, dbt: DbtCli):
-                yield from dbt.cli(["build"], manifest=manifest, context=context).stream()
+                yield from dbt.cli(["build"], context=context).stream()
     """
     unique_ids = select_unique_ids_from_manifest(
         select=select, exclude=exclude or "", manifest_json=manifest.raw_manifest
@@ -60,6 +60,7 @@ def dbt_assets(
         dbt_nodes=manifest.node_info_by_dbt_unique_id,
         deps=deps,
         io_manager_key=io_manager_key,
+        manifest=manifest,
     )
 
     def inner(fn) -> AssetsDefinition:


### PR DESCRIPTION
## Summary & Motivation

The user no longer needs to explicitly pass the manifest when invoking `DbtCli.cli` from inside `@dbt_assets`. The aim is to reduce boilerplate and help avoid errors that would be caused by passing different manifests to the `@dbt_assets` and `DbtCli.cli`.

Previous:

```python
    @dbt_assets(manifest=manifest)
    def all_dbt_assets(context, dbt: DbtCli):
        yield from dbt.cli(["build"], manifest=manifest, context=context).stream()
```

With this PR:
```python
    @dbt_assets(manifest=manifest)
    def all_dbt_assets(context, dbt: DbtCli):
        yield from dbt.cli(["build"], context=context).stream()
```

## How I Tested These Changes
