### PR TITLE
call "graphs" "op graphs" in the docs

### DIFF
--- a/docs/content/_navigation.json
+++ b/docs/content/_navigation.json
@@ -120,23 +120,17 @@
           {
             "title": "Op retries",
             "path": "/concepts/ops-jobs-graphs/op-retries"
-          }
-        ]
-      },
-      {
-        "title": "Graphs",
-        "path": "/concepts/ops-jobs-graphs/graphs",
-        "children": [
+          },
           {
-            "title": "Graphs",
+            "title": "Op graphs",
             "path": "/concepts/ops-jobs-graphs/graphs"
           },
           {
-            "title": "Nesting Graphs",
+            "title": "Nesting op graphs",
             "path": "/concepts/ops-jobs-graphs/nesting-graphs"
           },
           {
-            "title": "Dynamic Graphs",
+            "title": "Dynamic op graphs",
             "path": "/concepts/ops-jobs-graphs/dynamic-graphs"
           }
         ]

--- a/docs/content/concepts.mdx
+++ b/docs/content/concepts.mdx
@@ -41,6 +41,8 @@ An asset is an object in persistent storage, such as a table, file, or persisted
 
 Ops are the core unit of computation in Dagster. They typically perform relatively simple tasks, such as executing a database query or sending a Slack message.
 
+An op graph is a set of interconnected ops or sub-graphs. While individual ops typically perform simple tasks, ops can be assembled into a graph to accomplish complex tasks.
+
 <ArticleList>
   <ArticleListItem
     title="Ops"
@@ -58,25 +60,16 @@ Ops are the core unit of computation in Dagster. They typically perform relative
     title="Op retries"
     href="/concepts/ops-jobs-graphs/op-retries"
   ></ArticleListItem>
-</ArticleList>
-
----
-
-## Graphs
-
-A graph is a set of interconnected ops or sub-graphs. While individual ops typically perform simple tasks, ops can be assembled into a graph to accomplish complex tasks.
-
-<ArticleList>
   <ArticleListItem
-    title="Graphs"
+    title="Op graphs"
     href="/concepts/ops-jobs-graphs/graphs"
   ></ArticleListItem>
   <ArticleListItem
-    title="Nesting graphs"
+    title="Nesting op graphs"
     href="/concepts/ops-jobs-graphs/nesting-graphs"
   ></ArticleListItem>
   <ArticleListItem
-    title="Dynamic graphs"
+    title="Dynamic op graphs"
     href="/concepts/ops-jobs-graphs/dynamic-graphs"
   ></ArticleListItem>
 </ArticleList>

--- a/docs/content/concepts/assets/graph-backed-assets.mdx
+++ b/docs/content/concepts/assets/graph-backed-assets.mdx
@@ -1,11 +1,11 @@
 ---
 title: Graph-Backed Assets | Dagster
-description: Defining a software-defined asset with multiple discrete computations combined in a graph.
+description: Defining a software-defined asset with multiple discrete computations combined in an op graph.
 ---
 
 # Graph-Backed Assets
 
