### PR TITLE
Fix lazy auto materialize policy when missing

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/freshness_based_auto_materialize.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_based_auto_materialize.py
@@ -208,6 +208,7 @@ def determine_asset_partitions_to_auto_materialize_for_freshness(
                 execution_period is not None
                 and execution_period.start <= current_time
                 and expected_data_time is not None
+                # This is the check that's failing
                 and expected_data_time >= execution_period.start
                 and all(
                     condition.decision_type == AutoMaterializeDecisionType.MATERIALIZE

--- a/python_modules/dagster/dagster/_core/definitions/freshness_based_auto_materialize.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_based_auto_materialize.py
@@ -32,9 +32,6 @@ def get_execution_period_for_policy(
     effective_data_time: Optional[datetime.datetime],
     current_time: datetime.datetime,
 ) -> pendulum.Period:
-    if effective_data_time is None:
-        return pendulum.Period(start=current_time, end=current_time)
-
     if freshness_policy.cron_schedule:
         tick_iterator = cron_string_iterator(
             start_timestamp=current_time.timestamp(),
@@ -51,6 +48,14 @@ def get_execution_period_for_policy(
                 return pendulum.Period(start=required_data_time, end=tick)
 
     else:
+        # occurs when asset is missing
+        if effective_data_time is None:
+            return pendulum.Period(
+                # require data from at most maximum_lag_delta ago
+                start=current_time - freshness_policy.maximum_lag_delta,
+                # this data should be available as soon as possible
+                end=current_time,
+            )
         return pendulum.Period(
             # we don't want to execute this too frequently
             start=effective_data_time + 0.9 * freshness_policy.maximum_lag_delta,
@@ -208,7 +213,7 @@ def determine_asset_partitions_to_auto_materialize_for_freshness(
                 execution_period is not None
                 and execution_period.start <= current_time
                 and expected_data_time is not None
-                # This is the check that's failing
+                # if this is False, then executing it would still leave the asset overdue
                 and expected_data_time >= execution_period.start
                 and all(
                     condition.decision_type == AutoMaterializeDecisionType.MATERIALIZE

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/auto_materialize_policy_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/auto_materialize_policy_scenarios.py
@@ -1,3 +1,4 @@
+import datetime
 from typing import Sequence
 
 from dagster import (
@@ -79,7 +80,12 @@ static_partitioned_eager_after_non_partitioned = [
 
 non_auto_to_lazy = [
     asset_def("non_auto"),
-    asset_def("auto", ["non_auto"], auto_materialize_policy=AutoMaterializePolicy.lazy()),
+    asset_def(
+        "auto",
+        ["non_auto"],
+        auto_materialize_policy=AutoMaterializePolicy.lazy(),
+        freshness_policy=FreshnessPolicy(maximum_lag_minutes=60),
+    ),
 ]
 
 
@@ -447,10 +453,11 @@ auto_materialize_policy_scenarios = {
         cursor_from=AssetReconciliationScenario(
             assets=non_auto_to_lazy,
             asset_selection=AssetSelection.keys("auto"),
-            unevaluated_runs=[],
+            unevaluated_runs=[run(["non_auto"])],
             expected_run_requests=[],
         ),
-        unevaluated_runs=[run(["non_auto"])],
+        unevaluated_runs=[],
+        evaluation_delta=datetime.timedelta(hours=2),
         expected_run_requests=[run_request(["auto"])],
     ),
 }

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/auto_materialize_policy_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/auto_materialize_policy_scenarios.py
@@ -77,6 +77,11 @@ static_partitioned_eager_after_non_partitioned = [
     ),
 ]
 
+non_auto_to_lazy = [
+    asset_def("non_auto"),
+    asset_def("auto", ["non_auto"], auto_materialize_policy=AutoMaterializePolicy.lazy()),
+]
+
 
 def with_auto_materialize_policy(
     assets_defs: Sequence[AssetsDefinition], auto_materialize_policy: AutoMaterializePolicy
@@ -435,5 +440,17 @@ auto_materialize_policy_scenarios = {
             "C": {ParentMaterializedAutoMaterializeCondition()},
             "D": {ParentMaterializedAutoMaterializeCondition()},
         },
+    ),
+    "no_auto_materialize_policy_to_lazy": AssetReconciliationScenario(
+        assets=non_auto_to_lazy,
+        asset_selection=AssetSelection.keys("auto"),
+        cursor_from=AssetReconciliationScenario(
+            assets=non_auto_to_lazy,
+            asset_selection=AssetSelection.keys("auto"),
+            unevaluated_runs=[],
+            expected_run_requests=[],
+        ),
+        unevaluated_runs=[run(["non_auto"])],
+        expected_run_requests=[run_request(["auto"])],
     ),
 }

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/auto_materialize_policy_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/auto_materialize_policy_scenarios.py
@@ -450,13 +450,7 @@ auto_materialize_policy_scenarios = {
     "no_auto_materialize_policy_to_lazy": AssetReconciliationScenario(
         assets=non_auto_to_lazy,
         asset_selection=AssetSelection.keys("auto"),
-        cursor_from=AssetReconciliationScenario(
-            assets=non_auto_to_lazy,
-            asset_selection=AssetSelection.keys("auto"),
-            unevaluated_runs=[run(["non_auto"])],
-            expected_run_requests=[],
-        ),
-        unevaluated_runs=[],
+        unevaluated_runs=[run(["non_auto"])],
         evaluation_delta=datetime.timedelta(hours=2),
         expected_run_requests=[run_request(["auto"])],
     ),

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/auto_materialize_policy_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/auto_materialize_policy_scenarios.py
@@ -451,7 +451,7 @@ auto_materialize_policy_scenarios = {
         assets=non_auto_to_lazy,
         asset_selection=AssetSelection.keys("auto"),
         unevaluated_runs=[run(["non_auto"])],
-        evaluation_delta=datetime.timedelta(hours=2),
+        evaluation_delta=datetime.timedelta(minutes=55),
         expected_run_requests=[run_request(["auto"])],
     ),
 }

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/auto_materialize_policy_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/auto_materialize_policy_scenarios.py
@@ -447,11 +447,18 @@ auto_materialize_policy_scenarios = {
             "D": {ParentMaterializedAutoMaterializeCondition()},
         },
     ),
-    "no_auto_materialize_policy_to_lazy": AssetReconciliationScenario(
+    "no_auto_materialize_policy_to_missing_lazy": AssetReconciliationScenario(
         assets=non_auto_to_lazy,
         asset_selection=AssetSelection.keys("auto"),
         unevaluated_runs=[run(["non_auto"])],
         evaluation_delta=datetime.timedelta(minutes=55),
+        expected_run_requests=[run_request(["auto"])],
+    ),
+    "no_auto_materialize_policy_to_lazy": AssetReconciliationScenario(
+        assets=non_auto_to_lazy,
+        asset_selection=AssetSelection.keys("auto"),
+        unevaluated_runs=[run(["non_auto", "auto"]), run(["non_auto"])],
+        between_runs_delta=datetime.timedelta(minutes=55),
         expected_run_requests=[run_request(["auto"])],
     ),
 }


### PR DESCRIPTION
Due to a bug we wouldn't auto materialize missing assets for freshness. Apply @OwenKephart 's fix https://elementl-workspace.slack.com/archives/C04UD72HHQX/p1689051806948539 to push the start of the period earlier