### PR TITLE
add partitionsByAssets to backfillParams for ranged partition backfill

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -2034,6 +2034,7 @@ input MarshalledOutput {
 input LaunchBackfillParams {
   selector: PartitionSetSelector
   partitionNames: [String!]
+  partitionsByAssets: [PartitionsByAssetSelector]
   reexecutionSteps: [String!]
   assetSelection: [AssetKeyInput!]
   fromFailure: Boolean
@@ -2045,6 +2046,20 @@ input LaunchBackfillParams {
 input PartitionSetSelector {
   partitionSetName: String!
   repositorySelector: RepositorySelector!
+}
+
+input PartitionsByAssetSelector {
+  assetKey: AssetKeyInput!
+  partitions: PartitionsSelector
+}
+
+input PartitionsSelector {
+  range: PartitionRangeSelector!
+}
+
+input PartitionRangeSelector {
+  start: String!
+  end: String!
 }
 
 input RunsFilter {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -1512,6 +1512,7 @@ export type LaunchBackfillParams = {
   forceSynchronousSubmission?: InputMaybe<Scalars['Boolean']>;
   fromFailure?: InputMaybe<Scalars['Boolean']>;
   partitionNames?: InputMaybe<Array<Scalars['String']>>;
+  partitionsByAssets?: InputMaybe<Array<InputMaybe<PartitionsByAssetSelector>>>;
   reexecutionSteps?: InputMaybe<Array<Scalars['String']>>;
   selector?: InputMaybe<PartitionSetSelector>;
   tags?: InputMaybe<Array<ExecutionTag>>;
@@ -2237,6 +2238,11 @@ export type PartitionKeys = {
 
 export type PartitionKeysOrError = PartitionKeys | PartitionSubsetDeserializationError;
 
+export type PartitionRangeSelector = {
+  end: Scalars['String'];
+  start: Scalars['String'];
+};
+
 export enum PartitionRangeStatus {
   FAILED = 'FAILED',
   MATERIALIZED = 'MATERIALIZED',
@@ -2356,7 +2362,16 @@ export type Partitions = {
   results: Array<Partition>;
 };
 
+export type PartitionsByAssetSelector = {
+  assetKey: AssetKeyInput;
+  partitions?: InputMaybe<PartitionsSelector>;
+};
+
 export type PartitionsOrError = Partitions | PythonError;
+
+export type PartitionsSelector = {
+  range: PartitionRangeSelector;
+};
 
 export type PathMetadataEntry = MetadataEntry & {
   __typename: 'PathMetadataEntry';
@@ -7018,6 +7033,10 @@ export const buildLaunchBackfillParams = (
       overrides && overrides.hasOwnProperty('fromFailure') ? overrides.fromFailure! : true,
     partitionNames:
       overrides && overrides.hasOwnProperty('partitionNames') ? overrides.partitionNames! : [],
+    partitionsByAssets:
+      overrides && overrides.hasOwnProperty('partitionsByAssets')
+        ? overrides.partitionsByAssets!
+        : [],
     reexecutionSteps:
       overrides && overrides.hasOwnProperty('reexecutionSteps') ? overrides.reexecutionSteps! : [],
     selector:
@@ -8457,6 +8476,18 @@ export const buildPartitionKeys = (
   };
 };
 
+export const buildPartitionRangeSelector = (
+  overrides?: Partial<PartitionRangeSelector>,
+  _relationshipsToOmit: Set<string> = new Set(),
+): PartitionRangeSelector => {
+  const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
+  relationshipsToOmit.add('PartitionRangeSelector');
+  return {
+    end: overrides && overrides.hasOwnProperty('end') ? overrides.end! : 'numquam',
+    start: overrides && overrides.hasOwnProperty('start') ? overrides.start! : 'eum',
+  };
+};
+
 export const buildPartitionRun = (
   overrides?: Partial<PartitionRun>,
   _relationshipsToOmit: Set<string> = new Set(),
@@ -8689,6 +8720,44 @@ export const buildPartitions = (
   return {
     __typename: 'Partitions',
     results: overrides && overrides.hasOwnProperty('results') ? overrides.results! : [],
+  };
+};
+
+export const buildPartitionsByAssetSelector = (
+  overrides?: Partial<PartitionsByAssetSelector>,
+  _relationshipsToOmit: Set<string> = new Set(),
+): PartitionsByAssetSelector => {
+  const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
+  relationshipsToOmit.add('PartitionsByAssetSelector');
+  return {
+    assetKey:
+      overrides && overrides.hasOwnProperty('assetKey')
+        ? overrides.assetKey!
+        : relationshipsToOmit.has('AssetKeyInput')
+        ? ({} as AssetKeyInput)
+        : buildAssetKeyInput({}, relationshipsToOmit),
+    partitions:
+      overrides && overrides.hasOwnProperty('partitions')
+        ? overrides.partitions!
+        : relationshipsToOmit.has('PartitionsSelector')
+        ? ({} as PartitionsSelector)
+        : buildPartitionsSelector({}, relationshipsToOmit),
+  };
+};
+
+export const buildPartitionsSelector = (
+  overrides?: Partial<PartitionsSelector>,
+  _relationshipsToOmit: Set<string> = new Set(),
+): PartitionsSelector => {
+  const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
+  relationshipsToOmit.add('PartitionsSelector');
+  return {
+    range:
+      overrides && overrides.hasOwnProperty('range')
+        ? overrides.range!
+        : relationshipsToOmit.has('PartitionRangeSelector')
+        ? ({} as PartitionRangeSelector)
+        : buildPartitionRangeSelector({}, relationshipsToOmit),
   };
 };
 

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
@@ -85,10 +85,8 @@ def create_and_launch_partition_backfill(
             if partitions_by_assets
             else True
         ),
-        (
-            "partitions_by_assets cannot be used together with asset_selection, selector, or"
-            " partitionNames"
-        ),
+        "partitions_by_assets cannot be used together with asset_selection, selector, or"
+        " partitionNames",
     )
 
     tags = {t["key"]: t["value"] for t in backfill_params.get("tags", [])}

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, List, Optional, Sequence, Union, cast
 import dagster._check as check
 import pendulum
 from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
-from dagster._core.definitions.selector import RepositorySelector
+from dagster._core.definitions.selector import PartitionsByAssetSelector, RepositorySelector
 from dagster._core.errors import DagsterError, DagsterUserCodeProcessError
 from dagster._core.events import AssetKey
 from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
@@ -74,6 +74,22 @@ def create_and_launch_partition_backfill(
         if backfill_params.get("assetSelection")
         else None
     )
+
+    partitions_by_assets = backfill_params.get("partitionsByAssets")
+
+    check.invariant(
+        (
+            asset_selection is None
+            and backfill_params.get("selector") is None
+            and backfill_params.get("partitionNames") is None
+            if partitions_by_assets
+            else True
+        ),
+        (
+            "partitions_by_assets cannot be used together with asset_selection, selector, or"
+            " partitionNames"
+        ),
+    ),
 
     tags = {t["key"]: t["value"] for t in backfill_params.get("tags", [])}
     backfill_timestamp = pendulum.now("UTC").timestamp()
@@ -181,6 +197,26 @@ def create_and_launch_partition_backfill(
                 utc_datetime_from_timestamp(backfill_timestamp),
             ),
             all_partitions=backfill_params.get("allPartitions", False),
+        )
+    elif partitions_by_assets is not None:
+        asset_graph = ExternalAssetGraph.from_workspace(graphene_info.context)
+        _assert_permission_for_asset_graph(
+            graphene_info, asset_graph, asset_selection, Permissions.LAUNCH_PARTITION_BACKFILL
+        )
+        backfill = PartitionBackfill.from_partitions_by_assets(
+            backfill_id=backfill_id,
+            asset_graph=asset_graph,
+            backfill_timestamp=backfill_timestamp,
+            tags=tags,
+            dynamic_partitions_store=CachingInstanceQueryer(
+                graphene_info.context.instance,
+                asset_graph,
+                utc_datetime_from_timestamp(backfill_timestamp),
+            ),
+            partitions_by_assets=[
+                PartitionsByAssetSelector.from_graphql_input(partitions_by_asset_selector)
+                for partitions_by_asset_selector in partitions_by_assets
+            ],
         )
     else:
         raise DagsterError(

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
@@ -199,6 +199,14 @@ def create_and_launch_partition_backfill(
             all_partitions=backfill_params.get("allPartitions", False),
         )
     elif partitions_by_assets is not None:
+        if backfill_params.get("forceSynchronousSubmission"):
+            raise DagsterError(
+                "forceSynchronousSubmission is not supported for pure asset backfills"
+            )
+
+        if backfill_params.get("fromFailure"):
+            raise DagsterError("fromFailure is not supported for pure asset backfills")
+
         asset_graph = ExternalAssetGraph.from_workspace(graphene_info.context)
         _assert_permission_for_asset_graph(
             graphene_info, asset_graph, asset_selection, Permissions.LAUNCH_PARTITION_BACKFILL

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
@@ -89,7 +89,7 @@ def create_and_launch_partition_backfill(
             "partitions_by_assets cannot be used together with asset_selection, selector, or"
             " partitionNames"
         ),
-    ),
+    )
 
     tags = {t["key"]: t["value"] for t in backfill_params.get("tags", [])}
     backfill_timestamp = pendulum.now("UTC").timestamp()

--- a/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
@@ -137,9 +137,36 @@ class GraphenePartitionSetSelector(graphene.InputObjectType):
         name = "PartitionSetSelector"
 
 
+class GraphenePartitionRangeSelector(graphene.InputObjectType):
+    start = graphene.NonNull(graphene.String)
+    end = graphene.NonNull(graphene.String)
+
+    class Meta:
+        description = """This type represents a partition range selection with start and end."""
+        name = "PartitionRangeSelector"
+
+
+class GraphenePartitionsSelector(graphene.InputObjectType):
+    range = graphene.NonNull(GraphenePartitionRangeSelector)
+
+    class Meta:
+        description = """This type represents a partitions selection."""
+        name = "PartitionsSelector"
+
+
+class GraphenePartitionsByAssetSelector(graphene.InputObjectType):
+    assetKey = graphene.NonNull(GrapheneAssetKeyInput)
+    partitions = graphene.InputField(GraphenePartitionsSelector)
+
+    class Meta:
+        description = """This type represents a partitions selection for an asset."""
+        name = "PartitionsByAssetSelector"
+
+
 class GrapheneLaunchBackfillParams(graphene.InputObjectType):
     selector = graphene.InputField(GraphenePartitionSetSelector)
     partitionNames = graphene.List(graphene.NonNull(graphene.String))
+    partitionsByAssets = graphene.List(GraphenePartitionsByAssetSelector)
     reexecutionSteps = graphene.List(graphene.NonNull(graphene.String))
     assetSelection = graphene.InputField(graphene.List(graphene.NonNull(GrapheneAssetKeyInput)))
     fromFailure = graphene.Boolean()
@@ -301,6 +328,7 @@ types = [
     GrapheneMarshalledOutput,
     GrapheneLaunchBackfillParams,
     GraphenePartitionSetSelector,
+    GraphenePartitionsByAssetSelector,
     GrapheneRunsFilter,
     GraphenePipelineSelector,
     GrapheneRepositorySelector,

--- a/python_modules/dagster/dagster/_core/definitions/selector.py
+++ b/python_modules/dagster/dagster/_core/definitions/selector.py
@@ -311,7 +311,6 @@ class PartitionSetSelector(
         }
 
 
-@whitelist_for_serdes
 class PartitionRangeSelector(
     NamedTuple(
         "_PartitionRangeSelector",
@@ -359,7 +358,7 @@ class PartitionsSelector(
 
     def to_graphql_input(self):
         return {
-            "range": self.range.to_graphql_input(),
+            "range": self.partition_range.to_graphql_input(),
         }
 
     @staticmethod
@@ -369,7 +368,6 @@ class PartitionsSelector(
         )
 
 
-@whitelist_for_serdes
 class PartitionsByAssetSelector(
     NamedTuple(
         "PartitionsByAssetSelector",

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -18,7 +18,10 @@ from typing import (
     cast,
 )
 
-from dagster import _check as check
+from dagster import (
+    PartitionKeyRange,
+    _check as check,
+)
 from dagster._core.definitions.asset_daemon_context import build_run_requests
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -332,6 +332,10 @@ class AssetBackfillData(NamedTuple):
         backfill_start_time: datetime,
         partitions_by_assets: Sequence[PartitionsByAssetSelector],
     ) -> "AssetBackfillData":
+        """Create an AssetBackfillData object from a list of PartitionsByAssetSelector objects.
+        Accepts a list of asset partitions selections, used to determine the target partitions to backfill.
+        For targeted assets, if partitioned and no partitions selections are provided, targets all partitions.
+        """
         check.sequence_param(partitions_by_assets, "partitions_by_asset", PartitionsByAssetSelector)
 
         non_partitioned_asset_keys = set()

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -16,6 +16,7 @@ from dagster._serdes import whitelist_for_serdes
 from dagster._utils import utc_datetime_from_timestamp
 from dagster._utils.error import SerializableErrorInfo
 
+from ..definitions.selector import PartitionsByAssetSelector
 from .asset_backfill import (
     AssetBackfillData,
     PartitionedAssetBackfillStatus,
@@ -354,5 +355,29 @@ class PartitionBackfill(
                 dynamic_partitions_store=dynamic_partitions_store,
                 all_partitions=all_partitions,
                 backfill_start_time=utc_datetime_from_timestamp(backfill_timestamp),
+            ).serialize(dynamic_partitions_store=dynamic_partitions_store),
+        )
+
+    @classmethod
+    def from_partitions_by_assets(
+        cls,
+        backfill_id: str,
+        asset_graph: AssetGraph,
+        backfill_timestamp: float,
+        tags: Mapping[str, str],
+        dynamic_partitions_store: DynamicPartitionsStore,
+        partitions_by_assets: Sequence[PartitionsByAssetSelector],
+    ):
+        return cls(
+            backfill_id=backfill_id,
+            status=BulkActionStatus.REQUESTED,
+            from_failure=False,
+            tags=tags,
+            backfill_timestamp=backfill_timestamp,
+            serialized_asset_backfill_data=AssetBackfillData.from_partitions_by_assets(
+                asset_graph=asset_graph,
+                dynamic_partitions_store=dynamic_partitions_store,
+                backfill_start_time=utc_datetime_from_timestamp(backfill_timestamp),
+                partitions_by_assets=partitions_by_assets,
             ).serialize(dynamic_partitions_store=dynamic_partitions_store),
         )


### PR DESCRIPTION
## Summary & Motivation
This PR adds support for custom partition range backfill to the GraphQL mutation LaunchBackfillMutation.

On the API side, added `partitionsByAssets` to `launchBackfillParams`, e.g.
```
"partitionsByAssets": [
    {
      "assetKey": {path: ["a", "b", "c"]},
      "partitions": {
        "range": {
          "start": "2022-02-01",
          "end": "2022-02-04",
        }
      }
    }
  ]
```
Also, added logic in `./python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py` to turn those params into an `AssetBackfillData` targeting the specified partitions in range for given assets.

## How I Tested These Changes
Added a unit test in `./python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py` to test all possible cases. 


