### PR TITLE
Add partitions docstrings

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/multi_dimensional_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_dimensional_partitions.py
@@ -277,6 +277,17 @@ class MultiPartitionsDefinition(PartitionsDefinition[MultiPartitionKey]):
         current_time: Optional[datetime] = None,
         dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
     ) -> Sequence[MultiPartitionKey]:
+        """Sequence[MultiPartitionKey]: Returns a list of MultiPartitionKeys representing the
+        partition keys of the PartitionsDefinition.
+
+        Args:
+            current_time (Optional[datetime]): A datetime object representing the current time, only
+                applicable to time-based partition dimensions.
+            dynamic_partitions_store (Optional[DynamicPartitionsStore]): The DynamicPartitionsStore
+                object that is responsible for fetching dynamic partitions. Required when a
+                dimension is a DynamicPartitionsDefinition with a name defined. Users can pass the
+                DagsterInstance fetched via `context.instance` to this argument.
+        """
         partition_key_sequences = [
             partition_dim.partitions_def.get_partition_keys(
                 current_time=current_time, dynamic_partitions_store=dynamic_partitions_store

--- a/python_modules/dagster/dagster/_core/definitions/multi_dimensional_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_dimensional_partitions.py
@@ -277,8 +277,8 @@ class MultiPartitionsDefinition(PartitionsDefinition[MultiPartitionKey]):
         current_time: Optional[datetime] = None,
         dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
     ) -> Sequence[MultiPartitionKey]:
-        """Sequence[MultiPartitionKey]: Returns a list of MultiPartitionKeys representing the
-        partition keys of the PartitionsDefinition.
+        """Returns a list of MultiPartitionKeys representing the partition keys of the
+        PartitionsDefinition.
 
         Args:
             current_time (Optional[datetime]): A datetime object representing the current time, only
@@ -287,6 +287,9 @@ class MultiPartitionsDefinition(PartitionsDefinition[MultiPartitionKey]):
                 object that is responsible for fetching dynamic partitions. Required when a
                 dimension is a DynamicPartitionsDefinition with a name defined. Users can pass the
                 DagsterInstance fetched via `context.instance` to this argument.
+
+        Returns:
+            Sequence[MultiPartitionKey]
         """
         partition_key_sequences = [
             partition_dim.partitions_def.get_partition_keys(

--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -150,6 +150,17 @@ class PartitionsDefinition(ABC, Generic[T_str]):
         current_time: Optional[datetime] = None,
         dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
     ) -> Sequence[T_str]:
+        """Sequence[str]: Returns a list of strings representing the partition keys of the
+        PartitionsDefinition.
+
+        Args:
+            current_time (Optional[datetime]): A datetime object representing the current time, only
+                applicable to time-based partitions definitions.
+            dynamic_partitions_store (Optional[DynamicPartitionsStore]): The DynamicPartitionsStore
+                object that is responsible for fetching dynamic partitions. Required when the
+                partitions definition is a DynamicPartitionsDefinition with a name defined. Users
+                can pass the DagsterInstance fetched via `context.instance` to this argument.
+        """
         ...
 
     def __str__(self) -> str:
@@ -336,6 +347,17 @@ class StaticPartitionsDefinition(PartitionsDefinition[str]):
         current_time: Optional[datetime] = None,
         dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
     ) -> Sequence[str]:
+        """Sequence[str]: Returns a list of strings representing the partition keys of the
+        PartitionsDefinition.
+
+        Args:
+            current_time (Optional[datetime]): A datetime object representing the current time, only
+                applicable to time-based partitions definitions.
+            dynamic_partitions_store (Optional[DynamicPartitionsStore]): The DynamicPartitionsStore
+                object that is responsible for fetching dynamic partitions. Only applicable to
+                DynamicPartitionsDefinitions.
+
+        """
         return self._partition_keys
 
     def __hash__(self):
@@ -481,6 +503,17 @@ class DynamicPartitionsDefinition(
         current_time: Optional[datetime] = None,
         dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
     ) -> Sequence[str]:
+        """Sequence[str]: Returns a list of strings representing the partition keys of the
+        PartitionsDefinition.
+
+        Args:
+            current_time (Optional[datetime]): A datetime object representing the current time, only
+                applicable to time-based partitions definitions.
+            dynamic_partitions_store (Optional[DynamicPartitionsStore]): The DynamicPartitionsStore
+                object that is responsible for fetching dynamic partitions. Required when the
+                partitions definition is a DynamicPartitionsDefinition with a name defined. Users
+                can pass the DagsterInstance fetched via `context.instance` to this argument.
+        """
         if self.partition_fn:
             partitions = self.partition_fn(current_time)
             if all(isinstance(partition, Partition) for partition in partitions):
@@ -592,6 +625,8 @@ class PartitionedConfig(Generic[T_PartitionsDefinition]):
     def partitions_def(
         self,
     ) -> T_PartitionsDefinition:
+        """T_PartitionsDefinition: The partitions definition associated with this PartitionedConfig.
+        """
         return self._partitions
 
     @deprecated
@@ -600,6 +635,10 @@ class PartitionedConfig(Generic[T_PartitionsDefinition]):
     def run_config_for_partition_fn(
         self,
     ) -> Optional[Callable[[Partition], Mapping[str, Any]]]:
+        """Optional[Callable[[Partition], Mapping[str, Any]]]: A function that accepts a partition
+        and returns a dictionary representing the config to attach to runs for that partition.
+        Deprecated as of 1.3.3.
+        """
         return self._run_config_for_partition_fn
 
     @public
@@ -607,12 +646,18 @@ class PartitionedConfig(Generic[T_PartitionsDefinition]):
     def run_config_for_partition_key_fn(
         self,
     ) -> Optional[Callable[[str], Mapping[str, Any]]]:
-        return self._run_config_for_partition_key_fn
+        """Optional[Callable[[str], Mapping[str, Any]]]: A function that accepts a partition key
+        and returns a dictionary representing the config to attach to runs for that partition.
+        """
 
     @deprecated
     @public
     @property
     def tags_for_partition_fn(self) -> Optional[Callable[[Partition], Mapping[str, str]]]:
+        """Optional[Callable[[Partition], Mapping[str, str]]]: A function that
+        accepts a partition and returns a dictionary of tags to attach to runs for
+        that partition. Deprecated as of 1.3.3.
+        """
         return self._tags_for_partition_fn
 
     @public
@@ -620,10 +665,21 @@ class PartitionedConfig(Generic[T_PartitionsDefinition]):
     def tags_for_partition_key_fn(
         self,
     ) -> Optional[Callable[[str], Mapping[str, str]]]:
+        """Optional[Callable[[str], Mapping[str, str]]]: A function that
+        accepts a partition key and returns a dictionary of tags to attach to runs for
+        that partition.
+        """
         return self._tags_for_partition_key_fn
 
     @public
     def get_partition_keys(self, current_time: Optional[datetime] = None) -> Sequence[str]:
+        """Sequence[str]: A list of partition keys, representing the full set of partitions that
+        config can be applied to.
+
+        Args:
+            current_time (Optional[datetime]): A datetime object representing the current time. Only
+                applicable to time-based partitions definitions.
+        """
         return self.partitions_def.get_partition_keys(current_time)
 
     # Assumes partition key already validated

--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -150,8 +150,7 @@ class PartitionsDefinition(ABC, Generic[T_str]):
         current_time: Optional[datetime] = None,
         dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
     ) -> Sequence[T_str]:
-        """Sequence[str]: Returns a list of strings representing the partition keys of the
-        PartitionsDefinition.
+        """Returns a list of strings representing the partition keys of the PartitionsDefinition.
 
         Args:
             current_time (Optional[datetime]): A datetime object representing the current time, only
@@ -160,6 +159,9 @@ class PartitionsDefinition(ABC, Generic[T_str]):
                 object that is responsible for fetching dynamic partitions. Required when the
                 partitions definition is a DynamicPartitionsDefinition with a name defined. Users
                 can pass the DagsterInstance fetched via `context.instance` to this argument.
+
+        Returns:
+            Sequence[str]
         """
         ...
 
@@ -347,8 +349,7 @@ class StaticPartitionsDefinition(PartitionsDefinition[str]):
         current_time: Optional[datetime] = None,
         dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
     ) -> Sequence[str]:
