### PR TITLE
[ui] Handle unparseable table metadata records

### DIFF
--- a/js_modules/dagit/packages/core/src/metadata/__tests__/TableMetadataEntryComponent.test.tsx
+++ b/js_modules/dagit/packages/core/src/metadata/__tests__/TableMetadataEntryComponent.test.tsx
@@ -1,0 +1,59 @@
+import {render, screen} from '@testing-library/react';
+import * as React from 'react';
+
+import {
+  buildTable,
+  buildTableColumn,
+  buildTableMetadataEntry,
+  buildTableSchema,
+} from '../../graphql/types';
+import {TableMetadataEntryComponent} from '../MetadataEntry';
+
+describe('TableMetadataEntryComponent', () => {
+  it('renders a metadata table for the supplied records', async () => {
+    const entry = buildTableMetadataEntry({
+      label: 'hello world',
+      description: 'describe world',
+      table: buildTable({
+        records: ['{"foo": 1, "bar": 2}'],
+        schema: buildTableSchema({
+          columns: [buildTableColumn({name: 'foo'}), buildTableColumn({name: 'bar'})],
+        }),
+      }),
+    });
+
+    render(<TableMetadataEntryComponent entry={entry} />);
+    const rows = await screen.findAllByRole('row');
+    expect(rows).toHaveLength(2);
+    const [headerRow, dataRow] = rows;
+    expect(headerRow!).toHaveTextContent(/foobar/i);
+    expect(dataRow!).toHaveTextContent(/12/i);
+  });
+
+  it('renders an unparseable row', async () => {
+    const entry = buildTableMetadataEntry({
+      label: 'hello world',
+      description: 'describe world',
+      table: buildTable({
+        records: ['{"foo": 1, "bar": 2}', '{"foo": NaN, "bar": NaN}'],
+        schema: buildTableSchema({
+          columns: [buildTableColumn({name: 'foo'}), buildTableColumn({name: 'bar'})],
+        }),
+      }),
+    });
+
+    render(<TableMetadataEntryComponent entry={entry} />);
+    const rows = await screen.findAllByRole('row');
+    expect(rows).toHaveLength(3);
+    const [headerRow, dataRow, invalidRow] = rows;
+
+    // Display parseable rows as expected
+    expect(headerRow!).toHaveTextContent(/foobar/i);
+    expect(dataRow!).toHaveTextContent(/12/i);
+
+    // Display unparseable text in a single stretched cell
+    expect(invalidRow!.childNodes).toHaveLength(1);
+    expect(invalidRow!).toHaveTextContent(/could not parse/i);
+    expect(invalidRow!).toHaveTextContent(/{"foo": NaN, "bar": …/i);
+  });
+});


### PR DESCRIPTION
## Summary & Motivation

Resolves #15290.

When a `TableMetadataEntry` has an unparseable record (e.g. a `NaN` value), we currently just crash the whole log section.

Instead, filter out the unparseable values and show them underneath the rendered table rows.

<img width="442" alt="Screenshot 2023-07-18 at 12 51 57 PM" src="https://github.com/dagster-io/dagster/assets/2823852/3744dcd9-f3ed-44ea-81ca-8333d2d77f18">

## How I Tested These Changes

Jest.

View http://localhost:3000/locations/table_metadata_repository@dagster_test.toys.repo/asset-groups/default/lineage/alpha, with `'oh no'` in the list of invalid records. Verify that it appears as a full-width row, with a tooltip for showing the full record value.
