### PR TITLE
Default on auto-loading config into launchpad

### DIFF
--- a/js_modules/dagit/packages/core/src/app/Flags.tsx
+++ b/js_modules/dagit/packages/core/src/app/Flags.tsx
@@ -13,7 +13,7 @@ export const FeatureFlag = {
   flagSensorScheduleLogging: 'flagSensorScheduleLogging' as const,
   flagSidebarResources: 'flagSidebarResources' as const,
   flagHorizontalDAGs: 'flagHorizontalDAGs' as const,
-  flagAutoLoadDefaults: 'flagAutoLoadDefaults' as const,
+  flagDisableAutoLoadDefaults: 'flagDisableAutoLoadDefaults' as const,
 };
 export type FeatureFlagType = keyof typeof FeatureFlag;
 

--- a/js_modules/dagit/packages/core/src/app/getVisibleFeatureFlagRows.tsx
+++ b/js_modules/dagit/packages/core/src/app/getVisibleFeatureFlagRows.tsx
@@ -17,12 +17,12 @@ export const getVisibleFeatureFlagRows = () => [
     flagType: FeatureFlag.flagSidebarResources,
   },
   {
-    key: 'Experimental schedule/sensor logging view',
-    flagType: FeatureFlag.flagSensorScheduleLogging,
+    key: 'Disable automatically loading default config in launchpad',
+    flagType: FeatureFlag.flagDisableAutoLoadDefaults,
   },
   {
-    key: 'Automatically load default config in launchpad',
-    flagType: FeatureFlag.flagAutoLoadDefaults,
+    key: 'Experimental schedule/sensor logging view',
+    flagType: FeatureFlag.flagSensorScheduleLogging,
   },
   {
     key: 'Experimental instance-level concurrency limits',

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadStoredSessionsContainer.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadStoredSessionsContainer.tsx
@@ -29,12 +29,12 @@ interface Props {
 export const LaunchpadStoredSessionsContainer = (props: Props) => {
   const {launchpadType, pipeline, partitionSets, repoAddress, rootDefaultYaml} = props;
 
-  const {flagAutoLoadDefaults} = useFeatureFlags();
+  const {flagDisableAutoLoadDefaults} = useFeatureFlags();
   const initialDataForMode = useInitialDataForMode(
     pipeline,
     partitionSets,
     rootDefaultYaml,
-    flagAutoLoadDefaults,
+    !flagDisableAutoLoadDefaults,
   );
   const [data, onSave] = useExecutionSessionStorage(repoAddress, pipeline.name, initialDataForMode);
 

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadTransientSessionContainer.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadTransientSessionContainer.tsx
@@ -35,12 +35,12 @@ export const LaunchpadTransientSessionContainer = (props: Props) => {
     rootDefaultYaml,
   } = props;
 
-  const {flagAutoLoadDefaults} = useFeatureFlags();
+  const {flagDisableAutoLoadDefaults} = useFeatureFlags();
   const initialData = useInitialDataForMode(
     pipeline,
     partitionSets,
     rootDefaultYaml,
-    flagAutoLoadDefaults,
+    !flagDisableAutoLoadDefaults,
   );
   const initialSessionComplete = createSingleSession({
     ...sessionPresets,


### PR DESCRIPTION
## Summary

Toggles the feature-flag behavior for auto-loading config to be a "disable" flag that's off by default (meaning auto-load is on by default).

## Test Plan

Tested locally.
