### PR TITLE
Feat/add repository metadata

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/repository_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/repository_decorator.py
@@ -285,6 +285,7 @@ def repository(
         name (Optional[str]): The name of the repository. Defaults to the name of the decorated
             function.
         description (Optional[str]): A string description of the repository.
+        metadata (Optional[Dict[str, Any]]): Arbitrary metadata for the repository.
         top_level_resources (Optional[Mapping[str, ResourceDefinition]]): A dict of top-level
             resource keys to defintions, for resources which should be displayed in the UI.
 
@@ -327,6 +328,22 @@ def repository(
             def simple_repository():
                 return [simple_job, some_sensor, my_schedule]
 
+            ######################################################################
+            # A simple repository using the first form of the decorated function
+            # and custom metadata that will be displayed in the UI
+            ######################################################################
+
+            ...
+
+            @repository(
+                name='my_repo',
+                metadata={
+                    'team': 'Team A',
+                    'repository_version': '1.2.3',
+                    'environment': 'production',
+             })
+            def simple_repository():
+                return [simple_job, some_sensor, my_schedule]
 
             ######################################################################
             # A lazy-loaded repository

--- a/python_modules/dagster/dagster/_core/definitions/decorators/repository_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/repository_decorator.py
@@ -201,7 +201,7 @@ class _Repository:
             repository_def = RepositoryDefinition(
                 name=self.name,
                 description=self.description,
-                repository_metadata=self.metadata,
+                metadata=self.metadata,
                 repository_data=repository_data,
             )
 

--- a/python_modules/dagster/dagster/_core/definitions/decorators/repository_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/repository_decorator.py
@@ -17,6 +17,7 @@ from typing_extensions import TypeAlias
 
 import dagster._check as check
 from dagster._core.decorator_utils import get_function_params
+from dagster._core.definitions.metadata import MetadataMapping
 from dagster._core.definitions.resource_definition import ResourceDefinition
 from dagster._core.errors import DagsterInvalidDefinitionError
 
@@ -57,6 +58,7 @@ class _Repository:
         self,
         name: Optional[str] = None,
         description: Optional[str] = None,
+        metadata: Optional[MetadataMapping] = None,
         default_executor_def: Optional[ExecutorDefinition] = None,
         default_logger_defs: Optional[Mapping[str, LoggerDefinition]] = None,
         top_level_resources: Optional[Mapping[str, ResourceDefinition]] = None,
@@ -64,6 +66,7 @@ class _Repository:
     ):
         self.name = check.opt_str_param(name, "name")
         self.description = check.opt_str_param(description, "description")
+        self.metadata = check.opt_nullable_mapping_param(metadata, "metadata", key_type=str)
         self.default_executor_def = check.opt_inst_param(
             default_executor_def, "default_executor_def", ExecutorDefinition
         )
@@ -189,6 +192,7 @@ class _Repository:
                 self.name,
                 repository_definitions=list(_flatten(repository_definitions)),
                 description=self.description,
+                metadata=self.metadata,
                 default_executor_def=self.default_executor_def,
                 default_logger_defs=self.default_logger_defs,
                 _top_level_resources=self.top_level_resources,
@@ -197,6 +201,7 @@ class _Repository:
             repository_def = RepositoryDefinition(
                 name=self.name,
                 description=self.description,
+                repository_metadata=self.metadata,
                 repository_data=repository_data,
             )
 
@@ -225,6 +230,7 @@ def repository(
     *,
     name: Optional[str] = ...,
     description: Optional[str] = ...,
+    metadata: Optional[MetadataMapping] = ...,
     default_executor_def: Optional[ExecutorDefinition] = ...,
     default_logger_defs: Optional[Mapping[str, LoggerDefinition]] = ...,
     _top_level_resources: Optional[Mapping[str, ResourceDefinition]] = ...,
@@ -243,6 +249,7 @@ def repository(
     *,
     name: Optional[str] = None,
     description: Optional[str] = None,
+    metadata: Optional[MetadataMapping] = None,
     default_executor_def: Optional[ExecutorDefinition] = None,
     default_logger_defs: Optional[Mapping[str, LoggerDefinition]] = None,
     _top_level_resources: Optional[Mapping[str, ResourceDefinition]] = None,
@@ -381,6 +388,7 @@ def repository(
     return _Repository(
         name=name,
         description=description,
+        metadata=metadata,
         default_executor_def=default_executor_def,
         default_logger_defs=default_logger_defs,
         top_level_resources=_top_level_resources,

--- a/python_modules/dagster/dagster/_core/definitions/decorators/repository_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/repository_decorator.py
@@ -17,7 +17,10 @@ from typing_extensions import TypeAlias
 
 import dagster._check as check
 from dagster._core.decorator_utils import get_function_params
-from dagster._core.definitions.metadata import MetadataMapping
+from dagster._core.definitions.metadata import (
+    RawMetadataValue,
+    normalize_metadata,
+)
 from dagster._core.definitions.resource_definition import ResourceDefinition
 from dagster._core.errors import DagsterInvalidDefinitionError
 
@@ -58,7 +61,7 @@ class _Repository:
         self,
         name: Optional[str] = None,
         description: Optional[str] = None,
-        metadata: Optional[MetadataMapping] = None,
+        metadata: Optional[Dict[str, RawMetadataValue]] = None,
         default_executor_def: Optional[ExecutorDefinition] = None,
         default_logger_defs: Optional[Mapping[str, LoggerDefinition]] = None,
         top_level_resources: Optional[Mapping[str, ResourceDefinition]] = None,
@@ -66,7 +69,9 @@ class _Repository:
     ):
         self.name = check.opt_str_param(name, "name")
         self.description = check.opt_str_param(description, "description")
-        self.metadata = check.opt_nullable_mapping_param(metadata, "metadata", key_type=str)
+        self.metadata = normalize_metadata(
+            check.opt_mapping_param(metadata, "metadata", key_type=str)
+        )
         self.default_executor_def = check.opt_inst_param(
             default_executor_def, "default_executor_def", ExecutorDefinition
         )
@@ -230,7 +235,7 @@ def repository(
     *,
     name: Optional[str] = ...,
     description: Optional[str] = ...,
-    metadata: Optional[MetadataMapping] = ...,
+    metadata: Optional[Dict[str, RawMetadataValue]] = ...,
     default_executor_def: Optional[ExecutorDefinition] = ...,
     default_logger_defs: Optional[Mapping[str, LoggerDefinition]] = ...,
     _top_level_resources: Optional[Mapping[str, ResourceDefinition]] = ...,
@@ -249,7 +254,7 @@ def repository(
     *,
     name: Optional[str] = None,
     description: Optional[str] = None,
-    metadata: Optional[MetadataMapping] = None,
+    metadata: Optional[Dict[str, RawMetadataValue]] = None,
     default_executor_def: Optional[ExecutorDefinition] = None,
     default_logger_defs: Optional[Mapping[str, LoggerDefinition]] = None,
     _top_level_resources: Optional[Mapping[str, ResourceDefinition]] = None,
@@ -285,7 +290,7 @@ def repository(
         name (Optional[str]): The name of the repository. Defaults to the name of the decorated
             function.
         description (Optional[str]): A string description of the repository.
-        metadata (Optional[Dict[str, Any]]): Arbitrary metadata for the repository.
+        metadata (Optional[Dict[str, RawMetadataValue]]): Arbitrary metadata for the repository.
         top_level_resources (Optional[Mapping[str, ResourceDefinition]]): A dict of top-level
             resource keys to defintions, for resources which should be displayed in the UI.
 

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
@@ -23,6 +23,7 @@ from dagster._core.definitions.events import AssetKey, CoercibleToAssetKey
 from dagster._core.definitions.executor_definition import ExecutorDefinition
 from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.logger_definition import LoggerDefinition
+from dagster._core.definitions.metadata import MetadataMapping
 from dagster._core.definitions.resource_definition import ResourceDefinition
 from dagster._core.definitions.schedule_definition import ScheduleDefinition
 from dagster._core.definitions.sensor_definition import SensorDefinition
@@ -90,6 +91,8 @@ class RepositoryDefinition:
         name (str): The name of the repository.
         repository_data (RepositoryData): Contains the definitions making up the repository.
         description (Optional[str]): A string description of the repository.
+        metadata (Optional[MetadataMapping]): A map of arbitrary metadata for the
+            repository.
     """
 
     def __init__(
@@ -98,6 +101,7 @@ class RepositoryDefinition:
         *,
         repository_data,
         description=None,
+        metadata=None,
         repository_load_data=None,
     ):
         self._name = check_valid_name(name)
@@ -105,6 +109,8 @@ class RepositoryDefinition:
         self._repository_data: RepositoryData = check.inst_param(
             repository_data, "repository_data", RepositoryData
         )
+        self._metadata = check.opt_nullable_mapping_param(metadata, "metadata", key_type=str)
+
         self._repository_load_data = check.opt_inst_param(
             repository_load_data, "repository_load_data", RepositoryLoadData
         )
@@ -124,6 +130,12 @@ class RepositoryDefinition:
     def description(self) -> Optional[str]:
         """Optional[str]: A human-readable description of the repository."""
         return self._description
+
+    @public
+    @property
+    def metadata(self) -> Optional[MetadataMapping]:
+        """Optional[MetadataMapping]: Arbitrary metadata for the repository."""
+        return self._metadata
 
     def load_all_definitions(self):
         # force load of all lazy constructed code artifacts
@@ -387,6 +399,7 @@ class PendingRepositoryDefinition:
             Union[RepositoryListDefinition, "CacheableAssetsDefinition"]
         ],
         description: Optional[str] = None,
+        metadata: Optional[MetadataMapping] = None,
         default_logger_defs: Optional[Mapping[str, LoggerDefinition]] = None,
         default_executor_def: Optional[ExecutorDefinition] = None,
         _top_level_resources: Optional[Mapping[str, ResourceDefinition]] = None,
@@ -401,6 +414,7 @@ class PendingRepositoryDefinition:
         )
         self._name = name
         self._description = description
+        self._metadata = metadata
         self._default_logger_defs = default_logger_defs
         self._default_executor_def = default_executor_def
         self._top_level_resources = _top_level_resources
@@ -458,6 +472,7 @@ class PendingRepositoryDefinition:
             self._name,
             repository_data=repository_data,
             description=self._description,
+            metadata=self._metadata,
             repository_load_data=repository_load_data,
         )
 

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
@@ -36,9 +36,6 @@ from dagster._utils import hash_collection
 
 from .repository_data import CachingRepositoryData, RepositoryData
 from .valid_definitions import (
-    SINGLETON_REPOSITORY_NAME as SINGLETON_REPOSITORY_NAME,
-    VALID_REPOSITORY_DATA_DICT_KEYS as VALID_REPOSITORY_DATA_DICT_KEYS,
-    PendingRepositoryListDefinition as PendingRepositoryListDefinition,
     RepositoryListDefinition as RepositoryListDefinition,
 )
 
@@ -108,7 +105,7 @@ class RepositoryDefinition:
         self._repository_data: RepositoryData = check.inst_param(
             repository_data, "repository_data", RepositoryData
         )
-        self._metadata = check.opt_nullable_mapping_param(metadata, "metadata", key_type=str)
+        self._metadata = check.opt_mapping_param(metadata, "metadata", key_type=str)
         self._repository_load_data = check.opt_inst_param(
             repository_load_data, "repository_load_data", RepositoryLoadData
         )

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
@@ -91,8 +91,7 @@ class RepositoryDefinition:
         name (str): The name of the repository.
         repository_data (RepositoryData): Contains the definitions making up the repository.
         description (Optional[str]): A string description of the repository.
-        metadata (Optional[MetadataMapping]): A map of arbitrary metadata for the
-            repository.
+        metadata (Optional[MetadataMapping]): A map of arbitrary metadata for the repository.
     """
 
     def __init__(
@@ -110,7 +109,6 @@ class RepositoryDefinition:
             repository_data, "repository_data", RepositoryData
         )
         self._metadata = check.opt_nullable_mapping_param(metadata, "metadata", key_type=str)
-
         self._repository_load_data = check.opt_inst_param(
             repository_load_data, "repository_load_data", RepositoryLoadData
         )

--- a/python_modules/dagster/dagster/_core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external_data.py
@@ -157,7 +157,7 @@ class ExternalRepositoryData(
             external_resource_data=check.opt_nullable_sequence_param(
                 external_resource_data, "external_resource_data", of_type=ExternalResourceData
             ),
-            metadata=check.opt_nullable_mapping_param(metadata, "metadata", key_type=str),
+            metadata=check.opt_mapping_param(metadata, "metadata", key_type=str),
             utilized_env_vars=check.opt_nullable_mapping_param(
                 utilized_env_vars,
                 "utilized_env_vars",

--- a/python_modules/dagster/dagster/_core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external_data.py
@@ -61,6 +61,7 @@ from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
 from dagster._core.definitions.metadata import (
     MetadataFieldSerializer,
+    MetadataMapping,
     MetadataUserInput,
     MetadataValue,
     normalize_metadata,
@@ -108,6 +109,7 @@ class ExternalRepositoryData(
             ("external_job_datas", Optional[Sequence["ExternalJobData"]]),
             ("external_job_refs", Optional[Sequence["ExternalJobRef"]]),
             ("external_resource_data", Optional[Sequence["ExternalResourceData"]]),
+            ("metadata", Optional[MetadataMapping]),
             ("utilized_env_vars", Optional[Mapping[str, Sequence["EnvVarConsumer"]]]),
         ],
     )
@@ -122,6 +124,7 @@ class ExternalRepositoryData(
         external_job_datas: Optional[Sequence["ExternalJobData"]] = None,
         external_job_refs: Optional[Sequence["ExternalJobRef"]] = None,
         external_resource_data: Optional[Sequence["ExternalResourceData"]] = None,
+        metadata: Optional[MetadataMapping] = None,
         utilized_env_vars: Optional[Mapping[str, Sequence["EnvVarConsumer"]]] = None,
     ):
         return super(ExternalRepositoryData, cls).__new__(
@@ -154,6 +157,7 @@ class ExternalRepositoryData(
             external_resource_data=check.opt_nullable_sequence_param(
                 external_resource_data, "external_resource_data", of_type=ExternalResourceData
             ),
+            metadata=check.opt_nullable_mapping_param(metadata, "metadata", key_type=str),
             utilized_env_vars=check.opt_nullable_mapping_param(
                 utilized_env_vars,
                 "utilized_env_vars",
@@ -1324,6 +1328,7 @@ def external_repository_data_from_def(
             ],
             key=lambda rd: rd.name,
         ),
+        metadata=repository_def.metadata,
         utilized_env_vars={
             env_var: [
                 EnvVarConsumer(type=EnvVarConsumerType.RESOURCE, name=res_name)

--- a/python_modules/dagster/dagster_tests/api_tests/api_tests_repo.py
+++ b/python_modules/dagster/dagster_tests/api_tests/api_tests_repo.py
@@ -172,7 +172,7 @@ def sensor_raises_dagster_error(_):
     raise DagsterError("Dagster error")
 
 
-@repository
+@repository(metadata={"string": "foo", "integer": 123})
 def bar_repo():
     return {
         "jobs": {

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_repository.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_repository.py
@@ -35,6 +35,7 @@ def test_streaming_external_repositories_api_grpc(instance):
 
         assert isinstance(external_repository_data, ExternalRepositoryData)
         assert external_repository_data.name == "bar_repo"
+        assert external_repository_data.metadata == {"string": "foo", "integer": 123}
 
 
 def test_streaming_external_repositories_error(instance):

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_repository.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_repository.py
@@ -2,7 +2,7 @@ import sys
 from contextlib import contextmanager
 
 import pytest
-from dagster import job, op, repository
+from dagster import IntMetadataValue, TextMetadataValue, job, op, repository
 from dagster._api.snapshot_repository import (
     sync_get_streaming_external_repositories_data_grpc,
 )
@@ -35,7 +35,10 @@ def test_streaming_external_repositories_api_grpc(instance):
 
         assert isinstance(external_repository_data, ExternalRepositoryData)
         assert external_repository_data.name == "bar_repo"
-        assert external_repository_data.metadata == {"string": "foo", "integer": 123}
+        assert external_repository_data.metadata == {
+            "string": TextMetadataValue("foo"),
+            "integer": IntMetadataValue(123),
+        }
 
 
 def test_streaming_external_repositories_error(instance):

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/__snapshots__/test_active_data.ambr
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/__snapshots__/test_active_data.ambr
@@ -2286,6 +2286,7 @@
       }
     ],
     "external_sensor_datas": [],
+    "metadata": null,
     "name": "repo",
     "utilized_env_vars": {}
   }

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/__snapshots__/test_active_data.ambr
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/__snapshots__/test_active_data.ambr
@@ -2286,7 +2286,7 @@
       }
     ],
     "external_sensor_datas": [],
-    "metadata": null,
+    "metadata": {},
     "name": "repo",
     "utilized_env_vars": {}
   }

--- a/python_modules/dagster/dagster_tests/general_tests/test_repository.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_repository.py
@@ -6,8 +6,10 @@ from dagster import (
     AssetKey,
     GraphDefinition,
     Int,
+    IntMetadataValue,
     IOManager,
     JobDefinition,
+    TextMetadataValue,
     asset,
     graph,
     io_manager,
@@ -93,7 +95,10 @@ def metadata_repository():
 
 
 def test_repository_metadata():
-    assert metadata_repository.metadata == {"string": "foo", "integer": 123}
+    assert metadata_repository.metadata == {
+        "string": TextMetadataValue("foo"),
+        "integer": IntMetadataValue(123),
+    }
 
 
 @repository

--- a/python_modules/dagster/dagster_tests/general_tests/test_repository.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_repository.py
@@ -87,6 +87,18 @@ def test_repository_construction():
     assert dagster_test_repository
 
 
+@repository(metadata={"string": "foo", "integer": 123})
+def metadata_repository():
+    return []
+
+
+def test_repository_metadata():
+    assert metadata_repository.repository_metadata == {
+        "string": "foo",
+        "integer": 123,
+    }
+
+
 @repository
 def empty_repository():
     return []

--- a/python_modules/dagster/dagster_tests/general_tests/test_repository.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_repository.py
@@ -93,10 +93,7 @@ def metadata_repository():
 
 
 def test_repository_metadata():
-    assert metadata_repository.metadata == {
-        "string": "foo",
-        "integer": 123,
-    }
+    assert metadata_repository.metadata == {"string": "foo", "integer": 123}
 
 
 @repository

--- a/python_modules/dagster/dagster_tests/general_tests/test_repository.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_repository.py
@@ -93,7 +93,7 @@ def metadata_repository():
 
 
 def test_repository_metadata():
-    assert metadata_repository.repository_metadata == {
+    assert metadata_repository.metadata == {
         "string": "foo",
         "integer": 123,
     }


### PR DESCRIPTION
## Summary & Motivation

Implements a metadata dict for a code location, see https://github.com/dagster-io/dagster/issues/15090

What is missing is the UI implementation in `js_modules`.