### PR TITLE
Enable gRPC readiness probes by default

### DIFF
--- a/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
@@ -87,7 +87,16 @@ spec:
                 optional: true
             {{- end }}
           resources: {{ $deployment.resources | toYaml | nindent 12 }}
-        {{- if $deployment.readinessProbe }}
+        # Only disable readiness if explicitly set to false
+        {{- if not $deployment.readinessProbe }}
+          readinessProbe:
+            exec:
+              command: ["dagster", "api", "grpc-health-check", "-p", "{{ $deployment.port }}"]
+            periodSeconds: 20
+            timeoutSeconds: 3
+            successThreshold: 1
+            failureThreshold: 15
+        {{- else if ne $deployment.readinessProbe.enabled false }}
           {{- if not $deployment.readinessProbe.exec }}
           readinessProbe:
             exec:

--- a/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
@@ -93,7 +93,7 @@ spec:
             exec:
               command: ["dagster", "api", "grpc-health-check", "-p", "{{ $deployment.port }}"]
             periodSeconds: 20
-            timeoutSeconds: 3
+            timeoutSeconds: 10
             successThreshold: 1
             failureThreshold: 15
         {{- else if ne $deployment.readinessProbe.enabled false }}

--- a/helm/dagster/charts/dagster-user-deployments/values.schema.json
+++ b/helm/dagster/charts/dagster-user-deployments/values.schema.json
@@ -168,8 +168,8 @@
             "properties": {},
             "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.Probe"
         },
