### PR TITLE
[fix] Pythonic config fix for Pydantic 1.9.x

### DIFF
--- a/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
@@ -1797,7 +1797,7 @@ def separate_resource_params(cls: Type[BaseModel], data: Dict[str, Any]) -> Sepa
     """
     keys_by_alias = {field.alias: field for field in cls.__fields__.values()}
     data_with_annotation: List[Tuple[str, Any, Type]] = [
-        (k, v, keys_by_alias[k].annotation) for k, v in data.items() if k in keys_by_alias
+        (k, v, keys_by_alias[k].outer_type_) for k, v in data.items() if k in keys_by_alias
     ]
     out = SeparatedResourceParams(
         resources={k: v for k, v, t in data_with_annotation if _is_annotated_as_resource_type(t)},

--- a/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
@@ -1797,7 +1797,10 @@ def separate_resource_params(cls: Type[BaseModel], data: Dict[str, Any]) -> Sepa
     """
     keys_by_alias = {field.alias: field for field in cls.__fields__.values()}
     data_with_annotation: List[Tuple[str, Any, Type]] = [
-        (k, v, keys_by_alias[k].outer_type_) for k, v in data.items() if k in keys_by_alias
+        # No longer exists in Pydantic 2.x, will need to be updated when we upgrade
+        (k, v, keys_by_alias[k].outer_type_)
+        for k, v in data.items()
+        if k in keys_by_alias
     ]
     out = SeparatedResourceParams(
         resources={k: v for k, v, t in data_with_annotation if _is_annotated_as_resource_type(t)},


### PR DESCRIPTION
## Summary

Remove dependence on `ModelField.annotation`, referring instead to `outer_type_` (which is populated with the same value in the constructor). This field only existed in Pydantic 1.10.x+, so it was causing issues for users using Pydantic 1.9.x: https://dagster.slack.com/archives/C01U954MEER/p1690242616967279


## Test Plan

Installed Pydantic 1.9.1 locally and ensured tests fail, succeed after change.