### PR TITLE
feat(dbt): add adapters to `setup.py` by reading `profiles.yml`

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/include/setup.py.jinja
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/include/setup.py.jinja
@@ -9,6 +9,9 @@ setup(
         "dagster-cloud",
         "dagster-dbt",
         "dbt-core>=1.4.0",
+        {% for dbt_adapter in dbt_adapter_packages -%}
+        "{{ dbt_adapter }}",
+        {%- endfor %}
     ],
     extras_require={
         "dev": [

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_app.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_app.py
@@ -56,6 +56,7 @@ def test_project_scaffold_command_with_precompiled_manifest(
     assert dagster_project_dir.exists()
     assert dagster_project_dir.joinpath(project_name).exists()
     assert not any(path.suffix == ".jinja" for path in dagster_project_dir.glob("**/*"))
+    assert "dbt-duckdb" in dagster_project_dir.joinpath("setup.py").read_text()
 
     subprocess.run(["dbt", "compile"], cwd=dbt_project_dir, check=True)
 
@@ -105,6 +106,7 @@ def test_project_scaffold_command_with_runtime_manifest(
     assert dagster_project_dir.joinpath(project_name).exists()
     assert not any(path.suffix == ".jinja" for path in dagster_project_dir.glob("**/*"))
     assert not dbt_project_dir.joinpath("target", "manifest.json").exists()
+    assert "dbt-duckdb" in dagster_project_dir.joinpath("setup.py").read_text()
 
     monkeypatch.chdir(tmp_path)
     sys.path.append(os.fspath(tmp_path))


### PR DESCRIPTION
## Summary & Motivation
Automatically add adapters to the scaffold by inspecting the contents of `profiles.yml`.

See the following for a list of supported adapters:
- https://docs.getdbt.com/docs/supported-data-platforms
- https://docs.getdbt.com/docs/community-adapters

## How I Tested These Changes
pytest
