### PR TITLE
Assorted dagster-webserver renames

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/pipelines/dagster_oss_main.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/pipelines/dagster_oss_main.py
@@ -2,8 +2,8 @@ import os
 import re
 from typing import List, Optional
 
-from dagster_buildkite.steps.dagit_ui import build_dagit_ui_steps, skip_if_no_dagit_changes
 from dagster_buildkite.steps.dagster import build_dagster_steps, build_repo_wide_steps
+from dagster_buildkite.steps.dagster_ui import build_dagster_ui_steps, skip_if_no_dagster_ui_changes
 from dagster_buildkite.steps.docs import build_docs_steps
 from dagster_buildkite.steps.trigger import build_trigger_step
 from dagster_buildkite.utils import BuildkiteStep, is_release_branch, safe_getenv
@@ -40,7 +40,9 @@ def build_dagster_oss_main_steps() -> List[BuildkiteStep]:
                 env={
                     "DAGSTER_BRANCH": branch_name,
                     "DAGSTER_COMMIT_HASH": commit_hash,
-                    "DAGIT_ONLY_OSS_CHANGE": "1" if not skip_if_no_dagit_changes() else "",
+                    "DAGSTER_UI_ONLY_OSS_CHANGE": "1"
+                    if not skip_if_no_dagster_ui_changes()
+                    else "",
                     "DAGSTER_CHECKOUT_DEPTH": _get_setting("DAGSTER_CHECKOUT_DEPTH") or "100",
                 },
             ),
@@ -49,7 +51,7 @@ def build_dagster_oss_main_steps() -> List[BuildkiteStep]:
     # Full pipeline.
     steps += build_repo_wide_steps()
     steps += build_docs_steps()
-    steps += build_dagit_ui_steps()
+    steps += build_dagster_ui_steps()
     steps += build_dagster_steps()
 
     return steps

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster_ui.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster_ui.py
@@ -9,7 +9,7 @@ from ..step_builder import CommandStepBuilder
 from ..utils import CommandStep, is_feature_branch
 
 
-def skip_if_no_dagit_changes():
+def skip_if_no_dagster_ui_changes():
     if not is_feature_branch():
         return None
 
@@ -25,9 +25,9 @@ def skip_if_no_dagit_changes():
     return "No changes that affect the JS webapp"
 
 
-def build_dagit_ui_steps() -> List[CommandStep]:
+def build_dagster_ui_steps() -> List[CommandStep]:
     return [
-        CommandStepBuilder(":typescript: dagit-ui")
+        CommandStepBuilder(":typescript: dagster-ui")
         .run(
             "cd js_modules/dagit",
             # Explicitly install Node 16.x because BK is otherwise running 12.x.
@@ -37,6 +37,6 @@ def build_dagit_ui_steps() -> List[CommandStep]:
             "tox -vv -e py310",
         )
         .on_test_image(AvailablePythonVersion.get_default())
-        .with_skip(skip_if_no_dagit_changes())
+        .with_skip(skip_if_no_dagster_ui_changes())
         .build(),
     ]

--- a/examples/deploy_docker/tests/test_deploy_docker.py
+++ b/examples/deploy_docker/tests/test_deploy_docker.py
@@ -126,14 +126,14 @@ def test_deploy_docker():
 
         start_time = time.time()
 
-        dagit_host = os.environ.get("DEPLOY_DOCKER_DAGIT_HOST", "localhost")
+        webserver_host = os.environ.get("DEPLOY_DOCKER_DAGIT_HOST", "localhost")
 
         while True:
             if time.time() - start_time > 15:
-                raise Exception("Timed out waiting for dagit server to be available")
+                raise Exception("Timed out waiting for webserver to be available")
 
             try:
-                sanity_check = requests.get(f"http://{dagit_host}:3000/dagit_info")
+                sanity_check = requests.get(f"http://{webserver_host}:3000/server_info")
                 assert "dagster_webserver" in sanity_check.text
                 break
             except requests.exceptions.ConnectionError:
@@ -142,10 +142,7 @@ def test_deploy_docker():
             time.sleep(1)
 
         res = requests.get(
-            "http://{dagit_host}:3000/graphql?query={query_string}".format(
-                dagit_host=dagit_host,
-                query_string=PIPELINES_OR_ERROR_QUERY,
-            )
+            f"http://{webserver_host}:3000/graphql?query={PIPELINES_OR_ERROR_QUERY}"
         ).json()
 
         data = res.get("data")