-[Basic software-defined assets](/concepts/assets/software-defined-assets#a-basic-software-defined-asset) are computed using a single op. If generating an asset involves multiple discrete computations, you can use graph-backed assets by separating each computation into an op and building a graph to combine your computations. This allows you to launch re-executions of runs at the op boundaries, but doesn't require you to link each intermediate value to an asset in persistent storage.
+[Basic software-defined assets](/concepts/assets/software-defined-assets#a-basic-software-defined-asset) are computed using a single op. If generating an asset involves multiple discrete computations, you can use graph-backed assets by separating each computation into an op and assembling them into an op graph to combine your computations. This allows you to launch re-executions of runs at the op boundaries, but doesn't require you to link each intermediate value to an asset in persistent storage.
 
 ---
 
@@ -138,7 +138,7 @@ def foo(context, bar_1):
         yield Output(bar_1 + 2, output_name="foo_2")
 ```
 
-Because Dagster flattens each graph into a flat input/output mapping between ops under the hood, any op that produces an output of the graph must be structured to yield its outputs optionally, enabling the outputs to be returned independently.
+Because Dagster flattens each op graph into a flat input/output mapping between ops under the hood, any op that produces an output of the graph must be structured to yield its outputs optionally, enabling the outputs to be returned independently.
 
 In the example, `foo` and `baz` produce outputs of `my_graph`. Subsequently, their outputs need to be yielded optionally. Because `foo` yields multiple outputs, we must structure our code to conditionally yield its outputs like in the code snippet above.
 

--- a/docs/content/concepts/ops-jobs-graphs/graphs.mdx
+++ b/docs/content/concepts/ops-jobs-graphs/graphs.mdx
@@ -1,9 +1,9 @@
 ---
-title: Graphs | Dagster
-description: Graphs are sets of interconnected ops or sub-graphs and form the core of jobs.
+title: Op Graphs | Dagster
+description: Op graphs are sets of interconnected ops or sub-graphs and form the core of jobs.
 ---
 
-# Graphs
+# Op Graphs
 
 A graph is a set of interconnected [ops](/concepts/ops-jobs-graphs/ops) or sub-graphs. While individual ops typically perform simple tasks, ops can be assembled into a graph to accomplish complex tasks.
 
@@ -17,22 +17,22 @@ Graphs can be used in three different ways:
 
 ## Relevant APIs
 
-| Name                                                   | Description                                                                                                                                                                                                                   |
-| ------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| <PyObject module="dagster" object="graph" decorator /> | The decorator used to define a graph, which can form the basis for multiple jobs.                                                                                                                                             |
-| <PyObject module="dagster" object="GraphDefinition" /> | A graph definition, which is a set of ops (or [sub-graphs](/concepts/ops-jobs-graphs/nesting-graphs)) wired together. Forms the core of a job. Typically constructed using the <PyObject object="job" decorator /> decorator. |
-|                                                        |                                                                                                                                                                                                                               |
+| Name                                                   | Description                                                                                                                                                                                                                       |
+| ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| <PyObject module="dagster" object="graph" decorator /> | The decorator used to define an op graph, which can form the basis for multiple jobs.                                                                                                                                             |
+| <PyObject module="dagster" object="GraphDefinition" /> | An op graph definition, which is a set of ops (or [sub-graphs](/concepts/ops-jobs-graphs/nesting-graphs)) wired together. Forms the core of a job. Typically constructed using the <PyObject object="job" decorator /> decorator. |
+|                                                        |                                                                                                                                                                                                                                   |
 
 ---
 
-## Creating graphs
+## Creating op graphs
 
 - [Using the @graph decorator](#using-the-graph-decorator)
-- [Graph patterns](#graph-patterns)
+- [Graph patterns](#op-graph-patterns)
 
 ### Using the @graph decorator
 
-To create a graph, use the <PyObject module="dagster" object="graph" decorator /> decorator.
+To create an op graph, use the <PyObject module="dagster" object="graph" decorator /> decorator.
 
 In the following example, we return one output from the root op (`return_one`) and pass data along through single inputs and outputs:
 
@@ -55,15 +55,15 @@ def linear():
     add_one(add_one(add_one(return_one())))
 ```
 
-### Graph patterns
+### Op graph patterns
 
-Need some inspiration? Using the patterns below, you can build graphs:
+Need some inspiration? Using the patterns below, you can build op graphs:
 
 - [That re-use ops](#that-re-use-ops)
 - [With multiple inputs](#with-multiple-inputs)
 - [With conditional branching](#with-conditional-branching)
 - [With a fixed fan-in](#with-a-fixed-fan-in)
-- [That contain other graphs](#that-contain-other-graphs)
+- [That contain other op graphs](#that-contain-other-op-graphs)
 - [That use dynamic outputs](#using-dynamic-outputs)
 
 #### That re-use ops
@@ -210,13 +210,13 @@ def fan_in():
 
 In this example, we have 10 ops that all output the number `1`. The `sum_fan_in` op takes all of these outputs as a list and sums them.
 
-#### That contain other graphs
+#### That contain other op graphs
 
-Graphs can contain other graphs, or sub-graphs. Refer to the [Nesting graphs documentation](/concepts/ops-jobs-graphs/nesting-graphs) for more info and examples.
+Op graphs can contain other op graphs. Refer to the [Nesting op graphs documentation](/concepts/ops-jobs-graphs/nesting-graphs) for more info and examples.
 
 #### Using dynamic outputs
 
-Using dynamic outputs, you can duplicate portions of a graph at runtime. Refer to the [Dynamic graphs documentation](/concepts/ops-jobs-graphs/dynamic-graphs) for more info and examples.
+Using dynamic outputs, you can duplicate portions of an op graph at runtime. Refer to the [Dynamic graphs documentation](/concepts/ops-jobs-graphs/dynamic-graphs) for more info and examples.
 
 ---
 
@@ -314,7 +314,7 @@ one_plus_one_from_constructor = GraphDefinition(
 
 #### Using YAML (GraphDSL)
 
-Sometimes you may want to construct the dependencies of a graph definition from a YAML file or similar. This is useful when migrating to Dagster from other workflow systems.
+Sometimes you may want to construct the dependencies of an op graph definition from a YAML file or similar. This is useful when migrating to Dagster from other workflow systems.
 
 For example, you can have a YAML like this:
 
@@ -403,12 +403,12 @@ def define_dep_dsl_graph() -> GraphDefinition:
 
 ### Inside assets
 
-Graphs can be used to create [software-defined assets](/concepts/assets/software-defined-assets). Graph-backed assets are useful if you have an existing graph that produces and consumes assets.
+Op graphs can be used to create [software-defined assets](/concepts/assets/software-defined-assets). Graph-backed assets are useful if you have an existing op graph that produces and consumes assets.
 
 Wrapping your graph inside a software-defined asset gives you all the benefits of software-defined assets — like cross-job lineage — without requiring you to change the code inside your graph. Refer to the [graph-backed assets documentation](/concepts/assets/graph-backed-assets) for more info and examples.
 
 ### Directly inside jobs
 
-Ready to start using your graphs in Dagster jobs? Refer to the [Jobs documentation](/concepts/ops-jobs-graphs/jobs) for detailed info and examples.
+Ready to start using your op graphs in Dagster jobs? Refer to the [Jobs documentation](/concepts/ops-jobs-graphs/jobs) for detailed info and examples.
 
 ---

--- a/python_modules/dagster/dagster/_core/definitions/decorators/graph_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/graph_decorator.py
@@ -134,14 +134,14 @@ def graph(
     tags: Optional[Mapping[str, Any]] = None,
     config: Optional[Union[ConfigMapping, Mapping[str, Any]]] = None,
 ) -> Union[GraphDefinition, _Graph]:
-    """Create a graph with the specified parameters from the decorated composition function.
+    """Create an op graph with the specified parameters from the decorated composition function.
 
     Using this decorator allows you to build up a dependency graph by writing a
     function that invokes ops (or other graphs) and passes the output to subsequent invocations.
 
     Args:
         name (Optional[str]):
-            The name of the graph. Must be unique within any :py:class:`RepositoryDefinition` containing the graph.
+            The name of the op graph. Must be unique within any :py:class:`RepositoryDefinition` containing the graph.
         description (Optional[str]):
             A human-readable description of the graph.
         input_defs (Optional[List[InputDefinition]]):

--- a/python_modules/dagster/dagster/_core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/graph_definition.py
@@ -120,9 +120,9 @@ def create_adjacency_lists(
 
 
 class GraphDefinition(NodeDefinition):
-    """Defines a Dagster graph.
+    """Defines a Dagster op graph.
 
-    A graph is made up of
+    An op graph is made up of
 
     - Nodes, which can either be an op (the functional unit of computation), or another graph.
     - Dependencies, which determine how the values produced by nodes as outputs flow from


### PR DESCRIPTION
## Summary & Motivation

Conceptually, Dagster has two kinds of graphs:
- Asset graphs
- Op graphs

The "Graphs" page in the docs refers to the latter:

<img width="297" alt="image" src="https://github.com/dagster-io/dagster/assets/654855/8c5f95d1-27b9-4bf4-93f4-4a939ee84da0">

This PR proposes using the term "op graph" instead of just "graph" in our docs.  This also nests the "Op Graphs" section underneath the "Ops" section.

A deeper change would be to rename `@graph` to `@op_graph`, but I don't think we need to make this change before making the docs more specific.

## How I Tested These Changes
