### PR TITLE
add warnings, error messages about limited support for global concurrency limits

### DIFF
--- a/docs/content/guides/limiting-concurrency-in-data-pipelines.mdx
+++ b/docs/content/guides/limiting-concurrency-in-data-pipelines.mdx
@@ -390,7 +390,10 @@ height={1638}
 
 ### Limiting op/asset concurrency across runs
 
-<Note>This feature is experimental.</Note>
+<Note>
+  This feature is experimental and is only supported with Postgres/MySQL
+  storages.
+</Note>
 
 Limits can be specified on the Dagster instance using the special op tag `dagster/concurrency_key`. If this instance limit would be exceeded by launching an op/asset, then the op/asset will be queued.
 

--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -2130,6 +2130,7 @@ type Instance {
   hasInfo: Boolean!
   hasCapturedLogManager: Boolean!
   autoMaterializePaused: Boolean!
+  supportsConcurrencyLimits: Boolean!
   concurrencyLimits: [ConcurrencyKeyInfo!]!
 }
 

--- a/js_modules/dagit/packages/core/src/graphql/types.ts
+++ b/js_modules/dagit/packages/core/src/graphql/types.ts
@@ -1292,6 +1292,7 @@ export type Instance = {
   info: Maybe<Scalars['String']>;
   runLauncher: Maybe<RunLauncher>;
   runQueuingSupported: Scalars['Boolean'];
+  supportsConcurrencyLimits: Scalars['Boolean'];
 };
 
 export type InstigationEvent = {
@@ -6592,6 +6593,10 @@ export const buildInstance = (
       overrides && overrides.hasOwnProperty('runQueuingSupported')
         ? overrides.runQueuingSupported!
         : true,
+    supportsConcurrencyLimits:
+      overrides && overrides.hasOwnProperty('supportsConcurrencyLimits')
+        ? overrides.supportsConcurrencyLimits!
+        : false,
   };
 };
 

