### PR TITLE
Add tool tips to auto materialize ui

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/CollapsibleSection.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/CollapsibleSection.tsx
@@ -1,14 +1,15 @@
-import {Box, Colors, Icon, Subheading} from '@dagster-io/ui';
+import {Box, Colors, Icon, Subheading, Tooltip} from '@dagster-io/ui';
 import * as React from 'react';
 import styled from 'styled-components/macro';
 
 interface Props {
   header: React.ReactNode;
+  details: JSX.Element | string;
   headerRightSide?: React.ReactNode;
   children: React.ReactNode;
 }
 
-export const CollapsibleSection = ({header, headerRightSide, children}: Props) => {
+export const CollapsibleSection = ({header, details, headerRightSide, children}: Props) => {
   const [isCollapsed, setIsCollapsed] = React.useState(false);
   return (
     <Box
@@ -31,6 +32,9 @@ export const CollapsibleSection = ({header, headerRightSide, children}: Props) =
               style={{transform: isCollapsed ? 'rotate(-90deg)' : 'rotate(0deg)'}}
             />
             <Subheading>{header}</Subheading>
+            <Tooltip content={details} placement="top">
+              <Icon color={Colors.Gray500} name="info" />
+            </Tooltip>
           </Box>
           {headerRightSide}
         </Box>

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/Conditions.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/Conditions.tsx
@@ -59,7 +59,10 @@ export const ConditionsWithPartitions = ({
 
   return (
     <>
-      <CollapsibleSection header="Materialization conditions met">
+      <CollapsibleSection
+        header="Materialization conditions met"
+        details="These conditions trigger materializations, unless they are overriden by a skip or discard condition."
+      >
         <Box flex={{direction: 'column', gap: 8}}>
           <Condition
             text="Materialization is missing"
@@ -91,7 +94,10 @@ export const ConditionsWithPartitions = ({
           />
         </Box>
       </CollapsibleSection>
-      <CollapsibleSection header="Skip conditions met">
+      <CollapsibleSection
+        header="Skip conditions met"
+        details="Skipped partitions will be materialized in a future evaluation, once the skip condition is resolved."
+      >
         <Condition
           text="Waiting on upstream data"
           met={conditionResults.has('ParentOutdatedAutoMaterializeCondition')}
@@ -104,7 +110,10 @@ export const ConditionsWithPartitions = ({
           }
         />
       </CollapsibleSection>
-      <CollapsibleSection header="Discard conditions met">
+      <CollapsibleSection
+        header="Discard conditions met"
+        details="Discarded partitions will not be materialized unless new materialization conditions occur. You may want to run a manual backfill to respond to the materialize conditions."
+      >
         <Condition
           text={`Exceeds ${
             maxMaterializationsPerMinute === 1
@@ -133,7 +142,10 @@ export const ConditionsNoPartitions = ({
 }: ConditionsProps) => {
   return (
     <>
-      <CollapsibleSection header="Materialization conditions met">
+      <CollapsibleSection
+        header="Materialization conditions met"
+        details="These conditions trigger a materialization, unless they are blocked by a skip or discard condition."
+      >
         <Box flex={{direction: 'column', gap: 8}}>
           <Condition
             text="Materialization is missing"
@@ -153,7 +165,10 @@ export const ConditionsNoPartitions = ({
           />
         </Box>
       </CollapsibleSection>
-      <CollapsibleSection header="Skip conditions met">
+      <CollapsibleSection
+        header="Skip conditions met"
+        details="Skips will materialize in a future evaluation, once the skip condition is resolved."
+      >
         <Condition
           text="Waiting on upstream data"
           met={conditionResults.has('ParentOutdatedAutoMaterializeCondition')}


### PR DESCRIPTION

<img width="1502" alt="Screenshot 2023-07-19 at 4 52 51 PM" src="https://github.com/dagster-io/dagster/assets/22018973/17c5b035-b9de-4c92-840d-06e50a75a5ee">


(alternatively, in black:)

<img width="972" alt="Screenshot 2023-07-19 at 3 59 25 PM" src="https://github.com/dagster-io/dagster/assets/22018973/9671738e-8d54-469e-976f-8bc5117de689">



