### PR TITLE
Add link to Azure AD docs for SCIM integration with Dagster

### DIFF
--- a/docs/content/dagster-cloud/account/authentication/utilizing-scim-provisioning.mdx
+++ b/docs/content/dagster-cloud/account/authentication/utilizing-scim-provisioning.mdx
@@ -72,6 +72,10 @@ Dagster Cloud currently supports SCIM provisioning for the following Identity Pr
     href="/dagster-cloud/account/authentication/okta/scim-provisioning"
     title="Okta"
   ></ArticleListItem>
+  <ArticleListItem
+    href="https://learn.microsoft.com/en-us/azure/active-directory/saas-apps/dagster-cloud-provisioning-tutorial"
+    title="Azure AD"
+  ></ArticleListItem>
 </ArticleList>
 
 Use the setup guide for your IdP to get started.

--- a/docs/content/dagster-cloud/account/authentication/utilizing-scim-provisioning.mdx
+++ b/docs/content/dagster-cloud/account/authentication/utilizing-scim-provisioning.mdx
@@ -74,7 +74,7 @@ Dagster Cloud currently supports SCIM provisioning for the following Identity Pr
   ></ArticleListItem>
   <ArticleListItem
     href="https://learn.microsoft.com/en-us/azure/active-directory/saas-apps/dagster-cloud-provisioning-tutorial"
-    title="Azure AD"
+    title="Microsoft Azure AD"
   ></ArticleListItem>
 </ArticleList>
 


### PR DESCRIPTION
## Summary & Motivation

Azure AD enabled their SCIM integration with Dagster. Adding a link to the docs on their site.
