### PR TITLE
[dagster-webserver] docker images and examples

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -144,8 +144,8 @@ deploy_docker_example_extra_cmds = [
     *network_buildkite_container("docker_example_network"),
     *connect_sibling_docker_container(
         "docker_example_network",
-        "docker_example_dagit",
-        "DEPLOY_DOCKER_DAGIT_HOST",
+        "docker_example_webserver",
+        "DEPLOY_DOCKER_WEBSERVER_HOST",
     ),
     "popd",
 ]

--- a/examples/assets_pandas_type_metadata/README.md
+++ b/examples/assets_pandas_type_metadata/README.md
@@ -27,7 +27,7 @@ pip install -e ".[dev]"
 Once you've done this, you can run:
 
 ```
-dagit
+dagster-webserver
 ```
 
-to view this example in Dagster's UI, Dagit.
+to view this example in Dagster's UI.

--- a/examples/deploy_docker/Dockerfile_dagster
+++ b/examples/deploy_docker/Dockerfile_dagster
@@ -1,4 +1,4 @@
-# Dagster libraries to run both dagit and the dagster-daemon. Does not
+# Dagster libraries to run both dagster-webserver and the dagster-daemon. Does not
 # need to have access to any pipeline code.
 
 FROM python:3.7-slim

--- a/examples/deploy_docker/Dockerfile_user_code
+++ b/examples/deploy_docker/Dockerfile_user_code
@@ -1,7 +1,7 @@
 FROM python:3.7-slim
 
 # Checkout and install dagster libraries needed to run the gRPC server
-# exposing your repository to dagit and dagster-daemon, and to load the DagsterInstance
+# exposing your repository to dagster-webserver and dagster-daemon, and to load the DagsterInstance
 
 RUN pip install \
     dagster \

--- a/examples/deploy_docker/docker-compose.yml
+++ b/examples/deploy_docker/docker-compose.yml
@@ -13,11 +13,12 @@ services:
     networks:
       - docker_example_network
 
-  # This service runs the gRPC server that loads your user code, in both dagit
+  # This service runs the gRPC server that loads your user code, in both dagster-webserver
   # and dagster-daemon. By setting DAGSTER_CURRENT_IMAGE to its own image, we tell the
   # run launcher to use this same image when launching runs in a new container as well.
   # Multiple containers like this can be deployed separately - each just needs to run on
-  # its own port, and have its own entry in the workspace.yaml file that's loaded by dagit.
+  # its own port, and have its own entry in the workspace.yaml file that's loaded by the
+      # webserver.
   docker_example_user_code:
     build:
       context: .
@@ -33,22 +34,22 @@ services:
     networks:
       - docker_example_network
 
-  # This service runs dagit, which loads your user code from the user code container.
-  # Since our instance uses the QueuedRunCoordinator, any runs submitted from dagit will be put on
+  # This service runs dagster-webserver, which loads your user code from the user code container.
+  # Since our instance uses the QueuedRunCoordinator, any runs submitted from the webserver will be put on
   # a queue and later dequeued and launched by dagster-daemon.
-  docker_example_dagit:
+  docker_example_webserver:
     build:
       context: .
       dockerfile: ./Dockerfile_dagster
     entrypoint:
-      - dagit
+      - dagster-webserver
       - -h
       - "0.0.0.0"
       - -p
       - "3000"
       - -w
       - workspace.yaml
-    container_name: docker_example_dagit
+    container_name: docker_example_webserver
     expose:
       - "3000"
     ports:
@@ -57,7 +58,7 @@ services:
       DAGSTER_POSTGRES_USER: "postgres_user"
       DAGSTER_POSTGRES_PASSWORD: "postgres_password"
       DAGSTER_POSTGRES_DB: "postgres_db"
-    volumes: # Make docker client accessible so we can terminate containers from dagit
+    volumes: # Make docker client accessible so we can terminate containers from the webserver
       - /var/run/docker.sock:/var/run/docker.sock
       - /tmp/io_manager_storage:/tmp/io_manager_storage
     networks:

--- a/examples/deploy_docker/from_source/Dockerfile_dagster
+++ b/examples/deploy_docker/from_source/Dockerfile_dagster
@@ -1,4 +1,4 @@
-# Dagster libraries to run both dagit and the dagster-daemon. Does not
+# Dagster libraries to run both dagster-webserver and the dagster-daemon. Does not
 # need to have access to any pipeline code.
 
 FROM python:3.7-slim

