### PR TITLE
Fix Incorrect Method Name in DagsterDbtTranslator Docs

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
@@ -156,7 +156,7 @@ class DagsterDbtTranslator:
 
                 class CustomDagsterDbtTranslator(DagsterDbtTranslator):
                     @classmethod
-                    def get_group(cls, dbt_resource_props: Mapping[str, Any]) -> Optional[str]:
+                    def get_group_name(cls, dbt_resource_props: Mapping[str, Any]) -> Optional[str]:
                         return "custom_group_prefix" + node_info.get("config", {}).get("group")
         """
         return default_group_from_dbt_resource_props(dbt_resource_props)


### PR DESCRIPTION
## Summary & Motivation
- Method referenced in the `Examples` section of the docstring for `get_group_name` is `get_group`
- Aligning the method referenced in the docstring with the actual method name
- Elsewhere in the file this is consistent (i.e. `get_metadata` and `get_description` etc.)

Bug in the prod docs https://docs.dagster.io/_modules/dagster_dbt/dagster_dbt_translator#DagsterDbtTranslator
<img width="642" alt="image" src="https://github.com/dagster-io/dagster/assets/29241719/866bc0a7-6ff6-4e74-9329-1835141fe333">