### PR TITLE
Add evaluation retention line to ui

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AutomaterializeLeftPanel.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AutomaterializeLeftPanel.tsx
@@ -65,49 +65,38 @@ export const AutomaterializeLeftList = (props: ListProps) => {
         const isSelected = selectedEvaluation?.evaluationId === evaluation.evaluationId;
         if (evaluation.__typename === 'no_conditions_met') {
           return (
-            <>
-              <EvaluationListItem
-                key={`skip-${evaluation.evaluationId}`}
-                onClick={() => {
-                  onSelectEvaluation(evaluation);
-                }}
-                $selected={isSelected}
-              >
-                <Box flex={{direction: 'column', gap: 4}} style={{width: '100%'}}>
-                  <div>
-                    {evaluation.startTimestamp ? (
-                      evaluation.amount === 1 ? (
-                        '1 evaluation'
-                      ) : (
-                        `${compactNumber(evaluation.amount)} evaluations`
-                      )
+            <EvaluationListItem
+              key={`skip-${evaluation.evaluationId}`}
+              onClick={() => {
+                onSelectEvaluation(evaluation);
+              }}
+              $selected={isSelected}
+            >
+              <Box flex={{direction: 'column', gap: 4}} style={{width: '100%'}}>
+                <div>
+                  {evaluation.startTimestamp ? (
+                    evaluation.amount === 1 ? (
+                      '1 evaluation'
                     ) : (
-                      <>
-                        {evaluation.endTimestamp === 'now' ? (
-                          'Before now'
-                        ) : (
-                          <>
-                            Before <TimestampDisplay timestamp={evaluation.endTimestamp} />
-                          </>
-                        )}
-                      </>
-                    )}
-                  </div>
-                  <Caption color={isSelected ? Colors.Blue700 : Colors.Gray700}>
-                    No conditions met
-                  </Caption>
-                </Box>
-              </EvaluationListItem>
-              {!evaluation.startTimestamp ? (
-                <Box
-                  border={{side: 'top', color: Colors.KeylineGray, width: 1}}
-                  flex={{direction: 'column', gap: 4}}
-                  style={{width: '100%', padding: '20px 12px', marginTop: '12px'}}
-                >
-                  <small>Evaluations are retained for 1 week.</small>
-                </Box>
-              ) : null}
-            </>
+                      `${compactNumber(evaluation.amount)} evaluations`
+                    )
+                  ) : (
+                    <>
+                      {evaluation.endTimestamp === 'now' ? (
+                        'Before now'
+                      ) : (
+                        <>
+                          Before <TimestampDisplay timestamp={evaluation.endTimestamp} />
+                        </>
+                      )}
+                    </>
+                  )}
+                </div>
+                <Caption color={isSelected ? Colors.Blue700 : Colors.Gray700}>
+                  No conditions met
+                </Caption>
+              </Box>
+            </EvaluationListItem>
           );
         }
 
@@ -134,6 +123,13 @@ export const AutomaterializeLeftList = (props: ListProps) => {
           </EvaluationListItem>
         );
       })}
+      <Box
+        border={{side: 'top', color: Colors.KeylineGray, width: 1}}
+        padding={{vertical: 20, horizontal: 12}}
+        margin={{top: 12}}
+      >
+        <Caption>Evaluations are retained for 1 week</Caption>
+      </Box>
     </Box>
   );
 };

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AutomaterializeLeftPanel.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AutomaterializeLeftPanel.tsx
@@ -65,38 +65,49 @@ export const AutomaterializeLeftList = (props: ListProps) => {
         const isSelected = selectedEvaluation?.evaluationId === evaluation.evaluationId;
         if (evaluation.__typename === 'no_conditions_met') {
           return (
-            <EvaluationListItem
-              key={`skip-${evaluation.evaluationId}`}
-              onClick={() => {
-                onSelectEvaluation(evaluation);
-              }}
-              $selected={isSelected}
-            >
-              <Box flex={{direction: 'column', gap: 4}} style={{width: '100%'}}>
-                <div>
-                  {evaluation.startTimestamp ? (
-                    evaluation.amount === 1 ? (
-                      '1 evaluation'
-                    ) : (
-                      `${compactNumber(evaluation.amount)} evaluations`
-                    )
-                  ) : (
-                    <>
-                      {evaluation.endTimestamp === 'now' ? (
-                        'Before now'
+            <>
+              <EvaluationListItem
+                key={`skip-${evaluation.evaluationId}`}
+                onClick={() => {
+                  onSelectEvaluation(evaluation);
+                }}
+                $selected={isSelected}
+              >
+                <Box flex={{direction: 'column', gap: 4}} style={{width: '100%'}}>
+                  <div>
+                    {evaluation.startTimestamp ? (
+                      evaluation.amount === 1 ? (
+                        '1 evaluation'
                       ) : (
-                        <>
-                          Before <TimestampDisplay timestamp={evaluation.endTimestamp} />
-                        </>
-                      )}
-                    </>
-                  )}
-                </div>
-                <Caption color={isSelected ? Colors.Blue700 : Colors.Gray700}>
-                  No conditions met
-                </Caption>
-              </Box>
-            </EvaluationListItem>
+                        `${compactNumber(evaluation.amount)} evaluations`
+                      )
+                    ) : (
+                      <>
+                        {evaluation.endTimestamp === 'now' ? (
+                          'Before now'
+                        ) : (
+                          <>
+                            Before <TimestampDisplay timestamp={evaluation.endTimestamp} />
+                          </>
+                        )}
+                      </>
+                    )}
+                  </div>
+                  <Caption color={isSelected ? Colors.Blue700 : Colors.Gray700}>
+                    No conditions met
+                  </Caption>
+                </Box>
+              </EvaluationListItem>
+              {!evaluation.startTimestamp ? (
+                <Box
+                  border={{side: 'top', color: Colors.KeylineGray, width: 1}}
+                  flex={{direction: 'column', gap: 4}}
+                  style={{width: '100%', padding: '20px 12px', marginTop: '12px'}}
+                >
+                  <small>Evaluations are retained for 1 week.</small>
+                </Box>
+              ) : null}
+            </>
           );
         }
 


### PR DESCRIPTION
Josh had this in a design, I think it's really important for the `No conditions met before now` case

![Screenshot 2023-07-27 at 4 14 22 PM](https://github.com/dagster-io/dagster/assets/22018973/6321212d-40af-4536-8e23-0052d20903d4)
