### PR TITLE
deprecate compute log manager

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/ref.py
+++ b/python_modules/dagster/dagster/_core/instance/ref.py
@@ -1,5 +1,7 @@
 import os
 from typing import TYPE_CHECKING, Any, Mapping, NamedTuple, Optional, Sequence, Type
+from dagster._core.storage.captured_log_manager import CapturedLogManager
+from dagster._utils.backcompat import deprecation_warning
 
 import yaml
 
@@ -527,7 +529,15 @@ class InstanceRef(
     def compute_log_manager(self) -> "ComputeLogManager":
         from dagster._core.storage.compute_log_manager import ComputeLogManager
 
-        return self.compute_logs_data.rehydrate(as_type=ComputeLogManager)
+        compute_log_manager = self.compute_logs_data.rehydrate(as_type=ComputeLogManager)
+        if not isinstance(compute_log_manager, CapturedLogManager):
+            deprecation_warning(
+                "The ComputeLogManager interface",
+                "1.5.0",
+                "It has been replaced by the CapturedLogManager interface.",
+            )
+
+        return compute_log_manager
 
     @property
     def scheduler(self) -> Optional["Scheduler"]:


### PR DESCRIPTION
## Summary & Motivation
For cleanliness... we could also choose to bump it further into the future (`2.0`?)

## How I Tested These Changes
BK