### PR TITLE
accept Path and dict args for manifest argument of `@dbt_assets`

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -799,12 +799,10 @@ class DbtCliInvocation:
         Examples:
             .. code-block:: python
 
+                from pathlib import Path
                 from dagster_dbt import DbtCli, DbtManifest, dbt_assets
 
-                manifest = DbtManifest.read(path="target/manifest.json")
-
-
-                @dbt_assets(manifest=manifest)
+                @dbt_assets(manifest=Path("target", "manifest.json"))
                 def my_dbt_assets(context, dbt: DbtCli):
                     yield from dbt.cli(["run"], context=context).stream()
         """
@@ -980,12 +978,10 @@ class DbtCli(ConfigurableResource):
         Examples:
             .. code-block:: python
 
+                from pathlib import Path
                 from dagster_dbt import DbtCli, DbtManifest, dbt_assets
 
-                manifest = DbtManifest.read(path="target/manifest.json")
-
-
-                @dbt_assets(manifest=manifest)
+                @dbt_assets(manifest=Path("target", "manifest.json"))
                 def my_dbt_assets(context, dbt: DbtCli):
                     yield from dbt.cli(["run"], context=context).stream()
         """

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_decorator.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 from typing import AbstractSet, Any, Mapping, Optional
 
@@ -32,6 +33,25 @@ def test_materialize(test_project_dir):
     assert materialize(
         [all_dbt_assets], resources={"dbt": DbtCli(project_dir=test_project_dir)}
     ).success
+
+
+@pytest.mark.parametrize("manifest", [json.load(manifest_path.open()), manifest_path])
+def test_manifest_argument(manifest):
+    @dbt_assets(manifest=manifest)
+    def my_dbt_assets():
+        ...
+
+    assert my_dbt_assets.keys == {
+        AssetKey.from_user_string(key)
+        for key in [
+            "sort_by_calories",
+            "cold_schema/sort_cold_cereals_by_calories",
+            "subdir_schema/least_caloric",
+            "sort_hot_cereals_by_calories",
+            "orders_snapshot",
+            "cereals",
+        ]
+    }
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary & Motivation

The aim here is to make it so that users don't need to understand dagster-dbt's notion of a DbtManifest until they need it.

The current `DbtManifest` class is kind of two things:
1. A simple wrapper around a raw manifest
2. A set of override-able methods that act as a translation layer between dbt concepts and Dagster concepts

It's probably going to make sense to rename `DbtManifest` to something like `DagsterDbtManifest` or `DbtManifestAdapter` in order to disambiguate from the dbt library's `Manifest` class and to make it clear that the manifest is responsible for (2).

Allowing a Path or JSON blob allows users who don't need to think about (2) to avoid dealing with this Dagster concept, as well as removing a small amount of boilerplate.

## How I Tested These Changes
