### PR TITLE
adding backfill policy to asset definitions and related API objects

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -165,7 +165,7 @@ class AssetGraph:
                 group_names_by_key.update(asset.group_names_by_key)
                 freshness_policies_by_key.update(asset.freshness_policies_by_key)
                 auto_materialize_policies_by_key.update(asset.auto_materialize_policies_by_key)
-                backfill_policies_by_key.update(asset.backfill_policies_by_key)
+                backfill_policies_by_key.update({key: asset.backfill_policy for key in asset.keys})
                 if len(asset.keys) > 1 and not asset.can_subset:
                     for key in asset.keys:
                         required_multi_asset_sets_by_key[key] = asset.keys

--- a/python_modules/dagster/dagster/_core/definitions/asset_out.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_out.py
@@ -3,6 +3,7 @@ from typing import Any, Mapping, NamedTuple, Optional, Sequence, Type, Union
 import dagster._check as check
 from dagster._annotations import PublicAttr
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
+from dagster._core.definitions.backfill_policy import BackfillPolicy
 from dagster._core.definitions.events import (
     AssetKey,
     CoercibleToAssetKey,
@@ -31,6 +32,7 @@ class AssetOut(
             ("code_version", PublicAttr[Optional[str]]),
             ("freshness_policy", PublicAttr[Optional[FreshnessPolicy]]),
             ("auto_materialize_policy", PublicAttr[Optional[AutoMaterializePolicy]]),
+            ("backfill_policy", PublicAttr[Optional[BackfillPolicy]]),
         ],
     )
 ):