-        "ReadinessProbe": {
-            "title": "ReadinessProbe",
+        "ReadinessProbeWithEnabled": {
+            "title": "ReadinessProbeWithEnabled",
             "type": "object",
             "properties": {},
             "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.Probe"
@@ -286,7 +286,7 @@
                     "$ref": "#/definitions/LivenessProbe"
                 },
                 "readinessProbe": {
-                    "$ref": "#/definitions/ReadinessProbe"
+                    "$ref": "#/definitions/ReadinessProbeWithEnabled"
                 },
                 "startupProbe": {
                     "$ref": "#/definitions/StartupProbe"

--- a/helm/dagster/charts/dagster-user-deployments/values.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/values.yaml
@@ -120,6 +120,8 @@ deployments:
     # Readiness probe detects when the pod is ready to serve requests.
     # https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes
     readinessProbe:
+      # Readiness probes are enabled by default.
+      enabled: true
       # If `readinessProbe` has no `exec` field, then the following default will be used:
       # exec:
       #   command: ["dagster", "api", "grpc-health-check", "-p", "{{ $deployment.port }}"]

--- a/helm/dagster/schema/schema/charts/dagster_user_deployments/subschema/user_deployments.py
+++ b/helm/dagster/schema/schema/charts/dagster_user_deployments/subschema/user_deployments.py
@@ -1,12 +1,17 @@
 from typing import Dict, List, Optional, Union
 
-from pydantic import BaseModel
+from pydantic import BaseModel, create_model
 
 from ...utils import kubernetes
 
 
 class UserDeploymentIncludeConfigInLaunchedRuns(BaseModel):
     enabled: bool
+
+
+ReadinessProbeWithEnabled = create_model(
+    "ReadinessProbeWithEnabled", __base__=(kubernetes.ReadinessProbe), enabled=(bool)
+)
 
 
 class UserDeployment(BaseModel):
@@ -27,7 +32,7 @@ class UserDeployment(BaseModel):
     securityContext: Optional[kubernetes.SecurityContext]
     resources: Optional[kubernetes.Resources]
     livenessProbe: Optional[kubernetes.LivenessProbe]
-    readinessProbe: Optional[kubernetes.ReadinessProbe]
+    readinessProbe: Optional[ReadinessProbeWithEnabled]
     startupProbe: Optional[kubernetes.StartupProbe]
     labels: Optional[Dict[str, str]]
     volumeMounts: Optional[List[kubernetes.VolumeMount]]

--- a/helm/dagster/schema/schema_tests/test_user_deployments.py
+++ b/helm/dagster/schema/schema_tests/test_user_deployments.py
@@ -9,10 +9,10 @@ from kubernetes.client import models
 from schema.charts.dagster.subschema.global_ import Global
 from schema.charts.dagster.values import DagsterHelmValues
 from schema.charts.dagster_user_deployments.subschema.user_deployments import (
+    ReadinessProbeWithEnabled,
     UserDeployment,
     UserDeploymentIncludeConfigInLaunchedRuns,
     UserDeployments,
-    ReadinessProbeWithEnabled,
 )
 from schema.charts.dagster_user_deployments.values import DagsterUserDeploymentsHelmValues
 from schema.charts.utils import kubernetes
@@ -445,7 +445,7 @@ def test_readiness_probe_enabled_by_default(template: HelmTemplate):
         "-p",
         "3030",
     ]
-    assert container.readiness_probe.timeout_seconds == 3
+    assert container.readiness_probe.timeout_seconds == 10
 
 
 def test_readiness_probe_can_be_disabled(template: HelmTemplate):

--- a/helm/dagster/schema/schema_tests/test_user_deployments.py
+++ b/helm/dagster/schema/schema_tests/test_user_deployments.py
@@ -12,6 +12,7 @@ from schema.charts.dagster_user_deployments.subschema.user_deployments import (
     UserDeployment,
     UserDeploymentIncludeConfigInLaunchedRuns,
     UserDeployments,
+    ReadinessProbeWithEnabled,
 )
 from schema.charts.dagster_user_deployments.values import DagsterUserDeploymentsHelmValues
 from schema.charts.utils import kubernetes
@@ -421,9 +422,8 @@ def test_startup_probe_enabled(template: HelmTemplate, enabled: bool):
     assert (container.startup_probe is not None) == enabled
 
 
-def test_readiness_probes(template: HelmTemplate):
+def test_readiness_probe_enabled_by_default(template: HelmTemplate):
     deployment = create_simple_user_deployment("foo")
-    deployment.readinessProbe = kubernetes.ReadinessProbe.construct(timeout_seconds=3)
     helm_values = DagsterHelmValues.construct(
         dagsterUserDeployments=UserDeployments.construct(deployments=[deployment])
     )
@@ -438,6 +438,60 @@ def test_readiness_probes(template: HelmTemplate):
     assert container.startup_probe is None
     assert container.startup_probe is None
     assert container.readiness_probe is not None
+    assert container.readiness_probe._exec.command == [  # noqa: SLF001
+        "dagster",
+        "api",
+        "grpc-health-check",
+        "-p",
+        "3030",
+    ]
+    assert container.readiness_probe.timeout_seconds == 3
+
+
+def test_readiness_probe_can_be_disabled(template: HelmTemplate):
+    deployment = create_simple_user_deployment("foo")
+    deployment.readinessProbe = ReadinessProbeWithEnabled.construct(enabled=False)
+    helm_values = DagsterHelmValues.construct(
+        dagsterUserDeployments=UserDeployments.construct(deployments=[deployment])
+    )
+
+    dagster_user_deployment = template.render(helm_values)
+    assert len(dagster_user_deployment) == 1
+    dagster_user_deployment = dagster_user_deployment[0]
+
+    assert len(dagster_user_deployment.spec.template.spec.containers) == 1
+    container = dagster_user_deployment.spec.template.spec.containers[0]
+
+    assert container.startup_probe is None
+    assert container.startup_probe is None
+    assert container.readiness_probe is None
+
+
+def test_readiness_probe_can_be_customized(template: HelmTemplate):
+    deployment = create_simple_user_deployment("foo")
+    deployment.readinessProbe = ReadinessProbeWithEnabled.construct(timeoutSeconds=42)
+    helm_values = DagsterHelmValues.construct(
+        dagsterUserDeployments=UserDeployments.construct(deployments=[deployment])
+    )
+
+    dagster_user_deployment = template.render(helm_values)
+    assert len(dagster_user_deployment) == 1
+    dagster_user_deployment = dagster_user_deployment[0]
+
+    assert len(dagster_user_deployment.spec.template.spec.containers) == 1
+    container = dagster_user_deployment.spec.template.spec.containers[0]
+
+    assert container.startup_probe is None
+    assert container.startup_probe is None
+    assert container.readiness_probe is not None
+    assert container.readiness_probe._exec.command == [  # noqa: SLF001
+        "dagster",
+        "api",
+        "grpc-health-check",
+        "-p",
+        "3030",
+    ]
+    assert container.readiness_probe.timeout_seconds == 42
 
 
 def test_readiness_probes_subchart(subchart_template: HelmTemplate):

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -562,6 +562,12 @@
                 "enabled"
             ]
         },
+        "ReadinessProbeWithEnabled": {
+            "title": "ReadinessProbeWithEnabled",
+            "type": "object",
+            "properties": {},
+            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.Probe"
+        },
         "UserDeployment": {
             "title": "UserDeployment",
             "type": "object",
@@ -650,7 +656,7 @@
                     "$ref": "#/definitions/LivenessProbe"
                 },
                 "readinessProbe": {
-                    "$ref": "#/definitions/ReadinessProbe"
+                    "$ref": "#/definitions/ReadinessProbeWithEnabled"
                 },
                 "startupProbe": {
                     "$ref": "#/definitions/StartupProbe"

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -389,6 +389,8 @@ dagster-user-deployments:
       # Readiness probe detects when the pod is ready to serve requests.
       # https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes
       readinessProbe:
+        # Readiness probes are enabled by default.
+        enabled: true
         # If `readinessProbe` has no `exec` field, then the following default will be used:
         # exec:
         #   command: ["dagster", "api", "grpc-health-check", "-p", "{{ $deployment.port }}"]


### PR DESCRIPTION
Currently users don't have readiness probes on their grpc servers unless they explicitly opt in. Change this to opt out. Would be good timing if we get it in for 1.4, though I don't envision it causing issues. [We just bumped the timeout](https://github.com/dagster-io/dagster/pull/9073) from 3 seconds to 10 so it's very forgiving