### PR TITLE
[ui] Hide __ASSET_JOB references on the sensor pages

### DIFF
--- a/js_modules/dagit/packages/core/src/sensors/SensorDetails.tsx
+++ b/js_modules/dagit/packages/core/src/sensors/SensorDetails.tsx
@@ -152,7 +152,7 @@ export const SensorDetails: React.FC<{
           </tr>
           {sensor.targets && sensor.targets.length ? (
             <tr>
-              <td>Job / Asset</td>
+              <td>Target</td>
               <td>
                 <SensorTargetList targets={sensor.targets} repoAddress={repoAddress} />
               </td>

--- a/js_modules/dagit/packages/core/src/sensors/SensorMonitoredAssets.tsx
+++ b/js_modules/dagit/packages/core/src/sensors/SensorMonitoredAssets.tsx
@@ -1,0 +1,20 @@
+import {Box} from '@dagster-io/ui';
+import * as React from 'react';
+
+import {AssetLink} from '../assets/AssetLink';
+import {SensorMetadata} from '../graphql/types';
+
+export const SensorMonitoredAssets: React.FC<{
+  metadata: SensorMetadata | undefined;
+}> = ({metadata}) => {
+  if (!metadata?.assetKeys?.length) {
+    return <span />;
+  }
+  return (
+    <Box flex={{direction: 'column', gap: 2}}>
+      {metadata.assetKeys.map((key) => (
+        <AssetLink key={key.path.join('/')} path={key.path} icon="asset" />
+      ))}
+    </Box>
+  );
+};

--- a/js_modules/dagit/packages/core/src/sensors/SensorTargetList.tsx
+++ b/js_modules/dagit/packages/core/src/sensors/SensorTargetList.tsx
@@ -1,0 +1,35 @@
+import {Box} from '@dagster-io/ui';
+import * as React from 'react';
+
+import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
+import {PipelineReference} from '../pipelines/PipelineReference';
+import {isThisThingAJob, useRepository} from '../workspace/WorkspaceContext';
+import {RepoAddress} from '../workspace/types';
+
+export const SensorTargetList: React.FC<{
+  targets: {pipelineName: string}[] | null | undefined;
+  repoAddress: RepoAddress;
+}> = ({targets, repoAddress}) => {
+  const repo = useRepository(repoAddress);
+  if (!targets) {
+    return <span />;
+  }
+
+  const visibleTargets = targets.filter((target) => !isHiddenAssetGroupJob(target.pipelineName));
+
+  return (
+    <Box flex={{direction: 'column', gap: 2}}>
+      {visibleTargets.length < targets.length && <span>A selection of assets</span>}
+      {visibleTargets.map((target) =>
+        target.pipelineName ? (
+          <PipelineReference
+            key={target.pipelineName}
+            pipelineName={target.pipelineName}
+            pipelineHrefContext={repoAddress}
+            isJob={!!(repo && isThisThingAJob(repo, target.pipelineName))}
+          />
+        ) : null,
+      )}
+    </Box>
+  );
+};

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedSensorRow.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedSensorRow.tsx
@@ -11,7 +11,6 @@ import {TickTag, TICK_TAG_FRAGMENT} from '../instigation/InstigationTick';
 import {BasicInstigationStateFragment} from '../overview/types/BasicInstigationStateFragment.types';
 import {RUN_TIME_FRAGMENT} from '../runs/RunUtils';
 import {humanizeSensorInterval} from '../sensors/SensorDetails';
-import {SensorMonitoredAssets} from '../sensors/SensorMonitoredAssets';
 import {SensorSwitch, SENSOR_SWITCH_FRAGMENT} from '../sensors/SensorSwitch';
 import {SensorTargetList} from '../sensors/SensorTargetList';
 import {HeaderCell, Row, RowCell} from '../ui/VirtualizedTable';
@@ -138,7 +137,6 @@ export const VirtualizedSensorRow = (props: SensorRowProps) => {
         <RowCell>
           <Box flex={{direction: 'column', gap: 4}} style={{fontSize: '12px'}}>
             <SensorTargetList targets={sensorData?.targets} repoAddress={repoAddress} />
-            <SensorMonitoredAssets metadata={sensorData?.metadata} />
           </Box>
         </RowCell>
         <RowCell>
@@ -207,7 +205,7 @@ export const VirtualizedSensorHeader = (props: {checkbox: React.ReactNode}) => {
         </HeaderCell>
       ) : null}
       <HeaderCell>Name</HeaderCell>
-      <HeaderCell>Job / Asset</HeaderCell>
+      <HeaderCell>Target</HeaderCell>
       <HeaderCell>Running</HeaderCell>
       <HeaderCell>Frequency</HeaderCell>
       <HeaderCell>Last tick</HeaderCell>

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedSensorRow.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedSensorRow.tsx
@@ -5,19 +5,18 @@ import {Link} from 'react-router-dom';
 import styled from 'styled-components/macro';
 
 import {useQueryRefreshAtInterval, FIFTEEN_SECONDS} from '../app/QueryRefresh';
-import {AssetLink} from '../assets/AssetLink';
 import {InstigationStatus, InstigationType} from '../graphql/types';
 import {LastRunSummary} from '../instance/LastRunSummary';
 import {TickTag, TICK_TAG_FRAGMENT} from '../instigation/InstigationTick';
 import {BasicInstigationStateFragment} from '../overview/types/BasicInstigationStateFragment.types';
-import {PipelineReference} from '../pipelines/PipelineReference';
 import {RUN_TIME_FRAGMENT} from '../runs/RunUtils';
 import {humanizeSensorInterval} from '../sensors/SensorDetails';
+import {SensorMonitoredAssets} from '../sensors/SensorMonitoredAssets';
 import {SensorSwitch, SENSOR_SWITCH_FRAGMENT} from '../sensors/SensorSwitch';
+import {SensorTargetList} from '../sensors/SensorTargetList';
 import {HeaderCell, Row, RowCell} from '../ui/VirtualizedTable';
 
 import {LoadingOrNone, useDelayedRowQuery} from './VirtualizedWorkspaceTable';
-import {isThisThingAJob, useRepository} from './WorkspaceContext';
 import {RepoAddress} from './types';
 import {SingleSensorQuery, SingleSensorQueryVariables} from './types/VirtualizedSensorRow.types';
 import {workspacePathFromAddress} from './workspacePath';
@@ -47,8 +46,6 @@ export const VirtualizedSensorRow = (props: SensorRowProps) => {
     start,
     height,
   } = props;
-
-  const repo = useRepository(repoAddress);
 
   const [querySensor, queryResult] = useLazyQuery<SingleSensorQuery, SingleSensorQueryVariables>(
     SINGLE_SENSOR_QUERY,
@@ -140,27 +137,8 @@ export const VirtualizedSensorRow = (props: SensorRowProps) => {
         </RowCell>
         <RowCell>
           <Box flex={{direction: 'column', gap: 4}} style={{fontSize: '12px'}}>
-            {sensorData?.targets && sensorData.targets.length ? (
-              <Box flex={{direction: 'column', gap: 2}}>
-                {sensorData.targets.map((target) => (
-                  <PipelineReference
-                    key={target.pipelineName}
-                    showIcon
-                    size="small"
-                    pipelineName={target.pipelineName}
-                    pipelineHrefContext={repoAddress}
-                    isJob={!!(repo && isThisThingAJob(repo, target.pipelineName))}
-                  />
-                ))}
-              </Box>
-            ) : null}
-            {sensorData?.metadata.assetKeys && sensorData.metadata.assetKeys.length ? (
-              <Box flex={{direction: 'column', gap: 2}}>
-                {sensorData.metadata.assetKeys.map((key) => (
-                  <AssetLink key={key.path.join('/')} path={key.path} icon="asset" />
-                ))}
-              </Box>
-            ) : null}
+            <SensorTargetList targets={sensorData?.targets} repoAddress={repoAddress} />
+            <SensorMonitoredAssets metadata={sensorData?.metadata} />
           </Box>
         </RowCell>
         <RowCell>


### PR DESCRIPTION
## Summary & Motivation

This is a quick fix for the issue raised in https://github.com/dagster-io/dagster/issues/14844. We don't have the information about the exact assets in your selection, but we can see that the targets are asset jobs and show "A selection of assets". (Fixes https://github.com/dagster-io/dagster/issues/14844)

I think there are a few other things we should consider changing:

- Backfills have "targets" and sensors have "Asset / Job". I'm tempted to change the labeling in the table + details page to say "Target" to match the backfill terminology.

- We are currently showing `sensor.metadata.assetKeys` in the Asset / Job column. Confusingly these are not the targeted asset keys, they're the monitored asset keys (if the sensor is an @asset_sensor). To make this more clear in the code I wrapped the rendering into a component called `<SensorMonitoredAssets />`, but the placement of them in the table (beneath the "A selection of assets" or job target info) might be confusing to users. I don't have a better placement idea - perhaps we just remove them from the list view. 

<img width="1400" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/4c5f2409-62e0-42ab-9ed2-4b1a79f746a0">

Loom of this: https://www.loom.com/share/056baeb022fe4c95874656b2a576267b

## How I Tested These Changes

I tested these with a few asset_sensor, op job and asset job sensors
