### PR TITLE
[fix] Ensure Airbyte, Fivetran Pythonic resources go through initialization when loading from instance

### DIFF
--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
@@ -614,7 +614,7 @@ class AirbyteInstanceCacheableAssetsDefinition(AirbyteCoreCacheableAssetsDefinit
         )
         self._workspace_id = workspace_id
         self._airbyte_instance: AirbyteResource = (
-            airbyte_resource_def
+            airbyte_resource_def.process_config_and_initialize()
             if isinstance(airbyte_resource_def, AirbyteResource)
             else airbyte_resource_def(build_init_resource_context())
         )

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_load_from_instance.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_load_from_instance.py
@@ -4,6 +4,7 @@ import pytest
 import responses
 from dagster import (
     AssetKey,
+    EnvVar,
     FreshnessPolicy,
     InputContext,
     IOManager,
@@ -18,6 +19,7 @@ from dagster._core.definitions.metadata.table import TableColumn, TableSchema
 from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvalidInvocationError
 from dagster._core.execution.context.init import build_init_resource_context
 from dagster._core.execution.with_resources import with_resources
+from dagster._core.instance_for_test import environ
 from dagster_airbyte import AirbyteCloudResource, AirbyteResource, airbyte_resource
 from dagster_airbyte.asset_defs import AirbyteConnectionMetadata, load_assets_from_airbyte_instance
 
@@ -33,11 +35,14 @@ TEST_FRESHNESS_POLICY = FreshnessPolicy(maximum_lag_minutes=60)
 
 
 @pytest.fixture(name="airbyte_instance", params=[True, False], scope="module")
-def airbyte_instance_fixture(request) -> AirbyteResource:
-    if request.param:
-        return AirbyteResource(host="some_host", port="8000")
-    else:
-        return airbyte_resource(build_init_resource_context({"host": "some_host", "port": "8000"}))
+def airbyte_instance_fixture(request):
+    with environ({"AIRBYTE_HOST": "some_host"}):
+        if request.param:
+            yield AirbyteResource(host=EnvVar("AIRBYTE_HOST"), port="8000")
+        else:
+            yield airbyte_resource(
+                build_init_resource_context({"host": "some_host", "port": "8000"})
+            )
 
 
 @responses.activate
@@ -77,21 +82,22 @@ def test_load_from_instance(
 
         return TestIOManager()
 
+    base_url = "http://some_host:8000/api/v1"
     responses.add(
         method=responses.POST,
-        url=airbyte_instance.api_base_url + "/workspaces/list",
+        url=base_url + "/workspaces/list",
         json=get_instance_workspaces_json(),
         status=200,
     )
     responses.add(
         method=responses.POST,
-        url=airbyte_instance.api_base_url + "/connections/list",
+        url=base_url + "/connections/list",
         json=get_instance_connections_json(),
         status=200,
     )
     responses.add(
         method=responses.POST,
-        url=airbyte_instance.api_base_url + "/operations/list",
+        url=base_url + "/operations/list",
         json=get_instance_operations_json(),
         status=200,
     )
@@ -228,19 +234,19 @@ def test_load_from_instance(
 
     responses.add(
         method=responses.POST,
-        url=airbyte_instance.api_base_url + "/connections/get",
+        url=base_url + "/connections/get",
         json=get_project_connection_json(),
         status=200,
     )
     responses.add(
         method=responses.POST,
-        url=airbyte_instance.api_base_url + "/connections/sync",
+        url=base_url + "/connections/sync",
         json={"job": {"id": 1}},
         status=200,
     )
     responses.add(
         method=responses.POST,
-        url=airbyte_instance.api_base_url + "/jobs/get",
+        url=base_url + "/jobs/get",
         json=get_project_job_json(),
         status=200,
     )

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
@@ -320,7 +320,7 @@ class FivetranInstanceCacheableAssetsDefinition(CacheableAssetsDefinition):
     ):
         self._fivetran_resource_def = fivetran_resource_def
         self._fivetran_instance: FivetranResource = (
-            fivetran_resource_def
+            fivetran_resource_def.process_config_and_initialize()
             if isinstance(fivetran_resource_def, FivetranResource)
             else fivetran_resource_def(build_init_resource_context())
         )

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_load_from_instance.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_load_from_instance.py
@@ -1,3 +1,4 @@
+import base64
 from typing import Any
 
 import pytest
@@ -5,6 +6,7 @@ import responses
 from dagster import (
     AssetIn,
     AssetKey,
+    EnvVar,
     InputContext,
     IOManager,
     OutputContext,
@@ -15,11 +17,13 @@ from dagster._core.definitions.assets_job import build_assets_job
 from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.definitions.metadata.table import TableColumn, TableSchema
 from dagster._core.execution.with_resources import with_resources
+from dagster._core.instance_for_test import environ
 from dagster_fivetran import FivetranResource
 from dagster_fivetran.asset_defs import (
     FivetranConnectionMetadata,
     load_assets_from_fivetran_instance,
 )
+from responses import matchers
 
 from dagster_fivetran_tests.utils import (
     DEFAULT_CONNECTOR_ID,
@@ -48,173 +52,184 @@ from dagster_fivetran_tests.utils import (
 def test_load_from_instance(
     connector_to_group_fn, filter_connector, connector_to_asset_key_fn, multiple_connectors
 ):
-    load_calls = []
+    with environ({"FIVETRAN_API_KEY": "some_key", "FIVETRAN_API_SECRET": "some_secret"}):
+        load_calls = []
 
-    @io_manager
-    def test_io_manager(_context) -> IOManager:
-        class TestIOManager(IOManager):
-            def handle_output(self, context: OutputContext, obj) -> None:
-                assert context.dagster_type.is_nothing
-                return
+        @io_manager
+        def test_io_manager(_context) -> IOManager:
+            class TestIOManager(IOManager):
+                def handle_output(self, context: OutputContext, obj) -> None:
+                    assert context.dagster_type.is_nothing
+                    return
 
-            def load_input(self, context: InputContext) -> Any:
-                load_calls.append(context.asset_key)
-                return None
+                def load_input(self, context: InputContext) -> Any:
+                    load_calls.append(context.asset_key)
+                    return None
 
-        return TestIOManager()
+            return TestIOManager()
 
-    ft_resource = FivetranResource(api_key="some_key", api_secret="some_secret")
-
-    with responses.RequestsMock() as rsps:
-        rsps.add(
-            method=rsps.GET,
-            url=ft_resource.api_base_url + "groups",
-            json=get_sample_groups_response(),
-            status=200,
+        ft_resource = FivetranResource(
+            api_key=EnvVar("FIVETRAN_API_KEY"), api_secret=EnvVar("FIVETRAN_API_SECRET")
         )
-        rsps.add(
-            method=rsps.GET,
-            url=ft_resource.api_base_url + "groups/some_group/connectors",
-            json=get_sample_connectors_response_multiple()
-            if multiple_connectors
-            else get_sample_connectors_response(),
-            status=200,
-        )
-        rsps.add(
-            rsps.GET,
-            f"{ft_resource.api_connector_url}{DEFAULT_CONNECTOR_ID}/schemas",
-            json=get_complex_sample_connector_schema_config(),
-        )
-        if multiple_connectors:
+
+        b64_encoded_auth_str = base64.b64encode(b"some_key:some_secret").decode("utf-8")
+        expected_auth_header = {"Authorization": f"Basic {b64_encoded_auth_str}"}
+
+        with responses.RequestsMock() as rsps:
+            rsps.add(
+                method=rsps.GET,
+                url=ft_resource.api_base_url + "groups",
+                json=get_sample_groups_response(),
+                status=200,
+                match=[matchers.header_matcher(expected_auth_header)],
+            )
+            rsps.add(
+                method=rsps.GET,
+                url=ft_resource.api_base_url + "groups/some_group/connectors",
+                json=get_sample_connectors_response_multiple()
+                if multiple_connectors
+                else get_sample_connectors_response(),
+                status=200,
+                match=[matchers.header_matcher(expected_auth_header)],
+            )
             rsps.add(
                 rsps.GET,
-                f"{ft_resource.api_connector_url}{DEFAULT_CONNECTOR_ID_2}/schemas",
+                f"{ft_resource.api_connector_url}{DEFAULT_CONNECTOR_ID}/schemas",
                 json=get_complex_sample_connector_schema_config(),
             )
+            if multiple_connectors:
+                rsps.add(
+                    rsps.GET,
+                    f"{ft_resource.api_connector_url}{DEFAULT_CONNECTOR_ID_2}/schemas",
+                    json=get_complex_sample_connector_schema_config(),
+                    match=[matchers.header_matcher(expected_auth_header)],
+                )
 
-        if connector_to_group_fn:
-            ft_cacheable_assets = load_assets_from_fivetran_instance(
-                ft_resource,
-                connector_to_group_fn=connector_to_group_fn,
-                connector_filter=(lambda _: False) if filter_connector else None,
-                connector_to_asset_key_fn=connector_to_asset_key_fn,
-                connector_to_io_manager_key_fn=(lambda _: "test_io_manager"),
+            if connector_to_group_fn:
+                ft_cacheable_assets = load_assets_from_fivetran_instance(
+                    ft_resource,
+                    connector_to_group_fn=connector_to_group_fn,
+                    connector_filter=(lambda _: False) if filter_connector else None,
+                    connector_to_asset_key_fn=connector_to_asset_key_fn,
+                    connector_to_io_manager_key_fn=(lambda _: "test_io_manager"),
+                )
+            else:
+                ft_cacheable_assets = load_assets_from_fivetran_instance(
+                    ft_resource,
+                    connector_filter=(lambda _: False) if filter_connector else None,
+                    connector_to_asset_key_fn=connector_to_asset_key_fn,
+                    io_manager_key="test_io_manager",
+                )
+            ft_assets = ft_cacheable_assets.build_definitions(
+                ft_cacheable_assets.compute_cacheable_data()
             )
-        else:
-            ft_cacheable_assets = load_assets_from_fivetran_instance(
-                ft_resource,
-                connector_filter=(lambda _: False) if filter_connector else None,
-                connector_to_asset_key_fn=connector_to_asset_key_fn,
-                io_manager_key="test_io_manager",
-            )
-        ft_assets = ft_cacheable_assets.build_definitions(
-            ft_cacheable_assets.compute_cacheable_data()
-        )
-        ft_assets = with_resources(ft_assets, {"test_io_manager": test_io_manager})
+            ft_assets = with_resources(ft_assets, {"test_io_manager": test_io_manager})
 
-    if filter_connector:
-        assert len(ft_assets) == 0
-        return
+        if filter_connector:
+            assert len(ft_assets) == 0
+            return
 
-    # Create set of expected asset keys
-    tables = {
-        AssetKey(["xyz1", "abc2"]),
-        AssetKey(["xyz1", "abc1"]),
-        AssetKey(["abc", "xyz"]),
-    }
-    if connector_to_asset_key_fn:
+        # Create set of expected asset keys
         tables = {
+            AssetKey(["xyz1", "abc2"]),
+            AssetKey(["xyz1", "abc1"]),
+            AssetKey(["abc", "xyz"]),
+        }
+        if connector_to_asset_key_fn:
+            tables = {
+                connector_to_asset_key_fn(
+                    FivetranConnectionMetadata("some_service.some_name", "", "=", []),
+                    ".".join(t.path),
+                )
+                for t in tables
+            }
+
+        # Set up a downstream asset to consume the xyz output table
+        xyz_asset_key = (
             connector_to_asset_key_fn(
                 FivetranConnectionMetadata("some_service.some_name", "", "=", []),
-                ".".join(t.path),
+                "abc.xyz",
             )
-            for t in tables
-        }
-
-    # Set up a downstream asset to consume the xyz output table
-    xyz_asset_key = (
-        connector_to_asset_key_fn(
-            FivetranConnectionMetadata("some_service.some_name", "", "=", []),
-            "abc.xyz",
+            if connector_to_asset_key_fn
+            else AssetKey(["abc", "xyz"])
         )
-        if connector_to_asset_key_fn
-        else AssetKey(["abc", "xyz"])
-    )
 
-    @asset(ins={"xyz": AssetIn(key=xyz_asset_key)})
-    def downstream_asset(xyz):
-        return
+        @asset(ins={"xyz": AssetIn(key=xyz_asset_key)})
+        def downstream_asset(xyz):
+            return
 
-    all_assets = [downstream_asset] + ft_assets
+        all_assets = [downstream_asset] + ft_assets
 
-    # Check schema metadata is added correctly to asset def
-    assert any(
-        out.metadata.get("table_schema")
-        == MetadataValue.table_schema(
-            TableSchema(
-                columns=[
-                    TableColumn(name="column_1", type="any"),
-                    TableColumn(name="column_2", type="any"),
-                    TableColumn(name="column_3", type="any"),
-                ]
+        # Check schema metadata is added correctly to asset def
+        assert any(
+            out.metadata.get("table_schema")
+            == MetadataValue.table_schema(
+                TableSchema(
+                    columns=[
+                        TableColumn(name="column_1", type="any"),
+                        TableColumn(name="column_2", type="any"),
+                        TableColumn(name="column_3", type="any"),
+                    ]
+                )
             )
+            for out in ft_assets[0].node_def.output_defs
         )
-        for out in ft_assets[0].node_def.output_defs
-    )
 
-    assert ft_assets[0].keys == tables
-    assert all(
-        [
-            ft_assets[0].group_names_by_key.get(t)
-            == (
-                connector_to_group_fn("some_service.some_name")
-                if connector_to_group_fn
-                else "some_service_some_name"
-            )
-            for t in tables
-        ]
-    )
-    assert len(ft_assets[0].op.output_defs) == len(tables)
+        assert ft_assets[0].keys == tables
+        assert all(
+            [
+                ft_assets[0].group_names_by_key.get(t)
+                == (
+                    connector_to_group_fn("some_service.some_name")
+                    if connector_to_group_fn
+                    else "some_service_some_name"
+                )
+                for t in tables
+            ]
+        )
+        assert len(ft_assets[0].op.output_defs) == len(tables)
 
-    # Kick off a run to materialize all assets
-    final_data = {"succeeded_at": "2021-01-01T02:00:00.0Z"}
-    fivetran_sync_job = build_assets_job(
-        name="fivetran_assets_job",
-        assets=all_assets,
-    )
+        # Kick off a run to materialize all assets
+        final_data = {"succeeded_at": "2021-01-01T02:00:00.0Z"}
+        fivetran_sync_job = build_assets_job(
+            name="fivetran_assets_job",
+            assets=all_assets,
+        )
 
-    with responses.RequestsMock() as rsps:
-        api_prefixes = [
-            f"{ft_resource.api_connector_url}{DEFAULT_CONNECTOR_ID}",
-        ]
-        if multiple_connectors:
-            api_prefixes.append(f"{ft_resource.api_connector_url}{DEFAULT_CONNECTOR_ID_2}")
-        for api_prefix in api_prefixes:
-            rsps.add(rsps.PATCH, api_prefix, json=get_sample_update_response())
-            rsps.add(rsps.POST, f"{api_prefix}/force", json=get_sample_sync_response())
-            # connector schema
-            rsps.add(
-                rsps.GET, f"{api_prefix}/schemas", json=get_complex_sample_connector_schema_config()
-            )
-            # initial state
-            rsps.add(rsps.GET, api_prefix, json=get_sample_connector_response())
-            # n polls before updating
-            for _ in range(2):
+        with responses.RequestsMock() as rsps:
+            api_prefixes = [
+                f"{ft_resource.api_connector_url}{DEFAULT_CONNECTOR_ID}",
+            ]
+            if multiple_connectors:
+                api_prefixes.append(f"{ft_resource.api_connector_url}{DEFAULT_CONNECTOR_ID_2}")
+            for api_prefix in api_prefixes:
+                rsps.add(rsps.PATCH, api_prefix, json=get_sample_update_response())
+                rsps.add(rsps.POST, f"{api_prefix}/force", json=get_sample_sync_response())
+                # connector schema
+                rsps.add(
+                    rsps.GET,
+                    f"{api_prefix}/schemas",
+                    json=get_complex_sample_connector_schema_config(),
+                )
+                # initial state
                 rsps.add(rsps.GET, api_prefix, json=get_sample_connector_response())
-            # final state will be updated
-            rsps.add(rsps.GET, api_prefix, json=get_sample_connector_response(data=final_data))
+                # n polls before updating
+                for _ in range(2):
+                    rsps.add(rsps.GET, api_prefix, json=get_sample_connector_response())
+                # final state will be updated
+                rsps.add(rsps.GET, api_prefix, json=get_sample_connector_response(data=final_data))
 
-        result = fivetran_sync_job.execute_in_process()
-        asset_materializations = [
-            event
-            for event in result.events_for_node("fivetran_sync_some_connector")
-            if event.event_type_value == "ASSET_MATERIALIZATION"
-        ]
-        assert len(asset_materializations) == 3
-        asset_keys = set(
-            mat.event_specific_data.materialization.asset_key for mat in asset_materializations
-        )
-        assert asset_keys == tables
+            result = fivetran_sync_job.execute_in_process()
+            asset_materializations = [
+                event
+                for event in result.events_for_node("fivetran_sync_some_connector")
+                if event.event_type_value == "ASSET_MATERIALIZATION"
+            ]
+            assert len(asset_materializations) == 3
+            asset_keys = set(
+                mat.event_specific_data.materialization.asset_key for mat in asset_materializations
+            )
+            assert asset_keys == tables
 
-        # Validate IO manager is called to retrieve the xyz asset which our downstream asset depends on
-        assert load_calls == [xyz_asset_key]
+            # Validate IO manager is called to retrieve the xyz asset which our downstream asset depends on
+            assert load_calls == [xyz_asset_key]


### PR DESCRIPTION
## Summary

Fixes an issue which arose when trying to use `EnvVar`-configured Pythonic resources in a Definitions-time context (e.g. loading Fivetran or Airbyte assets from an instance).

This was a regression which occurred as a side-effect of the change in  #14306 which made Pythonic resources expect fully processed config. #14527 introduced a new `process_config_and_initialize` method which fully evaluates a Pythonic resource's config, and fixed the DBT resources, but did not apply the same change to Fivetran and Airbyte.

This PR calls `process_config_and_initialize` as part of the load-from-instance methods in both integrations, and puts this path under test. It's unfortunate that this wasn't caught because none of our existing unit tests hit the overlap of `EnvVar` + Pythonic resource + Definitions-time load-from-instance call.

## Test Plan

Put this `EnvVar` + Pythonic resource + load-from-instance case  under unit test.