@@ -61,6 +63,7 @@ class AssetOut(
             asset is intended to be.
         auto_materialize_policy (Optional[AutoMaterializePolicy]): AutoMaterializePolicy to apply to
             the specified asset.
+        backfill_policy (Optional[BackfillPolicy]): BackfillPolicy to apply to the specified asset.
     """
 
     def __new__(
@@ -76,6 +79,7 @@ class AssetOut(
         code_version: Optional[str] = None,
         freshness_policy: Optional[FreshnessPolicy] = None,
         auto_materialize_policy: Optional[AutoMaterializePolicy] = None,
+        backfill_policy: Optional[BackfillPolicy] = None,
     ):
         if isinstance(key_prefix, str):
             key_prefix = [key_prefix]
@@ -100,6 +104,9 @@ class AssetOut(
             ),
             auto_materialize_policy=check.opt_inst_param(
                 auto_materialize_policy, "auto_materialize_policy", AutoMaterializePolicy
+            ),
+            backfill_policy=check.opt_inst_param(
+                backfill_policy, "backfill_policy", BackfillPolicy
             ),
         )
 

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -22,6 +22,7 @@ from dagster._annotations import public
 from dagster._core.decorator_utils import get_function_params
 from dagster._core.definitions.asset_layer import get_dep_node_handles_of_graph_backed_asset
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
+from dagster._core.definitions.backfill_policy import BackfillPolicy, BackfillPolicyType
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
 from dagster._core.definitions.metadata import ArbitraryMetadataMapping
 from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionsDefinition
@@ -83,6 +84,7 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
     _metadata_by_key: Mapping[AssetKey, ArbitraryMetadataMapping]
     _freshness_policies_by_key: Mapping[AssetKey, FreshnessPolicy]
     _auto_materialize_policies_by_key: Mapping[AssetKey, AutoMaterializePolicy]
+    _backfill_policies_by_key: Mapping[AssetKey, BackfillPolicy]
     _code_versions_by_key: Mapping[AssetKey, Optional[str]]
     _descriptions_by_key: Mapping[AssetKey, str]
 
@@ -102,6 +104,7 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
         metadata_by_key: Optional[Mapping[AssetKey, ArbitraryMetadataMapping]] = None,
         freshness_policies_by_key: Optional[Mapping[AssetKey, FreshnessPolicy]] = None,
         auto_materialize_policies_by_key: Optional[Mapping[AssetKey, AutoMaterializePolicy]] = None,
+        backfill_policies_by_key: Optional[Mapping[AssetKey, BackfillPolicy]] = None,
         descriptions_by_key: Optional[Mapping[AssetKey, str]] = None,
         # if adding new fields, make sure to handle them in the with_attributes, from_graph, and
         # get_attributes_dict methods
@@ -232,6 +235,24 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
             value_type=AutoMaterializePolicy,
         )
 
+        self._backfill_policies_by_key = check.opt_mapping_param(
+            backfill_policies_by_key,
+            "backfill_policies_by_key",
+            key_type=AssetKey,
+            value_type=BackfillPolicy,
+        )
+
+        if self._partitions_def is None:
+            # check if backfill policy is BackfillPolicyType.SINGLE_RUN if asset is not partitioned
+            for key, backfill_policy in self._backfill_policies_by_key.items():
+                check.param_invariant(
+                    backfill_policy.policy_type is BackfillPolicyType.SINGLE_RUN
+                    if backfill_policy
+                    else True,
+                    "backfill_policies_by_key",
+                    "Non partitioned asset can only have single run backfill policy",
+                )
+
         _validate_self_deps(
             input_keys=self._keys_by_input_name.values(),
             output_keys=self._selected_asset_keys,
@@ -255,6 +276,7 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
         metadata_by_key: Optional[Mapping[AssetKey, ArbitraryMetadataMapping]],
         freshness_policies_by_key: Optional[Mapping[AssetKey, FreshnessPolicy]],
         auto_materialize_policies_by_key: Optional[Mapping[AssetKey, AutoMaterializePolicy]],
+        backfill_policies_by_key: Optional[Mapping[AssetKey, BackfillPolicy]],
         descriptions_by_key: Optional[Mapping[AssetKey, str]],
     ) -> "AssetsDefinition":
         return AssetsDefinition(
@@ -271,6 +293,7 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
             metadata_by_key=metadata_by_key,
             freshness_policies_by_key=freshness_policies_by_key,
             auto_materialize_policies_by_key=auto_materialize_policies_by_key,
+            backfill_policies_by_key=backfill_policies_by_key,
             descriptions_by_key=descriptions_by_key,
         )
 
@@ -323,6 +346,7 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
         auto_materialize_policies_by_output_name: Optional[
             Mapping[str, Optional[AutoMaterializePolicy]]
         ] = None,
+        backfill_policies_by_output_name: Optional[Mapping[str, Optional[BackfillPolicy]]] = None,
         can_subset: bool = False,
     ) -> "AssetsDefinition":
         """Constructs an AssetsDefinition from a GraphDefinition.
@@ -375,6 +399,9 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
                 AutoMaterializePolicy to be associated with some or all of the output assets for this node.
                 Keys are the names of the outputs, and values are the AutoMaterializePolicies to be attached
                 to the associated asset.
+            backfill_policies_by_output_name (Optional[Mapping[str, Optional[BackfillPolicy]]]): Defines a
+                BackfillPolicy to be associated with some or all of the output assets for this node.
+                Keys are the names of the outputs, and values are the backfill policies to be attached
         """
         if resource_defs is not None:
             experimental_arg_warning("resource_defs", "AssetsDefinition.from_graph")
@@ -393,6 +420,7 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
             metadata_by_output_name=metadata_by_output_name,
             freshness_policies_by_output_name=freshness_policies_by_output_name,
             auto_materialize_policies_by_output_name=auto_materialize_policies_by_output_name,
+            backfill_policies_by_output_name=backfill_policies_by_output_name,
             can_subset=can_subset,
         )
 
@@ -415,6 +443,7 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
         auto_materialize_policies_by_output_name: Optional[
             Mapping[str, Optional[AutoMaterializePolicy]]
         ] = None,
+        backfill_policies_by_output_name: Optional[Mapping[str, Optional[BackfillPolicy]]] = None,
         can_subset: bool = False,
     ) -> "AssetsDefinition":
         """Constructs an AssetsDefinition from an OpDefinition.
@@ -463,6 +492,9 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
                 AutoMaterializePolicy to be associated with some or all of the output assets for this node.
                 Keys are the names of the outputs, and values are the AutoMaterializePolicies to be attached
                 to the associated asset.
+            backfill_policies_by_output_name (Optional[Mapping[str, Optional[BackfillPolicy]]]): Defines a
+                BackfillPolicy to be associated with some or all of the output assets for this node.
+                Keys are the names of the outputs, and values are the backfill policies to be attached.
         """
         return AssetsDefinition._from_node(
             node_def=op_def,
@@ -478,6 +510,7 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
             metadata_by_output_name=metadata_by_output_name,
             freshness_policies_by_output_name=freshness_policies_by_output_name,
             auto_materialize_policies_by_output_name=auto_materialize_policies_by_output_name,
+            backfill_policies_by_output_name=backfill_policies_by_output_name,
             can_subset=can_subset,
         )
 
@@ -500,6 +533,7 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
         auto_materialize_policies_by_output_name: Optional[
             Mapping[str, Optional[AutoMaterializePolicy]]
         ] = None,
+        backfill_policies_by_output_name: Optional[Mapping[str, Optional[BackfillPolicy]]] = None,
         can_subset: bool = False,
     ) -> "AssetsDefinition":
         node_def = check.inst_param(node_def, "node_def", NodeDefinition)
@@ -601,6 +635,13 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
                 if auto_materialize_policy is not None
             }
             if auto_materialize_policies_by_output_name
+            else None,
+            backfill_policies_by_key={
+                keys_by_output_name_with_prefix[output_name]: backfill_policy
+                for output_name, backfill_policy in backfill_policies_by_output_name.items()
+                if backfill_policy is not None
+            }
+            if backfill_policies_by_output_name
             else None,
             descriptions_by_key={
                 keys_by_output_name_with_prefix[output_name]: description
@@ -747,6 +788,10 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
     def auto_materialize_policies_by_key(self) -> Mapping[AssetKey, AutoMaterializePolicy]:
         return self._auto_materialize_policies_by_key
 
+    @property
+    def backfill_policies_by_key(self) -> Mapping[AssetKey, BackfillPolicy]:
+        return self._backfill_policies_by_key
+
     @public
     @property
     def partitions_def(self) -> Optional[PartitionsDefinition]:
@@ -815,6 +860,7 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
         auto_materialize_policy: Optional[
             Union[AutoMaterializePolicy, Mapping[AssetKey, AutoMaterializePolicy]]
         ] = None,
+        backfill_policy: Optional[Union[BackfillPolicy, Mapping[AssetKey, BackfillPolicy]]] = None,
     ) -> "AssetsDefinition":
         output_asset_key_replacements = check.opt_mapping_param(
             output_asset_key_replacements,
@@ -908,6 +954,32 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
                     output_asset_key_replacements.get(key, key)
                 ] = replaced_auto_materialize_policy
 
+        if backfill_policy:
+            backfill_policy_conflicts = (
+                self.backfill_policies_by_key.keys()
+                if isinstance(backfill_policy, BackfillPolicy)
+                else (backfill_policy.keys() & self.backfill_policies_by_key.keys())
+            )
+            if backfill_policy_conflicts:
+                raise DagsterInvalidDefinitionError(
+                    "BackfillPolicy already exists on assets"
+                    f" {', '.join(key.to_string() for key in backfill_policy_conflicts)}"
+                )
+
+        replaced_backfill_policies_by_key = {}
+        for key in self.keys:
+            if isinstance(backfill_policy, BackfillPolicy):
+                replaced_backfill_policy = backfill_policy
+            elif backfill_policy:
+                replaced_backfill_policy = backfill_policy.get(key)
+            else:
+                replaced_backfill_policy = self.backfill_policies_by_key.get(key)
+
+            if replaced_backfill_policy:
+                replaced_backfill_policies_by_key[
+                    output_asset_key_replacements.get(key, key)
+                ] = replaced_backfill_policy
+
         replaced_descriptions_by_key = {
             output_asset_key_replacements.get(key, key): description
             for key, description in descriptions_by_key.items()
@@ -955,6 +1027,7 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
             metadata_by_key=replaced_metadata_by_key,
             freshness_policies_by_key=replaced_freshness_policies_by_key,
             auto_materialize_policies_by_key=replaced_auto_materialize_policies_by_key,
+            backfill_policies_by_key=replaced_backfill_policies_by_key,
             descriptions_by_key=replaced_descriptions_by_key,
         )
 
@@ -1198,6 +1271,7 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
             metadata_by_key=self._metadata_by_key,
             freshness_policies_by_key=self._freshness_policies_by_key,
             auto_materialize_policies_by_key=self._auto_materialize_policies_by_key,
+            backfill_policies_by_key=self._backfill_policies_by_key,
             descriptions_by_key=self._descriptions_by_key,
         )
 

--- a/python_modules/dagster/dagster/_core/definitions/backfill_policy.py
+++ b/python_modules/dagster/dagster/_core/definitions/backfill_policy.py
@@ -1,0 +1,75 @@
+from enum import Enum
+from typing import NamedTuple, Optional
+
+import dagster._check as check
+from dagster._annotations import experimental, public
+
+
+class BackfillPolicyType(Enum):
+    SINGLE_RUN = "SINGLE_RUN"
+    MULTI_RUN = "MULTI_RUN"
+
+
+@experimental
+class BackfillPolicy(
+    NamedTuple(
+        "_BackfillPolicy",
+        [
+            ("is_single_run", bool),
+            ("max_partitions_per_run", Optional[int]),
+        ],
+    )
+):
+    """An BackfillPolicy specifies how Dagster should attempt to backfill an asset.
+    todo: add more docs.
+    """
+
+    def __new__(
+        cls,
+        is_single_run: bool = False,
+        max_partitions_per_run: Optional[int] = 1,
+    ):
+        check.invariant(
+            (is_single_run and max_partitions_per_run is None)
+            or (is_single_run is False and max_partitions_per_run is not None),
+            (
+                "Single run does not support max_partitions_per_run and non single run requires"
+                " max_partitions_per_run"
+            ),
+        )
+
+        return super(BackfillPolicy, cls).__new__(
+            cls,
+            is_single_run=is_single_run,
+            max_partitions_per_run=max_partitions_per_run,
+        )
+
+    @public
+    @staticmethod
+    def single_run() -> "BackfillPolicy":
+        """Constructs an single_run BackfillPolicy."""
+        return BackfillPolicy(
+            is_single_run=True,
+            max_partitions_per_run=None,
+        )
+
+    @public
+    @staticmethod
+    def multi_run(max_partitions_per_run: Optional[int] = 1) -> "BackfillPolicy":
+        """Constructs a multi_run AutoMaterializePolicy.
+
+        Args:
+            max_partitions_per_run (Optional[int]): The maximum number of partitions in a single run. Defaults to 1.
+        """
+        return BackfillPolicy(
+            is_single_run=False,
+            max_partitions_per_run=check.opt_int_param(
+                max_partitions_per_run, "max_partitions_per_run"
+            ),
+        )
+
+    @property
+    def policy_type(self) -> BackfillPolicyType:
+        if self.is_single_run is True:
+            return BackfillPolicyType.SINGLE_RUN
+        return BackfillPolicyType.MULTI_RUN

--- a/python_modules/dagster/dagster/_core/definitions/backfill_policy.py
+++ b/python_modules/dagster/dagster/_core/definitions/backfill_policy.py
@@ -20,7 +20,34 @@ class BackfillPolicy(
     )
 ):
     """An BackfillPolicy specifies how Dagster should attempt to backfill an asset.
-    todo: add more docs.
+
+    There are two main kinds of auto-materialize policies: single run and multi run. And it only applies
+    to partitioned assets.
+
+    In essence, an asset with a single run backfill policy will be take a single dagster run to backfill
+    all of its partitions at once, if the asset is partitioned.
+
+    An asset with a multi run backfill policy will take multiple dagster runs to backfill all of its partitions.
+    Each dagster run will backfill a subset of the partitions, the number of partitions to backfill in each
+    dagster run is specified by the `max_partitions_per_run` parameter.
+
+    For example:
+
+    - If an asset has 100 partitions, and the `max_partitions_per_run` is set to 10, then it will
+    be backfilled in 10 dagster runs, each dagster run will backfill 10 partitions.
+
+    - If an asset has 100 partitions, and the `max_partitions_per_run` is set to 11, then it will
+    be backfilled in 10 dagster runs, the first 9 dagster runs will backfill 11 partitions, and the last one run
+    will backfill the remaining 9 partitions.
+
+    For an asset that is not partitioned, backfill policy should not be assigned to it since we can only backfill
+    such asset as a whole.
+
+    **Warning:**
+
+    Constructing an BackfillPolicy directly is not recommended as the API is subject to change.
+    BackfillPolicy.single_run() and BackfillPolicy.multi_run(max_partitions_per_run=x) are the recommended API.
+
     """
 
     def __new__(cls, max_partitions_per_run: Optional[int] = 1):
@@ -32,16 +59,18 @@ class BackfillPolicy(
     @public
     @staticmethod
     def single_run() -> "BackfillPolicy":
-        """Constructs an single_run BackfillPolicy."""
+        """Creates a BackfillPolicy that executes the entire backfill in a single run."""
         return BackfillPolicy(max_partitions_per_run=None)
 
     @public
     @staticmethod
     def multi_run(max_partitions_per_run: int = 1) -> "BackfillPolicy":
-        """Constructs a multi_run AutoMaterializePolicy.
+        """Creates a BackfillPolicy that executes the entire backfill in multiple runs.
+        Each run will backfill [max_partitions_per_run] number of partitions.
 
         Args:
-            max_partitions_per_run (Optional[int]): The maximum number of partitions in a single run. Defaults to 1.
+            max_partitions_per_run (Optional[int]): The maximum number of partitions in each run of the
+            multiple runs. Defaults to 1.
         """
         return BackfillPolicy(
             max_partitions_per_run=check.int_param(max_partitions_per_run, "max_partitions_per_run")

--- a/python_modules/dagster/dagster/_core/definitions/cacheable_assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/cacheable_assets.py
@@ -37,7 +37,7 @@ class AssetsDefinitionCacheableData(
                 "auto_materialize_policies_by_output_name",
                 Optional[Mapping[str, AutoMaterializePolicy]],
             ),
-            ("backfill_policies_by_output_name", Optional[Mapping[str, BackfillPolicy]]),
+            ("backfill_policy", Optional[BackfillPolicy]),
         ],
     )
 ):
