### PR TITLE
[docs] update sda docs to use deps more

### DIFF
--- a/docs/content/concepts/assets/asset-auto-execution.mdx
+++ b/docs/content/concepts/assets/asset-auto-execution.mdx
@@ -36,8 +36,8 @@ def asset1():
     ...
 
 
-@asset(auto_materialize_policy=AutoMaterializePolicy.eager())
-def asset2(asset1):
+@asset(auto_materialize_policy=AutoMaterializePolicy.eager(), deps=[asset1])
+def asset2():
     ...
 ```
 
@@ -61,8 +61,8 @@ def asset1():
     ...
 
 
-@asset
-def asset2(asset1):
+@asset(deps=[asset1])
+def asset2():
     ...
 
 
@@ -91,8 +91,9 @@ def asset1():
 @asset(
     auto_materialize_policy=AutoMaterializePolicy.lazy(),
     freshness_policy=FreshnessPolicy(maximum_lag_minutes=24 * 60),
+    deps=[asset1],
 )
-def asset2(asset1):
+def asset2():
     ...
 ```
 
@@ -109,16 +110,17 @@ def asset1():
     ...
 
 
-@asset(auto_materialize_policy=AutoMaterializePolicy.lazy())
-def asset2(asset1):
+@asset(auto_materialize_policy=AutoMaterializePolicy.lazy(), deps=[asset1])
+def asset2():
     ...
 
 
 @asset(
     auto_materialize_policy=AutoMaterializePolicy.lazy(),
     freshness_policy=FreshnessPolicy(maximum_lag_minutes=24 * 60),
+    deps=[asset2],
 )
-def asset3(asset2):
+def asset3():
     ...
 ```
 
@@ -175,8 +177,9 @@ def asset1():
 @asset(
     partitions_def=DailyPartitionsDefinition(start_date="2020-10-10"),
     auto_materialize_policy=AutoMaterializePolicy.eager(),
+    deps=[asset1],
 )
-def asset2(asset1):
+def asset2():
     ...
 ```
 

--- a/docs/content/concepts/assets/graph-backed-assets.mdx
+++ b/docs/content/concepts/assets/graph-backed-assets.mdx
@@ -56,9 +56,9 @@ def slack_files_table():
     return store_files(fetch_files_from_slack())
 ```
 
-### Defining basic dependencies for graph-backed assets
+### Defining managed-loading dependencies for graph-backed assets
 
-Similar to with basic software-defined assets, Dagster infers the upstream assets from the names of the arguments to the decorated function.
+Similar to software-defined assets, Dagster infers the upstream assets from the names of the arguments to the decorated function. Dagster will then delegate loading the data to an [I/O manager](/concepts/io-management/io-managers).
 
 The example below includes an asset named `middle_asset`. `middle_asset` depends on `upstream_asset`, and `downstream_asset` depends on `middle_asset`:
 

--- a/docs/content/concepts/assets/software-defined-assets.mdx
+++ b/docs/content/concepts/assets/software-defined-assets.mdx
@@ -504,7 +504,7 @@ def test_my_simple_asset():
     assert result == [1, 2, 3]
 ```
 
-If you have an asset with upstream dependencies:
+If you have an asset with managed-loading upstream dependencies:
 
 ```python file=/concepts/assets/asset_testing.py startafter=start_more_complex_asset endbefore=end_more_complex_asset
 @asset
@@ -544,7 +544,7 @@ def test_uses_resource() -> None:
     assert result == {"foo": "bar"}
 ```
 
-If you use a context object in your function, you can use <PyObject object="build_op_context" /> to generate the `context` object, because under the hood the function decorated by `@asset` is an op.
+If you use a context object in your function, you can use <PyObject object="build_asset_context" /> to generate the `context` object, because under the hood the function decorated by `@asset` is an op.
 
 Consider the following asset that uses a context object:
 

