### PR TITLE
:star: add metadata argument to Definitions.load_asset_value

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -445,7 +445,7 @@ class Definitions:
         python_type: Optional[Type] = None,
         instance: Optional[DagsterInstance] = None,
         partition_key: Optional[str] = None,
-        input_metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> object:
         """Load the contents of an asset as a Python object.
 
@@ -460,7 +460,7 @@ class Definitions:
             python_type (Optional[Type]): The python type to load the asset as. This is what will
                 be returned inside `load_input` by `context.dagster_type.typing_type`.
             partition_key (Optional[str]): The partition of the asset to load.
-            input_metadata (Optional[Dict[str, Any]]): Input metadata to pass to the :py:class:`IOManager`
+            metadata (Optional[Dict[str, Any]]): Input metadata to pass to the :py:class:`IOManager`
                 (is equivalent to setting the metadata argument in `In` or `AssetIn`).
 
         Returns:
@@ -471,7 +471,7 @@ class Definitions:
             python_type=python_type,
             instance=instance,
             partition_key=partition_key,
-            input_metadata=input_metadata,
+            metadata=metadata,
         )
 
     @public

--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -9,6 +9,7 @@ from typing import (
     Sequence,
     Type,
     Union,
+    Dict,
 )
 
 import dagster._check as check
@@ -444,6 +445,7 @@ class Definitions:
         python_type: Optional[Type] = None,
         instance: Optional[DagsterInstance] = None,
         partition_key: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> object:
         """Load the contents of an asset as a Python object.
 
@@ -458,6 +460,7 @@ class Definitions:
             python_type (Optional[Type]): The python type to load the asset as. This is what will
                 be returned inside `load_input` by `context.dagster_type.typing_type`.
             partition_key (Optional[str]): The partition of the asset to load.
+            metadata (Optional[Dict[str, Any]]): A dict of metadata to pass (or override) to the IOManager.
 
         Returns:
             The contents of an asset as a Python object.
@@ -467,6 +470,7 @@ class Definitions:
             python_type=python_type,
             instance=instance,
             partition_key=partition_key,
+            metadata=metadata,
         )
 
     @public

--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -1,6 +1,7 @@
 from typing import (
     TYPE_CHECKING,
     Any,
+    Dict,
     Iterable,
     List,
     Mapping,
@@ -9,7 +10,6 @@ from typing import (
     Sequence,
     Type,
     Union,
-    Dict,
 )
 
 import dagster._check as check

--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -445,7 +445,7 @@ class Definitions:
         python_type: Optional[Type] = None,
         instance: Optional[DagsterInstance] = None,
         partition_key: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        input_metadata: Optional[Dict[str, Any]] = None,
     ) -> object:
         """Load the contents of an asset as a Python object.
 
@@ -460,7 +460,8 @@ class Definitions:
             python_type (Optional[Type]): The python type to load the asset as. This is what will
                 be returned inside `load_input` by `context.dagster_type.typing_type`.
             partition_key (Optional[str]): The partition of the asset to load.
-            metadata (Optional[Dict[str, Any]]): A dict of metadata to pass (or override) to the IOManager.
+            input_metadata (Optional[Dict[str, Any]]): Input metadata to pass to the :py:class:`IOManager`
+                (is equivalent to setting the metadata argument in `In` or `AssetIn`).
 
         Returns:
             The contents of an asset as a Python object.
@@ -470,7 +471,7 @@ class Definitions:
             python_type=python_type,
             instance=instance,
             partition_key=partition_key,
-            metadata=metadata,
+            input_metadata=input_metadata,
         )
 
     @public

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
@@ -2,6 +2,7 @@ from typing import (
     TYPE_CHECKING,
     AbstractSet,
     Any,
+    Dict,
     Iterable,
     List,
     Mapping,
@@ -10,7 +11,6 @@ from typing import (
     Sequence,
     Type,
     Union,
-    Dict,
 )
 
 import dagster._check as check

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
@@ -311,7 +311,7 @@ class RepositoryDefinition:
         python_type: Optional[Type] = None,
         instance: Optional[DagsterInstance] = None,
         partition_key: Optional[str] = None,
-        input_metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
         resource_config: Optional[Any] = None,
     ) -> object:
         """Load the contents of an asset as a Python object.
@@ -327,7 +327,7 @@ class RepositoryDefinition:
             python_type (Optional[Type]): The python type to load the asset as. This is what will
                 be returned inside `load_input` by `context.dagster_type.typing_type`.
             partition_key (Optional[str]): The partition of the asset to load.