--- a/examples/deploy_docker/from_source/Dockerfile_user_code
+++ b/examples/deploy_docker/from_source/Dockerfile_user_code
@@ -3,7 +3,7 @@ FROM python:3.7-slim
 COPY ./python_modules/ /tmp/python_modules/
 
 # Checkout and install dagster libraries needed to run the gRPC server
-# exposing your repository to dagit and dagster-daemon, and to load the DagsterInstance
+# exposing your repository to dagster-webserver and dagster-daemon, and to load the DagsterInstance
 
 WORKDIR /tmp
 

--- a/examples/deploy_docker/from_source/build.sh
+++ b/examples/deploy_docker/from_source/build.sh
@@ -22,9 +22,9 @@ pushd $BASE_DIR
 mkdir -p python_modules
 mkdir -p python_modules/libraries/
 
-if [[ -z ${DAGIT_DONT_BUILD_JS_BUNDLE+x} ]]; then
+if [[ -z ${DAGSTER_UI_DONT_BUILD_JS_BUNDLE+x} ]]; then
     echo -e "--- \033[32m:wrench: Building JS bundle\033[0m"
-    echo -e "(set DAGIT_DONT_BUILD_JS_BUNDLE to skip)"
+    echo -e "(set DAGSTER_UI_DONT_BUILD_JS_BUNDLE to skip)"
     pushd ${ROOT}
     make rebuild_ui
     popd

--- a/examples/deploy_docker/from_source/docker-compose.yml
+++ b/examples/deploy_docker/from_source/docker-compose.yml
@@ -1,6 +1,6 @@
 version: "3.7"
 
-# Build these services with ./build.sh to access the dagster/dagit code from master
+# Build these services with ./build.sh to access the dagster/webserver code from master
 
 services:
   # This service runs the postgres DB used by dagster for run storage, schedule storage,
@@ -15,11 +15,11 @@ services:
     networks:
       - docker_example_network
 
-  # This service runs the gRPC server that loads and executes your user code, in both dagit
+  # This service runs the gRPC server that loads and executes your user code, in both dagster-webserver
   # and dagster-daemon. By setting DAGSTER_CURRENT_IMAGE to its own image, we tell the
   # run launcher to use this same image when launching runs in a new container as well.
   # Multiple containers like this can be deployed separately - each just needs to run on
-  # its own port, and have its own entry in the workspace.yaml file that's loaded by dagit.
+  # its own port, and have its own entry in the workspace.yaml file that's loaded by the webserver.
   docker_example_user_code:
     build:
       context: .
@@ -35,10 +35,10 @@ services:
     networks:
       - docker_example_network
 
-  # This service runs dagit, which loads the user code from the user code container.
-  # Since our instance uses the QueuedRunCoordinator, any runs submitted from dagit will be put on
+  # This service runs the dagster-webserver, which loads the user code from the user code container.
+  # Since our instance uses the QueuedRunCoordinator, any runs submitted from the webserver will be put on
   # a queue and later dequeued and launched by dagster-daemon.
-  docker_example_dagit:
+  docker_example_webserver:
     build:
       context: .
       dockerfile: ./Dockerfile_dagster
@@ -50,7 +50,7 @@ services:
       - "3000"
       - -w
       - workspace.yaml
-    container_name: docker_example_dagit
+    container_name: docker_example_webserver
     expose:
       - "3000"
     ports:
@@ -59,7 +59,7 @@ services:
       DAGSTER_POSTGRES_USER: "postgres_user"
       DAGSTER_POSTGRES_PASSWORD: "postgres_password"
       DAGSTER_POSTGRES_DB: "postgres_db"
-    volumes: # Make docker client accessible so we can terminate containers from dagit
+    volumes: # Make docker client accessible so we can terminate containers from the webserver
       - /var/run/docker.sock:/var/run/docker.sock
       - /tmp/io_manager_storage:/tmp/io_manager_storage
     networks:

--- a/examples/deploy_docker/tests/test_deploy_docker.py
+++ b/examples/deploy_docker/tests/test_deploy_docker.py
@@ -126,7 +126,7 @@ def test_deploy_docker():
 
         start_time = time.time()
 