--- a/docs/content/concepts/assets/software-defined-assets.mdx
+++ b/docs/content/concepts/assets/software-defined-assets.mdx
@@ -544,7 +544,7 @@ def test_uses_resource() -> None:
     assert result == {"foo": "bar"}
 ```
 
-If you use a context object in your function, you can use <PyObject object="build_asset_context" /> to generate the `context` object, because under the hood the function decorated by `@asset` is an op.
+If you use a context object in your function, you can use <PyObject object="build_op_context" /> to generate the `context` object, because under the hood the function decorated by `@asset` is an op.
 
 Consider the following asset that uses a context object:
 

--- a/docs/content/guides/dagster/automating-pipelines.mdx
+++ b/docs/content/guides/dagster/automating-pipelines.mdx
@@ -144,8 +144,8 @@ def asset1():
     ...
 
 
-@asset(auto_materialize_policy=AutoMaterializePolicy.eager())
-def asset2(asset1):
+@asset(auto_materialize_policy=AutoMaterializePolicy.eager(), deps=[asset1])
+def asset2():
     ...
 ```
 

--- a/examples/docs_snippets/docs_snippets/concepts/assets/auto_materialize_eager.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/auto_materialize_eager.py
@@ -6,6 +6,6 @@ def asset1():
     ...
 
 
-@asset(auto_materialize_policy=AutoMaterializePolicy.eager())
-def asset2(asset1):
+@asset(auto_materialize_policy=AutoMaterializePolicy.eager(), deps=[asset1])
+def asset2():
     ...

--- a/examples/docs_snippets/docs_snippets/concepts/assets/auto_materialize_lazy.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/auto_materialize_lazy.py
@@ -9,6 +9,7 @@ def asset1():
 @asset(
     auto_materialize_policy=AutoMaterializePolicy.lazy(),
     freshness_policy=FreshnessPolicy(maximum_lag_minutes=24 * 60),
+    deps=[asset1],
 )
-def asset2(asset1):
+def asset2():
     ...

--- a/examples/docs_snippets/docs_snippets/concepts/assets/auto_materialize_lazy_transitive.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/auto_materialize_lazy_transitive.py
@@ -6,14 +6,15 @@ def asset1():
     ...
 
 
-@asset(auto_materialize_policy=AutoMaterializePolicy.lazy())
-def asset2(asset1):
+@asset(auto_materialize_policy=AutoMaterializePolicy.lazy(), deps=[asset1])
+def asset2():
     ...
 
 
 @asset(
     auto_materialize_policy=AutoMaterializePolicy.lazy(),
     freshness_policy=FreshnessPolicy(maximum_lag_minutes=24 * 60),
+    deps=[asset2],
 )
-def asset3(asset2):
+def asset3():
     ...

--- a/examples/docs_snippets/docs_snippets/concepts/assets/auto_materialize_multiple.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/auto_materialize_multiple.py
@@ -11,8 +11,8 @@ def asset1():
     ...
 
 
-@asset
-def asset2(asset1):
+@asset(deps=[asset1])
+def asset2():
     ...
 
 

--- a/examples/docs_snippets/docs_snippets/concepts/assets/auto_materialize_time_partitions.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/auto_materialize_time_partitions.py
@@ -12,6 +12,7 @@ def asset1():
 @asset(
     partitions_def=DailyPartitionsDefinition(start_date="2020-10-10"),
     auto_materialize_policy=AutoMaterializePolicy.eager(),
+    deps=[asset1],
 )
-def asset2(asset1):
+def asset2():
     ...


### PR DESCRIPTION
## Summary & Motivation
In an effort to make `deps` a first class concept, I'm updating the concept code snippets where it makes sense to use `deps` rather than other ways to defining dependencies. 

This PR updates the Assets section of the concepts.

I chose to update whatever examples I could to use deps. We could alternatively move some of those back to arg-based deps to show them as equally usable (specifically thinking about the auto materialization page)

Several examples could not be updated because they are incompatible with `deps`. I either left them as is, or opened issues for ones that we should address with API changes

## How I Tested These Changes
