### PR TITLE
[time-window-partitions][perf] stop validating when unnecessary

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -323,6 +323,7 @@ class TimeWindowPartitionsDefinition(
     def time_windows_for_partition_keys(
         self,
         partition_keys: Sequence[str],
+        validate: bool = True,
     ) -> Sequence[TimeWindow]:
         if len(partition_keys) == 0:
             return []
@@ -348,20 +349,21 @@ class TimeWindowPartitionsDefinition(
                 )
                 partition_key_time_windows.append(next(cur_windows_iterator))
 
-        start_time_window = self.get_first_partition_window()
-        end_time_window = self.get_last_partition_window()
+        if validate:
+            start_time_window = self.get_first_partition_window()
+            end_time_window = self.get_last_partition_window()
 
-        if end_time_window is None or start_time_window is None:
-            check.failed("No partitions in the PartitionsDefinition")
+            if start_time_window is None or end_time_window is None:
+                check.failed("No partitions in the PartitionsDefinition")
 
-        start_timestamp = start_time_window.start.timestamp()
-        end_timestamp = end_time_window.end.timestamp()
+            start_timestamp = start_time_window.start.timestamp()
+            end_timestamp = end_time_window.end.timestamp()
 
-        partition_key_time_windows = [
-            tw
-            for tw in partition_key_time_windows
-            if tw.start.timestamp() >= start_timestamp and tw.end.timestamp() <= end_timestamp
-        ]
+            partition_key_time_windows = [
+                tw
+                for tw in partition_key_time_windows
+                if tw.start.timestamp() >= start_timestamp and tw.end.timestamp() <= end_timestamp
+            ]
         return partition_key_time_windows
 
     def start_time_for_partition_key(self, partition_key: str) -> datetime:
@@ -1395,6 +1397,7 @@ class TimeWindowPartitionsSubset(PartitionsSubset):
             result_time_windows, _ = self._add_partitions_to_time_windows(
                 initial_windows=[],
                 partition_keys=list(check.not_none(self._included_partition_keys)),
+                validate=False,
             )
             self._included_time_windows = result_time_windows
         return self._included_time_windows
@@ -1474,14 +1477,17 @@ class TimeWindowPartitionsSubset(PartitionsSubset):
         ]
 
     def _add_partitions_to_time_windows(
-        self, initial_windows: Sequence[TimeWindow], partition_keys: Sequence[str]
+        self,
+        initial_windows: Sequence[TimeWindow],
+        partition_keys: Sequence[str],
+        validate: bool = True,
     ) -> Tuple[Sequence[TimeWindow], int]:
         """Merges a set of partition keys into an existing set of time windows, returning the
         minimized set of time windows and the number of partitions added.
         """
         result_windows = [*initial_windows]
         time_windows = self._partitions_def.time_windows_for_partition_keys(
-            list(partition_keys),
+            list(partition_keys), validate=validate
         )
         num_added_partitions = 0
         for window in sorted(time_windows):

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_time_window_partition_mapping.py
@@ -329,20 +329,6 @@ def test_daily_to_daily_many_to_one():
         (
             DailyPartitionsDefinition(start_date="2022-01-01"),
             DailyPartitionsDefinition(start_date="2021-01-01"),
-            ["2021-12-31"],
-            [],
-            datetime(2022, 1, 1, 1),
-        ),
-        (
-            DailyPartitionsDefinition(start_date="2022-01-01"),
-            DailyPartitionsDefinition(start_date="2021-01-01"),
-            ["2021-12-30"],
-            [],
-            datetime(2022, 12, 31, 1),
-        ),
-        (
-            DailyPartitionsDefinition(start_date="2022-01-01"),
-            DailyPartitionsDefinition(start_date="2021-01-01"),
             ["2022-12-30"],
             ["2022-12-30"],
             datetime(2022, 12, 31, 1),


### PR DESCRIPTION
## Summary & Motivation

When we create a TimeWindowPartitionsSubset, there's an implicit contract that it doesn't contain invalid partition keys. Sometimes, we create this subset using time windows directly, but sometimes (especially in the partition mapping case), we create this subset with explicit keys (which then need to be converted into time windows later on).

This short-circuits some of the checking logic in the conversion from regular partition string to time window.

This is especially important in cases where the start_offset / end_offset are non-zero, as these end up generating very expensive calls to get_last_partition_window / get_first_partition_window

## How I Tested These Changes
