### PR TITLE
have custom dbt metadata override default metadata instead of appending

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/asset_defs.py
@@ -45,10 +45,10 @@ from dagster_dbt.asset_utils import (
     default_description_fn,
     default_freshness_policy_fn,
     default_group_fn,
-    default_metadata_fn,
     get_asset_deps,
     get_deps,
 )
+from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator
 
 from ..errors import DagsterDbtCloudJobInvariantViolationError
 from ..utils import ASSET_RESOURCE_TYPES, result_to_events
@@ -337,6 +337,18 @@ class DbtCloudCacheableAssetsDefinition(CacheableAssetsDefinition):
         """Given all of the nodes and dependencies for a dbt Cloud job, build the cacheable
         representation that generate the asset definition for the job.
         """
+
+        class CustomDagsterDbtTranslator(DagsterDbtTranslator):
+            @classmethod
+            def get_asset_key(cls, dbt_resource_props):
+                return self._node_info_to_asset_key(dbt_resource_props)
+
+            @classmethod
+            def get_description(cls, dbt_resource_props):
+                # We shouldn't display the raw sql. Instead, inspect if dbt docs were generated,
+                # and attach metadata to link to the docs.
+                return default_description_fn(dbt_resource_props, display_raw_sql=False)
+
         (
             asset_deps,
             asset_ins,
@@ -349,19 +361,13 @@ class DbtCloudCacheableAssetsDefinition(CacheableAssetsDefinition):
         ) = get_asset_deps(
             dbt_nodes=dbt_nodes,
             deps=dbt_dependencies,
-            node_info_to_asset_key=self._node_info_to_asset_key,
             node_info_to_group_fn=self._node_info_to_group_fn,
             node_info_to_freshness_policy_fn=self._node_info_to_freshness_policy_fn,
             node_info_to_auto_materialize_policy_fn=self._node_info_to_auto_materialize_policy_fn,
-            # TODO: In the future, allow this function to be specified
-            node_info_to_definition_metadata_fn=default_metadata_fn,
             # TODO: In the future, allow the IO manager to be specified.
             io_manager_key=None,
-            # We shouldn't display the raw sql. Instead, inspect if dbt docs were generated,
-            # and attach metadata to link to the docs.
-            node_info_to_description_fn=lambda node_info: default_description_fn(
-                node_info, display_raw_sql=False
-            ),
+            dagster_dbt_translator=CustomDagsterDbtTranslator(),
+            manifest=None,
         )
 
         return AssetsDefinitionCacheableData(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
@@ -345,8 +345,6 @@ def test_custom_definition_metadata():
     with open(manifest_path, "r", encoding="utf8") as f:
         manifest_json = json.load(f)
 
-    dbt_assets_default = load_assets_from_dbt_manifest(manifest_json=manifest_json)
-
     dbt_assets_custom = load_assets_from_dbt_manifest(
         manifest_json=manifest_json,
         node_info_to_definition_metadata_fn=lambda node_info: {
@@ -355,16 +353,10 @@ def test_custom_definition_metadata():
         },
     )
 
-    has_some_schema = False
     for asset_key, custom_metadata in dbt_assets_custom[0].metadata_by_key.items():
-        default_metadata = dbt_assets_default[0].metadata_by_key[asset_key]
-        if custom_metadata.get("table_schema") is not None:
-            has_some_schema = True
-        assert custom_metadata.get("table_schema") == default_metadata.get("table_schema")
+        assert custom_metadata.get("table_schema") is None
         assert custom_metadata["foo_key"] == asset_key.path[-1]
         assert custom_metadata["bar_key"] == 1.0
-
-    assert has_some_schema
 
 
 def test_partitions(dbt_seed, dbt_cli_resource_factory, test_project_dir, dbt_config_dir):


### PR DESCRIPTION
## Summary & Motivation

This PR includes a minor refactor of how customization functions are passed through the dbt internals. We now construct a `DagsterDbtTranslator` instead of passing all the functions around as their own arguments.

## How I Tested These Changes
