### PR TITLE
[dbt] add dagster_dbt_translator argument to load_assets_from_* functions and deprecate old arguments

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/__init__.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/__init__.py
@@ -41,7 +41,10 @@ from .core import (
     DbtCliEventMessage as DbtCliEventMessage,
     DbtCliInvocation as DbtCliInvocation,
 )
-from .dagster_dbt_translator import DagsterDbtTranslator as DagsterDbtTranslator
+from .dagster_dbt_translator import (
+    DagsterDbtTranslator as DagsterDbtTranslator,
+    KeyPrefixDagsterDbtTranslator as KeyPrefixDagsterDbtTranslator,
+)
 from .dbt_manifest_asset_selection import DbtManifestAssetSelection as DbtManifestAssetSelection
 
 # isort: split

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -243,8 +243,8 @@ def get_asset_deps(
     node_info_to_freshness_policy_fn,
     node_info_to_auto_materialize_policy_fn,
     node_info_to_definition_metadata_fn,
+    node_info_to_description_fn,
     io_manager_key,
-    display_raw_sql,
 ) -> Tuple[
     Dict[AssetKey, Set[AssetKey]],
     Dict[AssetKey, Tuple[str, In]],
@@ -288,7 +288,7 @@ def get_asset_deps(
             output_name,
             Out(
                 io_manager_key=io_manager_key,
-                description=default_description_fn(node_info, display_raw_sql),
+                description=node_info_to_description_fn(node_info),
                 metadata=metadata,
                 is_required=False,
                 dagster_type=Nothing,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/asset_defs.py
@@ -42,6 +42,7 @@ from dagster._utils.backcompat import experimental_arg_warning
 from dagster_dbt.asset_utils import (
     default_asset_key_fn,
     default_auto_materialize_policy_fn,
+    default_description_fn,
     default_freshness_policy_fn,
     default_group_fn,
     default_metadata_fn,
@@ -358,7 +359,9 @@ class DbtCloudCacheableAssetsDefinition(CacheableAssetsDefinition):
             io_manager_key=None,
             # We shouldn't display the raw sql. Instead, inspect if dbt docs were generated,
             # and attach metadata to link to the docs.
-            display_raw_sql=False,
+            node_info_to_description_fn=lambda node_info: default_description_fn(
+                node_info, display_raw_sql=False
+            ),
         )
 
         return AssetsDefinitionCacheableData(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
@@ -1,6 +1,10 @@
-from typing import Any, Mapping
+from typing import Any, Mapping, Optional
 
 from dagster import AssetKey
+from dagster._core.definitions.events import (
+    CoercibleToAssetKeyPrefix,
+    check_opt_coercible_to_asset_key_prefix_param,
+)
 
 from .asset_utils import default_asset_key_fn, default_description_fn, default_metadata_fn
 
@@ -90,3 +94,37 @@ class DagsterDbtTranslator:
                         return {"custom": "metadata"}
         """
         return default_metadata_fn(node_info)
+
+
+class KeyPrefixDagsterDbtTranslator:
+    """A DagsterDbtTranslator that applies prefixes to the asset keys generated from dbt resources.
+
+    Attributes:
+        asset_key_prefix (Optional[Union[str, Sequence[str]]]): A prefix to apply to all dbt models,
+            seeds, snapshots, etc. This will *not* apply to dbt sources.
+        source_asset_key_prefix (Optional[Union[str, Sequence[str]]]): A prefix to apply to all dbt
+            sources.
+    """
+
+    def __init__(
+        self,
+        asset_key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
+        source_asset_key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
+    ):
+        self._asset_key_prefix = (
+            check_opt_coercible_to_asset_key_prefix_param(asset_key_prefix, "asset_key_prefix")
+            or []
+        )
+        self._source_asset_key_prefix = (
+            check_opt_coercible_to_asset_key_prefix_param(
+                source_asset_key_prefix, "source_asset_key_prefix"
+            )
+            or []
+        )
+
+    def node_info_to_asset_key(self, node_info: Mapping[str, Any]) -> AssetKey:
+        base_key = default_asset_key_fn(node_info)
+        if node_info["resource_type"] == "source":
+            return base_key.with_prefix(self._source_asset_key_prefix)
+        else:
+            return base_key.with_prefix(self._asset_key_prefix)


### PR DESCRIPTION
## Summary & Motivation

A few changes here to `load_assets_from_dbt_project` and `load_assets_from_dbt_manifest`:
- Requires keyword arguments for all arguments except `manifest`, `project_dir`, and `profiles_dir`. **This is a breaking change.**
- Adds a `dagster_dbt_translator` argument.
- Raises deprecation warnings.
- Updates api docs with deprecations.
- Adds a `KeyPrefixDagsterDbtTranslator` subclass of `DagsterDbtTranslator` to make it easier to provide key prefixes.

## How I Tested These Changes
