### PR TITLE
Update dagit -> dagster-webserver for helm server entry point

### DIFF
--- a/helm/dagster/templates/helpers/_helpers.tpl
+++ b/helm/dagster/templates/helpers/_helpers.tpl
@@ -41,7 +41,7 @@ If release name contains chart name it will be used as a full name.
 
 {{- define "dagster.dagit.dagitCommand" -}}
 {{- $userDeployments := index .Values "dagster-user-deployments" }}
-dagit -h 0.0.0.0 -p {{ .Values.dagit.service.port }}
+dagster-webserver -h 0.0.0.0 -p {{ .Values.dagit.service.port }}
 {{- if $userDeployments.enabled }} -w /dagster-workspace/workspace.yaml {{- end -}}
 {{- with .Values.dagit.dbStatementTimeout }} --db-statement-timeout {{ . }} {{- end -}}
 {{- with .Values.dagit.dbPoolRecycle }} --db-pool-recycle {{ . }} {{- end -}}


### PR DESCRIPTION
## Summary & Motivation

This PR changes the `dagster-helm` chart so that it launches `dagster-webserver` instead of `dagit`, thus not printing a deprecation warning.

The bulk of webserver renames are upstack at #15356 , the entry point change is separated into this PR so that it can be merged separately if necessary.

## How I Tested These Changes

Existing test suite.