### PR TITLE
Retry .watch() tests

### DIFF
--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -473,6 +473,8 @@ class TestEventLogStorage:
             for run in runs:
                 instance.delete_run(run)
 
+    # .watch() is async, there's a small chance they don't run before the asserts
+    @pytest.mark.flaky(reruns=1)
     def test_event_log_storage_watch(self, test_run_id, storage):
         if not self.can_watch():
             pytest.skip("storage cannot watch runs")
@@ -843,6 +845,8 @@ class TestEventLogStorage:
 
             assert set(map(lambda e: e.run_id, out_events_two)) == {result_two.run_id}
 
+    # .watch() is async, there's a small chance they don't run before the asserts
+    @pytest.mark.flaky(reruns=1)
     def test_event_watcher_single_run_event(self, storage, test_run_id):
         if not self.can_watch():
             pytest.skip("storage cannot watch runs")
@@ -862,6 +866,8 @@ class TestEventLogStorage:
         assert len(event_list) == len(events)
         assert all([isinstance(event, EventLogEntry) for event in event_list])
 
+    # .watch() is async, there's a small chance they don't run before the asserts
+    @pytest.mark.flaky(reruns=1)
     def test_event_watcher_filter_run_event(self, instance, storage):
         if not self.can_watch():
             pytest.skip("storage cannot watch runs")
@@ -889,6 +895,8 @@ class TestEventLogStorage:
             assert len(event_list) == len(events_two)
             assert all([isinstance(event, EventLogEntry) for event in event_list])
 
+    # .watch() is async, there's a small chance they don't run before the asserts
+    @pytest.mark.flaky(reruns=1)
     def test_event_watcher_filter_two_runs_event(self, storage, instance):
         if not self.can_watch():
             pytest.skip("storage cannot watch runs")
@@ -1466,6 +1474,8 @@ class TestEventLogStorage:
                     ),
                 )
 
+    # .watch() is async, there's a small chance they don't run before the asserts
+    @pytest.mark.flaky(reruns=1)
     def test_watch_exc_recovery(self, storage):
         if not self.can_watch():
             pytest.skip("storage cannot watch runs")


### PR DESCRIPTION
For flakes like https://buildkite.com/dagster/dagster/builds/61889#018964eb-68ce-48ff-a180-c632da10a2d6

At least for sqlite, .watch() is async (it uses a filewatcher). Every once in a while, we'll get to an assert before the event handler has run. We could:
- put time.sleeps in the tests
- retry and hope things pass, since they almost always do
- join the watcher somehow? I don't see a way to do this

Sprinkling sleeps around felt worse so I went with the latter, but it's not strongly held opinion