### PR TITLE
feat(dbt): use relative path for dbt project

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/app.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/app.py
@@ -66,6 +66,16 @@ def copy_scaffold(
         dbt_project_yaml: Dict[str, Any] = yaml.safe_load(fd)
         dbt_project_name: str = dbt_project_yaml["name"]
 
+    dbt_project_dir_relative_path = Path(
+        os.path.relpath(
+            dbt_project_dir,
+            start=dagster_project_dir.joinpath(project_name),
+        )
+    )
+    dbt_project_dir_relative_path_parts = [
+        f'"{part}"' for part in dbt_project_dir_relative_path.parts
+    ]
+
     env = Environment(loader=FileSystemLoader(dagster_project_dir))
 
     for path in dagster_project_dir.glob("**/*"):
@@ -75,7 +85,7 @@ def copy_scaffold(
             template_path = path.relative_to(dagster_project_dir).as_posix()
 
             env.get_template(template_path).stream(
-                dbt_project_dir=os.fspath(dbt_project_dir),
+                dbt_project_dir_relative_path_parts=dbt_project_dir_relative_path_parts,
                 dbt_project_name=dbt_project_name,
                 dbt_assets_name=f"{dbt_project_name}_dbt_assets",
                 project_name=project_name,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/include/scaffold/definitions.py.jinja
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/include/scaffold/definitions.py.jinja
@@ -1,10 +1,10 @@
+import os
 from pathlib import Path
 
 from dagster import Definitions, OpExecutionContext
-
 from dagster_dbt import DbtCli, dbt_assets
 
-dbt_project_dir = Path("{{ dbt_project_dir }}")
+dbt_project_dir = Path(__file__).parent.joinpath({{ dbt_project_dir_relative_path_parts | join(', ')}})
 dbt_manifest_path = dbt_project_dir.joinpath("target", "manifest.json")
 
 
@@ -26,7 +26,7 @@ defs = Definitions(
     schedules=schedules,
     resources={
         "dbt": DbtCli(
-            project_dir=dbt_project_dir.as_posix(),
+            project_dir=os.fspath(dbt_project_dir),
         ),
     },
 )


### PR DESCRIPTION
## Summary & Motivation
- Construct a reference to the dbt project using a relative path, rather than an absolute path. This is a nice change for build systems, where the absolute filesystem paths may change.
- Furthermore, don't assume a UNIX machine when constructing paths. Use `os.fspath` for constructing the string representation of the path, rather than `.as_posix()`.

## How I Tested These Changes
pytest

### Example
```bash
dagster ❯ dagster-dbt project scaffold --project-name test_project --dbt-project-dir ../dagster_dbt_tests/dbt_projects/test_dagster_metadata/
Running with dagster-dbt version: 1!0+dev.
Initializing Dagster project test_project in the current working directory for dbt project directory /Users/rexledesma/elementl/dagster/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_metadata
Your Dagster project has been initialized. To view your dbt project in Dagster, run the following commands:

 cd '/Users/rexledesma/elementl/dagster/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_metadata' \
   && dbt parse --target-path target \
   && cd '/Users/rexledesma/elementl/dagster/python_modules/libraries/dagster-dbt/dagster_dbt/test_project' \
   && dagster dev


~/elementl/dagster/python_modules/libraries/dagster-dbt/dagster_dbt rl/dbt-project-relative-path*
dagster ❯ cat test_project/test_project/definitions.py
───────┬──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
       │ File: test_project/test_project/definitions.py
───────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   1   │ import os
   2   │ from pathlib import Path
   3   │
   4   │ from dagster import Definitions, OpExecutionContext
   5   │ from dagster_dbt import DbtCli, dbt_assets
   6   │
   7   │ dbt_project_dir = Path(__file__).parent.joinpath("..", "..", "..", "dagster_dbt_tests", "dbt_projects", "test_dagster_metadata")
   8   │ dbt_manifest_path = dbt_project_dir.joinpath("target", "manifest.json")
   9   │
  10   │
  11   │ @dbt_assets(manifest=dbt_manifest_path)
  12   │ def test_dagster_metadata_dbt_assets(context: OpExecutionContext, dbt: DbtCli):
  13   │     yield from dbt.cli(["build"], context=context).stream()
  14   │
  15   │
  16   │ schedules = [
  17   │     test_dagster_metadata_dbt_assets.build_schedule_from_dbt_selection(
  18   │         job_name="materialize_dbt_models",
  19   │         cron_schedule="0 0 * * *",
  20   │         dbt_select="fqn:*",
  21   │     )
  22   │ ]
  23   │
  24   │ defs = Definitions(
  25   │     assets=[test_dagster_metadata_dbt_assets],
  26   │     schedules=schedules,
  27   │     resources={
  28   │         "dbt": DbtCli(
  29   │             project_dir=os.fspath(dbt_project_dir),
  30   │         ),
  31   │     },
  32   │ )
───────┴──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
```