### PR TITLE
[ui] Fix WebWorkers when using path-prefix

### DIFF
--- a/js_modules/dagit/packages/app/package.json
+++ b/js_modules/dagit/packages/app/package.json
@@ -39,7 +39,7 @@
     "eslint-webpack-plugin": "3.1.1",
     "prettier": "2.2.1",
     "typescript": "5.0.2",
-    "webpack": "^5.0.0",
+    "webpack": "^5.88.1",
     "webpack-bundle-analyzer": "^4.7.0"
   },
   "scripts": {

--- a/js_modules/dagit/packages/core/src/search/createSearchWorker.tsx
+++ b/js_modules/dagit/packages/core/src/search/createSearchWorker.tsx
@@ -29,6 +29,7 @@ export type WorkerSearchResult = {
 export const createSearchWorker = (
   key: string,
   fuseOptions: Fuse.IFuseOptions<SearchResult>,
+  staticPathRoot?: string,
 ): WorkerSearchResult => {
   const searchWorker = spawnSearchWorker(key);
   const listeners: Set<QueryListener> = new Set();
@@ -54,7 +55,7 @@ export const createSearchWorker = (
    * @param results - Prepackaged search results, supplied via GraphQL or otherwise
    */
   const update = (results: SearchResult[]) => {
-    searchWorker.postMessage({type: 'set-results', results, fuseOptions});
+    searchWorker.postMessage({type: 'set-results', results, fuseOptions, staticPathRoot});
   };
 
   /**

--- a/js_modules/dagit/packages/core/src/search/fuse.tsx
+++ b/js_modules/dagit/packages/core/src/search/fuse.tsx
@@ -1,0 +1,4 @@
+import Fuse from 'fuse.js';
+
+// A local export for the `import` call in fuseSearch.worker.
+export {Fuse};

--- a/js_modules/dagit/packages/core/src/search/useGlobalSearch.tsx
+++ b/js_modules/dagit/packages/core/src/search/useGlobalSearch.tsx
@@ -1,6 +1,7 @@
 import {gql, useLazyQuery} from '@apollo/client';
 import * as React from 'react';
 
+import {AppContext} from '../app/AppContext';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {displayNameForAssetKey, isHiddenAssetGroupJob} from '../asset-graph/Utils';
 import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
@@ -176,6 +177,7 @@ const EMPTY_RESPONSE = {queryString: '', results: []};
  * A `terminate` function is provided, but it's probably not necessary to use it.
  */
 export const useGlobalSearch = () => {
+  const {staticPathRoot} = React.useContext(AppContext);
   const primarySearch = React.useRef<WorkerSearchResult>();
   const secondarySearch = React.useRef<WorkerSearchResult>();
 
@@ -183,7 +185,7 @@ export const useGlobalSearch = () => {
     onCompleted: (data: SearchPrimaryQuery) => {
       const results = primaryDataToSearchResults({data});
       if (!primarySearch.current) {
-        primarySearch.current = createSearchWorker('primary', fuseOptions);
+        primarySearch.current = createSearchWorker('primary', fuseOptions, staticPathRoot);
       }
       primarySearch.current.update(results);
     },
@@ -193,7 +195,7 @@ export const useGlobalSearch = () => {
     onCompleted: (data: SearchSecondaryQuery) => {
       const results = secondaryDataToSearchResults({data});
       if (!secondarySearch.current) {
-        secondarySearch.current = createSearchWorker('secondary', fuseOptions);
+        secondarySearch.current = createSearchWorker('secondary', fuseOptions, staticPathRoot);
       }
       secondarySearch.current.update(results);
     },

--- a/js_modules/dagit/packages/core/src/workers/dagre_layout.worker.ts
+++ b/js_modules/dagit/packages/core/src/workers/dagre_layout.worker.ts
@@ -15,7 +15,8 @@ self.addEventListener('message', (event) => {
   // Before we attempt any imports, manually set the Webpack public path to the static path root.
   // This allows us to import paths when a path-prefix value has been set.
   if (data.staticPathRoot) {
-    (self as any).__webpack_public_path__ = data.staticPathRoot;
+    // @ts-expect-error -- Cannot add annotation to magic webpack var
+    __webpack_public_path__ = data.staticPathRoot;
   }
 
   switch (data.type) {

--- a/js_modules/dagit/packages/core/src/workers/fuseSearch.worker.ts
+++ b/js_modules/dagit/packages/core/src/workers/fuseSearch.worker.ts
@@ -1,24 +1,28 @@
-import Fuse from 'fuse.js';
-
-import {SearchResult} from '../search/types';
-
 /**
  * A Web Worker that creates and queries a Fuse object.
  */
-
-let fuseObject: null | Fuse<SearchResult[]> = null;
+let fuseObject: any = null;
 
 self.addEventListener('message', (event) => {
   const {data} = event;
 
   switch (data.type) {
     case 'set-results': {
-      if (!fuseObject) {
-        fuseObject = new Fuse(data.results, data.fuseOptions);
-      } else {
-        fuseObject.setCollection(data.results);
+      // Before we attempt any imports, manually set the Webpack public path to the static path root.
+      // This allows us to import paths when a path-prefix value has been set.
+      if (data.staticPathRoot) {
+        // @ts-expect-error -- Cannot add annotation to magic webpack var
+        __webpack_public_path__ = data.staticPathRoot;
       }
-      self.postMessage({type: 'ready'});
+
+      import('../search/fuse').then(({Fuse}) => {
+        if (!fuseObject) {
+          fuseObject = new Fuse(data.results, data.fuseOptions);
+        } else {
+          fuseObject.setCollection(data.results);
+        }
+        self.postMessage({type: 'ready'});
+      });
       break;
     }
     case 'query': {
@@ -32,5 +36,3 @@ self.addEventListener('message', (event) => {
     }
   }
 });
-
-export {};

--- a/js_modules/dagit/yarn.lock
+++ b/js_modules/dagit/yarn.lock
@@ -2053,7 +2053,7 @@ __metadata:
     uuid: ^9.0.0
     validator: ^13.7.0
     web-vitals: ^2.1.3
-    webpack: ^5.0.0
+    webpack: ^5.88.1
     webpack-bundle-analyzer: ^4.7.0
   languageName: unknown
   linkType: soft
@@ -7269,6 +7269,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"acorn-import-assertions@npm:^1.9.0":
+  version: 1.9.0
+  resolution: "acorn-import-assertions@npm:1.9.0"
+  peerDependencies:
+    acorn: ^8
+  checksum: 944fb2659d0845c467066bdcda2e20c05abe3aaf11972116df457ce2627628a81764d800dd55031ba19de513ee0d43bb771bc679cc0eda66dc8b4fade143bc0c
+  languageName: node
+  linkType: hard
+
 "acorn-jsx@npm:^5.3.1, acorn-jsx@npm:^5.3.2":
   version: 5.3.2
   resolution: "acorn-jsx@npm:5.3.2"
@@ -10887,6 +10896,16 @@ __metadata:
     graceful-fs: ^4.2.4
     tapable: ^2.2.0
   checksum: 76d6844c4393d76beed5b3ce6cf5a98dee3ad5c84a9887f49ccde1224e3b7af201dfbd5a57ebf2b49f623b74883df262d50ff480d3cc02fc2881fc58b84e1bbe
+  languageName: node
+  linkType: hard
+
+"enhanced-resolve@npm:^5.15.0":
+  version: 5.15.0
+  resolution: "enhanced-resolve@npm:5.15.0"
+  dependencies:
+    graceful-fs: ^4.2.4
+    tapable: ^2.2.0
+  checksum: fbd8cdc9263be71cc737aa8a7d6c57b43d6aa38f6cc75dde6fcd3598a130cc465f979d2f4d01bb3bf475acb43817749c79f8eef9be048683602ca91ab52e4f11
   languageName: node
   linkType: hard
 
@@ -21030,6 +21049,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"schema-utils@npm:^3.2.0":
+  version: 3.3.0
+  resolution: "schema-utils@npm:3.3.0"
+  dependencies:
+    "@types/json-schema": ^7.0.8
+    ajv: ^6.12.5
+    ajv-keywords: ^3.5.2
+  checksum: ea56971926fac2487f0757da939a871388891bc87c6a82220d125d587b388f1704788f3706e7f63a7b70e49fc2db974c41343528caea60444afd5ce0fe4b85c0
+  languageName: node
+  linkType: hard
+
 "schema-utils@npm:^4.0.0":
   version: 4.0.1
   resolution: "schema-utils@npm:4.0.1"
@@ -23859,6 +23889,43 @@ __metadata:
   bin:
     webpack: bin/webpack.js
   checksum: 1a6eecaffac3226d80f4e8f330b32e0ff117d9dafd8700166d230afbc171d68ea1ff55a9939fa789307f7b9d11881889ccb8e6cd79d4ccbaeef916788ce73fdb
+  languageName: node
+  linkType: hard
+
+"webpack@npm:^5.88.1":
+  version: 5.88.1
+  resolution: "webpack@npm:5.88.1"
+  dependencies:
+    "@types/eslint-scope": ^3.7.3
+    "@types/estree": ^1.0.0
+    "@webassemblyjs/ast": ^1.11.5
+    "@webassemblyjs/wasm-edit": ^1.11.5
+    "@webassemblyjs/wasm-parser": ^1.11.5
+    acorn: ^8.7.1
+    acorn-import-assertions: ^1.9.0
+    browserslist: ^4.14.5
+    chrome-trace-event: ^1.0.2
+    enhanced-resolve: ^5.15.0
+    es-module-lexer: ^1.2.1
+    eslint-scope: 5.1.1
+    events: ^3.2.0
+    glob-to-regexp: ^0.4.1
+    graceful-fs: ^4.2.9
+    json-parse-even-better-errors: ^2.3.1
+    loader-runner: ^4.2.0
+    mime-types: ^2.1.27
+    neo-async: ^2.6.2
+    schema-utils: ^3.2.0
+    tapable: ^2.1.1
+    terser-webpack-plugin: ^5.3.7
+    watchpack: ^2.4.0
+    webpack-sources: ^3.2.3
+  peerDependenciesMeta:
+    webpack-cli:
+      optional: true
+  bin:
+    webpack: bin/webpack.js
+  checksum: 726e7e05ab2e7c142609a673dd6aa1a711ed97f349418a2a393d650c5ddad172d191257f60e1e37f6b2a77261571c202aabd5ce9240791a686774f0801cf5ec2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary & Motivation

Resolves #14894.

WebWorkers are failing in the `--path-prefix` case again. In this case it surfaced with global search, but the DAG layout worker has been broken too. This may have been broken for a while.

The magic `__webpack_public_path__` var apparently cannot be prefixed with a namespace. When the `(self as any)` is removed, Webpack behaves as expected and the path prefix is correctly applied to the subsequent `import`.

I added `@ts-expect-error` annotations to this to suppress the resulting error.

## How I Tested These Changes

With `--path-prefix=/foo`, run the app and perform a search. Verify that search behaves correctly, with no WebWorker-related errors.

Repeat without path prefix, verify same.
