### PR TITLE
[dagit] Frontload "ops" and "resources" keys when autoloading config

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_environment_schema.ambr
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_environment_schema.ambr
@@ -47,17 +47,17 @@
     'runConfigSchemaOrError': dict({
       '__typename': 'RunConfigSchema',
       'rootDefaultYaml': '''
-        execution:
-          config:
-            retries:
-              enabled: {}
-        loggers: {}
         ops:
           sum_op:
             inputs: {}
           sum_sq_op: {}
         resources:
           io_manager: {}
+        execution:
+          config:
+            retries:
+              enabled: {}
+        loggers: {}
   
       ''',
     }),

--- a/python_modules/dagster/dagster/_core/snap/snap_to_yaml.py
+++ b/python_modules/dagster/dagster/_core/snap/snap_to_yaml.py
@@ -12,6 +12,9 @@ def _safe_json_loads(json_str: Optional[str]) -> object:
         return None
 
 
+PRIORITY_CONFIG_KEYS = ("ops", "resources")
+
+
 def default_values_yaml_from_type_snap(
     snapshot: ConfigSchemaSnapshot,
     type_snap: ConfigTypeSnap,
@@ -25,7 +28,7 @@ def default_values_yaml_from_type_snap(
     # OrderedDicts
     run_config_dict_sorted: Mapping[str, Any] = dict(
         (k, run_config_dict.get(k))
-        for k in ["ops", "resources", *run_config_dict.keys()]
+        for k in [*PRIORITY_CONFIG_KEYS, *run_config_dict.keys()]
         if k in run_config_dict
     )
     return dump_run_config_yaml(run_config_dict_sorted, sort_keys=False)

--- a/python_modules/dagster/dagster/_utils/yaml_utils.py
+++ b/python_modules/dagster/dagster/_utils/yaml_utils.py
@@ -146,7 +146,11 @@ def load_run_config_yaml(yaml_str: str) -> Mapping[str, object]:
     return yaml.load(yaml_str, Loader=DagsterRunConfigYamlLoader)
 
 
-def dump_run_config_yaml(run_config: Mapping[str, Any]) -> str:
+def dump_run_config_yaml(run_config: Mapping[str, Any], sort_keys: bool = True) -> str:
     return yaml.dump(
-        run_config, Dumper=DagsterRunConfigYamlDumper, default_flow_style=False, allow_unicode=True
+        run_config,
+        Dumper=DagsterRunConfigYamlDumper,
+        default_flow_style=False,
+        allow_unicode=True,
+        sort_keys=sort_keys,
     )

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_snap_to_yaml.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_snap_to_yaml.py
@@ -69,17 +69,17 @@ def test_print_root() -> None:
     root_type = external_a_job.config_schema_snapshot.get_config_snap(root_config_key)
     assert (
         default_values_yaml_from_type_snap(external_a_job.config_schema_snapshot, root_type)
-        == """execution:
+        == """ops:
+  an_op: {}
+resources:
+  io_manager: {}
+execution:
   config:
     multiprocess:
       max_concurrent: 0
       retries:
         enabled: {}
 loggers: {}
-ops:
-  an_op: {}
-resources:
-  io_manager: {}
 """
     )
 
@@ -109,19 +109,19 @@ def test_print_root_op_config() -> None:
     root_type = external_a_job.config_schema_snapshot.get_config_snap(root_config_key)
     assert (
         default_values_yaml_from_type_snap(external_a_job.config_schema_snapshot, root_type)
-        == """execution:
+        == """ops:
+  an_op:
+    config:
+      a_str_with_default: foo
+resources:
+  io_manager: {}
+execution:
   config:
     multiprocess:
       max_concurrent: 0
       retries:
         enabled: {}
 loggers: {}
-ops:
-  an_op:
-    config:
-      a_str_with_default: foo
-resources:
-  io_manager: {}
 """
     )
 
@@ -153,14 +153,7 @@ def test_print_root_complex_op_config() -> None:
     root_type = external_a_job.config_schema_snapshot.get_config_snap(root_config_key)
     assert (
         default_values_yaml_from_type_snap(external_a_job.config_schema_snapshot, root_type)
-        == """execution:
-  config:
-    multiprocess:
-      max_concurrent: 0
-      retries:
-        enabled: {}
-loggers: {}
-ops:
+        == """ops:
   an_op:
     config:
       my_list:
@@ -170,5 +163,12 @@ ops:
         a_default_int: 1
 resources:
   io_manager: {}
+execution:
+  config:
+    multiprocess:
+      max_concurrent: 0
+      retries:
+        enabled: {}
+loggers: {}
 """
     )


### PR DESCRIPTION
## Summary

Reorder the autoloaded default config keys to put ops and resources at the top, since users most often would care about these.


## Test Plan

Tested locally.
