### PR TITLE
[refactor] autodoc_dagster.py -> dagster-sphinx

### DIFF
--- a/docs/sphinx/Makefile
+++ b/docs/sphinx/Makefile
@@ -4,7 +4,7 @@
 
 # You can set these variables from the command line.
 SPHINXOPTS    =
-SPHINXBUILD   = sphinx-build
+SPHINXBUILD   = sphinx-build -j auto
 PAPER         =
 BUILDDIR      = _build
 

--- a/docs/sphinx/_ext/dagster-sphinx/dagster_sphinx/__init__.py
+++ b/docs/sphinx/_ext/dagster-sphinx/dagster_sphinx/__init__.py
@@ -1,0 +1,161 @@
+from typing import List, Optional, Sequence, Tuple, Type, TypeVar
+
+import docutils.nodes as nodes
+from dagster._annotations import is_deprecated, is_public
+from sphinx.addnodes import versionmodified
+from sphinx.application import Sphinx
+from sphinx.environment import BuildEnvironment
+from sphinx.ext.autodoc import (
+    ClassDocumenter,
+    ObjectMembers,
+    Options as AutodocOptions,
+)
+from sphinx.util import logging
+from typing_extensions import Literal, TypeAlias
+
+from dagster_sphinx.configurable import ConfigurableDocumenter
+
+logger = logging.getLogger(__name__)
+
+##### Useful links for Sphinx documentation
+#
+# [Event reference] https://www.sphinx-doc.org/en/master/extdev/appapi.html#sphinx-core-events
+#   These events are emitted during the build and can be hooked into during the
+#   build process.
+# [autodoc] https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html
+#   Autodoc is not sphinx itself, but it is the central extension that reads
+#   docstrings.
+# [Sphinx extensions API] https://www.sphinx-doc.org/en/master/extdev/index.html
+#   Root page for learning about writing extensions.
+
+
+# See: https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#docstring-preprocessing
+# Autodoc doesn't provide it's own alias.
+AutodocObjectType: TypeAlias = Literal[
+    "module", "class", "exception", "function", "method", "attribute"
+]
+
+
+def record_error(env: BuildEnvironment, message: str) -> None:
+    """Record an error in the Sphinx build environment. The error list is
+    globally available during the build.
+    """
+    logger.info(message)
+    if not hasattr(env, "dagster_errors"):
+        setattr(env, "dagster_errors", [])
+    getattr(env, "dagster_errors").append(message)
+
+
+# ########################
+# ##### CHECKS
+# ########################
+
+
+def check_public_method_has_docstring(env: BuildEnvironment, name: str, obj: object) -> None:
+    if name != "__init__" and not obj.__doc__:
+        message = (
+            f"Docstring not found for {object.__name__}.{name}. "
+            "All public methods and properties must have docstrings."
+        )
+        record_error(env, message)
+
+
+def check_class_docstring_has_no_attributes(
+    env: BuildEnvironment, name: str, docstring: Sequence[str]
+) -> None:
+    if any(line.startswith(".. attribute::") for line in docstring):
+        message = f'Object {name} has "Attributes:" in docstring. Use "Args:" insetad.'
+        record_error(env, message)
+
+
+class DagsterClassDocumenter(ClassDocumenter):
+    """Overrides the default autodoc ClassDocumenter to adds some extra options."""
+
+    objtype = "class"
+
+    def get_object_members(self, want_all: bool) -> Tuple[bool, ObjectMembers]:
+        _, unfiltered_members = super().get_object_members(want_all)
+        # Use form `is_public(self.object, attr_name) if possible, because to access a descriptor
+        # object (returned by e.g. `@staticmethod`) you need to go in through
+        # `self.object.__dict__`-- the value provided in the member list is _not_ the descriptor!
+        filtered_members = [
+            m
+            for m in unfiltered_members
+            if m[0] in self.object.__dict__ and is_public(self.object.__dict__[m[0]])
+        ]
+        for member in filtered_members:
+            check_public_method_has_docstring(self.env, member[0], member[1])
+        return False, filtered_members
+
+
+# This is a hook that will be executed for every processed docstring. It modifies the lines of the
+# docstring in place.
+def process_docstring(
+    app: Sphinx,
+    what: AutodocObjectType,
+    name: str,
+    obj: object,
+    options: AutodocOptions,
+    lines: List[str],
+) -> None:
+    assert app.env is not None
+    if isinstance(obj, type):
+        check_class_docstring_has_no_attributes(app.env, name, lines)
+
+    # Insert a "deprecated" sphinx directive (this is built-in to autodoc) for objects flagged with
+    # @deprecated.
+    if is_deprecated(obj):
+        # Note that these are in reversed order from how they will appear because we insert at the
+        # front. We insert the <placeholder> string because the directive requires an argument that
+        # we can't supply (we would have to know the version at which the object was deprecated).
+        # We discard the "<placeholder>" string in `substitute_deprecated_text`.
+        for line in ["", ".. deprecated:: <placeholder>"]:
+            lines.insert(0, line)
+
+
+T_Node = TypeVar("T_Node", bound=nodes.Node)
+
+
+def get_child_as(node: nodes.Node, index: int, node_type: Type[T_Node]) -> T_Node:
+    child = node.children[index]
+    assert isinstance(
+        child, node_type
+    ), f"Docutils node not of expected type. Expected `{node_type}`, got `{type(child)}`."
+    return child
+
+
+def substitute_deprecated_text(app: Sphinx, doctree: nodes.Element, docname: str) -> None:
+    # The `.. deprecated::` directive is rendered as a `versionmodified` node.
+    # Find them all and replace the auto-generated text, which requires a version argument, with a
+    # plain string "Deprecated".
+    for node in doctree.findall(versionmodified):
+        paragraph = get_child_as(node, 0, nodes.paragraph)
+        inline = get_child_as(paragraph, 0, nodes.inline)
+        text = get_child_as(inline, 0, nodes.Text)
+        inline.replace(text, nodes.Text("Deprecated"))
+
+
+def check_custom_errors(app: Sphinx, exc: Optional[Exception] = None) -> None:
+    dagster_errors = getattr(app.env, "dagster_errors", [])
+    if len(dagster_errors) > 0:
+        for error_msg in dagster_errors:
+            logger.info(error_msg)
+        raise Exception(
+            f"Bulid failed. Found {len(dagster_errors)} violations of docstring requirements."
+        )
+
+
+def setup(app):
+    app.setup_extension("sphinx.ext.autodoc")  # Require autodoc extension
+    app.add_autodocumenter(ConfigurableDocumenter)
+    # override allows `.. autoclass::` to invoke DagsterClassDocumenter instead of default
+    app.add_autodocumenter(DagsterClassDocumenter, override=True)
+    app.connect("autodoc-process-docstring", process_docstring)
+    app.connect("doctree-resolved", substitute_deprecated_text)
+    app.connect("build-finished", check_custom_errors)
+
+    return {
+        "version": "0.1",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/docs/sphinx/_ext/dagster-sphinx/dagster_sphinx/__init__.py
+++ b/docs/sphinx/_ext/dagster-sphinx/dagster_sphinx/__init__.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Sequence, Tuple, Type, TypeVar
+from typing import List, Optional, Tuple, Type, TypeVar
 
 import docutils.nodes as nodes
 from dagster._annotations import is_deprecated, is_public
@@ -60,14 +60,6 @@ def check_public_method_has_docstring(env: BuildEnvironment, name: str, obj: obj
         record_error(env, message)
 
 
-def check_class_docstring_has_no_attributes(
-    env: BuildEnvironment, name: str, docstring: Sequence[str]
-) -> None:
-    if any(line.startswith(".. attribute::") for line in docstring):
-        message = f'Object {name} has "Attributes:" in docstring. Use "Args:" insetad.'
-        record_error(env, message)
-
-
 class DagsterClassDocumenter(ClassDocumenter):
     """Overrides the default autodoc ClassDocumenter to adds some extra options."""
 
@@ -99,8 +91,6 @@ def process_docstring(
     lines: List[str],
 ) -> None:
     assert app.env is not None
-    if isinstance(obj, type):
-        check_class_docstring_has_no_attributes(app.env, name, lines)
 
     # Insert a "deprecated" sphinx directive (this is built-in to autodoc) for objects flagged with
     # @deprecated.

--- a/docs/sphinx/_ext/dagster-sphinx/setup.py
+++ b/docs/sphinx/_ext/dagster-sphinx/setup.py
@@ -1,0 +1,23 @@
+from setuptools import find_packages, setup
+
+setup(
+    name="dagster-sphinx",
+    version="0.0.1",
+    author="Elementl",
+    author_email="hello@elementl.com",
+    license="Apache-2.0",
+    description="Dagster-specific sphinx extension.",
+    url="https://github.com/dagster-io/dagster",
+    classifiers=[
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+    ],
+    packages=find_packages(exclude=["dagster_sphinx_tests*"]),
+    install_requires=[
+        "sphinx",
+        "sphinx_toolbox",
+    ],
+)

--- a/docs/sphinx/_ext/dagster-sphinx/tox.ini
+++ b/docs/sphinx/_ext/dagster-sphinx/tox.ini
@@ -1,0 +1,11 @@
+[tox]
+skipsdist = true
+
+[testenv]
+download = True
+passenv = CI_PULL_REQUEST COVERALLS_REPO_TOKEN BUILDKITE*
+allowlist_externals =
+  /bin/bash
+commands =
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
+  pytest -c ../../pyproject.toml -vv {posargs}

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -79,11 +79,6 @@ project = "Dagster"
 copyright = "2019, Dagster Labs, Inc"  # noqa: A001
 author = "Dagster Labs"
 
-# The short X.Y version
-version = ""
-# The full version, including alpha/beta/rc tags
-release = ""
-
 # -- General configuration ---------------------------------------------------
 
 # NOTE: `sphinx.ext.*` extensions are built-in to sphinx-- all others are supplied by other
@@ -101,8 +96,8 @@ extensions = [
     "sphinx.ext.viewcode",
     # Directives for automatically documenting CLIs built with the `click` package.
     "sphinx_click.ext",
-    # Dagster-Labs-authored extension with custom directives and sphinx processing.
-    "autodoc_dagster",
+    # Dagster-labs-authored extension with custom directives and sphinx processing.
+    "dagster_sphinx",
     # Renders a collapsible HTML component. Used by autodoc_dagster.
     "sphinx_toolbox.collapse",
 ]

--- a/docs/tox.ini
+++ b/docs/tox.ini
@@ -14,6 +14,7 @@ deps =
   sphinx-click==4.3.0
   sphinx_toolbox
   sphinxcontrib-serializinghtml<1.1.6 # pin away new version that manifests TypeError
+  -e sphinx/_ext/dagster-sphinx
 
   # Can't stub deps because processed by sphinx-click
   -e ../python_modules/dagster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ target-versions = ['py38', 'py39', 'py310', 'py311']
 
 include = [
   ".buildkite/dagster-buildkite",
+  "docs/sphinx/_ext/dagster-sphinx",
   "python_modules",
   "examples",
   "integration_tests",

--- a/pyright/alt-1/requirements-pinned.txt
+++ b/pyright/alt-1/requirements-pinned.txt
@@ -171,7 +171,7 @@ pendulum==2.1.2
 pexpect==4.8.0
 pickleshare==0.7.5
 Pillow==10.0.0
-platformdirs==3.8.1
+platformdirs==3.9.1
 pluggy==1.2.0
 -e examples/project_fully_featured
 prometheus-client==0.17.1

--- a/pyright/master/include.txt
+++ b/pyright/master/include.txt
@@ -1,4 +1,5 @@
 .buildkite/dagster-buildkite
+docs/sphinx/_ext/dagster-sphinx
 python_modules
 examples
 integration_tests

--- a/pyright/master/requirements-pinned.txt
+++ b/pyright/master/requirements-pinned.txt
@@ -5,6 +5,7 @@ aiohttp==3.8.5
 aiohttp-retry==2.8.3
 aiosignal==1.3.1
 alembic==1.11.3
+alabaster==0.7.13
 altair==4.2.2
 amqp==5.1.1
 aniso8601==9.0.1
@@ -19,6 +20,8 @@ apache-airflow-providers-ftp==3.5.0
 apache-airflow-providers-http==4.1.0
 apache-airflow-providers-imap==3.3.0
 apache-airflow-providers-sqlite==3.4.3
+apeye==1.4.0
+apeye-core==1.1.4
 apispec==6.3.0
 appdirs==1.4.4
 appnope==0.1.3
@@ -34,6 +37,7 @@ asttokens==2.2.1
 async-lru==2.0.4
 async-timeout==4.0.3
 attrs==23.1.0
+autodocsumm==0.2.11
 autoflake==2.2.0
 -e python_modules/automation
 avro==1.10.2
@@ -55,6 +59,7 @@ bokeh==3.2.2
 boto3==1.28.33
 botocore==1.31.33
 buildkite-test-collector==0.1.7
+CacheControl==0.13.1
 cached-property==1.5.2
 cachelib==0.9.0
 cachetools==5.3.1
@@ -87,6 +92,7 @@ coverage==7.3.0
 cron-descriptor==1.4.0
 croniter==1.4.1
 cryptography==41.0.3
+cssutils==2.7.1
 cycler==0.11.0
 -e python_modules/dagit
 -e python_modules/dagster
@@ -136,6 +142,7 @@ cycler==0.11.0
 -e python_modules/libraries/dagster-snowflake-pandas
 -e python_modules/libraries/dagster-snowflake-pyspark
 -e python_modules/libraries/dagster-spark
+-e docs/sphinx/_ext/dagster-sphinx
 -e python_modules/libraries/dagster-ssh
 -e python_modules/dagster-test
 -e python_modules/libraries/dagster-twilio
@@ -160,6 +167,7 @@ decorator==5.1.1
 defusedxml==0.7.1
 Deprecated==1.2.14
 -e examples/development_to_production
+dict2css==0.3.0
 diff-match-patch==20200713
 dill==0.3.7
 distlib==0.3.7
@@ -170,7 +178,8 @@ docker-image-py==0.1.12
 docker-pycreds==0.4.0
 -e examples/docs_snippets
 docstring-parser==0.15
-docutils==0.20.1
+docutils==0.18.1
+domdf-python-tools==3.6.1
 duckdb==0.8.1
 email-validator==1.3.1
 entrypoints==0.4
@@ -226,6 +235,7 @@ grpcio-tools==1.57.0
 gunicorn==21.2.0
 h11==0.14.0
 hologram==0.0.16
+html5lib==1.1
 httpcore==0.17.3
 httplib2==0.22.0
 httptools==0.6.0
@@ -307,6 +317,7 @@ multidict==6.0.4
 multimethod==1.9.1
 mypy-extensions==1.0.0
 mysql-connector-python==8.1.0
+natsort==8.4.0
 nbclient==0.8.0
 nbconvert==7.7.4
 nbformat==5.9.2
@@ -444,9 +455,23 @@ slack-sdk==3.21.3
 smmap==5.0.0
 sniffio==1.3.0
 snowflake-connector-python==3.1.0
+snowballstemmer==2.2.0
 snowflake-sqlalchemy==1.4.7
 sortedcontainers==2.4.0
 soupsieve==2.4.1
+Sphinx==5.0.2
+sphinx-autodoc-typehints==1.19.1
+sphinx-click==4.3.0
+sphinx-jinja2-compat==0.2.0
+sphinx-prompt==1.5.0
+sphinx-tabs==3.4.1
+sphinx-toolbox==3.4.0
+sphinxcontrib-applehelp==1.0.4
+sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-htmlhelp==2.0.1
+sphinxcontrib-jsmath==1.0.1
+sphinxcontrib-qthelp==1.0.3
+sphinxcontrib-serializinghtml==1.1.5
 SQLAlchemy==1.4.49
 SQLAlchemy-JSONField==1.0.1.post0
 SQLAlchemy-Utils==0.41.1

--- a/pyright/master/requirements.txt
+++ b/pyright/master/requirements.txt
@@ -26,6 +26,7 @@
 
 ### LIBRARIES
 
+-e docs/sphinx/_ext/dagster-sphinx
 -e python_modules/automation
 -e python_modules/dagster[pyright,test]
 -e python_modules/dagit


### PR DESCRIPTION
## Summary & Motivation

Our custom sphinx extension `autodoc_dagster` currently lives in a single file. This PR breaks it into a separate Python package `dagster-sphinx` and refactors it somewhat. This was necessary due to the growing complexity of the extension due to recent and in-progress docs improvements.

This PR also adds the new package to the pyright master env, which introduces `sphinx` and `docutils` dependencies and necessitate a pyright pins update (bouns: developing a sphinx plugin is way more pleasant with pyright/LSP help).

## How I Tested These Changes

Built docs.