### PR TITLE
feat(dbt): use `orjson`

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
@@ -1,4 +1,3 @@
-import json
 from pathlib import Path
 from typing import (
     Any,
@@ -15,6 +14,7 @@ from typing import (
 )
 
 import dagster._check as check
+import orjson
 from dagster import (
     AssetKey,
     AssetOut,
@@ -81,8 +81,8 @@ def dbt_assets(
     """
     check.inst_param(manifest, "manifest", (Path, dict))
     if isinstance(manifest, Path):
-        with manifest.open("r") as handle:
-            manifest = cast(Mapping[str, Any], json.load(handle))
+        with manifest.open("rb") as handle:
+            manifest = cast(Mapping[str, Any], orjson.loads(handle.read()))
 
     unique_ids = select_unique_ids_from_manifest(
         select=select, exclude=exclude or "", manifest_json=manifest

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -1,4 +1,3 @@
-import json
 import os
 import shutil
 import subprocess
@@ -18,6 +17,7 @@ from typing import (
 )
 
 import dateutil.parser
+import orjson
 from dagster import (
     AssetObservation,
     AssetsDefinition,
@@ -62,7 +62,7 @@ class DbtCliEventMessage:
 
         We assume that the log format is json.
         """
-        raw_event: Dict[str, Any] = json.loads(log)
+        raw_event: Dict[str, Any] = orjson.loads(log)
 
         return cls(raw_event=raw_event)
 
@@ -326,7 +326,7 @@ class DbtCliInvocation:
         """
         artifact_path = self.target_path.joinpath(artifact)
         with artifact_path.open() as handle:
-            return json.loads(handle.read())
+            return orjson.loads(handle.read())
 
     def _raise_on_error(self) -> None:
         """Ensure that the dbt CLI process has completed. If the process has not successfully

--- a/python_modules/libraries/dagster-dbt/setup.py
+++ b/python_modules/libraries/dagster-dbt/setup.py
@@ -38,6 +38,7 @@ setup(
         "dbt-core<1.6",
         "Jinja2",
         "networkx",
+        "orjson",
         "requests",
         "rich",
         "typer",


### PR DESCRIPTION
## Summary & Motivation
Use a more efficient library for parsing json, `orjson`, when loading json from the raw dbt logs.

This is a backend detail, and this shouldn't affect the user, nor will they know about its existence. The user is free to choose between `json` and `orjson` as they please.

## How I Tested These Changes
bk
