### PR TITLE
test(dbt): add retries and identify slowest tests

### DIFF
--- a/python_modules/libraries/dagster-dbt/tox.ini
+++ b/python_modules/libraries/dagster-dbt/tox.ini
@@ -19,6 +19,6 @@ allowlist_externals =
   /bin/bash
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
-  dbt_13X: pytest -c ../../../pyproject.toml -vv {posargs}
-  dbt_14X: pytest -c ../../../pyproject.toml -vv {posargs}
-  dbt_15X: pytest -c ../../../pyproject.toml -vv {posargs}
+  dbt_13X: pytest --reruns 2 --durations 10 -c ../../../pyproject.toml -vv {posargs}
+  dbt_14X: pytest --reruns 2 --durations 10 -c ../../../pyproject.toml -vv {posargs}
+  dbt_15X: pytest --reruns 2 --durations 10 -c ../../../pyproject.toml -vv {posargs}


### PR DESCRIPTION
## Summary & Motivation
The `dagster-dbt` test suite has been consistently hitting 25 mins and has been having flakes.

We need to find a way to make it faster.

## How I Tested These Changes
bk
