### PR TITLE
feat(dbt): allow asset materializations when invoking `DbtCliResource.cli` from op

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
@@ -21,12 +21,15 @@ from typing import (
 import dateutil
 from dagster import (
     AssetKey,
+    AssetMaterialization,
+    AssetObservation,
     AssetsDefinition,
     AutoMaterializePolicy,
     FreshnessPolicy,
     In,
     OpExecutionContext,
     Out,
+    Output,
     PartitionsDefinition,
     PermissiveConfig,
     _check as check,
@@ -34,10 +37,7 @@ from dagster import (
     op,
 )
 from dagster._core.definitions.events import (
-    AssetMaterialization,
-    AssetObservation,
     CoercibleToAssetKeyPrefix,
-    Output,
 )
 from dagster._core.definitions.metadata import MetadataUserInput, RawMetadataValue
 from dagster._core.errors import DagsterInvalidSubsetError
@@ -246,7 +246,7 @@ def _stream_event_iterator(
     ],
     kwargs: Dict[str, Any],
     manifest_json: Mapping[str, Any],
-) -> Iterator[Union[AssetObservation, Output]]:
+) -> Iterator[Union[AssetMaterialization, AssetObservation, Output]]:
     """Yields events for a dbt cli invocation. Emits outputs as soon as the relevant dbt logs are
     emitted.
     """


### PR DESCRIPTION
## Summary & Motivation
Allow `AssetMaterialization` to be emitted when `DbtCliResource` is invoked in an `@op`. This was possible before using internal APIs, but we lost it in our migration to `DagsterDbtTranslator`. 

Make this experience more first-class, so we don't lose this ability in the future.

```python
import json
from pathlib import Path

from dagster import Output, op
from dagster_dbt import DbtCliResource

manifest = json.loads(Path("target", "manifest.json").read_text())


@op
def my_dbt_op(dbt: DbtCliResource):
    yield from dbt.cli(["run"], manifest=manifest).stream(yield_asset_materialization=True)
    yield Output(None)
```

## How I Tested These Changes
pytest
