### PR TITLE
fix(dbt): test scaffold using different project names

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_app.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_app.py
@@ -23,8 +23,8 @@ runner = CliRunner()
 def dbt_project_dir_fixture(tmp_path: Path) -> Path:
     dbt_project_dir = tmp_path.joinpath("test_dagster_metadata")
     shutil.copytree(
-        test_dagster_metadata_dbt_project_path,
-        tmp_path.joinpath("test_dagster_metadata"),
+        src=test_dagster_metadata_dbt_project_path,
+        dst=dbt_project_dir,
     )
 
     return dbt_project_dir
@@ -83,7 +83,7 @@ def test_project_scaffold_command_with_runtime_manifest(
 ) -> None:
     monkeypatch.chdir(tmp_path)
 
-    project_name = "test_dagster_scaffold"
+    project_name = "test_dagster_scaffold_runtime_manifest"
     dagster_project_dir = tmp_path.joinpath(project_name)
 
     result = runner.invoke(
@@ -110,6 +110,7 @@ def test_project_scaffold_command_with_runtime_manifest(
     sys.path.append(os.fspath(tmp_path))
 
     with pytest.raises(FileNotFoundError):
+        monkeypatch.delenv("DAGSTER_DBT_PARSE_PROJECT_ON_LOAD", raising=False)
         getattr(
             importlib.import_module(f"{project_name}.{project_name}.definitions"),
             "defs",
@@ -136,7 +137,7 @@ def test_project_scaffold_command_on_invalid_dbt_project(
 ) -> None:
     monkeypatch.chdir(tmp_path)
 
-    project_name = "test_dagster_scaffold"
+    project_name = "test_dagster_scaffold_invalid_dbt_project"
     dagster_project_dir = tmp_path.joinpath(project_name)
 
     result = runner.invoke(
@@ -145,7 +146,7 @@ def test_project_scaffold_command_on_invalid_dbt_project(
             "project",
             "scaffold",
             "--project-name",
-            "test_dagster_scaffold",
+            project_name,
             "--dbt-project-dir",
             os.fspath(tmp_path),
         ],


### PR DESCRIPTION
## Summary & Motivation
There was some odd interactions happening with our temporary directory fixture since we were reusing the same project name for scaffolding in the tests.

Circumvent that by using different project names.

## How I Tested These Changes
pytest
