### PR TITLE
feat(dbt): allow `.wait()` to chain methods on `DbtCliInvocation`

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/include/scaffold/definitions.py.jinja
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/include/scaffold/definitions.py.jinja
@@ -10,8 +10,7 @@ dbt = DbtCliResource(project_dir=os.fspath(dbt_project_dir))
 # If DAGSTER_DBT_PARSE_PROJECT_ON_LOAD is set, a manifest will be created at runtime.
 # Otherwise, we expect a manifest to be present in the project's target directory.
 if os.getenv("DAGSTER_DBT_PARSE_PROJECT_ON_LOAD"):
-    dbt_parse_invocation = dbt.cli([{{ dbt_parse_command | join(', ')}}], manifest={})
-    dbt_parse_invocation.wait()
+    dbt_parse_invocation = dbt.cli([{{ dbt_parse_command | join(', ')}}], manifest={}).wait()
     dbt_manifest_path = dbt_parse_invocation.target_path.joinpath("manifest.json")
 else:
     dbt_manifest_path = dbt_project_dir.joinpath("target", "manifest.json")


### PR DESCRIPTION
## Summary & Motivation
JSON parsing can be expensive. For dbt CLI invocations that don't need access to the event stream, we provide a way to skip parsing and run the command to completion.

Sample usage:

```python
import json
from dagster_dbt import DbtCliResource

with open("path/to/manifest.json", "r") as f:
    manifest = json.load(f)

dbt = DbtCliResource(project_dir="/path/to/dbt/project")

dbt_cli_task = dbt.cli(["run"], manifest=manifest).wait()
```

## How I Tested These Changes
pytest