-        """Sequence[str]: Returns a list of strings representing the partition keys of the
-        PartitionsDefinition.
+        """Returns a list of strings representing the partition keys of the PartitionsDefinition.
 
         Args:
             current_time (Optional[datetime]): A datetime object representing the current time, only
@@ -356,6 +357,9 @@ class StaticPartitionsDefinition(PartitionsDefinition[str]):
             dynamic_partitions_store (Optional[DynamicPartitionsStore]): The DynamicPartitionsStore
                 object that is responsible for fetching dynamic partitions. Only applicable to
                 DynamicPartitionsDefinitions.
+
+        Returns:
+            Sequence[str]
 
         """
         return self._partition_keys
@@ -503,7 +507,7 @@ class DynamicPartitionsDefinition(
         current_time: Optional[datetime] = None,
         dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
     ) -> Sequence[str]:
-        """Sequence[str]: Returns a list of strings representing the partition keys of the
+        """Returns a list of strings representing the partition keys of the
         PartitionsDefinition.
 
         Args:
@@ -513,6 +517,9 @@ class DynamicPartitionsDefinition(
                 object that is responsible for fetching dynamic partitions. Required when the
                 partitions definition is a DynamicPartitionsDefinition with a name defined. Users
                 can pass the DagsterInstance fetched via `context.instance` to this argument.
+
+        Returns:
+            Sequence[str]
         """
         if self.partition_fn:
             partitions = self.partition_fn(current_time)
