### PR TITLE
[docs] update op events output page

### DIFF
--- a/docs/content/concepts/ops-jobs-graphs/op-events.mdx
+++ b/docs/content/concepts/ops-jobs-graphs/op-events.mdx
@@ -38,7 +38,17 @@ Yielding events from within the body of an op is a useful way of communicating w
 
 Because returning a value from an op is such a fundamental part of creating a data pipeline, we have a few different interfaces for this functionality.
 
-For many use cases, Dagster ops can be used directly with python's native type annotations without additional modification. Check out the docs on [Op Outputs](/concepts/ops-jobs-graphs/ops#outputs) to learn more about this functionality. Dagster also provides the <PyObject object="Output"/> object, which opens up additional functionality to outputs when using Dagster, such as [specifying output metadata](/concepts/ops-jobs-graphs/op-events#attaching-metadata-to-outputs) and [conditional branching](/concepts/ops-jobs-graphs/graphs#with-conditional-branching), all while maintaining coherent type annotations.
+For many use cases, Dagster ops can be used directly with python's native type annotations without additional modification.
+
+```python file=/concepts/ops_jobs_graphs/ops.py startafter=start_output_op_marker endbefore=end_output_op_marker
+@op
+def my_output_op():
+    return 5
+```
+
+Check out the docs on [Op Outputs](/concepts/ops-jobs-graphs/ops#outputs) to learn more about this functionality.
+
+Dagster also provides the <PyObject object="Output"/> object, which opens up additional functionality to outputs when using Dagster, such as [specifying output metadata](/concepts/ops-jobs-graphs/op-events#attaching-metadata-to-outputs) and [conditional branching](/concepts/ops-jobs-graphs/graphs#with-conditional-branching), all while maintaining coherent type annotations.
 
 <PyObject object="Output" /> objects can be either returned or yielded. The Output
 type is also generic, for use with return annotations:
@@ -51,19 +61,22 @@ from typing import Tuple
 # Using Output as type annotation without inner type
 @op
 def my_output_op() -> Output:
-    return Output("some_value")
+    return Output("some_value", metadata={"some_metadata": "a_value"})
 
 
 # A single output with a parameterized type annotation
 @op
 def my_output_generic_op() -> Output[int]:
-    return Output(5)
+    return Output(5, metadata={"some_metadata": "a_value"})
 
 
 # Multiple outputs using parameterized type annotation
 @op(out={"int_out": Out(), "str_out": Out()})
 def my_multiple_generic_output_op() -> Tuple[Output[int], Output[str]]:
-    return (Output(5), Output("foo"))
+    return (
+        Output(5, metadata={"some_metadata": "a_value"}),
+        Output("foo", metadata={"some_metadata": "another_value"}),
+    )
 ```
 
 When <PyObject object="Output" /> objects are yielded, type annotations cannot be used. Instead, type information can be specified using the `out` argument of the op decorator.

--- a/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/op_events.py
+++ b/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/op_events.py
@@ -68,19 +68,22 @@ from typing import Tuple
 # Using Output as type annotation without inner type
 @op
 def my_output_op() -> Output:
-    return Output("some_value")
+    return Output("some_value", metadata={"some_metadata": "a_value"})
 
 
 # A single output with a parameterized type annotation
 @op
 def my_output_generic_op() -> Output[int]:
-    return Output(5)
+    return Output(5, metadata={"some_metadata": "a_value"})
 
 
 # Multiple outputs using parameterized type annotation
 @op(out={"int_out": Out(), "str_out": Out()})
 def my_multiple_generic_output_op() -> Tuple[Output[int], Output[str]]:
-    return (Output(5), Output("foo"))
+    return (
+        Output(5, metadata={"some_metadata": "a_value"}),
+        Output("foo", metadata={"some_metadata": "another_value"}),
+    )
 
 
 # end_op_output_4


### PR DESCRIPTION
## Summary & Motivation
A user was confused by the op events page discussing outputs and thought that all returned values from an op needed to be wrapping in `Output`. I can see why this is the case since we don't showcase the reasons you use `Output` in the doc examples.  https://dagster.slack.com/archives/C01U954MEER/p1688763698975829

I put together these updates to add the use of `metadata` to `Output` to give some indication that `Output` is being used because we are attaching other information. I also adding the non Output version in the little introduction paragraph. Let me know if you think these help! 

## How I Tested These Changes
