### PR TITLE
Fix RunRequest typehint in docstring

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/run_request.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_request.py
@@ -126,7 +126,7 @@ class RunRequest(
             Required for sensors that target multiple jobs.
         asset_selection (Optional[Sequence[AssetKey]]): A sequence of AssetKeys that should be
             launched with this run.
-        stale_assets_only (Optional[Sequence[AssetKey]]): Set to true to further narrow the asset
+        stale_assets_only (bool): Set to true to further narrow the asset
             selection to stale assets. If passed without an asset selection, all stale assets in the
             job will be materialized. If the job does not materialize assets, this flag is ignored.
         partition_key (Optional[str]): The partition key for this run request.


### PR DESCRIPTION
## Summary & Motivation

The docstring of the RunRequest class showed the wrong type for the `stale_assets_only` parameter. According to the typehint of the class this should be `bool`. This made the documentation very confusion for me. I changes the type in the documentation to `bool`.
