### PR TITLE
fix(dbt): add tests for loading scaffolded Dagster project

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/include/scaffold/definitions.py.jinja
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/include/scaffold/definitions.py.jinja
@@ -1,23 +1,23 @@
 from pathlib import Path
 
-from dagster import Definitions
+from dagster import Definitions, OpExecutionContext
 
-from dagster_dbt import DbtCli, DbtManifest, dbt_assets
+from dagster_dbt import DbtCli, dbt_assets
 
 dbt_project_dir = Path("{{ dbt_project_dir }}")
 dbt_manifest_path = dbt_project_dir.joinpath("target", "manifest.json")
-dbt_manifest = DbtManifest.read(path=dbt_manifest_path)
 
 
-@dbt_assets(manifest=dbt_manifest)
-def {{ dbt_assets_name }}(dbt: DbtCli):
-    yield from dbt.cli(["build"], manifest=dbt_manifest).stream()
+@dbt_assets(manifest=dbt_manifest_path)
+def {{ dbt_assets_name }}(context: OpExecutionContext, dbt: DbtCli):
+    yield from dbt.cli(["build"], context=context).stream()
 
 
 schedules = [
-    dbt_manifest.build_schedule(
+    {{ dbt_assets_name }}.build_schedule_from_dbt_selection(
         job_name="materialize_dbt_models",
         cron_schedule="0 0 * * *",
+        dbt_select="fqn:*",
     )
 ]
 

--- a/python_modules/libraries/dagster-dbt/setup.py
+++ b/python_modules/libraries/dagster-dbt/setup.py
@@ -37,9 +37,11 @@ setup(
         f"dagster{pin}",
         # Follow the version support constraints for dbt Core: https://docs.getdbt.com/docs/dbt-versions/core
         "dbt-core<1.6",
+        "Jinja2",
         "networkx",
         "requests",
-        "typer[all]",
+        "rich",
+        "typer",
     ],
     extras_require={
         "test": [


### PR DESCRIPTION
## Summary & Motivation
After scaffolding the project:
- Compile the manifest associated with the dbt project
- Load the Dagster definitions from the scaffolded project 
- Assert that the desired definitions are present and run successfully

Along the way, fix errors in the scaffold resulting from API names changing around.

## How I Tested These Changes
pytest
