### PR TITLE
[docs] Introduce deps and the DuckDB resource in the DuckDB guide/tutorial

### DIFF
--- a/docs/content/integrations/duckdb/using-duckdb-with-dagster.mdx
+++ b/docs/content/integrations/duckdb/using-duckdb-with-dagster.mdx
@@ -5,14 +5,14 @@ description: Store your Dagster assets in DuckDB
 
 # Using Dagster with DuckDB
 
-This tutorial focuses on how to store and load Dagster's [Software-defined Assets (SDAs)](/concepts/assets/software-defined-assets) in DuckDB.
+This tutorial focuses on how to create, consume, and interact with DuckDB tables in Dagster's [Software-defined Assets (SDAs)](/concepts/assets/software-defined-assets).
+
+The `dagster-duckdb` library provides two ways to interact with DuckDB tables. The [resource](TODO-LINK) allows you to directly run SQL queries against tables within an asset's compute function. The [I/O manager](TODO-LINK) transfers the responsibility of storing and loading DataFrames as DuckDB tables to Dagster.
 
 By the end of the tutorial, you will:
 
-- Configure a DuckDB I/O manager
-- Create a table in DuckDB using a Dagster asset
-- Make a DuckDB table available in Dagster
-- Load DuckDB tables in downstream assets
+- TODO - fill out with what we do
+
 
 This guide focuses on storing and loading Pandas DataFrames in DuckDB. Dagster also supports using PySpark and Polars DataFrames with DuckDB. The concepts from this guide apply to working with PySpark and Polars DataFrames, and you can learn more about setting up and using the DuckDB I/O manager with PySpark and Polars DataFrames in the [reference guide](/integrations/duckdb/reference).
 
@@ -29,8 +29,18 @@ To complete this tutorial, you'll need:
   ```
 
 ---
+## Part 1: Using the DuckDB Resource
 
-## Step 1: Configure the DuckDB I/O manager
+### Step 1: Configure the DuckDB Resource
+To configure the DuckDB resource, you must provide a path to a DuckDB database. If this database does not exist, it will be created for you:
+
+
+
+---
+
+## Part 2: Using the DuckDB I/O Manager
+
+### Step 1: Configure the DuckDB I/O manager
 
 The DuckDB I/O manager requires some configuration to connect to your database. You must provide a path where a DuckDB database will be created. Additionally, you can specify a `schema` where the DuckDB I/O manager will create tables.
 
@@ -58,7 +68,7 @@ For more info about each of the configuration values, refer to the <PyObject mod
 
 ---
 
-## Step 2: Create tables in DuckDB
+### Step 2: Create tables in DuckDB
 
 The DuckDB I/O manager can create and update tables for your Dagster-defined assets, but you can also make existing DuckDB tables available to Dagster.
 
@@ -66,7 +76,7 @@ The DuckDB I/O manager can create and update tables for your Dagster-defined ass
 
 <TabItem name="Create tables in DuckDB from Dagster assets">
 
-### Store a Dagster asset as a table in DuckDB
+#### Store a Dagster asset as a table in DuckDB
 
 To store data in DuckDB using the DuckDB I/O manager, the definitions of your assets don't need to change. You can tell Dagster to use the DuckDB I/O manager, like in [Step 1: Configure the DuckDB I/O manager](#step-1-configure-the-duckdb-io-manager), and Dagster will handle storing and loading your assets in DuckDB.
 
@@ -98,7 +108,7 @@ When Dagster materializes the `iris_dataset` asset using the configuration from 
 
 <TabItem name="Make existing tables available in Dagster">
 
-### Make an existing table available in Dagster
+#### Make an existing table available in Dagster
 
 If you already have tables in DuckDB, you may want to make them available to other Dagster assets. You can accomplish this by using [source assets](/concepts/assets/software-defined-assets#defining-external-asset-dependencies) for these tables. By creating a source asset for the existing table, you tell Dagster how to find the table so it can be fetched for downstream assets.
 
@@ -117,7 +127,7 @@ Because we already supplied the database and schema in the I/O manager configura
 
 ---
 
-## Step 3: Load DuckDB tables in downstream assets
+### Step 3: Load DuckDB tables in downstream assets
 
 Once you have created an asset or source asset that represents a table in DuckDB, you will likely want to create additional assets that work with the data. Dagster and the DuckDB I/O manager allow you to load the data stored in DuckDB tables into downstream assets.
 
@@ -142,7 +152,7 @@ When materializing these assets, Dagster will use the `DuckDBPandasIOManager` to
 
 ---
 
-## Completed code example
+### Completed code example
 
 When finished, your code should look like the following:
 

--- a/docs/content/integrations/duckdb/using-duckdb-with-dagster.mdx
+++ b/docs/content/integrations/duckdb/using-duckdb-with-dagster.mdx
@@ -5,9 +5,23 @@ description: Store your Dagster assets in DuckDB
 
 # Using Dagster with DuckDB
 
-This tutorial focuses on how to create and interact with DuckDB tables in Dagster's [Software-defined Assets (SDAs)](/concepts/assets/software-defined-assets).
+This tutorial focuses on creating and interacting with DuckDB tables using Dagster's [Software-defined Assets (SDAs)](/concepts/assets/software-defined-assets).
 
-The `dagster-duckdb` library provides two ways to interact with DuckDB tables. The [resource](TODO-LINK) allows you to directly run SQL queries against tables within an asset's compute function. The [I/O manager](TODO-LINK) transfers the responsibility of storing and loading DataFrames as DuckDB tables to Dagster.
+The `dagster-duckdb` library provides two ways to interact with DuckDB tables. The [resource](/concepts/resources) allows you to directly run SQL queries against tables within an asset's compute function. The [I/O manager](/concepts/io-management/io-managers) transfers the responsibility of storing and loading DataFrames as DuckDB tables to Dagster.
+
+This tutorial is divided in two parts. Both parts will create the same assets, but how the data is stored in DuckDB will differ. In [Part 1](#part-1-using-the-duckdb-resource) you will:
+
+- Set up and configure the DuckDB resource.
+- Use the DuckDB resource to execute a SQL query to create a table.
+- Use the DuckDB resource to execute a SQL query to interact with the table.
+
+In [Part 2](#part-2-using-the-duckdb-io-manager) you will:
+
+- Set up and configure the DuckDB I/O manager.
+- Use Pandas to create a DataFrame, then delegate responsibility creating a table to the DuckDB I/O manager.
+- Use the DuckDB I/O manager to load the table into memory so that you can interact with it using the Pandas library.
+
+When writing your own assets, you may choose one or the other (or both) approaches depending on your storage requirements. See [When to use I/O managers](TODO-LINK) to learn more.
 
 By the end of the tutorial, you will:
 
@@ -29,14 +43,13 @@ To complete this tutorial, you'll need:
 
 ---
 
-This tutorial is divided in two parts. Both parts will create the same assets, but how the data is stored in DuckDb will differ. In [Part 1](#part-1-using-the-duckdb-resource) you will use the DuckDB resource to manually execute SQL queries to create tables and interact with those tables. In [Part 2](#part-2-using-the-duckdb-io-manager) you will transfer the responsibility for generating the SQL to create and interact with tables to the DuckDB I/O manager. When writing your own assets, you may choose one or the other (or both) approaches depending on your storage requirements. See [When to use I/O managers](TODO-LINK) to learn more.
+## Part 1: Using the DuckDB resource
 
-## Part 1: Using the DuckDB Resource
-
+---
 
 ### Step 1: Configure the DuckDB resource
 
-To use the DuckDB resource, you add it to your `Definitions` object. The DuckDB resource requires some configuration. You must set a path to a duckdb database as the `database` configuration value. If the database does not already exist, it will be created for you:
+To use the DuckDB resource, you'll need to add it to your `Definitions` object. The DuckDB resource requires some configuration. You must set a path to a DuckDB database as the `database` configuration value. If the database does not already exist, it will be created for you:
 
 ```python file=/integrations/duckdb/tutorial/resource/configuration.py startafter=start_example endbefore=end_example
 from dagster_duckdb import DuckDBResource
