### PR TITLE
[auto-materialize] Fix mapping from unpartitioned to time partitioned assets

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
@@ -409,6 +409,7 @@ def find_parent_materialized_asset_partitions(
     target_asset_keys_and_parents: AbstractSet[AssetKey],
     asset_graph: AssetGraph,
     can_reconcile_fn: Callable[[AssetKeyPartitionKey], bool] = lambda _: True,
+    map_old_time_partitions: bool = True,
 ) -> Tuple[AbstractSet[AssetKeyPartitionKey], Optional[int]]:
     """Finds asset partitions in the given selection whose parents have been materialized since
     latest_storage_id.
@@ -452,7 +453,8 @@ def find_parent_materialized_asset_partitions(
                     # when mapping from unpartitioned assets to time partitioned assets, we ignore
                     # historical time partitions
                     and (
-                        not isinstance(child_partitions_def, TimeWindowPartitionsDefinition)
+                        map_old_time_partitions
+                        or not isinstance(child_partitions_def, TimeWindowPartitionsDefinition)
                         or child.partition_key
                         == child_partitions_def.get_last_partition_key(
                             current_time=instance_queryer.evaluation_time
@@ -702,6 +704,7 @@ def determine_asset_partitions_to_auto_materialize(
         target_asset_keys_and_parents=target_asset_keys_and_parents,
         asset_graph=asset_graph,
         can_reconcile_fn=can_reconcile_candidate,
+        map_old_time_partitions=False,
     )
 
     def get_waiting_on_asset_keys(candidate: AssetKeyPartitionKey) -> FrozenSet[AssetKey]:

--- a/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
@@ -674,17 +674,6 @@ def determine_asset_partitions_to_auto_materialize(
             or candidate.asset_key not in target_asset_keys
             # must not be currently backfilled
             or candidate in instance_queryer.get_active_backfill_target_asset_graph_subset()
-            or (
-                # is not a root asset
-                candidate.asset_key not in asset_graph.root_asset_keys
-                # has a rate limit
-                and auto_materialize_policy.max_materializations_per_minute is not None
-                # would exceed the rate limit
-                and len(
-                    materialization_requests_by_asset_key[candidate.asset_key].union({candidate})
-                )
-                > auto_materialize_policy.max_materializations_per_minute
-            )
             # must not have invalid parent partitions
             or len(
                 asset_graph.get_parents_partitions(


### PR DESCRIPTION
## Summary & Motivation

This is a temporary fix for a perf regression caused by removing the time window partition scope minutes. In the specific case where an unpartitioned asset is upstream of a time partitioned assets, the general interpretation that we take is that this update is only relevant to the latest partition of the time partitioned asset. However, we don't currently represent this in the 

The net result is that the update to the unpartitioned upstream would result in us evaluating every single downstream, then creating a bunch of discard reasons for all of the partitions that we skipped (due to the rate limit). Beyond being slow, this would be confusing to a user who would not understand why those partitions would need to be discarded in the first place.

## How I Tested These Changes
