### PR TITLE
DbtAssetsDefinition and DagsterDbtTranslator

### DIFF
--- a/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/build.py
+++ b/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/build.py
@@ -1,11 +1,9 @@
 from dagster import OpExecutionContext
-from dagster_dbt import DbtCli, DbtManifest, dbt_assets
+from dagster_dbt import DbtCli, dbt_assets
 
 from ..constants import MANIFEST_PATH
 
-manifest = DbtManifest.read(path=MANIFEST_PATH)
 
-
-@dbt_assets(manifest=manifest)
+@dbt_assets(manifest=MANIFEST_PATH)
 def my_dbt_assets(context: OpExecutionContext, dbt: DbtCli):
     yield from dbt.cli(["build"], context=context).stream()

--- a/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/customize_asset_keys.py
+++ b/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/customize_asset_keys.py
@@ -1,20 +1,17 @@
 from typing import Any, Mapping
 
 from dagster import AssetKey, OpExecutionContext
-from dagster_dbt import DbtCli, DbtManifest, dbt_assets
+from dagster_dbt import DagsterDbtTranslator, DbtCli, dbt_assets
 
 from ..constants import MANIFEST_PATH
 
 
-class CustomizedDbtManifest(DbtManifest):
+class CustomDagsterDbtTranslator(DagsterDbtTranslator):
     @classmethod
     def node_info_to_asset_key(cls, node_info: Mapping[str, Any]) -> AssetKey:
         return AssetKey(["prefix", node_info["alias"]])
 
 
-manifest = CustomizedDbtManifest.read(path=MANIFEST_PATH)
-
-
-@dbt_assets(manifest=manifest)
+@dbt_assets(manifest=MANIFEST_PATH, dagster_dbt_translator=CustomDagsterDbtTranslator())
 def my_dbt_assets(context: OpExecutionContext, dbt: DbtCli):
     yield from dbt.cli(["build"], context=context).stream()

--- a/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/customize_description.py
+++ b/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/customize_description.py
@@ -1,12 +1,12 @@
 from typing import Any, Mapping
 
 from dagster import OpExecutionContext
-from dagster_dbt import DbtCli, DbtManifest, dbt_assets
+from dagster_dbt import DagsterDbtTranslator, DbtCli, dbt_assets
 
 from ..constants import MANIFEST_PATH
 
 
-class CustomizedDbtManifest(DbtManifest):
+class CustomDagsterDbtTranslator(DagsterDbtTranslator):
     @classmethod
     def node_info_to_description(cls, node_info: Mapping[str, Any]) -> str:
         description_sections = []
@@ -22,9 +22,6 @@ class CustomizedDbtManifest(DbtManifest):
         return "\n\n".join(description_sections)
 
 
-manifest = CustomizedDbtManifest.read(path=MANIFEST_PATH)
-
-
-@dbt_assets(manifest=manifest)
+@dbt_assets(manifest=MANIFEST_PATH, dagster_dbt_translator=CustomDagsterDbtTranslator())
 def my_dbt_assets(context: OpExecutionContext, dbt: DbtCli):
     yield from dbt.cli(["build"], context=context).stream()

--- a/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/partitions.py
+++ b/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/partitions.py
@@ -1,22 +1,20 @@
 import json
 
 from dagster import DailyPartitionsDefinition, OpExecutionContext
-from dagster_dbt import DbtCli, DbtManifest, dbt_assets
+from dagster_dbt import DbtCli, dbt_assets
 
 from ..constants import MANIFEST_PATH
 
 DBT_SELECT_SEED = "resource_type:seed"
 
-manifest = DbtManifest.read(path=MANIFEST_PATH)
 
-
-@dbt_assets(manifest=manifest, select=DBT_SELECT_SEED)
+@dbt_assets(manifest=MANIFEST_PATH, select=DBT_SELECT_SEED)
 def dbt_seed_assets(context: OpExecutionContext, dbt: DbtCli):
     yield from dbt.cli(["seed"], context=context).stream()
 
 
 @dbt_assets(
-    manifest=manifest,
+    manifest=MANIFEST_PATH,
     exclude=DBT_SELECT_SEED,
     partitions_def=DailyPartitionsDefinition(start_date="2023-05-01"),
 )

--- a/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/runtime_metadata.py
+++ b/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/runtime_metadata.py
@@ -1,10 +1,13 @@
+import json
+
 from dagster import OpExecutionContext, Output
-from dagster_dbt import DbtCli, DbtManifest, dbt_assets
+from dagster_dbt import DbtCli, dbt_assets
 from dateutil import parser
 
 from ..constants import MANIFEST_PATH
 
-manifest = DbtManifest.read(path=MANIFEST_PATH)
+with MANIFEST_PATH.open() as f:
+    manifest = json.load(f)
 
 
 @dbt_assets(manifest=manifest)

--- a/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/seed_run_test.py
+++ b/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/seed_run_test.py
@@ -1,12 +1,10 @@
 from dagster import OpExecutionContext
-from dagster_dbt import DbtCli, DbtManifest, dbt_assets
+from dagster_dbt import DbtCli, dbt_assets
 
 from ..constants import MANIFEST_PATH
 
-manifest = DbtManifest.read(path=MANIFEST_PATH)
 
