### PR TITLE
[ui] Automaterialization: Show correct middle panel for evaluation id

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AssetAutomaterializePolicyPage.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AssetAutomaterializePolicyPage.tsx
@@ -111,7 +111,9 @@ export const AssetAutomaterializePolicyPage = ({
             <AutomaterializeMiddlePanel
               assetKey={assetKey}
               assetHasDefinedPartitions={assetHasDefinedPartitions}
-              selectedEvaluationId={selectedEvaluationId}
+              // Use the evaluation ID of the current evaluation object, if any. Otherwise
+              // fall back to the evaluation ID from the query parameter, if any.
+              selectedEvaluationId={selectedEvaluation?.evaluationId || selectedEvaluationId}
               maxMaterializationsPerMinute={maxMaterializationsPerMinute}
             />
           </Box>


### PR DESCRIPTION
## Summary & Motivation

When landing on the automaterialization page for an asset, we're currently showing a middle panel with no evaluation contents inside of it, even if the first evaluation in the list has actual evaluation state.

This is because we're passing through the `evaluation` ID value from the query parameter, which may be undefined. When this happens, no matching evaluation is found in the list retrieved by the middle panel, so we always show the "no conditions met" state.

Instead, when an evaluation has been found at the page level for the evaluation ID query value (including in the case where evaluation ID is undefined, and we just pick the first evaluation in the list), use that evaluation ID as the selected evaluation ID for the middle panel. This way we have an evaluation ID for that evaluation object to use when querying in the middle panel, which should result in the correct evaluation appearing there. If no evaluation ID is provided because no evaluation was found, fall back to "no conditions met".

I feel like there's probably a way to do this without the middle panel requerying and without losing our place while paginating, but I don't think I have time right now to try to hunt that down.

## How I Tested These Changes

Kick off a materialization of an upstream asset. Verify that when the downstream asset begins its launch, viewing its automaterialization page with no specific evaluation ID correctly shows the "launched" evaluation selected on the left and shown in detail in the middle panel.
