### PR TITLE
Document new restrictions to agent tokens

### DIFF
--- a/docs/content/dagster-cloud/account/managing-user-agent-tokens.mdx
+++ b/docs/content/dagster-cloud/account/managing-user-agent-tokens.mdx
@@ -13,15 +13,9 @@ In this guide, we'll walk you through creating and revoking user and agent token
 ## Managing agent tokens
 
 <Note>
-  To manage agent tokens, you need{" "}
-  <a href="/dagster-cloud/account/managing-users">
-    one of the following user roles
-  </a>{" "}
-  in Dagster Cloud:
-  <ul>
-    <li>Organization Admin, or</li>
-    <li>Editor or Admin in at least one deployment</li>
-  </ul>
+  To manage agent tokens, you need to be an{" "}
+  <a href="/dagster-cloud/account/managing-users">Organization Admin</a> in
+  Dagster Cloud.
 </Note>
 
 Agent tokens are used to authenticate [Hybrid agents](/dagster-cloud/deployment/agents) with the Dagster Cloud Agents API.

--- a/docs/content/dagster-cloud/account/managing-users/managing-user-roles-permissions.mdx
+++ b/docs/content/dagster-cloud/account/managing-users/managing-user-roles-permissions.mdx
@@ -447,32 +447,32 @@ Agent tokens are accessed in the UI by navigating to **user menu (your icon) > C
       </td>
       <td className="bg-red-50">❌</td>
       <td className="bg-red-50">❌</td>
-      <td className="bg-green-50">✅</td>
-      <td className="bg-green-50">✅</td>
+      <td className="bg-red-50">❌</td>
+      <td className="bg-red-50">❌</td>
       <td className="bg-green-50">✅</td>
     </tr>
     <tr>
       <td>Create agent tokens</td>
       <td className="bg-red-50">❌</td>
       <td className="bg-red-50">❌</td>
-      <td className="bg-green-50">✅</td>
-      <td className="bg-green-50">✅</td>
+      <td className="bg-red-50">❌</td>
+      <td className="bg-red-50">❌</td>
       <td className="bg-green-50">✅</td>
     </tr>
     <tr>
       <td>Edit agent tokens</td>
       <td className="bg-red-50">❌</td>
       <td className="bg-red-50">❌</td>
-      <td className="bg-green-50">✅</td>
-      <td className="bg-green-50">✅</td>
+      <td className="bg-red-50">❌</td>
+      <td className="bg-red-50">❌</td>
       <td className="bg-green-50">✅</td>
     </tr>
     <tr>
       <td>Revoke agent tokens</td>
       <td className="bg-red-50">❌</td>
       <td className="bg-red-50">❌</td>
-      <td className="bg-green-50">✅</td>
-      <td className="bg-green-50">✅</td>
+      <td className="bg-red-50">❌</td>
+      <td className="bg-red-50">❌</td>
       <td className="bg-green-50">✅</td>
     </tr>
   </tbody>

--- a/docs/content/dagster-cloud/managing-deployments/branch-deployments/using-branch-deployments-with-github.mdx
+++ b/docs/content/dagster-cloud/managing-deployments/branch-deployments/using-branch-deployments-with-github.mdx
@@ -22,7 +22,7 @@ Using this approach to branch deployments may be a good fit if:
 
 To complete the steps in this guide, you'll need:
 
-- **Editor** or **Admin** permissions in Dagster Cloud
+- **Organization Admin** permissions in Dagster Cloud
 - **The ability to run a new agent in your infrastructure**. This isn't required if you're using [Serverless deployment](/dagster-cloud/deployment/serverless).
 - **The ability to configure GitHub Actions for your repository**. This isn't required if you used the Dagster Cloud GitHub app to connect your repository as a [code location](/dagster-cloud/managing-deployments/code-locations).
 

--- a/docs/content/dagster-cloud/managing-deployments/branch-deployments/using-branch-deployments-with-gitlab.mdx
+++ b/docs/content/dagster-cloud/managing-deployments/branch-deployments/using-branch-deployments-with-gitlab.mdx
@@ -22,7 +22,7 @@ Using this approach to branch deployments may be a good fit if:
 
 To complete the steps in this guide, you'll need:
 
-- **Editor** or **Admin** permissions in Dagster Cloud
+- **Organization Admin** permissions in Dagster Cloud
 - **The ability to run a new agent in your infrastructure**. This isn't required if you're using [Serverless deployment](/dagster-cloud/deployment/serverless).
 - **The ability to configure Gitlab CI/CD for your project**. This isn't required if you used the Dagster Cloud Gitlab app to connect your project as a [code location](/dagster-cloud/managing-deployments/code-locations).
 

--- a/docs/content/dagster-cloud/managing-deployments/branch-deployments/using-branch-deployments.mdx
+++ b/docs/content/dagster-cloud/managing-deployments/branch-deployments/using-branch-deployments.mdx
@@ -23,7 +23,7 @@ Using this approach to branch deployments may be a good fit if:
 
 Utilizing Branch Deployments requires setting up two components: the Branch Deployment agent and CI platform. You'll need:
 
-- **Editor** or **Admin** permissions in Dagster Cloud
+- **Organization Admin** permissions in Dagster Cloud
 - To install the [`dagster-cloud` CLI](/dagster-cloud/managing-deployments/dagster-cloud-cli)
 - The ability to run a new agent in your infrastructure
 - The ability to configure your CI platform


### PR DESCRIPTION
Previously, any Editor, Admin, or Org Admin could manage agent tokens. Given a user can be an Editor or Admin in some deployments but only a Viewer in others, being able to manage agent tokens creates odd loopholes. For example, a user who is an Admin in "staging" but only a viewer in "prod" could configure an agent that serves requests from "prod."

This change updates our docs to reflect a change to our internal security posture; going forward, only Org Admins will be able to manage agent tokens.