### PR TITLE
Make OpExecutionContext.job_def public

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -199,6 +199,7 @@ class OpExecutionContext(AbstractComputeExecutionContext):
         """dict: The run config for the current execution."""
         return self._step_execution_context.run_config
 
+    @public
     @property
     def job_def(self) -> JobDefinition:
         """JobDefinition: The currently executing pipeline."""


### PR DESCRIPTION
## Summary & Motivation

`JobDefinition` is already public and there's lots of useful info on it.

## How I Tested These Changes

Existing test suite.