@@ -59,7 +59,7 @@ class AssetsDefinitionCacheableData(
         auto_materialize_policies_by_output_name: Optional[
             Mapping[str, AutoMaterializePolicy]
         ] = None,
-        backfill_policies_by_output_name: Optional[Mapping[str, BackfillPolicy]] = None,
+        backfill_policy: Optional[BackfillPolicy] = None,
     ):
         extra_metadata = check.opt_nullable_mapping_param(extra_metadata, "extra_metadata")
         try:
@@ -103,11 +103,8 @@ class AssetsDefinitionCacheableData(
                 key_type=str,
                 value_type=AutoMaterializePolicy,
             ),
-            backfill_policies_by_output_name=check.opt_nullable_mapping_param(
-                backfill_policies_by_output_name,
-                "backfill_policies_by_output_name",
-                key_type=str,
-                value_type=BackfillPolicy,
+            backfill_policy=check.opt_inst_param(
+                backfill_policy, "backfill_policy", BackfillPolicy
             ),
         )
 
@@ -258,7 +255,7 @@ class PrefixOrGroupWrappedCacheableAssetsDefinition(WrappedCacheableAssetsDefini
         auto_materialize_policy: Optional[
             Union[AutoMaterializePolicy, Mapping[AssetKey, AutoMaterializePolicy]]
         ] = None,
-        backfill_policy: Optional[Union[BackfillPolicy, Mapping[AssetKey, BackfillPolicy]]] = None,
+        backfill_policy: Optional[BackfillPolicy] = None,
     ):
         self._output_asset_key_replacements = output_asset_key_replacements or {}
         self._input_asset_key_replacements = input_asset_key_replacements or {}