--- a/js_modules/dagit/packages/core/src/instance/InstanceConcurrency.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceConcurrency.tsx
@@ -67,7 +67,12 @@ const InstanceConcurrencyPage = React.memo(() => {
 
   const content = data ? (
     flagInstanceConcurrencyLimits ? (
-      <ConcurrencyLimits limits={data.instance.concurrencyLimits} refetch={queryResult.refetch} />
+      <ConcurrencyLimits
+        instanceConfig={data.instance.info}
+        limits={data.instance.concurrencyLimits}
+        hasSupport={data.instance.supportsConcurrencyLimits}
+        refetch={queryResult.refetch}
+      />
     ) : (
       <Redirect to="/config" />
     )
@@ -108,9 +113,11 @@ type DialogAction =
   | undefined;
 
 export const ConcurrencyLimits: React.FC<{
+  instanceConfig: string | null;
+  hasSupport: boolean;
   limits: ConcurrencyLimitFragment[];
   refetch: () => void;
-}> = ({limits, refetch}) => {
+}> = ({instanceConfig, hasSupport, limits, refetch}) => {
   const [action, setAction] = React.useState<DialogAction>();
   const [selectedRuns, setSelectedRuns] = React.useState<string[] | undefined>(undefined);
   const [selectedKey, setSelectedKey] = React.useState<string | undefined>(undefined);
@@ -132,6 +139,36 @@ export const ConcurrencyLimits: React.FC<{
   const onDelete = (concurrencyKey: string) => {
     setAction({actionType: 'delete', concurrencyKey});
   };
+
+  if (!hasSupport && instanceConfig && instanceConfig.includes('SqliteEventLogStorage')) {
+    return (
+      <Box margin={24}>
+        <NonIdealState
+          icon="error"
+          title="No concurrency support"
+          description={
+            'This instance does not support global concurrency limits. You will need to ' +
+            'configure a different storage implementation (e.g. postgres/mysql) to use this ' +
+            'feature.'
+          }
+        />
+      </Box>
+    );
+  } else if (!hasSupport) {
+    return (
+      <Box margin={24}>
+        <NonIdealState
+          icon="error"
+          title="No concurrency support"
+          description={
+            'This instance does not currently support global concurrency limits. You may need to ' +
+            'run `dagster instance migrate` to add the necessary tables to your dagster storage ' +
+            'to support this feature.'
+          }
+        />
+      </Box>
+    );
+  }
 
   return (
     <>
@@ -555,6 +592,8 @@ export const INSTANCE_CONCURRENCY_LIMITS_QUERY = gql`
   query InstanceConcurrencyLimitsQuery {
     instance {
       id
+      info
+      supportsConcurrencyLimits
       concurrencyLimits {
         ...ConcurrencyLimitFragment
       }

--- a/js_modules/dagit/packages/core/src/instance/InstanceConcurrency.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceConcurrency.tsx
@@ -148,7 +148,7 @@ export const ConcurrencyLimits: React.FC<{
           title="No concurrency support"
           description={
             'This instance does not support global concurrency limits. You will need to ' +
-            'configure a different storage implementation (e.g. postgres/mysql) to use this ' +
+            'configure a different storage implementation (e.g. Postgres/MySQL) to use this ' +
             'feature.'
           }
         />

--- a/js_modules/dagit/packages/core/src/instance/InstanceConcurrency.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceConcurrency.tsx
@@ -113,10 +113,10 @@ type DialogAction =
   | undefined;
 
 export const ConcurrencyLimits: React.FC<{
-  instanceConfig: string | null;
-  hasSupport: boolean;
   limits: ConcurrencyLimitFragment[];
   refetch: () => void;
+  instanceConfig?: string | null;
+  hasSupport?: boolean;
 }> = ({instanceConfig, hasSupport, limits, refetch}) => {
   const [action, setAction] = React.useState<DialogAction>();
   const [selectedRuns, setSelectedRuns] = React.useState<string[] | undefined>(undefined);
@@ -154,7 +154,7 @@ export const ConcurrencyLimits: React.FC<{
         />
       </Box>
     );
-  } else if (!hasSupport) {
+  } else if (hasSupport === false) {
     return (
       <Box margin={24}>
         <NonIdealState

--- a/js_modules/dagit/packages/core/src/instance/types/InstanceConcurrency.types.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/InstanceConcurrency.types.ts
@@ -17,6 +17,8 @@ export type InstanceConcurrencyLimitsQuery = {
   instance: {
     __typename: 'Instance';
     id: string;
+    info: string | null;
+    supportsConcurrencyLimits: boolean;
     concurrencyLimits: Array<{
       __typename: 'ConcurrencyKeyInfo';
       concurrencyKey: string;

--- a/python_modules/dagster-graphql/dagster_graphql/schema/instance.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/instance.py
@@ -125,6 +125,7 @@ class GrapheneInstance(graphene.ObjectType):
     hasInfo = graphene.NonNull(graphene.Boolean)
     hasCapturedLogManager = graphene.NonNull(graphene.Boolean)
     autoMaterializePaused = graphene.NonNull(graphene.Boolean)
+    supportsConcurrencyLimits = graphene.NonNull(graphene.Boolean)
     concurrencyLimits = non_null_list(GrapheneConcurrencyKeyInfo)
 
     class Meta:
@@ -166,6 +167,9 @@ class GrapheneInstance(graphene.ObjectType):
 
     def resolve_autoMaterializePaused(self, _graphene_info: ResolveInfo):
         return get_auto_materialize_paused(self._instance)
+
+    def resolve_supportsConcurrencyLimits(self, _graphene_info: ResolveInfo):
+        return self._instance.event_log_storage.supports_global_concurrency_limits
 
     def resolve_concurrencyLimits(self, _graphene_info: ResolveInfo):
         res = []

--- a/python_modules/dagster/dagster/_cli/instance.py
+++ b/python_modules/dagster/dagster/_cli/instance.py
@@ -143,7 +143,7 @@ def check_concurrency_support(instance: DagsterInstance):
     if isinstance(instance.event_log_storage, SqliteEventLogStorage):
         raise click.ClickException(
             "This instance storage does not support global concurrency limits. You will need "
-            "to configure a different storage implementation (e.g. postgres/mysql) to use this "
+            "to configure a different storage implementation (e.g. Postgres/MySQL) to use this "
             "feature."
         )
 

--- a/python_modules/dagster/dagster/_cli/instance.py
+++ b/python_modules/dagster/dagster/_cli/instance.py
@@ -98,6 +98,7 @@ def concurrency_cli():
 @click.argument("key", required=False)
 def get_concurrency(key, **kwargs):
     with DagsterInstance.get() as instance:
+        check_concurrency_support(instance)
         if kwargs.get("all"):
             keys = instance.event_log_storage.get_concurrency_keys()
             if not keys:
@@ -128,5 +129,28 @@ def concurrency_print_key(instance: DagsterInstance, key: str):
 @click.argument("limit", required=True, type=click.INT)
 def set_concurrency(key, limit):
     with DagsterInstance.get() as instance:
+        check_concurrency_support(instance)
         instance.event_log_storage.set_concurrency_slots(key, limit)
         click.echo(f"Set concurrency limit for {key} to {limit}.")
+
+
+def check_concurrency_support(instance: DagsterInstance):
+    from dagster._core.storage.event_log.sqlite.sqlite_event_log import SqliteEventLogStorage
+
+    if instance.event_log_storage.supports_global_concurrency_limits:
+        return
+
+    if isinstance(instance.event_log_storage, SqliteEventLogStorage):
+        raise click.ClickException(
+            "This instance storage does not support global concurrency limits. You will need "
+            "to configure a different storage implementation (e.g. postgres/mysql) to use this "
+            "feature."
+        )
+
+    # not a sqlite storage, but may not have run `dagster instance migrate` to add the tables for
+    # concurrency support
+    raise click.ClickException(
+        "This instance storage does not currently support global concurrency limits. You may need "
+        "to run `dagster instance migrate` to add the necessary tables in your dagster storage to "
+        "support this feature."
+    )

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_concurrency_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_concurrency_command.py
@@ -11,7 +11,22 @@ def mock_instance_runner():
     with tempfile.TemporaryDirectory() as dagster_home_temp:
         with instance_for_test(
             temp_dir=dagster_home_temp,
+            overrides={
+                "event_log_storage": {
+                    "module": "dagster.utils.test",
+                    "class": "ConcurrencyEnabledSqliteTestEventLogStorage",
+                    "config": {"base_dir": dagster_home_temp},
+                }
+            },
         ) as instance:
+            runner = CliRunner(env={"DAGSTER_HOME": dagster_home_temp})
+            yield instance, runner
+
+
+@pytest.fixture(name="unsupported_instance_runner")
+def mock_unsupported_instance_runner():
+    with tempfile.TemporaryDirectory() as dagster_home_temp:
+        with instance_for_test(temp_dir=dagster_home_temp) as instance:
             runner = CliRunner(env={"DAGSTER_HOME": dagster_home_temp})
             yield instance, runner
 
@@ -46,3 +61,14 @@ def test_set_concurrency(instance_runner):
     result = runner.invoke(set_concurrency, ["foo", "1"])
     assert result.exit_code == 0
     assert "Set concurrency limit for foo to 1" in result.output
+
+
+def test_unsupported(unsupported_instance_runner):
+    _instance, runner = unsupported_instance_runner
+    result = runner.invoke(get_concurrency)
+    assert result.exit_code == 1
+    assert "does not support global concurrency limits" in result.output
+
+    result = runner.invoke(set_concurrency, ["foo", "1"])
+    assert result.exit_code == 1
+    assert "does not support global concurrency limits" in result.output


### PR DESCRIPTION
## Summary & Motivation
Got some bug reports of global op concurrency not working correctly... We weren't gating the UI/CLI correctly on storage support for it.

## How I Tested These Changes
Inspection, changed storage layer to default sqlite storage.