-        webserver_host = os.environ.get("DEPLOY_DOCKER_DAGIT_HOST", "localhost")
+        webserver_host = os.environ.get("DEPLOY_DOCKER_WEBSERVER_HOST", "localhost")
 
         while True:
             if time.time() - start_time > 15:

--- a/examples/deploy_docker/tox.ini
+++ b/examples/deploy_docker/tox.ini
@@ -3,7 +3,7 @@ skipsdist = True
 
 [testenv]
 download = True
-passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE* DEPLOY_DOCKER_DAGIT_HOST
+passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE* DEPLOY_DOCKER_WEBSERVER_HOST
 deps =
   -e ../../python_modules/dagster[test]
 allowlist_externals =

--- a/examples/deploy_ecs/Dockerfile
+++ b/examples/deploy_ecs/Dockerfile
@@ -17,10 +17,10 @@ RUN git clone https://github.com/dagster-io/dagster.git
 COPY requirements-dagster.txt $DAGSTER_HOME
 RUN pip install -r requirements-dagster.txt
 
-# Dagit
-FROM dagster as dagit
-COPY requirements-dagit.txt $DAGSTER_HOME
-RUN pip install -r requirements-dagit.txt
+# Webserver
+FROM dagster as webserver
+COPY requirements-webserver.txt $DAGSTER_HOME
+RUN pip install -r requirements-webserver.txt
 
 # User Code gRPC Server
 # You can either include all of your repositories in this

--- a/examples/deploy_ecs/README.md
+++ b/examples/deploy_ecs/README.md
@@ -14,7 +14,7 @@ This directory contains annotated files for deploying Dagster with an EcsRunLaun
   ```
 6. [Create ECR Repositories](https://docs.aws.amazon.com/cli/latest/reference/ecr/create-repository.html) for our images:
   ```sh
