### PR TITLE
Don't store empty evaluations

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -553,6 +553,7 @@ def build_auto_materialize_asset_evaluations(
             asset_graph, asset_key, conditions, dynamic_partitions_store
         )
         for asset_key, conditions in conditions_by_asset_key.items()
+        if conditions
     ]
 
 


### PR DESCRIPTION
We use default dicts so these can get filled with empty items. We could put a check everywhere we insert but I think this does the trick