-            input_metadata (Optional[Dict[str, Any]]): Input metadata to pass to the :py:class:`IOManager`
+            metadata (Optional[Dict[str, Any]]): Input metadata to pass to the :py:class:`IOManager`
                 (is equivalent to setting the metadata argument in `In` or `AssetIn`).
             resource_config (Optional[Any]): A dictionary of resource configurations to be passed
                 to the :py:class:`IOManager`.
@@ -344,7 +344,7 @@ class RepositoryDefinition:
                 asset_key,
                 python_type=python_type,
                 partition_key=partition_key,
-                input_metadata=input_metadata,
+                metadata=metadata,
                 resource_config=resource_config,
             )
 

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
@@ -311,7 +311,7 @@ class RepositoryDefinition:
         python_type: Optional[Type] = None,
         instance: Optional[DagsterInstance] = None,
         partition_key: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        input_metadata: Optional[Dict[str, Any]] = None,
         resource_config: Optional[Any] = None,
     ) -> object:
         """Load the contents of an asset as a Python object.
@@ -327,7 +327,8 @@ class RepositoryDefinition:
             python_type (Optional[Type]): The python type to load the asset as. This is what will
                 be returned inside `load_input` by `context.dagster_type.typing_type`.
             partition_key (Optional[str]): The partition of the asset to load.
-            metadata (Optional[Dict[str, Any]]): A dict of metadata to pass (or override) to the IOManager.
+            input_metadata (Optional[Dict[str, Any]]): Input metadata to pass to the :py:class:`IOManager`
+                (is equivalent to setting the metadata argument in `In` or `AssetIn`).
             resource_config (Optional[Any]): A dictionary of resource configurations to be passed
                 to the :py:class:`IOManager`.
 
@@ -343,7 +344,7 @@ class RepositoryDefinition:
                 asset_key,
                 python_type=python_type,
                 partition_key=partition_key,
-                metadata=metadata,
+                input_metadata=input_metadata,
                 resource_config=resource_config,
             )
 

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
@@ -10,6 +10,7 @@ from typing import (
     Sequence,
     Type,
     Union,
+    Dict,
 )
 
 import dagster._check as check
@@ -310,6 +311,7 @@ class RepositoryDefinition:
         python_type: Optional[Type] = None,
         instance: Optional[DagsterInstance] = None,
         partition_key: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
         resource_config: Optional[Any] = None,
     ) -> object:
         """Load the contents of an asset as a Python object.
@@ -325,6 +327,7 @@ class RepositoryDefinition:
             python_type (Optional[Type]): The python type to load the asset as. This is what will
                 be returned inside `load_input` by `context.dagster_type.typing_type`.
             partition_key (Optional[str]): The partition of the asset to load.
+            metadata (Optional[Dict[str, Any]]): A dict of metadata to pass (or override) to the IOManager.
             resource_config (Optional[Any]): A dictionary of resource configurations to be passed
                 to the :py:class:`IOManager`.
 
@@ -340,6 +343,7 @@ class RepositoryDefinition:
                 asset_key,
                 python_type=python_type,
                 partition_key=partition_key,
+                metadata=metadata,
                 resource_config=resource_config,
             )
 

--- a/python_modules/dagster/dagster/_core/storage/asset_value_loader.py
+++ b/python_modules/dagster/dagster/_core/storage/asset_value_loader.py
@@ -75,7 +75,7 @@ class AssetValueLoader:
         *,
         python_type: Optional[Type[object]] = None,
         partition_key: Optional[str] = None,
