### PR TITLE
fix(dbt): disable threading affinity for OpenBlas

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_app.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_app.py
@@ -22,8 +22,13 @@ test_dagster_metadata_dbt_project_path = Path(__file__).parent.joinpath(
 runner = CliRunner()
 
 
+@pytest.fixture(name="disable_openblas_threading_affinity")
+def disable_openblas_threading_affinity_fixture(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENBLAS_MAIN_FREE", "1")
+
+
 @pytest.fixture(name="dbt_project_dir")
-def dbt_project_dir_fixture(tmp_path: Path) -> Path:
+def dbt_project_dir_fixture(tmp_path: Path, disable_openblas_threading_affinity) -> Path:
     dbt_project_dir = tmp_path.joinpath("test_dagster_metadata")
     shutil.copytree(
         src=test_dagster_metadata_dbt_project_path,


### PR DESCRIPTION
## Summary & Motivation
We keep on seeing `OPENBLAS_MAIN_FREE` as an error in buildkite when dbt tests flake. Attempt to quash that by setting this variable `OPENBLAS_MAIN_FREE=1`, which disables thread affinity.

## How I Tested These Changes
bk and pray
