### PR TITLE
Light warnings refactor

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -598,6 +598,7 @@ def __getattr__(name: str) -> TypingAny:
             breaking_version,
             additional_warn_text=f"Use `{name}` instead.",
             stacklevel=stacklevel,
+            key=value.__name__,
         )
         return value
     else:

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -531,9 +531,9 @@ from dagster._utils import (
 from dagster._utils.alert import (
     make_email_on_run_failure_sensor as make_email_on_run_failure_sensor,
 )
-from dagster._utils.backcompat import ExperimentalWarning as ExperimentalWarning
 from dagster._utils.dagster_type import check_dagster_type as check_dagster_type
 from dagster._utils.log import get_dagster_logger as get_dagster_logger
+from dagster._utils.warnings import ExperimentalWarning as ExperimentalWarning
 from dagster.version import __version__ as __version__
 
 # ruff: isort: split
@@ -554,7 +554,7 @@ from typing import (
 
 from typing_extensions import Final
 
-from dagster._utils.backcompat import deprecation_warning
+from dagster._utils.warnings import deprecation_warning
 
 # NOTE: Unfortunately we have to declare deprecated aliases twice-- the
 # TYPE_CHECKING declaration satisfies linters and type checkers, but the entry
@@ -598,7 +598,6 @@ def __getattr__(name: str) -> TypingAny:
             breaking_version,
             additional_warn_text=f"Use `{name}` instead.",
             stacklevel=stacklevel,
-            key=value.__name__,
         )
         return value
     else:

--- a/python_modules/dagster/dagster/_annotations.py
+++ b/python_modules/dagster/dagster/_annotations.py
@@ -11,7 +11,7 @@ from dagster._core.decorator_utils import (
     get_decorator_target,
     is_resource_def,
 )
-from dagster._utils.backcompat import (
+from dagster._utils.warnings import (
     deprecation_warning,
     experimental_warning,
 )

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -33,7 +33,7 @@ from dagster._core.definitions.time_window_partitions import TimeWindowPartition
 from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvalidInvocationError
 from dagster._utils import IHasInternalInit
 from dagster._utils.backcompat import (
-    ExperimentalWarning,
+    disable_dagster_warnings,
 )
 from dagster._utils.merger import merge_dicts
 
@@ -794,9 +794,7 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
     def infer_partition_mapping(
         self, upstream_asset_key: AssetKey, upstream_partitions_def: Optional[PartitionsDefinition]
     ) -> PartitionMapping:
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=ExperimentalWarning)
-
+        with disable_dagster_warnings():
             partition_mapping = self._partition_mappings.get(upstream_asset_key)
             return infer_partition_mapping(
                 partition_mapping, self._partitions_def, upstream_partitions_def
@@ -1120,9 +1118,7 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
         return self._output_to_source_asset(output_names[0])
 
     def _output_to_source_asset(self, output_name: str) -> SourceAsset:
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=ExperimentalWarning)
-
+        with disable_dagster_warnings():
             output_def = self.node_def.resolve_output_to_origin(
                 output_name, NodeHandle(self.node_def.name, parent=None)
             )[0]

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -32,10 +32,10 @@ from dagster._core.definitions.time_window_partition_mapping import TimeWindowPa
 from dagster._core.definitions.time_window_partitions import TimeWindowPartitionsDefinition
 from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvalidInvocationError
 from dagster._utils import IHasInternalInit
-from dagster._utils.backcompat import (
+from dagster._utils.merger import merge_dicts
+from dagster._utils.warnings import (
     disable_dagster_warnings,
 )
-from dagster._utils.merger import merge_dicts
 
 from .dependency import NodeHandle
 from .events import AssetKey, CoercibleToAssetKey, CoercibleToAssetKeyPrefix

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -29,7 +29,7 @@ from dagster._core.definitions.resource_annotation import (
 from dagster._core.definitions.source_asset import SourceAsset
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.types.dagster_type import DagsterType
-from dagster._utils.backcompat import (
+from dagster._utils.warnings import (
     disable_dagster_warnings,
 )
 

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -1,4 +1,3 @@
-import warnings
 from inspect import Parameter
 from typing import (
     AbstractSet,
@@ -31,7 +30,7 @@ from dagster._core.definitions.source_asset import SourceAsset
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.types.dagster_type import DagsterType
 from dagster._utils.backcompat import (
-    ExperimentalWarning,
+    disable_dagster_warnings,
 )
 
 from ..asset_in import AssetIn
@@ -324,9 +323,7 @@ class _Asset:
             if not self.key
             else self.key
         )
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=ExperimentalWarning)
-
+        with disable_dagster_warnings():
             arg_resource_keys = {arg.name for arg in get_resource_args(fn)}
 
             bare_required_resource_keys = set(self.required_resource_keys)
@@ -595,9 +592,7 @@ def multi_asset(
                 " the asset or produced by this asset. Valid keys:"
                 f" {list(valid_asset_deps)[:20]}",
             )
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=ExperimentalWarning)
-
+        with disable_dagster_warnings():
             op_required_resource_keys = required_resource_keys - arg_resource_keys
 
             op = _Op(

--- a/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
@@ -31,7 +31,7 @@ from dagster._core.definitions.resource_annotation import (
 )
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.types.dagster_type import DagsterTypeKind
-from dagster._utils.backcompat import normalize_renamed_param
+from dagster._utils.warnings import normalize_renamed_param
 
 from ..input import In, InputDefinition
 from ..output import Out

--- a/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
@@ -29,7 +29,7 @@ from dagster._serdes.serdes import (
     WhitelistMap,
     pack_value,
 )
-from dagster._utils.backcompat import (
+from dagster._utils.warnings import (
     deprecation_warning,
     normalize_renamed_param,
 )

--- a/python_modules/dagster/dagster/_core/definitions/observe.py
+++ b/python_modules/dagster/dagster/_core/definitions/observe.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Any, Mapping, Optional, Sequence
 import dagster._check as check
 from dagster._core.definitions.assets_job import build_source_asset_observation_job
 from dagster._core.definitions.definitions_class import Definitions
-from dagster._utils.backcompat import disable_dagster_warnings
+from dagster._utils.warnings import disable_dagster_warnings
 
 from ..instance import DagsterInstance
 from .source_asset import SourceAsset

--- a/python_modules/dagster/dagster/_core/definitions/observe.py
+++ b/python_modules/dagster/dagster/_core/definitions/observe.py
@@ -1,10 +1,9 @@
-import warnings
 from typing import TYPE_CHECKING, Any, Mapping, Optional, Sequence
 
 import dagster._check as check
 from dagster._core.definitions.assets_job import build_source_asset_observation_job
 from dagster._core.definitions.definitions_class import Definitions
-from dagster._utils.backcompat import ExperimentalWarning
+from dagster._utils.backcompat import disable_dagster_warnings
 
 from ..instance import DagsterInstance
 from .source_asset import SourceAsset
@@ -47,11 +46,7 @@ def observe(
     partition_key = check.opt_str_param(partition_key, "partition_key")
     resources = check.opt_mapping_param(resources, "resources", key_type=str)
 
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "ignore", category=ExperimentalWarning, message=".*build_source_asset_observation_job.*"
-        )
-
+    with disable_dagster_warnings():
         observation_job = build_source_asset_observation_job(
             "in_process_observation_job", source_assets
         )

--- a/python_modules/dagster/dagster/_core/definitions/op_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_definition.py
@@ -33,7 +33,7 @@ from dagster._core.definitions.resource_requirement import (
 from dagster._core.errors import DagsterInvalidInvocationError, DagsterInvariantViolationError
 from dagster._core.types.dagster_type import DagsterType, DagsterTypeKind
 from dagster._utils import IHasInternalInit
-from dagster._utils.backcompat import normalize_renamed_param
+from dagster._utils.warnings import normalize_renamed_param
 
 from .definition_config_schema import (
     IDefinitionConfigSchema,

--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -38,10 +38,10 @@ from dagster._core.instance import DagsterInstance, DynamicPartitionsStore
 from dagster._core.storage.tags import PARTITION_NAME_TAG, PARTITION_SET_TAG
 from dagster._serdes import whitelist_for_serdes
 from dagster._utils import xor
-from dagster._utils.backcompat import (
+from dagster._utils.cached_method import cached_method
+from dagster._utils.warnings import (
     normalize_renamed_param,
 )
-from dagster._utils.cached_method import cached_method
 
 from ..errors import (
     DagsterInvalidDefinitionError,

--- a/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
@@ -1,6 +1,5 @@
 import collections.abc
 import itertools
-import warnings
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from datetime import datetime
@@ -33,7 +32,7 @@ from dagster._core.definitions.partition import (
 from dagster._core.definitions.time_window_partitions import TimeWindowPartitionsDefinition
 from dagster._core.instance import DynamicPartitionsStore
 from dagster._serdes import whitelist_for_serdes
-from dagster._utils.backcompat import ExperimentalWarning
+from dagster._utils.backcompat import disable_dagster_warnings
 from dagster._utils.cached_method import cached_method
 
 
@@ -1042,8 +1041,7 @@ def infer_partition_mapping(
         if _can_infer_single_to_multi_partition_mapping(
             upstream_partitions_def, downstream_partitions_def
         ):
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore", category=ExperimentalWarning)
+            with disable_dagster_warnings():
                 return MultiToSingleDimensionPartitionMapping()
         elif isinstance(upstream_partitions_def, TimeWindowPartitionsDefinition) and isinstance(
             downstream_partitions_def, TimeWindowPartitionsDefinition

--- a/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
@@ -32,8 +32,8 @@ from dagster._core.definitions.partition import (
 from dagster._core.definitions.time_window_partitions import TimeWindowPartitionsDefinition
 from dagster._core.instance import DynamicPartitionsStore
 from dagster._serdes import whitelist_for_serdes
-from dagster._utils.backcompat import disable_dagster_warnings
 from dagster._utils.cached_method import cached_method
+from dagster._utils.warnings import disable_dagster_warnings
 
 
 class UpstreamPartitionsResult(NamedTuple):

--- a/python_modules/dagster/dagster/_core/definitions/resolved_asset_deps.py
+++ b/python_modules/dagster/dagster/_core/definitions/resolved_asset_deps.py
@@ -3,7 +3,7 @@ from typing import AbstractSet, Dict, Iterable, List, Mapping, Tuple, cast
 
 from dagster._core.definitions.events import AssetKey
 from dagster._core.errors import DagsterInvalidDefinitionError
-from dagster._utils.backcompat import experimental_warning
+from dagster._utils.warnings import experimental_warning
 
 from .assets import AssetsDefinition
 from .source_asset import SourceAsset

--- a/python_modules/dagster/dagster/_core/definitions/source_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/source_asset.py
@@ -1,4 +1,3 @@
-import warnings
 from typing import (
     AbstractSet,
     Any,
@@ -48,7 +47,7 @@ from dagster._core.errors import (
     DagsterInvalidObservationError,
 )
 from dagster._core.storage.io_manager import IOManagerDefinition
-from dagster._utils.backcompat import ExperimentalWarning
+from dagster._utils.backcompat import disable_dagster_warnings
 from dagster._utils.merger import merge_dicts
 
 # Going with this catch-all for the time-being to permit pythonic resources
@@ -300,9 +299,7 @@ class SourceAsset(ResourceAddable):
             if self.get_io_manager_key() != DEFAULT_IO_MANAGER_KEY
             else None
         )
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=ExperimentalWarning)
-
+        with disable_dagster_warnings():
             return SourceAsset(
                 key=self.key,
                 io_manager_key=io_manager_key,
@@ -325,9 +322,7 @@ class SourceAsset(ResourceAddable):
                 f" {self.key.to_user_string()}"
             )
 
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=ExperimentalWarning)
-
+        with disable_dagster_warnings():
             return SourceAsset(
                 key=key or self.key,
                 metadata=self.raw_metadata,

--- a/python_modules/dagster/dagster/_core/definitions/source_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/source_asset.py
@@ -47,8 +47,8 @@ from dagster._core.errors import (
     DagsterInvalidObservationError,
 )
 from dagster._core.storage.io_manager import IOManagerDefinition
-from dagster._utils.backcompat import disable_dagster_warnings
 from dagster._utils.merger import merge_dicts
+from dagster._utils.warnings import disable_dagster_warnings
 
 # Going with this catch-all for the time-being to permit pythonic resources
 SourceAssetObserveFunction: TypeAlias = Callable[..., Any]

--- a/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
@@ -1,5 +1,4 @@
 import inspect
-import warnings
 from functools import wraps
 from typing import (
     Any,
@@ -30,6 +29,7 @@ from dagster._core.definitions.decorators.op_decorator import DecoratedOpFunctio
 from dagster._core.definitions.op_definition import OpDefinition
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.types.dagster_type import DagsterTypeKind, is_generic_output_annotation
+from dagster._utils.backcompat import disable_dagster_warnings
 
 from ..context.compute import OpExecutionContext
 
@@ -236,9 +236,7 @@ def validate_and_coerce_op_result_to_iterator(
                     dynamic_output = cast(DynamicOutput, item)
                     _check_output_object_name(dynamic_output, output_def, position)
 
-                    with warnings.catch_warnings():
-                        warnings.simplefilter("ignore", category=DeprecationWarning)
-
+                    with disable_dagster_warnings():
                         yield DynamicOutput(
                             output_name=output_def.name,
                             value=dynamic_output.value,
@@ -256,9 +254,7 @@ def validate_and_coerce_op_result_to_iterator(
                     )
                 _check_output_object_name(element, output_def, position)
 
-                with warnings.catch_warnings():
-                    warnings.simplefilter("ignore", category=DeprecationWarning)
-
+                with disable_dagster_warnings():
                     yield Output(
                         output_name=output_def.name,
                         value=element.value,

--- a/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
@@ -29,7 +29,7 @@ from dagster._core.definitions.decorators.op_decorator import DecoratedOpFunctio
 from dagster._core.definitions.op_definition import OpDefinition
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.types.dagster_type import DagsterTypeKind, is_generic_output_annotation
-from dagster._utils.backcompat import disable_dagster_warnings
+from dagster._utils.warnings import disable_dagster_warnings
 
 from ..context.compute import OpExecutionContext
 

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
@@ -1,5 +1,4 @@
 import inspect
-import warnings
 from typing import (
     AbstractSet,
     Any,
@@ -65,7 +64,7 @@ from dagster._core.storage.tags import BACKFILL_ID_TAG, MEMOIZED_RUN_TAG
 from dagster._core.types.dagster_type import DagsterType
 from dagster._utils import iterate_with_context
 from dagster._utils.backcompat import (
-    ExperimentalWarning,
+    disable_dagster_warnings,
     experimental_warning,
 )
 from dagster._utils.timing import time_execution_scope
@@ -157,9 +156,7 @@ def _step_output_error_checked_user_event_sequence(
             step_context.observe_output(output.output_name)
 
             metadata = step_context.get_output_metadata(output.output_name)
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore", category=DeprecationWarning)
-
+            with disable_dagster_warnings():
                 output = Output(
                     value=output.value,
                     output_name=output.output_name,
@@ -532,9 +529,7 @@ def _get_output_asset_materializations(
 
     if asset_partitions:
         for partition in asset_partitions:
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore", category=DeprecationWarning)
-
+            with disable_dagster_warnings():
                 tags.update(
                     get_tags_from_multi_partition_key(partition)
                     if isinstance(partition, MultiPartitionKey)
@@ -548,9 +543,7 @@ def _get_output_asset_materializations(
                     tags=tags,
                 )
     else:
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=DeprecationWarning)
-
+        with disable_dagster_warnings():
             yield AssetMaterialization(asset_key=asset_key, metadata=all_metadata, tags=tags)
 
 
@@ -687,9 +680,7 @@ def _store_output(
             )
 
         if manager_metadata:
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore", category=ExperimentalWarning)
-
+            with disable_dagster_warnings():
                 materialization = AssetMaterialization(
                     asset_key=mgr_materialization.asset_key,
                     description=mgr_materialization.description,

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
@@ -63,11 +63,11 @@ from dagster._core.execution.resolve_versions import resolve_step_output_version
 from dagster._core.storage.tags import BACKFILL_ID_TAG, MEMOIZED_RUN_TAG
 from dagster._core.types.dagster_type import DagsterType
 from dagster._utils import iterate_with_context
-from dagster._utils.backcompat import (
+from dagster._utils.timing import time_execution_scope
+from dagster._utils.warnings import (
     disable_dagster_warnings,
     experimental_warning,
 )
-from dagster._utils.timing import time_execution_scope
 
 from .compute import OpOutputUnion
 from .compute_generator import create_op_compute_wrapper

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -66,12 +66,12 @@ from dagster._core.storage.tags import (
 from dagster._serdes import ConfigurableClass
 from dagster._seven import get_current_datetime_in_utc
 from dagster._utils import PrintFn, traced
-from dagster._utils.backcompat import (
+from dagster._utils.error import serializable_error_info_from_exc_info
+from dagster._utils.merger import merge_dicts
+from dagster._utils.warnings import (
     deprecation_warning,
     experimental_warning,
 )
-from dagster._utils.error import serializable_error_info_from_exc_info
-from dagster._utils.merger import merge_dicts
 
 from .config import (
     DAGSTER_CONFIG_YAML_FILENAME,

--- a/python_modules/dagster/dagster/_core/types/builtin_config_schemas.py
+++ b/python_modules/dagster/dagster/_core/types/builtin_config_schemas.py
@@ -1,5 +1,4 @@
 import pickle
-import warnings
 
 import dagster._check as check
 import dagster._seven as seven
@@ -15,7 +14,7 @@ from dagster._config import (
     ScalarUnion,
     Selector,
 )
-from dagster._utils.backcompat import ExperimentalWarning
+from dagster._utils.backcompat import disable_dagster_warnings
 
 from .config_schema import dagster_type_loader
 
@@ -66,8 +65,7 @@ def define_builtin_scalar_input_schema(scalar_name, config_scalar_type):
     check.inst_param(config_scalar_type, "config_scalar_type", ConfigType)
     check.param_invariant(config_scalar_type.kind == ConfigTypeKind.SCALAR, "config_scalar_type")
     # TODO: https://github.com/dagster-io/dagster/issues/3084
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", category=ExperimentalWarning)
+    with disable_dagster_warnings():
 
         @dagster_type_loader(
             ScalarUnion(

--- a/python_modules/dagster/dagster/_core/types/builtin_config_schemas.py
+++ b/python_modules/dagster/dagster/_core/types/builtin_config_schemas.py
@@ -14,7 +14,7 @@ from dagster._config import (
     ScalarUnion,
     Selector,
 )
-from dagster._utils.backcompat import disable_dagster_warnings
+from dagster._utils.warnings import disable_dagster_warnings
 
 from .config_schema import dagster_type_loader
 

--- a/python_modules/dagster/dagster/_serdes/serdes.py
+++ b/python_modules/dagster/dagster/_serdes/serdes.py
@@ -42,8 +42,8 @@ from typing_extensions import Final, Self, TypeAlias, TypeVar
 import dagster._check as check
 import dagster._seven as seven
 from dagster._utils import is_named_tuple_instance, is_named_tuple_subclass
-from dagster._utils.backcompat import disable_dagster_warnings
 from dagster._utils.cached_method import cached_method
+from dagster._utils.warnings import disable_dagster_warnings
 
 from .errors import DeserializationError, SerdesUsageError, SerializationError
 

--- a/python_modules/dagster/dagster/_serdes/serdes.py
+++ b/python_modules/dagster/dagster/_serdes/serdes.py
@@ -13,7 +13,6 @@ Why not pickle?
   (in memory, not human readable, etc) just handle the json case effectively.
 """
 import collections.abc
-import warnings
 from abc import ABC, abstractmethod
 from enum import Enum
 from functools import partial
@@ -43,6 +42,7 @@ from typing_extensions import Final, Self, TypeAlias, TypeVar
 import dagster._check as check
 import dagster._seven as seven
 from dagster._utils import is_named_tuple_instance, is_named_tuple_subclass
+from dagster._utils.backcompat import disable_dagster_warnings
 from dagster._utils.cached_method import cached_method
 
 from .errors import DeserializationError, SerdesUsageError, SerializationError
@@ -784,8 +784,7 @@ def deserialize_value(
     check.str_param(val, "val")
 
     # Never issue warnings when deserializing deprecated objects.
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", DeprecationWarning)
+    with disable_dagster_warnings():
         context = UnpackContext()
         unpacked_value = seven.json.loads(
             val, object_hook=partial(_unpack_object, whitelist_map=whitelist_map, context=context)

--- a/python_modules/dagster/dagster/_utils/warnings.py
+++ b/python_modules/dagster/dagster/_utils/warnings.py
@@ -116,16 +116,8 @@ T_Decoratable = TypeVar("T_Decoratable", bound=Decoratable)
 
 
 def suppress_dagster_warnings(__obj: T_Decoratable) -> T_Decoratable:
-    """Mark a method/function as ignoring Dagster-generated warnings. This quiets any
-    `ExperimentalWarnings` or `DeprecationWarnings` issued by the Dagster framework. Other libraries
-    issuing warnings are not affected.
-
-    Note that this works by toggling the global `DAGSTER_WARNINGS_DISABLED` flag, rather than
-    invoking `warnings.catch_warnings`. This is because we want to keep our warnings from being
-    issued at all, rather than merely caught and suppressed by Python. This allows us to track
-    whether a warning has been emitted in a user-visible way-- if we emitted the warnings but
-    filtered them elsewhere in our code with `warnings.catch_warnings`, it would be difficult to
-    track whether a warning had ever actually been shown to the user.
+    """Mark a method/function as ignoring Dagster-generated warnings. This suppresses any
+    `ExperimentalWarnings` or `DeprecationWarnings` when the function is called.
 
     Usage:
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
@@ -51,7 +51,9 @@ from dagster._core.snap.dep_snapshot import (
 from dagster._core.storage.event_log.base import EventRecordsFilter
 from dagster._core.test_utils import ignore_warning, instance_for_test
 from dagster._utils import safe_tempfile_path
-from dagster._utils.backcompat import ExperimentalWarning
+from dagster._utils.backcompat import (
+    disable_dagster_warnings,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -1378,9 +1380,7 @@ def reconstruct_asset_job():
 
 
 def test_asset_selection_reconstructable():
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", category=ExperimentalWarning)
-        warnings.simplefilter("ignore", category=DeprecationWarning)
+    with disable_dagster_warnings():
         with instance_for_test() as instance:
             run = instance.create_run_for_job(
                 job_def=my_job, asset_selection=frozenset([AssetKey("f")])
@@ -1893,9 +1893,7 @@ def test_resolve_dependency_in_group():
         del asset1
         assert context.asset_key_for_input("asset1") == AssetKey(["abc", "asset1"])
 
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", category=ExperimentalWarning)
-
+    with disable_dagster_warnings():
         assert materialize_to_memory([asset1, asset2]).success
 
 
@@ -1915,9 +1913,7 @@ def test_resolve_dependency_fail_across_groups():
             " sources"
         ),
     ):
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=ExperimentalWarning)
-
+        with disable_dagster_warnings():
             materialize_to_memory([asset1, asset2])
 
 
@@ -1944,9 +1940,7 @@ def test_resolve_dependency_multi_asset_different_groups():
             " sources"
         ),
     ):
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=ExperimentalWarning)
-
+        with disable_dagster_warnings():
             materialize_to_memory([upstream, assets])
 
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
@@ -51,7 +51,7 @@ from dagster._core.snap.dep_snapshot import (
 from dagster._core.storage.event_log.base import EventRecordsFilter
 from dagster._core.test_utils import ignore_warning, instance_for_test
 from dagster._utils import safe_tempfile_path
-from dagster._utils.backcompat import (
+from dagster._utils.warnings import (
     disable_dagster_warnings,
 )
 

--- a/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_warnings.py
+++ b/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_warnings.py
@@ -6,7 +6,7 @@ from dagster._annotations import experimental
 from dagster._check import CheckError
 from dagster._utils.backcompat import (
     normalize_renamed_param,
-    quiet_experimental_warnings,
+    suppress_dagster_warnings,
 )
 
 
@@ -22,19 +22,19 @@ def is_new(old_flag=None, new_flag=None):
     return actual_new_flag
 
 
-def test_backcompat_default():
+def test_renamed_param_default():
     assert is_new() is None
 
 
-def test_backcompat_new_flag():
+def test_renamed_param_new_name():
     assert is_new(new_flag=False) is False
 
 
-def test_backcompat_old_flag():
+def test_renamed_param_old_name():
     assert is_new(old_flag=False) is True
 
 
-def test_backcompat_both_set():
+def test_renamed_param_both_names():
     with pytest.raises(
         CheckError,
         match=re.escape('Do not use deprecated "old_flag" now that you are using "new_flag".'),
@@ -42,7 +42,7 @@ def test_backcompat_both_set():
         is_new(old_flag=False, new_flag=True)
 
 
-def test_quiet_experimental_warnings() -> None:
+def test_suppress_dagster_warnings() -> None:
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
 
@@ -61,7 +61,7 @@ def test_quiet_experimental_warnings() -> None:
         def my_experimental_function(my_arg) -> None:
             pass
 
-        @quiet_experimental_warnings
+        @suppress_dagster_warnings
         def my_quiet_wrapper(my_arg) -> None:
             my_experimental_function(my_arg)
 
@@ -70,7 +70,7 @@ def test_quiet_experimental_warnings() -> None:
         assert len(w) == 0
 
 
-def test_quiet_experimental_warnings_on_class() -> None:
+def test_suppress_dagster_warnings_on_class() -> None:
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
 
@@ -92,7 +92,7 @@ def test_quiet_experimental_warnings_on_class() -> None:
                 pass
 
         class MyExperimentalWrapped(MyExperimentalTwo):
-            @quiet_experimental_warnings
+            @suppress_dagster_warnings
             def __init__(self, string_in: str) -> None:
                 super().__init__(string_in)
 

--- a/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_warnings.py
+++ b/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_warnings.py
@@ -4,7 +4,7 @@ import warnings
 import pytest
 from dagster._annotations import experimental
 from dagster._check import CheckError
-from dagster._utils.backcompat import (
+from dagster._utils.warnings import (
     normalize_renamed_param,
     suppress_dagster_warnings,
 )

--- a/python_modules/dagster/dagster_tests/test_annotations.py
+++ b/python_modules/dagster/dagster_tests/test_annotations.py
@@ -23,7 +23,7 @@ from dagster._annotations import (
     public,
 )
 from dagster._check import CheckError
-from dagster._utils.backcompat import ExperimentalWarning
+from dagster._utils.warnings import ExperimentalWarning
 from typing_extensions import Annotated
 
 from dagster_tests.general_tests.utils_tests.utils import assert_no_warnings

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/conftest.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/conftest.py
@@ -13,7 +13,7 @@ from dagster._core.storage.dagster_run import DagsterRun
 from dagster._core.test_utils import in_process_test_workspace, instance_for_test
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._core.workspace.context import WorkspaceRequestContext
-from dagster._utils.backcompat import disable_dagster_warnings
+from dagster._utils.warnings import disable_dagster_warnings
 
 from . import repo
 

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/conftest.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/conftest.py
@@ -1,5 +1,4 @@
 import json
-import warnings
 from collections import namedtuple
 from contextlib import contextmanager
 from typing import Any, Callable, ContextManager, Iterator, Mapping, Sequence
@@ -7,7 +6,6 @@ from typing import Any, Callable, ContextManager, Iterator, Mapping, Sequence
 import boto3
 import moto
 import pytest
-from dagster import ExperimentalWarning
 from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.host_representation.external import ExternalJob
 from dagster._core.instance import DagsterInstance
@@ -15,6 +13,7 @@ from dagster._core.storage.dagster_run import DagsterRun
 from dagster._core.test_utils import in_process_test_workspace, instance_for_test
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._core.workspace.context import WorkspaceRequestContext
+from dagster._utils.backcompat import disable_dagster_warnings
 
 from . import repo
 
@@ -22,9 +21,8 @@ Secret = namedtuple("Secret", ["name", "arn"])
 
 
 @pytest.fixture(autouse=True)
-def ignore_experimental_warning() -> Iterator[None]:
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", category=ExperimentalWarning)
+def ignore_dagster_warnings() -> Iterator[None]:
+    with disable_dagster_warnings():
         yield
 
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/__init__.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/__init__.py
@@ -58,7 +58,7 @@ import importlib
 from typing import TYPE_CHECKING, Any, Mapping, Sequence, Tuple
 
 from dagster._core.libraries import DagsterLibraryRegistry
-from dagster._utils.backcompat import deprecation_warning
+from dagster._utils.warnings import deprecation_warning
 from typing_extensions import Final
 
 DagsterLibraryRegistry.register("dagster-dbt", __version__)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
@@ -42,11 +42,11 @@ from dagster._core.definitions.events import (
 )
 from dagster._core.definitions.metadata import MetadataUserInput, RawMetadataValue
 from dagster._core.errors import DagsterInvalidSubsetError
-from dagster._utils.backcompat import (
+from dagster._utils.merger import deep_merge_dicts
+from dagster._utils.warnings import (
     deprecation_warning,
     normalize_renamed_param,
 )
-from dagster._utils.merger import deep_merge_dicts
 
 from dagster_dbt.asset_utils import (
     default_asset_key_fn,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -32,8 +32,8 @@ from dagster import (
     _check as check,
     define_asset_job,
 )
-from dagster._utils.backcompat import deprecation_warning
 from dagster._utils.merger import merge_dicts
+from dagster._utils.warnings import deprecation_warning
 
 from .utils import input_name_fn, output_name_fn
 

--- a/python_modules/libraries/dagster-managed-elements/dagster_managed_elements/cli.py
+++ b/python_modules/libraries/dagster-managed-elements/dagster_managed_elements/cli.py
@@ -7,7 +7,7 @@ from typing import Optional, Sequence
 
 import click
 import click_spinner
-from dagster._utils.backcompat import disable_dagster_warnings
+from dagster._utils.warnings import disable_dagster_warnings
 
 from dagster_managed_elements.types import ManagedElementDiff, ManagedElementReconciler
 

--- a/python_modules/libraries/dagster-managed-elements/dagster_managed_elements/cli.py
+++ b/python_modules/libraries/dagster-managed-elements/dagster_managed_elements/cli.py
@@ -2,13 +2,12 @@ import functools
 import importlib
 import logging
 import sys
-import warnings
 from types import ModuleType
 from typing import Optional, Sequence
 
 import click
 import click_spinner
-from dagster._utils.backcompat import ExperimentalWarning
+from dagster._utils.backcompat import disable_dagster_warnings
 
 from dagster_managed_elements.types import ManagedElementDiff, ManagedElementReconciler
 
@@ -35,8 +34,7 @@ def get_reconcilable_objects_from_module(
         sys.path.append(module_dir)
 
     try:
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=ExperimentalWarning)
+        with disable_dagster_warnings():
             current_level = logging.getLogger().level
             logging.getLogger().setLevel(logging.ERROR)
             module = importlib.import_module(module_str)

--- a/python_modules/libraries/dagster-msteams/dagster_msteams/hooks.py
+++ b/python_modules/libraries/dagster-msteams/dagster_msteams/hooks.py
@@ -3,7 +3,7 @@ from typing import Callable, Optional
 from dagster._annotations import deprecated_param
 from dagster._core.definitions import failure_hook, success_hook
 from dagster._core.execution.context.hook import HookContext
-from dagster._utils.backcompat import normalize_renamed_param
+from dagster._utils.warnings import normalize_renamed_param
 
 from dagster_msteams.card import Card
 

--- a/python_modules/libraries/dagster-msteams/dagster_msteams/sensors.py
+++ b/python_modules/libraries/dagster-msteams/dagster_msteams/sensors.py
@@ -8,7 +8,7 @@ from dagster._core.definitions.run_status_sensor_definition import (
     run_failure_sensor,
 )
 from dagster._core.definitions.unresolved_asset_job_definition import UnresolvedAssetJobDefinition
-from dagster._utils.backcompat import normalize_renamed_param
+from dagster._utils.warnings import normalize_renamed_param
 
 from dagster_msteams.card import Card
 from dagster_msteams.client import TeamsClient

--- a/python_modules/libraries/dagster-pagerduty/dagster_pagerduty/hooks.py
+++ b/python_modules/libraries/dagster-pagerduty/dagster_pagerduty/hooks.py
@@ -4,7 +4,7 @@ from dagster._annotations import deprecated_param
 from dagster._core.definitions import failure_hook
 from dagster._core.definitions.hook_definition import HookDefinition
 from dagster._core.execution.context.hook import HookContext
-from dagster._utils.backcompat import normalize_renamed_param
+from dagster._utils.warnings import normalize_renamed_param
 
 
 def _default_summary_fn(context: HookContext) -> str:

--- a/python_modules/libraries/dagster-pagerduty/dagster_pagerduty/resources.py
+++ b/python_modules/libraries/dagster-pagerduty/dagster_pagerduty/resources.py
@@ -4,7 +4,7 @@ import pypd
 from dagster import ConfigurableResource, resource
 from dagster._config.pythonic_config import infer_schema_from_config_class
 from dagster._core.definitions.resource_definition import dagster_maintained_resource
-from dagster._utils.backcompat import quiet_experimental_warnings
+from dagster._utils.backcompat import suppress_dagster_warnings
 from pydantic import Field as PyField
 
 
@@ -170,7 +170,7 @@ class PagerDutyService(ConfigurableResource):
     config_schema=infer_schema_from_config_class(PagerDutyService),
     description="""This resource is for posting events to PagerDuty.""",
 )
-@quiet_experimental_warnings
+@suppress_dagster_warnings
 def pagerduty_resource(context) -> PagerDutyService:
     """A resource for posting events (alerts) to PagerDuty.
 

--- a/python_modules/libraries/dagster-pagerduty/dagster_pagerduty/resources.py
+++ b/python_modules/libraries/dagster-pagerduty/dagster_pagerduty/resources.py
@@ -4,7 +4,7 @@ import pypd
 from dagster import ConfigurableResource, resource
 from dagster._config.pythonic_config import infer_schema_from_config_class
 from dagster._core.definitions.resource_definition import dagster_maintained_resource
-from dagster._utils.backcompat import suppress_dagster_warnings
+from dagster._utils.warnings import suppress_dagster_warnings
 from pydantic import Field as PyField
 
 

--- a/python_modules/libraries/dagster-slack/dagster_slack/hooks.py
+++ b/python_modules/libraries/dagster-slack/dagster_slack/hooks.py
@@ -3,7 +3,7 @@ from typing import Callable, Optional
 from dagster._annotations import deprecated_param
 from dagster._core.definitions import failure_hook, success_hook
 from dagster._core.execution.context.hook import HookContext
-from dagster._utils.backcompat import normalize_renamed_param
+from dagster._utils.warnings import normalize_renamed_param
 
 
 def _default_status_message(context: HookContext, status: str) -> str:

--- a/python_modules/libraries/dagster-slack/dagster_slack/sensors.py
+++ b/python_modules/libraries/dagster-slack/dagster_slack/sensors.py
@@ -24,7 +24,7 @@ from dagster._core.definitions.run_status_sensor_definition import (
     run_failure_sensor,
 )
 from dagster._core.definitions.unresolved_asset_job_definition import UnresolvedAssetJobDefinition
-from dagster._utils.backcompat import normalize_renamed_param
+from dagster._utils.warnings import normalize_renamed_param
 from slack_sdk.web.client import WebClient
 
 if TYPE_CHECKING:


### PR DESCRIPTION
## Summary & Motivation

- `quiet_experimental_warnings` has been renamed to `suppress_dagster_warnings` and it now suppresses `DeprecationWarning` as well.
- Implementation of `suppress_dagster_warnings` broken out into separate `disable_dagster_warnings` decorator, allowing access to this functionality outside a decorator-appropriate context.
- `dagster._utils.backcompat` module renamed to `dagster._utils.warnings`-- this is more accurate.
- Replace a variety of two-line (`warnings.catch_warnings(...):`, `warings.simplefliter(...)`) instances with `suppress_dagster_warnings`

## How I Tested These Changes

New unit tests