### PR TITLE
[ui] Show freshness policy info in Fresh state, use "minutes old" not "minutes overdue"

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/components/Popover.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/Popover.tsx
@@ -13,7 +13,7 @@ import {FontFamily} from './styles';
 export const GlobalPopoverStyle = createGlobalStyle`
   .dagster-popover.bp4-popover2,
   .dagster-popover.bp4-popover {
-    box-shadow: rgba(0, 0, 0, 0.12) 0px 2px 12px;
+    box-shadow: rgba(0, 0, 0, 0.18) 0px 2px 12px;
   }
 
   .dagster-popover .bp4-popover2-content,

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/OverdueTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/OverdueTag.tsx
@@ -43,20 +43,19 @@ export const OverdueTag: React.FC<{
   policy: Pick<FreshnessPolicy, 'cronSchedule' | 'cronScheduleTimezone' | 'maximumLagMinutes'>;
   assetKey: AssetKeyInput;
 }> = ({liveData, policy, assetKey}) => {
-  console.log(liveData);
-
   if (!liveData?.freshnessInfo) {
     return null;
   }
 
   const {freshnessInfo} = liveData;
-  const policyDescription = freshnessPolicyDescription(policy);
 
   if (freshnessInfo.currentMinutesLate === null) {
     return (
       <Tooltip
         content={
-          <div style={{maxWidth: 400}}>{`${STALE_UNMATERIALIZED_MSG} ${policyDescription}`}</div>
+          <div style={{maxWidth: 400}}>{`${STALE_UNMATERIALIZED_MSG} ${freshnessPolicyDescription(
+            policy,
+          )}`}</div>
         }
       >
         <Tag intent="danger" icon="warning">
@@ -67,12 +66,10 @@ export const OverdueTag: React.FC<{
   }
 
   if (freshnessInfo.currentMinutesLate === 0) {
-    return policyDescription ? (
-      <Tooltip content={<div style={{maxWidth: 400}}>{policyDescription}</div>}>
+    return (
+      <OverdueLineagePopover assetKey={assetKey} liveData={liveData}>
         <Tag intent="success" icon="check_circle" />
-      </Tooltip>
-    ) : (
-      <Tag intent="success" icon="check_circle" />
+      </OverdueLineagePopover>
     );
   }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/OverdueTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/OverdueTag.tsx
@@ -166,39 +166,46 @@ const OverdueLineagePopoverContent: React.FC<{
           ? `The asset's freshness policy requires it to be derived from data ${policyStr}`
           : `The asset's freshness policy requires it is ${policyStr}`}
       </Box>
-      <Box
-        padding={12}
-        style={{fontWeight: 600}}
-        border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
-      >
-        Latest materialization:
-      </Box>
-      <Box
-        padding={12}
-        flex={{justifyContent: 'space-between'}}
-        border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
-      >
-        <Timestamp timestamp={{ms: Number(timestamp)}} />
-        <TimeSinceWithOverdueColor
-          timestamp={Number(timestamp)}
-          relativeTo={cronSchedule ? Number(lastEvaluationTimestamp) : 'now'}
-          maximumLagMinutes={data.freshnessPolicy.maximumLagMinutes}
-        />
-      </Box>
-      <Box padding={12} style={{fontWeight: 600}}>
-        Latest materialization sources data from:
-      </Box>
-      <Box
-        style={{maxHeight: '240px', overflowY: 'auto', marginLeft: -1, marginRight: -1}}
-        onClick={(e) => e.stopPropagation()}
-      >
-        <AssetMaterializationUpstreamTable
-          data={data}
-          maximumLagMinutes={data.freshnessPolicy.maximumLagMinutes}
-          relativeTo={cronSchedule ? Number(lastEvaluationTimestamp) : 'now'}
-          assetKey={assetKey}
-        />
-      </Box>
+      {hasUpstreams ? (
+        <>
+          <Box padding={12} style={{fontWeight: 600}}>
+            Latest materialization sources data from:
+          </Box>
+          <Box
+            style={{maxHeight: '240px', overflowY: 'auto', marginLeft: -1, marginRight: -1}}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <AssetMaterializationUpstreamTable
+              data={data}
+              maximumLagMinutes={data.freshnessPolicy.maximumLagMinutes}
+              relativeTo={cronSchedule ? Number(lastEvaluationTimestamp) : 'now'}
+              assetKey={assetKey}
+            />
+          </Box>
+        </>
+      ) : (
+        <>
+          <Box
+            padding={12}
+            style={{fontWeight: 600}}
+            border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+          >
+            Latest materialization:
+          </Box>
+          <Box
+            padding={12}
+            flex={{justifyContent: 'space-between'}}
+            border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+          >
+            <Timestamp timestamp={{ms: Number(timestamp)}} />
+            <TimeSinceWithOverdueColor
+              timestamp={Number(timestamp)}
+              relativeTo={cronSchedule ? Number(lastEvaluationTimestamp) : 'now'}
+              maximumLagMinutes={data.freshnessPolicy.maximumLagMinutes}
+            />
+          </Box>
+        </>
+      )}
     </Box>
   );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__stories__/OverdueTag.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__stories__/OverdueTag.stories.tsx
