### PR TITLE
refactor(dbt): rename `DbtCli` to `DbtCliResource`

### DIFF
--- a/docs/sphinx/sections/api/apidocs/libraries/dagster-dbt.rst
+++ b/docs/sphinx/sections/api/apidocs/libraries/dagster-dbt.rst
@@ -54,12 +54,10 @@ Resources (dbt Core)
 CLI Resource
 ------------
 
-.. autoclass:: DbtCli
+.. autoclass:: DbtCliResource
 
 Deprecated (dbt Core)
 -----------------------
-
-.. autoclass:: DbtCliResource
 
 .. autoclass:: DbtCliOutput
 

--- a/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/__init__.py
+++ b/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/__init__.py
@@ -1,5 +1,5 @@
 from dagster import Definitions
-from dagster_dbt import DbtCli
+from dagster_dbt import DbtCliResource
 
 from .assets.build import my_dbt_assets
 from .constants import DBT_PROJECT_DIR
@@ -11,7 +11,7 @@ defs = Definitions(
     schedules=[daily_dbt_assets_schedule, hourly_staging_dbt_assets],
     jobs=[my_dbt_job],
     resources={
-        "dbt": DbtCli(
+        "dbt": DbtCliResource(
             project_dir=DBT_PROJECT_DIR,
             global_config_flags=["--no-use-colors"],
             profile="jaffle_shop",

--- a/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/build.py
+++ b/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/build.py
@@ -1,9 +1,9 @@
 from dagster import OpExecutionContext
-from dagster_dbt import DbtCli, dbt_assets
+from dagster_dbt import DbtCliResource, dbt_assets
 
 from ..constants import MANIFEST_PATH
 
 
 @dbt_assets(manifest=MANIFEST_PATH)
-def my_dbt_assets(context: OpExecutionContext, dbt: DbtCli):
+def my_dbt_assets(context: OpExecutionContext, dbt: DbtCliResource):
     yield from dbt.cli(["build"], context=context).stream()

--- a/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/customize_asset_keys.py
+++ b/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/customize_asset_keys.py
@@ -1,7 +1,7 @@
 from typing import Any, Mapping
 
 from dagster import AssetKey, OpExecutionContext
-from dagster_dbt import DagsterDbtTranslator, DbtCli, dbt_assets
+from dagster_dbt import DagsterDbtTranslator, DbtCliResource, dbt_assets
 
 from ..constants import MANIFEST_PATH
 
@@ -13,5 +13,5 @@ class CustomDagsterDbtTranslator(DagsterDbtTranslator):
 
 
 @dbt_assets(manifest=MANIFEST_PATH, dagster_dbt_translator=CustomDagsterDbtTranslator())
-def my_dbt_assets(context: OpExecutionContext, dbt: DbtCli):
+def my_dbt_assets(context: OpExecutionContext, dbt: DbtCliResource):
     yield from dbt.cli(["build"], context=context).stream()

--- a/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/customize_description.py
+++ b/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/customize_description.py
@@ -1,7 +1,7 @@
 from typing import Any, Mapping
 
 from dagster import OpExecutionContext
-from dagster_dbt import DagsterDbtTranslator, DbtCli, dbt_assets
+from dagster_dbt import DagsterDbtTranslator, DbtCliResource, dbt_assets
 
 from ..constants import MANIFEST_PATH
 
@@ -23,5 +23,5 @@ class CustomDagsterDbtTranslator(DagsterDbtTranslator):
 
 
 @dbt_assets(manifest=MANIFEST_PATH, dagster_dbt_translator=CustomDagsterDbtTranslator())
-def my_dbt_assets(context: OpExecutionContext, dbt: DbtCli):
+def my_dbt_assets(context: OpExecutionContext, dbt: DbtCliResource):
     yield from dbt.cli(["build"], context=context).stream()

--- a/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/dependencies.py
+++ b/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/dependencies.py
@@ -2,13 +2,13 @@ from typing import Any
 
 import pandas as pd
 from dagster import AssetOut, OpExecutionContext, Output, asset, multi_asset
-from dagster_dbt import DbtCli, dbt_assets
+from dagster_dbt import DbtCliResource, dbt_assets
 
 from ..constants import MANIFEST_PATH
 
 
 @dbt_assets(manifest=MANIFEST_PATH)
-def my_dbt_assets(context: OpExecutionContext, dbt: DbtCli):
+def my_dbt_assets(context: OpExecutionContext, dbt: DbtCliResource):
     yield from dbt.cli(["build"], context=context).stream()
 
 

--- a/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/partitions.py
+++ b/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/partitions.py
@@ -1,7 +1,7 @@
 import json
 
 from dagster import DailyPartitionsDefinition, OpExecutionContext
-from dagster_dbt import DbtCli, dbt_assets
+from dagster_dbt import DbtCliResource, dbt_assets
 
 from ..constants import MANIFEST_PATH
 
@@ -9,7 +9,7 @@ DBT_SELECT_SEED = "resource_type:seed"
 
 
 @dbt_assets(manifest=MANIFEST_PATH, select=DBT_SELECT_SEED)
-def dbt_seed_assets(context: OpExecutionContext, dbt: DbtCli):
+def dbt_seed_assets(context: OpExecutionContext, dbt: DbtCliResource):
     yield from dbt.cli(["seed"], context=context).stream()
 
 
@@ -18,7 +18,7 @@ def dbt_seed_assets(context: OpExecutionContext, dbt: DbtCli):
     exclude=DBT_SELECT_SEED,
     partitions_def=DailyPartitionsDefinition(start_date="2023-05-01"),
 )
-def dbt_daily_assets(context: OpExecutionContext, dbt: DbtCli):
+def dbt_daily_assets(context: OpExecutionContext, dbt: DbtCliResource):
     dbt_vars = {"date": context.partition_key}
     dbt_args = ["run", "--vars", json.dumps(dbt_vars)]
 

--- a/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/runtime_metadata.py
+++ b/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/runtime_metadata.py
@@ -1,7 +1,7 @@
 import json
 
 from dagster import OpExecutionContext, Output
-from dagster_dbt import DbtCli, dbt_assets
+from dagster_dbt import DbtCliResource, dbt_assets
 from dateutil import parser
 
 from ..constants import MANIFEST_PATH
@@ -11,7 +11,7 @@ with MANIFEST_PATH.open() as f:
 
 
 @dbt_assets(manifest=manifest)
-def my_dbt_assets(context: OpExecutionContext, dbt: DbtCli):
+def my_dbt_assets(context: OpExecutionContext, dbt: DbtCliResource):
     for event in dbt.cli(["build"], context=context).stream_raw_events():
         for dagster_event in event.to_default_asset_events(manifest=manifest):
             if isinstance(dagster_event, Output):

--- a/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/seed_run_test.py
+++ b/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/seed_run_test.py
@@ -1,11 +1,11 @@
 from dagster import OpExecutionContext
-from dagster_dbt import DbtCli, dbt_assets
+from dagster_dbt import DbtCliResource, dbt_assets
 
 from ..constants import MANIFEST_PATH
 
 
 @dbt_assets(manifest=MANIFEST_PATH)
-def my_dbt_assets(context: OpExecutionContext, dbt: DbtCli):
+def my_dbt_assets(context: OpExecutionContext, dbt: DbtCliResource):
     dbt_commands = [
         ["seed"],
         ["run"],

--- a/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/separate_asset_defs.py
+++ b/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/separate_asset_defs.py
@@ -1,16 +1,16 @@
 from dagster import OpExecutionContext
-from dagster_dbt import DbtCli, dbt_assets
+from dagster_dbt import DbtCliResource, dbt_assets
 
 from ..constants import MANIFEST_PATH
 
 
 @dbt_assets(manifest=MANIFEST_PATH, select="resource_type:seed")
-def dbt_seed_assets(context: OpExecutionContext, dbt: DbtCli):
+def dbt_seed_assets(context: OpExecutionContext, dbt: DbtCliResource):
     yield from dbt.cli(["seed"], context=context).stream()
 
 
 @dbt_assets(manifest=MANIFEST_PATH, select="fqn:staging.*")
-def dbt_staging_assets(context: OpExecutionContext, dbt: DbtCli):
+def dbt_staging_assets(context: OpExecutionContext, dbt: DbtCliResource):
     dbt_commands = [
         ["run"],
         ["test"],
@@ -21,7 +21,7 @@ def dbt_staging_assets(context: OpExecutionContext, dbt: DbtCli):
 
 
 @dbt_assets(manifest=MANIFEST_PATH, select="fqn:customers fqn:orders")
-def my_dbt_assets(context: OpExecutionContext, dbt: DbtCli):
+def my_dbt_assets(context: OpExecutionContext, dbt: DbtCliResource):
     dbt_commands = [
         ["run"],
         ["test"],

--- a/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/use_artifacts.py
+++ b/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/assets/use_artifacts.py
@@ -2,13 +2,13 @@ import pprint
 import sys
 
 from dagster import OpExecutionContext
-from dagster_dbt import DbtCli, dbt_assets
+from dagster_dbt import DbtCliResource, dbt_assets
 
 from ..constants import MANIFEST_PATH
 
 
 @dbt_assets(manifest=MANIFEST_PATH)
-def my_dbt_assets(context: OpExecutionContext, dbt: DbtCli):
+def my_dbt_assets(context: OpExecutionContext, dbt: DbtCliResource):
     dbt_build = dbt.cli(["build"], context=context)
 
     yield from dbt_build.stream()

--- a/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/jobs/yield_materializations.py
+++ b/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/jobs/yield_materializations.py
@@ -1,7 +1,7 @@
 import json
 
 from dagster import AssetMaterialization, Output, job, op
-from dagster_dbt import DbtCli
+from dagster_dbt import DbtCliResource
 
 from ..constants import MANIFEST_PATH
 
@@ -10,7 +10,7 @@ with MANIFEST_PATH.open("r") as f:
 
 
 @op
-def my_dbt_build_op(dbt: DbtCli):
+def my_dbt_build_op(dbt: DbtCliResource):
     for dagster_event in dbt.cli(["build"], manifest=manifest).stream():
         if isinstance(dagster_event, Output):
             yield AssetMaterialization(

--- a/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/schedules/define_schedules.py
+++ b/examples/experimental/tutorial_dbt_dagster_v2/tutorial_dbt_dagster_v2/schedules/define_schedules.py
@@ -1,10 +1,10 @@
-from dagster_dbt import DbtCli, dbt_assets
+from dagster_dbt import DbtCliResource, dbt_assets
 
 from ..constants import MANIFEST_PATH
 
 
 @dbt_assets(manifest=MANIFEST_PATH)
-def all_dbt_assets(context, dbt: DbtCli):
+def all_dbt_assets(context, dbt: DbtCliResource):
     yield from dbt.cli(["build"], context=context).stream()
 
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/__init__.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/__init__.py
@@ -36,9 +36,9 @@ from .version import __version__ as __version__
 
 from .asset_decorator import dbt_assets as dbt_assets
 from .core import (
-    DbtCli as DbtCli,
     DbtCliEventMessage as DbtCliEventMessage,
     DbtCliInvocation as DbtCliInvocation,
+    DbtCliResource as DbtCliResource,
 )
 from .dagster_dbt_translator import (
     DagsterDbtTranslator as DagsterDbtTranslator,
@@ -71,7 +71,6 @@ if TYPE_CHECKING:
     from .core import (
         DbtCliClientResource as DbtCliClientResource,
         DbtCliOutput as DbtCliOutput,
-        DbtCliResource as DbtCliResource,
         dbt_cli_resource as dbt_cli_resource,
     )
     from .dbt_resource import DbtResource as DbtResource
@@ -99,23 +98,18 @@ _DEPRECATED: Final[Mapping[str, Tuple[str, str, str]]] = {
             (
                 "DbtCliClientResource",
                 "dagster_dbt.core",
-                "DbtCliClientResource is deprecated. Use DbtCli instead.",
+                "DbtCliClientResource is deprecated. Use DbtCliResource instead.",
             ),
             ("DbtCliOutput", "dagster_dbt.core", None),
             (
-                "DbtCliResource",
-                "dagster_dbt.core",
-                "DbtCliResource is deprecated. Use DbtCli instead.",
-            ),
-            (
                 "dbt_cli_resource",
                 "dagster_dbt.core",
-                "dbt_cli_resource is deprecated. Use DbtCli instead.",
+                "dbt_cli_resource is deprecated. Use DbtCliResource instead.",
             ),
             (
                 "DbtResource",
                 "dagster_dbt.dbt_resource",
-                "DbtResource is deprecated. Use DbtCli instead.",
+                "DbtResource is deprecated. Use DbtCliResource instead.",
             ),
             ("DagsterDbtCliFatalRuntimeError", "dagster_dbt.errors", None),
             ("DagsterDbtCliHandledRuntimeError", "dagster_dbt.errors", None),

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
@@ -74,10 +74,10 @@ def dbt_assets(
             from pathlib import Path
 
             from dagster import OpExecutionContext
-            from dagster_dbt import DbtCli, dbt_assets
+            from dagster_dbt import DbtCliResource, dbt_assets
 
             @dbt_assets(manifest=Path("target", "manifest.json"))
-            def my_dbt_assets(context: OpExecutionContext, dbt: DbtCli):
+            def my_dbt_assets(context: OpExecutionContext, dbt: DbtCliResource):
                 yield from dbt.cli(["build"], context=context).stream()
     """
     check.inst_param(manifest, "manifest", (Path, dict))

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/__init__.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/__init__.py
@@ -1,11 +1,10 @@
 from .resources import (
     DbtCliClientResource as DbtCliClientResource,
-    DbtCliResource as DbtCliResource,
     dbt_cli_resource as dbt_cli_resource,
 )
 from .resources_v2 import (
-    DbtCli as DbtCli,
     DbtCliEventMessage as DbtCliEventMessage,
     DbtCliInvocation as DbtCliInvocation,
+    DbtCliResource as DbtCliResource,
 )
 from .types import DbtCliOutput as DbtCliOutput

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources.py
@@ -5,7 +5,6 @@ from dagster import resource
 from dagster._annotations import public
 from dagster._config.pythonic_config import ConfigurableResource, IAttachDifferentObjectToOpContext
 from dagster._core.definitions.resource_definition import dagster_maintained_resource
-from dagster._utils.backcompat import deprecation_warning
 from dagster._utils.merger import merge_dicts
 from pydantic import Field
 
@@ -469,35 +468,6 @@ class DbtCliClient(DbtClient):
         return parse_manifest(project_dir, target_path)
 
 
-class DbtCliResource(DbtCliClient):
-    """Deprecated. Use `DbtCli` instead."""
-
-    def __init__(
-        self,
-        executable: str,
-        default_flags: Mapping[str, Any],
-        warn_error: bool,
-        ignore_handled_error: bool,
-        target_path: str,
-        logger: Optional[Any] = None,
-        docs_url: Optional[str] = None,
-        json_log_format: bool = True,
-        capture_logs: bool = True,
-        debug: bool = False,
-    ):
-        super().__init__(
-            default_flags=default_flags,
-            executable=executable,
-            warn_error=warn_error,
-            ignore_handled_error=ignore_handled_error,
-            target_path=target_path,
-            docs_url=docs_url,
-            json_log_format=json_log_format,
-            capture_logs=capture_logs,
-            debug=debug,
-        )
-
-
 class DbtCliClientResource(ConfigurableResourceWithCliFlags, IAttachDifferentObjectToOpContext):
     """Resource which issues dbt CLI commands against a configured dbt project."""
 
@@ -538,7 +508,6 @@ class DbtCliClientResource(ConfigurableResourceWithCliFlags, IAttachDifferentObj
 def dbt_cli_resource(context) -> DbtCliClient:
     """This resource issues dbt CLI commands against a configured dbt project."""
     # all config options that are intended to be used as flags for dbt commands
-    deprecation_warning("dbt_cli_resource", "1.5", "Use DbtCli instead.")
 
     default_flags = {
         k: v for k, v in context.resource_config.items() if k not in COMMON_OPTION_KEYS

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -204,12 +204,12 @@ class DbtCliInvocation:
             .. code-block:: python
 
                 import json
-                from dagster_dbt import DbtCli
+                from dagster_dbt import DbtCliResource
 
                 with open("path/to/manifest.json", "r") as f:
                     manifest = json.load(f)
 
-                dbt = DbtCli(project_dir="/path/to/dbt/project")
+                dbt = DbtCliResource(project_dir="/path/to/dbt/project")
 
                 dbt_cli_task = dbt.cli(["run"], manifest=manifest)
                 dbt_cli_task.wait()
@@ -226,12 +226,12 @@ class DbtCliInvocation:
             .. code-block:: python
 
                 import json
-                from dagster_dbt import DbtCli
+                from dagster_dbt import DbtCliResource
 
                 with open("path/to/manifest.json", "r") as f:
                     manifest = json.load(f)
 
-                dbt = DbtCli(project_dir="/path/to/dbt/project")
+                dbt = DbtCliResource(project_dir="/path/to/dbt/project")
 
                 dbt_cli_task = dbt.cli(["run"], manifest=manifest)
                 dbt_cli_task.wait()
@@ -253,10 +253,10 @@ class DbtCliInvocation:
             .. code-block:: python
 
                 from pathlib import Path
-                from dagster_dbt import DbtCli, dbt_assets
+                from dagster_dbt import DbtCliResource, dbt_assets
 
                 @dbt_assets(manifest=Path("target", "manifest.json"))
-                def my_dbt_assets(context, dbt: DbtCli):
+                def my_dbt_assets(context, dbt: DbtCliResource):
                     yield from dbt.cli(["run"], context=context).stream()
         """
         for event in self.stream_raw_events():
@@ -317,12 +317,12 @@ class DbtCliInvocation:
             .. code-block:: python
 
                 import json
-                from dagster_dbt import DbtCli
+                from dagster_dbt import DbtCliResource
 
                 with open("path/to/manifest.json", "r") as f:
                     manifest = json.load(f)
 
-                dbt = DbtCli(project_dir="/path/to/dbt/project")
+                dbt = DbtCliResource(project_dir="/path/to/dbt/project")
 
                 dbt_cli_task = dbt.cli(["run"], manifest=manifest)
                 dbt_cli_task.wait()
@@ -336,7 +336,7 @@ class DbtCliInvocation:
             return json.loads(handle.read())
 
 
-class DbtCli(ConfigurableResource):
+class DbtCliResource(ConfigurableResource):
     """A resource used to execute dbt CLI commands.
 
     Attributes:
@@ -356,9 +356,9 @@ class DbtCli(ConfigurableResource):
     Examples:
         .. code-block:: python
 
-            from dagster_dbt import DbtCli
+            from dagster_dbt import DbtCliResource
 
-            dbt = DbtCli(
+            dbt = DbtCliResource(
                 project_dir="/path/to/dbt/project",
                 global_config_flags=["--no-use-colors"],
                 profile="jaffle_shop",
@@ -444,10 +444,10 @@ class DbtCli(ConfigurableResource):
             .. code-block:: python
 
                 from pathlib import Path
-                from dagster_dbt import DbtCli, dbt_assets
+                from dagster_dbt import DbtCliResource, dbt_assets
 
                 @dbt_assets(manifest=Path("target", "manifest.json"))
-                def my_dbt_assets(context, dbt: DbtCli):
+                def my_dbt_assets(context, dbt: DbtCliResource):
                     yield from dbt.cli(["run"], context=context).stream()
         """
         target_path = self._get_unique_target_path(context=context)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/types.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/types.py
@@ -9,8 +9,8 @@ class DbtCliOutput(DbtOutput):
     """The results of executing a dbt command, along with additional metadata about the dbt CLI
     process that was run.
 
-    This class is deprecated, because it's only produced by methods of the DbtCliResource class,
-    which is deprecated in favor of DbtCli.
+    This class is deprecated, because it's only produced by methods of the DbtCliClientResource class,
+    which is deprecated in favor of DbtCliResource.
 
     Note that users should not construct instances of this class directly. This class is intended
     to be constructed from the JSON output of dbt commands.

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/include/scaffold/definitions.py.jinja
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/include/scaffold/definitions.py.jinja
@@ -2,14 +2,14 @@ import os
 from pathlib import Path
 
 from dagster import Definitions, OpExecutionContext
-from dagster_dbt import DbtCli, dbt_assets
+from dagster_dbt import DbtCliResource, dbt_assets
 
 dbt_project_dir = Path(__file__).parent.joinpath({{ dbt_project_dir_relative_path_parts | join(', ')}})
 dbt_manifest_path = dbt_project_dir.joinpath("target", "manifest.json")
 
 
 @dbt_assets(manifest=dbt_manifest_path)
-def {{ dbt_assets_name }}(context: OpExecutionContext, dbt: DbtCli):
+def {{ dbt_assets_name }}(context: OpExecutionContext, dbt: DbtCliResource):
     yield from dbt.cli(["build"], context=context).stream()
 
 
@@ -25,7 +25,7 @@ defs = Definitions(
     assets=[{{ dbt_assets_name }}],
     schedules=schedules,
     resources={
-        "dbt": DbtCli(
+        "dbt": DbtCliResource(
             project_dir=os.fspath(dbt_project_dir),
         ),
     },

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/conftest.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/conftest.py
@@ -4,7 +4,7 @@ import subprocess
 import dbt.version
 import pytest
 from dagster._utils import file_relative_path, pushd
-from dagster_dbt import DbtCli, DbtCliClientResource, dbt_cli_resource
+from dagster_dbt import DbtCliClientResource, DbtCliResource, dbt_cli_resource
 from packaging import version
 
 # ======= CONFIG ========
@@ -55,10 +55,10 @@ def dbt_python_config_dir():
         "legacy",
         "DbtCliClientResource",
         pytest.param(
-            "DbtCli",
+            "DbtCliResource",
             marks=pytest.mark.skipif(
                 version.parse(dbt.version.__version__) < version.parse("1.4.0"),
-                reason="DbtCli resource only supports dbt 1.4+",
+                reason="DbtCliResource only supports dbt 1.4+",
             ),
         ),
     ],
@@ -70,8 +70,8 @@ def dbt_cli_resource_factory(request):
             profiles_dir=kwargs.get("profiles_dir"),
             json_log_format=kwargs.get("json_log_format", True),
         )
-    elif request.param == "DbtCli":
-        return lambda **kwargs: DbtCli(
+    elif request.param == "DbtCliResource":
+        return lambda **kwargs: DbtCliResource(
             project_dir=kwargs["project_dir"], profile=kwargs.get("profile")
         )
     else:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_decorator.py
@@ -14,7 +14,7 @@ from dagster import (
 )
 from dagster._core.definitions.utils import DEFAULT_IO_MANAGER_KEY
 from dagster._core.errors import DagsterInvalidDefinitionError
-from dagster_dbt import DbtCli
+from dagster_dbt import DbtCliResource
 from dagster_dbt.asset_decorator import dbt_assets
 from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator
 
@@ -31,11 +31,11 @@ with open(test_dagster_metadata_manifest_path, "r") as f:
 
 def test_materialize(test_project_dir):
     @dbt_assets(manifest=manifest)
-    def all_dbt_assets(context, dbt: DbtCli):
+    def all_dbt_assets(context, dbt: DbtCliResource):
         yield from dbt.cli(["build"], context=context).stream()
 
     assert materialize(
-        [all_dbt_assets], resources={"dbt": DbtCli(project_dir=test_project_dir)}
+        [all_dbt_assets], resources={"dbt": DbtCliResource(project_dir=test_project_dir)}
     ).success
 
 


### PR DESCRIPTION
## Summary & Motivation
Follow the convention for naming Dagster resources by adding a `Resource` suffix to the existing `DbtCli` class. 

## How I Tested These Changes
bk
