### PR TITLE
remove deprecated UnresolvedAssetJob.resolve args

### DIFF
--- a/examples/docs_snippets/docs_snippets/integrations/dagstermill/iris_notebook_config.py
+++ b/examples/docs_snippets/docs_snippets/integrations/dagstermill/iris_notebook_config.py
@@ -1,4 +1,5 @@
 from dagster import asset
+from dagster._core.definitions.asset_graph import AssetGraph
 
 
 # placeholder so that the test works. this isn't used in the docs
@@ -45,4 +46,4 @@ assets_with_resource = with_resources(
 config_asset_job = define_asset_job(
     name="config_asset_job",
     selection=AssetSelection.assets(iris_kmeans_jupyter_notebook).upstream(),
-).resolve(assets_with_resource, [])
+).resolve(asset_graph=AssetGraph.from_assets(assets_with_resource))

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
@@ -10,6 +10,7 @@ from dagster import (
     asset,
     define_asset_job,
 )
+from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
 from dagster._core.execution.asset_backfill import (
     AssetBackfillData,
@@ -267,7 +268,9 @@ def _mock_asset_backfill_runs(
             raise Exception("fail")
         return Output(5)
 
-    define_asset_job("my_job", [dummy_asset]).resolve([dummy_asset], []).execute_in_process(
+    define_asset_job("my_job", [dummy_asset]).resolve(
+        asset_graph=AssetGraph.from_assets([dummy_asset])
+    ).execute_in_process(
         tags={**DagsterRun.tags_for_backfill_id(backfill_id)},
         partition_key=partition_key,
         raise_on_error=False,

--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -16,6 +16,7 @@ from dagster._annotations import deprecated, experimental, public
 from dagster._config.pythonic_config import (
     attach_resource_id_to_key_mapping,
 )
+from dagster._core.definitions.asset_graph import InternalAssetGraph
 from dagster._core.definitions.events import AssetKey, CoercibleToAssetKey
 from dagster._core.definitions.executor_definition import ExecutorDefinition
 from dagster._core.definitions.logger_definition import LoggerDefinition
@@ -517,3 +518,7 @@ class Definitions:
         point is to defer that resolution until later.
         """
         return self._created_pending_or_normal_repo
+
+    def get_asset_graph(self) -> InternalAssetGraph:
+        """Get the AssetGraph for this set of definitions."""
+        return self.get_repository_def().asset_graph

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
@@ -320,8 +320,7 @@ def build_caching_repository_data_from_dict(
         elif isinstance(raw_job_def, UnresolvedAssetJobDefinition):
             repository_definitions["jobs"][key] = raw_job_def.resolve(
                 # TODO: https://github.com/dagster-io/dagster/issues/8263
-                assets=[],
-                source_assets=[],
+                asset_graph=AssetGraph.from_assets([]),
                 default_executor_def=None,
             )
         elif not isinstance(raw_job_def, JobDefinition) and not isfunction(raw_job_def):

--- a/python_modules/dagster/dagster_tests/api_tests/api_tests_repo.py
+++ b/python_modules/dagster/dagster_tests/api_tests/api_tests_repo.py
@@ -15,6 +15,7 @@ from dagster import (
     schedule,
     usable_as_dagster_type,
 )
+from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.decorators.sensor_decorator import sensor
 from dagster._core.definitions.partition import (
     PartitionedConfig,
@@ -179,7 +180,7 @@ def bar_repo():
             "baz": lambda: baz_job,
             "dynamic_job": define_asset_job(
                 "dynamic_job", [dynamic_asset], partitions_def=dynamic_partitions_def
-            ).resolve([dynamic_asset], []),
+            ).resolve(asset_graph=AssetGraph.from_assets([dynamic_asset])),
             "fail": fail_job,
             "foo": foo_job,
             "forever": forever_job,

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_asset_partition_mappings.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_asset_partition_mappings.py
@@ -399,8 +399,8 @@ def test_multipartitions_def_partition_mapping_infer_identity():
         )
         return 1
 
-    assets_job = define_asset_job("foo", [upstream, downstream]).resolve([upstream, downstream], [])
     asset_graph = AssetGraph.from_assets([upstream, downstream])
+    assets_job = define_asset_job("foo", [upstream, downstream]).resolve(asset_graph=asset_graph)
 
     assert (
         asset_graph.get_partition_mapping(upstream.key, downstream.key)

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_unresolved_asset_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_unresolved_asset_job.py
@@ -22,6 +22,7 @@ from dagster import (
     repository,
 )
 from dagster._core.definitions import asset, multi_asset
+from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.decorators.hook_decorator import failure_hook, success_hook
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.load_assets_from_modules import prefix_assets
@@ -220,9 +221,9 @@ def test_resolve_subset_job_errors(job_selection, use_multi, expected_error):
     if expected_error:
         expected_class, expected_message = expected_error
         with pytest.raises(expected_class, match=expected_message):
-            job_def.resolve(assets=_get_assets_defs(use_multi), source_assets=[])
+            job_def.resolve(asset_graph=AssetGraph.from_assets(_get_assets_defs(use_multi)))
     else:
-        assert job_def.resolve(assets=_get_assets_defs(use_multi), source_assets=[])
+        assert job_def.resolve(asset_graph=AssetGraph.from_assets(_get_assets_defs(use_multi)))
 
 
 @pytest.mark.parametrize(
@@ -268,11 +269,13 @@ def test_simple_graph_backed_asset_subset(job_selection, expected_assets):
     final_assets = with_resources([a_asset, b_asset, c_asset], {"asset_io_manager": io_manager_def})
 
     # run once so values exist to load from
-    define_asset_job("initial").resolve(final_assets, source_assets=[]).execute_in_process()
+    define_asset_job("initial").resolve(
+        asset_graph=AssetGraph.from_assets(final_assets)
+    ).execute_in_process()
 
     # now build the subset job
     job = define_asset_job("asset_job", selection=job_selection).resolve(
-        final_assets, source_assets=[]
+        asset_graph=AssetGraph.from_assets(final_assets)
     )
 
     result = job.execute_in_process()
@@ -360,11 +363,13 @@ def test_define_selection_job(job_selection, expected_assets, use_multi, prefixe
     )
 
     # run once so values exist to load from
-    define_asset_job("initial").resolve(final_assets, source_assets=[]).execute_in_process()
+    define_asset_job("initial").resolve(
+        asset_graph=AssetGraph.from_assets(final_assets)
+    ).execute_in_process()
 
     # now build the subset job
     job = define_asset_job("asset_job", selection=job_selection).resolve(
-        final_assets, source_assets=[]
+        asset_graph=AssetGraph.from_assets(final_assets)
     )
 
     with instance_for_test() as instance:
@@ -451,7 +456,7 @@ def test_define_selection_job_assets_definition_selection():
     all_assets = [asset1, asset2, asset3]
 
     job1 = define_asset_job("job1", selection=[asset1, asset2]).resolve(
-        all_assets, source_assets=[]
+        asset_graph=AssetGraph.from_assets(all_assets)
     )
     asset_keys = list(job1.asset_layer.asset_keys)
     assert len(asset_keys) == 2
@@ -470,7 +475,7 @@ def test_root_asset_selection():
 
     # Source asset should not be included in the job
     assert define_asset_job("job", selection="*b").resolve(
-        assets=[a, b], source_assets=[SourceAsset("source")]
+        asset_graph=AssetGraph.from_assets([a, b, SourceAsset("source")])
     )
 
 
@@ -484,7 +489,7 @@ def test_source_asset_selection_missing():
         return a + 1
 
     with pytest.raises(DagsterInvalidDefinitionError, match="sources"):
-        define_asset_job("job", selection="*b").resolve(assets=[a, b], source_assets=[])
+        define_asset_job("job", selection="*b").resolve(asset_graph=AssetGraph.from_assets([a, b]))
 
 
 @asset
@@ -493,19 +498,25 @@ def foo():
 
 
 def test_executor_def():
-    job = define_asset_job("with_exec", executor_def=in_process_executor).resolve([foo], [])
+    job = define_asset_job("with_exec", executor_def=in_process_executor).resolve(
+        asset_graph=AssetGraph.from_assets([foo])
+    )
     assert job.executor_def == in_process_executor
 
 
 def test_tags():
     my_tags = {"foo": "bar"}
-    job = define_asset_job("with_tags", tags=my_tags).resolve([foo], [])
+    job = define_asset_job("with_tags", tags=my_tags).resolve(
+        asset_graph=AssetGraph.from_assets([foo])
+    )
     assert job.tags == my_tags
 
 
 def test_description():
     description = "Some very important description"
-    job = define_asset_job("with_tags", description=description).resolve([foo], [])
+    job = define_asset_job("with_tags", description=description).resolve(
+        asset_graph=AssetGraph.from_assets([foo])
+    )
     assert job.description == description
 
 
@@ -546,7 +557,7 @@ def test_config():
                 "other_config_asset": {"config": {"val": 3}},
             }
         },
-    ).resolve(assets=[foo, config_asset, other_config_asset], source_assets=[])
+    ).resolve(asset_graph=AssetGraph.from_assets([foo, config_asset, other_config_asset]))
 
     result = job.execute_in_process()
 
@@ -591,7 +602,7 @@ def test_subselect_config(selection, config):
         resource_defs={"asset_io_manager": io_manager_def},
     )
     job = define_asset_job("config_job", config={"ops": config}, selection=selection).resolve(
-        assets=all_assets, source_assets=[]
+        asset_graph=AssetGraph.from_assets(all_assets)
     )
 
     result = job.execute_in_process()
@@ -602,7 +613,7 @@ def test_subselect_config(selection, config):
 def test_simple_partitions():
     partitions_def = HourlyPartitionsDefinition(start_date="2020-01-01-00:00")
     job = define_asset_job("hourly", partitions_def=partitions_def).resolve(
-        _get_partitioned_assets(partitions_def), []
+        asset_graph=AssetGraph.from_assets(_get_partitioned_assets(partitions_def)),
     )
     assert job.partitions_def == partitions_def
 
@@ -624,7 +635,9 @@ def test_hooks():
     def bar(_):
         pass
 
-    job = define_asset_job("with_hooks", hooks={foo, bar}).resolve([a, b], [])
+    job = define_asset_job("with_hooks", hooks={foo, bar}).resolve(
+        asset_graph=AssetGraph.from_assets([a, b])
+    )
     assert job.hook_defs == {foo, bar}
 
 
@@ -646,7 +659,7 @@ def test_hooks_with_resources():
         pass
 
     job = define_asset_job("with_hooks", hooks={foo, bar}).resolve(
-        [a, b], [], resource_defs={"a": 1, "b": 2, "c": 3}
+        asset_graph=AssetGraph.from_assets([a, b]), resource_defs={"a": 1, "b": 2, "c": 3}
     )
     assert job.hook_defs == {foo, bar}
 

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
@@ -18,6 +18,7 @@ from dagster import (
     op,
 )
 from dagster._core.definitions import AssetIn, SourceAsset, asset, build_assets_job, multi_asset
+from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.metadata import MetadataValue, normalize_metadata
 from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionsDefinition
 from dagster._core.definitions.partition import ScheduleType
@@ -194,8 +195,12 @@ def test_assets_excluded_from_subset_not_in_job():
         return c
 
     all_assets = [abc, a2, c2]
-    as_job = define_asset_job("as_job", selection="a*").resolve(all_assets, [])
-    cs_job = define_asset_job("cs_job", selection="*c2").resolve(all_assets, [])
+    as_job = define_asset_job("as_job", selection="a*").resolve(
+        asset_graph=AssetGraph.from_assets(all_assets)
+    )
+    cs_job = define_asset_job("cs_job", selection="*c2").resolve(
+        asset_graph=AssetGraph.from_assets(all_assets)
+    )
 
     external_asset_nodes = external_asset_graph_from_defs([as_job, cs_job], source_assets_by_key={})
 
@@ -429,7 +434,7 @@ def test_inter_op_dependency():
         pass
 
     subset_job = define_asset_job("subset_job", selection="mixed").resolve(
-        [in1, in2, assets, downstream], []
+        asset_graph=AssetGraph.from_assets([in1, in2, assets, downstream]),
     )
     all_assets_job = build_assets_job("assets_job", [in1, in2, assets, downstream])
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_default_io_manager.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_default_io_manager.py
@@ -8,6 +8,7 @@ from dagster import (
     op,
     reconstructable,
 )
+from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.errors import DagsterSubprocessError
 from dagster._core.storage.fs_io_manager import PickledObjectFilesystemIOManager
 from dagster._core.test_utils import environ, instance_for_test
@@ -75,7 +76,9 @@ def foo_io_manager_asset(context):
 
 
 def create_asset_job():
-    return define_asset_job(name="foo_io_manager_asset_job").resolve([foo_io_manager_asset], [])
+    return define_asset_job(name="foo_io_manager_asset_job").resolve(
+        asset_graph=AssetGraph.from_assets([foo_io_manager_asset])
+    )
 
 
 def test_asset_override_default_io_manager(instance):

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_multi_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_multi_partitions.py
@@ -19,6 +19,7 @@ from dagster import (
     materialize,
     repository,
 )
+from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionsDefinition
 from dagster._core.definitions.time_window_partitions import TimeWindow, get_time_partitions_def
 from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvariantViolationError
@@ -424,7 +425,7 @@ def test_dynamic_dimension_in_multipartitioned_asset():
 
     dynamic_multipartitioned_job = define_asset_job(
         "dynamic_multipartitioned_job", [my_asset, asset2], partitions_def=multipartitions_def
-    ).resolve([my_asset, asset2], [])
+    ).resolve(asset_graph=AssetGraph.from_assets([my_asset, asset2]))
 
     with instance_for_test() as instance:
         instance.add_dynamic_partitions("dynamic", ["1"])
@@ -474,7 +475,7 @@ def test_context_partition_time_window():
 
     multipartitioned_job = define_asset_job(
         "my_job", [my_asset], partitions_def=partitions_def
-    ).resolve([my_asset], [])
+    ).resolve(asset_graph=AssetGraph.from_assets([my_asset]))
     multipartitioned_job.execute_in_process(
         partition_key=MultiPartitionKey({"date": "2020-01-01", "static": "a"})
     )
@@ -494,7 +495,7 @@ def test_context_invalid_partition_time_window():
 
     multipartitioned_job = define_asset_job(
         "my_job", [my_asset], partitions_def=partitions_def
-    ).resolve([my_asset], [])
+    ).resolve(asset_graph=AssetGraph.from_assets([my_asset]))
     with pytest.raises(
         DagsterInvariantViolationError,
         match=(

--- a/python_modules/dagster/dagster_tests/execution_tests/dynamic_tests/test_reexecute.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/dynamic_tests/test_reexecute.py
@@ -15,6 +15,7 @@ from dagster import (
     op,
     reconstructable,
 )
+from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.decorators.asset_decorator import asset
 from dagster._core.definitions.events import Output
 from dagster._core.definitions.output import DynamicOut, Out
@@ -572,14 +573,15 @@ def asset_job():
         ),
         executor_def=in_process_executor,
     ).resolve(
-        assets=[
-            branching_asset,
-            echo_branching,
-            absent_asset,
-            mapped_fail_asset,
-            echo_mapped,
-        ],
-        source_assets=[],
+        asset_graph=AssetGraph.from_assets(
+            [
+                branching_asset,
+                echo_branching,
+                absent_asset,
+                mapped_fail_asset,
+                echo_mapped,
+            ]
+        )
     )
 
 

--- a/python_modules/dagster/dagster_tests/storage_tests/test_partition_status_cache.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_partition_status_cache.py
@@ -36,7 +36,7 @@ def test_get_cached_status_unpartitioned():
         return 1
 
     asset_graph = AssetGraph.from_assets([asset1])
-    asset_job = define_asset_job("asset_job").resolve([asset1], [])
+    asset_job = define_asset_job("asset_job").resolve(asset_graph=asset_graph)
 
     asset_key = AssetKey("asset1")
 
@@ -80,12 +80,12 @@ def test_get_cached_partition_status_changed_time_partitions():
 
     asset_key = AssetKey("asset1")
     asset_graph = AssetGraph.from_assets([asset1])
-    asset_job = define_asset_job("asset_job").resolve([asset1], [])
+    asset_job = define_asset_job("asset_job").resolve(asset_graph=asset_graph)
 
     def _swap_partitions_def(new_partitions_def, asset, asset_graph, asset_job):
         asset._partitions_def = new_partitions_def  # noqa: SLF001
-        asset_job = define_asset_job("asset_job").resolve([asset], [])
         asset_graph = AssetGraph.from_assets([asset])
+        asset_job = define_asset_job("asset_job").resolve(asset_graph=asset_graph)
         return asset, asset_job, asset_graph
 
     with instance_for_test() as created_instance:
@@ -129,12 +129,12 @@ def test_get_cached_partition_status_by_asset():
 
     asset_key = AssetKey("asset1")
     asset_graph = AssetGraph.from_assets([asset1])
-    asset_job = define_asset_job("asset_job").resolve([asset1], [])
+    asset_job = define_asset_job("asset_job").resolve(asset_graph=asset_graph)
 
     def _swap_partitions_def(new_partitions_def, asset, asset_graph, asset_job):
         asset._partitions_def = new_partitions_def  # noqa: SLF001
-        asset_job = define_asset_job("asset_job").resolve([asset], [])
         asset_graph = AssetGraph.from_assets([asset])
+        asset_job = define_asset_job("asset_job").resolve(asset_graph=asset_graph)
         return asset, asset_job, asset_graph
 
     with instance_for_test() as created_instance:
@@ -221,7 +221,7 @@ def test_multipartition_get_cached_partition_status():
 
     asset_key = AssetKey("asset1")
     asset_graph = AssetGraph.from_assets([asset1])
-    asset_job = define_asset_job("asset_job").resolve([asset1], [])
+    asset_job = define_asset_job("asset_job").resolve(asset_graph=asset_graph)
 
     with instance_for_test() as created_instance:
         traced_counter.set(Counter())
@@ -283,7 +283,7 @@ def test_cached_status_on_wipe():
 
     asset_key = AssetKey("asset1")
     asset_graph = AssetGraph.from_assets([asset1])
-    asset_job = define_asset_job("asset_job").resolve([asset1], [])
+    asset_job = define_asset_job("asset_job").resolve(asset_graph=asset_graph)
 
     with instance_for_test() as created_instance:
         asset_records = list(created_instance.get_asset_records([AssetKey("asset1")]))
@@ -315,7 +315,7 @@ def test_dynamic_partitions_status_not_cached():
 
     asset_key = AssetKey("asset1")
     asset_graph = AssetGraph.from_assets([asset1])
-    asset_job = define_asset_job("asset_job").resolve([asset1], [])
+    asset_job = define_asset_job("asset_job").resolve(asset_graph=asset_graph)
 
     with instance_for_test() as created_instance:
         asset_records = list(created_instance.get_asset_records([AssetKey("asset1")]))
@@ -340,7 +340,7 @@ def test_failure_cache():
 
     asset_key = AssetKey("asset1")
     asset_graph = AssetGraph.from_assets([asset1])
-    asset_job = define_asset_job("asset_job").resolve([asset1], [])
+    asset_job = define_asset_job("asset_job").resolve(asset_graph=asset_graph)
 
     with instance_for_test() as created_instance:
         # no events
@@ -458,7 +458,7 @@ def test_failure_cache_added():
 
     asset_key = AssetKey("asset1")
     asset_graph = AssetGraph.from_assets([asset1])
-    asset_job = define_asset_job("asset_job").resolve([asset1], [])
+    asset_job = define_asset_job("asset_job").resolve(asset_graph=asset_graph)
 
     with instance_for_test() as created_instance:
         created_instance.update_asset_cached_status_data(
@@ -492,7 +492,7 @@ def test_failure_cache_in_progress_runs():
 
     asset_key = AssetKey("asset1")
     asset_graph = AssetGraph.from_assets([asset1])
-    define_asset_job("asset_job").resolve([asset1], [])
+    define_asset_job("asset_job").resolve(asset_graph=asset_graph)
 
     with instance_for_test() as created_instance:
         run_1 = create_run_for_test(created_instance)
@@ -586,7 +586,7 @@ def test_cache_cancelled_runs():
 
     asset_key = AssetKey("asset1")
     asset_graph = AssetGraph.from_assets([asset1])
-    define_asset_job("asset_job").resolve([asset1], [])
+    define_asset_job("asset_job").resolve(asset_graph=asset_graph)
 
     with instance_for_test() as created_instance:
         run_1 = create_run_for_test(created_instance)
@@ -687,7 +687,7 @@ def test_failure_cache_concurrent_materializations():
 
     asset_key = AssetKey("asset1")
     asset_graph = AssetGraph.from_assets([asset1])
-    define_asset_job("asset_job").resolve([asset1], [])
+    define_asset_job("asset_job").resolve(asset_graph=asset_graph)
 
     with instance_for_test() as created_instance:
         run_1 = create_run_for_test(created_instance)
@@ -762,7 +762,10 @@ def test_failed_partitioned_asset_converted_to_multipartitioned():
         raise Exception("oops")
 
     with instance_for_test() as created_instance:
-        my_job = define_asset_job("asset_job", partitions_def=daily_def).resolve([my_asset], [])
+        asset_graph = AssetGraph.from_assets([my_asset])
+        my_job = define_asset_job("asset_job", partitions_def=daily_def).resolve(
+            asset_graph=asset_graph
+        )
 
         my_job.execute_in_process(
             instance=created_instance, partition_key="2023-01-01", raise_on_error=False
@@ -774,8 +777,8 @@ def test_failed_partitioned_asset_converted_to_multipartitioned():
                 "b": StaticPartitionsDefinition(["a", "b"]),
             }
         )
-        my_job = define_asset_job("asset_job").resolve([my_asset], [])
         asset_graph = AssetGraph.from_assets([my_asset])
+        my_job = define_asset_job("asset_job").resolve(asset_graph=asset_graph)
         asset_key = AssetKey("my_asset")
 
         cached_status = get_and_update_asset_status_cache_value(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_asset_defs.py
@@ -17,6 +17,7 @@ from dagster import (
     file_relative_path,
 )
 from dagster._config.field_utils import EnvVar
+from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.test_utils import environ, instance_for_test
 from dagster_dbt import (
     DagsterDbtCloudJobInvariantViolationError,
@@ -222,7 +223,7 @@ def test_load_assets_from_dbt_cloud_job(
     materialize_cereal_assets = define_asset_job(
         name="materialize_cereal_assets",
         selection=AssetSelection.assets(*dbt_cloud_assets),
-    ).resolve(assets=dbt_cloud_assets, source_assets=[])
+    ).resolve(asset_graph=AssetGraph.from_assets(dbt_cloud_assets))
 
     with instance_for_test() as instance:
         result = materialize_cereal_assets.execute_in_process(instance=instance)
@@ -336,7 +337,7 @@ def test_load_assets_from_cached_compile_run(
     materialize_cereal_assets = define_asset_job(
         name="materialize_cereal_assets",
         selection=AssetSelection.assets(*dbt_cloud_assets),
-    ).resolve(assets=dbt_cloud_assets, source_assets=[])
+    ).resolve(asset_graph=AssetGraph.from_assets(dbt_cloud_assets))
 
     with instance_for_test() as instance:
         result = materialize_cereal_assets.execute_in_process(instance=instance)
@@ -574,7 +575,7 @@ def test_partitions(mocker, dbt_cloud, dbt_cloud_service):
     materialize_cereal_assets = define_asset_job(
         name="materialize_partitioned_cereal_assets",
         selection=AssetSelection.assets(*dbt_cloud_assets),
-    ).resolve(assets=dbt_cloud_assets, source_assets=[])
+    ).resolve(asset_graph=AssetGraph.from_assets(dbt_cloud_assets))
 
     with instance_for_test() as instance:
         result = materialize_cereal_assets.execute_in_process(
@@ -669,7 +670,7 @@ def test_subsetting(
     materialize_cereal_assets = define_asset_job(
         name="materialize_cereal_assets",
         selection=asset_selection,
-    ).resolve(assets=list(dbt_cloud_assets) + [hanger1, hanger2], source_assets=[])
+    ).resolve(asset_graph=AssetGraph.from_assets([*dbt_cloud_assets, hanger1, hanger2]))
 
     with instance_for_test() as instance:
         result = materialize_cereal_assets.execute_in_process(instance=instance)

--- a/python_modules/libraries/dagstermill/dagstermill/examples/repository.py
+++ b/python_modules/libraries/dagstermill/dagstermill/examples/repository.py
@@ -23,6 +23,7 @@ from dagster import (
     with_resources,
 )
 from dagster._config.pythonic_config import Config
+from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.utils import DEFAULT_OUTPUT
 from dagster._utils import PICKLE_PROTOCOL, file_relative_path
 
@@ -601,7 +602,7 @@ assets = with_resources(
 def make_resolved_job(asset):
     return define_asset_job(
         name=f"{asset.key.to_user_string()}_job", selection=AssetSelection.assets(asset).upstream()
-    ).resolve(assets, [])
+    ).resolve(asset_graph=AssetGraph.from_assets(assets))
 
 
 hello_world_asset_job = make_resolved_job(hello_world_asset)


### PR DESCRIPTION
## Summary & Motivation

The `assets` and `source_assets` args to `UnresolvedAssetJob.resolve` were deprecated for removal in 1.3. This PR removes them.

It also adds support for passing `Definitions` to `UnresolvedAssetJob.resolve`-- this opens the door to making the method public.

## How I Tested These Changes

New unit test for passing `Definitions` to `UnresolvedAssetJob.resolve`.