### PR TITLE
Revert "Preserve run config on partition selection"

### DIFF
--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadSession.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadSession.tsx
@@ -480,7 +480,7 @@ const LaunchpadSession: React.FC<LaunchpadSessionProps> = (props) => {
           body: <PythonErrorInfo error={partition.runConfigOrError} />,
         });
       } else {
-        runConfigYaml = currentSession.runConfigYaml || partition.runConfigOrError.yaml;
+        runConfigYaml = partition.runConfigOrError.yaml;
       }
 
       const solidSelection = sessionSolidSelection || partition.solidSelection;


### PR DESCRIPTION
Reverts dagster-io/dagster#15198

Reverting due to default config preventing partition specific config from taking its place.