### PR TITLE
Patch for serdes of StaticPartitionsDefinition

### DIFF
--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -26,10 +26,12 @@ from dagster._cli.debug import DebugRunPayload
 from dagster._core.definitions.dependency import NodeHandle
 from dagster._core.definitions.events import UNDEFINED_ASSET_KEY_PATH, AssetLineageInfo
 from dagster._core.definitions.metadata import MetadataValue
+from dagster._core.definitions.partition import StaticPartitionsDefinition
 from dagster._core.errors import DagsterInvalidInvocationError
 from dagster._core.events import DagsterEvent, StepMaterializationData
 from dagster._core.events.log import EventLogEntry
 from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
+from dagster._core.host_representation.external_data import ExternalStaticPartitionsDefinitionData
 from dagster._core.instance import DagsterInstance, InstanceRef
 from dagster._core.scheduler.instigation import InstigatorState, InstigatorTick
 from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus, RunsFilter
@@ -1250,3 +1252,13 @@ def test_metadata_serialization():
         },
     ]
     assert deserialize_value(serialized_mat, AssetMaterialization) == mat
+
+
+# When receiving pre-1.4 static partitions definitions from user code, it is possible they contain
+# duplicates. We need to de-dup them at the serdes/"External" layer before reconstructing the
+# partitions definition in the host process to avoid an error.
+def test_static_partitions_definition_dup_keys_backcompat():
+    received_from_user = ExternalStaticPartitionsDefinitionData(partition_keys=["a", "b", "a"])
+    assert received_from_user.get_partitions_definition() == StaticPartitionsDefinition(
+        partition_keys=["a", "b"]
+    )


### PR DESCRIPTION
## Summary & Motivation

v1.4 made `StaticPartitionsDefinition` error if given duplicate keys. This caused host process errors for users who had not upgraded their user code to 1.4 and had duplicate keys, since the host process `StaticPartitionsDefinition` would throw an error. This PR removes dups in `ExternalStaticPartitionsDefinitionData`, which should eliminate any dups received from the user before they hit the error-throwing code in `StaticPartitionsDefinition`.

## How I Tested These Changes

New unit test. It is imperfect since it doesn't test against an actual older version.
