### PR TITLE
[fix] When loading config defaults for asset subselection, ensure scaffold button respects subset

### DIFF
--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadAllowedRoot.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadAllowedRoot.tsx
@@ -35,6 +35,7 @@ const filterDefaultYamlForSubselection = (defaultYaml: string, opNames: Set<stri
   const parsedYaml = yaml.parse(defaultYaml);
 
   const opsConfig = parsedYaml['ops'];
+  console.log(opNames);
   if (opsConfig) {
     const filteredOpKeys = Object.keys(opsConfig).filter((entry: any) => {
       return opNames.has(entry);

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadAllowedRoot.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadAllowedRoot.tsx
@@ -35,7 +35,6 @@ const filterDefaultYamlForSubselection = (defaultYaml: string, opNames: Set<stri
   const parsedYaml = yaml.parse(defaultYaml);
 
   const opsConfig = parsedYaml['ops'];
-  console.log(opNames);
   if (opsConfig) {
     const filteredOpKeys = Object.keys(opsConfig).filter((entry: any) => {
       return opNames.has(entry);

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadSession.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadSession.tsx
@@ -85,6 +85,7 @@ interface LaunchpadSessionProps {
   partitionSets: LaunchpadSessionPartitionSetsFragment;
   repoAddress: RepoAddress;
   initialExecutionSessionState?: Partial<IExecutionSession>;
+  rootDefaultYaml: string | undefined;
 }
 
 interface ILaunchpadSessionState {
@@ -172,6 +173,7 @@ const LaunchpadSession: React.FC<LaunchpadSessionProps> = (props) => {
     partitionSets,
     pipeline,
     repoAddress,
+    rootDefaultYaml,
   } = props;
 
   const client = useApolloClient();
@@ -259,11 +261,11 @@ const LaunchpadSession: React.FC<LaunchpadSessionProps> = (props) => {
     configSchemaOrError?.__typename === 'ModeNotFoundError' ? configSchemaOrError : undefined;
 
   const anyDefaultsToExpand = React.useMemo(() => {
-    if (!runConfigSchema?.rootDefaultYaml) {
+    if (!rootDefaultYaml) {
       return false;
     }
     try {
-      const defaultsYaml = yaml.parse(sanitizeConfigYamlString(runConfigSchema?.rootDefaultYaml));
+      const defaultsYaml = yaml.parse(sanitizeConfigYamlString(rootDefaultYaml));
 
       const currentUserConfig = yaml.parse(sanitizeConfigYamlString(currentSession.runConfigYaml));
       const updatedRunConfigData = merge(defaultsYaml, currentUserConfig);
@@ -272,7 +274,7 @@ const LaunchpadSession: React.FC<LaunchpadSessionProps> = (props) => {
     } catch (err) {
       return false;
     }
-  }, [currentSession.runConfigYaml, runConfigSchema?.rootDefaultYaml]);
+  }, [currentSession.runConfigYaml, rootDefaultYaml]);
 
   const onScaffoldMissingConfig = () => {
     const config = runConfigSchema ? scaffoldPipelineConfig(runConfigSchema) : {};
@@ -287,8 +289,8 @@ const LaunchpadSession: React.FC<LaunchpadSessionProps> = (props) => {
   };
 
   const onExpandDefaults = () => {
-    if (runConfigSchema?.rootDefaultYaml) {
-      const defaultsYaml = yaml.parse(sanitizeConfigYamlString(runConfigSchema?.rootDefaultYaml));
+    if (rootDefaultYaml) {
+      const defaultsYaml = yaml.parse(sanitizeConfigYamlString(rootDefaultYaml));
 
       const currentUserConfig = yaml.parse(sanitizeConfigYamlString(currentSession.runConfigYaml));
       const updatedRunConfigData = merge(defaultsYaml, currentUserConfig);

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadStoredSessionsContainer.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadStoredSessionsContainer.tsx
@@ -58,6 +58,7 @@ export const LaunchpadStoredSessionsContainer = (props: Props) => {
         pipeline={pipeline}
         partitionSets={partitionSets}
         repoAddress={repoAddress}
+        rootDefaultYaml={rootDefaultYaml}
       />
     </>
   );

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadTransientSessionContainer.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadTransientSessionContainer.tsx
@@ -62,6 +62,7 @@ export const LaunchpadTransientSessionContainer = (props: Props) => {
       pipeline={pipeline}
       partitionSets={partitionSets}
       repoAddress={repoAddress}
+      rootDefaultYaml={rootDefaultYaml}
     />
   );
 };


### PR DESCRIPTION
## Summary

When scaffolding default config for a subset of assets, we drop config for assets we are not materializing (#15227). As found in dogfooding today, this filtering is not carried over to the "scaffold default config values" button. This PR fixes this by passing down the filtered values.

## Test Plan

Tested locally.
