### PR TITLE
:bug: fix UPathIOManager loading multiple partitions from a non-partitioned run

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
@@ -267,6 +267,8 @@ class UPathIOManager(MemoizableIOManager):
         Otherwise, raise an error.
 
         Args:
+            context (InputContext): IOManager Input context
+            partition_key (str): the partition key corresponding to the partition being loaded
             path (UPath): The path to the partition.
             backcompat_path (Optional[UPath]): The path to the partition in the backcompat location.
 

--- a/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
@@ -255,7 +255,11 @@ class UPathIOManager(MemoizableIOManager):
         return obj
 
     def _load_partition_from_path(
-        self, context: InputContext, path: "UPath", backcompat_path: Optional["UPath"] = None
+        self,
+        context: InputContext,
+        partition_key: str,
+        path: "UPath",
+        backcompat_path: Optional["UPath"] = None,
     ) -> Any:
         """1. Try to load the partition from the normal path.
         2. If it was not found, try to load it from the backcompat path.
@@ -269,7 +273,6 @@ class UPathIOManager(MemoizableIOManager):
         Returns:
             Any: The object loaded from the partition.
         """
-        partition_key = context.partition_key
         allow_missing_partitions = (
             context.metadata.get("allow_missing_partitions", False)
             if context.metadata is not None
@@ -315,7 +318,10 @@ class UPathIOManager(MemoizableIOManager):
         if not inspect.iscoroutinefunction(self.load_from_path):
             for partition_key in context.asset_partition_keys:
                 obj = self._load_partition_from_path(
-                    context, paths[partition_key], backcompat_paths.get(partition_key)
+                    context,
+                    partition_key,
+                    paths[partition_key],
+                    backcompat_paths.get(partition_key),
                 )
                 if obj is not None:  # in case some partitions were skipped
                     objs[partition_key] = obj
@@ -332,7 +338,10 @@ class UPathIOManager(MemoizableIOManager):
                     tasks.append(
                         loop.create_task(
                             self._load_partition_from_path(
-                                context, paths[partition_key], backcompat_paths.get(partition_key)
+                                context,
+                                partition_key,
+                                paths[partition_key],
+                                backcompat_paths.get(partition_key),
                             )
                         )
                     )

--- a/python_modules/dagster/dagster_tests/storage_tests/test_upath_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_upath_io_manager.py
@@ -237,7 +237,7 @@ def test_upath_io_manager_multiple_partitions_from_non_partitioned_run(
             partition_key=partition_key,
         )
 
-    result = materialize([downstream_asset])
+    result = materialize([upstream_asset.to_source_asset(), downstream_asset])
 
     downstream_asset_data = result.output_for_node("downstream_asset", "result")
     assert set(downstream_asset_data.keys()) == {"A", "B"}

--- a/python_modules/dagster/dagster_tests/storage_tests/test_upath_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_upath_io_manager.py
@@ -229,7 +229,7 @@ def test_upath_io_manager_multiple_static_partitions(dummy_io_manager: DummyIOMa
 
 
 def test_upath_io_manager_multiple_partitions_from_non_partitioned_run(tmp_path: Path):
-    my_io_manager = PickleIOManager(tmp_path)
+    my_io_manager = PickleIOManager(UPath(tmp_path))
 
     upstream_partitions_def = StaticPartitionsDefinition(["A", "B"])
 

--- a/python_modules/dagster/dagster_tests/storage_tests/test_upath_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_upath_io_manager.py
@@ -54,6 +54,16 @@ class DummyIOManager(UPathIOManager):
         return str(path)
 
 
+class PickleIOManager(UPathIOManager):
+    def dump_to_path(self, context: OutputContext, obj: List, path: UPath):
+        with path.open("wb") as file:
+            pickle.dump(obj, file)
+
+    def load_from_path(self, context: InputContext, path: UPath) -> List:
+        with path.open("rb") as file:
+            return pickle.load(file)
+
+
 @pytest.fixture
 def dummy_io_manager(tmp_path: Path) -> IOManagerDefinition:
     @io_manager(config_schema={"base_path": Field(str, is_required=False)})
@@ -218,16 +228,16 @@ def test_upath_io_manager_multiple_static_partitions(dummy_io_manager: DummyIOMa
     assert set(downstream_asset_data.keys()) == {"A", "B"}
 
 
-def test_upath_io_manager_multiple_partitions_from_non_partitioned_run(
-    dummy_io_manager: DummyIOManager,
-):
+def test_upath_io_manager_multiple_partitions_from_non_partitioned_run(tmp_path: Path):
+    my_io_manager = PickleIOManager(tmp_path)
+
     upstream_partitions_def = StaticPartitionsDefinition(["A", "B"])
 
-    @asset(partitions_def=upstream_partitions_def)
+    @asset(partitions_def=upstream_partitions_def, io_manager_def=my_io_manager)
     def upstream_asset(context: AssetExecutionContext) -> str:
         return context.partition_key
 
-    @asset(ins={"upstream_asset": AssetIn(partition_mapping=AllPartitionMapping())})
+    @asset(ins={"upstream_asset": AssetIn(partition_mapping=AllPartitionMapping())}, io_manager_def=my_io_manager)
     def downstream_asset(upstream_asset: Dict[str, str]) -> Dict[str, str]:
         return upstream_asset
 

--- a/python_modules/dagster/dagster_tests/storage_tests/test_upath_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_upath_io_manager.py
@@ -237,7 +237,10 @@ def test_upath_io_manager_multiple_partitions_from_non_partitioned_run(tmp_path:
     def upstream_asset(context: AssetExecutionContext) -> str:
         return context.partition_key
 
-    @asset(ins={"upstream_asset": AssetIn(partition_mapping=AllPartitionMapping())}, io_manager_def=my_io_manager)
+    @asset(
+        ins={"upstream_asset": AssetIn(partition_mapping=AllPartitionMapping())},
+        io_manager_def=my_io_manager,
+    )
     def downstream_asset(upstream_asset: Dict[str, str]) -> Dict[str, str]:
         return upstream_asset
 


### PR DESCRIPTION
## Summary & Motivation
My recent changes to the UPathIOManager regarding async support introduced a bug when loading multiple partitions from a non-partitioned run. 

This affects any partitioned asset -> non-partitioned asset conversion (like using `AllPartitionMapping`).

I was trying to use `context.partition_key`, which (1) caused an error (2) was the wrong key (the key for the partition being loaded had to be used instead). 

This PR fixes this problem and adds a test for this case.

## How I Tested These Changes
Added a test