### PR TITLE
[auto-materialize] Add large partitioned auto materializers

### DIFF
--- a/python_modules/dagster-test/dagster_test/toys/auto_materializing/large_graph.py
+++ b/python_modules/dagster-test/dagster_test/toys/auto_materializing/large_graph.py
@@ -1,0 +1,91 @@
+import itertools
+from typing import List, NamedTuple, Optional, Sequence
+
+from dagster import (
+    AssetsDefinition,
+    AutoMaterializePolicy,
+    DailyPartitionsDefinition,
+    HourlyPartitionsDefinition,
+    PartitionsDefinition,
+    StaticPartitionsDefinition,
+    asset,
+    repository,
+)
+
+
+class AssetLayerConfig(NamedTuple):
+    n_assets: int
+    n_upstreams_per_asset: int = 0
+    partitions_def: Optional[PartitionsDefinition] = None
+
+
+def build_assets(
+    id: str,
+    layer_configs: Sequence[AssetLayerConfig],
+    auto_materialize_policy: AutoMaterializePolicy = AutoMaterializePolicy.eager(),
+) -> List[AssetsDefinition]:
+    layers = []
+
+    for layer_config in layer_configs:
+        parent_index = 0
+        layer = []
+        for i in range(layer_config.n_assets):
+            if layer_config.n_upstreams_per_asset > 0:
+                # each asset connects to n_upstreams_per_asset assets from the above layer, chosen
+                # in a round-robin manner
+                non_argument_deps = {
+                    layers[-1][(parent_index + j) % len(layers[-1])].key
+                    for j in range(layer_config.n_upstreams_per_asset)
+                }
+                parent_index += layer_config.n_upstreams_per_asset
+            else:
+                non_argument_deps = set()
+
+            @asset(
+                partitions_def=layer_config.partitions_def,
+                name=f"{id}_{len(layers)}_{i}",
+                auto_materialize_policy=auto_materialize_policy,
+                non_argument_deps=non_argument_deps,
+            )
+            def _asset():
+                pass
+
+            layer.append(_asset)
+        layers.append(layer)
+
+    return list(itertools.chain(*layers))
+
+
+hourly = HourlyPartitionsDefinition(start_date="2022-01-01-00:00")
+daily = DailyPartitionsDefinition(
+    start_date="2022-01-01",
+)
+static = StaticPartitionsDefinition(partition_keys=[f"p{i}" for i in range(100)])
+
+
+@repository
+def auto_materialize_large_time_graph():
+    return build_assets(
+        id="hourly_to_daily",
+        layer_configs=[
+            AssetLayerConfig(n_assets=10, partitions_def=hourly),
+            AssetLayerConfig(n_assets=50, n_upstreams_per_asset=5, partitions_def=hourly),
+            AssetLayerConfig(n_assets=50, n_upstreams_per_asset=5, partitions_def=hourly),
+            AssetLayerConfig(n_assets=100, n_upstreams_per_asset=4, partitions_def=daily),
+            AssetLayerConfig(n_assets=100, n_upstreams_per_asset=4, partitions_def=daily),
+        ],
+    )
+
+
+@repository
+def auto_materialize_large_static_graph():
+    return build_assets(
+        id="static_and_unpartitioned",
+        layer_configs=[
+            AssetLayerConfig(n_assets=10, partitions_def=None),
+            AssetLayerConfig(n_assets=50, n_upstreams_per_asset=5, partitions_def=static),
+            AssetLayerConfig(n_assets=50, n_upstreams_per_asset=5, partitions_def=static),
+            AssetLayerConfig(n_assets=100, n_upstreams_per_asset=4, partitions_def=static),
+            AssetLayerConfig(n_assets=100, n_upstreams_per_asset=4, partitions_def=None),
+        ],
+    )

--- a/python_modules/dagster-test/dagster_test/toys/repo.py
+++ b/python_modules/dagster-test/dagster_test/toys/repo.py
@@ -52,6 +52,10 @@ from dagster_test.toys.sleepy import sleepy_job
 from dagster_test.toys.software_defined_assets import software_defined_assets
 from dagster_test.toys.unreliable import unreliable_job
 
+from .auto_materializing.large_graph import (
+    auto_materialize_large_static_graph as auto_materialize_large_static_graph,
+    auto_materialize_large_time_graph as auto_materialize_large_time_graph,
+)
 from .auto_materializing.repo_1 import auto_materialize_repo_1 as auto_materialize_repo_1
 from .auto_materializing.repo_2 import auto_materialize_repo_2 as auto_materialize_repo_2
 from .schedules import get_toys_schedules


### PR DESCRIPTION
## Summary & Motivation

Adds two large asset graphs (~300 assets) each, which we can backfill (once deployed) to simulate more "realistic" performance characteristics out in the real world.

## How I Tested These Changes

Run dagster dev in the root of the dagster project, these new repos showed up.