### PR TITLE
Temp pin responses==0.23.1

### DIFF
--- a/examples/temp_pins.txt
+++ b/examples/temp_pins.txt
@@ -10,3 +10,4 @@
 # and verify that these example projects work. We use this file to
 # temporarily introduce pins for these tests until the next version of
 # Dagster is published to PyPI.
+responses==0.23.1

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -117,7 +117,7 @@ setup(
             "pytest-runner==5.2",
             "pytest-xdist==2.1.0",
             "pytest==7.0.1",  # last version supporting python 3.6
-            "responses",
+            "responses<=0.23.1",  # https://github.com/getsentry/responses/issues/654
             "syrupy<4",  # 3.7 compatible,
             "tox==3.25.0",
             "yamllint",


### PR DESCRIPTION
responses==0.23.2 forces us onto urllib>=2.0.0 which causes a whole new pip resolution chain.

https://github.com/getsentry/responses/issues/654

Pinning until all of these packages support urllib3>=2.0.0