### PR TITLE
allow ScheduleDefinition to target asset selection instead of job

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/schedule_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/schedule_decorator.py
@@ -24,6 +24,7 @@ from dagster._core.errors import (
 )
 from dagster._utils import ensure_gen
 
+from ..asset_selection import AssetSelection
 from ..run_request import RunRequest, SkipReason
 from ..schedule_definition import (
     DecoratedScheduleFunction,
@@ -56,6 +57,7 @@ def schedule(
     job: Optional[ExecutableDefinition] = None,
     default_status: DefaultScheduleStatus = DefaultScheduleStatus.STOPPED,
     required_resource_keys: Optional[Set[str]] = None,
+    asset_selection: Optional[AssetSelection] = None,
 ) -> Callable[[RawScheduleEvaluationFunction], ScheduleDefinition]:
     """Creates a schedule following the provided cron schedule and requests runs for the provided job.
 
@@ -98,6 +100,8 @@ def schedule(
         default_status (DefaultScheduleStatus): Whether the schedule starts as running or not. The default
             status can be overridden from the Dagster UI or via the GraphQL API.
         required_resource_keys (Optional[Set[str]]): The set of resource keys required by the schedule.
+        asset_selection (AssetSelection): (Experimental) an asset selection to launch a run for if
+            this schedule runs. This can be provided instead of specifying a job.
     """
 
     def inner(fn: RawScheduleEvaluationFunction) -> ScheduleDefinition:
@@ -182,6 +186,7 @@ def schedule(
             job=job,
             default_status=default_status,
             required_resource_keys=required_resource_keys,
+            asset_selection=asset_selection,
             run_config=None,  # cannot supply run_config or run_config_fn to decorator
             run_config_fn=None,
             tags=None,  # cannot supply tags or tags_fn to decorator

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data.py
@@ -482,7 +482,7 @@ class CachingRepositoryData(RepositoryData):
     def _validate_schedule(self, schedule: ScheduleDefinition) -> ScheduleDefinition:
         job_names = self.get_job_names()
 
-        if schedule.job_name not in job_names:
+        if not schedule.asset_selection and schedule.job_name not in job_names:
             raise DagsterInvalidDefinitionError(
                 f'ScheduleDefinition "{schedule.name}" targets job "{schedule.job_name}" '
                 "which was not found in this repository."

--- a/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
@@ -561,20 +561,12 @@ class ScheduleDefinition(IHasInternalInit):
         required_resource_keys: Optional[Set[str]] = None,
         asset_selection: Optional[AssetSelection] = None,
     ):
-        if (
-            sum(
-                [
-                    int(job is not None),
-                    int(job_name is not None),
-                    int(asset_selection is not None),
-                ]
-            )
-            > 1
-        ):
-            raise DagsterInvalidDefinitionError(
-                "Attempted to provide more than one of 'job', 'jobs', 'job_name', and "
-                "'asset_selection' params to SensorDefinition. Must provide only one."
-            )
+        if asset_selection:
+            if job is not None and job_name is not None:
+                raise DagsterInvalidDefinitionError(
+                    "Attempted to provide both asset_selection and job to ScheduleDefinition. Must "
+                    "provide only one."
+                )
 
         self._cron_schedule = check.inst_param(cron_schedule, "cron_schedule", (str, Sequence))
         if not isinstance(self._cron_schedule, str):


### PR DESCRIPTION
## Summary & Motivation
addresses https://github.com/dagster-io/dagster/issues/11997

this pr basically mirrors the sensor implementation in https://github.com/dagster-io/dagster/pull/10417

new apis:
class-based schedule definition:
```python
my_schedule = ScheduleDefinition(
    cron_schedule="* * * * *",
    asset_selection=AssetSelection.assets(asset1),
)
```

decorator-based:
```python
@schedule(asset_selection=AssetSelection.all(), cron_schedule="@daily")
def targets_asset_selection_decorator_schedule():
    return [
        RunRequest(run_key="A", asset_selection=[asset1.key]),
        RunRequest(run_key="B", asset_selection=[asset2.key]),
    ]
```
where run_request.asset_selection operates within the outer asset_selection scope (mirrors the sensor's behavior)

## How I Tested These Changes
unit test
dagit loads: https://www.loom.com/share/974055ee977d46fa87a8f3106ac5da22
