### PR TITLE
add helm values for concurrency free run monitoring

### DIFF
--- a/docs/content/guides/limiting-concurrency-in-data-pipelines.mdx
+++ b/docs/content/guides/limiting-concurrency-in-data-pipelines.mdx
@@ -394,11 +394,16 @@ height={1638}
 
 Limits can be specified on the Dagster instance using the special op tag `dagster/concurrency_key`. If this instance limit would be exceeded by launching an op/asset, then the op/asset will be queued.
 
-For example, to globally limit the number of running ops touching Redshift to two, the op must be first tagged with the global concurrency key:
+For example, to globally limit the number of running ops touching Redshift to two, the op/asset must be first tagged with the global concurrency key:
 
-```python file=/concepts/ops_jobs_graphs/job_execution.py startafter=start_global_concurrency endbefore=end_global_concurrency
+```python file=/deploying/concurrency_limits/concurrency_limits.py startafter=start_global_concurrency endbefore=end_global_concurrency
 @op(tags={"dagster/concurrency_key": "redshift"})
 def my_redshift_op():
+    ...
+
+
+@asset(op_tags={"dagster/concurrency_key": "redshift"})
+def my_redshift_table():
     ...
 ```
 
@@ -418,7 +423,7 @@ The concurrency key should match the name that the op/asset is tagged with. For 
 
 With a global concurrency limit set, it is useful to configure your instance to automatically free slots for canceled/failed runs. Certain execution errors can cause steps to exit without freeing an occupied concurrency slot.
 
-To automatically recover from this state, you can configure your instance's run monitoring to automatically free concurrency slots for runs that have reached some terminal state (e.g. failed or canceled runs). 
+To automatically recover from this state, you can configure your instance's run monitoring to automatically free concurrency slots for runs that have reached some terminal state (e.g. failed or canceled runs).
 
 In `dagster.yaml`, you can configure the interval between a run end and the slot clean up like so:
 

--- a/docs/content/guides/limiting-concurrency-in-data-pipelines.mdx
+++ b/docs/content/guides/limiting-concurrency-in-data-pipelines.mdx
@@ -414,6 +414,8 @@ To specify limits on the number of ops/assets tagged with a particular concurren
 
 The concurrency key should match the name that the op/asset is tagged with. For example, if the op/asset is tagged with `dagster/concurrency_key: redshift`, then the concurrency key should be `redshift`.
 
+#### Freeing concurrency slots
+
 With a global concurrency limit set, it is useful to configure your instance to automatically free slots for canceled/failed runs. Certain execution errors can cause steps to exit without freeing an occupied concurrency slot.
 
 To automatically recover from this state, you can configure your instance's run monitoring to automatically free concurrency slots for runs that have reached some terminal state (e.g. failed or canceled runs). 

--- a/docs/content/guides/limiting-concurrency-in-data-pipelines.mdx
+++ b/docs/content/guides/limiting-concurrency-in-data-pipelines.mdx
@@ -414,7 +414,13 @@ To specify limits on the number of ops/assets tagged with a particular concurren
 
 The concurrency key should match the name that the op/asset is tagged with. For example, if the op/asset is tagged with `dagster/concurrency_key: redshift`, then the concurrency key should be `redshift`.
 
----
+- With a global concurrency limit set, it is useful to configure your instance to automatically free slots for canceled / failed runs. Certain execution errors can cause steps to exit without freeing an occupied concurrency slot. To automatically recover from this state, you can configure your instance's run monitoring to automatically free concurrency slots for runs that have reached some terminal state (e.g. failed or canceled runs). You can configure the interval between a run end and the slot clean up in your `dagster.yaml`:
+
+```yaml file=/deploying/concurrency_limits/dagster.yaml startafter=start_free_slots endbefore=end_free_slots
+run_monitoring:
+  enabled: true
+  free_slots_after_run_end_seconds: 300 # free any hanging concurrency slots after 5 minutes from the end of a run
+```
 
 ## Troubleshooting
 

--- a/docs/content/guides/limiting-concurrency-in-data-pipelines.mdx
+++ b/docs/content/guides/limiting-concurrency-in-data-pipelines.mdx
@@ -414,7 +414,11 @@ To specify limits on the number of ops/assets tagged with a particular concurren
 
 The concurrency key should match the name that the op/asset is tagged with. For example, if the op/asset is tagged with `dagster/concurrency_key: redshift`, then the concurrency key should be `redshift`.
 
-- With a global concurrency limit set, it is useful to configure your instance to automatically free slots for canceled / failed runs. Certain execution errors can cause steps to exit without freeing an occupied concurrency slot. To automatically recover from this state, you can configure your instance's run monitoring to automatically free concurrency slots for runs that have reached some terminal state (e.g. failed or canceled runs). You can configure the interval between a run end and the slot clean up in your `dagster.yaml`:
+With a global concurrency limit set, it is useful to configure your instance to automatically free slots for canceled/failed runs. Certain execution errors can cause steps to exit without freeing an occupied concurrency slot.
+
+To automatically recover from this state, you can configure your instance's run monitoring to automatically free concurrency slots for runs that have reached some terminal state (e.g. failed or canceled runs). 
+
+In `dagster.yaml`, you can configure the interval between a run end and the slot clean up like so:
 
 ```yaml file=/deploying/concurrency_limits/dagster.yaml startafter=start_free_slots endbefore=end_free_slots
 run_monitoring:

