### PR TITLE
Throw error on duplicate partition key in StaticPartitionsDefinition

### DIFF
--- a/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_partition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_partition.py
@@ -1,3 +1,4 @@
+import re
 from typing import Sequence
 
 import pytest
@@ -32,8 +33,12 @@ def test_invalid_partition_key():
         StaticPartitionsDefinition(["foo", "foo...bar"])
 
 
-def test_count_unique_static_partitions():
-    return StaticPartitionsDefinition(["foo", "foo"]).get_num_partitions() == 1
+def test_duplicate_partition_key():
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match=re.escape("Duplicate instances of partition keys: ['foo']"),
+    ):
+        StaticPartitionsDefinition(["foo", "bar", "foo"])
 
 
 def test_partitions_def_to_string():

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_multi_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_multi_partitions.py
@@ -404,18 +404,6 @@ def test_get_num_partitions():
         set(multipartitions_def.get_partition_keys())
     )
 
-    static_keys = ["a", "a", "a"]
-    daily_partitions_def = DailyPartitionsDefinition(start_date="2015-01-01")
-    multipartitions_def = MultiPartitionsDefinition(
-        {
-            "date": daily_partitions_def,
-            "static": StaticPartitionsDefinition(static_keys),
-        }
-    )
-    assert multipartitions_def.get_num_partitions() == len(
-        set(multipartitions_def.get_partition_keys())
-    )
-
 
 def test_dynamic_dimension_in_multipartitioned_asset():
     multipartitions_def = MultiPartitionsDefinition(


### PR DESCRIPTION
## Summary & Motivation

According to a comment, this was supposed to have been implemented for 1.3.

## How I Tested These Changes

Added a test.