--- a/python_modules/dagster/dagster/_core/definitions/cacheable_assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/cacheable_assets.py
@@ -9,6 +9,7 @@ import dagster._seven as seven
 from dagster._config.field_utils import compute_fields_hash
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
+from dagster._core.definitions.backfill_policy import BackfillPolicy
 from dagster._core.definitions.events import AssetKey, CoercibleToAssetKeyPrefix
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
 from dagster._core.definitions.metadata import MetadataUserInput
@@ -36,6 +37,7 @@ class AssetsDefinitionCacheableData(
                 "auto_materialize_policies_by_output_name",
                 Optional[Mapping[str, AutoMaterializePolicy]],
             ),
+            ("backfill_policies_by_output_name", Optional[Mapping[str, BackfillPolicy]]),
         ],
     )
 ):
@@ -57,6 +59,7 @@ class AssetsDefinitionCacheableData(
         auto_materialize_policies_by_output_name: Optional[
             Mapping[str, AutoMaterializePolicy]
         ] = None,
+        backfill_policies_by_output_name: Optional[Mapping[str, BackfillPolicy]] = None,
     ):
         extra_metadata = check.opt_nullable_mapping_param(extra_metadata, "extra_metadata")
         try:
@@ -99,6 +102,12 @@ class AssetsDefinitionCacheableData(
                 "auto_materialize_policies_by_output_name",
                 key_type=str,
                 value_type=AutoMaterializePolicy,
+            ),
+            backfill_policies_by_output_name=check.opt_nullable_mapping_param(
+                backfill_policies_by_output_name,
+                "backfill_policies_by_output_name",
+                key_type=str,
+                value_type=BackfillPolicy,
             ),
         )
 
@@ -174,6 +183,7 @@ class CacheableAssetsDefinition(ResourceAddable, ABC):
         group_name: Optional[str],
         freshness_policy: Optional[FreshnessPolicy],
         auto_materialize_policy: Optional[AutoMaterializePolicy],
