### PR TITLE
enable freeing concurrency slots from run view

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -1245,6 +1245,7 @@ type Run implements PipelineRun {
   hasReExecutePermission: Boolean!
   hasTerminatePermission: Boolean!
   hasDeletePermission: Boolean!
+  hasConcurrencyKeySlots: Boolean!
 }
 
 type SelectorTypeConfigError implements PipelineConfigValidationError {

--- a/js_modules/dagit/packages/core/src/graphql/types.ts
+++ b/js_modules/dagit/packages/core/src/graphql/types.ts
@@ -3159,6 +3159,7 @@ export type Run = PipelineRun & {
   endTime: Maybe<Scalars['Float']>;
   eventConnection: EventConnection;
   executionPlan: Maybe<ExecutionPlan>;
+  hasConcurrencyKeySlots: Scalars['Boolean'];
   hasDeletePermission: Scalars['Boolean'];
   hasReExecutePermission: Scalars['Boolean'];
   hasTerminatePermission: Scalars['Boolean'];
@@ -10104,6 +10105,10 @@ export const buildRun = (
         : relationshipsToOmit.has('ExecutionPlan')
         ? ({} as ExecutionPlan)
         : buildExecutionPlan({}, relationshipsToOmit),
+    hasConcurrencyKeySlots:
+      overrides && overrides.hasOwnProperty('hasConcurrencyKeySlots')
+        ? overrides.hasConcurrencyKeySlots!
+        : true,
     hasDeletePermission:
       overrides && overrides.hasOwnProperty('hasDeletePermission')
         ? overrides.hasDeletePermission!

--- a/js_modules/dagit/packages/core/src/instance/InstanceConcurrency.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceConcurrency.tsx
@@ -570,7 +570,7 @@ const SET_CONCURRENCY_LIMIT_MUTATION = gql`
   }
 `;
 
-const FREE_CONCURRENCY_SLOTS_FOR_RUN_MUTATION = gql`
+export const FREE_CONCURRENCY_SLOTS_FOR_RUN_MUTATION = gql`
   mutation FreeConcurrencySlotsForRun($runId: String!) {
     freeConcurrencySlotsForRun(runId: $runId)
   }

--- a/js_modules/dagit/packages/core/src/instance/types/JobMenu.types.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/JobMenu.types.ts
@@ -30,6 +30,7 @@ export type RunReExecutionQuery = {
         updateTime: number | null;
         startTime: number | null;
         endTime: number | null;
+        hasConcurrencyKeySlots: boolean;
         repositoryOrigin: {
           __typename: 'RepositoryOrigin';
           id: string;

--- a/js_modules/dagit/packages/core/src/runs/RunDetails.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunDetails.tsx
@@ -35,13 +35,13 @@ import {AnchorButton} from '../ui/AnchorButton';
 import {workspacePathFromRunDetails, workspacePipelinePath} from '../workspace/workspacePath';
 
 import {DeletionDialog} from './DeletionDialog';
+import {doneStatuses} from './RunStatuses';
 import {RunTags} from './RunTags';
 import {RunsQueryRefetchContext} from './RunUtils';
 import {TerminationDialog} from './TerminationDialog';
 import {TimeElapsed} from './TimeElapsed';
 import {RunDetailsFragment} from './types/RunDetails.types';
 import {RunFragment} from './types/RunFragments.types';
-import {doneStatuses} from './RunStatuses';
 
 export const timingStringForStatus = (status?: RunStatus) => {
   switch (status) {

--- a/js_modules/dagit/packages/core/src/runs/RunDetails.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunDetails.tsx
@@ -164,7 +164,7 @@ export const RunConfigDialog: React.FC<{run: RunFragment; isJob: boolean}> = ({r
     if (resp.data?.freeConcurrencySlotsForRun) {
       await showSharedToaster({
         intent: 'success',
-        icon: 'copy_to_clipboard_done',
+        icon: 'check_circle',
         message: 'Freed concurrency slots',
       });
     }

--- a/js_modules/dagit/packages/core/src/runs/RunDetails.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunDetails.tsx
@@ -1,4 +1,4 @@
-import {gql} from '@apollo/client';
+import {gql, useMutation} from '@apollo/client';
 import {
   Button,
   Colors,
@@ -21,8 +21,14 @@ import styled from 'styled-components/macro';
 
 import {AppContext} from '../app/AppContext';
 import {showSharedToaster} from '../app/DomUtils';
+import {useFeatureFlags} from '../app/Flags';
 import {useCopyToClipboard} from '../app/browser';
 import {RunStatus} from '../graphql/types';
+import {FREE_CONCURRENCY_SLOTS_FOR_RUN_MUTATION} from '../instance/InstanceConcurrency';
+import {
+  FreeConcurrencySlotsForRunMutation,
+  FreeConcurrencySlotsForRunMutationVariables,
+} from '../instance/types/InstanceConcurrency.types';
 import {NO_LAUNCH_PERMISSION_MESSAGE} from '../launchpad/LaunchRootExecutionButton';
 import {TimestampDisplay} from '../schedules/TimestampDisplay';
 import {AnchorButton} from '../ui/AnchorButton';
@@ -35,6 +41,7 @@ import {TerminationDialog} from './TerminationDialog';
 import {TimeElapsed} from './TimeElapsed';
 import {RunDetailsFragment} from './types/RunDetails.types';
 import {RunFragment} from './types/RunFragments.types';
+import {doneStatuses} from './RunStatuses';
 
 export const timingStringForStatus = (status?: RunStatus) => {
   switch (status) {
@@ -125,10 +132,11 @@ export const RunDetails: React.FC<{
   );
 };
 
-type VisibleDialog = 'config' | 'delete' | 'terminate' | null;
+type VisibleDialog = 'config' | 'delete' | 'terminate' | 'free_slots' | null;
 
 export const RunConfigDialog: React.FC<{run: RunFragment; isJob: boolean}> = ({run, isJob}) => {
   const {runConfigYaml} = run;
+  const {flagInstanceConcurrencyLimits} = useFeatureFlags();
   const [visibleDialog, setVisibleDialog] = React.useState<VisibleDialog>(null);
 
   const {rootServerURI} = React.useContext(AppContext);
@@ -137,6 +145,11 @@ export const RunConfigDialog: React.FC<{run: RunFragment; isJob: boolean}> = ({r
   const copy = useCopyToClipboard();
   const history = useHistory();
 
+  const [freeSlots] = useMutation<
+    FreeConcurrencySlotsForRunMutation,
+    FreeConcurrencySlotsForRunMutationVariables
+  >(FREE_CONCURRENCY_SLOTS_FOR_RUN_MUTATION);
+
   const copyConfig = async () => {
     copy(runConfigYaml);
     await showSharedToaster({
@@ -144,6 +157,17 @@ export const RunConfigDialog: React.FC<{run: RunFragment; isJob: boolean}> = ({r
       icon: 'copy_to_clipboard_done',
       message: 'Copied!',
     });
+  };
+
+  const freeConcurrencySlots = async () => {
+    const resp = await freeSlots({variables: {runId: run.id}});
+    if (resp.data?.freeConcurrencySlotsForRun) {
+      await showSharedToaster({
+        intent: 'success',
+        icon: 'copy_to_clipboard_done',
+        message: 'Freed concurrency slots',
+      });
+    }
   };
 
   const jobPath = workspacePathFromRunDetails({
@@ -182,6 +206,15 @@ export const RunConfigDialog: React.FC<{run: RunFragment; isJob: boolean}> = ({r
                   onClick={() => window.open(`${rootServerURI}/download_debug/${run.id}`)}
                 />
               </Tooltip>
+              {flagInstanceConcurrencyLimits &&
+              run.hasConcurrencyKeySlots &&
+              doneStatuses.has(run.status) ? (
+                <MenuItem
+                  text="Free concurrency slots"
+                  icon={<Icon name="lock" />}
+                  onClick={freeConcurrencySlots}
+                />
+              ) : null}
               {run.hasDeletePermission ? (
                 <MenuItem
                   icon="delete"
@@ -296,5 +329,6 @@ export const RUN_DETAILS_FRAGMENT = gql`
     startTime
     endTime
     status
+    hasConcurrencyKeySlots
   }
 `;

--- a/js_modules/dagit/packages/core/src/runs/__tests__/types/RunActionButtonsTestQuery.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/__tests__/types/RunActionButtonsTestQuery.types.ts
@@ -28,6 +28,7 @@ export type RunActionButtonsTestQuery = {
         updateTime: number | null;
         startTime: number | null;
         endTime: number | null;
+        hasConcurrencyKeySlots: boolean;
         repositoryOrigin: {
           __typename: 'RepositoryOrigin';
           id: string;

--- a/js_modules/dagit/packages/core/src/runs/types/RunDetails.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunDetails.types.ts
@@ -8,4 +8,5 @@ export type RunDetailsFragment = {
   startTime: number | null;
   endTime: number | null;
   status: Types.RunStatus;
+  hasConcurrencyKeySlots: boolean;
 };

--- a/js_modules/dagit/packages/core/src/runs/types/RunFragments.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunFragments.types.ts
@@ -21,6 +21,7 @@ export type RunFragment = {
   updateTime: number | null;
   startTime: number | null;
   endTime: number | null;
+  hasConcurrencyKeySlots: boolean;
   repositoryOrigin: {
     __typename: 'RepositoryOrigin';
     id: string;
@@ -2259,6 +2260,7 @@ export type RunPageFragment = {
   updateTime: number | null;
   startTime: number | null;
   endTime: number | null;
+  hasConcurrencyKeySlots: boolean;
   repositoryOrigin: {
     __typename: 'RepositoryOrigin';
     id: string;

--- a/js_modules/dagit/packages/core/src/runs/types/RunRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunRoot.types.ts
@@ -30,6 +30,7 @@ export type RunRootQuery = {
         updateTime: number | null;
         startTime: number | null;
         endTime: number | null;
+        hasConcurrencyKeySlots: boolean;
         repositoryOrigin: {
           __typename: 'RepositoryOrigin';
           id: string;

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs.py
@@ -1,4 +1,5 @@
 import copy
+import tempfile
 
 import yaml
 from dagster import AssetMaterialization, Output, job, op, repository
@@ -1032,26 +1033,39 @@ def test_asset_batching():
 
 
 def test_run_has_concurrency_slots():
-    with instance_for_test() as instance:
-        repo = get_asset_repo()
-        instance.event_log_storage.set_concurrency_slots("foo", 1)
-        run_id = instance.create_run_for_job(
-            repo.get_job("foo_job"), status=DagsterRunStatus.FAILURE
-        ).run_id
+    with tempfile.TemporaryDirectory() as temp_dir:
+        with instance_for_test(
+            overrides={
+                "event_log_storage": {
+                    "module": "dagster.utils.test",
+                    "class": "ConcurrencyEnabledSqliteTestEventLogStorage",
+                    "config": {"base_dir": temp_dir},
+                },
+            }
+        ) as instance:
+            repo = get_asset_repo()
+            instance.event_log_storage.set_concurrency_slots("foo", 1)
+            run_id = instance.create_run_for_job(
+                repo.get_job("foo_job"), status=DagsterRunStatus.FAILURE
+            ).run_id
 
-        with define_out_of_process_context(__file__, "asset_repo", instance) as context:
-            result = execute_dagster_graphql(context, RUN_CONCURRENCY_QUERY)
-            assert result.data
-            assert len(result.data["pipelineRunsOrError"]["results"]) == 1
-            assert result.data["pipelineRunsOrError"]["results"][0]["runId"] == run_id
-            assert not result.data["pipelineRunsOrError"]["results"][0]["hasConcurrencyKeySlots"]
+            with define_out_of_process_context(__file__, "asset_repo", instance) as context:
+                result = execute_dagster_graphql(context, RUN_CONCURRENCY_QUERY)
+                assert result.data
+                assert len(result.data["pipelineRunsOrError"]["results"]) == 1
+                assert result.data["pipelineRunsOrError"]["results"][0]["runId"] == run_id
+                assert not result.data["pipelineRunsOrError"]["results"][0][
+                    "hasConcurrencyKeySlots"
+                ]
 
-        claim = instance.event_log_storage.claim_concurrency_slot("foo", run_id, "fake_step_key")
-        assert claim.is_claimed
+            claim = instance.event_log_storage.claim_concurrency_slot(
+                "foo", run_id, "fake_step_key"
+            )
+            assert claim.is_claimed
 
-        with define_out_of_process_context(__file__, "asset_repo", instance) as context:
-            result = execute_dagster_graphql(context, RUN_CONCURRENCY_QUERY)
-            assert result.data
-            assert len(result.data["pipelineRunsOrError"]["results"]) == 1
-            assert result.data["pipelineRunsOrError"]["results"][0]["runId"] == run_id
-            assert result.data["pipelineRunsOrError"]["results"][0]["hasConcurrencyKeySlots"]
+            with define_out_of_process_context(__file__, "asset_repo", instance) as context:
+                result = execute_dagster_graphql(context, RUN_CONCURRENCY_QUERY)
+                assert result.data
+                assert len(result.data["pipelineRunsOrError"]["results"]) == 1
+                assert result.data["pipelineRunsOrError"]["results"][0]["runId"] == run_id
+                assert result.data["pipelineRunsOrError"]["results"][0]["hasConcurrencyKeySlots"]


### PR DESCRIPTION
## Summary & Motivation
Currently, the only place from dagit where you can free concurrency slots for a run is through `Deployment` > `Concurrency limits` > `Active runs` > run action menu.

This adds the ability to free concurrency slots from the Run page actions menu.

## How I Tested These Changes
BK, saw option available for concurrency-blocking run.
