### PR TITLE
Coerce asset_partitions to a set

### DIFF
--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -581,9 +581,12 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
             for asset_partition, latest_storage_id in self._get_latest_materialization_or_observation_storage_ids_by_asset_partition(
                 asset_key=asset_key
             ).items()
-            if (asset_partitions is None or asset_partition in set(asset_partitions))
-            and (latest_storage_id or 0) > (after_cursor or 0)
+            if (latest_storage_id or 0) > (after_cursor or 0)
         }
+
+        if asset_partitions:
+            updated_after_cursor = updated_after_cursor.intersection(set(asset_partitions))
+
         if not updated_after_cursor:
             return set()
         # for regular assets, don't bother checking versions

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -581,7 +581,7 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
             for asset_partition, latest_storage_id in self._get_latest_materialization_or_observation_storage_ids_by_asset_partition(
                 asset_key=asset_key
             ).items()
-            if (asset_partitions is None or asset_partition in asset_partitions)
+            if (asset_partitions is None or asset_partition in set(asset_partitions))
             and (latest_storage_id or 0) > (after_cursor or 0)
         }
         if not updated_after_cursor:


### PR DESCRIPTION
This comparison hasn't been as quick as the comment indicates. Profiling suggests that a lot of time is being spent in this particular set comparsion.

It looks like `asset_partitions` is being provided as an `Optional[Sequence[AssetPartitionKey]]` but being treated as if it's a set. This naively coerces the sequence to a set for our comparison but I think a better implementation might involve updating our call sites to make sure we're passing a set in the first place.