### PR TITLE
tweaks to argument order, types, and docs for get_status_by_partition

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -1857,14 +1857,18 @@ class DagsterInstance(DynamicPartitionsStore):
     @public
     @traced
     def get_status_by_partition(
-        self, asset_key: AssetKey, partitions_def: PartitionsDefinition, partition_keys: List[str]
+        self,
+        asset_key: AssetKey,
+        partition_keys: Sequence[str],
+        partitions_def: PartitionsDefinition,
     ) -> Optional[Mapping[str, AssetPartitionStatus]]:
-        """Get the current status of provided partition_keys.
+        """Get the current status of provided partition_keys for the provided asset.
 
         Args:
-            asset_key (AssetKey):
-            partitions_def (PartitionsDefinition):
-            partition_keys (List[str]):
+            asset_key (AssetKey): The asset to get per-partition status for.
+            partition_keys (Sequence[str]): The partitions to get status for.
+            partitions_def (PartitionsDefinition): The PartitionsDefinition of the asset to get
+                per-partition status for.
 
         Returns:
             Optional[Mapping[str, AssetPartitionStatus]]: status for each partition key

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
@@ -738,7 +738,7 @@ def test_get_status_by_partition(mock_get_and_update):
     with instance_for_test() as instance:
         partition_status = instance.get_status_by_partition(
             AssetKey("test-asset"),
-            DailyPartitionsDefinition(start_date="2023-06-01"),
             ["2023-07-01"],
+            DailyPartitionsDefinition(start_date="2023-06-01"),
         )
         assert partition_status == {"2023-07-01": AssetPartitionStatus.IN_PROGRESS}


### PR DESCRIPTION
## Summary & Motivation

- Add a bit more docs.
- Use `Sequence` instead of `List`, to indicate that we won't mutate it.
- Move `partitions_def` argument to the end. I think that, in the future, it will be possible to improve the implementation so that in some cases this argument isn't required. Better to put non-required arguments at the end.

## How I Tested These Changes
