### PR TITLE
Implement dagster-k8s restart policy

### DIFF
--- a/integration_tests/test_suites/k8s-test-suite/tests/test_k8s_job_op.py
+++ b/integration_tests/test_suites/k8s-test-suite/tests/test_k8s_job_op.py
@@ -151,7 +151,7 @@ def test_k8s_job_op_with_timeout_fail(namespace, cluster_provider):
     def timeout_job():
         timeout_op()
 
-    with pytest.raises(DagsterK8sError, match=r"Timed out while waiting for job \w+ to complete"):
+    with pytest.raises(DagsterK8sError, match=r"Timed out while waiting for pod to become ready"):
         timeout_job.execute_in_process()
 
 

--- a/integration_tests/test_suites/k8s-test-suite/tests/test_k8s_job_op.py
+++ b/integration_tests/test_suites/k8s-test-suite/tests/test_k8s_job_op.py
@@ -151,7 +151,7 @@ def test_k8s_job_op_with_timeout_fail(namespace, cluster_provider):
     def timeout_job():
         timeout_op()
 
-    with pytest.raises(DagsterK8sError, match="Timed out while waiting for pod to become ready"):
+    with pytest.raises(DagsterK8sError, match=r"Timed out while waiting for job \w+ to complete"):
         timeout_job.execute_in_process()
 
 
@@ -377,3 +377,56 @@ def test_k8s_job_op_with_paralellism(namespace, cluster_provider):
 
     assert "HI" in pods_logs[0]
     assert "HI" in pods_logs[1]
+
+
+@pytest.mark.default
+def test_k8s_job_op_with_restart_policy(namespace, cluster_provider):
+    """This tests works by creating a file in a volume mount, and then incrementing the number
+    in the file on each retry. If the number is 2, then the pod will succeed. Otherwise, it will
+    fail. This is to test that the pod restart policy is working as expected.
+    """
+    with_restart_policy = k8s_job_op.configured(
+        {
+            "image": "busybox",
+            "command": ["/bin/sh", "-c"],
+            "args": [
+                "filename=/data/retries; (count=$(cat $filename) && echo $(($count+1)) >"
+                " $filename) || (touch $filename && echo 0 > $filename); retries=$(cat $filename);"
+                ' if [ "$retries" = "2" ]; then echo HI && exit 0; else exit 1; fi;'
+            ],
+            "volume_mounts": [
+                {
+                    "name": "retry-policy-persistent-storage",
+                    "mount_path": "/data",
+                }
+            ],
+            "namespace": namespace,
+            "load_incluster_config": False,
+            "kubeconfig_file": cluster_provider.kubeconfig_file,
+            "job_spec_config": {
+                "backoffLimit": 4,
+                "parallelism": 2,
+                "completions": 2,
+            },
+            "pod_spec_config": {
+                "restart_policy": "OnFailure",
+                "volumes": [
+                    {
+                        "name": "retry-policy-persistent-storage",
+                        "empty_dir": {},
+                    }
+                ],
+            },
+        },
+        name="with_restart_policy",
+    )
+
+    @job
+    def with_restart_policy_job():
+        with_restart_policy()
+
+    execute_result = with_restart_policy_job.execute_in_process()
+    run_id = execute_result.dagster_run.run_id
+    job_name = get_k8s_job_name(run_id, with_restart_policy.name)
+
+    assert "HI" in _get_pod_logs(cluster_provider, job_name, namespace)

