### PR TITLE
Missed readiness probe timeout setting

### DIFF
--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -393,7 +393,7 @@ dagster-user-deployments:
         # exec:
         #   command: ["dagster", "api", "grpc-health-check", "-p", "{{ $deployment.port }}"]
         periodSeconds: 20
-        timeoutSeconds: 3
+        timeoutSeconds: 10
         successThreshold: 1
         failureThreshold: 15  # Allow roughly 300 seconds to start up by default
 


### PR DESCRIPTION
https://github.com/dagster-io/dagster/pull/9073/files bumped the timeout for dagit and the grpc server in the subchart, but not the grpc server in the main chart