### PR TITLE
[docs] Some cleanup on tags and hierarchy

### DIFF
--- a/docs/content/concepts/assets/asset-auto-execution.mdx
+++ b/docs/content/concepts/assets/asset-auto-execution.mdx
@@ -14,7 +14,7 @@ At a high-level, there are two factors that can be used to determine when an ass
 
 Assets can be auto-materialized "eagerly" – i.e. immediately after upstream changes occur. Or they can be auto-materialized "lazily" – i.e. by waiting until downstream <PyObject object="FreshnessPolicy" pluralize /> dictate that they need to be fresh. Or a mixture of both.
 
-### Turning on auto-materializing
+## Turning on auto-materializing
 
 To enable assets to be automatically materialized, you need to first flip a toggle in the Dagster UI.
 
@@ -23,7 +23,7 @@ To enable assets to be automatically materialized, you need to first flip a togg
 
 **First time using auto-materialize? Have a large number of partitioned assets?** We recommend starting small: add auto-materialize policies only to a subset of your assets and then expand incrementally. Auto-materializing has a startup cost that’s roughly proportional to the number of materialized partitions of assets that are ancestors of assets with auto-materialize policies. Turning on auto-materializing with large numbers of partitioned assets at once can overload the database and make the database unavailable to other Dagster components that rely on it.
 
-### Auto-materialize policies
+## Auto-materialize policies
 
 You can set up an asset to be auto-materialized by assigning it an <PyObject object="AutoMaterializePolicy" />. In this example, we use <PyObject object="AutoMaterializePolicy" method="eager" /> to indicate that, any time that `asset1` is materialized, `asset2` should be automatically materialized right after:
 
@@ -126,7 +126,7 @@ def asset3():
 
 If multiple assets with freshness policies depend on the same upstream asset, Dagster will try to intelligently materialize the upstream asset at times that allow it to minimize the number of runs of the upstream asset, while meeting the downstream freshness policies.
 
-### Auto-materialize policies and data versions
+## Auto-materialize policies and data versions
 
 _Observable source assets_ are assets that your data pipeline doesn't materialize, but that you provide a function for that can tell when they've changed. If you set an <PyObject object="AutoMaterializePolicy" /> on an asset that's downstream of an [observable source asset](/concepts/assets/asset-observations#observable-source-assets), then changes to the source asset will be treated as new upstream data that can cause the downstream asset to be auto-materialized.
 
