### PR TITLE
docs(dbt): divest from `with` in examples

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
@@ -81,8 +81,7 @@ def dbt_assets(
     """
     check.inst_param(manifest, "manifest", (Path, dict))
     if isinstance(manifest, Path):
-        with manifest.open("rb") as handle:
-            manifest = cast(Mapping[str, Any], orjson.loads(handle.read()))
+        manifest = cast(Mapping[str, Any], orjson.loads(manifest.read_bytes()))
 
     unique_ids = select_unique_ids_from_manifest(
         select=select, exclude=exclude or "", manifest_json=manifest

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
@@ -753,8 +753,7 @@ def load_assets_from_dbt_manifest(
         Union[Mapping[str, Any], Path], check.inst_param(manifest, "manifest", (Path, dict))
     )
     if isinstance(manifest, Path):
-        with manifest.open("r") as handle:
-            manifest = cast(Mapping[str, Any], json.load(handle))
+        manifest = cast(Mapping[str, Any], json.loads(manifest.read_bytes()))
 
     _raise_warnings_for_deprecated_args(
         "load_assets_from_dbt_manifest",

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_manifest_asset_selection.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_manifest_asset_selection.py
@@ -28,10 +28,11 @@ class DbtManifestAssetSelection(AssetSelection):
         .. code-block:: python
 
             import json
+            from pathlib import Path
+
             from dagster_dbt import DbtManifestAssetSelection
 
-            with open("path/to/manifest.json", "r") as f:
-                manifest = json.load(f)
+            manifest = json.loads(Path("path/to/manifest.json").read_text())
 
             # select the dbt assets that have the tag "foo".
             my_selection = DbtManifestAssetSelection(manifest=manifest, select="tag:foo")


### PR DESCRIPTION
## Summary & Motivation
Don't show the concept of context managers in user-facing API documentation. Instead, use built-in methods that handle the context for us.

Also, fix our internal implementation to use the built-in methods.

## How I Tested These Changes
read
