### PR TITLE
[ui] Fix issue rendering op graphs >50 nodes, weak worker TS types

### DIFF
--- a/js_modules/dagit/packages/core/src/app/Util.tsx
+++ b/js_modules/dagit/packages/core/src/app/Util.tsx
@@ -131,13 +131,13 @@ export function patchCopyToRemoveZeroWidthUnderscores() {
   });
 }
 
-export function asyncMemoize<T, R>(
-  fn: (arg: T, ...rest: any[]) => PromiseLike<R>,
+export function asyncMemoize<T, R, U extends (arg: T, ...rest: any[]) => PromiseLike<R>>(
+  fn: U,
   hashFn?: (arg: T, ...rest: any[]) => any,
   hashSize?: number,
-): (arg: T, ...rest: any[]) => Promise<R> {
+): U {
   const cache = new LRU(hashSize || 50);
-  return async (arg: T, ...rest: any[]) => {
+  return (async (arg: T, ...rest: any[]) => {
     const key = hashFn ? hashFn(arg, ...rest) : arg;
     if (cache.has(key)) {
       return Promise.resolve(cache.get(key) as R);
@@ -145,7 +145,7 @@ export function asyncMemoize<T, R>(
     const r = (await fn(arg, ...rest)) as R;
     cache.set(key, r);
     return r;
-  };
+  }) as any;
 }
 
 // Simple memoization function for methods that take a single object argument.

--- a/js_modules/dagit/packages/core/src/graph/asyncGraphLayout.ts
+++ b/js_modules/dagit/packages/core/src/graph/asyncGraphLayout.ts
@@ -110,7 +110,7 @@ export function useOpLayout(ops: ILayoutOp[], parentOp?: ILayoutOp) {
   React.useEffect(() => {
     async function runAsyncLayout() {
       dispatch({type: 'loading'});
-      const layout = await asyncGetFullOpLayout(ops, parentOp, staticPathRoot);
+      const layout = await asyncGetFullOpLayout(ops, {parentOp}, staticPathRoot);
       dispatch({
         type: 'layout',
         payload: {layout, cacheKey},


### PR DESCRIPTION
## Summary & Motivation

This is a fairly urgent fix for https://github.com/dagster-io/dagster/issues/15353

The `{}` wrapping the options on the async version of this function call got missed because our async memoize method was loosely typed and gave all the parameters the type. This PR fixes the invocation, and also updates the types on this method so that this is type checked.

This went unnoticed because seeing this locally requires having an op graph with more than 50 nodes, or changing `ASYNC_LAYOUT_SOLID_COUNT` to a very small number.

## How I Tested These Changes

I set `ASYNC_LAYOUT_SOLID_COUNT` to a very low number causing the web worker to be used.