### PR TITLE
[docs] - Fix link on /tutorial page

### DIFF
--- a/docs/content/tutorial.mdx
+++ b/docs/content/tutorial.mdx
@@ -17,7 +17,7 @@ By the end of this tutorial, you will:
 - [Install Dagster](/tutorial/setup)
 - [Write an asset that ingests data](/tutorial/writing-your-first-asset)
 - [Make DataFrames and visualizations and connect them together](/tutorial/building-an-asset-graph)
-- [Automate your pipelines to run on a schedule](/tutorial/building-an-asset-graph)
+- [Automate your pipelines to run on a schedule](/tutorial/scheduling-your-pipeline)
 - [Use I/O managers to save your data](/tutorial/saving-your-data)
 - [Manage your control plane of services and integrations](/tutorial/connecting-to-external-services)
 - [Learn what's next in Dagster](/tutorial/next-steps)


### PR DESCRIPTION
## Summary & Motivation

Fixing #15463, where a link on `/tutorial` points to the wrong section of the tutorial.

## How I Tested These Changes

👀 , local
