### PR TITLE
[dagit] Add error catching around default-loading button state in launchpad

### DIFF
--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadSession.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadSession.tsx
@@ -262,12 +262,16 @@ const LaunchpadSession: React.FC<LaunchpadSessionProps> = (props) => {
     if (!runConfigSchema?.rootDefaultYaml) {
       return false;
     }
-    const defaultsYaml = yaml.parse(sanitizeConfigYamlString(runConfigSchema?.rootDefaultYaml));
+    try {
+      const defaultsYaml = yaml.parse(sanitizeConfigYamlString(runConfigSchema?.rootDefaultYaml));
 
-    const currentUserConfig = yaml.parse(sanitizeConfigYamlString(currentSession.runConfigYaml));
-    const updatedRunConfigData = merge(defaultsYaml, currentUserConfig);
+      const currentUserConfig = yaml.parse(sanitizeConfigYamlString(currentSession.runConfigYaml));
+      const updatedRunConfigData = merge(defaultsYaml, currentUserConfig);
 
-    return yaml.stringify(currentUserConfig) !== yaml.stringify(updatedRunConfigData);
+      return yaml.stringify(currentUserConfig) !== yaml.stringify(updatedRunConfigData);
+    } catch (err) {
+      return false;
+    }
   }, [currentSession.runConfigYaml, runConfigSchema?.rootDefaultYaml]);
 
   const onScaffoldMissingConfig = () => {


### PR DESCRIPTION
## Summary

This code would sometimes cause a frontend error if the YAML parse of the user's supplied YAML failed. Adds a try/catch to just default the button state to disabled if the user's yaml doesn't parse for whatever reason.