@@ -673,12 +680,15 @@ class PartitionedConfig(Generic[T_PartitionsDefinition]):
 
     @public
     def get_partition_keys(self, current_time: Optional[datetime] = None) -> Sequence[str]:
-        """Sequence[str]: A list of partition keys, representing the full set of partitions that
+        """Returns a list of partition keys, representing the full set of partitions that
         config can be applied to.
 
         Args:
             current_time (Optional[datetime]): A datetime object representing the current time. Only
                 applicable to time-based partitions definitions.
+
+        Returns:
+            Sequence[str]
         """
         return self.partitions_def.get_partition_keys(current_time)
 

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -548,6 +548,9 @@ class TimeWindowPartitionsDefinition(
     @public
     @property
     def schedule_type(self) -> Optional[ScheduleType]:
+        """Optional[ScheduleType]: An enum representing the partition cadence (hourly, daily,
+        weekly, or monthly).
+        """
         if re.fullmatch(r"\d+ \* \* \* \*", self.cron_schedule):
             return ScheduleType.HOURLY
         elif re.fullmatch(r"\d+ \d+ \* \* \*", self.cron_schedule):
@@ -562,6 +565,10 @@ class TimeWindowPartitionsDefinition(
     @public
     @property
     def minute_offset(self) -> int:
+        """int: Number of minutes past the hour to "split" partitions. Defaults to 0.
+
+        For example, returns 15 if each partition starts at 15 minutes past the hour.
+        """
         match = re.fullmatch(r"(\d+) (\d+|\*) (\d+|\*) (\d+|\*) (\d+|\*)", self.cron_schedule)
         if match is None:
             check.failed(f"{self.cron_schedule} has no minute offset")
@@ -570,6 +577,10 @@ class TimeWindowPartitionsDefinition(
     @public
     @property
     def hour_offset(self) -> int:
+        """int: Number of hours past 00:00 to "split" partitions. Defaults to 0.
+
+        For example, returns 1 if each partition starts at 01:00.
+        """
         match = re.fullmatch(r"(\d+|\*) (\d+) (\d+|\*) (\d+|\*) (\d+|\*)", self.cron_schedule)
         if match is None:
             check.failed(f"{self.cron_schedule} has no hour offset")
@@ -578,6 +589,18 @@ class TimeWindowPartitionsDefinition(
     @public
     @property
     def day_offset(self) -> int:
+        """int: For a weekly or monthly partitions definition, returns the day to "split" partitions
+        by. Each partition will start on this day, and end before this day in the following
+        week/month. Returns 0 if the day_offset parameter is unset in the
+        WeeklyPartitionsDefinition, MonthlyPartitionsDefinition, or the provided cron schedule.
+
+        For weekly partitions, returns a value between 0 (representing Sunday) and 6 (representing
+        Saturday). Providing a value of 1 means that a partition will exist weekly from Monday to
+        the following Sunday.
+
+        For monthly partitions, returns a value between 0 (the first day of the month) and 31 (the
+        last possible day of the month).
+        """
         schedule_type = self.schedule_type
         if schedule_type == ScheduleType.WEEKLY:
             match = re.fullmatch(r"(\d+|\*) (\d+|\*) (\d+|\*) (\d+|\*) (\d+)", self.cron_schedule)


### PR DESCRIPTION
Adds docstrings for the following methods:
- PartitionedConfig.get_partition_keys
- PartitionedConfig.partitions_def
- PartitionedConfig.run_config_for_partition_fn
- PartitionedConfig.run_config_for_partition_key_fn
- PartitionedConfig.tags_for_partition_fn
- PartitionedConfig.tags_for_partition_key_fn
- PartitionsDefinition.get_partition_keys
- TimeWindowPartitionsDefinition.day_offset
- TimeWindowPartitionsDefinition.hour_offset
- TimeWindowPartitionsDefinition.minute_offset
- TimeWindowPartitionsDefinition.schedule_type
- StaticPartitionsDefinition.get_partition_keys
- MultiPartitionsDefinition.get_partition_keys
- DynamicPartitionsDefinition.get_partition_keys