+        backfill_policy: Optional[BackfillPolicy],
     ) -> "CacheableAssetsDefinition":
         """Utility method which allows setting attributes for all assets in this
         CacheableAssetsDefinition, since the keys may not be known at the time of
@@ -184,6 +194,7 @@ class CacheableAssetsDefinition(ResourceAddable, ABC):
             group_name_for_all_assets=group_name,
             freshness_policy=freshness_policy,
             auto_materialize_policy=auto_materialize_policy,
+            backfill_policy=backfill_policy,
         )
 
 
@@ -247,6 +258,7 @@ class PrefixOrGroupWrappedCacheableAssetsDefinition(WrappedCacheableAssetsDefini
         auto_materialize_policy: Optional[
             Union[AutoMaterializePolicy, Mapping[AssetKey, AutoMaterializePolicy]]
         ] = None,
+        backfill_policy: Optional[Union[BackfillPolicy, Mapping[AssetKey, BackfillPolicy]]] = None,
     ):
         self._output_asset_key_replacements = output_asset_key_replacements or {}
         self._input_asset_key_replacements = input_asset_key_replacements or {}
@@ -255,6 +267,7 @@ class PrefixOrGroupWrappedCacheableAssetsDefinition(WrappedCacheableAssetsDefini
         self._prefix_for_all_assets = prefix_for_all_assets
         self._freshness_policy = freshness_policy
         self._auto_materialize_policy = auto_materialize_policy
+        self._backfill_policy = backfill_policy
 
         check.invariant(
             not (group_name_for_all_assets and group_names_by_key),
@@ -349,6 +362,7 @@ class PrefixOrGroupWrappedCacheableAssetsDefinition(WrappedCacheableAssetsDefini
             group_names_by_key=group_names_by_key,
             freshness_policy=self._freshness_policy,
             auto_materialize_policy=self._auto_materialize_policy,
+            backfill_policy=self._backfill_policy,
         )
 
 

--- a/python_modules/dagster/dagster/_core/definitions/external_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/external_asset_graph.py
@@ -20,6 +20,7 @@ from dagster._core.selector.subset_selector import DependencyGraph
 from dagster._core.workspace.workspace import IWorkspace
 
 from .asset_graph import AssetGraph
+from .backfill_policy import BackfillPolicy
 from .events import AssetKey
 from .freshness_policy import FreshnessPolicy
 from .partition import PartitionsDefinition
@@ -39,6 +40,7 @@ class ExternalAssetGraph(AssetGraph):
         group_names_by_key: Mapping[AssetKey, Optional[str]],
         freshness_policies_by_key: Mapping[AssetKey, Optional[FreshnessPolicy]],
         auto_materialize_policies_by_key: Mapping[AssetKey, Optional[AutoMaterializePolicy]],
+        backfill_policies_by_key: Mapping[AssetKey, Optional[BackfillPolicy]],
         required_multi_asset_sets_by_key: Optional[Mapping[AssetKey, AbstractSet[AssetKey]]],
         repo_handles_by_key: Mapping[AssetKey, RepositoryHandle],
         job_names_by_key: Mapping[AssetKey, Sequence[str]],
@@ -54,6 +56,7 @@ class ExternalAssetGraph(AssetGraph):
             group_names_by_key=group_names_by_key,
             freshness_policies_by_key=freshness_policies_by_key,
             auto_materialize_policies_by_key=auto_materialize_policies_by_key,
+            backfill_policies_by_key=backfill_policies_by_key,
             required_multi_asset_sets_by_key=required_multi_asset_sets_by_key,
             code_versions_by_key=code_versions_by_key,
             is_observable_by_key=is_observable_by_key,
@@ -114,6 +117,7 @@ class ExternalAssetGraph(AssetGraph):
         group_names_by_key = {}
         freshness_policies_by_key = {}
         auto_materialize_policies_by_key = {}
+        backfill_policies_by_key = {}
         asset_keys_by_atomic_execution_unit_id: Dict[str, Set[AssetKey]] = defaultdict(set)
         repo_handles_by_key = {
             node.asset_key: repo_handle
@@ -167,6 +171,7 @@ class ExternalAssetGraph(AssetGraph):
             group_names_by_key[node.asset_key] = node.group_name
             freshness_policies_by_key[node.asset_key] = node.freshness_policy
             auto_materialize_policies_by_key[node.asset_key] = node.auto_materialize_policy
+            backfill_policies_by_key[node.asset_key] = node.backfill_policy
 
             if node.atomic_execution_unit_id is not None:
                 asset_keys_by_atomic_execution_unit_id[node.atomic_execution_unit_id].add(
@@ -192,6 +197,7 @@ class ExternalAssetGraph(AssetGraph):
             group_names_by_key=group_names_by_key,
             freshness_policies_by_key=freshness_policies_by_key,
             auto_materialize_policies_by_key=auto_materialize_policies_by_key,
+            backfill_policies_by_key=backfill_policies_by_key,
             required_multi_asset_sets_by_key=required_multi_asset_sets_by_key,
             repo_handles_by_key=repo_handles_by_key,
             job_names_by_key=job_names_by_key,

--- a/python_modules/dagster/dagster/_core/definitions/load_assets_from_modules.py
+++ b/python_modules/dagster/dagster/_core/definitions/load_assets_from_modules.py
@@ -7,6 +7,7 @@ from typing import Dict, Generator, Iterable, List, Optional, Sequence, Set, Tup
 
 import dagster._check as check
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
+from dagster._core.definitions.backfill_policy import BackfillPolicy
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
 from dagster._core.errors import DagsterInvalidDefinitionError
 
@@ -102,6 +103,7 @@ def load_assets_from_modules(
     *,
     freshness_policy: Optional[FreshnessPolicy] = None,
     auto_materialize_policy: Optional[AutoMaterializePolicy] = None,
+    backfill_policy: Optional[BackfillPolicy] = None,
     source_key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
 ) -> Sequence[Union[AssetsDefinition, SourceAsset, CacheableAssetsDefinition]]:
     """Constructs a list of assets and source assets from the given modules.
