### PR TITLE
Evaluations ui move results to bottom

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AutomaterializeMiddlePanelNoPartitions.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AutomaterializeMiddlePanelNoPartitions.tsx
@@ -30,7 +30,7 @@ export const AutomaterializeMiddlePanelNoPartitions = ({
     const count = runIds.length;
 
     if (count === 0 || !selectedEvaluation?.conditions) {
-      return null;
+      return <small>Not launched</small>;
     }
 
     return <AutomaterializeRunTag runId={runIds[0]!} />;
@@ -57,14 +57,28 @@ export const AutomaterializeMiddlePanelNoPartitions = ({
         border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
         flex={{alignItems: 'center', justifyContent: 'space-between'}}
       >
-        <Subheading>Result</Subheading>
-        <div>{headerRight()}</div>
+        <Subheading>Evaluation</Subheading>
       </Box>
       <ConditionsNoPartitions
         conditionResults={conditionResults}
         maxMaterializationsPerMinute={maxMaterializationsPerMinute}
         parentOutdatedWaitingOnAssetKeys={parentOutdatedWaitingOnAssetKeys}
       />
+      <Box
+        // style={{flex: '0 0 96px'}}
+        border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+        flex={{alignItems: 'center', justifyContent: 'space-between'}}
+      >
+        <Box
+          style={{flex: '0', backgroundColor: Colors.Gray100}}
+          padding={{horizontal: 32, vertical: 24}}
+        >
+          <Subheading>Result</Subheading>
+        </Box>
+        <Box flex={{alignItems: 'flex-end'}} padding={{horizontal: 16}}>
+          <div>{headerRight()}</div>
+        </Box>
+      </Box>
     </Box>
   );
 };

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AutomaterializeMiddlePanelWithPartitions.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AutomaterializeMiddlePanelWithPartitions.tsx
@@ -112,12 +112,19 @@ export const AutomaterializeMiddlePanelWithPartitions = ({
       <AutomaterializeRequestedPartitionsLink
         runIds={runIds}
         partitionKeys={Array.from(partitionKeys)}
+        intent="success"
       />
     );
   };
 
   return (
     <Box flex={{direction: 'column', grow: 1}}>
+      <ConditionsWithPartitions
+        conditionResults={conditionResults}
+        conditionToPartitions={conditionToPartitions}
+        maxMaterializationsPerMinute={maxMaterializationsPerMinute}
+        parentOutdatedWaitingOnAssetKeys={parentOutdatedWaitingOnAssetKeys}
+      />
       <Box
         style={{flex: '0 0 48px'}}
         padding={{horizontal: 16}}
@@ -127,12 +134,6 @@ export const AutomaterializeMiddlePanelWithPartitions = ({
         <Subheading>Result</Subheading>
         <div>{headerRight()}</div>
       </Box>
-      <ConditionsWithPartitions
-        conditionResults={conditionResults}
-        conditionToPartitions={conditionToPartitions}
-        maxMaterializationsPerMinute={maxMaterializationsPerMinute}
-        parentOutdatedWaitingOnAssetKeys={parentOutdatedWaitingOnAssetKeys}
-      />
     </Box>
   );
 };

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AutomaterializeMiddlePanelWithPartitions.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AutomaterializeMiddlePanelWithPartitions.tsx
@@ -103,7 +103,7 @@ export const AutomaterializeMiddlePanelWithPartitions = ({
     const count = runIds.length;
 
     if (count === 0 || !selectedEvaluation?.conditions) {
-      return null;
+      return <small>No partitions launched</small>;
     }
 
     const {conditions} = selectedEvaluation;
@@ -125,8 +125,7 @@ export const AutomaterializeMiddlePanelWithPartitions = ({
         border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
         flex={{alignItems: 'center', justifyContent: 'space-between'}}
       >
-        <Subheading>Result</Subheading>
-        <div>{headerRight()}</div>
+        <Subheading>Evaluation</Subheading>
       </Box>
       <ConditionsWithPartitions
         conditionResults={conditionResults}
@@ -134,6 +133,22 @@ export const AutomaterializeMiddlePanelWithPartitions = ({
         maxMaterializationsPerMinute={maxMaterializationsPerMinute}
         parentOutdatedWaitingOnAssetKeys={parentOutdatedWaitingOnAssetKeys}
       />
+
+      <Box
+        // style={{flex: '0 0 96px'}}
+        border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+        flex={{alignItems: 'center', justifyContent: 'space-between'}}
+      >
+        <Box
+          style={{flex: '0', backgroundColor: Colors.Gray100}}
+          padding={{horizontal: 32, vertical: 24}}
+        >
+          <Subheading>Result</Subheading>
+        </Box>
+        <Box flex={{alignItems: 'flex-end'}} padding={{horizontal: 16}}>
+          <div>{headerRight()}</div>
+        </Box>
+      </Box>
     </Box>
   );
 };

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AutomaterializeMiddlePanelWithPartitions.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AutomaterializeMiddlePanelWithPartitions.tsx
@@ -119,12 +119,6 @@ export const AutomaterializeMiddlePanelWithPartitions = ({
 
   return (
     <Box flex={{direction: 'column', grow: 1}}>
-      <ConditionsWithPartitions
-        conditionResults={conditionResults}
-        conditionToPartitions={conditionToPartitions}
-        maxMaterializationsPerMinute={maxMaterializationsPerMinute}
-        parentOutdatedWaitingOnAssetKeys={parentOutdatedWaitingOnAssetKeys}
-      />
       <Box
         style={{flex: '0 0 48px'}}
         padding={{horizontal: 16}}
@@ -134,6 +128,12 @@ export const AutomaterializeMiddlePanelWithPartitions = ({
         <Subheading>Result</Subheading>
         <div>{headerRight()}</div>
       </Box>
+      <ConditionsWithPartitions
+        conditionResults={conditionResults}
+        conditionToPartitions={conditionToPartitions}
+        maxMaterializationsPerMinute={maxMaterializationsPerMinute}
+        parentOutdatedWaitingOnAssetKeys={parentOutdatedWaitingOnAssetKeys}
+      />
     </Box>
   );
 };

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AutomaterializeRequestedPartitionsLink.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AutomaterializeRequestedPartitionsLink.tsx
@@ -1,4 +1,6 @@
 import {gql, useQuery} from '@apollo/client';
+// eslint-disable-next-line no-restricted-imports
+import {Tag as BlueprintTag} from '@blueprintjs/core';
 import {
   Box,
   Button,
@@ -32,9 +34,10 @@ import {
 interface Props {
   runIds?: string[];
   partitionKeys: string[];
+  intent?: React.ComponentProps<typeof BlueprintTag>['intent'];
 }
 
-export const AutomaterializeRequestedPartitionsLink = ({runIds, partitionKeys}: Props) => {
+export const AutomaterializeRequestedPartitionsLink = ({runIds, partitionKeys, intent}: Props) => {
   const [isOpen, setIsOpen] = React.useState(false);
   const [queryString, setQueryString] = React.useState('');
   const queryLowercase = queryString.toLocaleLowerCase();
@@ -63,7 +66,7 @@ export const AutomaterializeRequestedPartitionsLink = ({runIds, partitionKeys}: 
     }
 
     return runIds ? (
-      <PartitionAndRunList runIds={runIds} partitionKeys={filteredPartitionKeys} />
+      <PartitionAndRunList runIds={runIds} partitionKeys={filteredPartitionKeys} intent={intent} />
     ) : (
       <VirtualizedPartitionList partitionKeys={partitionKeys} />
     );
@@ -71,7 +74,9 @@ export const AutomaterializeRequestedPartitionsLink = ({runIds, partitionKeys}: 
 
   return (
     <>
-      <ButtonLink onClick={() => setIsOpen(true)}>{label}</ButtonLink>
+      <ButtonLink onClick={() => setIsOpen(true)}>
+        <Tag intent={intent}>{label}</Tag>
+      </ButtonLink>
       <Dialog
         isOpen={isOpen}
         onClose={() => setIsOpen(false)}

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AutomaterializeRequestedPartitionsLink.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AutomaterializeRequestedPartitionsLink.tsx
@@ -74,9 +74,14 @@ export const AutomaterializeRequestedPartitionsLink = ({runIds, partitionKeys, i
 
   return (
     <>
-      <ButtonLink onClick={() => setIsOpen(true)}>
+      <Box>
         <Tag intent={intent}>{label}</Tag>
-      </ButtonLink>
+        <ButtonLink onClick={() => setIsOpen(true)}>
+          <small style={{marginLeft: 10}}>
+            <a>View details</a>
+          </small>
+        </ButtonLink>
+      </Box>
       <Dialog
         isOpen={isOpen}
         onClose={() => setIsOpen(false)}

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AutomaterializeRequestedPartitionsLink.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AutomaterializeRequestedPartitionsLink.tsx
@@ -1,6 +1,4 @@
 import {gql, useQuery} from '@apollo/client';
-// eslint-disable-next-line no-restricted-imports
-import {Tag as BlueprintTag} from '@blueprintjs/core';
 import {
   Box,
   Button,
@@ -12,6 +10,7 @@ import {
   Spinner,
   Tag,
   TextInput,
+  Caption,
 } from '@dagster-io/ui';
 import {useVirtualizer} from '@tanstack/react-virtual';
 import * as React from 'react';
@@ -34,7 +33,7 @@ import {
 interface Props {
   runIds?: string[];
   partitionKeys: string[];
-  intent?: React.ComponentProps<typeof BlueprintTag>['intent'];
+  intent?: React.ComponentProps<typeof Tag>['intent'];
 }
 
 export const AutomaterializeRequestedPartitionsLink = ({runIds, partitionKeys, intent}: Props) => {
@@ -74,12 +73,10 @@ export const AutomaterializeRequestedPartitionsLink = ({runIds, partitionKeys, i
 
   return (
     <>
-      <Box>
+      <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
         <Tag intent={intent}>{label}</Tag>
         <ButtonLink onClick={() => setIsOpen(true)}>
-          <small style={{marginLeft: 10}}>
-            <a>View details</a>
-          </small>
+          <Caption>View details</Caption>
         </ButtonLink>
       </Box>
       <Dialog

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/Conditions.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/Conditions.tsx
@@ -42,9 +42,11 @@ export const ConditionsWithPartitions = ({
   maxMaterializationsPerMinute,
   parentOutdatedWaitingOnAssetKeys,
 }: ConditionsWithPartitionsProps) => {
-  const buildRightElement = (partitionKeys: string[]) => {
+  const buildRightElement = (partitionKeys: string[], intent?: any) => {
     if (partitionKeys?.length) {
-      return <AutomaterializeRequestedPartitionsLink partitionKeys={partitionKeys} />;
+      return (
+        <AutomaterializeRequestedPartitionsLink partitionKeys={partitionKeys} intent={intent} />
+      );
     }
     return <div style={{color: Colors.Gray400}}>&ndash;</div>;
   };
@@ -106,6 +108,7 @@ export const ConditionsWithPartitions = ({
           met={conditionResults.has('MaxMaterializationsExceededAutoMaterializeCondition')}
           rightElement={buildRightElement(
             conditionToPartitions['MaxMaterializationsExceededAutoMaterializeCondition'],
+            'danger',
           )}
         />
       </CollapsibleSection>

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/Conditions.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/Conditions.tsx
@@ -1,4 +1,4 @@
-import {Colors, Box, Icon} from '@dagster-io/ui';
+import {Colors, Box, Icon, Tag} from '@dagster-io/ui';
 import * as React from 'react';
 
 import {AssetKey} from '../types';
@@ -21,7 +21,7 @@ const Condition = ({text, met, rightElement}: ConditionProps) => {
   return (
     <Box
       flex={{direction: 'row', alignItems: 'center', justifyContent: 'space-between'}}
-      style={{minHeight: 24}}
+      style={{height: 24}}
     >
       <Box flex={{direction: 'row', alignItems: 'center', gap: 8}}>
         <Icon name={met ? 'done' : 'close'} color={met ? Colors.Dark : Colors.Gray500} />
@@ -45,7 +45,10 @@ export const ConditionsWithPartitions = ({
   maxMaterializationsPerMinute,
   parentOutdatedWaitingOnAssetKeys,
 }: ConditionsWithPartitionsProps) => {
-  const buildRightElement = (partitionKeys: string[], intent?: any) => {
+  const buildRightElement = (
+    partitionKeys: string[],
+    intent?: React.ComponentProps<typeof Tag>['intent'],
+  ) => {
     if (partitionKeys?.length) {
       return (
         <AutomaterializeRequestedPartitionsLink partitionKeys={partitionKeys} intent={intent} />

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/Conditions.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/Conditions.tsx
@@ -19,7 +19,10 @@ interface ConditionProps {
 
 const Condition = ({text, met, rightElement}: ConditionProps) => {
   return (
-    <Box flex={{direction: 'row', alignItems: 'center', justifyContent: 'space-between'}}>
+    <Box
+      flex={{direction: 'row', alignItems: 'center', justifyContent: 'space-between'}}
+      style={{minHeight: 24}}
+    >
       <Box flex={{direction: 'row', alignItems: 'center', gap: 8}}>
         <Icon name={met ? 'done' : 'close'} color={met ? Colors.Dark : Colors.Gray500} />
         <div style={{color: met ? Colors.Dark : Colors.Gray500}}>{text}</div>

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/WaitingOnAssetKeysLink.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/WaitingOnAssetKeysLink.tsx
@@ -62,7 +62,9 @@ export const WaitingOnAssetKeysLink = ({assetKeys}: Props) => {
 
   return (
     <>
-      <ButtonLink onClick={() => setIsOpen(true)}>{label}</ButtonLink>
+      <ButtonLink onClick={() => setIsOpen(true)}>
+        <small>{label}</small>
+      </ButtonLink>
       <Dialog
         isOpen={isOpen}
         onClose={() => setIsOpen(false)}

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/WaitingOnPartitionAssetKeysLink.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/WaitingOnPartitionAssetKeysLink.tsx
@@ -8,6 +8,7 @@ import {
   Button,
   NonIdealState,
   Icon,
+  Tag,
 } from '@dagster-io/ui';
 import {useVirtualizer} from '@tanstack/react-virtual';
 import * as React from 'react';
@@ -67,7 +68,9 @@ export const WaitingOnPartitionAssetKeysLink = ({assetKeysByPartition}: Props) =
 
   return (
     <>
-      <ButtonLink onClick={() => setIsOpen(true)}>{label}</ButtonLink>
+      <ButtonLink onClick={() => setIsOpen(true)}>
+        <Tag intent="warning">{label}</Tag>
+      </ButtonLink>
       <Dialog
         isOpen={isOpen}
         onClose={() => setIsOpen(false)}

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/WaitingOnPartitionAssetKeysLink.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/WaitingOnPartitionAssetKeysLink.tsx
@@ -9,6 +9,7 @@ import {
   NonIdealState,
   Icon,
   Tag,
+  Caption,
 } from '@dagster-io/ui';
 import {useVirtualizer} from '@tanstack/react-virtual';
 import * as React from 'react';
@@ -68,9 +69,12 @@ export const WaitingOnPartitionAssetKeysLink = ({assetKeysByPartition}: Props) =
 
   return (
     <>
-      <ButtonLink onClick={() => setIsOpen(true)}>
+      <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
         <Tag intent="warning">{label}</Tag>
-      </ButtonLink>
+        <ButtonLink onClick={() => setIsOpen(true)}>
+          <Caption>View details</Caption>
+        </ButtonLink>
+      </Box>
       <Dialog
         isOpen={isOpen}
         onClose={() => setIsOpen(false)}


### PR DESCRIPTION
Update, I turned down the height of the result box a bit. Not sure which I prefer
<img width="1449" alt="Screenshot 2023-07-19 at 11 51 44 PM" src="https://github.com/dagster-io/dagster/assets/22018973/2b16ec59-5d84-4ad2-b52a-7f332180d5fa">


Old images with a larger box
<img width="1502" alt="Screenshot 2023-07-19 at 5 38 26 PM" src="https://github.com/dagster-io/dagster/assets/22018973/7bb8ada4-54a5-4871-abfb-9caf060ad451">
<img width="1502" alt="Screenshot 2023-07-19 at 5 38 20 PM" src="https://github.com/dagster-io/dagster/assets/22018973/92d16987-95b0-4553-80f8-20d218838050">
<img width="1502" alt="Screenshot 2023-07-19 at 5 38 17 PM" src="https://github.com/dagster-io/dagster/assets/22018973/16e93ccb-cdcf-45cf-9423-8c4b1447b8ab">
<img width="1502" alt="Screenshot 2023-07-19 at 5 41 11 PM" src="https://github.com/dagster-io/dagster/assets/22018973/07c63c0b-b1d4-469b-877c-383fdc1e5b65">