@@ -172,8 +169,9 @@ def test_deploy_docker():
         }
 
         launch_res = requests.post(
-            "http://{dagit_host}:3000/graphql?query={query_string}&variables={variables}".format(
-                dagit_host=dagit_host,
+            "http://{webserver_host}:3000/graphql?query={query_string}&variables={variables}"
+            .format(
+                webserver_host=webserver_host,
                 query_string=LAUNCH_PIPELINE_MUTATION,
                 variables=json.dumps(variables),
             )
@@ -185,7 +183,7 @@ def test_deploy_docker():
         run_id = run["runId"]
         assert run["status"] == "QUEUED"
 
-        _wait_for_run_status(run_id, dagit_host, DagsterRunStatus.SUCCESS)
+        _wait_for_run_status(run_id, webserver_host, DagsterRunStatus.SUCCESS)
 
         # Launch a job that uses the docker executor
 
@@ -201,8 +199,9 @@ def test_deploy_docker():
         }
 
         launch_res = requests.post(
-            "http://{dagit_host}:3000/graphql?query={query_string}&variables={variables}".format(
-                dagit_host=dagit_host,
+            "http://{webserver_host}:3000/graphql?query={query_string}&variables={variables}"
+            .format(
+                webserver_host=webserver_host,
                 query_string=LAUNCH_PIPELINE_MUTATION,
                 variables=json.dumps(variables),
             )
@@ -214,7 +213,7 @@ def test_deploy_docker():
         run_id = run["runId"]
         assert run["status"] == "QUEUED"
 
-        _wait_for_run_status(run_id, dagit_host, DagsterRunStatus.SUCCESS)
+        _wait_for_run_status(run_id, webserver_host, DagsterRunStatus.SUCCESS)
 
         # Launch a hanging pipeline and terminate it
         variables = {
@@ -229,8 +228,9 @@ def test_deploy_docker():
         }
 
         launch_res = requests.post(
-            "http://{dagit_host}:3000/graphql?query={query_string}&variables={variables}".format(
-                dagit_host=dagit_host,
+            "http://{webserver_host}:3000/graphql?query={query_string}&variables={variables}"
+            .format(
+                webserver_host=webserver_host,
                 query_string=LAUNCH_PIPELINE_MUTATION,
                 variables=json.dumps(variables),
             )
@@ -241,11 +241,12 @@ def test_deploy_docker():
         run = launch_res["data"]["launchPipelineExecution"]["run"]
         hanging_run_id = run["runId"]
 
-        _wait_for_run_status(hanging_run_id, dagit_host, DagsterRunStatus.STARTED)
+        _wait_for_run_status(hanging_run_id, webserver_host, DagsterRunStatus.STARTED)
 
         terminate_res = requests.post(
-            "http://{dagit_host}:3000/graphql?query={query_string}&variables={variables}".format(
-                dagit_host=dagit_host,
+            "http://{webserver_host}:3000/graphql?query={query_string}&variables={variables}"
+            .format(
+                webserver_host=webserver_host,
                 query_string=TERMINATE_MUTATION,
                 variables=json.dumps({"runId": hanging_run_id}),
             )
@@ -256,10 +257,10 @@ def test_deploy_docker():
             == "TerminateRunSuccess"
         ), str(terminate_res)
 
-        _wait_for_run_status(hanging_run_id, dagit_host, DagsterRunStatus.CANCELED)
+        _wait_for_run_status(hanging_run_id, webserver_host, DagsterRunStatus.CANCELED)
 
 
-def _wait_for_run_status(run_id, dagit_host, desired_status):
+def _wait_for_run_status(run_id, webserver_host, desired_status):
     start_time = time.time()
 
     while True:
@@ -267,8 +268,9 @@ def _wait_for_run_status(run_id, dagit_host, desired_status):
             raise Exception(f"Timed out waiting for run to reach status {desired_status}")
 
         run_res = requests.get(
-            "http://{dagit_host}:3000/graphql?query={query_string}&variables={variables}".format(
-                dagit_host=dagit_host,
+            "http://{webserver_host}:3000/graphql?query={query_string}&variables={variables}"
+            .format(
+                webserver_host=webserver_host,
                 query_string=RUN_QUERY,
                 variables=json.dumps({"runId": run_id}),
             )

--- a/examples/deploy_ecs/tests/test_deploy.py
+++ b/examples/deploy_ecs/tests/test_deploy.py
@@ -124,4 +124,4 @@ def docker_compose(
 
 @pytest.mark.xfail
 def test_deploy(docker_compose, retrying_requests):
-    assert retrying_requests.get(f'http://{docker_compose["dagit"]}:3000/dagit_info').ok
+    assert retrying_requests.get(f'http://{docker_compose["dagit"]}:3000/server_info').ok

--- a/examples/docs_snippets/docs_snippets/concepts/resources/pythonic_resources.py
+++ b/examples/docs_snippets/docs_snippets/concepts/resources/pythonic_resources.py
@@ -303,7 +303,7 @@ class GitHubOrganization:
         self.name = name
 
     def repositories(self):
-        return ["dagster", "dagit", "dagster-graphql"]
+        return ["dagster", "dagster-webserver", "dagster-graphql"]
 
 
 class GitHub:

--- a/examples/docs_snippets/docs_snippets_tests/intro_tutorial_tests/test_cli_invocations.py
+++ b/examples/docs_snippets/docs_snippets_tests/intro_tutorial_tests/test_cli_invocations.py
@@ -99,7 +99,7 @@ def path_to_tutorial_file(path):
     )
 
 
-def load_dagit_for_workspace_cli_args(n_pipelines=1, **kwargs):
+def load_dagster_webserver_for_workspace_cli_args(n_pipelines=1, **kwargs):
     with instance_for_test() as instance:
         with get_workspace_process_context_from_kwargs(
             instance, version="", read_only=False, kwargs=kwargs
@@ -125,13 +125,15 @@ def load_dagit_for_workspace_cli_args(n_pipelines=1, **kwargs):
 @pytest.mark.parametrize(
     "dirname,filename,fn_name,_env_yaml,_mode,_preset,_return_code,_exception", cli_args
 )
-# dagit -f filename -n fn_name
+# dagster-webserver -f filename -n fn_name
 def test_load_pipeline(
     dirname, filename, fn_name, _env_yaml, _mode, _preset, _return_code, _exception
 ):
     with pushd(path_to_tutorial_file(dirname)):
         filepath = path_to_tutorial_file(os.path.join(dirname, filename))
-        load_dagit_for_workspace_cli_args(python_file=(filepath,), fn_name=fn_name)
+        load_dagster_webserver_for_workspace_cli_args(
+            python_file=(filepath,), fn_name=fn_name
+        )
 
 
 @pytest.mark.parametrize(

--- a/examples/project_fully_featured/project_fully_featured/__init__.py
+++ b/examples/project_fully_featured/project_fully_featured/__init__.py
@@ -19,7 +19,7 @@ deployment_name = os.environ.get("DAGSTER_DEPLOYMENT", "local")
 
 all_sensors = [activity_analytics_assets_sensor, recommender_assets_sensor]
 if deployment_name in ["prod", "staging"]:
-    all_sensors.append(make_slack_on_failure_sensor(base_url="my_dagit_url"))
+    all_sensors.append(make_slack_on_failure_sensor(base_url="my_webserver_url"))
 
 defs = Definitions(
     assets=all_assets,

--- a/examples/project_fully_featured/project_fully_featured/sensors/slack_on_failure_sensor.py
+++ b/examples/project_fully_featured/project_fully_featured/sensors/slack_on_failure_sensor.py
@@ -8,5 +8,5 @@ def make_slack_on_failure_sensor(base_url: str) -> SensorDefinition:
     return make_slack_on_run_failure_sensor(
         channel="#dogfooding-alert",
         slack_token=os.environ.get("SLACK_DAGSTER_ETL_BOT_TOKEN", ""),
-        dagit_base_url=base_url,
+        webserver_base_url=base_url,
     )

--- a/python_modules/automation/automation/docker/image_defs.py
+++ b/python_modules/automation/automation/docker/image_defs.py
@@ -111,7 +111,7 @@ def k8s_webserver_editable_cm(cwd: str) -> Iterator[None]:
 
 
 @contextlib.contextmanager
-def k8s_webserver_example_cm(cwd: str) -> Iterator[None]:
+def k8s_dagit_example(cwd: str) -> Iterator[None]:
     with copy_directories(
         get_core_celery_k8s_dirs()
         + [
@@ -197,7 +197,7 @@ def dagster_celery_k8s_editable_cm(cwd: str) -> Iterator[None]:
 
 # Some images have custom build context manager functions, listed here
 CUSTOM_BUILD_CONTEXTMANAGERS: Dict[str, Callable] = {
-    "k8s-webserver-example": k8s_webserver_example_cm,
+    "k8s-dagit-example": k8s_dagit_example,
     "user-code-example": user_code_example_cm,
     "user-code-example-editable": user_code_example_editable_cm,
     "dagster-k8s-editable": dagster_k8s_editable_cm,

--- a/python_modules/automation/automation/docker/image_defs.py
+++ b/python_modules/automation/automation/docker/image_defs.py
@@ -197,7 +197,7 @@ def dagster_celery_k8s_editable_cm(cwd: str) -> Iterator[None]:
 
 # Some images have custom build context manager functions, listed here
 CUSTOM_BUILD_CONTEXTMANAGERS: Dict[str, Callable] = {
-    "k8s-dagit-example": k8s_webserver_example_cm,
+    "k8s-webserver-example": k8s_webserver_example_cm,
     "user-code-example": user_code_example_cm,
     "user-code-example-editable": user_code_example_editable_cm,
     "dagster-k8s-editable": dagster_k8s_editable_cm,

--- a/python_modules/automation/automation/docker/images/README.md
+++ b/python_modules/automation/automation/docker/images/README.md
@@ -4,7 +4,7 @@
   as the default so that users can switch to Celery without hitting a dependency issue.
 - `user-code-example` (Helm default): Example job code.
 - `dagster-k8s`: `dagster-celery-k8s` without the Celery dependency.
-- `k8s-webserver-example` (deprecated): Webserver image that includes user code, from before gRPC servers were standard. Used to be the Helm default.
+- `k8s-dagit-example` (deprecated): Webserver image that includes user code, from before gRPC servers were standard. Used to be the Helm default.
 
 ## Creating an image
 

--- a/python_modules/automation/automation/docker/images/README.md
+++ b/python_modules/automation/automation/docker/images/README.md
@@ -4,7 +4,7 @@
   as the default so that users can switch to Celery without hitting a dependency issue.
 - `user-code-example` (Helm default): Example job code.
 - `dagster-k8s`: `dagster-celery-k8s` without the Celery dependency.
-- `k8s-dagit-example` (deprecated): Dagit image that includes user code, from before gRPC servers were standard. Used to be the Helm default.
+- `k8s-webserver-example` (deprecated): Webserver image that includes user code, from before gRPC servers were standard. Used to be the Helm default.
 
 ## Creating an image
 

--- a/python_modules/dagster-graphql/dagster_graphql/cli.py
+++ b/python_modules/dagster-graphql/dagster_graphql/cli.py
@@ -98,14 +98,15 @@ def execute_query_against_remote(host, query, variables):
     parsed_url = urlparse(host)
     if not (parsed_url.scheme and parsed_url.netloc):
         raise click.UsageError(
-            "Host {host} is not a valid URL. Host URL should include scheme ie http://localhost"
-            .format(host=host)
+            f"Host {host} is not a valid URL. Host URL should include scheme ie http://localhost."
         )
 
-    sanity_check = requests.get(urljoin(host, "/dagit_info"))
+    sanity_check = requests.get(urljoin(host, "/server_info"))
     sanity_check.raise_for_status()
-    if "dagit" not in sanity_check.text:
-        raise click.UsageError(f"Host {host} failed sanity check. It is not a dagit server.")
+    if "dagster_webserver" not in sanity_check.text:
+        raise click.UsageError(
+            f"Host {host} failed sanity check. It is not a dagster-webserver instance."
+        )
     response = requests.post(
         urljoin(host, "/graphql"),
         # send query and vars as post body to avoid uri length limits
@@ -161,7 +162,7 @@ PREDEFINED_QUERIES = {
     "--remote",
     "-r",
     type=click.STRING,
-    help="A URL for a remote instance running dagit server to send the GraphQL request to.",
+    help="A URL for a remote instance running dagster-webserver to send the GraphQL request to.",
 )
 @click.option(
     "--output",

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/__init__.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/__init__.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, AsyncIterator, Optional, Sequence, Tuple,
 
 # re-exports
 import dagster._check as check
+from dagster._annotations import deprecated
 from dagster._core.definitions.events import AssetKey
 from dagster._core.events import EngineEventData
 from dagster._core.instance import DagsterInstance
@@ -169,8 +170,17 @@ def delete_pipeline_run(
     return GrapheneDeletePipelineRunSuccess(run_id)
 
 
+@deprecated(
+    breaking_version="2.0",
+    emit_runtime_warning=False,
+    additional_warn_text="DAGIT_EVENT_LOAD_CHUNK_SIZE is the only deprecated part.",
+)
 def get_chunk_size() -> int:
-    return int(os.getenv("DAGIT_EVENT_LOAD_CHUNK_SIZE", "10000"))
+    return int(
+        os.getenv(
+            "DAGSTER_UI_EVENT_LOAD_CHUNK_SIZE", os.getenv("DAGIT_EVENT_LOAD_CHUNK_SIZE", "10000")
+        )
+    )
 
 
 async def gen_events_for_run(

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
@@ -221,8 +221,8 @@ def get_assets_latest_info(
             list(unstarted_run_ids_by_asset.get(asset_key, [])),
             list(in_progress_run_ids_by_asset.get(asset_key, [])),
             GrapheneRun(run_records_by_run_id[latest_run_ids_by_asset[asset_key]])
-            # Dagit error occurs if a run is terminated at the same time that this endpoint is called
-            # so we check to make sure the run ID exists in the run records
+            # Dagster UI error occurs if a run is terminated at the same time that this endpoint is
+            # called so we check to make sure the run ID exists in the run records.
             if asset_key in latest_run_ids_by_asset
             and latest_run_ids_by_asset[asset_key] in run_records_by_run_id
             else None,

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
@@ -417,7 +417,7 @@ class CrossRepoAssetDependedByLoader:
 
             for asset in all_depended_by_assets:
                 # SourceAssets defined as ExternalAssetNodes contain no definition data (e.g.
-                # no output or partition definition data) and no job_names. Dagit displays
+                # no output or partition definition data) and no job_names. The Dagster UI displays
                 # all ExternalAssetNodes with no job_names as foreign assets, so sink assets
                 # are defined as ExternalAssetNodes with no definition data.
                 sink_assets[asset.downstream_asset_key] = ExternalAssetNode(

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/telemetry.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/telemetry.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from ..schema.roots.mutation import GrapheneLogTelemetrySuccess
 
 
-def log_dagit_telemetry_event(
+def log_ui_telemetry_event(
     graphene_info: "ResolveInfo", action: str, client_time: str, client_id, metadata: str
 ) -> "GrapheneLogTelemetrySuccess":
     from ..schema.roots.mutation import GrapheneLogTelemetrySuccess

--- a/python_modules/dagster-graphql/dagster_graphql/schema/logs/events.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/logs/events.py
@@ -303,7 +303,7 @@ class GrapheneLogsCapturedEvent(graphene.ObjectType):
     externalStderrUrl = graphene.String()
     pid = graphene.Int()
     # legacy name for compute log file key... required for back-compat reasons, but has been
-    # renamed to fileKey for newer versions of dagit
+    # renamed to fileKey for newer versions of the Dagster UI
     logKey = graphene.NonNull(graphene.String)
 
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/mutation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/mutation.py
@@ -26,7 +26,7 @@ from ...implementation.execution import (
     wipe_assets,
 )
 from ...implementation.external import fetch_workspace, get_full_external_job_or_raise
-from ...implementation.telemetry import log_dagit_telemetry_event
+from ...implementation.telemetry import log_ui_telemetry_event
 from ...implementation.utils import (
     ExecutionMetadata,
     ExecutionParams,
@@ -667,7 +667,7 @@ class GrapheneLogTelemetryMutation(graphene.Mutation):
     def mutate(
         self, graphene_info: ResolveInfo, action: str, clientTime: str, clientId: str, metadata: str
     ):
-        action = log_dagit_telemetry_event(
+        action = log_ui_telemetry_event(
             graphene_info,
             action=action,
             client_time=clientTime,

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -410,7 +410,7 @@ class GrapheneQuery(graphene.ObjectType):
             " Note: Assets should "
         )
         + "not be defined in more than one repository - this query is used to present warnings and"
-        " errors in Dagit.",
+        " errors in the Dagster UI.",
     )
 
     partitionBackfillOrError = graphene.Field(

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/graphql_context_test_suite.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/graphql_context_test_suite.py
@@ -278,7 +278,8 @@ class EnvironmentManagers:
     def managed_grpc(target=None, location_name="test"):
         @contextmanager
         def _mgr_fn(instance, read_only):
-            """Relies on Dagit to load the code location in a subprocess and manage its lifecyle."""
+            """Relies on webserver to load the code location in a subprocess and manage its lifecyle.
+            """
             loadable_target_origin = (
                 target if target is not None else get_main_loadable_target_origin()
             )

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
@@ -228,7 +228,7 @@ def noop_op(_):
     pass
 
 
-# Won't pass cloud-dagit test suite without `in_process_executor`.
+# Won't pass cloud-webserver test suite without `in_process_executor`.
 @job(executor_def=in_process_executor)
 def noop_job():
     noop_op()

--- a/python_modules/dagster-graphql/tox.ini
+++ b/python_modules/dagster-graphql/tox.ini
@@ -13,7 +13,7 @@ deps =
 allowlist_externals =
   /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
   not_graphql_context_test_suite: pytest -c ../../pyproject.toml -m "not graphql_context_test_suite and not graphql_context_variants and not python_client_test_suite" -vv --durations 10 {posargs}
   sqlite_instance_multi_location: pytest -c ../../pyproject.toml -m "graphql_context_test_suite and sqlite_instance and multi_location" -vv --durations 10 {posargs}
   sqlite_instance_managed_grpc_env: pytest -c ../../pyproject.toml -m "graphql_context_test_suite and sqlite_instance and managed_grpc_env" -vv --durations 10 {posargs}

--- a/python_modules/dagster-test/Dockerfile
+++ b/python_modules/dagster-test/Dockerfile
@@ -21,7 +21,6 @@ RUN pip install \
     -e modules/dagster-graphql \
     -e modules/dagster-celery \
     -e modules/dagster-celery[flower,redis,kubernetes] \
-    -e modules/dagit \
     -e modules/dagster-webserver \
     -e modules/dagster-postgres \
     -e modules/dagster-pandas \
@@ -36,7 +35,7 @@ RUN pip install \
     -e . \
     pyparsing\<3.0.0
 
-RUN ! (pip list --exclude-editable | grep -e dagster -e dagit)
+RUN ! (pip list --exclude-editable | grep -e dagster)
 
 WORKDIR /dagster_test/test_project/
 

--- a/python_modules/dagster-test/dagster_test/test_project/build.sh
+++ b/python_modules/dagster-test/dagster_test/test_project/build.sh
@@ -46,7 +46,6 @@ alias copy_py="rsync -av \
       --exclude .coverage"
 
 copy_py $ROOT/python_modules/dagster \
-        $ROOT/python_modules/dagit \
         $ROOT/python_modules/dagster-webserver \
         $ROOT/python_modules/dagster-graphql \
         $ROOT/python_modules/libraries/dagster-airflow \

--- a/python_modules/dagster-test/dagster_test/toys/sensors.py
+++ b/python_modules/dagster-test/dagster_test/toys/sensors.py
@@ -122,7 +122,7 @@ def get_toys_sensors():
         channel="#toy-test",
         slack_token=os.environ.get("SLACK_DAGSTER_ETL_BOT_TOKEN"),
         monitored_jobs=[error_monster_failing_job],
-        dagit_base_url="http://localhost:3000",
+        webserver_base_url="http://localhost:3000",
     )
 
     @asset_sensor(asset_key=AssetKey("model"), job=log_asset_job)

--- a/python_modules/dagster-webserver/dagster_webserver/cli.py
+++ b/python_modules/dagster-webserver/dagster_webserver/cli.py
@@ -8,6 +8,7 @@ from typing import Optional
 import click
 import dagster._check as check
 import uvicorn
+from dagster._annotations import deprecated
 from dagster._cli.utils import get_possibly_temporary_instance_for_cli
 from dagster._cli.workspace import (
     get_workspace_process_context_from_kwargs,
@@ -257,6 +258,11 @@ def host_dagster_ui_with_workspace_process_context(
 cli = create_dagster_webserver_cli()
 
 
+@deprecated(
+    breaking_version="2.0",
+    subject="DAGIT_* environment variables, WEBSERVER_LOGGER_NAME",
+    emit_runtime_warning=False,
+)
 def main():
     # We only ever update this variable here. It is used to set the logger name as "dagit" if the
     # user invokes "dagit" on the command line.

--- a/python_modules/dagster-webserver/dagster_webserver/webserver.py
+++ b/python_modules/dagster-webserver/dagster_webserver/webserver.py
@@ -6,6 +6,7 @@ from typing import Generic, List, TypeVar
 
 import dagster._check as check
 from dagster import __version__ as dagster_version
+from dagster._annotations import deprecated
 from dagster._core.debug import DebugRunPayload
 from dagster._core.storage.cloud_storage_compute_log_manager import CloudStorageComputeLogManager
 from dagster._core.storage.compute_log_manager import ComputeIOType
@@ -271,11 +272,15 @@ class DagsterWebserver(GraphQLServer, Generic[T_IWorkspaceProcessContext]):
             *self.root_static_file_routes(),
         ]
 
+    @deprecated(
+        breaking_version="2.0",
+        subject="/dagit_info and /dagit/notebook endpoint",
+        emit_runtime_warning=False,
+    )
     def build_routes(self):
         routes = (
             [
                 Route("/server_info", self.webserver_info_endpoint),
-                # Remove /dagit_info with 2.0
                 Route("/dagit_info", self.webserver_info_endpoint),
                 Route(
                     "/graphql",
@@ -304,7 +309,6 @@ class DagsterWebserver(GraphQLServer, Generic[T_IWorkspaceProcessContext]):
                     "/notebook",
                     self.download_notebook,
                 ),
-                # Remove /dagit/notebook with 2.0
                 Route(
                     "/dagit/notebook",
                     self.download_notebook,

--- a/python_modules/dagster/README.md
+++ b/python_modules/dagster/README.md
@@ -74,13 +74,13 @@ If you're new to Dagster, we recommend reading about its [core concepts](https:/
 Dagster is available on PyPI and officially supports Python 3.8+.
 
 ```bash
-pip install dagster dagit
+pip install dagster dagster-webserver
 ```
 
-This installs two modules:
+This installs two packages:
 
-- **Dagster**: The core programming model.
-- **Dagit**: The web interface for developing and operating Dagster jobs and assets.
+- `dagster`: The core programming model.
+- `dagster-webserver`: The server that hosts Dagster's web UI for developing and operating Dagster jobs and assets.
 
 Running on Using a Mac with an M1 or M2 chip? Check the [install details here](https://docs.dagster.io/getting-started/install#installing-dagster-into-an-existing-python-environment).
 

--- a/python_modules/dagster/dagster/_cli/dev.py
+++ b/python_modules/dagster/dagster/_cli/dev.py
@@ -9,6 +9,7 @@ from typing import Optional
 import click
 
 import dagster._check as check
+from dagster._annotations import deprecated
 from dagster._serdes import serialize_value
 from dagster._serdes.ipc import interrupt_ipc_subprocess, open_ipc_subprocess
 from dagster._utils.log import configure_loggers
@@ -70,6 +71,9 @@ def dev_command_options(f):
     "-h",
     help="Host to use for the Dagster webserver.",
     required=False,
+)
+@deprecated(
+    breaking_version="2.0", subject="--dagit-port and --dagit-host args", emit_runtime_warning=False
 )
 def dev_command(
     code_server_log_level: str,

--- a/python_modules/dagster/dagster/_core/storage/alembic/README.md
+++ b/python_modules/dagster/dagster/_core/storage/alembic/README.md
@@ -38,7 +38,7 @@ To add a new back-compat test for sqlite, follow the following steps:
 1. Switch code branches to master or some revision before you’ve added the schema change.
 1. Change your dagster.yaml to use the default sqlite implementation for run/event_log storage.
 1. Make sure your configured storage directory (e.g. $DAGSTER_HOME/history) is wiped
-1. Start dagit and execute a pipeline run, to ensure that both the run db and per-run event_log dbs are created.
+1. Start dagster-webserver and execute a run, to ensure that both the run db and per-run event_log dbs are created.
 1. Copy the runs.db and all per-run event log dbs to the back compat test directory:
    - `mkdir -p python_modules/dagster/dagster_tests/general_tests/compat_tests/<my_schema_change>/sqlite/history`
    - `cp $DAGSTER_HOME/history/runs.db\* python_modules/dagster/dagster_tests/general_tests/compat_tests/<my_schema_change>/sqlite/history/`
@@ -71,7 +71,7 @@ To add a new back-compat test for postgres, follow the following steps:
        postgres_url: "postgresql://test:test@localhost:5432/test"
    ```
 1. Wipe, if you haven’t already dagster run wipe
-1. Start dagit and execute a pipeline run, to ensure that both the run db and per-run event_log dbs are created.
+1. Start dagster-webserver and execute a run, to ensure that both the run db and per-run event_log dbs are created.
 1. Create a pg dump file
    - `mkdir python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/<my_schema_change>/postgres`
    - `pg_dump test > python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/<my_schema_change>/postgres/pg_dump.txt`
@@ -104,7 +104,7 @@ To add a new back-compat test for mysql, follow the following steps:
        mysql_url: "mysql+mysqlconnector://test:test@localhost:3306/test"
    ```
 3. Wipe, if you haven’t already dagster run wipe
-4. Start dagit and execute a pipeline run, to ensure that both the run db and per-run event_log dbs are created.
+4. Start dagster-webserver and execute a run, to ensure that both the run db and per-run event_log dbs are created.
 5. Create a mysql dump file
    - `mkdir python_modules/libraries/dagster-mysql/dagster_mysql_tests/compat_tests/<my_schema_change>/mysql`
    - `mysqldump test > python_modules/libraries/dagster-mysql/dagster_mysql_tests/compat_tests/<my_schema_change>/mysql/mysql_dump.sql -p`

--- a/python_modules/dagster/dagster/_core/telemetry.py
+++ b/python_modules/dagster/dagster/_core/telemetry.py
@@ -68,6 +68,7 @@ ENABLED_STR = "enabled"
 DAGSTER_HOME_FALLBACK = "~/.dagster"
 MAX_BYTES = 10485760  # 10 MB = 10 * 1024 * 1024 bytes
 UPDATE_REPO_STATS = "update_repo_stats"
+# 'dagit' name is deprecated but we keep the same telemetry action name to avoid data disruption
 START_DAGSTER_WEBSERVER = "start_dagit_webserver"
 DAEMON_ALIVE = "daemon_alive"
 SCHEDULED_RUN_CREATED = "scheduled_run_created"

--- a/python_modules/dagster/dagster/_utils/log.py
+++ b/python_modules/dagster/dagster/_utils/log.py
@@ -8,6 +8,7 @@ import coloredlogs
 
 import dagster._check as check
 import dagster._seven as seven
+from dagster._annotations import deprecated
 from dagster._config import Enum, EnumValue
 from dagster._core.definitions.logger_definition import logger
 from dagster._core.utils import PYTHON_LOGGING_LEVELS_MAPPING, coerce_valid_log_level
@@ -216,6 +217,11 @@ def define_default_formatter():
     return logging.Formatter(default_format_string(), default_date_format_string())
 
 
+@deprecated(
+    breaking_version="2.0",
+    subject="loggers.dagit",
+    emit_runtime_warning=False,
+)
 def configure_loggers(handler="default", log_level="INFO"):
     LOGGING_CONFIG = {
         "version": 1,

--- a/python_modules/dagster/tox.ini
+++ b/python_modules/dagster/tox.ini
@@ -19,7 +19,7 @@ deps =
 allowlist_externals =
   /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
 
   api_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/api_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
   cli_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/cli_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}

--- a/python_modules/libraries/dagster-airbyte/tox.ini
+++ b/python_modules/libraries/dagster-airbyte/tox.ini
@@ -11,6 +11,6 @@ deps =
 allowlist_externals =
   /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
   unit: pytest -c ../../../pyproject.toml --ignore ./dagster_airbyte_tests/integration -vv {posargs}
   integration: pytest -c ../../../pyproject.toml ./dagster_airbyte_tests/integration -vv {posargs}

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_factory.py
@@ -43,7 +43,7 @@ def make_dagster_definitions_from_airflow_dag_bag(
                 return make_dagster_definition_from_airflow_dag_bag(my_dag_bag)
 
         Use Definitions as usual, for example:
-            `dagit -f path/to/make_dagster_definition.py`
+            `dagster-webserver -f path/to/make_dagster_definition.py`
 
     Args:
         dag_bag (DagBag): Airflow DagBag Model
@@ -93,7 +93,7 @@ def make_dagster_definitions_from_airflow_dags_path(
                 )
 
         Use RepositoryDefinition as usual, for example:
-        ``dagit -f path/to/make_dagster_repo.py -n make_repo_from_dir``
+        ``dagster-webserver -f path/to/make_dagster_repo.py -n make_repo_from_dir``
 
     Args:
         dag_path (str): Path to directory or file that contains Airflow Dags
@@ -156,7 +156,7 @@ def make_dagster_definitions_from_airflow_example_dags(
                 return make_dagster_definitions_from_airflow_example_dags()
 
         Use Definitions as usual, for example:
-            `dagit -f path/to/make_dagster_definitions.py`
+            `dagster-webserver -f path/to/make_dagster_definitions.py`
 
     Args:
         resource_defs: Optional[Mapping[str, ResourceDefinition]]

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_job_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_job_factory.py
@@ -51,7 +51,7 @@ def make_dagster_job_from_airflow_dag(
             my_dagster_job.execute_in_process()
 
     3. (Recommended) Add ``{'airflow_execution_date': utc_date_string}`` to the run tags,
-        such as in the Dagit UI. This will override behavior from (1) and (2)
+        such as in the Dagster UI. This will override behavior from (1) and (2)
 
 
     We apply normalized_name() to the dag id and task ids when generating job name and op

--- a/python_modules/libraries/dagster-airflow/tox.ini
+++ b/python_modules/libraries/dagster-airflow/tox.ini
@@ -19,7 +19,7 @@ deps =
 allowlist_externals =
   /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
   localdb-airflow1: airflow initdb
   localdb-airflow2: airflow db init
   default: pytest -m requires_no_db -vv {posargs}

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/compute_log_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/compute_log_manager.py
@@ -68,7 +68,7 @@ class S3ComputeLogManager(CloudStorageComputeLogManager, ConfigurableClass):
         skip_empty_files: (Optional[bool]): Skip upload of empty log files.
         upload_interval: (Optional[int]): Interval in seconds to upload partial log files to S3. By default, will only upload when the capture is complete.
         upload_extra_args: (Optional[dict]): Extra args for S3 file upload
-        show_url_only: (Optional[bool]): Only show the URL of the log file in Dagit, instead of fetching and displaying the full content. Default False.
+        show_url_only: (Optional[bool]): Only show the URL of the log file in the UI, instead of fetching and displaying the full content. Default False.
         region: (Optional[str]): The region of the S3 bucket. If not specified, will use the default region of the AWS session.
         inst_data (Optional[ConfigurableClassData]): Serializable representation of the compute
             log manager when newed up from config.

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/emr_tests/requirements.txt
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/emr_tests/requirements.txt
@@ -1,6 +1,6 @@
 boto3
 dagster
-dagit
+dagster-webserver
 dagster_aws
 dagster_pyspark
 dagster_spark

--- a/python_modules/libraries/dagster-aws/tox.ini
+++ b/python_modules/libraries/dagster-aws/tox.ini
@@ -12,5 +12,5 @@ deps =
 allowlist_externals =
   /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
   pytest -c ../../../pyproject.toml -vv {posargs}

--- a/python_modules/libraries/dagster-azure/tox.ini
+++ b/python_modules/libraries/dagster-azure/tox.ini
@@ -12,5 +12,5 @@ deps =
 allowlist_externals =
   /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
   pytest -c ../../../pyproject.toml -vv {posargs}

--- a/python_modules/libraries/dagster-celery-docker/tox.ini
+++ b/python_modules/libraries/dagster-celery-docker/tox.ini
@@ -17,5 +17,5 @@ deps =
 allowlist_externals =
   /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
   pytest -c ../../../pyproject.toml -vv {posargs}

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s_tests/test_launcher.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s_tests/test_launcher.py
@@ -110,7 +110,7 @@ def test_get_validated_celery_k8s_executor_config():
                     "job_namespace": {"env": "TEST_PIPELINE_RUN_NAMESPACE"},
                     "broker": {"env": "TEST_CELERY_BROKER"},
                     "backend": {"env": "TEST_CELERY_BACKEND"},
-                    "include": ["dagster", "dagit"],
+                    "include": ["dagster", "dagster-webserver"],
                     "config_source": {
                         "task_annotations": """{'*': {'on_failure': my_on_failure}}"""
                     },
@@ -139,7 +139,7 @@ def test_get_validated_celery_k8s_executor_config():
             "backend": "redis://some-redis-host:6379/0",
             "broker": "redis://some-redis-host:6379/0",
             "job_namespace": "my-namespace",
-            "include": ["dagster", "dagit"],
+            "include": ["dagster", "dagster-webserver"],
             "config_source": {"task_annotations": """{'*': {'on_failure': my_on_failure}}"""},
             "retries": {"disabled": {}},
             "job_image": "foo",
@@ -219,7 +219,7 @@ def test_get_validated_celery_k8s_executor_config_for_job():
                         "job_namespace": {"env": "TEST_PIPELINE_RUN_NAMESPACE"},
                         "broker": {"env": "TEST_CELERY_BROKER"},
                         "backend": {"env": "TEST_CELERY_BACKEND"},
-                        "include": ["dagster", "dagit"],
+                        "include": ["dagster", "dagster-webserver"],
                         "config_source": {
                             "task_annotations": """{'*': {'on_failure': my_on_failure}}"""
                         },
@@ -249,7 +249,7 @@ def test_get_validated_celery_k8s_executor_config_for_job():
             "job_namespace": "my-namespace",
             "backend": "redis://some-redis-host:6379/0",
             "broker": "redis://some-redis-host:6379/0",
-            "include": ["dagster", "dagit"],
+            "include": ["dagster", "dagster-webserver"],
             "config_source": {"task_annotations": """{'*': {'on_failure': my_on_failure}}"""},
             "retries": {"disabled": {}},
             "job_image": "foo",

--- a/python_modules/libraries/dagster-celery-k8s/tox.ini
+++ b/python_modules/libraries/dagster-celery-k8s/tox.ini
@@ -22,5 +22,5 @@ deps =
 allowlist_externals =
   /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
   pytest -c ../../../pyproject.toml -vv {posargs}

--- a/python_modules/libraries/dagster-celery/tox.ini
+++ b/python_modules/libraries/dagster-celery/tox.ini
@@ -19,5 +19,5 @@ deps =
 allowlist_externals =
   /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
   pytest -c ../../../pyproject.toml -vv {posargs} -s

--- a/python_modules/libraries/dagster-census/tox.ini
+++ b/python_modules/libraries/dagster-census/tox.ini
@@ -9,5 +9,5 @@ deps =
 whitelist_externals =
   /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
   pytest -c ../../../pyproject.toml -vv {posargs}

--- a/python_modules/libraries/dagster-dask/dagster_dask_tests/test_graphql.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask_tests/test_graphql.py
@@ -9,7 +9,7 @@ from dagster_graphql.test.utils import (
 )
 
 
-def test_execute_hammer_through_dagit():
+def test_execute_hammer_through_webserver():
     with instance_for_test() as instance:
         with get_workspace_process_context_from_kwargs(
             instance,

--- a/python_modules/libraries/dagster-dask/tox.ini
+++ b/python_modules/libraries/dagster-dask/tox.ini
@@ -13,5 +13,5 @@ deps =
 allowlist_externals =
   /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
   pytest -c ../../../pyproject.toml -vv {posargs}

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
@@ -145,9 +145,9 @@ DAGSTER_SYSTEM_ENV_VARS = {
             default_value=True,
             description=(
                 "Determines whether to display debug logs emitted while job is being polled. It can"
-                " be helpful for Dagit performance to set to False when running long-running or"
-                " fan-out Databricks jobs, to avoid forcing the UI to fetch large amounts of debug"
-                " logs."
+                " be helpful for Dagster UI performance to set to False when running long-running"
+                " or fan-out Databricks jobs, to avoid forcing the UI to fetch large amounts of"
+                " debug logs."
             ),
         ),
         "add_dagster_env_variables": Field(

--- a/python_modules/libraries/dagster-databricks/tox.ini
+++ b/python_modules/libraries/dagster-databricks/tox.ini
@@ -14,5 +14,5 @@ deps =
 allowlist_externals =
   /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
   pytest -c ../../../pyproject.toml -vv {posargs}

--- a/python_modules/libraries/dagster-datadog/tox.ini
+++ b/python_modules/libraries/dagster-datadog/tox.ini
@@ -10,5 +10,5 @@ deps =
 allowlist_externals =
   /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
   pytest -c ../../../pyproject.toml -vv {posargs}

--- a/python_modules/libraries/dagster-datahub/tox.ini
+++ b/python_modules/libraries/dagster-datahub/tox.ini
@@ -10,5 +10,5 @@ deps =
 allowlist_externals =
   /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
   pytest -c ../../../pyproject.toml -vv {posargs}

--- a/python_modules/libraries/dagster-dbt/tox.ini
+++ b/python_modules/libraries/dagster-dbt/tox.ini
@@ -18,7 +18,7 @@ deps =
 allowlist_externals =
   /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
   dbt_13X_legacy: pytest --reruns 2 --durations 10 -c ../../../pyproject.toml -m "legacy" -vv {posargs}
   dbt_14X_legacy: pytest --reruns 2 --durations 10 -c ../../../pyproject.toml -m "legacy" -vv {posargs}
   dbt_15X_legacy: pytest --reruns 2 --durations 10 -c ../../../pyproject.toml -m "legacy" -vv {posargs}

--- a/python_modules/libraries/dagster-docker/dagster_docker_tests/dagster.yaml
+++ b/python_modules/libraries/dagster-docker/dagster_docker_tests/dagster.yaml
@@ -1,4 +1,4 @@
-# for debugging local tests in Dagit
+# for debugging local tests in Dagster UI
 
 run_storage:
   module: dagster_postgres.run_storage.run_storage

--- a/python_modules/libraries/dagster-docker/tox.ini
+++ b/python_modules/libraries/dagster-docker/tox.ini
@@ -20,5 +20,5 @@ deps =
 allowlist_externals =
   /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
   pytest -c ../../../pyproject.toml -vv {posargs}

--- a/python_modules/libraries/dagster-duckdb-pandas/tox.ini
+++ b/python_modules/libraries/dagster-duckdb-pandas/tox.ini
@@ -11,5 +11,5 @@ deps =
 allowlist_externals =
   /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
   pytest -vv {posargs}

--- a/python_modules/libraries/dagster-duckdb-polars/tox.ini
+++ b/python_modules/libraries/dagster-duckdb-polars/tox.ini
@@ -11,7 +11,7 @@ deps =
 allowlist_externals =
   /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
   pytest -vv {posargs}
 [testenv:mypy]
 commands =

--- a/python_modules/libraries/dagster-duckdb-pyspark/tox.ini
+++ b/python_modules/libraries/dagster-duckdb-pyspark/tox.ini
@@ -11,5 +11,5 @@ deps =
 allowlist_externals =
   /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
   pytest -vv {posargs}

--- a/python_modules/libraries/dagster-duckdb/tox.ini
+++ b/python_modules/libraries/dagster-duckdb/tox.ini
@@ -10,5 +10,5 @@ deps =
 allowlist_externals =
   /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
   pytest -vv {posargs}

--- a/python_modules/libraries/dagster-fivetran/tox.ini
+++ b/python_modules/libraries/dagster-fivetran/tox.ini
@@ -10,5 +10,5 @@ deps =
 allowlist_externals =
   /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
   pytest -c ../../../pyproject.toml -vv {posargs}

--- a/python_modules/libraries/dagster-gcp-pandas/tox.ini
+++ b/python_modules/libraries/dagster-gcp-pandas/tox.ini
@@ -12,7 +12,7 @@ deps =
 allowlist_externals =
   /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
   pytest -vv {posargs}
 [testenv:mypy]
 commands =

--- a/python_modules/libraries/dagster-gcp-pyspark/tox.ini
+++ b/python_modules/libraries/dagster-gcp-pyspark/tox.ini
@@ -17,5 +17,5 @@ deps =
 allowlist_externals =
   /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
   pytest -c ../../../pyproject.toml -vv ./dagster_gcp_pyspark_tests

--- a/python_modules/libraries/dagster-gcp/tox.ini
+++ b/python_modules/libraries/dagster-gcp/tox.ini
@@ -11,5 +11,5 @@ deps =
 allowlist_externals =
   /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
     pytest {posargs} -vv {posargs}

--- a/python_modules/libraries/dagster-ge/tox.ini
+++ b/python_modules/libraries/dagster-ge/tox.ini
@@ -13,5 +13,5 @@ deps =
 allowlist_externals =
   /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
     pytest -c ../../../pyproject.toml -vv {posargs}

--- a/python_modules/libraries/dagster-github/tox.ini
+++ b/python_modules/libraries/dagster-github/tox.ini
@@ -10,5 +10,5 @@ deps =
 allowlist_externals =
   /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
     pytest -c ../../../pyproject.toml -vv {posargs}

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/conftest.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/conftest.py
@@ -42,7 +42,7 @@ def k8s_run_launcher_instance(kubeconfig_file):
                     "class": "K8sRunLauncher",
                     "module": "dagster_k8s",
                     "config": {
-                        "service_account_name": "dagit-admin",
+                        "service_account_name": "webserver-admin",
                         "instance_config_map": "dagster-instance",
                         "postgres_password_secret": "dagster-postgresql-secret",
                         "dagster_home": "/opt/dagster/dagster_home",

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_executor.py
@@ -394,7 +394,7 @@ def test_executor_init_container_context(
 @pytest.fixture
 def k8s_instance(kubeconfig_file):
     default_config = {
-        "service_account_name": "dagit-admin",
+        "service_account_name": "webserver-admin",
         "instance_config_map": "dagster-instance",
         "postgres_password_secret": "dagster-postgresql-secret",
         "dagster_home": "/opt/dagster/dagster_home",

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_launcher.py
@@ -28,7 +28,7 @@ def test_launcher_from_config(kubeconfig_file):
     }
 
     default_config = {
-        "service_account_name": "dagit-admin",
+        "service_account_name": "webserver-admin",
         "instance_config_map": "dagster-instance",
         "postgres_password_secret": "dagster-postgresql-secret",
         "dagster_home": "/opt/dagster/dagster_home",
@@ -71,7 +71,7 @@ def test_launcher_with_container_context(kubeconfig_file):
     # Construct a K8s run launcher in a fake k8s environment.
     mock_k8s_client_batch_api = mock.MagicMock()
     k8s_run_launcher = K8sRunLauncher(
-        service_account_name="dagit-admin",
+        service_account_name="webserver-admin",
         instance_config_map="dagster-instance",
         postgres_password_secret="dagster-postgresql-secret",
         dagster_home="/opt/dagster/dagster_home",
@@ -178,7 +178,7 @@ def test_launcher_with_k8s_config(kubeconfig_file):
     # Construct a K8s run launcher in a fake k8s environment.
     mock_k8s_client_batch_api = mock.MagicMock()
     k8s_run_launcher = K8sRunLauncher(
-        service_account_name="dagit-admin",
+        service_account_name="webserver-admin",
         instance_config_map="dagster-instance",
         postgres_password_secret="dagster-postgresql-secret",
         dagster_home="/opt/dagster/dagster_home",
@@ -279,7 +279,7 @@ def test_user_defined_k8s_config_in_run_tags(kubeconfig_file):
     # Construct a K8s run launcher in a fake k8s environment.
     mock_k8s_client_batch_api = mock.MagicMock()
     k8s_run_launcher = K8sRunLauncher(
-        service_account_name="dagit-admin",
+        service_account_name="webserver-admin",
         instance_config_map="dagster-instance",
         postgres_password_secret="dagster-postgresql-secret",
         dagster_home="/opt/dagster/dagster_home",
@@ -378,7 +378,7 @@ def test_raise_on_error(kubeconfig_file):
     # Construct a K8s run launcher in a fake k8s environment.
     mock_k8s_client_batch_api = mock.MagicMock()
     k8s_run_launcher = K8sRunLauncher(
-        service_account_name="dagit-admin",
+        service_account_name="webserver-admin",
         instance_config_map="dagster-instance",
         postgres_password_secret="dagster-postgresql-secret",
         dagster_home="/opt/dagster/dagster_home",
@@ -440,7 +440,7 @@ def test_no_postgres(kubeconfig_file):
     # Construct a K8s run launcher in a fake k8s environment.
     mock_k8s_client_batch_api = mock.MagicMock()
     k8s_run_launcher = K8sRunLauncher(
-        service_account_name="dagit-admin",
+        service_account_name="webserver-admin",
         instance_config_map="dagster-instance",
         dagster_home="/opt/dagster/dagster_home",
         job_image="fake_job_image",
@@ -504,7 +504,7 @@ def test_check_run_health(kubeconfig_file):
     mock_k8s_client_batch_api = mock.Mock(spec_set=["read_namespaced_job_status"])
 
     k8s_run_launcher = K8sRunLauncher(
-        service_account_name="dagit-admin",
+        service_account_name="webserver-admin",
         instance_config_map="dagster-instance",
         postgres_password_secret="dagster-postgresql-secret",
         dagster_home="/opt/dagster/dagster_home",

--- a/python_modules/libraries/dagster-k8s/tox.ini
+++ b/python_modules/libraries/dagster-k8s/tox.ini
@@ -21,5 +21,5 @@ deps =
 allowlist_externals =
   /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
     pytest --log-cli-level=INFO -vv {posargs}

--- a/python_modules/libraries/dagster-managed-elements/tox.ini
+++ b/python_modules/libraries/dagster-managed-elements/tox.ini
@@ -9,5 +9,5 @@ deps =
 allowlist_externals =
   /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
     pytest -vv {posargs}

--- a/python_modules/libraries/dagster-mlflow/dagster_mlflow/resources.py
+++ b/python_modules/libraries/dagster-mlflow/dagster_mlflow/resources.py
@@ -179,7 +179,7 @@ class MlFlow(metaclass=MlflowMeta):
 
     def cleanup_on_error(self):
         """Method ends mlflow run with correct exit status for failed runs. Note that
-        this method does not work when a job running in dagit fails, it seems
+        this method does not work when a job running in the webserver fails, it seems
         that in this case a different process runs the job and when it fails
         the stack trace is therefore not available. For this case we can use the
         cleanup_on_failure hook defined below.

--- a/python_modules/libraries/dagster-mlflow/tox.ini
+++ b/python_modules/libraries/dagster-mlflow/tox.ini
@@ -10,5 +10,5 @@ deps =
 allowlist_externals =
   /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
     pytest -c ../../../pyproject.toml -vv {posargs}

--- a/python_modules/libraries/dagster-msteams/dagster_msteams/hooks.py
+++ b/python_modules/libraries/dagster-msteams/dagster_msteams/hooks.py
@@ -65,7 +65,7 @@ def teams_on_failure(
 
     """
     webserver_base_url = normalize_renamed_param(
-        webserver_base_url, dagit_base_url, "webserver_base_url", "dagit_base_url"
+        webserver_base_url, "webserver_base_url", dagit_base_url, "dagit_base_url"
     )
 
     @failure_hook(required_resource_keys={"msteams"})
@@ -125,7 +125,7 @@ def teams_on_success(
 
     """
     webserver_base_url = normalize_renamed_param(
-        webserver_base_url, dagit_base_url, "webserver_base_url", "dagit_base_url"
+        webserver_base_url, "webserver_base_url", dagit_base_url, "dagit_base_url"
     )
 
     @success_hook(required_resource_keys={"msteams"})

--- a/python_modules/libraries/dagster-msteams/dagster_msteams/hooks.py
+++ b/python_modules/libraries/dagster-msteams/dagster_msteams/hooks.py
@@ -1,7 +1,9 @@
 from typing import Callable, Optional
 
+from dagster._annotations import deprecated_param
 from dagster._core.definitions import failure_hook, success_hook
 from dagster._core.execution.context.hook import HookContext
+from dagster._utils.backcompat import normalize_renamed_param
 
 from dagster_msteams.card import Card
 
@@ -18,23 +20,32 @@ def _default_success_message(context: HookContext) -> str:
     return _default_status_message(context, status="succeeded")
 
 
+@deprecated_param(
+    param="dagit_base_url",
+    breaking_version="2.0",
+    additional_warn_text="Use `webserver_base_url` instead.",
+)
 def teams_on_failure(
     message_fn: Callable[[HookContext], str] = _default_failure_message,
     dagit_base_url: Optional[str] = None,
+    webserver_base_url: Optional[str] = None,
 ):
     """Create a hook on step failure events that will message the given MS Teams webhook URL.
 
     Args:
         message_fn (Optional(Callable[[HookContext], str])): Function which takes in the
             HookContext outputs the message you want to send.
-        dagit_base_url: (Optional[str]): The base url of your Dagit instance. Specify this
+        dagit_base_url: (Optional[str]): The base url of your webserver instance. Specify this
+            to allow messages to include deeplinks to the specific run that triggered
+            the hook.
+        webserver_base_url: (Optional[str]): The base url of your webserver instance. Specify this
             to allow messages to include deeplinks to the specific run that triggered
             the hook.
 
     Examples:
         .. code-block:: python
 
-            @teams_on_failure(dagit_base_url="http://localhost:3000")
+            @teams_on_failure(webserver_base_url="http://localhost:3000")
             @job(...)
             def my_job():
                 pass
@@ -53,13 +64,16 @@ def teams_on_failure(
                 a_op.with_hooks(hook_defs={teams_on_failure("#foo", my_message_fn)})
 
     """
+    webserver_base_url = normalize_renamed_param(
+        webserver_base_url, dagit_base_url, "webserver_base_url", "dagit_base_url"
+    )
 
     @failure_hook(required_resource_keys={"msteams"})
     def _hook(context: HookContext):
         text = message_fn(context)
-        if dagit_base_url:
-            text += "<a href='{base_url}/runs/{run_id}'>View in Dagit</a>".format(
-                base_url=dagit_base_url,
+        if webserver_base_url:
+            text += "<a href='{base_url}/runs/{run_id}'>View in Dagster UI</a>".format(
+                base_url=webserver_base_url,
                 run_id=context.run_id,
             )
         card = Card()
@@ -69,23 +83,29 @@ def teams_on_failure(
     return _hook
 
 
+@deprecated_param(
+    param="dagit_base_url",
+    breaking_version="2.0",
+    additional_warn_text="Use `webserver_base_url` instead.",
+)
 def teams_on_success(
     message_fn: Callable[[HookContext], str] = _default_success_message,
     dagit_base_url: Optional[str] = None,
+    webserver_base_url: Optional[str] = None,
 ):
     """Create a hook on step success events that will message the given MS Teams webhook URL.
 
     Args:
         message_fn (Optional(Callable[[HookContext], str])): Function which takes in the
             HookContext outputs the message you want to send.
-        dagit_base_url: (Optional[str]): The base url of your Dagit instance. Specify this
+        dagit_base_url: (Optional[str]): The base url of your webserver instance. Specify this
             to allow messages to include deeplinks to the specific run that triggered
             the hook.
 
     Examples:
         .. code-block:: python
 
-            @teams_on_success(dagit_base_url="http://localhost:3000")
+            @teams_on_success(webserver_base_url="http://localhost:3000")
             @job(...)
             def my_job():
                 pass
@@ -104,13 +124,16 @@ def teams_on_success(
                 a_op.with_hooks(hook_defs={teams_on_success("#foo", my_message_fn)})
 
     """
+    webserver_base_url = normalize_renamed_param(
+        webserver_base_url, dagit_base_url, "webserver_base_url", "dagit_base_url"
+    )
 
     @success_hook(required_resource_keys={"msteams"})
     def _hook(context: HookContext):
         text = message_fn(context)
-        if dagit_base_url:
-            text += "<a href='{base_url}/runs/{run_id}'>View in Dagit</a>".format(
-                base_url=dagit_base_url,
+        if webserver_base_url:
+            text += "<a href='{base_url}/runs/{run_id}'>View in webserver</a>".format(
+                base_url=webserver_base_url,
                 run_id=context.run_id,
             )
         card = Card()

--- a/python_modules/libraries/dagster-msteams/dagster_msteams/sensors.py
+++ b/python_modules/libraries/dagster-msteams/dagster_msteams/sensors.py
@@ -1,12 +1,14 @@
 from typing import TYPE_CHECKING, Callable, Optional, Sequence, Union
 
 from dagster import DefaultSensorStatus
+from dagster._annotations import deprecated_param
 from dagster._core.definitions import GraphDefinition, JobDefinition
 from dagster._core.definitions.run_status_sensor_definition import (
     RunFailureSensorContext,
     run_failure_sensor,
 )
 from dagster._core.definitions.unresolved_asset_job_definition import UnresolvedAssetJobDefinition
+from dagster._utils.backcompat import normalize_renamed_param
 
 from dagster_msteams.card import Card
 from dagster_msteams.client import TeamsClient
@@ -25,6 +27,11 @@ def _default_failure_message(context: RunFailureSensorContext) -> str:
     )
 
 
+@deprecated_param(
+    param="dagit_base_url",
+    breaking_version="2.0",
+    additional_warn_text="Use `webserver_base_url` instead.",
+)
 def make_teams_on_run_failure_sensor(
     hook_url: str,
     message_fn: Callable[[RunFailureSensorContext], str] = _default_failure_message,
@@ -47,6 +54,7 @@ def make_teams_on_run_failure_sensor(
         ]
     ] = None,
     monitor_all_repositories: bool = False,
+    webserver_base_url: Optional[str] = None,
 ):
     """Create a sensor on run failures that will message the given MS Teams webhook URL.
 
@@ -60,7 +68,7 @@ def make_teams_on_run_failure_sensor(
         timeout: (Optional[float]): Connection timeout in seconds. Defaults to 60.
         verify: (Optional[bool]): Whether to verify the servers TLS certificate.
         name: (Optional[str]): The name of the sensor. Defaults to "teams_on_run_failure".
-        dagit_base_url: (Optional[str]): The base url of your Dagit instance. Specify this to allow
+        dagit_base_url: (Optional[str]): The base url of your webserver instance. Specify this to allow
             messages to include deeplinks to the failed run.
         default_status (DefaultSensorStatus): Whether the sensor starts as running or not. The default
             status can be overridden from Dagit or via the GraphQL API.
@@ -71,6 +79,8 @@ def make_teams_on_run_failure_sensor(
         monitor_all_repositories (bool): If set to True, the sensor will monitor all runs in the
             Dagster instance. If set to True, an error will be raised if you also specify
             monitored_jobs or job_selection. Defaults to False.
+        webserver_base_url: (Optional[str]): The base url of your webserver instance. Specify this to allow
+            messages to include deeplinks to the failed run.
 
     Examples:
         .. code-block:: python
@@ -99,6 +109,10 @@ def make_teams_on_run_failure_sensor(
 
 
     """
+    webserver_base_url = normalize_renamed_param(
+        webserver_base_url, dagit_base_url, "webserver_base_url", "dagit_base_url"
+    )
+
     teams_client = TeamsClient(
         hook_url=hook_url,
         http_proxy=http_proxy,

--- a/python_modules/libraries/dagster-msteams/dagster_msteams/sensors.py
+++ b/python_modules/libraries/dagster-msteams/dagster_msteams/sensors.py
@@ -104,13 +104,13 @@ def make_teams_on_run_failure_sensor(
             teams_on_run_failure = make_teams_on_run_failure_sensor(
                 hook_url=os.getenv("TEAMS_WEBHOOK_URL"),
                 message_fn=my_message_fn,
-                dagit_base_url="http://localhost:3000",
+                webserver_base_url="http://localhost:3000",
             )
 
 
     """
     webserver_base_url = normalize_renamed_param(
-        webserver_base_url, dagit_base_url, "webserver_base_url", "dagit_base_url"
+        webserver_base_url, "webserver_base_url", dagit_base_url, "dagit_base_url"
     )
 
     teams_client = TeamsClient(
@@ -129,9 +129,9 @@ def make_teams_on_run_failure_sensor(
     )
     def teams_on_run_failure(context: RunFailureSensorContext):
         text = message_fn(context)
-        if dagit_base_url:
+        if webserver_base_url:
             text += "<a href='{base_url}/runs/{run_id}'>View in Dagit</a>".format(
-                base_url=dagit_base_url,
+                base_url=webserver_base_url,
                 run_id=context.dagster_run.run_id,
             )
         card = Card()

--- a/python_modules/libraries/dagster-msteams/dagster_msteams_tests/test_hooks.py
+++ b/python_modules/libraries/dagster-msteams/dagster_msteams_tests/test_hooks.py
@@ -31,7 +31,9 @@ def test_failure_hook_on_op_instance(mock_teams_post_message):
         pass_op.alias("fail_op_with_hook").with_hooks(hook_defs={teams_on_failure()})()
         fail_op.alias("fail_op_without_hook")()
         fail_op.with_hooks(
-            hook_defs={teams_on_failure(message_fn=my_message_fn, dagit_base_url="localhost:3000")}
+            hook_defs={
+                teams_on_failure(message_fn=my_message_fn, webserver_base_url="localhost:3000")
+            }
         )()
 
     result = job_def.execute_in_process(
@@ -50,7 +52,9 @@ def test_success_hook_on_op_instance(mock_teams_post_message):
         pass_op.alias("success_solid_with_hook").with_hooks(hook_defs={teams_on_success()})()
         fail_op.alias("success_solid_without_hook")()
         fail_op.with_hooks(
-            hook_defs={teams_on_success(message_fn=my_message_fn, dagit_base_url="localhost:3000")}
+            hook_defs={
+                teams_on_success(message_fn=my_message_fn, webserver_base_url="localhost:3000")
+            }
         )()
 
     result = job_def.execute_in_process(
@@ -63,7 +67,7 @@ def test_success_hook_on_op_instance(mock_teams_post_message):
 
 @patch("dagster_msteams.client.TeamsClient.post_message")
 def test_failure_hook_decorator(mock_teams_post_message):
-    @teams_on_failure(dagit_base_url="http://localhost:3000/")
+    @teams_on_failure(webserver_base_url="http://localhost:3000/")
     @job(resource_defs={"msteams": msteams_resource})
     def job_def():
         pass_op()
@@ -80,7 +84,7 @@ def test_failure_hook_decorator(mock_teams_post_message):
 
 @patch("dagster_msteams.client.TeamsClient.post_message")
 def test_success_hook_decorator(mock_teams_post_message):
-    @teams_on_success(message_fn=my_message_fn, dagit_base_url="http://localhost:3000/")
+    @teams_on_success(message_fn=my_message_fn, webserver_base_url="http://localhost:3000/")
     @job(resource_defs={"msteams": msteams_resource})
     def job_def():
         pass_op()

--- a/python_modules/libraries/dagster-msteams/tox.ini
+++ b/python_modules/libraries/dagster-msteams/tox.ini
@@ -10,5 +10,5 @@ deps =
 allowlist_externals =
   /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
     pytest -c ../../../pyproject.toml -vv {posargs}

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/event_log/event_log.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/event_log/event_log.py
@@ -44,7 +44,7 @@ class MySQLEventLogStorage(SqlEventLogStorage, ConfigurableClass):
     """MySQL-backed event log storage.
 
     Users should not directly instantiate this class; it is instantiated by internal machinery when
-    ``dagit`` and ``dagster-graphql`` load, based on the values in the ``dagster.yaml`` file in
+    ``dagster-webserver`` and ``dagster-graphql`` load, based on the values in the ``dagster.yaml`` file in
     ``$DAGSTER_HOME``. Configuration of this class should be done by setting values in that file.
 
     .. literalinclude:: ../../../../../../examples/docs_snippets/docs_snippets/deploying/dagster-mysql-legacy.yaml
@@ -92,7 +92,7 @@ class MySQLEventLogStorage(SqlEventLogStorage, ConfigurableClass):
             stamp_alembic_rev(mysql_alembic_config(__file__), conn)
 
     def optimize_for_webserver(self, statement_timeout: int, pool_recycle: int) -> None:
-        # When running in dagit, hold an open connection
+        # When running in dagster-webserver, hold an open connection
         # https://github.com/dagster-io/dagster/issues/3719
         self._engine = create_engine(
             self.mysql_url,

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/run_storage/run_storage.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/run_storage/run_storage.py
@@ -43,7 +43,7 @@ class MySQLRunStorage(SqlRunStorage, ConfigurableClass):
     """MySQL-backed run storage.
 
     Users should not directly instantiate this class; it is instantiated by internal machinery when
-    ``dagit`` and ``dagster-graphql`` load, based on the values in the ``dagster.yaml`` file in
+    ``dagster-webserver`` and ``dagster-graphql`` load, based on the values in the ``dagster.yaml`` file in
     ``$DAGSTER_HOME``. Configuration of this class should be done by setting values in that file.
 
 
@@ -91,7 +91,7 @@ class MySQLRunStorage(SqlRunStorage, ConfigurableClass):
             stamp_alembic_rev(mysql_alembic_config(__file__), conn)
 
     def optimize_for_webserver(self, statement_timeout: int, pool_recycle: int) -> None:
-        # When running in dagit, hold 1 open connection
+        # When running in dagster-webserver, hold 1 open connection
         # https://github.com/dagster-io/dagster/issues/3719
         self._engine = create_engine(
             self.mysql_url,

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/schedule_storage/schedule_storage.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/schedule_storage/schedule_storage.py
@@ -36,7 +36,7 @@ class MySQLScheduleStorage(SqlScheduleStorage, ConfigurableClass):
     """MySQL-backed run storage.
 
     Users should not directly instantiate this class; it is instantiated by internal machinery when
-    ``dagit`` and ``dagster-graphql`` load, based on the values in the ``dagster.yaml`` file in
+    ``dagster-webserver`` and ``dagster-graphql`` load, based on the values in the ``dagster.yaml`` file in
     ``$DAGSTER_HOME``. Configuration of this class should be done by setting values in that file.
 
     .. literalinclude:: ../../../../../../examples/docs_snippets/docs_snippets/deploying/dagster-mysql-legacy.yaml
@@ -80,7 +80,7 @@ class MySQLScheduleStorage(SqlScheduleStorage, ConfigurableClass):
         self.optimize()
 
     def optimize_for_webserver(self, statement_timeout: int, pool_recycle: int) -> None:
-        # When running in dagit, hold an open connection
+        # When running in dagster-webserver, hold an open connection
         # https://github.com/dagster-io/dagster/issues/3719
         self._engine = create_engine(
             self.mysql_url,

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/storage.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/storage.py
@@ -19,7 +19,7 @@ class DagsterMySQLStorage(DagsterStorage, ConfigurableClass):
     """MySQL-backed dagster storage.
 
     Users should not directly instantiate this class; it is instantiated by internal machinery when
-    ``dagit`` and ``dagster-graphql`` load, based on the values in the ``dagster.yaml`` file in
+    ``dagster-webserver`` and ``dagster-graphql`` load, based on the values in the ``dagster.yaml`` file in
     ``$DAGSTER_HOME``. Configuration of this class should be done by setting values in that file.
 
     To use MySQL for storage, you can add a block such as the following to your

--- a/python_modules/libraries/dagster-mysql/tox.ini
+++ b/python_modules/libraries/dagster-mysql/tox.ini
@@ -10,5 +10,5 @@ deps =
 allowlist_externals =
   /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
     pytest -c ../../../pyproject.toml -vv {posargs}

--- a/python_modules/libraries/dagster-pagerduty/dagster_pagerduty/hooks.py
+++ b/python_modules/libraries/dagster-pagerduty/dagster_pagerduty/hooks.py
@@ -1,8 +1,10 @@
 from typing import Callable, Optional
 
+from dagster._annotations import deprecated_param
 from dagster._core.definitions import failure_hook
 from dagster._core.definitions.hook_definition import HookDefinition
 from dagster._core.execution.context.hook import HookContext
+from dagster._utils.backcompat import normalize_renamed_param
 
 
 def _default_summary_fn(context: HookContext) -> str:
@@ -17,10 +19,16 @@ def _source_fn(context: HookContext) -> str:
     return f"{context.job_name}"
 
 
+@deprecated_param(
+    param="dagit_base_url",
+    breaking_version="2.0",
+    additional_warn_text="Use `webserver_base_url` instead.",
+)
 def pagerduty_on_failure(
     severity: str,
     summary_fn: Callable[[HookContext], str] = _default_summary_fn,
     dagit_base_url: Optional[str] = None,
+    webserver_base_url: Optional[str] = None,
 ) -> HookDefinition:
     """Create a hook on step failure events that will trigger a PagerDuty alert.
 
@@ -29,7 +37,9 @@ def pagerduty_on_failure(
             influences the priority of any created incidents. Must be one of {info, warning, error, critical}
         summary_fn (Optional(Callable[[HookContext], str])): Function which takes in the HookContext
             outputs a summary of the issue.
-        dagit_base_url: (Optional[str]): The base url of your Dagit instance. Specify this to allow
+        dagit_base_url: (Optional[str]): The base url of your webserver instance. Specify this to allow
+            alerts to include deeplinks to the specific run that triggered the hook.
+        webserver_base_url: (Optional[str]): The base url of your webserver instance. Specify this to allow
             alerts to include deeplinks to the specific run that triggered the hook.
 
     Examples:
@@ -40,7 +50,7 @@ def pagerduty_on_failure(
 
             @job(
                 resource_defs={"pagerduty": pagerduty_resource},
-                hooks={pagerduty_on_failure("info", dagit_base_url="http://localhost:3000")},
+                hooks={pagerduty_on_failure("info", webserver_base_url="http://localhost:3000")},
             )
             def my_job():
                 my_op()
@@ -59,14 +69,17 @@ def pagerduty_on_failure(
                 my_op.with_hooks(hook_defs={pagerduty_on_failure(severity="critical", summary_fn=my_summary_fn)})
 
     """
+    webserver_base_url = normalize_renamed_param(
+        webserver_base_url, dagit_base_url, "webserver_base_url", "dagit_base_url"
+    )
 
     @failure_hook(required_resource_keys={"pagerduty"})
     def _hook(context: HookContext):
         custom_details = {}
-        if dagit_base_url:
+        if webserver_base_url:
             custom_details = {
-                "dagit url": "{base_url}/runs/{run_id}".format(
-                    base_url=dagit_base_url, run_id=context.run_id
+                "webserver url": "{base_url}/runs/{run_id}".format(
+                    base_url=webserver_base_url, run_id=context.run_id
                 )
             }
         context.resources.pagerduty.EventV2_create(

--- a/python_modules/libraries/dagster-pagerduty/dagster_pagerduty/hooks.py
+++ b/python_modules/libraries/dagster-pagerduty/dagster_pagerduty/hooks.py
@@ -70,7 +70,7 @@ def pagerduty_on_failure(
 
     """
     webserver_base_url = normalize_renamed_param(
-        webserver_base_url, dagit_base_url, "webserver_base_url", "dagit_base_url"
+        webserver_base_url, "webserver_base_url", dagit_base_url, "dagit_base_url"
     )
 
     @failure_hook(required_resource_keys={"pagerduty"})

--- a/python_modules/libraries/dagster-pagerduty/dagster_pagerduty_tests/test_hooks.py
+++ b/python_modules/libraries/dagster-pagerduty/dagster_pagerduty_tests/test_hooks.py
@@ -61,7 +61,7 @@ def test_failure_hook_decorator():
 
     @job(
         resource_defs={"pagerduty": pagerduty_resource},
-        hooks={pagerduty_on_failure(severity="info", dagit_base_url="localhost:3000")},
+        hooks={pagerduty_on_failure(severity="info", webserver_base_url="localhost:3000")},
     )
     def a_job():
         pass_op()

--- a/python_modules/libraries/dagster-pagerduty/tox.ini
+++ b/python_modules/libraries/dagster-pagerduty/tox.ini
@@ -10,5 +10,5 @@ deps =
 allowlist_externals =
   /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
     pytest -c ../../../pyproject.toml -vv {posargs}

--- a/python_modules/libraries/dagster-pandas/.coveragerc
+++ b/python_modules/libraries/dagster-pandas/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+branch = True

--- a/python_modules/libraries/dagster-pandas/.coveragerc
+++ b/python_modules/libraries/dagster-pandas/.coveragerc
@@ -1,2 +1,0 @@
-[run]
-branch = True

--- a/python_modules/libraries/dagster-pandas/dagster_pandas/constraints.py
+++ b/python_modules/libraries/dagster-pandas/dagster_pandas/constraints.py
@@ -138,7 +138,7 @@ class Constraint:
 
     Args:
         error_description (Optional[str]): The plain string description that is output in the terminal if the constraint fails.
-        markdown_description (Optional[str]): A markdown supported description that is emitted by dagit if the constraint fails.
+        markdown_description (Optional[str]): A markdown supported description that is shown in the Dagster UI if the constraint fails.
     """
 
     def __init__(self, error_description=None, markdown_description=None):
@@ -297,7 +297,7 @@ class DataFrameConstraint(Constraint):
 
     Args:
         error_description (Optional[str]): The plain string description that is output in the terminal if the constraint fails.
-        markdown_description (Optional[str]): A markdown supported description that is emitted by dagit if the constraint fails.
+        markdown_description (Optional[str]): A markdown supported description that is shown in the Dagster UI if the constraint fails.
     """
 
     def __init__(self, error_description=None, markdown_description=None):
@@ -892,7 +892,7 @@ class ColumnConstraint(Constraint):
 
     Args:
         error_description (Optional[str]): The plain string description that is output in the terminal if the constraint fails.
-        markdown_description (Optional[str]): A markdown supported description that is emitted by dagit if the constraint fails.
+        markdown_description (Optional[str]): A markdown supported description that is shown in the Dagster UI if the constraint fails.
     """
 
     def __init__(self, error_description=None, markdown_description=None):

--- a/python_modules/libraries/dagster-pandas/dagster_pandas/examples/Dockerfile
+++ b/python_modules/libraries/dagster-pandas/dagster_pandas/examples/Dockerfile
@@ -11,12 +11,12 @@ WORKDIR /tmp/
 # RUN pip install -r requirements.txt
 
 # ADD dagster dagster
-# ADD dagit dagit
+# ADD dagster-webserver dagster-webserver
 
 ADD . .
 
-RUN pip install --upgrade pip && pip install -e dagster && pip install dagit && pip install dagster-pandas && pip install dagstermill && pip install pytest
+RUN pip install --upgrade pip && pip install -e dagster && pip install dagster-webserver && pip install dagster-pandas && pip install dagstermill && pip install pytest
 
-# ENTRYPOINT [ "dagit" ]
+# ENTRYPOINT [ "dagster-webserver" ]
 # 
 # EXPOSE 3000

--- a/python_modules/libraries/dagster-pandas/tox.ini
+++ b/python_modules/libraries/dagster-pandas/tox.ini
@@ -11,6 +11,6 @@ deps =
 allowlist_externals =
   /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
   ipython kernel install --name "dagster" --user
   pytest -v{posargs}

--- a/python_modules/libraries/dagster-pandera/tox.ini
+++ b/python_modules/libraries/dagster-pandera/tox.ini
@@ -11,6 +11,6 @@ deps =
 allowlist_externals =
   /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
   ipython kernel install --name "dagster" --user
   pytest -v{posargs}

--- a/python_modules/libraries/dagster-papertrail/tox.ini
+++ b/python_modules/libraries/dagster-papertrail/tox.ini
@@ -10,5 +10,5 @@ deps =
 allowlist_externals =
   /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
     pytest -c ../../../pyproject.toml -vv {posargs}

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
@@ -47,7 +47,7 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
     """Postgres-backed event log storage.
 
     Users should not directly instantiate this class; it is instantiated by internal machinery when
-    ``dagit`` and ``dagster-graphql`` load, based on the values in the ``dagster.yaml`` file in
+    ``dagster-webserver`` and ``dagster-graphql`` load, based on the values in the ``dagster.yaml`` file in
     ``$DAGSTER_HOME``. Configuration of this class should be done by setting values in that file.
 
     To use Postgres for all of the components of your instance storage, you can add the following
@@ -113,7 +113,7 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
                 stamp_alembic_rev(pg_alembic_config(__file__), conn)
 
     def optimize_for_webserver(self, statement_timeout: int, pool_recycle: int) -> None:
-        # When running in dagit, hold an open connection and set statement_timeout
+        # When running in dagster-webserver, hold an open connection and set statement_timeout
         existing_options = self._engine.url.query.get("options")
         timeout_option = pg_statement_timeout(statement_timeout)
         if existing_options:
@@ -225,7 +225,7 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
         # This column is used nowhere else, and as of AssetObservation/AssetMaterializationPlanned
         # event creation, we want to extend this functionality to ensure that assets with any event
         # (observation, materialization, or materialization planned) yielded with timestamp
-        # > wipe timestamp display in Dagit.
+        # > wipe timestamp display in the Dagster UI.
 
         # As of the following PRs, we update last_materialization_timestamp to store the timestamp
         # of the latest asset observation, materialization, or materialization_planned that has occurred.

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/run_storage/run_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/run_storage/run_storage.py
@@ -41,7 +41,7 @@ class PostgresRunStorage(SqlRunStorage, ConfigurableClass):
     """Postgres-backed run storage.
 
     Users should not directly instantiate this class; it is instantiated by internal machinery when
-    ``dagit`` and ``dagster-graphql`` load, based on the values in the ``dagster.yaml`` file in
+    ``dagster-webserver`` and ``dagster-graphql`` load, based on the values in the ``dagster.yaml`` file in
     ``$DAGSTER_HOME``. Configuration of this class should be done by setting values in that file.
 
     To use Postgres for all of the components of your instance storage, you can add the following
@@ -107,7 +107,7 @@ class PostgresRunStorage(SqlRunStorage, ConfigurableClass):
                 stamp_alembic_rev(pg_alembic_config(__file__), conn)
 
     def optimize_for_webserver(self, statement_timeout: int, pool_recycle: int) -> None:
-        # When running in dagit, hold 1 open connection and set statement_timeout
+        # When running in dagster-webserver, hold 1 open connection and set statement_timeout
         existing_options = self._engine.url.query.get("options")
         timeout_option = pg_statement_timeout(statement_timeout)
         if existing_options:

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/schedule_storage/schedule_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/schedule_storage/schedule_storage.py
@@ -34,7 +34,7 @@ class PostgresScheduleStorage(SqlScheduleStorage, ConfigurableClass):
     """Postgres-backed run storage.
 
     Users should not directly instantiate this class; it is instantiated by internal machinery when
-    ``dagit`` and ``dagster-graphql`` load, based on the values in the ``dagster.yaml`` file in
+    ``dagster-webserver`` and ``dagster-graphql`` load, based on the values in the ``dagster.yaml`` file in
     ``$DAGSTER_HOME``. Configuration of this class should be done by setting values in that file.
 
     To use Postgres for all of the components of your instance storage, you can add the following
@@ -96,7 +96,7 @@ class PostgresScheduleStorage(SqlScheduleStorage, ConfigurableClass):
         self.optimize()
 
     def optimize_for_webserver(self, statement_timeout: int, pool_recycle: int) -> None:
-        # When running in dagit, hold an open connection and set statement_timeout
+        # When running in dagster-webserver, hold an open connection and set statement_timeout
         existing_options = self._engine.url.query.get("options")
         timeout_option = pg_statement_timeout(statement_timeout)
         if existing_options:

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/storage.py
@@ -19,7 +19,7 @@ class DagsterPostgresStorage(DagsterStorage, ConfigurableClass):
     """Postgres-backed dagster storage.
 
     Users should not directly instantiate this class; it is instantiated by internal machinery when
-    ``dagit`` and ``dagster-daemon`` load, based on the values in the ``dagster.yaml`` file in
+    ``dagster-webserver`` and ``dagster-daemon`` load, based on the values in the ``dagster.yaml`` file in
     ``$DAGSTER_HOME``. Configuration of this class should be done by setting values in that file.
 
     To use Postgres for storage, you can add a block such as the following to your

--- a/python_modules/libraries/dagster-postgres/tox.ini
+++ b/python_modules/libraries/dagster-postgres/tox.ini
@@ -10,5 +10,5 @@ deps =
 allowlist_externals =
   /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
     pytest -c ../../../pyproject.toml -vv {posargs}

--- a/python_modules/libraries/dagster-prometheus/tox.ini
+++ b/python_modules/libraries/dagster-prometheus/tox.ini
@@ -10,5 +10,5 @@ deps =
 allowlist_externals =
   /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
     pytest -c ../../../pyproject.toml -vv {posargs}

--- a/python_modules/libraries/dagster-pyspark/tox.ini
+++ b/python_modules/libraries/dagster-pyspark/tox.ini
@@ -12,5 +12,5 @@ deps =
 allowlist_externals =
   /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
     pytest -c ../../../pyproject.toml -vv {posargs}

--- a/python_modules/libraries/dagster-shell/tox.ini
+++ b/python_modules/libraries/dagster-shell/tox.ini
@@ -10,5 +10,5 @@ deps =
 allowlist_externals =
   /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
     pytest -c ../../../pyproject.toml -vv {posargs}

--- a/python_modules/libraries/dagster-slack/dagster_slack/hooks.py
+++ b/python_modules/libraries/dagster-slack/dagster_slack/hooks.py
@@ -68,7 +68,7 @@ def slack_on_failure(
 
     """
     webserver_base_url = normalize_renamed_param(
-        webserver_base_url, dagit_base_url, "webserver_base_url", "dagit_base_url"
+        webserver_base_url, "webserver_base_url", dagit_base_url, "dagit_base_url"
     )
 
     @failure_hook(required_resource_keys={"slack"})
@@ -129,7 +129,7 @@ def slack_on_success(
 
     """
     webserver_base_url = normalize_renamed_param(
-        webserver_base_url, dagit_base_url, "webserver_base_url", "dagit_base_url"
+        webserver_base_url, "webserver_base_url", dagit_base_url, "dagit_base_url"
     )
 
     @success_hook(required_resource_keys={"slack"})

--- a/python_modules/libraries/dagster-slack/dagster_slack/hooks.py
+++ b/python_modules/libraries/dagster-slack/dagster_slack/hooks.py
@@ -1,7 +1,9 @@
 from typing import Callable, Optional
 
+from dagster._annotations import deprecated_param
 from dagster._core.definitions import failure_hook, success_hook
 from dagster._core.execution.context.hook import HookContext
+from dagster._utils.backcompat import normalize_renamed_param
 
 
 def _default_status_message(context: HookContext, status: str) -> str:
@@ -21,10 +23,16 @@ def _default_success_message(context: HookContext) -> str:
     return _default_status_message(context, status="succeeded")
 
 
+@deprecated_param(
+    param="dagit_base_url",
+    breaking_version="2.0",
+    additional_warn_text="Use `webserver_base_url` instead.",
+)
 def slack_on_failure(
     channel: str,
     message_fn: Callable[[HookContext], str] = _default_failure_message,
     dagit_base_url: Optional[str] = None,
+    webserver_base_url: Optional[str] = None,
 ):
     """Create a hook on step failure events that will message the given Slack channel.
 
@@ -32,13 +40,15 @@ def slack_on_failure(
         channel (str): The channel to send the message to (e.g. "#my_channel")
         message_fn (Optional(Callable[[HookContext], str])): Function which takes in the HookContext
             outputs the message you want to send.
-        dagit_base_url: (Optional[str]): The base url of your Dagit instance. Specify this to allow
+        dagit_base_url: (Optional[str]): The base url of your webserver instance. Specify this to allow
+            messages to include deeplinks to the specific run that triggered the hook.
+        webserver_base_url: (Optional[str]): The base url of your webserver instance. Specify this to allow
             messages to include deeplinks to the specific run that triggered the hook.
 
     Examples:
         .. code-block:: python
 
-            @slack_on_failure("#foo", dagit_base_url="http://localhost:3000")
+            @slack_on_failure("#foo", webserver_base_url="http://localhost:3000")
             @job(...)
             def my_job():
                 pass
@@ -57,13 +67,16 @@ def slack_on_failure(
                 an_op.with_hooks(hook_defs={slack_on_failure("#foo", my_message_fn)})
 
     """
+    webserver_base_url = normalize_renamed_param(
+        webserver_base_url, dagit_base_url, "webserver_base_url", "dagit_base_url"
+    )
 
     @failure_hook(required_resource_keys={"slack"})
     def _hook(context: HookContext):
         text = message_fn(context)
-        if dagit_base_url:
-            text += "\n<{base_url}/runs/{run_id}|View in Dagit>".format(
-                base_url=dagit_base_url, run_id=context.run_id
+        if webserver_base_url:
+            text += "\n<{base_url}/runs/{run_id}|View in Dagster UI>".format(
+                base_url=webserver_base_url, run_id=context.run_id
             )
 
         context.resources.slack.chat_postMessage(channel=channel, text=text)
@@ -71,10 +84,16 @@ def slack_on_failure(
     return _hook
 
 
+@deprecated_param(
+    param="dagit_base_url",
+    breaking_version="2.0",
+    additional_warn_text="Use `webserver_base_url` instead.",
+)
 def slack_on_success(
     channel: str,
     message_fn: Callable[[HookContext], str] = _default_success_message,
     dagit_base_url: Optional[str] = None,
+    webserver_base_url: Optional[str] = None,
 ):
     """Create a hook on step success events that will message the given Slack channel.
 
@@ -82,13 +101,15 @@ def slack_on_success(
         channel (str): The channel to send the message to (e.g. "#my_channel")
         message_fn (Optional(Callable[[HookContext], str])): Function which takes in the HookContext
             outputs the message you want to send.
-        dagit_base_url: (Optional[str]): The base url of your Dagit instance. Specify this to allow
+        dagit_base_url: (Optional[str]): The base url of your webserver instance. Specify this to allow
+            messages to include deeplinks to the specific run that triggered the hook.
+        webserver_base_url: (Optional[str]): The base url of your webserver instance. Specify this to allow
             messages to include deeplinks to the specific run that triggered the hook.
 
     Examples:
         .. code-block:: python
 
-            @slack_on_success("#foo", dagit_base_url="http://localhost:3000")
+            @slack_on_success("#foo", webserver_base_url="http://localhost:3000")
             @job(...)
             def my_job():
                 pass
@@ -107,13 +128,16 @@ def slack_on_success(
                 an_op.with_hooks(hook_defs={slack_on_success("#foo", my_message_fn)})
 
     """
+    webserver_base_url = normalize_renamed_param(
+        webserver_base_url, dagit_base_url, "webserver_base_url", "dagit_base_url"
+    )
 
     @success_hook(required_resource_keys={"slack"})
     def _hook(context: HookContext):
         text = message_fn(context)
-        if dagit_base_url:
-            text += "\n<{base_url}/runs/{run_id}|View in Dagit>".format(
-                base_url=dagit_base_url, run_id=context.run_id
+        if webserver_base_url:
+            text += "\n<{base_url}/runs/{run_id}|View in Dagster UI>".format(
+                base_url=webserver_base_url, run_id=context.run_id
             )
 
         context.resources.slack.chat_postMessage(channel=channel, text=text)

--- a/python_modules/libraries/dagster-slack/dagster_slack/sensors.py
+++ b/python_modules/libraries/dagster-slack/dagster_slack/sensors.py
@@ -40,7 +40,7 @@ def _build_slack_blocks_and_text(
     context: T,
     text_fn: Callable[[T], str],
     blocks_fn: Optional[Callable[[T], List[Dict[Any, Any]]]],
-    dagit_base_url: Optional[str],
+    webserver_base_url: Optional[str],
 ) -> Tuple[List[Dict[str, Any]], str]:
     main_body_text = text_fn(context)
     blocks: List[Dict[Any, Any]] = []
@@ -74,18 +74,18 @@ def _build_slack_blocks_and_text(
             ]
         )
 
-    if dagit_base_url:
+    if webserver_base_url:
         if isinstance(context, RunFailureSensorContext):
-            url = f"{dagit_base_url}/runs/{context.dagster_run.run_id}"
+            url = f"{webserver_base_url}/runs/{context.dagster_run.run_id}"
         else:
-            url = f"{dagit_base_url}/assets/{'/'.join(context.asset_key.path)}"
+            url = f"{webserver_base_url}/assets/{'/'.join(context.asset_key.path)}"
         blocks.append(
             {
                 "type": "actions",
                 "elements": [
                     {
                         "type": "button",
-                        "text": {"type": "plain_text", "text": "View in Dagit"},
+                        "text": {"type": "plain_text", "text": "View in Dagster UI"},
                         "url": url,
                     }
                 ],
@@ -214,7 +214,7 @@ def make_slack_on_run_failure_sensor(
     )
     def slack_on_run_failure(context: RunFailureSensorContext):
         blocks, main_body_text = _build_slack_blocks_and_text(
-            context=context, text_fn=text_fn, blocks_fn=blocks_fn, dagit_base_url=dagit_base_url
+            context=context, text_fn=text_fn, blocks_fn=blocks_fn, webserver_base_url=dagit_base_url
         )
 
         slack_client.chat_postMessage(channel=channel, blocks=blocks, text=main_body_text)
@@ -322,7 +322,10 @@ def make_slack_on_freshness_policy_status_change_sensor(
             and context.previous_minutes_overdue != 0
         ):
             blocks, main_body_text = _build_slack_blocks_and_text(
-                context=context, text_fn=text_fn, blocks_fn=blocks_fn, dagit_base_url=dagit_base_url
+                context=context,
+                text_fn=text_fn,
+                blocks_fn=blocks_fn,
+                webserver_base_url=dagit_base_url,
             )
 
             slack_client.chat_postMessage(channel=channel, blocks=blocks, text=main_body_text)

--- a/python_modules/libraries/dagster-slack/dagster_slack_tests/test_hooks.py
+++ b/python_modules/libraries/dagster-slack/dagster_slack_tests/test_hooks.py
@@ -25,7 +25,7 @@ def test_failure_hook_on_op_instance(mock_api_call):
         pass_op.alias("solid_with_hook").with_hooks(hook_defs={slack_on_failure("#foo")})()
         fail_op.alias("fail_op_without_hook")()
         fail_op.with_hooks(
-            hook_defs={slack_on_failure(channel="#foo", dagit_base_url="localhost:3000")}
+            hook_defs={slack_on_failure(channel="#foo", webserver_base_url="localhost:3000")}
         )()
 
     result = job_def.execute_in_process(

--- a/python_modules/libraries/dagster-slack/tox.ini
+++ b/python_modules/libraries/dagster-slack/tox.ini
@@ -10,5 +10,5 @@ deps =
 allowlist_externals =
   /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
     pytest -c ../../../pyproject.toml -vv {posargs}

--- a/python_modules/libraries/dagster-snowflake-pandas/tox.ini
+++ b/python_modules/libraries/dagster-snowflake-pandas/tox.ini
@@ -10,5 +10,5 @@ deps =
 allowlist_externals =
   /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
     pytest -c ../../../pyproject.toml -vv {posargs}

--- a/python_modules/libraries/dagster-snowflake-pyspark/tox.ini
+++ b/python_modules/libraries/dagster-snowflake-pyspark/tox.ini
@@ -10,5 +10,5 @@ deps =
 allowlist_externals =
   /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
     pytest -c ../../../pyproject.toml -vv {posargs}

--- a/python_modules/libraries/dagster-snowflake/tox.ini
+++ b/python_modules/libraries/dagster-snowflake/tox.ini
@@ -11,5 +11,5 @@ deps =
 allowlist_externals =
   /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
     pytest -c ../../../pyproject.toml -vv {posargs}

--- a/python_modules/libraries/dagster-spark/tox.ini
+++ b/python_modules/libraries/dagster-spark/tox.ini
@@ -10,5 +10,5 @@ deps =
 allowlist_externals =
   /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
     pytest -c ../../../pyproject.toml -vv {posargs}

--- a/python_modules/libraries/dagster-ssh/tox.ini
+++ b/python_modules/libraries/dagster-ssh/tox.ini
@@ -10,5 +10,5 @@ deps =
 allowlist_externals =
   /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
     pytest -c ../../../pyproject.toml -vv {posargs}

--- a/python_modules/libraries/dagster-twilio/tox.ini
+++ b/python_modules/libraries/dagster-twilio/tox.ini
@@ -10,5 +10,5 @@ deps =
 allowlist_externals =
   /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
     pytest -c ../../../pyproject.toml -vv {posargs}

--- a/python_modules/libraries/dagster-wandb/tox.ini
+++ b/python_modules/libraries/dagster-wandb/tox.ini
@@ -15,5 +15,5 @@ deps =
 allowlist_externals =
   /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
   pytest -c ../../../pyproject.toml -vv ./dagster_wandb_tests

--- a/python_modules/libraries/dagstermill/dagstermill/asset_factory.py
+++ b/python_modules/libraries/dagstermill/dagstermill/asset_factory.py
@@ -104,7 +104,7 @@ def define_dagstermill_asset(
             if it does not. If not set, Dagster will accept any config provided for the op.
         metadata (Optional[Dict[str, Any]]): A dict of metadata entries for the asset.
         required_resource_keys (Optional[Set[str]]): Set of resource handles required by the notebook.
-        description (Optional[str]): Description of the asset to display in Dagit.
+        description (Optional[str]): Description of the asset to display in the Dagster UI.
         partitions_def (Optional[PartitionsDefinition]): Defines the set of partition keys that
             compose the asset.
         op_tags (Optional[Dict[str, Any]]): A dictionary of tags for the op that computes the asset.

--- a/python_modules/libraries/dagstermill/dagstermill/factory.py
+++ b/python_modules/libraries/dagstermill/dagstermill/factory.py
@@ -40,7 +40,7 @@ from .translator import DagsterTranslator
 
 
 def _clean_path_for_windows(notebook_path: str) -> str:
-    """In windows, the notebook cant render in dagit unless the C: prefix is removed.
+    """In windows, the notebook can't render in the Dagster UI unless the C: prefix is removed.
     os.path.splitdrive will split the path into (drive, tail), so just return the tail.
     """
     return os.path.splitdrive(notebook_path)[1]

--- a/python_modules/libraries/dagstermill/tox.ini
+++ b/python_modules/libraries/dagstermill/tox.ini
@@ -18,6 +18,6 @@ deps =
 allowlist_externals =
   /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
   ipython kernel install --name "dagster" --user
   pytest -v -vv {posargs}{posargs}


### PR DESCRIPTION
## Summary & Motivation

Clean up some lingering `dagit` references with renaming to "webserver" equivalent

- Buildkite function/var names
- `dagit_base_url` arg to multiple integration lib sensor creation functions
- Dagster README
- Various tests, comments, docstrings in integrations
- Toxfiles with `!windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'`

Note in several cases I added `@deprecated` tags with `emit_runtime_warning=False` in places where we want to mark deprecated functionality (e.g. definition of `/dagit_info` endpoint) but the function itself isn't deprecated. This is to be preferred to comments, as it will allow more easily finding and eliminating all deprecation sites at the time of an upgrade.

## How I Tested These Changes

Exsiting test suite