### PR TITLE
feat(dbt): check the type of `dagster_dbt_translator`

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
@@ -75,10 +75,39 @@ def dbt_assets(
             from dagster import OpExecutionContext
             from dagster_dbt import DbtCliResource, dbt_assets
 
+
             @dbt_assets(manifest=Path("target", "manifest.json"))
             def my_dbt_assets(context: OpExecutionContext, dbt: DbtCliResource):
                 yield from dbt.cli(["build"], context=context).stream()
+
+        .. code-block:: python
+
+            from pathlib import Path
+
+            from dagster import OpExecutionContext
+            from dagster_dbt import DagsterDbtTranslator, DbtCliResource, dbt_assets
+
+
+            class CustomDagsterDbtTranslator(DagsterDbtTranslator):
+                ...
+
+
+            @dbt_assets(
+                manifest=Path("target", "manifest.json"),
+                dagster_dbt_translator=CustomDagsterDbtTranslator(),
+            )
+            def my_dbt_assets(context: OpExecutionContext, dbt: DbtCliResource):
+                yield from dbt.cli(["build"], context=context).stream()
     """
+    check.inst_param(
+        dagster_dbt_translator,
+        "dagster_dbt_translator",
+        DagsterDbtTranslator,
+        additional_message=(
+            "Ensure that the argument is an instantiated class that subclasses"
+            " DagsterDbtTranslator."
+        ),
+    )
     check.inst_param(manifest, "manifest", (Path, dict))
     if isinstance(manifest, Path):
         manifest = cast(Mapping[str, Any], orjson.loads(manifest.read_bytes()))


### PR DESCRIPTION
## Summary & Motivation
`dagster_dbt_translator` should be an instantiated instance of a class. Validate the argument, and add an example.

We don't attempt to instantiate the argument on behalf of the user if the passed argument is `Type[T]` where `T = TypeVar("T", bound=DagsterDbtTranslator)` since the subclassed type might need its own arguments to instantiate itself.

## How I Tested These Changes
N/A
