### PR TITLE
feat(dbt): use dbt project name as default for Dagster project name

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_app.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_app.py
@@ -1,6 +1,8 @@
 import shutil
 from pathlib import Path
+from typing import Optional
 
+import pytest
 from dagster_dbt.cli.app import app
 from typer.testing import CliRunner
 
@@ -11,25 +13,34 @@ test_dagster_metadata_dbt_project_path = Path(__file__).parent.joinpath(
 runner = CliRunner()
 
 
-def test_project_scaffold_command(tmp_path: Path) -> None:
+@pytest.fixture(name="tmp_dbt_project")
+def tmp_dbt_project_fixture(tmp_path: Path) -> Path:
     shutil.copytree(test_dagster_metadata_dbt_project_path, tmp_path)
 
-    dagster_dbt_project_dir = tmp_path.joinpath("dagster")
+    return tmp_path
+
+
+@pytest.mark.parametrize("project_name", [None, "test"])
+def test_project_scaffold_command(tmp_dbt_project: Path, project_name: Optional[str]) -> None:
+    dagster_dbt_project_dir = tmp_dbt_project.joinpath("dagster")
 
     assert not dagster_dbt_project_dir.exists()
+
+    expected_project_name = project_name or "test_dagster_metadata"
+    project_name_args = ["--project-name", project_name] if project_name else []
 
     result = runner.invoke(
         app,
         [
             "project",
             "scaffold",
-            "--project-name",
-            "test",
+            *project_name_args,
             "--dbt-project-dir",
-            tmp_path.as_posix(),
+            tmp_dbt_project.as_posix(),
         ],
     )
 
     assert result.exit_code == 0
+    assert f"Initializing Dagster project {expected_project_name}" in result.stdout
     assert "Your Dagster project has been initialized" in result.stdout
     assert dagster_dbt_project_dir.exists()


### PR DESCRIPTION
## Summary & Motivation
Make `--project-name` optional, by defaulting the project name as the dbt project name. We retrieve this value from the `dbt_project.yml`, as specified through the value of `dbt_project_dir` command option.


## How I Tested These Changes
local, pytest

```bash
dagster ❯ dagster-dbt project scaffold
Running with dagster-dbt version: 1!0+dev.
Initializing Dagster project test_project in dbt project directory
/Users/rexledesma/elementl/dagster/python_modules/libraries/dagster-dbt/dagster_dbt/test_project
Running with dbt=1.5.1
Performance info: target/perf_info.json
Your Dagster project has been initialized. To view your dbt project in Dagster, run the following commands:

 ❱ 1 cd /Users/rexledesma/elementl/dagster/python_modules/libraries/dagster-dbt/dagster_dbt/test_project/dagster
 ❱ 2 dagster dev
```
