### PR TITLE
[dagit] Filter out empty entries in autoloaded default config

### DIFF
--- a/python_modules/dagster/dagster/_core/snap/snap_to_yaml.py
+++ b/python_modules/dagster/dagster/_core/snap/snap_to_yaml.py
@@ -15,12 +15,20 @@ def _safe_json_loads(json_str: Optional[str]) -> object:
 PRIORITY_CONFIG_KEYS = ("ops", "resources")
 
 
+def _filter_empty_dicts(to_filter: Any) -> Any:
+    if not isinstance(to_filter, Mapping):
+        return to_filter
+    else:
+        filtered_dict = {k: _filter_empty_dicts(v) for k, v in to_filter.items()}
+        return {k: v for k, v in filtered_dict.items() if v is not None and v != {}}
+
+
 def default_values_yaml_from_type_snap(
     snapshot: ConfigSchemaSnapshot,
     type_snap: ConfigTypeSnap,
 ) -> str:
     """Returns a YAML representation of the default values for the given type snap."""
-    run_config_dict = default_values_from_type_snap(type_snap, snapshot)
+    run_config_dict = _filter_empty_dicts(default_values_from_type_snap(type_snap, snapshot))
 
     # Sort the keys so that the output begins with the most useful keys (ops, resources)
     # We use a dict rather than an OrderedDict because in Py3.7+ the order of keys in a dict

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_snap_to_yaml.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_snap_to_yaml.py
@@ -69,17 +69,10 @@ def test_print_root() -> None:
     root_type = external_a_job.config_schema_snapshot.get_config_snap(root_config_key)
     assert (
         default_values_yaml_from_type_snap(external_a_job.config_schema_snapshot, root_type)
-        == """ops:
-  an_op: {}
-resources:
-  io_manager: {}
-execution:
+        == """execution:
   config:
     multiprocess:
       max_concurrent: 0
-      retries:
-        enabled: {}
-loggers: {}
 """
     )
 
@@ -113,15 +106,10 @@ def test_print_root_op_config() -> None:
   an_op:
     config:
       a_str_with_default: foo
-resources:
-  io_manager: {}
 execution:
   config:
     multiprocess:
       max_concurrent: 0
-      retries:
-        enabled: {}
-loggers: {}
 """
     )
 
@@ -161,14 +149,9 @@ def test_print_root_complex_op_config() -> None:
         foo: 1
       nested:
         a_default_int: 1
-resources:
-  io_manager: {}
 execution:
   config:
     multiprocess:
       max_concurrent: 0
-      retries:
-        enabled: {}
-loggers: {}
 """
     )


### PR DESCRIPTION
## Summary

Filters out empty dictionaries from the default config YAML presented to users on launchpad load, e.g.


**Before:**

```yaml
ops:
  my_op:
    config:
      my_string: foo
  my_other_op:
    config:
      my_other_string: bar
resources:
  io_manager: {}
execution:
  config:
    multiprocess:
      max_concurrent: 0
      retries:
        enabled: {}
loggers: {}
```

**After:**
```yaml
ops:
  my_op:
    config:
      my_string: foo
  my_other_op:
    config:
      my_other_string: bar
execution:
  config:
    multiprocess:
      max_concurrent: 0
```

## Test Plan

Updated tests.