### PR TITLE
Publish docs changes to branch-stable preview alias URLs

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Get branch preview subdomain
         if: github.event_name == 'pull_request'
-        run: echo "BRANCH_PREVIEW_SUBDOMAIN=$(( echo "${{ github.head_ref || github.ref_name }}" | sed 's/\//-/g' ))" >> "${GITHUB_ENV}"
+        run: echo "BRANCH_PREVIEW_SUBDOMAIN=$(( echo \"${{ github.head_ref || github.ref_name }}\" | sed 's/\//-/g' ))" >> "${GITHUB_ENV}"
       - name: Checkout
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: actions/checkout@v3

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -16,10 +16,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - name: Print environment
-        run: env
-      - name: ECHO branch
-        run: echo "Branch is ${{ github.head_ref || github.ref_name }}"
+      - name: Get branch preview subdomain
+        if: github.event_name == 'pull_request'
+        run: echo "BRANCH_PREVIEW_SUBDOMAIN=$(( echo "${{ github.head_ref || github.ref_name }}" | sed 's/\//-/g' ))" >> "${GITHUB_ENV}"
       - name: Checkout
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: actions/checkout@v3
@@ -64,7 +63,7 @@ jobs:
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           scope: ${{ secrets.VERCEL_ORG_ID }}
-          alias-domains: ${{ github.head_ref || github.ref_name }}.dagster-docs.io
+          alias-domains: ${{ env.BRANCH_PREVIEW_SUBDOMAIN }}.dagster.dagster-docs.io
 
       - name: Publish to Vercel
         uses: amondnet/vercel-action@v25

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -60,6 +60,7 @@ jobs:
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           scope: ${{ secrets.VERCEL_ORG_ID }}
+          alias-domains: {{BRANCH}}-dagster-elementl.vercel.app
 
       - name: Publish to Vercel
         uses: amondnet/vercel-action@v25

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -60,7 +60,7 @@ jobs:
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           scope: ${{ secrets.VERCEL_ORG_ID }}
-          alias-domains: {{BRANCH}}.dagster-docs.io
+          alias-domains: ${{ GITHUB_REF_NAME }}.dagster-docs.io
 
       - name: Publish to Vercel
         uses: amondnet/vercel-action@v25

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -16,6 +16,10 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
+      - name: Print environment
+        run: env
+      - name: ECHO branch
+        run: echo "Branch is ${{ github.head_ref || github.ref_name }}"
       - name: Checkout
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: actions/checkout@v3
@@ -60,7 +64,7 @@ jobs:
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           scope: ${{ secrets.VERCEL_ORG_ID }}
-          alias-domains: ${{ env.GITHUB_REF_NAME }}.dagster-docs.io
+          alias-domains: ${{ github.head_ref || github.ref_name }}.dagster-docs.io
 
       - name: Publish to Vercel
         uses: amondnet/vercel-action@v25

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -60,7 +60,7 @@ jobs:
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           scope: ${{ secrets.VERCEL_ORG_ID }}
-          alias-domains: ${{ GITHUB_REF_NAME }}.dagster-docs.io
+          alias-domains: ${{ env.GITHUB_REF_NAME }}.dagster-docs.io
 
       - name: Publish to Vercel
         uses: amondnet/vercel-action@v25

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Get branch preview subdomain
         if: github.event_name == 'pull_request'
-        run: echo "BRANCH_PREVIEW_SUBDOMAIN=$(( echo \"${{ github.head_ref || github.ref_name }}\" | sed 's/\//-/g' ))" >> "${GITHUB_ENV}"
+        run: echo "BRANCH_PREVIEW_SUBDOMAIN=$(( echo '${{ github.head_ref || github.ref_name }}' | sed 's/\//-/g' ))" >> "${GITHUB_ENV}"
       - name: Checkout
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: actions/checkout@v3

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -60,7 +60,7 @@ jobs:
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           scope: ${{ secrets.VERCEL_ORG_ID }}
-          alias-domains: {{BRANCH}}-dagster-elementl.vercel.app
+          alias-domains: {{BRANCH}}.dagster-docs.io
 
       - name: Publish to Vercel
         uses: amondnet/vercel-action@v25

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -18,7 +18,10 @@ jobs:
     steps:
       - name: Get branch preview subdomain
         if: github.event_name == 'pull_request'
-        run: echo "BRANCH_PREVIEW_SUBDOMAIN=$(( echo '${{ github.head_ref || github.ref_name }}' | sed 's/\//-/g' ))" >> "${GITHUB_ENV}"
+        run: |
+          BRANCH_PREVIEW_SUBDOMAIN=$(echo "${{ github.head_ref || github.ref_name }}" | sed 's/\//-/g')
+          echo "$BRANCH_PREVIEW_SUBDOMAIN"
+          echo "BRANCH_PREVIEW_SUBDOMAIN=$BRANCH_PREVIEW_SUBDOMAIN" >> "${GITHUB_ENV}"
       - name: Checkout
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: actions/checkout@v3

--- a/docs/content/getting-started.mdx
+++ b/docs/content/getting-started.mdx
@@ -2,7 +2,7 @@
 title: "Welcome to Dagster! | Dagster Docs"
 ---
 
-# Welcome to Dagster!
+# Welcome to Dagster!!!
 
 Dagster is an orchestrator that's designed for developing and maintaining data assets, such as tables, data sets, machine learning models, and reports.
 

--- a/docs/content/getting-started.mdx
+++ b/docs/content/getting-started.mdx
@@ -2,7 +2,7 @@
 title: "Welcome to Dagster! | Dagster Docs"
 ---
 
-# Welcome to Dagster!!!
+# Welcome to Dagster!
 
 Dagster is an orchestrator that's designed for developing and maintaining data assets, such as tables, data sets, machine learning models, and reports.
 


### PR DESCRIPTION
## Summary & Motivation
We want to have branch-stable preview URLs, so that docs edits won't generate new URLs.  This is useful for previewing things like release-candidates, etc.

In the github-actions comment, each preview will now have two URLs:
* The revision-specific preview URL (e.g. `dagster-docs-<hash>-elementl.vercel.app`)
* The branch-specific preview URL (e.g. `<branch_name>.dagster.dagster-docs.io`)

We'll have a similar setup for things like `dagster-website` / `elementl-website` (e.g. `<branch_name>.dagster-website.dagster-docs.io`).

If there's a preferred alternate domain, I can buy that domain instead.

## How I Tested These Changes
[prha-docs.dagster.dagster-docs.io](https://prha-docs.dagster.dagster-docs.io/)