@@ -118,6 +120,7 @@ def load_assets_from_modules(
             assets.
         auto_materialize_policy (Optional[AutoMaterializePolicy]): AutoMaterializePolicy to apply
             to all the loaded assets.
+        backfill_policy (Optional[AutoMaterializePolicy]): BackfillPolicy to apply to all the loaded assets.
         source_key_prefix (bool): Prefix to prepend to the keys of loaded SourceAssets. The returned
             assets will be copies of the loaded objects, with the prefix prepended.
 
@@ -131,6 +134,7 @@ def load_assets_from_modules(
     auto_materialize_policy = check.opt_inst_param(
         auto_materialize_policy, "auto_materialize_policy", AutoMaterializePolicy
     )
+    backfill_policy = check.opt_inst_param(backfill_policy, "backfill_policy", BackfillPolicy)
 
     (
         assets,
@@ -146,6 +150,7 @@ def load_assets_from_modules(
         group_name=group_name,
         freshness_policy=freshness_policy,
         auto_materialize_policy=auto_materialize_policy,
+        backfill_policy=backfill_policy,
         source_key_prefix=source_key_prefix,
     )
 
@@ -156,6 +161,7 @@ def load_assets_from_current_module(
     *,
     freshness_policy: Optional[FreshnessPolicy] = None,
     auto_materialize_policy: Optional[AutoMaterializePolicy] = None,
+    backfill_policy: Optional[BackfillPolicy] = None,
     source_key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
 ) -> Sequence[Union[AssetsDefinition, SourceAsset, CacheableAssetsDefinition]]:
     """Constructs a list of assets, source assets, and cacheable assets from the module where
@@ -172,6 +178,7 @@ def load_assets_from_current_module(
             assets.
         auto_materialize_policy (Optional[AutoMaterializePolicy]): AutoMaterializePolicy to apply
             to all the loaded assets.
+        backfill_policy (Optional[AutoMaterializePolicy]): BackfillPolicy to apply to all the loaded assets.
         source_key_prefix (bool): Prefix to prepend to the keys of loaded SourceAssets. The returned
             assets will be copies of the loaded objects, with the prefix prepended.
 
@@ -190,6 +197,7 @@ def load_assets_from_current_module(
         key_prefix=key_prefix,
         freshness_policy=freshness_policy,
         auto_materialize_policy=auto_materialize_policy,
+        backfill_policy=backfill_policy,
     )
 
 
@@ -222,6 +230,7 @@ def load_assets_from_package_module(
     *,
     freshness_policy: Optional[FreshnessPolicy] = None,
     auto_materialize_policy: Optional[AutoMaterializePolicy] = None,
+    backfill_policy: Optional[BackfillPolicy] = None,
     source_key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
 ) -> Sequence[Union[AssetsDefinition, SourceAsset, CacheableAssetsDefinition]]:
     """Constructs a list of assets and source assets that includes all asset
@@ -241,6 +250,7 @@ def load_assets_from_package_module(
             assets.
         auto_materialize_policy (Optional[AutoMaterializePolicy]): AutoMaterializePolicy to apply
             to all the loaded assets.
+        backfill_policy (Optional[AutoMaterializePolicy]): BackfillPolicy to apply to all the loaded assets.
         source_key_prefix (bool): Prefix to prepend to the keys of loaded SourceAssets. The returned
             assets will be copies of the loaded objects, with the prefix prepended.
 
@@ -254,6 +264,7 @@ def load_assets_from_package_module(
     auto_materialize_policy = check.opt_inst_param(
         auto_materialize_policy, "auto_materialize_policy", AutoMaterializePolicy
     )
+    backfill_policy = check.opt_inst_param(backfill_policy, "backfill_policy", BackfillPolicy)
 
     (
         assets,
@@ -268,6 +279,7 @@ def load_assets_from_package_module(
         group_name=group_name,
         freshness_policy=freshness_policy,
         auto_materialize_policy=auto_materialize_policy,
+        backfill_policy=backfill_policy,
         source_key_prefix=source_key_prefix,
     )
 
@@ -279,6 +291,7 @@ def load_assets_from_package_name(
     *,
     freshness_policy: Optional[FreshnessPolicy] = None,
     auto_materialize_policy: Optional[AutoMaterializePolicy] = None,
+    backfill_policy: Optional[BackfillPolicy] = None,
     source_key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
 ) -> Sequence[Union[AssetsDefinition, SourceAsset, CacheableAssetsDefinition]]:
     """Constructs a list of assets, source assets, and cacheable assets that includes all asset
@@ -296,6 +309,7 @@ def load_assets_from_package_name(
             assets.
         auto_materialize_policy (Optional[AutoMaterializePolicy]): AutoMaterializePolicy to apply
             to all the loaded assets.
+        backfill_policy (Optional[AutoMaterializePolicy]): BackfillPolicy to apply to all the loaded assets.
         source_key_prefix (bool): Prefix to prepend to the keys of loaded SourceAssets. The returned
             assets will be copies of the loaded objects, with the prefix prepended.
 
@@ -310,6 +324,7 @@ def load_assets_from_package_name(
         key_prefix=key_prefix,
         freshness_policy=freshness_policy,
         auto_materialize_policy=auto_materialize_policy,
+        backfill_policy=backfill_policy,
     )
 
 
@@ -419,6 +434,7 @@ def assets_with_attributes(
     group_name: Optional[str],
     freshness_policy: Optional[FreshnessPolicy],
     auto_materialize_policy: Optional[AutoMaterializePolicy],
+    backfill_policy: Optional[BackfillPolicy],
     source_key_prefix: Optional[Sequence[str]],
 ) -> Sequence[Union[AssetsDefinition, SourceAsset, CacheableAssetsDefinition]]:
     # There is a tricky edge case here where if a non-cacheable asset depends on a cacheable asset,
@@ -433,7 +449,7 @@ def assets_with_attributes(
             cached_asset.with_prefix_for_all(key_prefix) for cached_asset in cacheable_assets
         ]
 
-    if group_name or freshness_policy or auto_materialize_policy:
+    if group_name or freshness_policy or auto_materialize_policy or backfill_policy:
         assets_defs = [
             asset.with_attributes(
                 group_names_by_key={asset_key: group_name for asset_key in asset.keys}
@@ -441,6 +457,7 @@ def assets_with_attributes(
                 else None,
                 freshness_policy=freshness_policy,
                 auto_materialize_policy=auto_materialize_policy,
+                backfill_policy=backfill_policy,
             )
             for asset in assets_defs
         ]
@@ -454,6 +471,7 @@ def assets_with_attributes(
                 group_name,
                 freshness_policy=freshness_policy,
                 auto_materialize_policy=auto_materialize_policy,
+                backfill_policy=backfill_policy,
             )
             for cached_asset in cacheable_assets
         ]

--- a/python_modules/dagster/dagster/_core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external_data.py
@@ -1326,7 +1326,7 @@ def external_asset_graph_from_defs(
     freshness_policy_by_asset_key: Dict[AssetKey, FreshnessPolicy] = dict()
     metadata_by_asset_key: Dict[AssetKey, MetadataUserInput] = dict()
     auto_materialize_policy_by_asset_key: Dict[AssetKey, AutoMaterializePolicy] = dict()
-    backfill_policy_by_asset_key: Dict[AssetKey, BackfillPolicy] = dict()
+    backfill_policy_by_asset_key: Dict[AssetKey, Optional[BackfillPolicy]] = dict()
 
     deps: Dict[AssetKey, Dict[AssetKey, ExternalAssetDependency]] = defaultdict(dict)
     dep_by: Dict[AssetKey, Dict[AssetKey, ExternalAssetDependedBy]] = defaultdict(dict)
@@ -1377,7 +1377,9 @@ def external_asset_graph_from_defs(
             metadata_by_asset_key.update(assets_def.metadata_by_key)
             freshness_policy_by_asset_key.update(assets_def.freshness_policies_by_key)
             auto_materialize_policy_by_asset_key.update(assets_def.auto_materialize_policies_by_key)
-            backfill_policy_by_asset_key.update(assets_def.backfill_policies_by_key)
+            backfill_policy_by_asset_key.update(
+                {key: assets_def.backfill_policy for key in assets_def.keys}
+            )
             descriptions_by_asset_key.update(assets_def.descriptions_by_key)
             if len(assets_def.keys) > 1 and not assets_def.can_subset:
                 atomic_execution_unit_id = assets_def.unique_id

--- a/python_modules/dagster/dagster/_core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external_data.py
@@ -48,6 +48,7 @@ from dagster._core.definitions.asset_layer import AssetOutputInfo
 from dagster._core.definitions.asset_sensor_definition import AssetSensorDefinition
 from dagster._core.definitions.assets_job import is_base_asset_job_name
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
+from dagster._core.definitions.backfill_policy import BackfillPolicy
 from dagster._core.definitions.definition_config_schema import ConfiguredDefinitionConfigSchema
 from dagster._core.definitions.dependency import (
     GraphNode,
@@ -1074,6 +1075,7 @@ class ExternalAssetNode(
             ("atomic_execution_unit_id", Optional[str]),
             ("required_top_level_resources", Optional[Sequence[str]]),
             ("auto_materialize_policy", Optional[AutoMaterializePolicy]),
+            ("backfill_policy", Optional[BackfillPolicy]),
             ("auto_observe_interval_minutes", Optional[float]),
         ],
     )
@@ -1107,6 +1109,7 @@ class ExternalAssetNode(
         atomic_execution_unit_id: Optional[str] = None,
         required_top_level_resources: Optional[Sequence[str]] = None,
         auto_materialize_policy: Optional[AutoMaterializePolicy] = None,
+        backfill_policy: Optional[BackfillPolicy] = None,
         auto_observe_interval_minutes: Optional[float] = None,
     ):
         # backcompat logic to handle ExternalAssetNodes serialized without op_names/graph_name
@@ -1162,6 +1165,9 @@ class ExternalAssetNode(
                 auto_materialize_policy,
                 "auto_materialize_policy",
                 AutoMaterializePolicy,
+            ),
+            backfill_policy=check.opt_inst_param(
+                backfill_policy, "backfill_policy", BackfillPolicy
             ),
             auto_observe_interval_minutes=check.opt_numeric_param(
                 auto_observe_interval_minutes, "auto_observe_interval_minutes"
@@ -1320,6 +1326,7 @@ def external_asset_graph_from_defs(
     freshness_policy_by_asset_key: Dict[AssetKey, FreshnessPolicy] = dict()
     metadata_by_asset_key: Dict[AssetKey, MetadataUserInput] = dict()
     auto_materialize_policy_by_asset_key: Dict[AssetKey, AutoMaterializePolicy] = dict()
+    backfill_policy_by_asset_key: Dict[AssetKey, BackfillPolicy] = dict()
 
     deps: Dict[AssetKey, Dict[AssetKey, ExternalAssetDependency]] = defaultdict(dict)
     dep_by: Dict[AssetKey, Dict[AssetKey, ExternalAssetDependedBy]] = defaultdict(dict)
@@ -1370,6 +1377,7 @@ def external_asset_graph_from_defs(
             metadata_by_asset_key.update(assets_def.metadata_by_key)
             freshness_policy_by_asset_key.update(assets_def.freshness_policies_by_key)
             auto_materialize_policy_by_asset_key.update(assets_def.auto_materialize_policies_by_key)
+            backfill_policy_by_asset_key.update(assets_def.backfill_policies_by_key)
             descriptions_by_asset_key.update(assets_def.descriptions_by_key)
             if len(assets_def.keys) > 1 and not assets_def.can_subset:
                 atomic_execution_unit_id = assets_def.unique_id
@@ -1497,6 +1505,7 @@ def external_asset_graph_from_defs(
                 group_name=group_name_by_asset_key.get(asset_key, DEFAULT_GROUP_NAME),
                 freshness_policy=freshness_policy_by_asset_key.get(asset_key),
                 auto_materialize_policy=auto_materialize_policy_by_asset_key.get(asset_key),
+                backfill_policy=backfill_policy_by_asset_key.get(asset_key),
                 atomic_execution_unit_id=atomic_execution_unit_ids_by_asset_key.get(asset_key),
                 required_top_level_resources=required_top_level_resources,
             )

--- a/python_modules/dagster/dagster/_core/telemetry.py
+++ b/python_modules/dagster/dagster/_core/telemetry.py
@@ -39,6 +39,7 @@ from typing_extensions import ParamSpec
 
 import dagster._check as check
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicyType
+from dagster._core.definitions.backfill_policy import BackfillPolicyType
 from dagster._core.definitions.job_base import IJob
 from dagster._core.definitions.reconstruct import (
     ReconstructableJob,
@@ -477,6 +478,8 @@ def get_stats_from_external_repo(external_repo: "ExternalRepository") -> Mapping
     num_assets_with_freshness_policies_in_repo = 0
     num_assets_with_eager_auto_materialize_policies_in_repo = 0
     num_assets_with_lazy_auto_materialize_policies_in_repo = 0
+    num_assets_with_single_run_backfill_policies_in_repo = 0
+    num_assets_with_multi_run_backfill_policies_in_repo = 0
     num_source_assets_in_repo = 0
     num_observable_source_assets_in_repo = 0
     num_dbt_assets_in_repo = 0
@@ -500,6 +503,12 @@ def get_stats_from_external_repo(external_repo: "ExternalRepository") -> Mapping
                 num_assets_with_eager_auto_materialize_policies_in_repo += 1
             else:
                 num_assets_with_lazy_auto_materialize_policies_in_repo += 1
+
+        if asset.backfill_policy is not None:
+            if asset.backfill_policy.policy_type == BackfillPolicyType.SINGLE_RUN:
+                num_assets_with_single_run_backfill_policies_in_repo += 1
+            else:
+                num_assets_with_multi_run_backfill_policies_in_repo += 1
 
         if asset.is_source:
             num_source_assets_in_repo += 1
@@ -537,6 +546,12 @@ def get_stats_from_external_repo(external_repo: "ExternalRepository") -> Mapping
         ),
         "num_assets_with_lazy_auto_materialize_policies_in_repo": str(
             num_assets_with_lazy_auto_materialize_policies_in_repo
+        ),
+        "num_assets_with_single_run_backfill_policies_in_repo": str(
+            num_assets_with_single_run_backfill_policies_in_repo
+        ),
+        "num_assets_with_multi_run_backfill_policies_in_repo": str(
+            num_assets_with_multi_run_backfill_policies_in_repo
         ),
         "num_observable_source_assets_in_repo": str(num_observable_source_assets_in_repo),
         "num_dbt_assets_in_repo": str(num_dbt_assets_in_repo),

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
@@ -19,8 +19,8 @@ from dagster import (
 )
 from dagster._check import ParameterCheckError
 from dagster._core.definitions import AssetIn, SourceAsset, asset, build_assets_job, multi_asset
-from dagster._core.definitions.backfill_policy import BackfillPolicy
 from dagster._core.definitions.asset_graph import AssetGraph
+from dagster._core.definitions.backfill_policy import BackfillPolicy
 from dagster._core.definitions.metadata import MetadataValue, normalize_metadata
 from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionsDefinition
 from dagster._core.definitions.partition import ScheduleType

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_backfill_policy.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_backfill_policy.py
@@ -1,0 +1,6 @@
+from dagster._core.definitions.backfill_policy import BackfillPolicy, BackfillPolicyType
+
+
+def test_type():
+    assert BackfillPolicy.single_run().policy_type == BackfillPolicyType.SINGLE_RUN
+    assert BackfillPolicy.multi_run().policy_type == BackfillPolicyType.MULTI_RUN

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_backfill_policy.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_backfill_policy.py
@@ -1,6 +1,10 @@
+import pytest
+from dagster._check import ParameterCheckError
 from dagster._core.definitions.backfill_policy import BackfillPolicy, BackfillPolicyType
 
 
 def test_type():
     assert BackfillPolicy.single_run().policy_type == BackfillPolicyType.SINGLE_RUN
     assert BackfillPolicy.multi_run().policy_type == BackfillPolicyType.MULTI_RUN
+    with pytest.raises(ParameterCheckError):
+        BackfillPolicy.multi_run(max_partitions_per_run=None)


### PR DESCRIPTION
## Summary & Motivation
RFC: https://github.com/dagster-io/dagster/discussions/14829

This PR only introduces BackfillPolicy to the core API model layer, it should have no effect on the system that is not yet using the properties added. 

## How I Tested These Changes
While I am still working on adding more unit tests to make sure those added properties are working as expected, I ran the existing unit tests and they were all passing without issues. 

Also, please advise on the best way to do the unit testing mentioned above.