### PR TITLE
[docs] Docs search: Test new crawler index

### DIFF
--- a/docs/next/components/Search.tsx
+++ b/docs/next/components/Search.tsx
@@ -70,7 +70,7 @@ export function Search() {
       <Head>
         <link
           rel="preconnect"
-          href={`https://${process.env.NEXT_PUBLIC_ALGOLIA_APP_ID}-dsn.algolia.net`}
+          href={`https://${process.env.NEXT_PUBLIC_ALGOLIA_APP_ID_TEST}-dsn.algolia.net`}
           crossOrigin="true"
         />
       </Head>
@@ -126,9 +126,9 @@ export function Search() {
               }}
               onClose={onClose}
               insights
-              indexName={process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME}
-              apiKey={process.env.NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY}
-              appId={process.env.NEXT_PUBLIC_ALGOLIA_APP_ID}
+              indexName={process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME_TEST}
+              apiKey={process.env.NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY_TEST}
+              appId={process.env.NEXT_PUBLIC_ALGOLIA_APP_ID_TEST}
               navigator={{
                 navigate({itemUrl}) {
                   setIsOpen(false);

--- a/docs/next/pages/searchpage.tsx
+++ b/docs/next/pages/searchpage.tsx
@@ -4,10 +4,10 @@ import {Highlight, InstantSearch, Hits, SearchBox, Pagination} from 'react-insta
 import {findResultsState} from 'react-instantsearch-dom/server';
 
 const searchClient = algoliasearch(
-  process.env.NEXT_PUBLIC_ALGOLIA_APP_ID,
-  process.env.NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY,
+  process.env.NEXT_PUBLIC_ALGOLIA_APP_ID_TEST,
+  process.env.NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY_TEST,
 );
-const indexName = process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME;
+const indexName = process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME_TEST;
 
 function getPagePath(hit) {
   function parsedLevel(name) {


### PR DESCRIPTION
## Summary & Motivation

Kick off a Vercel preview deploy with Algolia API keys that point at the crawler index, for comparison with prod.

## How I Tested These Changes

`vercel env pull`, `yarn dev`, perform searches in app and verify (via network tab inspection in dev tools) that results are coming from the crawler index.
