### PR TITLE
[fix] Ensure scaffold default config button ignores map ordering

### DIFF
--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadSession.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadSession.tsx
@@ -268,7 +268,10 @@ const LaunchpadSession: React.FC<LaunchpadSessionProps> = (props) => {
       const currentUserConfig = yaml.parse(sanitizeConfigYamlString(currentSession.runConfigYaml));
       const updatedRunConfigData = merge(defaultsYaml, currentUserConfig);
 
-      return yaml.stringify(currentUserConfig) !== yaml.stringify(updatedRunConfigData);
+      return (
+        yaml.stringify(currentUserConfig, {sortMapEntries: true}) !==
+        yaml.stringify(updatedRunConfigData, {sortMapEntries: true})
+      );
     } catch (err) {
       return false;
     }


### PR DESCRIPTION
## Summary

Ensures that the "scaffold default config" button ignores differences in map ordering when deciding if there are any defaults to be expanded or not.


## Test Plan

Tested locally.