-  aws ecr create-repository --repository-name deploy_ecs/dagit
+  aws ecr create-repository --repository-name deploy_ecs/webserver
   aws ecr create-repository --repository-name deploy_ecs/daemon
   aws ecr create-repository --repository-name deploy_ecs/user_code
   ```
@@ -40,7 +40,7 @@ docker --context dagster-ecs compose --project-name dagster up
 
 The first time you run this command, Docker will provision the necessary resources to run your stack on ECS. `--context dagster-ecs` tells Docker to run the containers on the Docker ECS context that we created. `--project-name dagster` tells Docker how to name the stack.
 
-One of the resources Docker creates is an AWS ELB Load Balancer. You can access Dagit on port 3000 of the Load Balancer's URL. To find the Load Balancer's URL, look for the [Load Balancer tagged with our project name](https://console.aws.amazon.com/ec2/v2/home#LoadBalancers:tag:com.docker.compose.project=dagster-ecs).
+One of the resources Docker creates is an AWS ELB Load Balancer. You can access the Dagster webserver/UI on port 3000 of the Load Balancer's URL. To find the Load Balancer's URL, look for the [Load Balancer tagged with our project name](https://console.aws.amazon.com/ec2/v2/home#LoadBalancers:tag:com.docker.compose.project=dagster-ecs).
 
 Subsequent runs of this command will [execute a rolling update](https://docs.docker.com/cloud/ecs-integration/#rolling-update) of the stack.
 

--- a/examples/deploy_ecs/docker-compose.yml
+++ b/examples/deploy_ecs/docker-compose.yml
@@ -2,20 +2,20 @@
 version: "3.8"
 
 services:
-  # This service runs dagit. It has no user code; instead it loads its
+  # This service runs dagster-webserver. It has no user code; instead it loads its
   # jobs from the gRPC server running in the user_code service.
   # Because our instance uses the QueuedRunCoordinator, any runs submitted from
-  # dagit will be put on a queue and later dequeued and launched by
+  # the webserver will be put on a queue and later dequeued and launched by
   # the dagster-daemon service.
-  dagit:
+  webserver:
     platform: linux/amd64
     build:
       context: .
       dockerfile: ./Dockerfile
-      target: dagit
-    image: "$REGISTRY_URL/deploy_ecs/dagit"
-    container_name: dagit
-    command: "dagit -h 0.0.0.0 -p 3000 -w workspace.yaml"
+      target: webserver
+    image: "$REGISTRY_URL/deploy_ecs/webserver"
+    container_name: webserver
+    command: "dagster-webserver -h 0.0.0.0 -p 3000 -w workspace.yaml"
     ports:
       - "3000:3000"
     environment:

--- a/examples/deploy_ecs/from_source/Dockerfile
+++ b/examples/deploy_ecs/from_source/Dockerfile
@@ -21,21 +21,21 @@ RUN pip install \
   -e python_modules/libraries/dagster-aws \
   -e python_modules/libraries/dagster-postgres
 
-RUN ! pip list --exclude-editable | grep -e dagster -e dagit
+RUN ! pip list --exclude-editable | grep -e dagster
 
 WORKDIR $DAGSTER_HOME
 
-# Dagit
-FROM dagster as dagit
+# Webserver
+FROM dagster as webserver
 
 WORKDIR /tmp
 
 RUN pip install \
-  -e python_modules/dagit \
+  -e python_modules/dagster-webserver \
   -e python_modules/dagster-graphql \
   -e python_modules/dagster
 
-RUN ! pip list --exclude-editable | grep -e dagster -e dagit
+RUN ! pip list --exclude-editable | grep -e dagster
 
 WORKDIR $DAGSTER_HOME
 

--- a/examples/deploy_ecs/from_source/build.sh
+++ b/examples/deploy_ecs/from_source/build.sh
@@ -22,11 +22,11 @@ pushd $BASE_DIR
 mkdir -p python_modules
 mkdir -p python_modules/libraries/
 
-if [[ -z ${DAGIT_DONT_BUILD_JS_BUNDLE+x} ]]; then
+if [[ -z ${DAGSTER_UI_DONT_BUILD_JS_BUNDLE+x} ]]; then
     echo -e "--- \033[32m:wrench: Building JS bundle\033[0m"
-    echo -e "(set DAGIT_DONT_BUILD_JS_BUNDLE to skip)"
+    echo -e "(set DAGSTER_UI_DONT_BUILD_JS_BUNDLE to skip)"
     pushd ${ROOT}
-#    make rebuild_dagit
+#    make rebuild_ui
     popd
 fi
 
@@ -41,7 +41,7 @@ alias copy_py="rsync -av \
       --exclude .coverage"
 
 copy_py $ROOT/python_modules/dagster \
-        $ROOT/python_modules/dagit \
+        $ROOT/python_modules/dagster-webserver \
         $ROOT/python_modules/dagster-graphql \
         python_modules/
 

--- a/examples/deploy_ecs/from_source/docker-compose.yml
+++ b/examples/deploy_ecs/from_source/docker-compose.yml
@@ -2,20 +2,20 @@
 version: "3.8"
 
 services:
-  # This service runs dagit. It has no user code; instead it loads its
+  # This service runs dagster-webserver. It has no user code; instead it loads its
   # jobs from the gRPC server running in the user_code service.
   # Because our instance uses the QueuedRunCoordinator, any runs submitted from
-  # dagit will be put on a queue and later dequeued and launched by
+  # the websever will be put on a queue and later dequeued and launched by
   # the dagster-daemon service.
-  dagit:
+  webserver:
     platform: linux/amd64
     build:
       context: .
       dockerfile: ./Dockerfile
-      target: dagit
-    image: "$REGISTRY_URL/deploy_ecs/dagit"
-    container_name: dagit
-    command: "dagit -h 0.0.0.0 -p 3000 -w workspace.yaml"
+      target: webserver
+    image: "$REGISTRY_URL/deploy_ecs/webserver"
+    container_name: webserver
+    command: "dagster-webserver -h 0.0.0.0 -p 3000 -w workspace.yaml"
     ports:
       - "3000:3000"
     environment:

--- a/examples/deploy_ecs/requirements-dagit.txt
+++ b/examples/deploy_ecs/requirements-dagit.txt
@@ -1,2 +1,0 @@
-dagit
-dagster-graphql

--- a/examples/deploy_ecs/requirements-webserver.txt
+++ b/examples/deploy_ecs/requirements-webserver.txt
@@ -1,0 +1,2 @@
+dagster-webserver
+dagster-graphql

--- a/examples/deploy_ecs/tests/test_deploy.py
+++ b/examples/deploy_ecs/tests/test_deploy.py
@@ -124,4 +124,4 @@ def docker_compose(
 
 @pytest.mark.xfail
 def test_deploy(docker_compose, retrying_requests):
-    assert retrying_requests.get(f'http://{docker_compose["dagit"]}:3000/server_info').ok
+    assert retrying_requests.get(f'http://{docker_compose["webserver"]}:3000/server_info').ok

--- a/examples/deploy_ecs/tox.ini
+++ b/examples/deploy_ecs/tox.ini
@@ -3,7 +3,7 @@ skipsdist = True
 
 [testenv]
 download = True
-passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE* DEPLOY_DOCKER_DAGIT_HOST
+passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE* DEPLOY_DOCKER_WEBSERVER_HOST
 deps =
   -e ../../python_modules/dagster[test]
   -e ../../python_modules/dagster-test

--- a/examples/development_to_production/README.md
+++ b/examples/development_to_production/README.md
@@ -16,5 +16,5 @@ cd my-dagster-project
 pip install -e ".[dev]"
 
 # Load it in the web UI
-dagit
+dagster-webserver
 ```

