### PR TITLE
Add `config` argument to graph_asset

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -896,12 +896,12 @@ def graph_asset(
             partition_mappings=partition_mappings if partition_mappings else None,
             group_name=group_name,
             metadata_by_output_name={"result": metadata} if metadata else None,
-            freshness_policies_by_output_name={"result": freshness_policy}
-            if freshness_policy
-            else None,
-            auto_materialize_policies_by_output_name={"result": auto_materialize_policy}
-            if auto_materialize_policy
-            else None,
+            freshness_policies_by_output_name=(
+                {"result": freshness_policy} if freshness_policy else None
+            ),
+            auto_materialize_policies_by_output_name=(
+                {"result": auto_materialize_policy} if auto_materialize_policy else None
+            ),
             backfill_policy=backfill_policy,
             descriptions_by_output_name={"result": description} if description else None,
             resource_defs=resource_defs,

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -21,6 +21,7 @@ from dagster._builtins import Nothing
 from dagster._config import UserConfigSchema
 from dagster._core.decorator_utils import get_function_params, get_valid_name_permutations
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
+from dagster._core.definitions.config import ConfigMapping
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
 from dagster._core.definitions.metadata import ArbitraryMetadataMapping, MetadataUserInput
 from dagster._core.definitions.resource_annotation import (
@@ -754,7 +755,9 @@ def build_asset_ins(
 
 
 @overload
-def graph_asset(compose_fn: Callable) -> AssetsDefinition:
+def graph_asset(
+    compose_fn: Callable,
+) -> AssetsDefinition:
     ...
 
 
@@ -762,15 +765,17 @@ def graph_asset(compose_fn: Callable) -> AssetsDefinition:
 def graph_asset(
     *,
     name: Optional[str] = None,
-    key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
-    ins: Optional[Mapping[str, AssetIn]] = None,
     description: Optional[str] = None,
-    partitions_def: Optional[PartitionsDefinition] = None,
+    ins: Optional[Mapping[str, AssetIn]] = None,
+    config: Optional[Union[ConfigMapping, Mapping[str, Any]]] = None,
+    key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
     group_name: Optional[str] = None,
+    partitions_def: Optional[PartitionsDefinition] = None,
     metadata: Optional[MetadataUserInput] = ...,
     freshness_policy: Optional[FreshnessPolicy] = ...,
     auto_materialize_policy: Optional[AutoMaterializePolicy] = ...,
     backfill_policy: Optional[BackfillPolicy] = ...,
+    resource_defs: Optional[Mapping[str, ResourceDefinition]] = ...,
 ) -> Callable[[Callable[..., Any]], AssetsDefinition]:
     ...
 
@@ -779,11 +784,12 @@ def graph_asset(
     compose_fn: Optional[Callable] = None,
     *,
     name: Optional[str] = None,
-    key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
-    ins: Optional[Mapping[str, AssetIn]] = None,
     description: Optional[str] = None,
-    partitions_def: Optional[PartitionsDefinition] = None,
+    ins: Optional[Mapping[str, AssetIn]] = None,
+    config: Optional[Union[ConfigMapping, Mapping[str, Any]]] = None,
+    key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
     group_name: Optional[str] = None,
+    partitions_def: Optional[PartitionsDefinition] = None,
     metadata: Optional[MetadataUserInput] = None,
     freshness_policy: Optional[FreshnessPolicy] = None,
     auto_materialize_policy: Optional[AutoMaterializePolicy] = None,
@@ -799,16 +805,32 @@ def graph_asset(
         name (Optional[str]): The name of the asset.  If not provided, defaults to the name of the
             decorated function. The asset's name must be a valid name in Dagster (ie only contains
             letters, numbers, and underscores) and may not contain Python reserved keywords.
+        description (Optional[str]):
+            A human-readable description of the asset.
+        ins (Optional[Mapping[str, AssetIn]]): A dictionary that maps input names to information
+            about the input.
+        config (Optional[Union[ConfigMapping], Mapping[str, Any]):
+            Describes how the graph underlying the asset is configured at runtime.
+
+            If a :py:class:`ConfigMapping` object is provided, then the graph takes on the config
+            schema of this object. The mapping will be applied at runtime to generate the config for
+            the graph's constituent nodes.
+
+            If a dictionary is provided, then it will be used as the default run config for the
+            graph. This means it must conform to the config schema of the underlying nodes. Note
+            that the values provided will be viewable and editable in the Dagster UI, so be careful
+            with secrets. its constituent nodes.
+
+            If no value is provided, then the config schema for the graph is the default (derived
+            from the underlying nodes).
         key_prefix (Optional[Union[str, Sequence[str]]]): If provided, the asset's key is the
             concatenation of the key_prefix and the asset's name, which defaults to the name of
             the decorated function. Each item in key_prefix must be a valid name in Dagster (ie only
             contains letters, numbers, and underscores) and may not contain Python reserved keywords.
-        ins (Optional[Mapping[str, AssetIn]]): A dictionary that maps input names to information
-            about the input.
-        partitions_def (Optional[PartitionsDefinition]): Defines the set of partition keys that
-            compose the asset.
         group_name (Optional[str]): A string name used to organize multiple assets into groups. If
             not provided, the name "default" is used.
+        partitions_def (Optional[PartitionsDefinition]): Defines the set of partition keys that
+            compose the asset.
         metadata (Optional[MetadataUserInput]): Dictionary of metadata to be associated with
             the asset.
         freshness_policy (Optional[FreshnessPolicy]): A constraint telling Dagster how often this asset is
@@ -832,91 +854,57 @@ def graph_asset(
             def slack_files_table():
                 return store_files(fetch_files_from_slack())
     """
-    if compose_fn is not None:
-        return _GraphBackedAsset()(compose_fn)
-
-    def inner(fn: Callable[..., Any]) -> AssetsDefinition:
-        return _GraphBackedAsset(
-            name=cast(Optional[str], name),  # (mypy bug that it can't infer name is Optional[str])
-            key_prefix=key_prefix,
-            ins=ins,
+    if compose_fn is None:
+        return lambda fn: graph_asset(  # type: ignore  # (decorator pattern)
+            fn,
+            name=name,
             description=description,
-            partitions_def=partitions_def,
+            ins=ins,
+            config=config,
+            key_prefix=key_prefix,
             group_name=group_name,
+            partitions_def=partitions_def,
             metadata=metadata,
             freshness_policy=freshness_policy,
             auto_materialize_policy=auto_materialize_policy,
             backfill_policy=backfill_policy,
             resource_defs=resource_defs,
-        )(fn)
-
-    return inner
-
-
-class _GraphBackedAsset:
-    def __init__(
-        self,
-        name: Optional[str] = None,
-        key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
-        ins: Optional[Mapping[str, AssetIn]] = None,
-        description: Optional[str] = None,
-        partitions_def: Optional[PartitionsDefinition] = None,
-        group_name: Optional[str] = None,
-        metadata: Optional[MetadataUserInput] = None,
-        freshness_policy: Optional[FreshnessPolicy] = None,
-        auto_materialize_policy: Optional[AutoMaterializePolicy] = None,
-        backfill_policy: Optional[BackfillPolicy] = None,
-        resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
-    ):
-        self.name = name
-
-        if isinstance(key_prefix, str):
-            key_prefix = [key_prefix]
-        self.key_prefix = key_prefix
-        self.ins = ins or {}
-        self.description = description
-        self.partitions_def = partitions_def
-        self.group_name = group_name
-        self.metadata = metadata
-        self.freshness_policy = freshness_policy
-        self.auto_materialize_policy = auto_materialize_policy
-        self.backfill_policy = backfill_policy
-        self.resource_defs = resource_defs
-
-    def __call__(self, fn: Callable) -> AssetsDefinition:
-        asset_name = self.name or fn.__name__
-        asset_ins = build_asset_ins(fn, self.ins or {}, set())
-        out_asset_key = AssetKey(list(filter(None, [*(self.key_prefix or []), asset_name])))
+        )
+    else:
+        key_prefix = [key_prefix] if isinstance(key_prefix, str) else key_prefix
+        ins = ins or {}
+        asset_name = name or compose_fn.__name__
+        asset_ins = build_asset_ins(compose_fn, ins or {}, set())
+        out_asset_key = AssetKey(list(filter(None, [*(key_prefix or []), asset_name])))
 
         keys_by_input_name = {
             input_name: asset_key for asset_key, (input_name, _) in asset_ins.items()
         }
         partition_mappings = {
             input_name: asset_in.partition_mapping
-            for input_name, asset_in in self.ins.items()
+            for input_name, asset_in in ins.items()
             if asset_in.partition_mapping
         }
-
-        op_graph = graph(name=out_asset_key.to_python_identifier(), description=self.description)(
-            fn
-        )
+        op_graph = graph(
+            name=out_asset_key.to_python_identifier(), description=description, config=config
+        )(compose_fn)
         return AssetsDefinition.from_graph(
             op_graph,
             keys_by_input_name=keys_by_input_name,
             keys_by_output_name={"result": out_asset_key},
-            partitions_def=self.partitions_def,
+            partitions_def=partitions_def,
             partition_mappings=partition_mappings if partition_mappings else None,
-            group_name=self.group_name,
-            metadata_by_output_name={"result": self.metadata} if self.metadata else None,
-            freshness_policies_by_output_name=(
-                {"result": self.freshness_policy} if self.freshness_policy else None
-            ),
-            auto_materialize_policies_by_output_name=(
-                {"result": self.auto_materialize_policy} if self.auto_materialize_policy else None
-            ),
-            backfill_policy=self.backfill_policy,
-            descriptions_by_output_name={"result": self.description} if self.description else None,
-            resource_defs=self.resource_defs,
+            group_name=group_name,
+            metadata_by_output_name={"result": metadata} if metadata else None,
+            freshness_policies_by_output_name={"result": freshness_policy}
+            if freshness_policy
+            else None,
+            auto_materialize_policies_by_output_name={"result": auto_materialize_policy}
+            if auto_materialize_policy
+            else None,
+            backfill_policy=backfill_policy,
+            descriptions_by_output_name={"result": description} if description else None,
+            resource_defs=resource_defs,
         )
 
 

--- a/python_modules/dagster/dagster/_core/definitions/decorators/graph_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/graph_decorator.py
@@ -175,6 +175,21 @@ def graph(
             Values that are not strings will be json encoded and must meet the criteria that
             `json.loads(json.dumps(value)) == value`.  These tag values may be overwritten by tag
             values provided at invocation time.
+
+       config (Optional[Union[ConfigMapping], Mapping[str, Any]):
+            Describes how the graph is configured at runtime.
+
+            If a :py:class:`ConfigMapping` object is provided, then the graph takes on the config
+            schema of this object. The mapping will be applied at runtime to generate the config for
+            the graph's constituent nodes.
+
+            If a dictionary is provided, then it will be used as the default run config for the
+            graph. This means it must conform to the config schema of the underlying nodes. Note
+            that the values provided will be viewable and editable in the Dagster UI, so be careful
+            with secrets. its constituent nodes.
+
+            If no value is provided, then the config schema for the graph is the default (derived
+            from the underlying nodes).
     """
     if compose_fn is not None:
         check.invariant(description is None)


### PR DESCRIPTION
## Summary & Motivation

Resolves #14944.
Resolves #12647.

- Add `config` arg to `@graph_asset`
- Add `config` docstring to `@graph`
- Light refactor of `@graph_asset` higher-order decorator style to eliminate duplication of long argument list.

`@graph_asset` is currently missing `config`. This has been reported by multiple users. IMO it should clearly be present since it's part of the standard functionality of `@graph`.

@sryza in #12647 you wrote:

>@asset doesn't currently have a config attribute, but we've been discussing adding one. Arguably, @graph_asset and @asset should be consistent on this.

`@graph_asset` combines arguments of both `@graph` and `@asset`, so I think it is important to add this regardless of whether it is added to `@asset` as well, as we need to be consistent with `@graph`.

## How I Tested These Changes

New unit test.
