### PR TITLE
Hide discard reasons for non partitioned assets

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AutomaterializeMiddlePanel.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AutomaterializeMiddlePanel.tsx
@@ -112,10 +112,5 @@ export const AutomaterializeMiddlePanel = (props: Props) => {
     );
   }
 
-  return (
-    <AutomaterializeMiddlePanelNoPartitions
-      selectedEvaluation={selectedEvaluation}
-      maxMaterializationsPerMinute={maxMaterializationsPerMinute}
-    />
-  );
+  return <AutomaterializeMiddlePanelNoPartitions selectedEvaluation={selectedEvaluation} />;
 };

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AutomaterializeMiddlePanelNoPartitions.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AutomaterializeMiddlePanelNoPartitions.tsx
@@ -9,13 +9,9 @@ import {EvaluationOrEmpty} from './types';
 
 interface Props {
   selectedEvaluation?: EvaluationOrEmpty;
-  maxMaterializationsPerMinute: number;
 }
 
-export const AutomaterializeMiddlePanelNoPartitions = ({
-  selectedEvaluation,
-  maxMaterializationsPerMinute,
-}: Props) => {
+export const AutomaterializeMiddlePanelNoPartitions = ({selectedEvaluation}: Props) => {
   const conditionResults = React.useMemo(() => {
     return new Set(
       (selectedEvaluation?.conditions || []).map((condition) => condition.__typename),
@@ -62,7 +58,6 @@ export const AutomaterializeMiddlePanelNoPartitions = ({
       </Box>
       <ConditionsNoPartitions
         conditionResults={conditionResults}
-        maxMaterializationsPerMinute={maxMaterializationsPerMinute}
         parentOutdatedWaitingOnAssetKeys={parentOutdatedWaitingOnAssetKeys}
       />
     </Box>

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/Conditions.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/Conditions.tsx
@@ -124,13 +124,11 @@ export const ConditionsWithPartitions = ({
 
 interface ConditionsProps {
   conditionResults: Set<ConditionType>;
-  maxMaterializationsPerMinute: number;
   parentOutdatedWaitingOnAssetKeys: AssetKey[];
 }
 
 export const ConditionsNoPartitions = ({
   conditionResults,
-  maxMaterializationsPerMinute,
   parentOutdatedWaitingOnAssetKeys,
 }: ConditionsProps) => {
   return (
@@ -164,16 +162,6 @@ export const ConditionsNoPartitions = ({
               <WaitingOnAssetKeysLink assetKeys={parentOutdatedWaitingOnAssetKeys} />
             ) : null
           }
-        />
-      </CollapsibleSection>
-      <CollapsibleSection header="Discard conditions met">
-        <Condition
-          text={`Exceeds ${
-            maxMaterializationsPerMinute === 1
-              ? '1 materialization'
-              : `${maxMaterializationsPerMinute} materializations`
-          } per minute`}
-          met={conditionResults.has('MaxMaterializationsExceededAutoMaterializeCondition')}
         />
       </CollapsibleSection>
     </>

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/__stories__/AutomaterializeMiddlePanelNoPartitions.stories.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/__stories__/AutomaterializeMiddlePanelNoPartitions.stories.tsx
@@ -21,7 +21,6 @@ export const WithoutPartitions = () => {
     >
       <div style={{width: '800px'}}>
         <AutomaterializeMiddlePanelNoPartitions
-          maxMaterializationsPerMinute={1}
           selectedEvaluation={SINGLE_MATERIALIZE_RECORD_NO_PARTITIONS}
         />
       </div>


### PR DESCRIPTION
Until we make the denominator of the rate limit configurable, we'll never discard non partitioned materializations. Hide the condition.

<img width="1502" alt="Screenshot 2023-07-19 at 4 56 58 PM" src="https://github.com/dagster-io/dagster/assets/22018973/b79aee78-f261-4048-8259-b8258b94b195">