@@ -51,12 +64,7 @@ defs = Definitions(
         )
     },
 )
-
-
-# end_example
 ```
-
----
 
 ### Step 2: Create tables in DuckDB
 
@@ -92,7 +100,7 @@ def iris_dataset(duckdb: DuckDBResource) -> None:
         conn.execute("CREATE TABLE iris.iris_dataset AS SELECT * FROM iris_df")
 ```
 
-In this example, you define an asset that fetches the Iris dataset as a Pandas DataFrame and renames the columns. Then, using the DuckDB resource, the DataFrame is stored in DuckDB as the `iris.iris_dataset` table.
+In this example, you're defining an asset that fetches the Iris dataset as a Pandas DataFrame and renames the columns. Then, using the DuckDB resource, the DataFrame is stored in DuckDB as the `iris.iris_dataset` table.
 
 </TabItem>
 
@@ -108,16 +116,13 @@ from dagster import SourceAsset
 iris_harvest_data = SourceAsset(key="iris_harvest_data")
 ```
 
-In this example, you create a <PyObject object="SourceAsset" /> for a pre-existing table called `iris_harvest_data`.
+In this example, you're creating a <PyObject object="SourceAsset" /> for a pre-existing table called `iris_harvest_data`.
 
 </TabItem>
 
 </TabGroup>
 
-
 Now you can run `dagster dev` and materialize the `iris_dataset` asset from the Dagster UI.
-
----
 
 ### Step 3: Define downstream assets
 
@@ -138,7 +143,7 @@ def iris_setosa(duckdb: DuckDBResource) -> None:
         )
 ```
 
-In this asset, you create second table that just contains the data for the Iris Setosa species. This asset has a dependency on the `iris_dataset` asset. To define this dependency, you provide the `iris_dataset` asset as a `dep` to the `iris_setosa` asset. You can then run the SQL query to create the table of Iris Setosa data.
+In this asset, you're creating second table that only contains the data for the _Iris Setosa_ species. This asset has a dependency on the `iris_dataset` asset. To define this dependency, you provide the `iris_dataset` asset as the `deps` parameter to the `iris_setosa` asset. You can then run the SQL query to create the table of _Iris Setosa_ data.
 
 ### Completed code example
 
@@ -189,7 +194,9 @@ defs = Definitions(
 )
 ```
 
-## Part 2: Using the DuckDB I/O Manager
+---
+
+## Part 2: Using the DuckDB I/O manager
 
 You may want to use an I/O manager to handle storing DataFrames as tables in DuckDB and loading DuckDB tables as DataFrames in downstream assets. Using an I/O manager is not required, and you can reference [When to use I/O managers](TODO-LINK) to learn more.
 
@@ -197,7 +204,7 @@ This section of the guide focuses on storing and loading Pandas DataFrames in Du
 
 ### Step 1: Configure the DuckDB I/O manager
 
-The DuckDB I/O manager requires some configuration to connect to your database. You must provide a path where a DuckDB database will be created. Additionally, you can specify a `schema` where the DuckDB I/O manager will create tables.
+To use the DuckDB I/O, you'll need to add it to your `Definitions` object. The DuckDB I/O manager requires some configuration to connect to your database. You must provide a path where a DuckDB database will be created. Additionally, you can specify a `schema` where the DuckDB I/O manager will create tables.
 
 ```python file=/integrations/duckdb/tutorial/io_manager/configuration.py startafter=start_example endbefore=end_example
 from dagster_duckdb_pandas import DuckDBPandasIOManager
