### PR TITLE
refactor(dbt): use `os.fspath` over `.as_posix()`

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/app.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/app.py
@@ -87,8 +87,8 @@ def copy_scaffold(
     for path in dagster_project_dir.glob("**/*"):
         if path.suffix == ".jinja":
             relative_path = path.relative_to(Path.cwd())
-            destination_path = relative_path.parent.joinpath(relative_path.stem).as_posix()
-            template_path = path.relative_to(dagster_project_dir).as_posix()
+            destination_path = os.fspath(relative_path.parent.joinpath(relative_path.stem))
+            template_path = os.fspath(path.relative_to(dagster_project_dir))
 
             env.get_template(template_path).stream(
                 dbt_project_dir_relative_path_parts=dbt_project_dir_relative_path_parts,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_app.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_app.py
@@ -1,4 +1,5 @@
 import importlib
+import os
 import shutil
 import subprocess
 import sys
@@ -45,7 +46,7 @@ def test_project_scaffold_command_with_precompiled_manifest(
             "--project-name",
             project_name,
             "--dbt-project-dir",
-            dbt_project_dir.as_posix(),
+            os.fspath(dbt_project_dir),
         ],
     )
 
@@ -61,7 +62,7 @@ def test_project_scaffold_command_with_precompiled_manifest(
     assert dbt_project_dir.joinpath("target", "manifest.json").exists()
 
     monkeypatch.chdir(tmp_path)
-    sys.path.append(tmp_path.as_posix())
+    sys.path.append(os.fspath(tmp_path))
 
     defs: Definitions = getattr(
         importlib.import_module(f"{project_name}.{project_name}.definitions"),
@@ -93,7 +94,7 @@ def test_project_scaffold_command_with_runtime_manifest(
             "--project-name",
             project_name,
             "--dbt-project-dir",
-            dbt_project_dir.as_posix(),
+            os.fspath(dbt_project_dir),
         ],
     )
 
@@ -106,7 +107,7 @@ def test_project_scaffold_command_with_runtime_manifest(
     assert not dbt_project_dir.joinpath("target", "manifest.json").exists()
 
     monkeypatch.chdir(tmp_path)
-    sys.path.append(tmp_path.as_posix())
+    sys.path.append(os.fspath(tmp_path))
 
     with pytest.raises(FileNotFoundError):
         getattr(
@@ -114,7 +115,7 @@ def test_project_scaffold_command_with_runtime_manifest(
             "defs",
         )
 
-    monkeypatch.setenv("DAGSTER_DBT_BUILD_PROJECT", "1")
+    monkeypatch.setenv("DAGSTER_DBT_PARSE_PROJECT_ON_LOAD", "1")
 
     defs: Definitions = getattr(
         importlib.import_module(f"{project_name}.{project_name}.definitions"),
@@ -146,7 +147,7 @@ def test_project_scaffold_command_on_invalid_dbt_project(
             "--project-name",
             "test_dagster_scaffold",
             "--dbt-project-dir",
-            tmp_path.as_posix(),
+            os.fspath(tmp_path),
         ],
     )
 


### PR DESCRIPTION
## Summary & Motivation
For windows compatability, don't assume `.as_posix()`. Let the string representation of the `Path` be determined using the operating system.

## How I Tested These Changes
bk
