### PR TITLE
Enforce max_materializations_per_minute as positive

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_policy.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_policy.py
@@ -75,6 +75,13 @@ class AutoMaterializePolicy(
             on_new_parent_data or for_freshness,
             "One of on_new_parent_data or for_freshness must be True",
         )
+        check.invariant(
+            max_materializations_per_minute is None or max_materializations_per_minute > 0,
+            (
+                "max_materializations_per_minute must be positive. To disable rate-limiting, set it"
+                " to None. To disable auto materializing, remove the policy."
+            ),
+        )
 
         return super(AutoMaterializePolicy, cls).__new__(
             cls,


### PR DESCRIPTION
Eh. Setting `max_materializations_per_minute=0` or to anything negative is vague. It currently blocks all materializations, which I guess is expected, but not useful and potentially confusing. I could imagine users expecting it to disable the limit (which they can do with `max_materializations_per_minute=None`, much better).

This is a breaking change, but it's to an unlikely setting on an experimental api. It'll take a while, but I'm going to check if any cloud customers have this set. Should lead to a useful script anyway.

**Update**: no cloud orgs have max_materializations < 1