@@ -151,7 +151,7 @@ def asset1():
     ...
 ```
 
-### Auto-materialization and partitions
+## Auto-materialization and partitions
 
 Partitioned assets can have <PyObject object="AutoMaterializePolicy" pluralize />. Partitions are eligible for auto-materialization when either:
 
@@ -190,13 +190,13 @@ object="DynamicPartitionsDefinition"
 pluralize
 /> do not have this limit, so all partitions will be automatically-materialized.
 
-### Rules of auto-materialization
+## Rules of auto-materialization
 
 - Assets will not be auto-materialized if any of their ancestors are currently being auto-materialized.
 - Assets will not be auto-materialized if any of their ancestors have not yet incorporated the newest materialization of their upstream assets.
 - If the run to auto-materialize an asset fails, it can be retried if [run retries](/deployment/run-retries) are configured. Otherwise, Dagster won't try to auto-materialize that asset again until it would auto-materialize it if the failed run had succeeded. I.e., if an asset has a daily freshness policy, and it fails, Dagster won't auto-materialize it again until the next day.
 - By default, no more than one materialization of a given asset will be kicked off per minute. Further materialization requests will be discarded, and will require manual backfilling to complete. This can be configured using the `max_materializations_per_minute` argument to <PyObject object="AutoMaterializePolicy" method="eager" /> and <PyObject object="AutoMaterializePolicy" method="lazy" />.
 
-### Run tags
+## Run tags
 
 Runs triggered by auto-materialize policies are tagged with `dagster/auto_materialize`: `true`. Additional tags can be configured in [`dagster.yaml` (OSS)](/deployment/dagster-instance#auto-materialize) or [deployment settings (Cloud)](/dagster-cloud/managing-deployments/deployment-settings-reference#auto-materialize).

--- a/docs/content/concepts/configuration/config-schema-legacy.mdx
+++ b/docs/content/concepts/configuration/config-schema-legacy.mdx
@@ -3,7 +3,7 @@ title: Run Configuration (Legacy) | Dagster
 description: Job run configuration allows providing parameters to jobs at the time they're executed.
 ---
 
-# Run Configuration (Legacy)
+# Run Configuration <Legacy />
 
 <Note>
   This guide covers using legacy APIs for the Dagster config system. For docs on

--- a/docs/content/concepts/configuration/configured.mdx
+++ b/docs/content/concepts/configuration/configured.mdx
@@ -3,7 +3,7 @@ title: Configured API (Legacy) | Dagster
 description: The Configured API offers a way to configure a Dagster entity at definition time.
 ---
 
-# Configured API (Legacy)
+# Configured API <Legacy />
 
 <Note>
   This guide covers using legacy APIs for the Dagster config system. For docs on

--- a/docs/content/concepts/io-management/io-managers-legacy.mdx
+++ b/docs/content/concepts/io-management/io-managers-legacy.mdx
@@ -3,7 +3,7 @@ title: IO Managers (Legacy) | Dagster
 description: IO Managers determine how to store asset/op outputs and load asset/op inputs.
 ---
 
-# IO Managers (Legacy)
+# IO Managers <Legacy />
 
 <Note>
   This guide covers using the legacy Dagster resource system. For docs on the

--- a/docs/content/concepts/logging/python-logging.mdx
+++ b/docs/content/concepts/logging/python-logging.mdx
@@ -58,7 +58,7 @@ height={250}
 
 Please note that you should generally be fairly selective about which logs you wish to capture, especially in a production context. It is possible to overload the event log storage with these events, which may cause certain pages in the UI to take a long time to load. Consider only capturing the most critical logs, and avoid including debug information if you expect to maintain a large amount of run history.
 
-Note: if a `python_log_level` is set (see: [Configuring A Python Log Level](#configuring-a-python-log-level)), then the loggers listed here will be set to the given level before a run is launched.
+Note: if a `python_log_level` is set (see: [Configuring A Python Log Level](#configuring-a-python-log-level-)), then the loggers listed here will be set to the given level before a run is launched.
 
 ### Example: Creating a captured python logger without modifying `dagster.yaml`
 
@@ -81,9 +81,9 @@ def ambitious_op():
 
 Note: The logging module retains global state, meaning the logger returned by this function will be identical if this function is called multiple times with the same arguments in the same process. This means that there may be unpredictable or unituitive results if you set the level of the returned python logger to different values in different parts of your code.
 
-## Configuring A Python Log Level (Experimental)
+## Configuring A Python Log Level <Experimental />
 
-If you want to set a global log level for your Dagster instance, you can do this by setting the `python_log_level` in your dagster.yaml file. This will set the log level of all loggers managed by Dagster. By default, this will just be the `context.log` logger. If there are custom python loggers that you wish to capture, see [Capturing Python Logs](#capturing-python-logs).
+If you want to set a global log level for your Dagster instance, you can do this by setting the `python_log_level` in your dagster.yaml file. This will set the log level of all loggers managed by Dagster. By default, this will just be the `context.log` logger. If there are custom python loggers that you wish to capture, see [Capturing Python Logs](#capturing-python-logs-).
 
 This allows you to filter out logs below a given level. For example, setting a log level of `INFO` will filter out all `DEBUG` level logs.
 

--- a/docs/content/concepts/ops-jobs-graphs/op-events.mdx
+++ b/docs/content/concepts/ops-jobs-graphs/op-events.mdx
@@ -48,7 +48,7 @@ def my_output_op():
 
 Check out the docs on [Op Outputs](/concepts/ops-jobs-graphs/ops#outputs) to learn more about this functionality.
 
-Dagster also provides the <PyObject object="Output"/> object, which opens up additional functionality to outputs when using Dagster, such as [specifying output metadata](/concepts/ops-jobs-graphs/op-events#attaching-metadata-to-outputs) and [conditional branching](/concepts/ops-jobs-graphs/graphs#with-conditional-branching), all while maintaining coherent type annotations.
+Dagster also provides the <PyObject object="Output"/> object, which opens up additional functionality to outputs when using Dagster, such as [specifying output metadata](/concepts/ops-jobs-graphs/op-events#attaching-metadata-to-outputs-) and [conditional branching](/concepts/ops-jobs-graphs/graphs#with-conditional-branching), all while maintaining coherent type annotations.
 
 <PyObject object="Output" /> objects can be either returned or yielded. The Output
 type is also generic, for use with return annotations:

--- a/docs/content/concepts/resources-legacy.mdx
+++ b/docs/content/concepts/resources-legacy.mdx
@@ -3,7 +3,7 @@ title: Resources (Legacy) | Dagster
 description: Resources enable you to separate graph logic from environment, and therefore make it easier to test and develop graphs in various environments.
 ---
 
-# Resources (Legacy)
+# Resources <Legacy />
 
 <Note>
   This guide covers using the legacy Dagster resource system. For docs on the

--- a/docs/next/components/mdx/MDXComponents.tsx
+++ b/docs/next/components/mdx/MDXComponents.tsx
@@ -368,8 +368,16 @@ const PlaceholderImage = ({caption = 'Placeholder Image'}) => {
 
 const Experimental = () => {
   return (
-    <div className="inline-flex items-center px-3 py-0.5 rounded-full align-baseline text-xs uppercase font-medium bg-sea-foam text-gable-green">
-      Experimental
+    <div className="experimental-tag inline-flex items-center px-3 py-0.5 rounded-full align-middle text-xs uppercase font-medium bg-sea-foam text-gable-green">
+      <span className="hidden">(</span>Experimental<span className="hidden">)</span>
+    </div>
+  );
+};
+
+const Legacy = () => {
+  return (
+    <div className="legacy-tag inline-flex items-center px-3 py-0.5 rounded-full align-middle text-xs uppercase font-medium bg-yellow-200 text-yellow-700">
+      <span className="hidden">(</span>Legacy<span className="hidden">)</span>
     </div>
   );
 };
@@ -757,6 +765,7 @@ export default {
   TODO,
   PlaceholderImage,
   Experimental,
+  Legacy,
   Icons,
   ReferenceTable,
   ReferenceTableItem,

--- a/docs/next/components/mdx/SidebarNavigation.tsx
+++ b/docs/next/components/mdx/SidebarNavigation.tsx
@@ -15,7 +15,8 @@ export function getItems(node, current) {
         current.url = url
           .replace(/^#cross-/, '#')
           .replace(/^#check-/, '#')
-          .replace(/-experimental-?$/, '');
+          .replace(/-experimental-?$/, '-')
+          .replace(/-legacy-?$/, '-');
       }
       if (item.type === `text`) {
         current.title = item['value'];

--- a/docs/next/tailwind.config.js
+++ b/docs/next/tailwind.config.js
@@ -114,7 +114,6 @@ module.exports = {
             },
             h1: {
               color: theme('colors.gable-green'),
-              fontSize: theme('fontSize.4xl'),
               marginTop: 40,
               fontFamily: theme('fontFamily.sans').join(','),
               fontWeight: theme('fontWeight.medium'),


### PR DESCRIPTION
## Summary & Motivation

Implement a handful of cleanup items on mdx rendering and hierarchy.

- Add a "Legacy" tag similar to our "Experimental" tag, to be a bit more consistent, replacing header text where we've written "(Legacy)"
- Fix a document where there was an `h1` and `h3`'s, but no `h2`. DocSearch doesn't want us skipping!
- Add hidden parentheses on the "Legacy" and "Experimental" tags so that they don't visually appear, but will appear in the crawled result.
- Use `vertical-align: middle` on these tags, because the baseline aligmment looks wrong to me.
- Remove the `fontSize` directive on `h1` in Tailwind config, because the `theme` function supplies an array that gets parsed into an invalid CSS value. It's not needed anyway, since our `h1` is styled correctly without it.
- Fixed links to experimental sections

<img width="613" alt="Screenshot 2023-07-25 at 10 37 17 AM" src="https://github.com/dagster-io/dagster/assets/2823852/65eaaaa1-9b9a-4a80-b9e3-bc650c5c1d0d">
<img width="357" alt="Screenshot 2023-07-25 at 10 36 59 AM" src="https://github.com/dagster-io/dagster/assets/2823852/85b5ac41-fae9-473e-af1e-4048fa9cea67">


## How I Tested These Changes

View http://localhost:3001/concepts/assets/asset-auto-execution (experimental) and http://localhost:3001/concepts/io-management/io-managers-legacy (legacy), verify that tags and all content render correclt.y
