### PR TITLE
feat(toml): allow code location name to be set from pyproject.toml

### DIFF
--- a/docs/next/components/mdx/includes/dagster/DagsterDevTabs.mdx
+++ b/docs/next/components/mdx/includes/dagster/DagsterDevTabs.mdx
@@ -46,6 +46,7 @@ To load definitions without supplying command line arguments, you can use the `p
 ```toml
 [tool.dagster]
 module_name = "your_module_name"  ## name of project's Python module
+code_location_name = "your_code_location_name"  ## optional, name of code location to display in the Dagster UI
 ```
 
 When defined, you can run this in the same directory as the `pyproject.toml` file:

--- a/python_modules/dagster/dagster/_core/workspace/load_target.py
+++ b/python_modules/dagster/dagster/_core/workspace/load_target.py
@@ -53,7 +53,7 @@ def get_origins_from_toml(path: str) -> Sequence[ManagedGrpcPythonEnvCodeLocatio
                 module_name=dagster_block["module_name"],
                 attribute=None,
                 working_directory=os.getcwd(),
-                location_name=None,
+                location_name=dagster_block.get("code_location_name"),
             ).create_origins()
         return []
 

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/toml_tests/single_module_with_code_location_name.toml
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/toml_tests/single_module_with_code_location_name.toml
@@ -1,0 +1,4 @@
+[tool.dagster]
+
+module_name = "baaz"
+code_location_name = "bar"

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/toml_tests/test_toml_loading.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/toml_tests/test_toml_loading.py
@@ -6,6 +6,14 @@ def test_load_python_module_from_toml():
     origins = get_origins_from_toml(file_relative_path(__file__, "single_module.toml"))
     assert len(origins) == 1
     assert origins[0].loadable_target_origin.module_name == "baaz"
+    assert origins[0].location_name == "baaz"
+
+    origins = get_origins_from_toml(
+        file_relative_path(__file__, "single_module_with_code_location_name.toml")
+    )
+    assert len(origins) == 1
+    assert origins[0].loadable_target_origin.module_name == "baaz"
+    assert origins[0].location_name == "bar"
 
 
 def test_load_empty_toml():


### PR DESCRIPTION
## Summary & Motivation
Allow the code location name to be specified in `pyproject.toml`, rather than using the module path of the code location.

This is used in `dagster-dbt project scaffold`, so that we can display the name of the code location as the name of the dbt project, rather than as `scaffold.definitions`.

## How I Tested These Changes
pytest, local
