### PR TITLE
fix(helm): bump user code example readinessProbe timeout

### DIFF
--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -393,7 +393,7 @@ dagster-user-deployments:
         # exec:
         #   command: ["dagster", "api", "grpc-health-check", "-p", "{{ $deployment.port }}"]
         periodSeconds: 20
-        timeoutSeconds: 3
+        timeoutSeconds: 10
         successThreshold: 1
         failureThreshold: 15  # Allow roughly 300 seconds to start up by default
 


### PR DESCRIPTION
## Summary & Motivation

Fix for issue https://github.com/dagster-io/dagster/issues/9014.

## How I Tested These Changes

I used a MacBook Pro Apple M1 Pro (like the issue creator) and also a Ubuntu 22.04 (AMD), and tested the changes with a local minikube cluster. Bumping the readiness probe timeout from 3 to 10 seconds results in the example user code container achieving ready status.