@@ -46,6 +46,13 @@ const mockFreshnessPolicy = buildFreshnessPolicy({
   lastEvaluationTimestamp: `${TEST_TIME}`,
 });
 
+const mockFreshnessPolicyMet = buildFreshnessPolicy({
+  cronSchedule: null,
+  cronScheduleTimezone: null,
+  maximumLagMinutes: 365 * 24 * 60,
+  lastEvaluationTimestamp: `${TEST_TIME}`,
+});
+
 function buildOverduePopoverMock(
   policy: FreshnessPolicy,
   hasUsedData = true,
@@ -161,11 +168,17 @@ export const NeverMaterialized = () => {
 
 export const Fresh = () => {
   return (
-    <MockedProvider cache={createAppCache()} mocks={[]}>
+    <MockedProvider
+      cache={createAppCache()}
+      mocks={[buildOverduePopoverMock(mockFreshnessPolicyMet)]}
+    >
       <OverdueTag
         assetKey={{path: ['inp8']}}
-        policy={mockFreshnessPolicy}
-        liveData={LiveDataForNodeMaterializedAndFresh}
+        policy={mockFreshnessPolicyMet}
+        liveData={{
+          ...mockLiveData,
+          freshnessInfo: {__typename: 'AssetFreshnessInfo', currentMinutesLate: 0},
+        }}
       />
     </MockedProvider>
   );

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/OverdueTag.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/OverdueTag.types.ts
@@ -13,6 +13,11 @@ export type OverduePopoverQuery = {
     | {
         __typename: 'AssetNode';
         id: string;
+        freshnessInfo: {
+          __typename: 'AssetFreshnessInfo';
+          currentLagMinutes: number | null;
+          currentMinutesLate: number | null;
+        } | null;
         freshnessPolicy: {
           __typename: 'FreshnessPolicy';
           cronSchedule: string | null;

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -698,6 +698,7 @@ type AssetDependency {
 }
 
 type AssetFreshnessInfo {
+  currentLagMinutes: Float
   currentMinutesLate: Float
   latestMaterializationMinutesLate: Float
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -127,6 +127,7 @@ export type AssetDependency = {
 
 export type AssetFreshnessInfo = {
   __typename: 'AssetFreshnessInfo';
+  currentLagMinutes: Maybe<Scalars['Float']>;
   currentMinutesLate: Maybe<Scalars['Float']>;
   latestMaterializationMinutesLate: Maybe<Scalars['Float']>;
 };
@@ -4360,6 +4361,10 @@ export const buildAssetFreshnessInfo = (
   relationshipsToOmit.add('AssetFreshnessInfo');
   return {
     __typename: 'AssetFreshnessInfo',
+    currentLagMinutes:
+      overrides && overrides.hasOwnProperty('currentLagMinutes')
+        ? overrides.currentLagMinutes!
+        : 5.23,
     currentMinutesLate:
       overrides && overrides.hasOwnProperty('currentMinutesLate')
         ? overrides.currentMinutesLate!

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -627,9 +627,7 @@ def get_freshness_info(
     from ..schema.freshness_policy import GrapheneAssetFreshnessInfo
 
     current_time = datetime.datetime.now(tz=datetime.timezone.utc)
-    result = data_time_resolver.get_minutes_overdue(
-        asset_key, evaluation_time=current_time
-    )
+    result = data_time_resolver.get_minutes_overdue(asset_key, evaluation_time=current_time)
     return GrapheneAssetFreshnessInfo(
         currentLagMinutes=result.lag_minutes,
         currentMinutesLate=result.overdue_minutes,

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -627,11 +627,12 @@ def get_freshness_info(
     from ..schema.freshness_policy import GrapheneAssetFreshnessInfo
 
     current_time = datetime.datetime.now(tz=datetime.timezone.utc)
-
+    result = data_time_resolver.get_minutes_overdue(
+        asset_key, evaluation_time=current_time
+    )
     return GrapheneAssetFreshnessInfo(
-        currentMinutesLate=data_time_resolver.get_current_minutes_late(
-            asset_key, evaluation_time=current_time
-        ),
+        currentLagMinutes=result.lag_minutes,
+        currentMinutesLate=result.overdue_minutes,
         latestMaterializationMinutesLate=None,
     )
 

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -629,8 +629,8 @@ def get_freshness_info(
     current_time = datetime.datetime.now(tz=datetime.timezone.utc)
     result = data_time_resolver.get_minutes_overdue(asset_key, evaluation_time=current_time)
     return GrapheneAssetFreshnessInfo(
-        currentLagMinutes=result.lag_minutes,
-        currentMinutesLate=result.overdue_minutes,
+        currentLagMinutes=result.lag_minutes if result else None,
+        currentMinutesLate=result.overdue_minutes if result else None,
         latestMaterializationMinutesLate=None,
     )
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/freshness_policy.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/freshness_policy.py
@@ -5,6 +5,9 @@ from dagster._seven import get_current_datetime_in_utc, get_timestamp_from_utc_d
 
 
 class GrapheneAssetFreshnessInfo(graphene.ObjectType):
+    # How old is the current data
+    currentLagMinutes = graphene.Field(graphene.Float)
+    # How overdue is the current data (currentLagMinutes - maximumLagMinutes)
     currentMinutesLate = graphene.Field(graphene.Float)
     latestMaterializationMinutesLate = graphene.Field(graphene.Float)
 

--- a/python_modules/dagster/dagster/_core/definitions/data_time.py
+++ b/python_modules/dagster/dagster/_core/definitions/data_time.py
@@ -25,8 +25,8 @@ from dagster._core.definitions.data_version import (
     DataVersion,
     get_input_event_pointer_tag,
 )
-from dagster._core.definitions.freshness_policy import FreshnessMinutes
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
+from dagster._core.definitions.freshness_policy import FreshnessMinutes
 from dagster._core.definitions.time_window_partitions import (
     TimeWindowPartitionsDefinition,
     TimeWindowPartitionsSubset,

--- a/python_modules/dagster/dagster/_core/definitions/data_time.py
+++ b/python_modules/dagster/dagster/_core/definitions/data_time.py
@@ -25,6 +25,7 @@ from dagster._core.definitions.data_version import (
     DataVersion,
     get_input_event_pointer_tag,
 )
+from dagster._core.definitions.freshness_policy import FreshnessMinutes
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
 from dagster._core.definitions.time_window_partitions import (
     TimeWindowPartitionsDefinition,
@@ -501,11 +502,11 @@ class CachingDataTimeResolver:
 
         return min(cast(AbstractSet[datetime.datetime], data_times), default=None)
 
-    def get_current_minutes_late(
+    def get_minutes_overdue(
         self,
         asset_key: AssetKey,
         evaluation_time: datetime.datetime,
-    ) -> Optional[float]:
+    ) -> Optional[FreshnessMinutes]:
         freshness_policy = self.asset_graph.freshness_policies_by_key.get(asset_key)
         if freshness_policy is None:
             raise DagsterInvariantViolationError(

--- a/python_modules/dagster/dagster/_core/definitions/freshness_policy.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_policy.py
@@ -20,6 +20,7 @@ class FreshnessConstraint(NamedTuple):
     required_data_time: datetime.datetime
     required_by_time: datetime.datetime
 
+
 class FreshnessMinutes(NamedTuple):
     overdue_minutes: float
     lag_minutes: float
@@ -188,7 +189,7 @@ class FreshnessPolicy(
         if evaluation_tick is None:
             return None
         required_time = evaluation_tick - self.maximum_lag_delta
-        
+
         return FreshnessMinutes(
             lag_minutes=max(0.0, (evaluation_tick - data_time).total_seconds() / 60),
             overdue_minutes=max(0.0, (required_time - data_time).total_seconds() / 60),

--- a/python_modules/dagster/dagster/_core/definitions/freshness_policy.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_policy.py
@@ -20,6 +20,10 @@ class FreshnessConstraint(NamedTuple):
     required_data_time: datetime.datetime
     required_by_time: datetime.datetime
 
+class FreshnessMinutes(NamedTuple):
+    overdue_minutes: float
+    lag_minutes: float
+
 
 @experimental
 @whitelist_for_serdes
@@ -167,7 +171,7 @@ class FreshnessPolicy(
         self,
         data_time: Optional[datetime.datetime],
         evaluation_time: datetime.datetime,
-    ) -> Optional[float]:
+    ) -> Optional[FreshnessMinutes]:
         """Returns a number of minutes past the specified freshness policy that this asset currently
         is. If the asset is missing upstream data, or is not materialized at all, then it is unknown
         how overdue it is, and this will return None.
@@ -184,4 +188,8 @@ class FreshnessPolicy(
         if evaluation_tick is None:
             return None
         required_time = evaluation_tick - self.maximum_lag_delta
-        return max(0.0, (required_time - data_time).total_seconds() / 60)
+        
+        return FreshnessMinutes(
+            lag_minutes=max(0.0, (evaluation_tick - data_time).total_seconds() / 60),
+            overdue_minutes=max(0.0, (required_time - data_time).total_seconds() / 60),
+        )

--- a/python_modules/dagster/dagster/_core/definitions/freshness_policy_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_policy_sensor_definition.py
@@ -262,10 +262,11 @@ class FreshnessPolicySensorDefinition(SensorDefinition):
                     continue
 
                 # get the current minutes_overdue value for this asset
-                minutes_late_by_key[asset_key] = data_time_resolver.get_current_minutes_late(
+                result = data_time_resolver.get_minutes_overdue(
                     evaluation_time=evaluation_time,
                     asset_key=asset_key,
                 )
+                minutes_late_by_key[asset_key] = result.overdue_minutes if result else None
 
                 resource_args_populated = validate_and_get_resource_dict(
                     context.resources, name, resource_arg_names

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_freshness_policy.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_freshness_policy.py
@@ -138,8 +138,8 @@ def test_policies_available_equals_evaluation_time(
         evaluation_time=evaluation_time,
     )
 
-    assert getattr(result, 'overdue_minutes', None) == expected_minutes_overdue
-    assert getattr(result, 'lag_minutes', None) == expected_minutes_lag
+    assert getattr(result, "overdue_minutes", None) == expected_minutes_overdue
+    assert getattr(result, "lag_minutes", None) == expected_minutes_lag
 
 
 def test_invalid_freshness_policies():

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_freshness_policy.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_freshness_policy.py
@@ -10,7 +10,8 @@ from dagster._seven.compat.pendulum import create_pendulum_time
         "policy",
         "used_data_time",
         "evaluation_time",
-        "expected_minutes_late",
+        "expected_minutes_overdue",
+        "expected_minutes_lag",
     ],
     [
         (
@@ -18,23 +19,27 @@ from dagster._seven.compat.pendulum import create_pendulum_time
             create_pendulum_time(2022, 1, 1, 0),
             create_pendulum_time(2022, 1, 1, 0, 25),
             0,
+            25,
         ),
         (
             FreshnessPolicy(maximum_lag_minutes=120),
             create_pendulum_time(2022, 1, 1, 0),
             create_pendulum_time(2022, 1, 1, 1),
             0,
+            60,
         ),
         (
             FreshnessPolicy(maximum_lag_minutes=30),
             create_pendulum_time(2022, 1, 1, 0),
             create_pendulum_time(2022, 1, 1, 1),
             30,
+            60,
         ),
         (
             FreshnessPolicy(maximum_lag_minutes=500),
             None,
             create_pendulum_time(2022, 1, 1, 0, 25),
+            None,
             None,
         ),
         # materialization happened before SLA
@@ -43,12 +48,14 @@ from dagster._seven.compat.pendulum import create_pendulum_time
             create_pendulum_time(2022, 1, 1, 23, 55),
             create_pendulum_time(2022, 1, 2, 0, 10),
             0,
+            5,
         ),
         # materialization happened after SLA, but is fine now
         (
             FreshnessPolicy(cron_schedule="@daily", maximum_lag_minutes=15),
             create_pendulum_time(2022, 1, 1, 0, 30),
             create_pendulum_time(2022, 1, 1, 1, 0),
+            0,
             0,
         ),
         # materialization for this data has not happened yet (day before)
@@ -59,6 +66,7 @@ from dagster._seven.compat.pendulum import create_pendulum_time
             # by midnight, expected data from up to 2022-01-02T23:00, but actual data is from
             # 2022-01-01T22:00, so you are 1 hour late
             60,
+            120,
         ),
         # weird one: at the end of each hour, your data should be no more than 5 hours old
         (
@@ -66,6 +74,7 @@ from dagster._seven.compat.pendulum import create_pendulum_time
             create_pendulum_time(2022, 1, 1, 1, 0),
             create_pendulum_time(2022, 1, 1, 4, 0),
             0,
+            180,
         ),
         (
             FreshnessPolicy(cron_schedule="@hourly", maximum_lag_minutes=60 * 5),
@@ -75,6 +84,7 @@ from dagster._seven.compat.pendulum import create_pendulum_time
             # in time, we expect to have the data from at least 5 hours ago (so 2AM), but we only
             # have data from 1:15, so we're 45 minutes late
             45,
+            45 + 60 * 5,
         ),
         # timezone tests
         (
@@ -87,6 +97,7 @@ from dagster._seven.compat.pendulum import create_pendulum_time
             create_pendulum_time(2022, 1, 1, 3, 15, tz="America/Los_Angeles"),
             # only have data up to 1AM in this timezone, but we need up to 2AM, so we're 1hr late
             60,
+            120,
         ),
         (
             # same as above, but specifying the input to the function in UTC
@@ -99,6 +110,7 @@ from dagster._seven.compat.pendulum import create_pendulum_time
             create_pendulum_time(2022, 1, 1, 3, 15, tz="America/Los_Angeles").in_tz("UTC"),
             # only have data up to 1AM in this timezone, but we need up to 2AM, so we're 1hr late
             60,
+            120,
         ),
         (
             FreshnessPolicy(
@@ -110,6 +122,7 @@ from dagster._seven.compat.pendulum import create_pendulum_time
             create_pendulum_time(2022, 1, 1, 2, 15, tz="America/Los_Angeles"),
             # it's not yet 3AM in this timezone, so we're not late
             0,
+            0,
         ),
     ],
 )
@@ -117,14 +130,16 @@ def test_policies_available_equals_evaluation_time(
     policy,
     used_data_time,
     evaluation_time,
-    expected_minutes_late,
+    expected_minutes_overdue,
+    expected_minutes_lag,
 ):
-    minutes_late = policy.minutes_overdue(
+    result = policy.minutes_overdue(
         data_time=used_data_time,
         evaluation_time=evaluation_time,
     )
 
-    assert minutes_late == expected_minutes_late
+    assert getattr(result, 'overdue_minutes', None) == expected_minutes_overdue
+    assert getattr(result, 'lag_minutes', None) == expected_minutes_lag
 
 
 def test_invalid_freshness_policies():


### PR DESCRIPTION
## Summary & Motivation

This PR addresses a few pieces of feedback from @sryza:

- Hovering over the "Fresh" icon opens the panel showing the calculation of the data age - it's no longer restricted to assets that are overdue.

- The panel (and all popover panels) have a slightly stronger shadow. (Discussed this with Josh a bit and we don't want to go too dark, but this does look better)

This PR also fixes a bug I hadn't noticed earlier. The final text essentially says "This asset's data is X minutes old, and the policy allows it to be Y minutes old", but it was using the "currentMinutesLate" which is not "minutes old" but "minutes overdue". I exposed the "minutes old" value in GraphQL and updated the copy.

- Todo: I think it'd be nice to rename `currentMinutesLate` to `currentOverdueMinutes` for consistency with `currentLagMinutes` and `maximumLagMinutes`, but that would make this a bit messy.

## How I Tested These Changes

Updated python tests + JS storybooks