### PR TITLE
feat(dbt): allow runtime compilation of manifest in Dagster scaffold

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/include/scaffold/definitions.py.jinja
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/include/scaffold/definitions.py.jinja
@@ -5,8 +5,16 @@ from dagster import Definitions, OpExecutionContext
 from dagster_dbt import DbtCliResource, dbt_assets
 
 dbt_project_dir = Path(__file__).parent.joinpath({{ dbt_project_dir_relative_path_parts | join(', ')}})
-dbt_manifest_path = dbt_project_dir.joinpath("target", "manifest.json")
+dbt = DbtCliResource(project_dir=os.fspath(dbt_project_dir))
 
+# If DAGSTER_DBT_PARSE_PROJECT_ON_LOAD is set, a manifest will be created at runtime.
+# Otherwise, we expect a manifest to be present in the project's target directory.
+if os.getenv("DAGSTER_DBT_PARSE_PROJECT_ON_LOAD"):
+    dbt_parse_invocation = dbt.cli([{{ dbt_parse_command | join(', ')}}], manifest={})
+    dbt_parse_invocation.wait()
+    dbt_manifest_path = dbt_parse_invocation.target_path.joinpath("manifest.json")
+else:
+    dbt_manifest_path = dbt_project_dir.joinpath("target", "manifest.json")
 
 @dbt_assets(manifest=dbt_manifest_path)
 def {{ dbt_assets_name }}(context: OpExecutionContext, dbt: DbtCliResource):
@@ -25,8 +33,6 @@ defs = Definitions(
     assets=[{{ dbt_assets_name }}],
     schedules=schedules,
     resources={
-        "dbt": DbtCliResource(
-            project_dir=os.fspath(dbt_project_dir),
-        ),
+        "dbt": dbt,
     },
 )


### PR DESCRIPTION
## Summary & Motivation
We essentially provide a workflow that emulates the behavior of `load_assets_from_dbt_project`. In this workflow, the dbt manifest is created at runtime, and is piped into `@dbt_assets`.

Users can invoke this flow when developing by doing:

```bash
DAGSTER_DBT_PARSE_PROJECT_ON_LOAD=1 dagster dev
```

## How I Tested These Changes
pytest, local