--- a/examples/docs_snippets/docs_snippets/deploying/systemd/dagit.service
+++ b/examples/docs_snippets/docs_snippets/deploying/systemd/dagit.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Run Dagit
+Description=Run dagster-webserver
 After=network.target
 
 [Service]
@@ -11,7 +11,7 @@ ExecStart=/bin/bash -c '\
     export LC_ALL=C.UTF-8 && \
     export LANG=C.UTF-8 && \
     source /opt/dagster/venv/bin/activate && \
-    /opt/dagster/venv/bin/dagit \
+    /opt/dagster/venv/bin/dagster-webserver \
         -h 0.0.0.0 \
         -p 3000 \
         -y /opt/dagster/app/workspace.yaml'

--- a/examples/experimental/script_to_assets_branching_io_manager/launch_branch.sh
+++ b/examples/experimental/script_to_assets_branching_io_manager/launch_branch.sh
@@ -1,2 +1,2 @@
 HOME_DIR=$(pwd)
-DAGSTER_DEPLOYMENT=my-featured-branch DAGSTER_HOME=$HOME_DIR/dev_dagster_home/ dagit -f hn_dagster.py -p 3001
+DAGSTER_DEPLOYMENT=my-featured-branch DAGSTER_HOME=$HOME_DIR/dev_dagster_home/ dagster-webserver -f hn_dagster.py -p 3001

--- a/examples/experimental/script_to_assets_branching_io_manager/launch_prod.sh
+++ b/examples/experimental/script_to_assets_branching_io_manager/launch_prod.sh
@@ -1,4 +1,4 @@
 # home_dir = `pwd`
 # echo `pwd`
 HOME_DIR=$(pwd)
-DAGSTER_DEPLOYMENT=prod DAGSTER_HOME=$HOME_DIR/prod_dagster_home/ dagit -f hn_dagster.py
+DAGSTER_DEPLOYMENT=prod DAGSTER_HOME=$HOME_DIR/prod_dagster_home/ dagster-webserver -f hn_dagster.py

--- a/examples/experimental/script_to_assets_branching_io_manager/requirements.txt
+++ b/examples/experimental/script_to_assets_branching_io_manager/requirements.txt
@@ -1,6 +1,5 @@
 dagster
-dagit
+dagster-webserver
 matplotlib
 pandas
 wordcloud
-

--- a/examples/feature_graph_backed_assets/README.md
+++ b/examples/feature_graph_backed_assets/README.md
@@ -21,7 +21,7 @@ pip install -e ".[dev]"
 Once you've done this, you can run:
 
 ```
-dagit
+dagster-webserver
 ```
 
-to view this example in Dagster's UI, Dagit.
+to view this example in Dagster's UI.

--- a/examples/project_analytics/README.md
+++ b/examples/project_analytics/README.md
@@ -34,10 +34,10 @@ To run locally, all you need is to install this package locally:
 pip install -e .
 ```
 
-Then start dagit
+Then start Dagster's webserver:
 
 ```bash
-dagit dev
+dagster dev
 ```
 
 ### Production

--- a/examples/project_fully_featured/README.md
+++ b/examples/project_fully_featured/README.md
@@ -29,10 +29,10 @@ pip install -e ".[dev]"
 Once you've done this, you can run:
 
 ```
