### PR TITLE
expose default dbt metadata function

### DIFF
--- a/docs/sphinx/sections/api/apidocs/libraries/dagster-dbt.rst
+++ b/docs/sphinx/sections/api/apidocs/libraries/dagster-dbt.rst
@@ -138,6 +138,8 @@ Utils
 
 .. autofunction:: group_from_dbt_resource_props_fallback_to_directory
 
+.. autofunction:: default_metadata_from_dbt_resource_props
+
 .. currentmodule:: dagster_dbt.utils
 
 .. autofunction:: generate_materializations

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/__init__.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/__init__.py
@@ -7,6 +7,7 @@ from .asset_utils import (
     build_dbt_asset_selection as build_dbt_asset_selection,
     build_schedule_from_dbt_selection as build_schedule_from_dbt_selection,
     default_group_from_dbt_resource_props as default_group_from_dbt_resource_props,
+    default_metadata_from_dbt_resource_props as default_metadata_from_dbt_resource_props,
     get_asset_key_for_model as get_asset_key_for_model,
     get_asset_key_for_source as get_asset_key_for_source,
     get_asset_keys_by_output_name_for_source as get_asset_keys_by_output_name_for_source,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
@@ -53,7 +53,7 @@ from dagster_dbt.asset_utils import (
     default_description_fn,
     default_freshness_policy_fn,
     default_group_from_dbt_resource_props,
-    default_metadata_fn,
+    default_metadata_from_dbt_resource_props,
     get_asset_deps,
     get_deps,
 )
@@ -497,7 +497,7 @@ def load_assets_from_dbt_project(
     ] = default_auto_materialize_policy_fn,
     node_info_to_definition_metadata_fn: Callable[
         [Mapping[str, Any]], Mapping[str, MetadataUserInput]
-    ] = default_metadata_fn,
+    ] = default_metadata_from_dbt_resource_props,
     display_raw_sql: Optional[bool] = None,
     dbt_resource_key: str = "dbt",
 ) -> Sequence[AssetsDefinition]:
@@ -666,7 +666,7 @@ def load_assets_from_dbt_manifest(
     ] = default_auto_materialize_policy_fn,
     node_info_to_definition_metadata_fn: Callable[
         [Mapping[str, Any]], Mapping[str, MetadataUserInput]
-    ] = default_metadata_fn,
+    ] = default_metadata_from_dbt_resource_props,
 ) -> Sequence[AssetsDefinition]:
     """Loads a set of dbt models, described in a manifest.json, into Dagster assets.
 
@@ -877,7 +877,7 @@ def _load_assets_from_dbt_manifest(
             "Can't specify both dagster_dbt_translator and display_raw_sql",
         )
         check.invariant(
-            node_info_to_definition_metadata_fn is default_metadata_fn,
+            node_info_to_definition_metadata_fn is default_metadata_from_dbt_resource_props,
             "Can't specify both dagster_dbt_translator and node_info_to_definition_metadata_fn",
         )
     else:
@@ -1033,7 +1033,7 @@ def _raise_warnings_for_deprecated_args(
             stacklevel=4,
         )
 
-    if node_info_to_definition_metadata_fn != default_metadata_fn:
+    if node_info_to_definition_metadata_fn != default_metadata_from_dbt_resource_props:
         deprecation_warning(
             f"The node_info_to_definition_metadata_fn arg of {public_fn_name}",
             "0.21",

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -342,7 +342,7 @@ def default_asset_key_fn(node_info: Mapping[str, Any]) -> AssetKey:
     return AssetKey(components)
 
 
-def default_metadata_fn(node_info: Mapping[str, Any]) -> Mapping[str, Any]:
+def default_metadata_from_dbt_resource_props(node_info: Mapping[str, Any]) -> Mapping[str, Any]:
     metadata: Dict[str, Any] = {}
     columns = node_info.get("columns", {})
     if len(columns) > 0:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
@@ -10,7 +10,7 @@ from .asset_utils import (
     default_asset_key_fn,
     default_description_fn,
     default_group_from_dbt_resource_props,
-    default_metadata_fn,
+    default_metadata_from_dbt_resource_props,
 )
 
 
@@ -120,7 +120,7 @@ class DagsterDbtTranslator:
                     def get_metadata(cls, dbt_resource_props: Mapping[str, Any]) -> Mapping[str, Any]:
                         return {"custom": "metadata"}
         """
-        return default_metadata_fn(dbt_resource_props)
+        return default_metadata_from_dbt_resource_props(dbt_resource_props)
 
     @classmethod
     def get_group_name(cls, dbt_resource_props: Mapping[str, Any]) -> Optional[str]:


### PR DESCRIPTION
## Summary & Motivation

A recent change made it so that, when users supply a custom dbt metadata function, we now use it to overwrite the default metadata instead of appending to it.

This PR exposes the default metadata function to make it possible for them to get the old behavior by doing something like this:

```python
from dagster_dbt import default_metadata_from_dbt_resource_props

def my_metadata_from_dbt_resource_props(dbt_resource_props):
    my_metadata = {...}
    return {**default_metadata_from_dbt_resource_props(dbt_resource_props), **my_metadata}
```

## How I Tested These Changes