-
-@dbt_assets(manifest=manifest)
+@dbt_assets(manifest=MANIFEST_PATH)
 def my_dbt_assets(context: OpExecutionContext, dbt: DbtCli):
     dbt_commands = [
         ["seed"],

--- a/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/separate_asset_defs.py
+++ b/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/separate_asset_defs.py
@@ -1,17 +1,15 @@
 from dagster import OpExecutionContext
-from dagster_dbt import DbtCli, DbtManifest, dbt_assets
+from dagster_dbt import DbtCli, dbt_assets
 
 from ..constants import MANIFEST_PATH
 
-manifest = DbtManifest.read(path=MANIFEST_PATH)
 
-
-@dbt_assets(manifest=manifest, select="resource_type:seed")
+@dbt_assets(manifest=MANIFEST_PATH, select="resource_type:seed")
 def dbt_seed_assets(context: OpExecutionContext, dbt: DbtCli):
     yield from dbt.cli(["seed"], context=context).stream()
 
 
-@dbt_assets(manifest=manifest, select="fqn:staging.*")
+@dbt_assets(manifest=MANIFEST_PATH, select="fqn:staging.*")
 def dbt_staging_assets(context: OpExecutionContext, dbt: DbtCli):
     dbt_commands = [
         ["run"],
@@ -22,7 +20,7 @@ def dbt_staging_assets(context: OpExecutionContext, dbt: DbtCli):
         yield from dbt.cli(dbt_command, context=context).stream()
 
 
-@dbt_assets(manifest=manifest, select="fqn:customers fqn:orders")
+@dbt_assets(manifest=MANIFEST_PATH, select="fqn:customers fqn:orders")
 def my_dbt_assets(context: OpExecutionContext, dbt: DbtCli):
     dbt_commands = [
         ["run"],

--- a/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/use_artifacts.py
+++ b/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/use_artifacts.py
@@ -2,14 +2,12 @@ import pprint
 import sys
 
 from dagster import OpExecutionContext
-from dagster_dbt import DbtCli, DbtManifest, dbt_assets
+from dagster_dbt import DbtCli, dbt_assets
 
 from ..constants import MANIFEST_PATH
 
-manifest = DbtManifest.read(path=MANIFEST_PATH)
 
-
-@dbt_assets(manifest=manifest)
+@dbt_assets(manifest=MANIFEST_PATH)
 def my_dbt_assets(context: OpExecutionContext, dbt: DbtCli):
     dbt_build = dbt.cli(["build"], context=context)
 

--- a/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/constants.py
+++ b/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/constants.py
@@ -1,4 +1,6 @@
+from pathlib import Path
+
 from dagster import file_relative_path
 
 DBT_PROJECT_DIR = file_relative_path(__file__, "../jaffle_shop")
-MANIFEST_PATH = file_relative_path(__file__, "../jaffle_shop/target/manifest.json")
+MANIFEST_PATH = Path(__file__) / "jaffle_shop" / "target" / "manifest.json"

--- a/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/jobs/yield_materializations.py
+++ b/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/jobs/yield_materializations.py
@@ -1,9 +1,12 @@
+import json
+
 from dagster import AssetMaterialization, Output, job, op
-from dagster_dbt import DbtCli, DbtManifest
+from dagster_dbt import DbtCli
 
 from ..constants import MANIFEST_PATH
 
-manifest = DbtManifest.read(path=MANIFEST_PATH)
+with MANIFEST_PATH.open("r") as f:
+    manifest = json.load(f)
 
 
 @op

--- a/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/schedules/define_schedules.py
+++ b/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/schedules/define_schedules.py
@@ -1,16 +1,20 @@
-from dagster_dbt import DbtManifest
+from dagster_dbt import DbtCli, dbt_assets
 
 from ..constants import MANIFEST_PATH
 
-manifest = DbtManifest.read(path=MANIFEST_PATH)
 
-daily_dbt_assets_schedule = manifest.build_schedule(
+@dbt_assets(manifest=MANIFEST_PATH)
+def all_dbt_assets(context, dbt: DbtCli):
+    yield from dbt.cli(["build"], context=context).stream()
+
+
+daily_dbt_assets_schedule = all_dbt_assets.build_schedule_from_dbt_select(
     job_name="all_dbt_assets",
     cron_schedule="0 0 * * *",
     dbt_select="fqn:*",
 )
 
-hourly_staging_dbt_assets = manifest.build_schedule(
+hourly_staging_dbt_assets = all_dbt_assets.build_schedule_from_dbt_select(
     job_name="staging_dbt_assets",
     cron_schedule="0 * * * *",
     dbt_select="fqn:staging.*",

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/__init__.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/__init__.py
@@ -40,9 +40,9 @@ from .core import (
     DbtCli as DbtCli,
     DbtCliEventMessage as DbtCliEventMessage,
     DbtCliInvocation as DbtCliInvocation,
-    DbtManifest as DbtManifest,
-    DbtManifestAssetSelection as DbtManifestAssetSelection,
 )
+from .dagster_dbt_translator import DagsterDbtTranslator as DagsterDbtTranslator
+from .dbt_manifest_asset_selection import DbtManifestAssetSelection as DbtManifestAssetSelection
 
 # isort: split
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
@@ -1,39 +1,48 @@
+import json
 from pathlib import Path
-from typing import Any, Callable, Dict, FrozenSet, Mapping, Optional, Set, Tuple, Union
+from typing import Any, Callable, Dict, FrozenSet, Mapping, Optional, Set, Tuple, Union, cast
 
 import dagster._check as check
-from dagster import AssetKey, AssetOut, AssetsDefinition, Nothing, PartitionsDefinition, multi_asset
+from dagster import (
+    AssetKey,
+    AssetOut,
+    Nothing,
+    PartitionsDefinition,
+    multi_asset,
+)
 from dagster._annotations import experimental
 
 from .asset_utils import (
-    MANIFEST_METADATA_KEY,
-    default_asset_key_fn,
     default_auto_materialize_policy_fn,
     default_code_version_fn,
-    default_description_fn,
     default_freshness_policy_fn,
     default_group_fn,
-    default_metadata_fn,
     get_deps,
-    output_name_fn,
 )
-from .core.resources_v2 import DbtManifest
-from .utils import ASSET_RESOURCE_TYPES, select_unique_ids_from_manifest
+from .dagster_dbt_translator import DagsterDbtTranslator
+from .dbt_assets_definition import DbtAssetsDefinition
+from .utils import (
+    ASSET_RESOURCE_TYPES,
+    get_node_info_by_dbt_unique_id_from_manifest,
+    output_name_fn,
+    select_unique_ids_from_manifest,
+)
 
 
 @experimental
 def dbt_assets(
     *,
-    manifest: Union[Mapping[str, Any], DbtManifest, Path],
+    manifest: Union[Mapping[str, Any], Path],
     select: str = "fqn:*",
     exclude: Optional[str] = None,
     io_manager_key: Optional[str] = None,
     partitions_def: Optional[PartitionsDefinition] = None,
-) -> Callable[..., AssetsDefinition]:
+    dagster_dbt_translator: DagsterDbtTranslator = DagsterDbtTranslator(),
+) -> Callable[..., DbtAssetsDefinition]:
     """Create a definition for how to compute a set of dbt resources, described by a manifest.json.
 
     Args:
-        manifest (Union[Mapping[str, Any], DbtManifest, Path]): The contents of a manifest.json file
+        manifest (Union[Mapping[str, Any], Path]): The contents of a manifest.json file
             or the path to a manifest.json file. A manifest.json contains a representation of a
             dbt project (models, tests, macros, etc). We use this representation to create
             corresponding Dagster assets.
@@ -59,17 +68,17 @@ def dbt_assets(
             def my_dbt_assets(context: OpExecutionContext, dbt: DbtCli):
                 yield from dbt.cli(["build"], context=context).stream()
     """
-    check.inst_param(manifest, "manifest", (Path, dict, DbtManifest))
+    check.inst_param(manifest, "manifest", (Path, dict))
     if isinstance(manifest, Path):
-        manifest = DbtManifest.read(path=manifest)
-    elif isinstance(manifest, Mapping):
-        manifest = DbtManifest(manifest)
+        with manifest.open("r") as handle:
+            manifest = cast(Mapping[str, Any], json.load(handle))
 
     unique_ids = select_unique_ids_from_manifest(
-        select=select, exclude=exclude or "", manifest_json=manifest.raw_manifest
+        select=select, exclude=exclude or "", manifest_json=manifest
     )
+    node_info_by_dbt_unique_id = get_node_info_by_dbt_unique_id_from_manifest(manifest)
     deps = get_deps(
-        dbt_nodes=manifest.node_info_by_dbt_unique_id,
+        dbt_nodes=node_info_by_dbt_unique_id,
         selected_unique_ids=unique_ids,
         asset_resource_types=ASSET_RESOURCE_TYPES,
     )
@@ -78,13 +87,13 @@ def dbt_assets(
         outs,
         internal_asset_deps,
     ) = get_dbt_multi_asset_args(
-        dbt_nodes=manifest.node_info_by_dbt_unique_id,
+        dbt_nodes=node_info_by_dbt_unique_id,
         deps=deps,
         io_manager_key=io_manager_key,
-        manifest=manifest,
+        dagster_dbt_translator=dagster_dbt_translator,
     )
 
-    def inner(fn) -> AssetsDefinition:
+    def inner(fn) -> DbtAssetsDefinition:
         asset_definition = multi_asset(
             outs=outs,
             internal_asset_deps=internal_asset_deps,
@@ -98,11 +107,10 @@ def dbt_assets(
             },
         )(fn)
 
-        return asset_definition.with_attributes(
-            input_asset_key_replacements=manifest.asset_key_replacements,
-            output_asset_key_replacements=manifest.asset_key_replacements,
-            descriptions_by_key=manifest.descriptions_by_asset_key,
-            metadata_by_key=manifest.metadata_by_asset_key,
+        return DbtAssetsDefinition.from_assets_def(
+            asset_definition,
+            manifest=manifest,
+            dagster_dbt_translator=dagster_dbt_translator,
         )
 
     return inner
@@ -112,9 +120,8 @@ def get_dbt_multi_asset_args(
     dbt_nodes: Mapping[str, Any],
     deps: Mapping[str, FrozenSet[str]],
     io_manager_key: Optional[str],
-    manifest: "DbtManifest",
+    dagster_dbt_translator: DagsterDbtTranslator,
 ) -> Tuple[Set[AssetKey], Dict[str, AssetOut], Dict[str, Set[AssetKey]]]:
-    """Use the standard defaults for dbt to construct the arguments for a dbt multi asset."""
     non_argument_deps: Set[AssetKey] = set()
     outs: Dict[str, AssetOut] = {}
     internal_asset_deps: Dict[str, Set[AssetKey]] = {}
@@ -123,18 +130,15 @@ def get_dbt_multi_asset_args(
         node_info = dbt_nodes[unique_id]
 
         output_name = output_name_fn(node_info)
-        asset_key = default_asset_key_fn(node_info)
+        asset_key = dagster_dbt_translator.node_info_to_asset_key(node_info)
 
         outs[output_name] = AssetOut(
             key=asset_key,
             dagster_type=Nothing,
             io_manager_key=io_manager_key,
-            description=default_description_fn(node_info, display_raw_sql=False),
+            description=dagster_dbt_translator.node_info_to_description(node_info),
             is_required=False,
-            metadata={  # type: ignore
-                **default_metadata_fn(node_info),
-                MANIFEST_METADATA_KEY: manifest,
-            },
+            metadata=dagster_dbt_translator.node_info_to_metadata(node_info),
             group_name=default_group_fn(node_info),
             code_version=default_code_version_fn(node_info),
             freshness_policy=default_freshness_policy_fn(node_info),
@@ -145,7 +149,7 @@ def get_dbt_multi_asset_args(
         output_internal_deps = internal_asset_deps.setdefault(output_name, set())
         for parent_unique_id in parent_unique_ids:
             parent_node_info = dbt_nodes[parent_unique_id]
-            parent_asset_key = default_asset_key_fn(parent_node_info)
+            parent_asset_key = dagster_dbt_translator.node_info_to_asset_key(parent_node_info)
 
             # Add this parent as an internal dependency
             output_internal_deps.add(parent_asset_key)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
@@ -53,9 +53,10 @@ from dagster_dbt.asset_utils import (
     get_deps,
 )
 from dagster_dbt.core.resources import DbtCliClient
-from dagster_dbt.core.resources_v2 import DbtCli, DbtManifest
+from dagster_dbt.core.resources_v2 import DbtCli
 from dagster_dbt.core.types import DbtCliOutput
 from dagster_dbt.core.utils import build_command_args_from_flags, execute_cli
+from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator
 from dagster_dbt.errors import DagsterDbtError
 from dagster_dbt.types import DbtOutput
 from dagster_dbt.utils import (
@@ -265,14 +266,15 @@ def _stream_event_iterator(
                 " metadata is yielded at runtime."
             )
 
-        class CustomDbtManifest(DbtManifest):
+        class CustomDagsterDbtTranslator(DagsterDbtTranslator):
             @classmethod
             def node_info_to_asset_key(cls, node_info: Mapping[str, Any]) -> AssetKey:
                 return node_info_to_asset_key(node_info)
 
         cli_output = dbt_resource.cli(
             args=["build" if use_build_command else "run", *build_command_args_from_flags(kwargs)],
-            manifest=CustomDbtManifest(raw_manifest=manifest_json),
+            manifest=manifest_json,
+            dagster_dbt_translator=CustomDagsterDbtTranslator(),
         )
         yield from cli_output.stream()
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -27,8 +27,6 @@ from dagster._utils.merger import merge_dicts
 
 from .utils import input_name_fn, output_name_fn
 
-MANIFEST_METADATA_KEY = "dagster_dbt/manifest"
-
 ###################
 # DEFAULT FUNCTIONS
 ###################

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/__init__.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/__init__.py
@@ -7,7 +7,5 @@ from .resources_v2 import (
     DbtCli as DbtCli,
     DbtCliEventMessage as DbtCliEventMessage,
     DbtCliInvocation as DbtCliInvocation,
-    DbtManifest as DbtManifest,
-    DbtManifestAssetSelection as DbtManifestAssetSelection,
 )
 from .types import DbtCliOutput as DbtCliOutput

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -7,8 +7,6 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import (
-    TYPE_CHECKING,
-    AbstractSet,
     Any,
     Dict,
     Iterator,
@@ -21,591 +19,26 @@ from typing import (
 
 import dateutil.parser
 from dagster import (
-    AssetKey,
     AssetObservation,
-    AssetSelection,
     ConfigurableResource,
     OpExecutionContext,
     Output,
-    ScheduleDefinition,
     _check as check,
-    define_asset_job,
     get_dagster_logger,
 )
-from dagster._annotations import experimental
-from dagster._core.definitions.asset_graph import AssetGraph
-from dagster._core.errors import DagsterInvalidInvocationError
 from dbt.contracts.results import NodeStatus
 from dbt.node_types import NodeType
 from pydantic import Field
 from typing_extensions import Literal
 
-from ..asset_utils import (
-    MANIFEST_METADATA_KEY,
-    default_asset_key_fn,
-    default_description_fn,
-    default_metadata_fn,
-    is_non_asset_node,
-    output_name_fn,
-)
+from ..asset_utils import output_name_fn
+from ..dagster_dbt_translator import DagsterDbtTranslator
 from ..errors import DagsterDbtCliRuntimeError
-from ..utils import ASSET_RESOURCE_TYPES, select_unique_ids_from_manifest
-
-if TYPE_CHECKING:
-    from dagster import RunConfig
 
 logger = get_dagster_logger()
 
 
 PARTIAL_PARSE_FILE_NAME = "partial_parse.msgpack"
-
-
-@experimental
-@dataclass
-class DbtManifest:
-    """A wrapper class around the dbt manifest to translate dbt concepts to Dagster concepts.
-
-    Args:
-        raw_manifest (Dict[str, Any]): The raw dictionary representation of the dbt manifest.
-
-    Examples:
-        .. code-block:: python
-
-            from dagster_dbt import DbtManifest
-
-            manifest = DbtManifest.read(path="path/to/manifest.json")
-    """
-
-    raw_manifest: Mapping[str, Any]
-
-    @classmethod
-    def read(cls, path: Union[str, os.PathLike]) -> "DbtManifest":
-        """Read the file path to a dbt manifest and create a DbtManifest object.
-
-        Args:
-            path(Union[str, os.PathLike]): The path to the dbt manifest.json file.
-
-        Returns:
-            DbtManifest: A DbtManifest object.
-
-        Examples:
-            .. code-block:: python
-
-                from dagster_dbt import DbtManifest
-
-                manifest = DbtManifest.read(path="path/to/manifest.json")
-        """
-        with open(path, "r") as handle:
-            raw_manifest: Dict[str, Any] = json.loads(handle.read())
-
-        return cls(raw_manifest=raw_manifest)
-
-    @property
-    def node_info_by_dbt_unique_id(self) -> Mapping[str, Mapping[str, Any]]:
-        """A mapping of a dbt node's unique id to the node's dictionary representation in the manifest.
-        """
-        return {
-            **self.raw_manifest["nodes"],
-            **self.raw_manifest["sources"],
-            **self.raw_manifest["exposures"],
-            **self.raw_manifest["metrics"],
-        }
-
-    @classmethod
-    def node_info_to_asset_key(cls, node_info: Mapping[str, Any]) -> AssetKey:
-        """A function that takes a dictionary representing the dbt node and returns the
-        Dagster asset key the represents the dbt node.
-
-        This method can be overridden to provide a custom asset key for a dbt node.
-
-        Args:
-            node_info (Mapping[str, Any]): A dictionary representing the dbt node.
-
-        Returns:
-            AssetKey: The Dagster asset key for the dbt node.
-
-        Examples:
-            .. code-block:: python
-
-                from typing import Any, Mapping
-
-                from dagster import AssetKey
-                from dagster_dbt import DbtManifest
-
-
-                class CustomizedDbtManifest(DbtManifest):
-                    @classmethod
-                    def node_info_to_asset_key(cls, node_info: Mapping[str, Any]) -> AssetKey:
-                        return AssetKey(["prefix", node_info["alias"]])
-
-
-                manifest = CustomizedDbtManifest.read(path="path/to/manifest.json")
-        """
-        return default_asset_key_fn(node_info)
-
-    @classmethod
-    def node_info_to_description(cls, node_info: Mapping[str, Any]) -> str:
-        """A function that takes a dictionary representing the dbt node and returns the
-        Dagster description the represents the dbt node.
-
-        This method can be overridden to provide a custom description for a dbt node.
-
-        Args:
-            node_info (Mapping[str, Any]): A dictionary representing the dbt node.
-
-        Returns:
-            str: The description for the dbt node.
-
-        Examples:
-            .. code-block:: python
-
-                from typing import Any, Mapping
-
-                from dagster_dbt import DbtManifest
-
-
-                class CustomizedDbtManifest(DbtManifest):
-                    @classmethod
-                    def node_info_to_description(cls, node_info: Mapping[str, Any]) -> str:
-                        return "custom description"
-
-
-                manifest = CustomizedDbtManifest.read(path="path/to/manifest.json")
-        """
-        return default_description_fn(node_info)
-
-    @classmethod
-    def node_info_to_metadata(cls, node_info: Mapping[str, Any]) -> Mapping[str, Any]:
-        """A function that takes a dictionary representing the dbt node and returns the
-        Dagster metadata the represents the dbt node.
-
-        This method can be overridden to provide custom metadata for a dbt node.
-
-        Args:
-            node_info (Mapping[str, Any]): A dictionary representing the dbt node.
-
-        Returns:
-            Mapping[str, Any]: A dictionary representing the Dagster metadata for the dbt node.
-
-        Examples:
-            .. code-block:: python
-
-                from typing import Any, Mapping
-
-                from dagster_dbt import DbtManifest
-
-
-                class CustomizedDbtManifest(DbtManifest):
-                    @classmethod
-                    def node_info_to_metadata(cls, node_info: Mapping[str, Any]) -> Mapping[str, Any]:
-                        return {"custom": "metadata"}
-
-
-                manifest = CustomizedDbtManifest.read(path="path/to/manifest.json")
-        """
-        return default_metadata_fn(node_info)
-
-    @property
-    def node_info_by_asset_key(self) -> Mapping[AssetKey, Mapping[str, Any]]:
-        """A mapping of the default asset key for a dbt node to the node's dictionary representation in the manifest.
-        """
-        return {
-            self.node_info_to_asset_key(node): node
-            for node in self.node_info_by_dbt_unique_id.values()
-        }
-
-    @property
-    def node_info_by_output_name(self) -> Mapping[str, Mapping[str, Any]]:
-        """A mapping of the default output name for a dbt node to the node's dictionary representation in the manifest.
-        """
-        return {
-            output_name_fn(node): node
-            for node in self.node_info_by_dbt_unique_id.values()
-            if node["resource_type"] in ASSET_RESOURCE_TYPES
-        }
-
-    @property
-    def asset_key_replacements(self) -> Mapping[AssetKey, AssetKey]:
-        """A mapping of replacement asset keys for a dbt node to the node's dictionary representation in the manifest.
-        """
-        return {
-            DbtManifest.node_info_to_asset_key(node_info): self.node_info_to_asset_key(node_info)
-            for node_info in self.node_info_by_dbt_unique_id.values()
-        }
-
-    @property
-    def descriptions_by_asset_key(self) -> Mapping[AssetKey, str]:
-        """A mapping of the default asset key for a dbt node to the node's description in the manifest.
-        """
-        return {
-            self.node_info_to_asset_key(node): self.node_info_to_description(node)
-            for node in self.node_info_by_dbt_unique_id.values()
-        }
-
-    @property
-    def metadata_by_asset_key(self) -> Mapping[AssetKey, Mapping[Any, str]]:
-        """A mapping of the default asset key for a dbt node to the node's metadata in the manifest.
-        """
-        return {
-            self.node_info_to_asset_key(node): self.node_info_to_metadata(node)
-            for node in self.node_info_by_dbt_unique_id.values()
-        }
-
-    def get_node_info_for_output_name(self, output_name: str) -> Mapping[str, Any]:
-        """Get a dbt node's dictionary representation in the manifest by its Dagster output name."""
-        return self.node_info_by_output_name[output_name]
-
-    def get_asset_key_for_output_name(self, output_name: str) -> AssetKey:
-        """Return the corresponding dbt node's Dagster asset key for a Dagster output name.
-
-        Args:
-            output_name (str): The Dagster output name.
-
-        Returns:
-            AssetKey: The corresponding dbt node's Dagster asset key.
-        """
-        return self.node_info_to_asset_key(self.get_node_info_for_output_name(output_name))
-
-    def get_asset_key_for_dbt_unique_id(self, unique_id: str) -> AssetKey:
-        node_info = self.node_info_by_dbt_unique_id.get(unique_id)
-
-        if not node_info:
-            raise DagsterInvalidInvocationError(
-                f"Could not find a dbt node with unique_id: {unique_id}. A unique ID consists of"
-                " the node type (model, source, seed, etc.), project name, and node name in a"
-                " dot-separated string. For example: model.my_project.my_model\n For more"
-                " information on the unique ID structure:"
-                " https://docs.getdbt.com/reference/artifacts/manifest-json"
-            )
-
-        return self.node_info_to_asset_key(node_info)
-
-    def get_asset_key_for_source(self, source_name: str) -> AssetKey:
-        """Returns the corresponding Dagster asset key for a dbt source with a singular table.
-
-        Args:
-            source_name (str): The name of the dbt source.
-
-        Raises:
-            DagsterInvalidInvocationError: If the source has more than one table.
-
-        Returns:
-            AssetKey: The corresponding Dagster asset key.
-
-        Examples:
-            .. code-block:: python
-
-                from dagster import asset
-                from dagster_dbt import DbtManifest
-
-                manifest = DbtManifest.read("path/to/manifest.json")
-
-
-                @asset(key=manifest.get_asset_key_for_source("my_source"))
-                def upstream_python_asset():
-                    ...
-        """
-        asset_keys_by_output_name = self.get_asset_keys_by_output_name_for_source(source_name)
-
-        if len(asset_keys_by_output_name) > 1:
-            raise DagsterInvalidInvocationError(
-                f"Source {source_name} has more than one table:"
-                f" {asset_keys_by_output_name.values()}. Use"
-                " `get_asset_keys_by_output_name_for_source` instead to get all tables for a"
-                " source."
-            )
-
-        return list(asset_keys_by_output_name.values())[0]
-
-    def get_asset_keys_by_output_name_for_source(self, source_name: str) -> Mapping[str, AssetKey]:
-        """Returns the corresponding Dagster asset keys for all tables in a dbt source.
-
-        This is a convenience method that makes it easy to define a multi-asset that generates
-        all the tables for a given dbt source.
-
-        Args:
-            source_name (str): The name of the dbt source.
-
-        Returns:
-            Mapping[str, AssetKey]: A mapping of the table name to corresponding Dagster asset key
-                for all tables in the given dbt source.
-
-        Examples:
-            .. code-block:: python
-
-                from dagster import AssetOut, multi_asset
-                from dagster_dbt import DbtManifest
-
-                manifest = DbtManifest.read("path/to/manifest.json")
-
-
-                @multi_asset(
-                    outs={
-                        name: AssetOut(key=asset_key)
-                        for name, asset_key in manifest.get_asset_keys_by_output_name_for_source(
-                            "raw_data"
-                        ).items()
-                    },
-                )
-                def upstream_python_asset():
-                    ...
-
-        """
-        check.str_param(source_name, "source_name")
-
-        matching_nodes = [
-            value
-            for value in self.raw_manifest["sources"].values()
-            if value["source_name"] == source_name
-        ]
-
-        if len(matching_nodes) == 0:
-            raise DagsterInvalidInvocationError(
-                f"Could not find a dbt source with name: {source_name}"
-            )
-
-        return {
-            output_name_fn(value): self.node_info_to_asset_key(value) for value in matching_nodes
-        }
-
-    def get_asset_key_for_model(self, model_name: str) -> AssetKey:
-        """Return the corresponding Dagster asset key for a dbt model.
-
-        Args:
-            model_name (str): The name of the dbt model.
-
-        Returns:
-            AssetKey: The corresponding Dagster asset key.
-
-        Examples:
-            .. code-block:: python
-
-                from dagster import asset
-                from dagster_dbt import DbtManifest
-
-                manifest = DbtManifest.read("path/to/manifest.json")
-
-
-                @asset(non_argument_deps={manifest.get_asset_key_for_model("customers")})
-                def cleaned_customers():
-                    ...
-        """
-        check.str_param(model_name, "model_name")
-
-        matching_models = [
-            value
-            for value in self.raw_manifest["nodes"].values()
-            if value["name"] == model_name and value["resource_type"] == "model"
-        ]
-
-        if len(matching_models) == 0:
-            raise DagsterInvalidInvocationError(
-                f"Could not find a dbt model with name: {model_name}"
-            )
-
-        return self.node_info_to_asset_key(next(iter(matching_models)))
-
-    def build_asset_selection(
-        self,
-        dbt_select: str = "fqn:*",
-        dbt_exclude: Optional[str] = None,
-    ) -> AssetSelection:
-        """Build an asset selection for a dbt selection string.
-
-        See https://docs.getdbt.com/reference/node-selection/syntax#how-does-selection-work for
-        more information.
-
-        Args:
-            dbt_select (str): A dbt selection string to specify a set of dbt resources.
-            dbt_exclude (Optional[str]): A dbt selection string to exclude a set of dbt resources.
-
-        Returns:
-            AssetSelection: An asset selection for the selected dbt nodes.
-
-        Examples:
-            .. code-block:: python
-
-                from dagster_dbt import DbtManifest
-
-                manifest = DbtManifest.read("path/to/manifest.json")
-
-                # Select the dbt assets that have the tag "foo".
-                my_selection = manifest.build_asset_selection(dbt_select="tag:foo")
-        """
-        return DbtManifestAssetSelection(
-            manifest=self,
-            select=dbt_select,
-            exclude=dbt_exclude,
-        )
-
-    def build_schedule(
-        self,
-        job_name: str,
-        cron_schedule: str,
-        dbt_select: str = "fqn:*",
-        dbt_exclude: Optional[str] = None,
-        tags: Optional[Mapping[str, str]] = None,
-        config: Optional["RunConfig"] = None,
-        execution_timezone: Optional[str] = None,
-    ) -> ScheduleDefinition:
-        """Build a schedule to materialize a specified set of dbt resources from a dbt selection string.
-
-        See https://docs.getdbt.com/reference/node-selection/syntax#how-does-selection-work for
-        more information.
-
-        Args:
-            job_name (str): The name of the job to materialize the dbt resources.
-            cron_schedule (str): The cron schedule to define the schedule.
-            dbt_select (str): A dbt selection string to specify a set of dbt resources.
-            dbt_exclude (Optional[str]): A dbt selection string to exclude a set of dbt resources.
-            tags (Optional[Mapping[str, str]]): A dictionary of tags (string key-value pairs) to attach
-                to the scheduled runs.
-            config (Optional[RunConfig]): The config that parameterizes the execution of this schedule.
-            execution_timezone (Optional[str]): Timezone in which the schedule should run.
-                Supported strings for timezones are the ones provided by the
-                `IANA time zone database <https://www.iana.org/time-zones>` - e.g. "America/Los_Angeles".
-
-        Returns:
-            ScheduleDefinition: A definition to materialize the selected dbt resources on a cron schedule.
-
-        Examples:
-            .. code-block:: python
-
-                from dagster_dbt import DbtManifest
-
-                manifest = DbtManifest.read("path/to/manifest.json")
-
-                daily_dbt_assets_schedule = manifest.build_schedule(
-                    job_name="all_dbt_assets",
-                    cron_schedule="0 0 * * *",
-                    dbt_select="fqn:*",
-                )
-        """
-        return ScheduleDefinition(
-            cron_schedule=cron_schedule,
-            job=define_asset_job(
-                name=job_name,
-                selection=self.build_asset_selection(
-                    dbt_select=dbt_select,
-                    dbt_exclude=dbt_exclude,
-                ),
-                config=config,
-                tags=tags,
-            ),
-            execution_timezone=execution_timezone,
-        )
-
-    def get_subset_selection_for_context(
-        self,
-        context: OpExecutionContext,
-        select: Optional[str] = None,
-        exclude: Optional[str] = None,
-    ) -> List[str]:
-        """Generate a dbt selection string to materialize the selected resources in a subsetted execution context.
-
-        See https://docs.getdbt.com/reference/node-selection/syntax#how-does-selection-work.
-
-        Args:
-            context (OpExecutionContext): The execution context for the current execution step.
-            select (Optional[str]): A dbt selection string to select resources to materialize.
-            exclude (Optional[str]): A dbt selection string to exclude resources from materializing.
-
-        Returns:
-            List[str]: dbt CLI arguments to materialize the selected resources in a
-                subsetted execution context.
-
-                If the current execution context is not performing a subsetted execution,
-                return CLI arguments composed of the inputed selection and exclusion arguments.
-        """
-        default_dbt_selection = []
-        if select:
-            default_dbt_selection += ["--select", select]
-        if exclude:
-            default_dbt_selection += ["--exclude", exclude]
-
-        # TODO: this should be a property on the context if this is a permanent indicator for
-        # determining whether the current execution context is performing a subsetted execution.
-        is_subsetted_execution = len(context.selected_output_names) != len(
-            context.assets_def.node_keys_by_output_name
-        )
-        if not is_subsetted_execution:
-            logger.info(
-                "A dbt subsetted execution is not being performed. Using the default dbt selection"
-                f" arguments `{default_dbt_selection}`."
-            )
-            return default_dbt_selection
-
-        selected_dbt_resources = []
-        for output_name in context.selected_output_names:
-            node_info = self.get_node_info_for_output_name(output_name)
-
-            # Explicitly select a dbt resource by its fully qualified name (FQN).
-            # https://docs.getdbt.com/reference/node-selection/methods#the-file-or-fqn-method
-            fqn_selector = f"fqn:{'.'.join(node_info['fqn'])}"
-
-            selected_dbt_resources.append(fqn_selector)
-
-        # Take the union of all the selected resources.
-        # https://docs.getdbt.com/reference/node-selection/set-operators#unions
-        union_selected_dbt_resources = ["--select"] + [" ".join(selected_dbt_resources)]
-
-        logger.info(
-            "A dbt subsetted execution is being performed. Overriding default dbt selection"
-            f" arguments `{default_dbt_selection}` with arguments: `{union_selected_dbt_resources}`"
-        )
-
-        return union_selected_dbt_resources
-
-
-@experimental
-class DbtManifestAssetSelection(AssetSelection):
-    """Defines a selection of assets from a dbt manifest wrapper and a dbt selection string.
-
-    Args:
-        manifest (DbtManifest): The dbt manifest wrapper.
-        select (str): A dbt selection string to specify a set of dbt resources.
-        exclude (Optional[str]): A dbt selection string to exclude a set of dbt resources.
-
-    Examples:
-        .. code-block:: python
-
-            from dagster_dbt import DbtManifest, DbtManifestAssetSelection
-
-            manifest = DbtManifest.read("path/to/manifest.json")
-
-            # Build the selection from the manifest: select the dbt assets that have the tag "foo".
-            my_selection = manifest.build_asset_selection(dbt_select="tag:foo")
-
-            # Or, manually build the same selection.
-            my_selection = DbtManifestAssetSelection(manifest=manifest, select="tag:foo")
-    """
-
-    def __init__(
-        self,
-        manifest: DbtManifest,
-        select: str = "fqn:*",
-        exclude: Optional[str] = None,
-    ) -> None:
-        self.manifest = check.inst_param(manifest, "manifest", DbtManifest)
-        self.select = check.str_param(select, "select")
-        self.exclude = check.opt_str_param(exclude, "exclude", default="")
-
-    def resolve_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetKey]:
-        dbt_nodes = self.manifest.node_info_by_dbt_unique_id
-
-        keys = set()
-        for unique_id in select_unique_ids_from_manifest(
-            select=self.select,
-            exclude=self.exclude,
-            manifest_json=self.manifest.raw_manifest,
-        ):
-            node_info = dbt_nodes[unique_id]
-            is_dbt_asset = node_info["resource_type"] in ASSET_RESOURCE_TYPES
-            if is_dbt_asset and not is_non_asset_node(node_info):
-                asset_key = self.manifest.node_info_to_asset_key(node_info)
-                keys.add(asset_key)
-
-        return keys
 
 
 @dataclass
@@ -634,12 +67,16 @@ class DbtCliEventMessage:
         return self.raw_event["info"]["msg"]
 
     def to_default_asset_events(
-        self, manifest: DbtManifest
+        self,
+        manifest: Mapping[str, Any],
+        dagster_dbt_translator: DagsterDbtTranslator = DagsterDbtTranslator(),
     ) -> Iterator[Union[Output, AssetObservation]]:
         """Convert a dbt CLI event to a set of corresponding Dagster events.
 
         Args:
-            manifest (DbtManifest): The dbt manifest wrapper.
+            manifest (Mapping[str, Any]): The dbt manifest blob.
+            dagster_dbt_translator (DagsterDbtTranslator): Optionally, a custom translator for
+                linking dbt nodes to Dagster assets.
 
         Returns:
             Iterator[Union[Output, AssetObservation]]: A set of corresponding Dagster events.
@@ -670,13 +107,15 @@ class DbtCliEventMessage:
                 },
             )
         elif node_resource_type == NodeType.Test and is_node_finished:
-            upstream_unique_ids: List[str] = manifest.raw_manifest["parent_map"][unique_id]
+            upstream_unique_ids: List[str] = manifest["parent_map"][unique_id]
 
             for upstream_unique_id in upstream_unique_ids:
-                upstream_node_info: Dict[str, Any] = manifest.raw_manifest["nodes"].get(
+                upstream_node_info: Dict[str, Any] = manifest["nodes"].get(
                     upstream_unique_id
-                ) or manifest.raw_manifest["sources"].get(upstream_unique_id)
-                upstream_asset_key = manifest.node_info_to_asset_key(upstream_node_info)
+                ) or manifest["sources"].get(upstream_unique_id)
+                upstream_asset_key = dagster_dbt_translator.node_info_to_asset_key(
+                    upstream_node_info
+                )
 
                 yield AssetObservation(
                     asset_key=upstream_asset_key,
@@ -693,14 +132,15 @@ class DbtCliInvocation:
 
     Args:
         process (subprocess.Popen): The process running the dbt command.
-        manifest (DbtManifest): The dbt manifest wrapper.
+        manifest (Mapping[str, Any]): The dbt manifest blob.
         project_dir (Path): The path to the dbt project.
         target_path (Path): The path to the dbt target folder.
         raise_on_error (bool): Whether to raise an exception if the dbt command fails.
     """
 
     process: subprocess.Popen
-    manifest: DbtManifest
+    manifest: Mapping[str, Any]
+    dagster_dbt_translator: DagsterDbtTranslator
     project_dir: Path
     target_path: Path
     raise_on_error: bool
@@ -710,7 +150,8 @@ class DbtCliInvocation:
         cls,
         args: List[str],
         env: Dict[str, str],
-        manifest: DbtManifest,
+        manifest: Mapping[str, Any],
+        dagster_dbt_translator: DagsterDbtTranslator,
         project_dir: Path,
         target_path: Path,
         raise_on_error: bool,
@@ -746,6 +187,7 @@ class DbtCliInvocation:
         return cls(
             process=process,
             manifest=manifest,
+            dagster_dbt_translator=dagster_dbt_translator,
             project_dir=project_dir,
             target_path=target_path,
             raise_on_error=raise_on_error,
@@ -760,13 +202,15 @@ class DbtCliInvocation:
         Examples:
             .. code-block:: python
 
-                from dagster_dbt import DbtCli, DbtManifest
+                import json
+                from dagster_dbt import DbtCli
 
-                manifest = DbtManifest.read(path="path/to/manifest.json")
+                with open("path/to/manifest.json", "r") as f:
+                    manifest = json.load(f)
+
                 dbt = DbtCli(project_dir="/path/to/dbt/project")
 
                 dbt_cli_task = dbt.cli(["run"], manifest=manifest)
-
                 dbt_cli_task.wait()
         """
         return list(self.stream_raw_events())
@@ -780,12 +224,16 @@ class DbtCliInvocation:
         Examples:
             .. code-block:: python
 
-                from dagster_dbt import DbtCli, DbtManifest
+                import json
+                from dagster_dbt import DbtCli
 
-                manifest = DbtManifest.read(path="path/to/manifest.json")
+                with open("path/to/manifest.json", "r") as f:
+                    manifest = json.load(f)
+
                 dbt = DbtCli(project_dir="/path/to/dbt/project")
 
                 dbt_cli_task = dbt.cli(["run"], manifest=manifest)
+                dbt_cli_task.wait()
 
                 if dbt_cli_task.is_successful():
                     ...
@@ -804,14 +252,16 @@ class DbtCliInvocation:
             .. code-block:: python
 
                 from pathlib import Path
-                from dagster_dbt import DbtCli, DbtManifest, dbt_assets
+                from dagster_dbt import DbtCli, dbt_assets
 
                 @dbt_assets(manifest=Path("target", "manifest.json"))
                 def my_dbt_assets(context, dbt: DbtCli):
                     yield from dbt.cli(["run"], context=context).stream()
         """
         for event in self.stream_raw_events():
-            yield from event.to_default_asset_events(manifest=self.manifest)
+            yield from event.to_default_asset_events(
+                manifest=self.manifest, dagster_dbt_translator=self.dagster_dbt_translator
+            )
 
     def stream_raw_events(self) -> Iterator[DbtCliEventMessage]:
         """Stream the events from the dbt CLI process.
@@ -865,9 +315,12 @@ class DbtCliInvocation:
         Examples:
             .. code-block:: python
 
-                from dagster_dbt import DbtCli, DbtManifest
+                import json
+                from dagster_dbt import DbtCli
 
-                manifest = DbtManifest.read(path="path/to/manifest.json")
+                with open("path/to/manifest.json", "r") as f:
+                    manifest = json.load(f)
+
                 dbt = DbtCli(project_dir="/path/to/dbt/project")
 
                 dbt_cli_task = dbt.cli(["run"], manifest=manifest)
@@ -965,7 +418,8 @@ class DbtCli(ConfigurableResource):
         args: List[str],
         *,
         raise_on_error: bool = True,
-        manifest: Optional[DbtManifest] = None,
+        manifest: Optional[Mapping[str, Any]] = None,
+        dagster_dbt_translator: Optional[DagsterDbtTranslator] = None,
         context: Optional[OpExecutionContext] = None,
     ) -> DbtCliInvocation:
         """Execute a dbt command.
@@ -973,8 +427,14 @@ class DbtCli(ConfigurableResource):
         Args:
             args (List[str]): The dbt CLI command to execute.
             raise_on_error (bool): Whether to raise an exception if the dbt CLI command fails.
-            manifest (DbtManifest): The dbt manifest wrapper.
-            context (Optional[OpExecutionContext]): The execution context.
+            manifest (Optional[Mapping[str, Any]]): The dbt manifest blob. If an execution context
+                from within `@dbt_assets` is provided to the context argument, then the manifest
+                provided to `@dbt_assets` will be used.
+            dagster_dbt_translator (Optional[DagsterDbtTranslator]): The translator to link dbt
+                nodes to Dagster assets. If an execution context from within `@dbt_assets` is
+                provided to the context argument, then the dagster_dbt_translator provided to
+                `@dbt_assets` will be used.
+            context (Optional[OpExecutionContext]): The execution context from within `@dbt_assets`.
 
         Returns:
             DbtCliInvocation: A task that can be used to retrieve the output of the dbt CLI command.
@@ -983,7 +443,7 @@ class DbtCli(ConfigurableResource):
             .. code-block:: python
 
                 from pathlib import Path
-                from dagster_dbt import DbtCli, DbtManifest, dbt_assets
+                from dagster_dbt import DbtCli, dbt_assets
 
                 @dbt_assets(manifest=Path("target", "manifest.json"))
                 def my_dbt_assets(context, dbt: DbtCli):
@@ -1004,38 +464,35 @@ class DbtCli(ConfigurableResource):
             "DBT_TARGET_PATH": target_path,
         }
 
-        if manifest is None:
-            if context is None:
-                check.failed("Either a context or a manifest argument must be provided")
-            assets_def = context.assets_def
-            if assets_def is None:
-                check.failed(
-                    "Must provide a value for the manifest argument if not executing as part of"
-                    " @dbt_assets"
-                )
-            manifest = (
-                (assets_def.metadata_by_key or {}).get(next(iter(assets_def.keys))) or {}
-            ).get(MANIFEST_METADATA_KEY)
-            if not isinstance(manifest, DbtManifest):
-                check.failed(
-                    "Must provide a value for the manifest argument if not executing as part of"
-                    " @dbt_assets"
-                )
+        from dagster_dbt.dbt_assets_definition import DbtAssetsDefinition
 
-        # TODO: verify that args does not have any selection flags if the context and manifest
-        # are passed to this function.
-        selection_args: List[str] = []
-        if context:
+        if context and context.assets_def and isinstance(context.assets_def, DbtAssetsDefinition):
+            dbt_assets_def = context.assets_def
+
             logger.info(
-                "A context and manifest were provided to the dbt CLI client. Selection arguments to"
+                "A DbtAssetsDefinition was provided to the dbt CLI client. Selection arguments to"
                 " dbt will automatically be interpreted from the execution environment."
             )
 
-            selection_args = manifest.get_subset_selection_for_context(
+            selection_args = dbt_assets_def.get_subset_selection_for_context(
                 context=context,
                 select=context.op.tags.get("dagster-dbt/select"),
                 exclude=context.op.tags.get("dagster-dbt/exclude"),
             )
+            manifest = dbt_assets_def.manifest
+            dagster_dbt_translator = dbt_assets_def.dagster_dbt_translator
+        else:
+            selection_args: List[str] = []
+            dbt_assets_def = None
+            if manifest is None:
+                check.failed(
+                    "Must provide a value for the manifest argument if not executing as part of"
+                    " @dbt_assets"
+                )
+            dagster_dbt_translator = dagster_dbt_translator or DagsterDbtTranslator()
+
+        # TODO: verify that args does not have any selection flags if the context and manifest
+        # are passed to this function.
 
         profile_args: List[str] = []
         if self.profile:
@@ -1051,6 +508,7 @@ class DbtCli(ConfigurableResource):
             args=args,
             env=env,
             manifest=manifest,
+            dagster_dbt_translator=dagster_dbt_translator,
             project_dir=project_dir,
             target_path=project_dir.joinpath(target_path),
             raise_on_error=raise_on_error,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
@@ -1,0 +1,92 @@
+from typing import Any, Mapping
+
+from dagster import AssetKey
+
+from .asset_utils import default_asset_key_fn, default_description_fn, default_metadata_fn
+
+
+class DagsterDbtTranslator:
+    @classmethod
+    def node_info_to_asset_key(cls, node_info: Mapping[str, Any]) -> AssetKey:
+        """A function that takes a dictionary representing the dbt node and returns the
+        Dagster asset key the represents the dbt node.
+
+        This method can be overridden to provide a custom asset key for a dbt node.
+
+        Args:
+            node_info (Mapping[str, Any]): A dictionary representing the dbt node.
+
+        Returns:
+            AssetKey: The Dagster asset key for the dbt node.
+
+        Examples:
+            .. code-block:: python
+
+                from typing import Any, Mapping
+
+                from dagster import AssetKey
+                from dagster_dbt import DagsterDbtTranslator
+
+
+                class CustomDagsterDbtTranslator(DagsterDbtTranslator):
+                    @classmethod
+                    def node_info_to_asset_key(cls, node_info: Mapping[str, Any]) -> AssetKey:
+                        return AssetKey(["prefix", node_info["alias"]])
+        """
+        return default_asset_key_fn(node_info)
+
+    @classmethod
+    def node_info_to_description(cls, node_info: Mapping[str, Any]) -> str:
+        """A function that takes a dictionary representing the dbt node and returns the
+        Dagster description the represents the dbt node.
+
+        This method can be overridden to provide a custom description for a dbt node.
+
+        Args:
+            node_info (Mapping[str, Any]): A dictionary representing the dbt node.
+
+        Returns:
+            str: The description for the dbt node.
+
+        Examples:
+            .. code-block:: python
+
+                from typing import Any, Mapping
+
+                from dagster_dbt import DagsterDbtTranslator
+
+
+                class CustomDagsterDbtTranslator(DagsterDbtTranslator):
+                    @classmethod
+                    def node_info_to_description(cls, node_info: Mapping[str, Any]) -> str:
+                        return "custom description"
+        """
+        return default_description_fn(node_info)
+
+    @classmethod
+    def node_info_to_metadata(cls, node_info: Mapping[str, Any]) -> Mapping[str, Any]:
+        """A function that takes a dictionary representing the dbt node and returns the
+        Dagster metadata the represents the dbt node.
+
+        This method can be overridden to provide custom metadata for a dbt node.
+
+        Args:
+            node_info (Mapping[str, Any]): A dictionary representing the dbt node.
+
+        Returns:
+            Mapping[str, Any]: A dictionary representing the Dagster metadata for the dbt node.
+
+        Examples:
+            .. code-block:: python
+
+                from typing import Any, Mapping
+
+                from dagster_dbt import DagsterDbtTranslator
+
+
+                class CustomDagsterDbtTranslator(DagsterDbtTranslator):
+                    @classmethod
+                    def node_info_to_metadata(cls, node_info: Mapping[str, Any]) -> Mapping[str, Any]:
+                        return {"custom": "metadata"}
+        """
+        return default_metadata_fn(node_info)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_assets_definition.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_assets_definition.py
@@ -1,0 +1,428 @@
+from typing import TYPE_CHECKING, Any, List, Mapping, Optional
+
+from dagster import (
+    AssetKey,
+    AssetsDefinition,
+    AssetSelection,
+    OpExecutionContext,
+    ScheduleDefinition,
+    _check as check,
+    define_asset_job,
+    get_dagster_logger,
+)
+from dagster._core.errors import DagsterInvalidInvocationError
+
+from .asset_utils import output_name_fn
+from .dagster_dbt_translator import DagsterDbtTranslator
+from .dbt_manifest_asset_selection import DbtManifestAssetSelection
+from .utils import ASSET_RESOURCE_TYPES, get_node_info_by_dbt_unique_id_from_manifest
+
+logger = get_dagster_logger()
+
+
+if TYPE_CHECKING:
+    from dagster import RunConfig
+
+
+class DbtAssetsDefinition(AssetsDefinition):
+    def __init__(
+        self,
+        *,
+        manifest: Mapping[str, Any],
+        dagster_dbt_translator: DagsterDbtTranslator,
+        **kwargs: Any,
+    ):
+        check.dict_param(manifest, "manifest", key_type=str)
+        check.inst_param(dagster_dbt_translator, "dagster_dbt_translator", DagsterDbtTranslator)
+
+        super().__init__(**kwargs)
+        self._manifest = manifest
+        self._dagster_dbt_translator = dagster_dbt_translator
+        self._node_info_by_dbt_unique_id = get_node_info_by_dbt_unique_id_from_manifest(manifest)
+
+    @staticmethod
+    def from_assets_def(
+        assets_def: AssetsDefinition,
+        manifest: Mapping[str, Any],
+        dagster_dbt_translator: DagsterDbtTranslator,
+    ) -> "DbtAssetsDefinition":
+        check.dict_param(manifest, "manifest", key_type=str)
+        check.inst_param(dagster_dbt_translator, "dagster_dbt_translator", DagsterDbtTranslator)
+
+        return DbtAssetsDefinition(
+            manifest=manifest,
+            dagster_dbt_translator=dagster_dbt_translator,
+            **assets_def.get_attributes_dict(),
+        )
+
+    def get_attributes_dict(self) -> Mapping[str, Any]:
+        return dict(
+            **super().get_attributes_dict(),
+            manifest=self.manifest,
+            dagster_dbt_translator=self.dagster_dbt_translator,
+        )
+
+    @property
+    def dagster_dbt_translator(self) -> DagsterDbtTranslator:
+        return self._dagster_dbt_translator
+
+    @property
+    def manifest(self) -> Mapping[str, Any]:
+        return self._manifest
+
+    @property
+    def node_info_by_asset_key(self) -> Mapping[AssetKey, Mapping[str, Any]]:
+        """A mapping of the default asset key for a dbt node to the node's dictionary representation in the manifest.
+        """
+        return {
+            self.dagster_dbt_translator.node_info_to_asset_key(node): node
+            for node in self._node_info_by_dbt_unique_id.values()
+        }
+
+    @property
+    def node_info_by_output_name(self) -> Mapping[str, Mapping[str, Any]]:
+        """A mapping of the default output name for a dbt node to the node's dictionary representation in the manifest.
+        """
+        return {
+            output_name_fn(node): node
+            for node in self._node_info_by_dbt_unique_id.values()
+            if node["resource_type"] in ASSET_RESOURCE_TYPES
+        }
+
+    @property
+    def descriptions_by_asset_key(self) -> Mapping[AssetKey, str]:
+        """A mapping of the default asset key for a dbt node to the node's description in the manifest.
+        """
+        return {
+            self.dagster_dbt_translator.node_info_to_asset_key(
+                node
+            ): self.dagster_dbt_translator.node_info_to_description(node)
+            for node in self._node_info_by_dbt_unique_id.values()
+        }
+
+    @property
+    def metadata_by_asset_key(self) -> Mapping[AssetKey, Mapping[Any, str]]:
+        """A mapping of the default asset key for a dbt node to the node's metadata in the manifest.
+        """
+        return {
+            self.dagster_dbt_translator.node_info_to_asset_key(
+                node
+            ): self.dagster_dbt_translator.node_info_to_metadata(node)
+            for node in self._node_info_by_dbt_unique_id.values()
+        }
+
+    def get_node_info_for_output_name(self, output_name: str) -> Mapping[str, Any]:
+        """Get a dbt node's dictionary representation in the manifest by its Dagster output name."""
+        return self.node_info_by_output_name[output_name]
+
+    def get_asset_key_for_output_name(self, output_name: str) -> AssetKey:
+        """Return the corresponding dbt node's Dagster asset key for a Dagster output name.
+
+        Args:
+            output_name (str): The Dagster output name.
+
+        Returns:
+            AssetKey: The corresponding dbt node's Dagster asset key.
+        """
+        return self.dagster_dbt_translator.node_info_to_asset_key(
+            self.get_node_info_for_output_name(output_name)
+        )
+
+    def get_asset_key_for_dbt_unique_id(self, unique_id: str) -> AssetKey:
+        node_info = self._node_info_by_dbt_unique_id.get(unique_id)
+
+        if not node_info:
+            raise DagsterInvalidInvocationError(
+                f"Could not find a dbt node with unique_id: {unique_id}. A unique ID consists of"
+                " the node type (model, source, seed, etc.), project name, and node name in a"
+                " dot-separated string. For example: model.my_project.my_model\n For more"
+                " information on the unique ID structure:"
+                " https://docs.getdbt.com/reference/artifacts/manifest-json"
+            )
+
+        return self.dagster_dbt_translator.node_info_to_asset_key(node_info)
+
+    def get_asset_key_for_source(self, source_name: str) -> AssetKey:
+        """Returns the corresponding Dagster asset key for a dbt source with a singular table.
+
+        Args:
+            source_name (str): The name of the dbt source.
+
+        Raises:
+            DagsterInvalidInvocationError: If the source has more than one table.
+
+        Returns:
+            AssetKey: The corresponding Dagster asset key.
+
+        Examples:
+            .. code-block:: python
+
+                from dagster import asset
+                from dagster_dbt import dbt_assets
+
+                @dbt_assets(manifest=...)
+                def all_dbt_assets():
+                    ...
+
+                @asset(key=all_dbt_assets.get_asset_key_for_source("my_source"))
+                def upstream_python_asset():
+                    ...
+        """
+        asset_keys_by_output_name = self.get_asset_keys_by_output_name_for_source(source_name)
+
+        if len(asset_keys_by_output_name) > 1:
+            raise DagsterInvalidInvocationError(
+                f"Source {source_name} has more than one table:"
+                f" {asset_keys_by_output_name.values()}. Use"
+                " `get_asset_keys_by_output_name_for_source` instead to get all tables for a"
+                " source."
+            )
+
+        return list(asset_keys_by_output_name.values())[0]
+
+    def get_asset_keys_by_output_name_for_source(self, source_name: str) -> Mapping[str, AssetKey]:
+        """Returns the corresponding Dagster asset keys for all tables in a dbt source.
+
+        This is a convenience method that makes it easy to define a multi-asset that generates
+        all the tables for a given dbt source.
+
+        Args:
+            source_name (str): The name of the dbt source.
+
+        Returns:
+            Mapping[str, AssetKey]: A mapping of the table name to corresponding Dagster asset key
+                for all tables in the given dbt source.
+
+        Examples:
+            .. code-block:: python
+
+                from dagster import AssetOut, multi_asset
+                from dagster_dbt import dbt_assets
+
+                @dbt_assets(manifest=...)
+                def all_dbt_assets():
+                    ...
+
+                @multi_asset(
+                    outs={
+                        name: AssetOut(key=asset_key)
+                        for name, asset_key in all_dbt_assets.get_asset_keys_by_output_name_for_source(
+                            "raw_data"
+                        ).items()
+                    },
+                )
+                def upstream_python_asset():
+                    ...
+
+        """
+        check.str_param(source_name, "source_name")
+
+        matching_nodes = [
+            value
+            for value in self._manifest["sources"].values()
+            if value["source_name"] == source_name
+        ]
+
+        if len(matching_nodes) == 0:
+            raise DagsterInvalidInvocationError(
+                f"Could not find a dbt source with name: {source_name}"
+            )
+
+        return {
+            output_name_fn(value): self.dagster_dbt_translator.node_info_to_asset_key(value)
+            for value in matching_nodes
+        }
+
+    def get_asset_key_for_model(self, model_name: str) -> AssetKey:
+        """Return the corresponding Dagster asset key for a dbt model.
+
+        Args:
+            model_name (str): The name of the dbt model.
+
+        Returns:
+            AssetKey: The corresponding Dagster asset key.
+
+        Examples:
+            .. code-block:: python
+
+                from dagster import asset
+                from dagster_dbt import dbt_assets
+
+                @dbt_assets(manifest=...)
+                def all_dbt_assets():
+                    ...
+
+
+                @asset(non_argument_deps={all_dbt_assets.get_asset_key_for_model("customers")})
+                def cleaned_customers():
+                    ...
+        """
+        check.str_param(model_name, "model_name")
+
+        matching_models = [
+            value
+            for value in self._manifest["nodes"].values()
+            if value["name"] == model_name and value["resource_type"] == "model"
+        ]
+
+        if len(matching_models) == 0:
+            raise DagsterInvalidInvocationError(
+                f"Could not find a dbt model with name: {model_name}"
+            )
+
+        return self.dagster_dbt_translator.node_info_to_asset_key(next(iter(matching_models)))
+
+    def build_dbt_asset_selection(
+        self,
+        dbt_select: str = "fqn:*",
+        dbt_exclude: Optional[str] = None,
+    ) -> AssetSelection:
+        """Build an asset selection for a dbt selection string.
+
+        See https://docs.getdbt.com/reference/node-selection/syntax#how-does-selection-work for
+        more information.
+
+        Args:
+            dbt_select (str): A dbt selection string to specify a set of dbt resources.
+            dbt_exclude (Optional[str]): A dbt selection string to exclude a set of dbt resources.
+
+        Returns:
+            AssetSelection: An asset selection for the selected dbt nodes.
+
+        Examples:
+            .. code-block:: python
+
+                from dagster_dbt import dbt_assets
+
+                @dbt_assets(manifest=...)
+                def all_dbt_assets():
+                    ...
+
+                # Select the dbt assets that have the tag "foo".
+                my_selection = all_dbt_assets.build_dbt_asset_selection(dbt_select="tag:foo")
+        """
+        return DbtManifestAssetSelection(
+            manifest=self._manifest,
+            select=dbt_select,
+            exclude=dbt_exclude,
+        )
+
+    def build_schedule_from_dbt_select(
+        self,
+        job_name: str,
+        cron_schedule: str,
+        dbt_select: str = "fqn:*",
+        dbt_exclude: Optional[str] = None,
+        tags: Optional[Mapping[str, str]] = None,
+        config: Optional["RunConfig"] = None,
+        execution_timezone: Optional[str] = None,
+    ) -> ScheduleDefinition:
+        """Build a schedule to materialize a specified set of dbt resources from a dbt selection string.
+
+        See https://docs.getdbt.com/reference/node-selection/syntax#how-does-selection-work for
+        more information.
+
+        Args:
+            job_name (str): The name of the job to materialize the dbt resources.
+            cron_schedule (str): The cron schedule to define the schedule.
+            dbt_select (str): A dbt selection string to specify a set of dbt resources.
+            dbt_exclude (Optional[str]): A dbt selection string to exclude a set of dbt resources.
+            tags (Optional[Mapping[str, str]]): A dictionary of tags (string key-value pairs) to attach
+                to the scheduled runs.
+            config (Optional[RunConfig]): The config that parameterizes the execution of this schedule.
+            execution_timezone (Optional[str]): Timezone in which the schedule should run.
+                Supported strings for timezones are the ones provided by the
+                `IANA time zone database <https://www.iana.org/time-zones>` - e.g. "America/Los_Angeles".
+
+        Returns:
+            ScheduleDefinition: A definition to materialize the selected dbt resources on a cron schedule.
+
+        Examples:
+            .. code-block:: python
+
+                from dagster_dbt import dbt_assets
+
+                @dbt_assets(manifest=...)
+                def all_dbt_assets():
+                    ...
+
+                daily_dbt_assets_schedule = all_dbt_assets.build_schedule_from_dbt_select(
+                    job_name="all_dbt_assets",
+                    cron_schedule="0 0 * * *",
+                    dbt_select="fqn:*",
+                )
+        """
+        return ScheduleDefinition(
+            cron_schedule=cron_schedule,
+            job=define_asset_job(
+                name=job_name,
+                selection=self.build_dbt_asset_selection(
+                    dbt_select=dbt_select,
+                    dbt_exclude=dbt_exclude,
+                ),
+                config=config,
+                tags=tags,
+            ),
+            execution_timezone=execution_timezone,
+        )
+
+    def get_subset_selection_for_context(
+        self,
+        context: OpExecutionContext,
+        select: Optional[str] = None,
+        exclude: Optional[str] = None,
+    ) -> List[str]:
+        """Generate a dbt selection string to materialize the selected resources in a subsetted execution context.
+
+        See https://docs.getdbt.com/reference/node-selection/syntax#how-does-selection-work.
+
+        Args:
+            context (OpExecutionContext): The execution context for the current execution step.
+            select (Optional[str]): A dbt selection string to select resources to materialize.
+            exclude (Optional[str]): A dbt selection string to exclude resources from materializing.
+
+        Returns:
+            List[str]: dbt CLI arguments to materialize the selected resources in a
+                subsetted execution context.
+
+                If the current execution context is not performing a subsetted execution,
+                return CLI arguments composed of the inputed selection and exclusion arguments.
+        """
+        default_dbt_selection = []
+        if select:
+            default_dbt_selection += ["--select", select]
+        if exclude:
+            default_dbt_selection += ["--exclude", exclude]
+
+        # TODO: this should be a property on the context if this is a permanent indicator for
+        # determining whether the current execution context is performing a subsetted execution.
+        is_subsetted_execution = len(context.selected_output_names) != len(
+            context.assets_def.node_keys_by_output_name
+        )
+        if not is_subsetted_execution:
+            logger.info(
+                "A dbt subsetted execution is not being performed. Using the default dbt selection"
+                f" arguments `{default_dbt_selection}`."
+            )
+            return default_dbt_selection
+
+        selected_dbt_resources = []
+        for output_name in context.selected_output_names:
+            node_info = self.get_node_info_for_output_name(output_name)
+
+            # Explicitly select a dbt resource by its fully qualified name (FQN).
+            # https://docs.getdbt.com/reference/node-selection/methods#the-file-or-fqn-method
+            fqn_selector = f"fqn:{'.'.join(node_info['fqn'])}"
+
+            selected_dbt_resources.append(fqn_selector)
+
+        # Take the union of all the selected resources.
+        # https://docs.getdbt.com/reference/node-selection/set-operators#unions
+        union_selected_dbt_resources = ["--select"] + [" ".join(selected_dbt_resources)]
+
+        logger.info(
+            "A dbt subsetted execution is being performed. Overriding default dbt selection"
+            f" arguments `{default_dbt_selection}` with arguments: `{union_selected_dbt_resources}`"
+        )
+
+        return union_selected_dbt_resources

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_manifest_asset_selection.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_manifest_asset_selection.py
@@ -1,0 +1,75 @@
+from typing import AbstractSet, Any, Mapping, Optional
+
+from dagster import (
+    AssetKey,
+    AssetSelection,
+    _check as check,
+)
+from dagster._annotations import experimental
+from dagster._core.definitions.asset_graph import AssetGraph
+
+from .asset_utils import is_non_asset_node
+from .dagster_dbt_translator import DagsterDbtTranslator
+from .utils import (
+    ASSET_RESOURCE_TYPES,
+    get_node_info_by_dbt_unique_id_from_manifest,
+    select_unique_ids_from_manifest,
+)
+
+
+@experimental
+class DbtManifestAssetSelection(AssetSelection):
+    """Defines a selection of assets from a dbt manifest wrapper and a dbt selection string.
+
+    Args:
+        manifest (Mapping[str, Any]): The dbt manifest blob.
+        select (str): A dbt selection string to specify a set of dbt resources.
+        exclude (Optional[str]): A dbt selection string to exclude a set of dbt resources.
+
+    Examples:
+        .. code-block:: python
+
+            import json
+            from dagster_dbt import DbtManifestAssetSelection
+
+            with open("path/to/manifest.json", "r") as f:
+                manifest = json.load(f)
+
+            # select the dbt assets that have the tag "foo".
+            my_selection = DbtManifestAssetSelection(manifest=manifest, select="tag:foo")
+    """
+
+    def __init__(
+        self,
+        manifest: Mapping[str, Any],
+        select: str = "fqn:*",
+        *,
+        dagster_dbt_translator: Optional[DagsterDbtTranslator] = None,
+        exclude: Optional[str] = None,
+    ) -> None:
+        self.manifest = check.dict_param(manifest, "manifest", key_type=str)
+        self.select = check.str_param(select, "select")
+        self.exclude = check.opt_str_param(exclude, "exclude", default="")
+        self.dagster_dbt_translator = check.opt_inst_param(
+            dagster_dbt_translator,
+            "dagster_dbt_translator",
+            DagsterDbtTranslator,
+            DagsterDbtTranslator(),
+        )
+
+    def resolve_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetKey]:
+        dbt_nodes = get_node_info_by_dbt_unique_id_from_manifest(self.manifest)
+
+        keys = set()
+        for unique_id in select_unique_ids_from_manifest(
+            select=self.select,
+            exclude=self.exclude,
+            manifest_json=self.manifest,
+        ):
+            node_info = dbt_nodes[unique_id]
+            is_dbt_asset = node_info["resource_type"] in ASSET_RESOURCE_TYPES
+            if is_dbt_asset and not is_non_asset_node(node_info):
+                asset_key = self.dagster_dbt_translator.node_info_to_asset_key(node_info)
+                keys.add(asset_key)
+
+        return keys

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
@@ -320,3 +320,16 @@ def select_unique_ids_from_manifest(
     selector = graph_selector.NodeSelector(graph, manifest, previous_state=previous_state)
     selected, _ = selector.select_nodes(parsed_spec)
     return selected
+
+
+def get_node_info_by_dbt_unique_id_from_manifest(
+    manifest: Mapping[str, Any]
+) -> Mapping[str, Mapping[str, Any]]:
+    """A mapping of a dbt node's unique id to the node's dictionary representation in the manifest.
+    """
+    return {
+        **manifest["nodes"],
+        **manifest["sources"],
+        **manifest["exposures"],
+        **manifest["metrics"],
+    }

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_selection.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_selection.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 from typing import Optional, Set
 
@@ -5,10 +6,11 @@ import pytest
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.events import AssetKey
 from dagster_dbt.asset_decorator import dbt_assets
-from dagster_dbt.core.resources_v2 import DbtManifest
 
 manifest_path = Path(__file__).parent.joinpath("..", "sample_manifest.json")
-manifest = DbtManifest.read(path=manifest_path)
+
+with open(manifest_path, "r") as f:
+    manifest = json.load(f)
 
 
 @pytest.mark.parametrize(
@@ -109,7 +111,7 @@ def test_dbt_asset_selection(
         ...
 
     asset_graph = AssetGraph.from_assets([my_dbt_assets])
-    asset_selection = manifest.build_asset_selection(
+    asset_selection = my_dbt_assets.build_dbt_asset_selection(
         dbt_select=select or "fqn:*",
         dbt_exclude=exclude,
     )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resources_v2.py
@@ -1,3 +1,4 @@
+import json
 import shutil
 from pathlib import Path
 from typing import List, Optional
@@ -9,7 +10,6 @@ from dagster_dbt.core.resources_v2 import (
     PARTIAL_PARSE_FILE_NAME,
     DbtCli,
     DbtCliEventMessage,
-    DbtManifest,
 )
 from dagster_dbt.errors import DagsterDbtCliRuntimeError
 
@@ -19,7 +19,8 @@ pytest.importorskip("dbt.version", minversion="1.4")
 
 
 manifest_path = Path(TEST_PROJECT_DIR).joinpath("manifest.json")
-manifest = DbtManifest.read(path=manifest_path)
+with open(manifest_path, "r") as f:
+    manifest = json.load(f)
 
 
 @pytest.mark.parametrize("global_config_flags", [[], ["--debug"]])
@@ -223,16 +224,12 @@ def test_dbt_cli_default_selection(exclude: Optional[str]) -> None:
     ],
 )
 def test_no_default_asset_events_emitted(data: dict) -> None:
-    manifest = DbtManifest(raw_manifest={})
-    asset_events = DbtCliEventMessage(raw_event={"data": data}).to_default_asset_events(
-        manifest=manifest
-    )
+    asset_events = DbtCliEventMessage(raw_event={"data": data}).to_default_asset_events(manifest={})
 
     assert list(asset_events) == []
 
 
 def test_to_default_asset_output_events() -> None:
-    manifest = DbtManifest(raw_manifest={})
     raw_event = {
         "data": {
             "node_info": {
@@ -245,7 +242,7 @@ def test_to_default_asset_output_events() -> None:
         }
     }
     asset_events = list(
-        DbtCliEventMessage(raw_event=raw_event).to_default_asset_events(manifest=manifest)
+        DbtCliEventMessage(raw_event=raw_event).to_default_asset_events(manifest={})
     )
 
     assert len(asset_events) == 1
@@ -257,30 +254,28 @@ def test_to_default_asset_output_events() -> None:
 
 
 def test_to_default_asset_observation_events() -> None:
-    manifest = DbtManifest(
-        raw_manifest={
-            "nodes": {
-                "a.b.c.d": {
-                    "resource_type": "model",
-                    "config": {},
-                    "name": "model",
-                }
-            },
-            "sources": {
-                "a.b.c.d.e": {
-                    "resource_type": "source",
-                    "source_name": "test",
-                    "name": "source",
-                }
-            },
-            "parent_map": {
-                "a.b.c": [
-                    "a.b.c.d",
-                    "a.b.c.d.e",
-                ]
-            },
-        }
-    )
+    manifest = {
+        "nodes": {
+            "a.b.c.d": {
+                "resource_type": "model",
+                "config": {},
+                "name": "model",
+            }
+        },
+        "sources": {
+            "a.b.c.d.e": {
+                "resource_type": "source",
+                "source_name": "test",
+                "name": "source",
+            }
+        },
+        "parent_map": {
+            "a.b.c": [
+                "a.b.c.d",
+                "a.b.c.d.e",
+            ]
+        },
+    }
     raw_event = {
         "data": {
             "node_info": {

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_schedules.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_schedules.py
@@ -1,13 +1,15 @@
+import json
 from pathlib import Path
 from typing import Mapping, Optional
 
 import pytest
 from dagster import RunConfig
 from dagster._core.definitions.unresolved_asset_job_definition import UnresolvedAssetJobDefinition
-from dagster_dbt.core.resources_v2 import DbtManifest, DbtManifestAssetSelection
+from dagster_dbt import DbtManifestAssetSelection, dbt_assets
 
 manifest_path = Path(__file__).parent.joinpath("..", "sample_manifest.json")
-manifest = DbtManifest.read(path=manifest_path)
+with open(manifest_path, "r") as f:
+    manifest = json.load(f)
 
 
 @pytest.mark.parametrize(
@@ -50,7 +52,11 @@ def test_dbt_build_schedule(
     config: Optional[RunConfig],
     execution_timezone: Optional[str],
 ) -> None:
-    test_daily_schedule = manifest.build_schedule(
+    @dbt_assets(manifest=manifest)
+    def my_dbt_assets():
+        ...
+
+    test_daily_schedule = my_dbt_assets.build_schedule_from_dbt_select(
         job_name=job_name,
         cron_schedule=cron_schedule,
         dbt_select=dbt_select,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_dependencies.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_dependencies.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 import pytest
@@ -7,21 +8,27 @@ from dagster import (
 )
 from dagster._core.errors import DagsterInvalidInvocationError
 from dagster_dbt.asset_decorator import dbt_assets
-from dagster_dbt.core.resources_v2 import DbtManifest
 
-test_dagster_metadata_manifest = DbtManifest.read(
-    path=Path(__file__).parent.joinpath("dbt_projects", "test_dagster_metadata", "manifest.json")
+manifest_path = Path(__file__).parent.joinpath(
+    "dbt_projects", "test_dagster_metadata", "manifest.json"
 )
+with open(manifest_path, "r") as f:
+    manifest = json.load(f)
+
+
+@dbt_assets(manifest=manifest)
+def my_dbt_assets():
+    ...
 
 
 def test_get_asset_key_for_dbt_unique_id() -> None:
-    assert test_dagster_metadata_manifest.get_asset_key_for_dbt_unique_id(
+    assert my_dbt_assets.get_asset_key_for_dbt_unique_id(
         "source.test_dagster_metadata.jaffle_shop.raw_events"
     ) == AssetKey(["jaffle_shop", "raw_events"])
 
 
 def test_get_explicit_asset_key_for_dbt_unique_id_() -> None:
-    assert test_dagster_metadata_manifest.get_asset_key_for_dbt_unique_id(
+    assert my_dbt_assets.get_asset_key_for_dbt_unique_id(
         "source.test_dagster_metadata.jaffle_shop.raw_customers"
     ) == AssetKey(["customized", "source", "jaffle_shop", "main", "raw_customers"])
 
@@ -29,11 +36,7 @@ def test_get_explicit_asset_key_for_dbt_unique_id_() -> None:
 def test_asset_downstream_of_dbt_asset() -> None:
     upstream_asset_key = AssetKey(["orders"])
 
-    @dbt_assets(manifest=test_dagster_metadata_manifest)
-    def my_dbt_assets():
-        ...
-
-    @asset(non_argument_deps={test_dagster_metadata_manifest.get_asset_key_for_model("orders")})
+    @asset(non_argument_deps={my_dbt_assets.get_asset_key_for_model("orders")})
     def downstream_python_asset():
         ...
 
@@ -43,13 +46,11 @@ def test_asset_downstream_of_dbt_asset() -> None:
 
 def test_nonexistent_dbt_unique_id() -> None:
     with pytest.raises(DagsterInvalidInvocationError):
-        test_dagster_metadata_manifest.get_asset_key_for_dbt_unique_id(unique_id="nonexistent")
+        my_dbt_assets.get_asset_key_for_dbt_unique_id(unique_id="nonexistent")
 
 
 def test_get_asset_keys_by_output_name_for_source() -> None:
-    assert test_dagster_metadata_manifest.get_asset_keys_by_output_name_for_source(
-        "jaffle_shop"
-    ) == {
+    assert my_dbt_assets.get_asset_keys_by_output_name_for_source("jaffle_shop") == {
         "raw_customers": AssetKey(["customized", "source", "jaffle_shop", "main", "raw_customers"]),
         "raw_events": AssetKey(["jaffle_shop", "raw_events"]),
     }
@@ -57,17 +58,15 @@ def test_get_asset_keys_by_output_name_for_source() -> None:
     with pytest.raises(
         DagsterInvalidInvocationError, match="Could not find a dbt source with name"
     ):
-        test_dagster_metadata_manifest.get_asset_keys_by_output_name_for_source("nonexistent")
+        my_dbt_assets.get_asset_keys_by_output_name_for_source("nonexistent")
 
 
 def test_get_asset_keys_for_model() -> None:
-    assert test_dagster_metadata_manifest.get_asset_key_for_model("stg_customers") == AssetKey(
+    assert my_dbt_assets.get_asset_key_for_model("stg_customers") == AssetKey(
         ["customized", "staging", "customers"]
     )
 
-    assert test_dagster_metadata_manifest.get_asset_key_for_model("customers") == AssetKey(
-        ["customers"]
-    )
+    assert my_dbt_assets.get_asset_key_for_model("customers") == AssetKey(["customers"])
 
     with pytest.raises(DagsterInvalidInvocationError, match="Could not find a dbt model with name"):
-        test_dagster_metadata_manifest.get_asset_key_for_model("nonexistent")
+        my_dbt_assets.get_asset_key_for_model("nonexistent")


### PR DESCRIPTION
## Summary & Motivation

Adds a `DbtAssetsDefinition` class, as described in https://github.com/dagster-io/internal/discussions/6143.

A `DbtAssetsDefinition` is an `AssetsDefinition`, plus:
- A manifest blob
- A `DagsterDbtTranslator`
- A set of convenience methods

Some of the convenience methods have different names than the names on `DbtManifest`. This avoids taking up namespace that could eventually go on `AssetsDefinition` itself, and makes it clear that they're dbt-specific:
- `build_schedule` -> `build_schedule_from_dbt_select`
- `build_asset_selection` -> `build_dbt_asset_selection`

Depends on https://github.com/dagster-io/dagster/pull/15212.

## How I Tested These Changes