--- a/integration_tests/test_suites/k8s-test-suite/tests/test_k8s_job_op.py
+++ b/integration_tests/test_suites/k8s-test-suite/tests/test_k8s_job_op.py
@@ -404,7 +404,7 @@ def test_k8s_job_op_with_restart_policy(namespace, cluster_provider):
             "load_incluster_config": False,
             "kubeconfig_file": cluster_provider.kubeconfig_file,
             "job_spec_config": {
-                "backoffLimit": 4,
+                "backoffLimit": 5,
                 "parallelism": 2,
                 "completions": 2,
             },

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
@@ -778,11 +778,11 @@ def construct_dagster_k8s_job(
             },
         ),
         "spec": merge_dicts(
+            {"restart_policy": "Never"},
             pod_spec_config,
             {
                 "image_pull_secrets": job_config.image_pull_secrets,
                 "service_account_name": service_account_name,
-                "restart_policy": "Never",
                 "containers": [container_config] + user_defined_containers,
                 "volumes": volumes,
             },

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
@@ -298,6 +298,50 @@ def execute_k8s_job(
         start_time=start_time,
     )
 
+    restart_policy = user_defined_k8s_config.pod_spec_config.get("restart_policy", "Never")
+
+    if restart_policy == "Never":
+        container_name = container_config.get("name", "dagster")
+
+        pods = api_client.wait_for_job_to_have_pods(
+            job_name,
+            namespace,
+            wait_timeout=timeout,
+            start_time=start_time,
+        )
+
+        pod_names = [p.metadata.name for p in pods]
+
+        if not pod_names:
+            raise Exception("No pod names in job after it started")
+
+        pod_to_watch = pod_names[0]
+        watch = kubernetes.watch.Watch()  # consider moving in to api_client
+
+        api_client.wait_for_pod(
+            pod_to_watch, namespace, wait_timeout=timeout, start_time=start_time
+        )
+
+        log_stream = watch.stream(
+            api_client.core_api.read_namespaced_pod_log,
+            name=pod_to_watch,
+            namespace=namespace,
+            container=container_name,
+        )
+
+        while True:
+            if timeout and time.time() - start_time > timeout:
+                watch.stop()
+                raise Exception("Timed out waiting for pod to finish")
+
+            try:
+                log_entry = next(log_stream)
+                print(log_entry)  # noqa: T201
+            except StopIteration:
+                break
+    else:
+        context.log.info("Pod logs are disabled, because restart_policy is not Never")
+
     if job_spec_config and job_spec_config.get("parallelism"):
         num_pods_to_wait_for = job_spec_config["parallelism"]
     else:

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
@@ -208,8 +208,6 @@ def execute_k8s_job(
     if command:
         container_config["command"] = command
 
-    container_name = container_config.get("name", "dagster")
-
     op_container_context = K8sContainerContext(
         image_pull_policy=image_pull_policy,
         image_pull_secrets=image_pull_secrets,
@@ -299,41 +297,6 @@ def execute_k8s_job(
         wait_timeout=timeout,
         start_time=start_time,
     )
-
-    pods = api_client.wait_for_job_to_have_pods(
-        job_name,
-        namespace,
-        wait_timeout=timeout,
-        start_time=start_time,
-    )
-
-    pod_names = [p.metadata.name for p in pods]
-
-    if not pod_names:
-        raise Exception("No pod names in job after it started")
-
-    pod_to_watch = pod_names[0]
-    watch = kubernetes.watch.Watch()  # consider moving in to api_client
-
-    api_client.wait_for_pod(pod_to_watch, namespace, wait_timeout=timeout, start_time=start_time)
-
-    log_stream = watch.stream(
-        api_client.core_api.read_namespaced_pod_log,
-        name=pod_to_watch,
-        namespace=namespace,
-        container=container_name,
-    )
-
-    while True:
-        if timeout and time.time() - start_time > timeout:
-            watch.stop()
-            raise Exception("Timed out waiting for pod to finish")
-
-        try:
-            log_entry = next(log_stream)
-            print(log_entry)  # noqa: T201
-        except StopIteration:
-            break
 
     if job_spec_config and job_spec_config.get("parallelism"):
         num_pods_to_wait_for = job_spec_config["parallelism"]


### PR DESCRIPTION
## Summary & Motivation

Currently, dagster-k8s doesn't support any other `restart_policy` value rather than `Never`. However, sometimes Kubernetes pods (applications running on them) are not that stable, and they crash from time to time. When `restart_policy` is `Never` it means that Kubernetes job will fail instantly, which means that Dagster operation also will be marked as failed. Setting `restart_policy` as `OnFailure` together with `backoffLimit` value of more than 1 ([by default](https://kubernetes.io/docs/concepts/workloads/controllers/job/#pod-backoff-failure-policy) it is set to 6) would mean that Kubernetes job wouldn't be marked as failed unless pods failed more than `backoffLimit`.

However, `dagster-k8s` will fail because `execute_k8s_job` waits for pod to start by calling `wait_for_pod` method. This method runs a loop that checks container status every 10 seconds by default. It means that there could be a scenario when container starts successfully and then immediately fails before `wait_for_pod` method marks pod as running. In that case, it raises `DagsterK8sError`, and operation is marked as failed, even though Kubernetes restarts container and job isn't marked as failed.

Main purpose of calling `wait_for_pod` method is to ensure that pod is running and then retrieve pod logs. However, if `parallelism` is more than 1, it will stream only one pod logs which means we don't have full visibility of Kubernetes job. Moreover, Kubernetes `read_namespaced_pod_log` doesn't handle container restarts. In order to handle container restarts, another Kubernetes `Watch` resource should be configured with `list_namespaced_pod` method which streams pod events. If container is restarted, it would appear as a pod event, and then we could delete old `Watch` that streams `read_namespaced_pod_log` and replace it with a new `Watch` that streams new container logs. Furthermore, it should be done for every pod in a job. So that's a lot of hassle to implement this properly (especially without async), just to print logs into a console which in most cases just creates a lot of unnecessary noise (e.g. 10 pods of log-intensive application). So, if there's no need to have pod logs printed to the console, there's no need to call `wait_for_pod` method.

Basically, removing `wait_for_pod` method means that instead of trying to validate pod state in the dagster-k8s, we leave this job for the Kubernetes.

## How I Tested These Changes

New integration test `test_k8s_job_op_with_restart_policy`.
