### PR TITLE
Disable 'expand default config' button in the no-op case

### DIFF
--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadSession.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadSession.tsx
@@ -258,6 +258,18 @@ const LaunchpadSession: React.FC<LaunchpadSessionProps> = (props) => {
   const modeError =
     configSchemaOrError?.__typename === 'ModeNotFoundError' ? configSchemaOrError : undefined;
 
+  const anyDefaultsToExpand = React.useMemo(() => {
+    if (!runConfigSchema?.rootDefaultYaml) {
+      return false;
+    }
+    const defaultsYaml = yaml.parse(sanitizeConfigYamlString(runConfigSchema?.rootDefaultYaml));
+
+    const currentUserConfig = yaml.parse(sanitizeConfigYamlString(currentSession.runConfigYaml));
+    const updatedRunConfigData = merge(defaultsYaml, currentUserConfig);
+
+    return yaml.stringify(currentUserConfig) !== yaml.stringify(updatedRunConfigData);
+  }, [currentSession.runConfigYaml, runConfigSchema?.rootDefaultYaml]);
+
   const onScaffoldMissingConfig = () => {
     const config = runConfigSchema ? scaffoldPipelineConfig(runConfigSchema) : {};
     try {
@@ -728,6 +740,7 @@ const LaunchpadSession: React.FC<LaunchpadSessionProps> = (props) => {
               onRemoveExtraPaths={(paths) => onRemoveExtraPaths(paths)}
               onScaffoldMissingConfig={onScaffoldMissingConfig}
               onExpandDefaults={onExpandDefaults}
+              anyDefaultsToExpand={anyDefaultsToExpand}
             />
           </>
         }

--- a/js_modules/dagit/packages/core/src/launchpad/RunPreview.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/RunPreview.tsx
@@ -230,7 +230,7 @@ const ExpandDefaultButton = ({
       {disabled ? (
         <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
           <Icon name="check_circle" color={Colors.Green500} />
-          No missing config
+          All defaults expanded
         </Box>
       ) : null}
     </Box>
@@ -247,6 +247,7 @@ interface RunPreviewProps {
   onRemoveExtraPaths: (paths: string[]) => void;
   onScaffoldMissingConfig: () => void;
   onExpandDefaults: () => void;
+  anyDefaultsToExpand: boolean;
   solidSelection: string[] | null;
 }
 
@@ -259,6 +260,7 @@ export const RunPreview: React.FC<RunPreviewProps> = (props) => {
     onRemoveExtraPaths,
     onScaffoldMissingConfig,
     onExpandDefaults,
+    anyDefaultsToExpand,
     solidSelection,
     runConfigSchema,
   } = props;
@@ -434,7 +436,10 @@ export const RunPreview: React.FC<RunPreviewProps> = (props) => {
                 missingNodes={missingNodes}
                 disabled={!missingNodes.length}
               />
-              <ExpandDefaultButton onExpandDefaults={onExpandDefaults} disabled={false} />
+              <ExpandDefaultButton
+                onExpandDefaults={onExpandDefaults}
+                disabled={!anyDefaultsToExpand}
+              />
               <RemoveExtraConfigButton
                 onRemoveExtraPaths={onRemoveExtraPaths}
                 extraNodes={extraNodes}


### PR DESCRIPTION
## Summary

To help make the behavior of the 'expand default config' button a bit more clear, disables the button when it would be a no-op (e.g. when all default values are already present or overridden)

<img width="382" alt="Screenshot 2023-07-11 at 11 14 13 AM" src="https://github.com/dagster-io/dagster/assets/10215173/3c99aea9-81a2-4203-8187-0997cc0a05db">


## Test Plan

Tested locally