@@ -247,7 +254,7 @@ def iris_dataset() -> pd.DataFrame:
     )
 ```
 
-In this example, you define an asset that fetches the Iris dataset as a Pandas DataFrame, renames the columns, then returns the DataFrame. The type signature of the function tells the I/O manager what data type it is working with, so it is important to include the return type `pd.DataFrame`.
+In this example, you're defining an asset that fetches the Iris dataset as a Pandas DataFrame, renames the columns, then returns the DataFrame. The type signature of the function tells the I/O manager what data type it is working with, so it is important to include the return type `pd.DataFrame`.
 
 When Dagster materializes the `iris_dataset` asset using the configuration from [Step 1: Configure the DuckDB I/O manager](#step-1-configure-the-duckdb-io-manager), the DuckDB I/O manager will create the table `IRIS.IRIS_DATASET` if it does not exist and replace the contents of the table with the value returned from the `iris_dataset` asset.
 
@@ -265,14 +272,12 @@ from dagster import SourceAsset
 iris_harvest_data = SourceAsset(key="iris_harvest_data")
 ```
 
-In this example, you create a <PyObject object="SourceAsset" /> for a pre-existing table containing iris harvests data. To make the data available to other Dagster assets, you need to tell the DuckDB I/O manager how to find the data.
+In this example, you're creating a <PyObject object="SourceAsset" /> for a pre-existing table containing iris harvests data. To make the data available to other Dagster assets, you need to tell the DuckDB I/O manager how to find the data.
 
 Because you already supplied the database and schema in the I/O manager configuration in [Step 1: Configure the DuckDB I/O manager](#step-1-configure-the-duckdb-io-manager), you only need to provide the table name. This is done with the `key` parameter in `SourceAsset`. When the I/O manager needs to load the `iris_harvest_data` in a downstream asset, it will select the data in the `IRIS.IRIS_HARVEST_DATA` table as a Pandas DataFrame and provide it to the downstream asset.
 
 </TabItem>
 </TabGroup>
-
----
 
 ### Step 3: Load DuckDB tables in downstream assets
 
@@ -291,7 +296,7 @@ def iris_setosa(iris_dataset: pd.DataFrame) -> pd.DataFrame:
     return iris_dataset[iris_dataset["species"] == "Iris-setosa"]
 ```
 
-In this asset, you provide the `iris_dataset` asset as a dependency to `iris_setosa`. The `DuckDBPandasIOManager` will load this asset into memory as a Pandas DataFrame. Then you create a DataFrame that just contains the data for the Iris Setosa species and return the DataFrame. Then the `DuckDBPandasIOManager` will store the DataFrame as the `IRIS.IRIS_SETOSA` table in DuckDB.
+In this asset, you're providing the `iris_dataset` asset as a dependency to `iris_setosa`. By supplying `iris_dataset` as a parameter to `iris_setosa`, Dagster knows to use the `DuckDBPandasIOManager` to load this asset into memory as a Pandas DataFrame and pass it as an argument to `iris_setosa`. Next, a DataFrame that only contains the data for the _Iris Setosa_ species is created and returned. Then the `DuckDBPandasIOManager` will store the DataFrame as the `IRIS.IRIS_SETOSA` table in DuckDB.
 
 ---
 

--- a/docs/content/integrations/duckdb/using-duckdb-with-dagster.mdx
+++ b/docs/content/integrations/duckdb/using-duckdb-with-dagster.mdx
@@ -33,7 +33,32 @@ This tutorial is divided in two parts. Both parts will create the same assets, b
 
 ## Part 1: Using the DuckDB Resource
 
-### Step 1: Create tables in DuckDB
+
+### Step 1: Configure the DuckDB resource
+
+To use the DuckDB resource, you add it to your `Definitions` object. The DuckDB resource requires some configuration. You must set a path to a duckdb database as the `database` configuration value. If the database does not already exist, it will be created for you:
+
+```python file=/integrations/duckdb/tutorial/resource/configuration.py startafter=start_example endbefore=end_example
+from dagster_duckdb import DuckDBResource
+
+from dagster import Definitions
+
+defs = Definitions(
+    assets=[iris_dataset],
+    resources={
+        "duckdb": DuckDBResource(
+            database="path/to/my_duckdb_database.duckdb",  # required
+        )
+    },
+)
+
+
+# end_example
+```
+
+---
+
+### Step 2: Create tables in DuckDB
 
 <TabGroup>
 
@@ -89,27 +114,6 @@ In this example, you create a <PyObject object="SourceAsset" /> for a pre-existi
 
 </TabGroup>
 
-### Step 2: Configure the DuckDB resource
-
-Before you can materialize your assets, the DuckDB resource requires some configuration. You must set a path to a duckdb database as the `database` configuration value. If the database does not already exist, it will be created for you:
-
-```python file=/integrations/duckdb/tutorial/resource/configuration.py startafter=start_example endbefore_end_example
-from dagster_duckdb import DuckDBResource
-
-from dagster import Definitions
-
-defs = Definitions(
-    assets=[iris_dataset],
-    resources={
-        "duckdb": DuckDBResource(
-            database="path/to/my_duckdb_database.duckdb",  # required
-        )
-    },
-)
-
-
-# end_example
-```
 
 Now you can run `dagster dev` and materialize the `iris_dataset` asset from the Dagster UI.
 

--- a/docs/content/integrations/duckdb/using-duckdb-with-dagster.mdx
+++ b/docs/content/integrations/duckdb/using-duckdb-with-dagster.mdx
@@ -93,17 +93,7 @@ In this example, you create a <PyObject object="SourceAsset" /> for a pre-existi
 
 Before you can materialize your assets, the DuckDB resource requires some configuration. You must set a path to a duckdb database as the `database` configuration value. If the database does not already exist, it will be created for you:
 
-```python file=/integrations/duckdb/tutorial/resource/configuration.py
-from dagster import asset
-
-
-@asset
-def iris_dataset():
-    return None
-
-
-# start_example
-
+```python file=/integrations/duckdb/tutorial/resource/configuration.py startafter=start_example endbefore_end_example
 from dagster_duckdb import DuckDBResource
 
 from dagster import Definitions
@@ -132,8 +122,6 @@ Once you have created an asset or source asset that represents a table in DuckDB
 ```python file=/integrations/duckdb/tutorial/resource/downstream.py startafter=start_example endbefore=end_example
 from dagster import asset
 
-from ..io_manager.source_asset import iris_harvest_data
-
 # this example uses the iris_dataset asset from Step 1
 
 
@@ -152,8 +140,49 @@ In this asset, you create second table that just contains the data for the Iris 
 
 When finished, your code should look like the following:
 
-```python file=/integrations/duckdb/tutorial/resource/full_example.py startafter=start_example endbefore=end_example
-No match for startAfter value "start_example"
+```python file=/integrations/duckdb/tutorial/resource/full_example.py
+import pandas as pd
+from dagster_duckdb import DuckDBResource
+
+from dagster import Definitions, SourceAsset, asset
+
+iris_harvest_data = SourceAsset(key="iris_harvest_data")
+
+
+@asset
+def iris_dataset(duckdb: DuckDBResource) -> None:
+    iris_df = pd.read_csv(
+        "https://docs.dagster.io/assets/iris.csv",
+        names=[
+            "sepal_length_cm",
+            "sepal_width_cm",
+            "petal_length_cm",
+            "petal_width_cm",
+            "species",
+        ],
+    )
+
+    with duckdb.get_connection() as conn:
+        conn.execute("CREATE TABLE iris.iris_dataset AS SELECT * FROM iris_df")
+
+
+@asset(deps=[iris_dataset])
+def iris_setosa(duckdb: DuckDBResource) -> None:
+    with duckdb.get_connection() as conn:
+        conn.execute(
+            "CREATE TABLE iris.iris_setosa AS SELECT * FROM iris.iris_dataset WHERE"
+            " species = 'Iris-setosa'"
+        )
+
+
+defs = Definitions(
+    assets=[iris_dataset],
+    resources={
+        "duckdb": DuckDBResource(
+            database="path/to/my_duckdb_database.duckdb",
+        )
+    },
+)
 ```
 
 ## Part 2: Using the DuckDB I/O Manager

--- a/docs/content/integrations/duckdb/using-duckdb-with-dagster.mdx
+++ b/docs/content/integrations/duckdb/using-duckdb-with-dagster.mdx
@@ -45,8 +45,6 @@ To complete this tutorial, you'll need:
 
 ## Part 1: Using the DuckDB resource
 
----
-
 ### Step 1: Configure the DuckDB resource
 
 To use the DuckDB resource, you'll need to add it to your `Definitions` object. The DuckDB resource requires some configuration. You must set a path to a DuckDB database as the `database` configuration value. If the database does not already exist, it will be created for you:
@@ -297,8 +295,6 @@ def iris_setosa(iris_dataset: pd.DataFrame) -> pd.DataFrame:
 ```
 
 In this asset, you're providing the `iris_dataset` asset as a dependency to `iris_setosa`. By supplying `iris_dataset` as a parameter to `iris_setosa`, Dagster knows to use the `DuckDBPandasIOManager` to load this asset into memory as a Pandas DataFrame and pass it as an argument to `iris_setosa`. Next, a DataFrame that only contains the data for the _Iris Setosa_ species is created and returned. Then the `DuckDBPandasIOManager` will store the DataFrame as the `IRIS.IRIS_SETOSA` table in DuckDB.
-
----
 
 ### Completed code example
 

--- a/docs/content/integrations/duckdb/using-duckdb-with-dagster.mdx
+++ b/docs/content/integrations/duckdb/using-duckdb-with-dagster.mdx
@@ -21,7 +21,7 @@ In [Part 2](#part-2-using-the-duckdb-io-manager) you will:
 - Use Pandas to create a DataFrame, then delegate responsibility creating a table to the DuckDB I/O manager.
 - Use the DuckDB I/O manager to load the table into memory so that you can interact with it using the Pandas library.
 
-When writing your own assets, you may choose one or the other (or both) approaches depending on your storage requirements. See [When to use I/O managers](TODO-LINK) to learn more.
+When writing your own assets, you may choose one or the other (or both) approaches depending on your storage requirements. See [When to use I/O managers](/concepts/io-managers#when-to-use-io-managers) to learn more.
 
 By the end of the tutorial, you will:
 
@@ -198,7 +198,7 @@ defs = Definitions(
 
 ## Part 2: Using the DuckDB I/O manager
 
-You may want to use an I/O manager to handle storing DataFrames as tables in DuckDB and loading DuckDB tables as DataFrames in downstream assets. Using an I/O manager is not required, and you can reference [When to use I/O managers](TODO-LINK) to learn more.
+You may want to use an I/O manager to handle storing DataFrames as tables in DuckDB and loading DuckDB tables as DataFrames in downstream assets. Using an I/O manager is not required, and you can reference [When to use I/O managers](/concepts/io-managers#when-to-use-io-managers) to learn more.
 
 This section of the guide focuses on storing and loading Pandas DataFrames in DuckDB, but Dagster also supports using PySpark and Polars DataFrames with DuckDB. The concepts from this guide apply to working with PySpark and Polars DataFrames, and you can learn more about setting up and using the DuckDB I/O manager with PySpark and Polars DataFrames in the [reference guide](/integrations/duckdb/reference).
 

--- a/docs/content/integrations/duckdb/using-duckdb-with-dagster.mdx
+++ b/docs/content/integrations/duckdb/using-duckdb-with-dagster.mdx
@@ -5,16 +5,15 @@ description: Store your Dagster assets in DuckDB
 
 # Using Dagster with DuckDB
 
-This tutorial focuses on how to create, consume, and interact with DuckDB tables in Dagster's [Software-defined Assets (SDAs)](/concepts/assets/software-defined-assets).
+This tutorial focuses on how to create and interact with DuckDB tables in Dagster's [Software-defined Assets (SDAs)](/concepts/assets/software-defined-assets).
 
 The `dagster-duckdb` library provides two ways to interact with DuckDB tables. The [resource](TODO-LINK) allows you to directly run SQL queries against tables within an asset's compute function. The [I/O manager](TODO-LINK) transfers the responsibility of storing and loading DataFrames as DuckDB tables to Dagster.
 
 By the end of the tutorial, you will:
 
-- TODO - fill out with what we do
-
-
-This guide focuses on storing and loading Pandas DataFrames in DuckDB. Dagster also supports using PySpark and Polars DataFrames with DuckDB. The concepts from this guide apply to working with PySpark and Polars DataFrames, and you can learn more about setting up and using the DuckDB I/O manager with PySpark and Polars DataFrames in the [reference guide](/integrations/duckdb/reference).
+- Understand how to interact with a DuckDB database using the DuckDB resource.
+- Understand how to use the DuckDB I/O manager to store and load DataFrames as DuckDB tables.
+- Understand how to define dependencies between assets corresponding to tables in a DuckDB database.
 
 ---
 
@@ -29,16 +28,139 @@ To complete this tutorial, you'll need:
   ```
 
 ---
+
+This tutorial is divided in two parts. Both parts will create the same assets, but how the data is stored in DuckDb will differ. In [Part 1](#part-1-using-the-duckdb-resource) you will use the DuckDB resource to manually execute SQL queries to create tables and interact with those tables. In [Part 2](#part-2-using-the-duckdb-io-manager) you will transfer the responsibility for generating the SQL to create and interact with tables to the DuckDB I/O manager. When writing your own assets, you may choose one or the other (or both) approaches depending on your storage requirements. See [When to use I/O managers](TODO-LINK) to learn more.
+
 ## Part 1: Using the DuckDB Resource
 
-### Step 1: Configure the DuckDB Resource
-To configure the DuckDB resource, you must provide a path to a DuckDB database. If this database does not exist, it will be created for you:
+### Step 1: Create tables in DuckDB
+
+<TabGroup>
+
+<TabItem name="Create DuckDB tables in Dagster">
+
+#### Create DuckDB tables in Dagster
+
+Using the DuckDB resource, you can create DuckDB tables using the DuckDB Python API:
+
+```python file=/integrations/duckdb/tutorial/resource/create_table.py startafter=start_example endbefore=end_example
+import pandas as pd
+from dagster_duckdb import DuckDBResource
+
+from dagster import asset
 
 
+@asset
+def iris_dataset(duckdb: DuckDBResource) -> None:
+    iris_df = pd.read_csv(
+        "https://docs.dagster.io/assets/iris.csv",
+        names=[
+            "sepal_length_cm",
+            "sepal_width_cm",
+            "petal_length_cm",
+            "petal_width_cm",
+            "species",
+        ],
+    )
+
+    with duckdb.get_connection() as conn:
+        conn.execute("CREATE TABLE iris.iris_dataset AS SELECT * FROM iris_df")
+```
+
+In this example, you define an asset that fetches the Iris dataset as a Pandas DataFrame and renames the columns. Then, using the DuckDB resource, the DataFrame is stored in DuckDB as the `iris.iris_dataset` table.
+
+</TabItem>
+
+<TabItem name="Make existing tables available in Dagster">
+
+#### Make existing tables available in Dagster
+
+If you already have tables in DuckDB, you may want to have other assets in Dagster depend on those tables. You can accomplish this by creating [source assets](/concepts/assets/software-defined-assets#defining-external-asset-dependencies) for these tables.
+
+```python file=/integrations/duckdb/tutorial/io_manager/source_asset.py
+from dagster import SourceAsset
+
+iris_harvest_data = SourceAsset(key="iris_harvest_data")
+```
+
+In this example, you create a <PyObject object="SourceAsset" /> for a pre-existing table called `iris_harvest_data`.
+
+</TabItem>
+
+</TabGroup>
+
+### Step 2: Configure the DuckDB resource
+
+Before you can materialize your assets, the DuckDB resource requires some configuration. You must set a path to a duckdb database as the `database` configuration value. If the database does not already exist, it will be created for you:
+
+```python file=/integrations/duckdb/tutorial/resource/configuration.py
+from dagster import asset
+
+
+@asset
+def iris_dataset():
+    return None
+
+
+# start_example
+
+from dagster_duckdb import DuckDBResource
+
+from dagster import Definitions
+
+defs = Definitions(
+    assets=[iris_dataset],
+    resources={
+        "duckdb": DuckDBResource(
+            database="path/to/my_duckdb_database.duckdb",  # required
+        )
+    },
+)
+
+
+# end_example
+```
+
+Now you can run `dagster dev` and materialize the `iris_dataset` asset from the Dagster UI.
 
 ---
 
+### Step 3: Define downstream assets
+
+Once you have created an asset or source asset that represents a table in DuckDB, you will likely want to create additional assets that work with the data.
+
+```python file=/integrations/duckdb/tutorial/resource/downstream.py startafter=start_example endbefore=end_example
+from dagster import asset
+
+from ..io_manager.source_asset import iris_harvest_data
+
+# this example uses the iris_dataset asset from Step 1
+
+
+@asset(deps=[iris_dataset])
+def iris_setosa(duckdb: DuckDBResource) -> None:
+    with duckdb.get_connection() as conn:
+        conn.execute(
+            "CREATE TABLE iris.iris_setosa AS SELECT * FROM iris.iris_dataset WHERE"
+            " species = 'Iris-setosa'"
+        )
+```
+
+In this asset, you create second table that just contains the data for the Iris Setosa species. This asset has a dependency on the `iris_dataset` asset. To define this dependency, you provide the `iris_dataset` asset as a `dep` to the `iris_setosa` asset. You can then run the SQL query to create the table of Iris Setosa data.
+
+### Completed code example
+
+When finished, your code should look like the following:
+
+```python file=/integrations/duckdb/tutorial/resource/full_example.py startafter=start_example endbefore=end_example
+No match for startAfter value "start_example"
+```
+
 ## Part 2: Using the DuckDB I/O Manager
+
+You may want to use an I/O manager to handle storing DataFrames as tables in DuckDB and loading DuckDB tables as DataFrames in downstream assets. Using an I/O manager is not required, and you can reference [When to use I/O managers](TODO-LINK) to learn more.
+
+This section of the guide focuses on storing and loading Pandas DataFrames in DuckDB, but Dagster also supports using PySpark and Polars DataFrames with DuckDB. The concepts from this guide apply to working with PySpark and Polars DataFrames, and you can learn more about setting up and using the DuckDB I/O manager with PySpark and Polars DataFrames in the [reference guide](/integrations/duckdb/reference).
 
 ### Step 1: Configure the DuckDB I/O manager
 
@@ -60,14 +182,6 @@ defs = Definitions(
 )
 ```
 
-With this configuration, if you materialized an asset called `iris_dataset`, the DuckDB I/O manager would store the data in the `IRIS.IRIS_DATASET` table in a database stored at `path/to/my_duckdb_database.duckdb`.
-
-Finally, in the <PyObject object="Definitions" /> object, we assign the <PyObject module="dagster_duckdb_pandas" object="DuckDBPandasIOManager" /> to the `io_manager` key. `io_manager` is a reserved key to set the default I/O manager for your assets.
-
-For more info about each of the configuration values, refer to the <PyObject module="dagster_duckdb_pandas" object="DuckDBPandasIOManager" /> API documentation.
-
----
-
 ### Step 2: Create tables in DuckDB
 
 The DuckDB I/O manager can create and update tables for your Dagster-defined assets, but you can also make existing DuckDB tables available to Dagster.
@@ -78,7 +192,7 @@ The DuckDB I/O manager can create and update tables for your Dagster-defined ass
 
 #### Store a Dagster asset as a table in DuckDB
 
-To store data in DuckDB using the DuckDB I/O manager, the definitions of your assets don't need to change. You can tell Dagster to use the DuckDB I/O manager, like in [Step 1: Configure the DuckDB I/O manager](#step-1-configure-the-duckdb-io-manager), and Dagster will handle storing and loading your assets in DuckDB.
+To store data in DuckDB using the DuckDB I/O manager, you can simply return a Pandas DataFrame from your asset. Dagster will handle storing and loading your assets in DuckDB.
 
 ```python file=/integrations/duckdb/tutorial/io_manager/basic_example.py
 import pandas as pd
@@ -100,7 +214,7 @@ def iris_dataset() -> pd.DataFrame:
     )
 ```
 
-In this example, we first define our [asset](/concepts/assets/software-defined-assets). Here, we are fetching the Iris dataset as a Pandas DataFrame and renaming the columns. The type signature of the function tells the I/O manager what data type it is working with, so it is important to include the return type `pd.DataFrame`.
+In this example, you define an asset that fetches the Iris dataset as a Pandas DataFrame, renames the columns, then returns the DataFrame. The type signature of the function tells the I/O manager what data type it is working with, so it is important to include the return type `pd.DataFrame`.
 
 When Dagster materializes the `iris_dataset` asset using the configuration from [Step 1: Configure the DuckDB I/O manager](#step-1-configure-the-duckdb-io-manager), the DuckDB I/O manager will create the table `IRIS.IRIS_DATASET` if it does not exist and replace the contents of the table with the value returned from the `iris_dataset` asset.
 
@@ -118,9 +232,9 @@ from dagster import SourceAsset
 iris_harvest_data = SourceAsset(key="iris_harvest_data")
 ```
 
-In this example, we create a <PyObject object="SourceAsset" /> for a pre-existing table containing iris harvests data. To make the data available to other Dagster assets, we need to tell the DuckDB I/O manager how to find the data.
+In this example, you create a <PyObject object="SourceAsset" /> for a pre-existing table containing iris harvests data. To make the data available to other Dagster assets, you need to tell the DuckDB I/O manager how to find the data.
 
-Because we already supplied the database and schema in the I/O manager configuration in [Step 1: Configure the DuckDB I/O manager](#step-1-configure-the-duckdb-io-manager), we only need to provide the table name. We do this with the `key` parameter in `SourceAsset`. When the I/O manager needs to load the `iris_harvest_data` in a downstream asset, it will select the data in the `IRIS.IRIS_HARVEST_DATA` table as a Pandas DataFrame and provide it to the downstream asset.
+Because you already supplied the database and schema in the I/O manager configuration in [Step 1: Configure the DuckDB I/O manager](#step-1-configure-the-duckdb-io-manager), you only need to provide the table name. This is done with the `key` parameter in `SourceAsset`. When the I/O manager needs to load the `iris_harvest_data` in a downstream asset, it will select the data in the `IRIS.IRIS_HARVEST_DATA` table as a Pandas DataFrame and provide it to the downstream asset.
 
 </TabItem>
 </TabGroup>
@@ -140,15 +254,11 @@ from dagster import asset
 
 
 @asset
-def iris_cleaned(iris_dataset: pd.DataFrame) -> pd.DataFrame:
-    return iris_dataset.dropna().drop_duplicates()
+def iris_setosa(iris_dataset: pd.DataFrame) -> pd.DataFrame:
+    return iris_dataset[iris_dataset["species"] == "Iris-setosa"]
 ```
 
-In this example, we want to provide the `iris_dataset` asset from the [Store a Dagster asset as a table in DuckDB](#store-a-dagster-asset-as-a-table-in-duckdb) example to the `iris_cleaned` asset.
-
-In `iris_cleaned`, the `iris_dataset` parameter tells Dagster that the value for the `iris_dataset` asset should be provided as input to `iris_cleaned`. If this feels too magical for you, refer to the [docs for explicitly specifying dependencies](/concepts/assets/software-defined-assets#defining-explicit-managed-loading-dependencies).
-
-When materializing these assets, Dagster will use the `DuckDBPandasIOManager` to fetch the `IRIS.IRIS_DATASET` as a Pandas DataFrame and pass this DataFrame as the `iris_dataset` parameter to `iris_cleaned`. When `iris_cleaned` returns a Pandas DataFrame, Dagster will use the `DuckDBPandasIOManager` to store the DataFrame as the `IRIS.IRIS_CLEANED` table in DuckDB.
+In this asset, you provide the `iris_dataset` asset as a dependency to `iris_setosa`. The `DuckDBPandasIOManager` will load this asset into memory as a Pandas DataFrame. Then you create a DataFrame that just contains the data for the Iris Setosa species and return the DataFrame. Then the `DuckDBPandasIOManager` will store the DataFrame as the `IRIS.IRIS_SETOSA` table in DuckDB.
 
 ---
 
@@ -180,12 +290,12 @@ def iris_dataset() -> pd.DataFrame:
 
 
 @asset
-def iris_cleaned(iris_dataset: pd.DataFrame) -> pd.DataFrame:
-    return iris_dataset.dropna().drop_duplicates()
+def iris_setosa(iris_dataset: pd.DataFrame) -> pd.DataFrame:
+    return iris_dataset[iris_dataset["species"] == "Iris-setosa"]
 
 
 defs = Definitions(
-    assets=[iris_dataset, iris_harvest_data, iris_cleaned],
+    assets=[iris_dataset, iris_harvest_data, iris_setosa],
     resources={
         "io_manager": DuckDBPandasIOManager(
             database="path/to/my_duckdb_database.duckdb",

--- a/docs/content/integrations/duckdb/using-duckdb-with-dagster.mdx
+++ b/docs/content/integrations/duckdb/using-duckdb-with-dagster.mdx
@@ -21,7 +21,7 @@ In [Part 2](#part-2-using-the-duckdb-io-manager) you will:
 - Use Pandas to create a DataFrame, then delegate responsibility creating a table to the DuckDB I/O manager.
 - Use the DuckDB I/O manager to load the table into memory so that you can interact with it using the Pandas library.
 
-When writing your own assets, you may choose one or the other (or both) approaches depending on your storage requirements. See [When to use I/O managers](/concepts/io-managers#when-to-use-io-managers) to learn more.
+When writing your own assets, you may choose one or the other (or both) approaches depending on your storage requirements. See [When to use I/O managers](/concepts/io-management/io-managers#when-to-use-io-managers) to learn more.
 
 By the end of the tutorial, you will:
 
@@ -196,7 +196,7 @@ defs = Definitions(
 
 ## Part 2: Using the DuckDB I/O manager
 
-You may want to use an I/O manager to handle storing DataFrames as tables in DuckDB and loading DuckDB tables as DataFrames in downstream assets. Using an I/O manager is not required, and you can reference [When to use I/O managers](/concepts/io-managers#when-to-use-io-managers) to learn more.
+You may want to use an I/O manager to handle storing DataFrames as tables in DuckDB and loading DuckDB tables as DataFrames in downstream assets. Using an I/O manager is not required, and you can reference [When to use I/O managers](/concepts/io-management/io-managers#when-to-use-io-managers) to learn more.
 
 This section of the guide focuses on storing and loading Pandas DataFrames in DuckDB, but Dagster also supports using PySpark and Polars DataFrames with DuckDB. The concepts from this guide apply to working with PySpark and Polars DataFrames, and you can learn more about setting up and using the DuckDB I/O manager with PySpark and Polars DataFrames in the [reference guide](/integrations/duckdb/reference).
 

--- a/examples/docs_snippets/docs_snippets/integrations/duckdb/tutorial/io_manager/full_example.py
+++ b/examples/docs_snippets/docs_snippets/integrations/duckdb/tutorial/io_manager/full_example.py
@@ -21,12 +21,12 @@ def iris_dataset() -> pd.DataFrame:
 
 
 @asset
-def iris_cleaned(iris_dataset: pd.DataFrame) -> pd.DataFrame:
-    return iris_dataset.dropna().drop_duplicates()
+def iris_setosa(iris_dataset: pd.DataFrame) -> pd.DataFrame:
+    return iris_dataset[iris_dataset["species"] == "Iris-setosa"]
 
 
 defs = Definitions(
-    assets=[iris_dataset, iris_harvest_data, iris_cleaned],
+    assets=[iris_dataset, iris_harvest_data, iris_setosa],
     resources={
         "io_manager": DuckDBPandasIOManager(
             database="path/to/my_duckdb_database.duckdb",

--- a/examples/docs_snippets/docs_snippets/integrations/duckdb/tutorial/io_manager/load_downstream.py
+++ b/examples/docs_snippets/docs_snippets/integrations/duckdb/tutorial/io_manager/load_downstream.py
@@ -10,8 +10,8 @@ from dagster import asset
 
 
 @asset
-def iris_cleaned(iris_dataset: pd.DataFrame) -> pd.DataFrame:
-    return iris_dataset.dropna().drop_duplicates()
+def iris_setosa(iris_dataset: pd.DataFrame) -> pd.DataFrame:
+    return iris_dataset[iris_dataset["species"] == "Iris-setosa"]
 
 
 # end_example

--- a/examples/docs_snippets/docs_snippets/integrations/duckdb/tutorial/resource/configuration.py
+++ b/examples/docs_snippets/docs_snippets/integrations/duckdb/tutorial/resource/configuration.py
@@ -1,0 +1,25 @@
+from dagster import asset
+
+
+@asset
+def iris_dataset():
+    return None
+
+
+# start_example
+
+from dagster_duckdb import DuckDBResource
+
+from dagster import Definitions
+
+defs = Definitions(
+    assets=[iris_dataset],
+    resources={
+        "duckdb": DuckDBResource(
+            database="path/to/my_duckdb_database.duckdb",  # required
+        )
+    },
+)
+
+
+# end_example

--- a/examples/docs_snippets/docs_snippets/integrations/duckdb/tutorial/resource/create_table.py
+++ b/examples/docs_snippets/docs_snippets/integrations/duckdb/tutorial/resource/create_table.py
@@ -1,0 +1,25 @@
+# start_example
+import pandas as pd
+from dagster_duckdb import DuckDBResource
+
+from dagster import asset
+
+
+@asset
+def iris_dataset(duckdb: DuckDBResource) -> None:
+    iris_df = pd.read_csv(
+        "https://docs.dagster.io/assets/iris.csv",
+        names=[
+            "sepal_length_cm",
+            "sepal_width_cm",
+            "petal_length_cm",
+            "petal_width_cm",
+            "species",
+        ],
+    )
+
+    with duckdb.get_connection() as conn:
+        conn.execute("CREATE TABLE iris.iris_dataset AS SELECT * FROM iris_df")
+
+
+# end_example

--- a/examples/docs_snippets/docs_snippets/integrations/duckdb/tutorial/resource/downstream.py
+++ b/examples/docs_snippets/docs_snippets/integrations/duckdb/tutorial/resource/downstream.py
@@ -4,8 +4,6 @@ from dagster_duckdb.resource import DuckDBResource
 # start_example
 from dagster import asset
 
-from ..io_manager.source_asset import iris_harvest_data
-
 # this example uses the iris_dataset asset from Step 1
 
 

--- a/examples/docs_snippets/docs_snippets/integrations/duckdb/tutorial/resource/downstream.py
+++ b/examples/docs_snippets/docs_snippets/integrations/duckdb/tutorial/resource/downstream.py
@@ -1,0 +1,21 @@
+from create_table import iris_dataset
+from dagster_duckdb.resource import DuckDBResource
+
+# start_example
+from dagster import asset
+
+from ..io_manager.source_asset import iris_harvest_data
+
+# this example uses the iris_dataset asset from Step 1
+
+
+@asset(deps=[iris_dataset])
+def iris_setosa(duckdb: DuckDBResource) -> None:
+    with duckdb.get_connection() as conn:
+        conn.execute(
+            "CREATE TABLE iris.iris_setosa AS SELECT * FROM iris.iris_dataset WHERE"
+            " species = 'Iris-setosa'"
+        )
+
+
+# end_example

--- a/examples/docs_snippets/docs_snippets/integrations/duckdb/tutorial/resource/full_example.py
+++ b/examples/docs_snippets/docs_snippets/integrations/duckdb/tutorial/resource/full_example.py
@@ -1,0 +1,42 @@
+import pandas as pd
+from dagster_duckdb import DuckDBResource
+
+from dagster import Definitions, SourceAsset, asset
+
+iris_harvest_data = SourceAsset(key="iris_harvest_data")
+
+
+@asset
+def iris_dataset(duckdb: DuckDBResource) -> None:
+    iris_df = pd.read_csv(
+        "https://docs.dagster.io/assets/iris.csv",
+        names=[
+            "sepal_length_cm",
+            "sepal_width_cm",
+            "petal_length_cm",
+            "petal_width_cm",
+            "species",
+        ],
+    )
+
+    with duckdb.get_connection() as conn:
+        conn.execute("CREATE TABLE iris.iris_dataset AS SELECT * FROM iris_df")
+
+
+@asset(deps=[iris_dataset])
+def iris_setosa(duckdb: DuckDBResource) -> None:
+    with duckdb.get_connection() as conn:
+        conn.execute(
+            "CREATE TABLE iris.iris_setosa AS SELECT * FROM iris.iris_dataset WHERE"
+            " species = 'Iris-setosa'"
+        )
+
+
+defs = Definitions(
+    assets=[iris_dataset],
+    resources={
+        "duckdb": DuckDBResource(
+            database="path/to/my_duckdb_database.duckdb",
+        )
+    },
+)


### PR DESCRIPTION
## Summary & Motivation
I want to update the three DB IO manager guides (DuckDB, Snowflake, BigQuery) to focus more on using resources and `deps` (in addition to still covering I/O managers). Starting with DuckDB, and then I will port the agreed upon changes to the other tutorials. 

My goals for the tutorial:
* teach users that they are not required to use I/O managers when they want to store data in a DB
* demonstrate how to use `deps` and the DuckDB resource
* still showcase the I/O manager so there is no reduction in quality of the existing content 


## How I Tested These Changes
