### PR TITLE
[ui] Link to auto-materialized assets from Run

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetView.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetView.tsx
@@ -77,6 +77,7 @@ export interface AssetViewParams {
   partition?: string;
   time?: string;
   asOf?: string;
+  evaluation?: string;
 }
 
 export const AssetView: React.FC<Props> = ({assetKey}) => {

--- a/js_modules/dagit/packages/core/src/assets/AutomaterializeTagWithEvaluation.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutomaterializeTagWithEvaluation.tsx
@@ -1,0 +1,75 @@
+import {Box, Colors, Icon, MiddleTruncate, Popover, Tag} from '@dagster-io/ui';
+import * as React from 'react';
+import {Link} from 'react-router-dom';
+
+import {assetDetailsPathForKey} from './assetDetailsPathForKey';
+import {AssetKey} from './types';
+
+const COLLATOR = new Intl.Collator(navigator.language, {sensitivity: 'base'});
+
+interface Props {
+  assetKeys: AssetKey[];
+  evaluationId: string;
+}
+
+export const AutomaterializeTagWithEvaluation = ({assetKeys, evaluationId}: Props) => {
+  const sortedKeys = React.useMemo(() => {
+    return [...assetKeys].sort((a, b) => COLLATOR.compare(a.path.join('/'), b.path.join('/')));
+  }, [assetKeys]);
+
+  return (
+    <Popover
+      placement="bottom"
+      content={
+        <div style={{width: '340px'}}>
+          <Box
+            padding={{vertical: 8, horizontal: 12}}
+            border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+            style={{fontWeight: 600}}
+          >
+            Auto-materialized
+          </Box>
+          <Box
+            flex={{direction: 'column', gap: 12}}
+            padding={{vertical: 12}}
+            style={{maxHeight: '220px', overflowY: 'auto'}}
+          >
+            {sortedKeys.map((assetKey) => {
+              const url = assetDetailsPathForKey(assetKey, {
+                view: 'auto-materialize-history',
+                evaluation: evaluationId,
+              });
+              return (
+                <Box
+                  key={url}
+                  padding={{vertical: 8, left: 12, right: 16}}
+                  flex={{
+                    direction: 'row',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                    gap: 8,
+                  }}
+                  style={{overflow: 'hidden'}}
+                >
+                  <Box
+                    flex={{direction: 'row', alignItems: 'center', gap: 8}}
+                    style={{overflow: 'hidden'}}
+                  >
+                    <Icon name="asset" />
+                    <MiddleTruncate text={assetKey.path.join('/')} />
+                  </Box>
+                  <Link to={url} style={{whiteSpace: 'nowrap'}}>
+                    View evaluation
+                  </Link>
+                </Box>
+              );
+            })}
+          </Box>
+        </div>
+      }
+      interactionKind="hover"
+    >
+      <Tag icon="auto_materialize_policy">Auto-materialized</Tag>
+    </Popover>
+  );
+};

--- a/js_modules/dagit/packages/core/src/runs/RunRoot.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunRoot.tsx
@@ -6,6 +6,7 @@ import {useParams} from 'react-router-dom';
 import {formatElapsedTime} from '../app/Util';
 import {useTrackPageView} from '../app/analytics';
 import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
+import {AutomaterializeTagWithEvaluation} from '../assets/AutomaterializeTagWithEvaluation';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {PipelineReference} from '../pipelines/PipelineReference';
 import {TimestampDisplay} from '../schedules/TimestampDisplay';
@@ -18,6 +19,7 @@ import {Run} from './Run';
 import {RunConfigDialog, RunDetails} from './RunDetails';
 import {RUN_PAGE_FRAGMENT} from './RunFragments';
 import {RunStatusTag} from './RunStatusTag';
+import {DagsterTag} from './RunTag';
 import {assetKeysForRun} from './RunUtils';
 import {RunRootQuery, RunRootQueryVariables} from './types/RunRoot.types';
 
@@ -42,6 +44,11 @@ export const RunRoot = () => {
   const isJob = React.useMemo(
     () => !!(run && repoMatch && isThisThingAJob(repoMatch.match, run.pipelineName)),
     [run, repoMatch],
+  );
+
+  const automaterializeTag = React.useMemo(
+    () => run?.tags.find((tag) => tag.key === DagsterTag.AssetEvaluationID) || null,
+    [run],
   );
 
   return (
@@ -135,6 +142,12 @@ export const RunRoot = () => {
                         </span>
                       </Tag>
                     </Popover>
+                  ) : null}
+                  {automaterializeTag && run.assetSelection?.length ? (
+                    <AutomaterializeTagWithEvaluation
+                      assetKeys={run.assetSelection}
+                      evaluationId={automaterializeTag.value}
+                    />
                   ) : null}
                 </Box>
               </>

--- a/js_modules/dagit/packages/core/src/runs/RunTag.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTag.tsx
@@ -24,6 +24,7 @@ export enum DagsterTag {
   AssetEventDataVersion = 'dagster/data_version',
   AssetEventDataVersionDeprecated = 'dagster/logical_version',
   AssetEventCodeVersion = 'dagster/code_version',
+  AssetEvaluationID = 'dagster/asset_evaluation_id',
   SnapshotID = 'dagster/snapshot_id', // This only exists on the client, not the server.
   User = 'user',
 


### PR DESCRIPTION
## Summary & Motivation

Resolves #15225.

For runs that have automaterialize tags, show an "Auto-materialized" tag in the header. Hovering on the tag shows the assets associated with the run, and the user can navigate directly to that evaluation ID on the asset's auto-materialize history page.

https://github.com/dagster-io/dagster/assets/2823852/9ba91cef-d34b-4c5f-8789-d13bb9d75f8c

## How I Tested These Changes

View a run that was launched from an auto-materialize policy. Verify that the tag appears in the header, and that hovering on the tag shows the assets assocaited with the run. Verify that clicking to view the evaluation goes to the asset's auto-materialization history at that evaluation number.

Verify that long lists of assets are limited by the popover but scrollable. Verify that asset names are sorted alphabetically.

Adjust the width of the popover to verify that asset names are middle-truncated if too long for the container.
