### PR TITLE
[RFC] [k8s] support merging args passed via container_context

### DIFF
--- a/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
@@ -714,7 +714,7 @@ def construct_dagster_k8s_job(
     container_config = copy.deepcopy(user_defined_k8s_config.container_config)
 
     if args is not None:
-        container_config["args"] = args
+        container_config["args"] = args + container_config["args"]
 
     user_defined_env_vars = container_config.pop("env", [])
 

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_launcher.py
@@ -202,7 +202,10 @@ def test_launcher_with_k8s_config(kubeconfig_file):
     container_context_config = {
         "k8s": {
             "run_k8s_config": {
-                "container_config": {"command": ["echo", "REPLACED"]},
+                "container_config": {
+                    "command": ["echo", "REPLACED"],
+                    "args": ["&&", "shutdown.sh"],
+                },
             }
         }
     }
@@ -265,6 +268,10 @@ def test_launcher_with_k8s_config(kubeconfig_file):
         # config from container context applied
         command = container.command
         assert command == ["echo", "REPLACED"]
+
+        args = container.args
+        assert args[-2] == "&&"
+        assert args[-1] == "shutdown.sh"
 
         # config from run launcher applied
         assert container.tty


### PR DESCRIPTION
In different cases such as dealing with sidecars (before official sidecar support) there are needs to do additional control flow before/after invoking the main dagster specific process in a run job. 

Currently our solution for this problem is to override the entrypoint `command` in with a script that wraps the invocation  of the dagster process with whatever additional work needs to happen as discussed here: https://github.com/dagster-io/dagster/discussions/12687. This approach requires creating a custom entrypoint script in your container image.

An alternative way to support this would be some way in config to supply information to change the `dagster api execute_run`  args that are passed to chain additional commands. 

## How I Tested These Changes

updated tests cases