--- a/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/job_execution.py
+++ b/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/job_execution.py
@@ -102,12 +102,3 @@ def tag_concurrency_job():
 
 
 # end_tag_concurrency
-
-
-# start_global_concurrency
-@op(tags={"dagster/concurrency_key": "redshift"})
-def my_redshift_op():
-    ...
-
-
-# end_global_concurrency

--- a/examples/docs_snippets/docs_snippets/deploying/concurrency_limits/concurrency_limits.py
+++ b/examples/docs_snippets/docs_snippets/deploying/concurrency_limits/concurrency_limits.py
@@ -1,4 +1,4 @@
-from dagster import job, schedule
+from dagster import asset, job, op, schedule
 
 # start_marker_priority
 
@@ -19,3 +19,17 @@ def less_important_schedule(_):
 
 
 # end_marker_priority
+
+
+# start_global_concurrency
+@op(tags={"dagster/concurrency_key": "redshift"})
+def my_redshift_op():
+    ...
+
+
+@asset(op_tags={"dagster/concurrency_key": "redshift"})
+def my_redshift_table():
+    ...
+
+
+# end_global_concurrency

--- a/examples/docs_snippets/docs_snippets/deploying/concurrency_limits/dagster.yaml
+++ b/examples/docs_snippets/docs_snippets/deploying/concurrency_limits/dagster.yaml
@@ -14,6 +14,14 @@ run_queue:
       value: "redshift"        # applies when the `database` tag has a value of `redshift`
       limit: 4
     - key: "dagster/backfill"  # applies when the `dagster/backfill` tag is present, regardless of value
-      limit: 10 
+      limit: 10
 
 # end_tag_example
+
+# start_free_slots
+
+run_monitoring:
+  enabled: true
+  free_slots_after_run_end_seconds: 300 # free any hanging concurrency slots after 5 minutes from the end of a run
+
+# end_free_slots

--- a/helm/dagster/templates/configmap-instance.yaml
+++ b/helm/dagster/templates/configmap-instance.yaml
@@ -97,6 +97,7 @@ data:
       max_resume_run_attempts: {{ $runMonitoring.maxResumeRunAttempts }}
       {{- end }}
       poll_interval_seconds: {{ $runMonitoring.pollIntervalSeconds }}
+      free_slots_after_run_end_seconds: {{ $runMonitoring.freeSlotsAfterRunEndSeconds }}
     {{- end }}
 
     {{- if and (.Values.dagsterDaemon.enabled) (.Values.dagsterDaemon.runRetries.enabled) }}

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -1107,6 +1107,9 @@ dagsterDaemon:
     # `k8s_job_executor` to run each op in its own Kubernetes job. To enable, set this value
     # to a value greater than 0.
     maxResumeRunAttempts: 0
+    # [Experimental] Number of seconds to wait after a run has ended with a success/failed/canceled
+    # status before freeing any concurrency slots that may have been retained.
+    freeSlotsAfterRunEndSeconds: 0
 
   runRetries:
     enabled: true

--- a/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/helm.py
+++ b/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/helm.py
@@ -751,6 +751,7 @@ def helm_chart_for_k8s_run_launcher(
                     "pollIntervalSeconds": 5,
                     "startTimeoutSeconds": 60,
                     "maxResumeRunAttempts": 3,
+                    "freeSlotsAfterRunEndSeconds": 300,
                 }
                 if run_monitoring
                 else {},


### PR DESCRIPTION
## Summary & Motivation
We should have solid support / documentation of the concurrency slot freeing daemon for any user checking out global op concurrency

## How I Tested These Changes
BK
