### PR TITLE
[auto-materialize][refactor] Rename AssetDaemonCursor and moved namedtuples to more appropriate files

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_auto_materialize_asset_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_auto_materialize_asset_evaluations.py
@@ -2,11 +2,9 @@ from datetime import datetime
 
 import dagster._check as check
 from dagster import AssetKey
-from dagster._core.definitions.asset_reconciliation_sensor import (
-    AssetReconciliationCursor,
-    AutoMaterializeAssetEvaluation,
-)
+from dagster._core.definitions.asset_daemon_cursor import AssetDaemonCursor
 from dagster._core.definitions.auto_materialize_condition import (
+    AutoMaterializeAssetEvaluation,
     MissingAutoMaterializeCondition,
     ParentMaterializedAutoMaterializeCondition,
     ParentOutdatedAutoMaterializeCondition,
@@ -364,7 +362,7 @@ class TestAutoMaterializeAssetEvaluations(ExecutingGraphQLContextTestMatrix):
 
     def test_current_evaluation_id(self, graphql_context: WorkspaceRequestContext):
         graphql_context.instance.daemon_cursor_storage.set_cursor_values(
-            {CURSOR_KEY: AssetReconciliationCursor.empty().serialize()}
+            {CURSOR_KEY: AssetDaemonCursor.empty().serialize()}
         )
 
         results = execute_dagster_graphql(
@@ -381,7 +379,7 @@ class TestAutoMaterializeAssetEvaluations(ExecutingGraphQLContextTestMatrix):
 
         graphql_context.instance.daemon_cursor_storage.set_cursor_values(
             {
-                CURSOR_KEY: AssetReconciliationCursor.empty()
+                CURSOR_KEY: AssetDaemonCursor.empty()
                 .with_updates(0, {}, set(), {}, 42, None, [], 0)  # type: ignore
                 .serialize()
             }

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
@@ -1,0 +1,264 @@
+import datetime
+import itertools
+import json
+from collections import defaultdict
+from typing import (
+    TYPE_CHECKING,
+    AbstractSet,
+    Dict,
+    Iterable,
+    Mapping,
+    NamedTuple,
+    Optional,
+    Sequence,
+    Set,
+    cast,
+)
+
+import dagster._check as check
+from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
+
+from .asset_graph import AssetGraph
+from .auto_materialize_condition import (
+    AutoMaterializeCondition,
+    AutoMaterializeDecisionType,
+)
+from .partition import (
+    PartitionsDefinition,
+    PartitionsSubset,
+)
+
+if TYPE_CHECKING:
+    from dagster._core.instance import DynamicPartitionsStore
+
+
+class AssetDaemonCursor(NamedTuple):
+    """State that's saved between reconciliation evaluations.
+
+    Attributes:
+        latest_storage_id:
+            The latest observed storage ID across all assets. Useful for finding out what has
+            happened since the last tick.
+        handled_root_asset_keys:
+            Every entry is a non-partitioned asset with no parents that has been requested by this
+            sensor, discarded by this sensor, or has been materialized (even if not by this sensor).
+        handled_root_partitions_by_asset_key:
+            Every key is a partitioned root asset. Every value is the set of that asset's partitions
+            that have been requested by this sensor, discarded by this sensor,
+            or have been materialized (even if not by this sensor).
+        last_observe_request_timestamp_by_asset_key:
+            Every key is an observable source asset that has been auto-observed. The value is the
+            timestamp of the tick that requested the observation.
+    """
+
+    latest_storage_id: Optional[int]
+    handled_root_asset_keys: AbstractSet[AssetKey]
+    handled_root_partitions_by_asset_key: Mapping[AssetKey, PartitionsSubset]
+    evaluation_id: int
+    last_observe_request_timestamp_by_asset_key: Mapping[AssetKey, float]
+
+    def was_previously_handled(self, asset_key: AssetKey) -> bool:
+        return asset_key in self.handled_root_asset_keys
+
+    def get_unhandled_partitions(
+        self,
+        asset_key: AssetKey,
+        asset_graph,
+        dynamic_partitions_store: "DynamicPartitionsStore",
+        current_time: datetime.datetime,
+    ) -> Iterable[str]:
+        partitions_def = asset_graph.get_partitions_def(asset_key)
+
+        handled_subset = self.handled_root_partitions_by_asset_key.get(
+            asset_key, partitions_def.empty_subset()
+        )
+
+        return handled_subset.get_partition_keys_not_in_subset(
+            current_time=current_time,
+            dynamic_partitions_store=dynamic_partitions_store,
+        )
+
+    def with_updates(
+        self,
+        latest_storage_id: Optional[int],
+        conditions_by_asset_partition: Mapping[
+            AssetKeyPartitionKey, AbstractSet[AutoMaterializeCondition]
+        ],
+        newly_materialized_root_asset_keys: AbstractSet[AssetKey],
+        newly_materialized_root_partitions_by_asset_key: Mapping[AssetKey, AbstractSet[str]],
+        evaluation_id: int,
+        asset_graph: AssetGraph,
+        newly_observe_requested_asset_keys: Sequence[AssetKey],
+        observe_request_timestamp: float,
+    ) -> "AssetDaemonCursor":
+        """Returns a cursor that represents this cursor plus the updates that have happened within the
+        tick.
+        """
+        handled_root_partitions_by_asset_key: Dict[AssetKey, Set[str]] = defaultdict(set)
+        handled_non_partitioned_root_assets: Set[AssetKey] = set()
+
+        for asset_partition, conditions in conditions_by_asset_partition.items():
+            if (
+                # only consider root assets
+                not asset_graph.has_non_source_parents(asset_partition.asset_key)
+                # which were discarded or materialized
+                and (
+                    AutoMaterializeDecisionType.from_conditions(conditions)
+                    in (
+                        AutoMaterializeDecisionType.DISCARD,
+                        AutoMaterializeDecisionType.MATERIALIZE,
+                    )
+                )
+            ):
+                if asset_partition.partition_key:
+                    handled_root_partitions_by_asset_key[asset_partition.asset_key].add(
+                        asset_partition.partition_key
+                    )
+                else:
+                    handled_non_partitioned_root_assets.add(asset_partition.asset_key)
+
+        result_handled_root_partitions_by_asset_key = {**self.handled_root_partitions_by_asset_key}
+        for asset_key in set(newly_materialized_root_partitions_by_asset_key.keys()) | set(
+            handled_root_partitions_by_asset_key.keys()
+        ):
+            prior_materialized_partitions = self.handled_root_partitions_by_asset_key.get(asset_key)
+            if prior_materialized_partitions is None:
+                prior_materialized_partitions = cast(
+                    PartitionsDefinition, asset_graph.get_partitions_def(asset_key)
+                ).empty_subset()
+
+            result_handled_root_partitions_by_asset_key[
+                asset_key
+            ] = prior_materialized_partitions.with_partition_keys(
+                itertools.chain(
+                    newly_materialized_root_partitions_by_asset_key[asset_key],
+                    handled_root_partitions_by_asset_key[asset_key],
+                )
+            )
+
+        result_handled_root_asset_keys = (
+            self.handled_root_asset_keys
+            | newly_materialized_root_asset_keys
+            | handled_non_partitioned_root_assets
+        )
+
+        result_last_observe_request_timestamp_by_asset_key = {
+            **self.last_observe_request_timestamp_by_asset_key
+        }
+        for asset_key in newly_observe_requested_asset_keys:
+            result_last_observe_request_timestamp_by_asset_key[
+                asset_key
+            ] = observe_request_timestamp
+
+        if latest_storage_id and self.latest_storage_id:
+            check.invariant(
+                latest_storage_id >= self.latest_storage_id,
+                "Latest storage ID should be >= previous latest storage ID",
+            )
+
+        return AssetDaemonCursor(
+            latest_storage_id=latest_storage_id or self.latest_storage_id,
+            handled_root_asset_keys=result_handled_root_asset_keys,
+            handled_root_partitions_by_asset_key=result_handled_root_partitions_by_asset_key,
+            evaluation_id=evaluation_id,
+            last_observe_request_timestamp_by_asset_key=result_last_observe_request_timestamp_by_asset_key,
+        )
+
+    @classmethod
+    def empty(cls) -> "AssetDaemonCursor":
+        return AssetDaemonCursor(
+            latest_storage_id=None,
+            handled_root_partitions_by_asset_key={},
+            handled_root_asset_keys=set(),
+            evaluation_id=0,
+            last_observe_request_timestamp_by_asset_key={},
+        )
+
+    @classmethod
+    def from_serialized(cls, cursor: str, asset_graph: AssetGraph) -> "AssetDaemonCursor":
+        data = json.loads(cursor)
+
+        if isinstance(data, list):  # backcompat
+            check.invariant(len(data) in [3, 4], "Invalid serialized cursor")
+            (
+                latest_storage_id,
+                serialized_handled_root_asset_keys,
+                serialized_handled_root_partitions_by_asset_key,
+            ) = data[:3]
+
+            evaluation_id = data[3] if len(data) == 4 else 0
+            serialized_last_observe_request_timestamp_by_asset_key = {}
+        else:
+            latest_storage_id = data["latest_storage_id"]
+            serialized_handled_root_asset_keys = data["handled_root_asset_keys"]
+            serialized_handled_root_partitions_by_asset_key = data[
+                "handled_root_partitions_by_asset_key"
+            ]
+            evaluation_id = data["evaluation_id"]
+            serialized_last_observe_request_timestamp_by_asset_key = data.get(
+                "last_observe_request_timestamp_by_asset_key", {}
+            )
+
+        handled_root_partitions_by_asset_key = {}
+        for (
+            key_str,
+            serialized_subset,
+        ) in serialized_handled_root_partitions_by_asset_key.items():
+            key = AssetKey.from_user_string(key_str)
+            if key not in asset_graph.materializable_asset_keys:
+                continue
+
+            partitions_def = asset_graph.get_partitions_def(key)
+            if partitions_def is None:
+                continue
+
+            try:
+                # in the case that the partitions def has changed, we may not be able to deserialize
+                # the corresponding subset. in this case, we just use an empty subset
+                handled_root_partitions_by_asset_key[key] = partitions_def.deserialize_subset(
+                    serialized_subset
+                )
+            except:
+                handled_root_partitions_by_asset_key[key] = partitions_def.empty_subset()
+        return cls(
+            latest_storage_id=latest_storage_id,
+            handled_root_asset_keys={
+                AssetKey.from_user_string(key_str) for key_str in serialized_handled_root_asset_keys
+            },
+            handled_root_partitions_by_asset_key=handled_root_partitions_by_asset_key,
+            evaluation_id=evaluation_id,
+            last_observe_request_timestamp_by_asset_key={
+                AssetKey.from_user_string(key_str): timestamp
+                for key_str, timestamp in serialized_last_observe_request_timestamp_by_asset_key.items()
+            },
+        )
+
+    @classmethod
+    def get_evaluation_id_from_serialized(cls, cursor: str) -> Optional[int]:
+        data = json.loads(cursor)
+        if isinstance(data, list):  # backcompat
+            check.invariant(len(data) in [3, 4], "Invalid serialized cursor")
+            return data[3] if len(data) == 4 else None
+        else:
+            return data["evaluation_id"]
+
+    def serialize(self) -> str:
+        serializable_handled_root_partitions_by_asset_key = {
+            key.to_user_string(): subset.serialize()
+            for key, subset in self.handled_root_partitions_by_asset_key.items()
+        }
+        serialized = json.dumps(
+            {
+                "latest_storage_id": self.latest_storage_id,
+                "handled_root_asset_keys": [
+                    key.to_user_string() for key in self.handled_root_asset_keys
+                ],
+                "handled_root_partitions_by_asset_key": serializable_handled_root_partitions_by_asset_key,
+                "evaluation_id": self.evaluation_id,
+                "last_observe_request_timestamp_by_asset_key": {
+                    key.to_user_string(): timestamp
+                    for key, timestamp in self.last_observe_request_timestamp_by_asset_key.items()
+                },
+            }
+        )
+        return serialized

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -3,10 +3,8 @@ from typing import Optional
 import pendulum
 
 import dagster._check as check
-from dagster._core.definitions.asset_reconciliation_sensor import (
-    AssetReconciliationCursor,
-    reconcile,
-)
+from dagster._core.definitions.asset_daemon_cursor import AssetDaemonCursor
+from dagster._core.definitions.asset_reconciliation_sensor import reconcile
 from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
 from dagster._core.definitions.run_request import RunRequest
 from dagster._core.definitions.selector import JobSubsetSelector
@@ -48,11 +46,7 @@ def _get_raw_cursor(instance: DagsterInstance) -> Optional[str]:
 
 def get_current_evaluation_id(instance: DagsterInstance) -> Optional[int]:
     raw_cursor = _get_raw_cursor(instance)
-    return (
-        AssetReconciliationCursor.get_evaluation_id_from_serialized(raw_cursor)
-        if raw_cursor
-        else None
-    )
+    return AssetDaemonCursor.get_evaluation_id_from_serialized(raw_cursor) if raw_cursor else None
 
 
 class AssetDaemon(IntervalDaemon):
@@ -103,9 +97,9 @@ class AssetDaemon(IntervalDaemon):
 
         raw_cursor = _get_raw_cursor(instance)
         cursor = (
-            AssetReconciliationCursor.from_serialized(raw_cursor, asset_graph)
+            AssetDaemonCursor.from_serialized(raw_cursor, asset_graph)
             if raw_cursor
-            else AssetReconciliationCursor.empty()
+            else AssetDaemonCursor.empty()
         )
 
         run_requests, new_cursor, evaluations = reconcile(

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/asset_reconciliation_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/asset_reconciliation_scenario.py
@@ -41,12 +41,10 @@ from dagster import (
     observable_source_asset,
     repository,
 )
+from dagster._core.definitions.asset_daemon_cursor import AssetDaemonCursor
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
-from dagster._core.definitions.asset_reconciliation_sensor import (
-    AssetReconciliationCursor,
-    AutoMaterializeCondition,
-    reconcile,
-)
+from dagster._core.definitions.asset_reconciliation_sensor import reconcile
+from dagster._core.definitions.auto_materialize_condition import AutoMaterializeCondition
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.definitions.data_version import DataVersionsByPartition
 from dagster._core.definitions.events import CoercibleToAssetKey
@@ -197,12 +195,10 @@ class AssetReconciliationScenario(NamedTuple):
                     )
 
                 # make sure we can deserialize it using the new asset graph
-                cursor = AssetReconciliationCursor.from_serialized(
-                    cursor.serialize(), repo.asset_graph
-                )
+                cursor = AssetDaemonCursor.from_serialized(cursor.serialize(), repo.asset_graph)
 
             else:
-                cursor = AssetReconciliationCursor.empty()
+                cursor = AssetDaemonCursor.empty()
 
         start = datetime.datetime.now()
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_daemon_cursor.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_daemon_cursor.py
@@ -1,10 +1,8 @@
 import json
 
 from dagster import AssetKey, StaticPartitionsDefinition, asset
+from dagster._core.definitions.asset_daemon_cursor import AssetDaemonCursor
 from dagster._core.definitions.asset_graph import AssetGraph
-from dagster._core.definitions.asset_reconciliation_sensor import (
-    AssetReconciliationCursor,
-)
 
 partitions = StaticPartitionsDefinition(partition_keys=["a", "b", "c"])
 
@@ -19,14 +17,12 @@ def test_asset_reconciliation_cursor_evaluation_id_backcompat():
         """[20, ["a"], {"my_asset": "{\\"version\\": 1, \\"subset\\": [\\"a\\"]}"}]"""
     )
 
-    assert (
-        AssetReconciliationCursor.get_evaluation_id_from_serialized(backcompat_serialized) is None
-    )
+    assert AssetDaemonCursor.get_evaluation_id_from_serialized(backcompat_serialized) is None
 
     asset_graph = AssetGraph.from_assets([my_asset])
-    c = AssetReconciliationCursor.from_serialized(backcompat_serialized, asset_graph)
+    c = AssetDaemonCursor.from_serialized(backcompat_serialized, asset_graph)
 
-    assert c == AssetReconciliationCursor(
+    assert c == AssetDaemonCursor(
         20,
         {AssetKey("a")},
         {AssetKey("my_asset"): partitions.empty_subset().with_partition_keys(["a"])},
@@ -38,11 +34,11 @@ def test_asset_reconciliation_cursor_evaluation_id_backcompat():
         21, {}, {AssetKey("my_asset")}, {AssetKey("my_asset"): {"a"}}, 1, asset_graph, {}, 0
     )
 
-    serdes_c2 = AssetReconciliationCursor.from_serialized(c2.serialize(), asset_graph)
+    serdes_c2 = AssetDaemonCursor.from_serialized(c2.serialize(), asset_graph)
     assert serdes_c2 == c2
     assert serdes_c2.evaluation_id == 1
 
-    assert AssetReconciliationCursor.get_evaluation_id_from_serialized(c2.serialize()) == 1
+    assert AssetDaemonCursor.get_evaluation_id_from_serialized(c2.serialize()) == 1
 
 
 def test_asset_reconciliation_cursor_auto_observe_backcompat():
@@ -71,7 +67,7 @@ def test_asset_reconciliation_cursor_auto_observe_backcompat():
         )
     )
 
-    cursor = AssetReconciliationCursor.from_serialized(
+    cursor = AssetDaemonCursor.from_serialized(
         serialized, asset_graph=AssetGraph.from_assets([asset1, asset2])
     )
     assert cursor.latest_storage_id == 25

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_auto_observe.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_auto_observe.py
@@ -1,7 +1,7 @@
 from dagster import AssetKey, DagsterInstance, observable_source_asset
+from dagster._core.definitions.asset_daemon_cursor import AssetDaemonCursor
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_reconciliation_sensor import (
-    AssetReconciliationCursor,
     get_auto_observe_run_requests,
     reconcile,
 )
@@ -107,7 +107,7 @@ def test_reconcile():
         asset_graph=asset_graph,
         target_asset_keys=set(),
         instance=instance,
-        cursor=AssetReconciliationCursor.empty(),
+        cursor=AssetDaemonCursor.empty(),
         materialize_run_tags=None,
         observe_run_tags={"tag1": "tag_value"},
     )


### PR DESCRIPTION
## Summary & Motivation

Breaking up the previous massive PR (https://github.com/dagster-io/dagster/pull/15317) into smaller chunks. This one just renames the AssetReconciliation cursor to the AssetDaemonCursor, puts it in a separate file, and moves the AutoMaterializeAssetEvaluation tuple into the auto_materialize_conditions.py file

## How I Tested These Changes
