### PR TITLE
[docs] Don't wrap Slack button in p tag

### DIFF
--- a/docs/next/components/JoinSlackButton.tsx
+++ b/docs/next/components/JoinSlackButton.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 export const JoinSlackButton: React.FC<{icon?: boolean}> = ({icon}) => {
   return (
     <>
-      <p className="self-center">
+      <div className="self-center">
         <a
           href="https://dagster.io/slack"
           className={
@@ -17,7 +17,7 @@ export const JoinSlackButton: React.FC<{icon?: boolean}> = ({icon}) => {
           </svg>
           <span className={icon ? 'hidden' : ''}>Join us on Slack</span>
         </a>
-      </p>
+      </div>
     </>
   );
 };


### PR DESCRIPTION
## Summary & Motivation

The `p` wrapper on the Slack button is being crawled as document content by DocSearch, resulting in corresponding records for every crawled page. Use a `div` instead since it doesn't really need to be a `p` anyway.

## How I Tested These Changes

yarn dev, verify that the Slack button is wrapped in a div.