-        input_metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
         resource_config: Optional[Any] = None,
     ) -> object:
         """Loads the contents of an asset as a Python object.
@@ -87,7 +87,7 @@ class AssetValueLoader:
             python_type (Optional[Type]): The python type to load the asset as. This is what will
                 be returned inside `load_input` by `context.dagster_type.typing_type`.
             partition_key (Optional[str]): The partition of the asset to load.
-            input_metadata (Optional[Dict[str, Any]]): Input metadata to pass to the :py:class:`IOManager`
+            metadata (Optional[Dict[str, Any]]): Input metadata to pass to the :py:class:`IOManager`
                 (is equivalent to setting the metadata argument in `In` or `AssetIn`).
             resource_config (Optional[Any]): A dictionary of resource configurations to be passed
                 to the :py:class:`IOManager`.
@@ -164,7 +164,7 @@ class AssetValueLoader:
             else None,
             asset_partitions_def=asset_partitions_def,
             instance=self._instance,
-            metadata=input_metadata,
+            metadata=metadata,
         )
 
         return io_manager.load_input(input_context)

--- a/python_modules/dagster/dagster/_core/storage/asset_value_loader.py
+++ b/python_modules/dagster/dagster/_core/storage/asset_value_loader.py
@@ -156,7 +156,7 @@ class AssetValueLoader:
             dagster_type=resolve_dagster_type(python_type),
             upstream_output=build_output_context(
                 name=name,
-                metadata=combined_metadata,
+                # metadata=combined_metadata,
                 asset_key=asset_key,
                 op_def=op_def,
                 resource_config=resource_config,
@@ -169,6 +169,7 @@ class AssetValueLoader:
             else None,
             asset_partitions_def=asset_partitions_def,
             instance=self._instance,
+            metadata=combined_metadata,
         )
 
         return io_manager.load_input(input_context)

--- a/python_modules/dagster/dagster/_core/storage/asset_value_loader.py
+++ b/python_modules/dagster/dagster/_core/storage/asset_value_loader.py
@@ -75,7 +75,7 @@ class AssetValueLoader:
         *,
         python_type: Optional[Type[object]] = None,
         partition_key: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        input_metadata: Optional[Dict[str, Any]] = None,
         resource_config: Optional[Any] = None,
     ) -> object:
         """Loads the contents of an asset as a Python object.
@@ -87,7 +87,8 @@ class AssetValueLoader:
             python_type (Optional[Type]): The python type to load the asset as. This is what will
                 be returned inside `load_input` by `context.dagster_type.typing_type`.
             partition_key (Optional[str]): The partition of the asset to load.
-            metadata (Optional[Dict[str, Any]]): A dict of metadata to pass (or override) to the IOManager.
+            input_metadata (Optional[Dict[str, Any]]): Input metadata to pass to the :py:class:`IOManager`
+                (is equivalent to setting the metadata argument in `In` or `AssetIn`).
             resource_config (Optional[Any]): A dictionary of resource configurations to be passed
                 to the :py:class:`IOManager`.
 
@@ -163,7 +164,7 @@ class AssetValueLoader:
             else None,
             asset_partitions_def=asset_partitions_def,
             instance=self._instance,
-            metadata=metadata,
+            metadata=input_metadata,
         )
 
         return io_manager.load_input(input_context)

--- a/python_modules/dagster/dagster_tests/general_tests/test_repository.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_repository.py
@@ -200,12 +200,19 @@ def test_asset_value_loader_with_metadata():
     def asset1():
         ...
 
+    @asset(metadata={"return": 20})
+    def asset2():
+        ...
+
     @repository
     def repo():
-        return with_resources([asset1], resource_defs={"io_manager": my_io_manager})
+        return with_resources([asset1, asset2], resource_defs={"io_manager": my_io_manager})
 
     value = repo.load_asset_value(AssetKey("asset1"))
     assert value == 5
 
     value = repo.load_asset_value(AssetKey("asset1"), metadata={"return": 10})
     assert value == 10
+
+    value = repo.load_asset_value(AssetKey("asset2"))
+    assert value == 5

--- a/python_modules/dagster/dagster_tests/general_tests/test_repository.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_repository.py
@@ -211,7 +211,7 @@ def test_asset_value_loader_with_metadata():
     value = repo.load_asset_value(AssetKey("asset1"))
     assert value == 5
 
-    value = repo.load_asset_value(AssetKey("asset1"), input_metadata={"return": 10})
+    value = repo.load_asset_value(AssetKey("asset1"), metadata={"return": 10})
     assert value == 10
 
     value = repo.load_asset_value(AssetKey("asset2"))

--- a/python_modules/dagster/dagster_tests/general_tests/test_repository.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_repository.py
@@ -211,7 +211,7 @@ def test_asset_value_loader_with_metadata():
     value = repo.load_asset_value(AssetKey("asset1"))
     assert value == 5
 
-    value = repo.load_asset_value(AssetKey("asset1"), metadata={"return": 10})
+    value = repo.load_asset_value(AssetKey("asset1"), input_metadata={"return": 10})
     assert value == 10
 
     value = repo.load_asset_value(AssetKey("asset2"))


### PR DESCRIPTION
## Summary & Motivation
Resolve #13542

I need this feature at my job. 
It seems like it makes sense to have this argument. 

## How I Tested These Changes
Added a test for `load_asset_value` with the new metadata argument
