### PR TITLE
Filter out default executor config when splatting defaults

### DIFF
--- a/python_modules/dagster/dagster/_core/snap/snap_to_yaml.py
+++ b/python_modules/dagster/dagster/_core/snap/snap_to_yaml.py
@@ -27,17 +27,23 @@ def _cleanup_run_config_dict(run_config_dict: Any) -> Any:
     """Performs cleanup of the run config dict to remove empty dicts and strip the default executor
     config if it has not been overridden, to make the output more readable.
     """
-    filtered_dict = _filter_empty_dicts(run_config_dict)
-
     # We manually strip the default executor config because
     # the max_concurrent default value is a sentinel and can be confusing
-    # if presented to the user
-    if filtered_dict.get("execution") == {
-        "config": {"multiprocess": {"max_concurrent": 0}},
-    }:
-        del filtered_dict["execution"]
+    # if presented to the user:
+    # execution:
+    #   config:
+    #     multiprocess:
+    #       max_concurrent: 0
+    if (
+        run_config_dict.get("execution", {})
+        .get("config", {})
+        .get("multiprocess", {})
+        .get("max_concurrent", None)
+        == 0
+    ):
+        del run_config_dict["execution"]["config"]["multiprocess"]["max_concurrent"]
 
-    return filtered_dict
+    return _filter_empty_dicts(run_config_dict)
 
 
 def default_values_yaml_from_type_snap(

--- a/python_modules/dagster/dagster/_core/snap/snap_to_yaml.py
+++ b/python_modules/dagster/dagster/_core/snap/snap_to_yaml.py
@@ -23,12 +23,29 @@ def _filter_empty_dicts(to_filter: Any) -> Any:
         return {k: v for k, v in filtered_dict.items() if v is not None and v != {}}
 
 
+def _cleanup_run_config_dict(run_config_dict: Any) -> Any:
+    """Performs cleanup of the run config dict to remove empty dicts and strip the default executor
+    config if it has not been overridden, to make the output more readable.
+    """
+    filtered_dict = _filter_empty_dicts(run_config_dict)
+
+    # We manually strip the default executor config because
+    # the max_concurrent default value is a sentinel and can be confusing
+    # if presented to the user
+    if filtered_dict.get("execution") == {
+        "config": {"multiprocess": {"max_concurrent": 0}},
+    }:
+        del filtered_dict["execution"]
+
+    return filtered_dict
+
+
 def default_values_yaml_from_type_snap(
     snapshot: ConfigSchemaSnapshot,
     type_snap: ConfigTypeSnap,
 ) -> str:
     """Returns a YAML representation of the default values for the given type snap."""
-    run_config_dict = _filter_empty_dicts(default_values_from_type_snap(type_snap, snapshot))
+    run_config_dict = _cleanup_run_config_dict(default_values_from_type_snap(type_snap, snapshot))
 
     # Sort the keys so that the output begins with the most useful keys (ops, resources)
     # We use a dict rather than an OrderedDict because in Py3.7+ the order of keys in a dict

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_snap_to_yaml.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_snap_to_yaml.py
@@ -69,11 +69,7 @@ def test_print_root() -> None:
     root_type = external_a_job.config_schema_snapshot.get_config_snap(root_config_key)
     assert (
         default_values_yaml_from_type_snap(external_a_job.config_schema_snapshot, root_type)
-        == """execution:
-  config:
-    multiprocess:
-      max_concurrent: 0
-"""
+        == "{}\n"
     )
 
 
@@ -106,10 +102,6 @@ def test_print_root_op_config() -> None:
   an_op:
     config:
       a_str_with_default: foo
-execution:
-  config:
-    multiprocess:
-      max_concurrent: 0
 """
     )
 
@@ -149,9 +141,5 @@ def test_print_root_complex_op_config() -> None:
         foo: 1
       nested:
         a_default_int: 1
-execution:
-  config:
-    multiprocess:
-      max_concurrent: 0
 """
     )


### PR DESCRIPTION
## Summary

Special case the default multi-process executor config when splatting out run config yaml, since it can be confusing for users:

```yaml
execution:
  config:
    multiprocess:
      max_concurrent: 0
```

Here, `max_concurrent: 0` is a sentinel value that adjusts concurrency to match the number of cores on the executing machine. The value of including this entry in the default config is lower than ops/resources since most users won't need to touch it - it's more liable to cause confusion.

## Test Plan

Update unit tests.