-dagit
+dagster-webserver
 ```
 
-to view this example in Dagster's UI, Dagit.
+to view this example in Dagster's UI.
 
 ## Asset groups
 

--- a/examples/tutorial_dbt_dagster/README.md
+++ b/examples/tutorial_dbt_dagster/README.md
@@ -26,9 +26,9 @@ cd my-dagster-project
 pip install -e ".[dev]"
 ```
 
-At this point, you can view the **completed** project in Dagit by running:
+At this point, you can view the **completed** project in the Dagster UI by running:
 
 ```shell
 cd tutorial_finished
-dagit
+dagster-webserver
 ```

--- a/examples/with_wandb/README.md
+++ b/examples/with_wandb/README.md
@@ -21,7 +21,7 @@ pip install -e ".[dev]"
 Once you've done this, you can run:
 
 ```
-dagit
+dagster-webserver
 ```
 
 ## Set up wandb

--- a/python_modules/automation/automation/docker/images/README.md
+++ b/python_modules/automation/automation/docker/images/README.md
@@ -1,6 +1,6 @@
 # Dagster Images
 
-- `dagster-celery-k8s` (Helm default): Host process image for Dagit, Daemon, and Celery workers. We use this
+- `dagster-celery-k8s` (Helm default): Host process image for Dagster Webserver, Daemon, and Celery workers. We use this
   as the default so that users can switch to Celery without hitting a dependency issue.
 - `user-code-example` (Helm default): Example job code.
 - `dagster-k8s`: `dagster-celery-k8s` without the Celery dependency.

--- a/python_modules/automation/automation/docker/images/buildkite-test/Dockerfile
+++ b/python_modules/automation/automation/docker/images/buildkite-test/Dockerfile
@@ -58,7 +58,7 @@ RUN apt-get update -yqq \
 # Install various packages used in running/installing/testing Dagster:
 # - git/make (cloning dagster, running checks defined in Makefile)
 # - openjdk-11-{jdk,jre}-headless 8 (Java required by pyspark) see: http://bit.ly/2ZIuHRh
-# - nodejs/yarn (dagit)
+# - nodejs/yarn (dagster UI)
 # - assorted others-- some may no longer be required, but leaving in place for now
 #
 # deb.nodesource script adds node source to apt

--- a/python_modules/automation/automation/docker/images/dagster-celery-k8s-editable/Dockerfile
+++ b/python_modules/automation/automation/docker/images/dagster-celery-k8s-editable/Dockerfile
@@ -12,4 +12,4 @@ RUN pip install \
     -e dagster-k8s \
     -e dagster-celery[flower,redis,kubernetes] \
     -e dagster-celery-k8s \
-    -e dagit
+    -e dagster-webserver

--- a/python_modules/automation/automation/docker/images/dagster-celery-k8s/Dockerfile
+++ b/python_modules/automation/automation/docker/images/dagster-celery-k8s/Dockerfile
@@ -15,4 +15,4 @@ RUN pip install \
     dagster-celery-k8s \
     dagster-gcp \
     dagster-graphql \
-    dagit
+    dagster-webserver

--- a/python_modules/automation/automation/docker/images/dagster-k8s-editable/Dockerfile
+++ b/python_modules/automation/automation/docker/images/dagster-k8s-editable/Dockerfile
@@ -11,4 +11,4 @@ RUN pip install \
     -e dagster-postgres \
     -e dagster-k8s \
     -e dagster-aws \
-    -e dagit
+    -e dagster-webserver

--- a/python_modules/automation/automation/docker/images/dagster-k8s/Dockerfile
+++ b/python_modules/automation/automation/docker/images/dagster-k8s/Dockerfile
@@ -13,4 +13,4 @@ RUN pip install \
     dagster-aws \
     dagster-gcp \
     dagster-graphql \
-    dagit
+    dagster-webserver

--- a/python_modules/automation/tox.ini
+++ b/python_modules/automation/tox.ini
@@ -56,5 +56,5 @@ deps =
 allowlist_externals =
   /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
   pytest -c ../../pyproject.toml -vv {posargs}


### PR DESCRIPTION
## Summary & Motivation

Update Docker images defined in `automation` and a few examples to use `dagster-webserver` instead of `dagit`. These previously slipped through the cracks.

## How I Tested These Changes

Existing test suite.