### PR TITLE
:zap: concurrent partition loading for PickledObjectS3IOManager

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
@@ -8,6 +8,7 @@ from fsspec import AbstractFileSystem
 from fsspec.implementations.local import LocalFileSystem
 
 from dagster import (
+    DagsterInvariantViolationError,
     InputContext,
     MetadataValue,
     MultiPartitionKey,
@@ -17,6 +18,7 @@ from dagster import (
 from dagster._core.storage.memoizable_io_manager import MemoizableIOManager
 
 if TYPE_CHECKING:
+    from fsspec.asyn import AsyncFileSystem
     from upath import UPath
 
 
@@ -436,6 +438,31 @@ class UPathIOManager(MemoizableIOManager):
         metadata.update(custom_metadata)  # type: ignore
 
         context.add_output_metadata(metadata)
+
+    @staticmethod
+    def get_async_filesystem(path: "Path") -> "AsyncFileSystem":
+        """A helper method, is useful inside an async `load_from_path`.
+        The returned `fsspec` FileSystem will have async IO methods.
+        https://filesystem-spec.readthedocs.io/en/latest/async.html.
+        """
+        if isinstance(path, Path) and not isinstance(path, UPath):
+            try:
+                from morefs.asyn_local import AsyncLocalFileSystem  # type: ignore
+
+                return AsyncLocalFileSystem()
+            except ImportError as e:
+                raise RuntimeError(
+                    "Install 'morefs[asynclocal]' to use `get_async_filesystem` with a local"
+                    " filesystem"
+                ) from e
+        elif isinstance(path, UPath):
+            kwargs = path._kwargs.copy()  # noqa
+            kwargs["asynchronous"] = True
+            return path._default_accessor(path._url, **kwargs)._fs  # noqa
+        else:
+            raise DagsterInvariantViolationError(
+                f"Path type {type(path)} is not supported by the UPathIOManager"
+            )
 
 
 def is_dict_type(type_obj) -> bool:

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
@@ -35,8 +35,11 @@ class PickledObjectS3IOManager(UPathIOManager):
         base_path = UPath(s3_prefix) if s3_prefix else None
         super().__init__(base_path=base_path)
 
-    def load_from_path(self, context: InputContext, path: UPath) -> Any:
-        return pickle.loads(self.s3.get_object(Bucket=self.bucket, Key=str(path))["Body"].read())
+    async def load_from_path(self, context: InputContext, path: UPath) -> Any:
+        fs = self.get_async_filesystem(path)
+        file = await fs.open_async(str(path), "rb")
+        data = await file.read()
+        return pickle.loads(data)
 
     def dump_to_path(self, context: OutputContext, obj: Any, path: UPath) -> None:
         if self.path_exists(path):


### PR DESCRIPTION
## Summary & Motivation
`UPathIOManager` has support for concurrent partitions loading. 
This PR enables this feature for the `PickledObjectS3IOManager`.

## How I Tested These Changes
