### PR TITLE
[RFC] don't require return type None annotation to bypass IO manager

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/context/system.py
+++ b/python_modules/dagster/dagster/_core/execution/context/system.py
@@ -587,13 +587,18 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
     def describe_op(self) -> str:
         return f'op "{self.node_handle}"'
 
-    def get_io_manager(self, step_output_handle: StepOutputHandle) -> IOManager:
+    def get_io_manager_key(self, step_output_handle: StepOutputHandle) -> str:
         step_output = self.execution_plan.get_step_output(step_output_handle)
         io_manager_key = (
             self.job_def.get_node(step_output.node_handle)
             .output_def_named(step_output.name)
             .io_manager_key
         )
+
+        return io_manager_key
+
+    def get_io_manager(self, step_output_handle: StepOutputHandle) -> IOManager:
+        io_manager_key = self.get_io_manager_key(step_output_handle)
 
         output_manager = getattr(self.resources, io_manager_key)
         return check.inst(output_manager, IOManager)

--- a/python_modules/dagster/dagster/_core/execution/context/system.py
+++ b/python_modules/dagster/dagster/_core/execution/context/system.py
@@ -587,18 +587,13 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
     def describe_op(self) -> str:
         return f'op "{self.node_handle}"'
 
-    def get_io_manager_key(self, step_output_handle: StepOutputHandle) -> str:
+    def get_io_manager(self, step_output_handle: StepOutputHandle) -> IOManager:
         step_output = self.execution_plan.get_step_output(step_output_handle)
         io_manager_key = (
             self.job_def.get_node(step_output.node_handle)
             .output_def_named(step_output.name)
             .io_manager_key
         )
-
-        return io_manager_key
-
-    def get_io_manager(self, step_output_handle: StepOutputHandle) -> IOManager:
-        io_manager_key = self.get_io_manager_key(step_output_handle)
 
         output_manager = getattr(self.resources, io_manager_key)
         return check.inst(output_manager, IOManager)

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
@@ -631,6 +631,10 @@ def _store_output(
     # handle_output in a generator so that errors will be caught within iterate_with_context.
 
     if output.value is not None:
+        # adding this metadata allows us to later find out if an output was stored using the I/O manager system
+        io_manager_key = step_context.get_io_manager_key(step_output_handle)
+        manager_metadata["io_manager_key"] = MetadataValue.text(io_manager_key)
+
         if not inspect.isgeneratorfunction(output_manager.handle_output):
 
             def _gen_fn():
@@ -647,7 +651,7 @@ def _store_output(
     else:
         # if None is returned, don't invoke an I/O manager
         def _no_op():
-            yield {"used_io_manager": False}
+            yield None
 
         handle_output_gen = _no_op()
 

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
@@ -634,6 +634,7 @@ def _store_output(
 
     if output_context.has_asset_key and output.value is None:
         # if the output is from an asset and None is returned, don't invoke an I/O manager
+        # and record that no I/O manager was used
         def _no_op():
             yield {"used_io_manager": False}
 

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
@@ -676,8 +676,9 @@ def _store_output(
         elif isinstance(elt, dict):  # should remove this?
             experimental_warning("Yielding metadata from an IOManager's handle_output() function")
             manager_metadata = {**manager_metadata, **normalize_metadata(elt)}
-        elif elt is None:
-            continue
+        # TODO if go back to a version where the no_op handle_output_gen returns None, then add this back in
+        # elif elt is None:
+        #     continue
         else:
             raise DagsterInvariantViolationError(
                 f"IO manager on output {output_def.name} has returned "

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
@@ -631,9 +631,8 @@ def _store_output(
     # handle_output in a generator so that errors will be caught within iterate_with_context.
 
     if output.value is not None:
-        # adding this metadata allows us to later find out if an output was stored using the I/O manager system
-        io_manager_key = step_context.get_io_manager_key(step_output_handle)
-        manager_metadata["io_manager_key"] = MetadataValue.text(io_manager_key)
+        # io_manager_key = step_context.get_io_manager_key(step_output_handle)
+        # manager_metadata["io_manager_key"] = MetadataValue.text(io_manager_key)
 
         if not inspect.isgeneratorfunction(output_manager.handle_output):
 
@@ -651,7 +650,7 @@ def _store_output(
     else:
         # if None is returned, don't invoke an I/O manager
         def _no_op():
-            yield None
+            yield {"used_io_manager": False}
 
         handle_output_gen = _no_op()
 

--- a/python_modules/dagster/dagster/_core/execution/plan/inputs.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/inputs.py
@@ -794,9 +794,6 @@ def _load_input_with_input_manager(
 
         # check if the output was stored via an I/O manager, or was None, and thus was not stored
         if latest_input_materialization.asset_materialization is not None:
-            # io_manager_key = latest_input_materialization.asset_materialization.metadata.get(
-            #     "io_manager_key", None
-            # )
             used_io_manager_metadata = (
                 latest_input_materialization.asset_materialization.metadata.get(
                     "used_io_manager", None

--- a/python_modules/dagster/dagster/_core/execution/plan/inputs.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/inputs.py
@@ -810,7 +810,7 @@ def _load_input_with_input_manager(
                     input_manager, context, step_context
                 )
     else:
-        # TODO handle op case
+        # TODO handle op case?
         yield from _load_input_with_input_manager_helper(input_manager, context, step_context)
 
 

--- a/python_modules/dagster/dagster/_core/execution/plan/inputs.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/inputs.py
@@ -794,10 +794,15 @@ def _load_input_with_input_manager(
 
         # check if the output was stored via an I/O manager, or was None, and thus was not stored
         if latest_input_materialization.asset_materialization is not None:
-            io_manager_key = latest_input_materialization.asset_materialization.metadata.get(
-                "io_manager_key", None
+            # io_manager_key = latest_input_materialization.asset_materialization.metadata.get(
+            #     "io_manager_key", None
+            # )
+            used_io_manager_metadata = (
+                latest_input_materialization.asset_materialization.metadata.get(
+                    "used_io_manager", None
+                )
             )
-            if io_manager_key is None:
+            if used_io_manager_metadata and not used_io_manager_metadata.value:
                 # I/O manager was not used to store the output of the asset, which means the output was None
                 yield None
             else:

--- a/python_modules/dagster/dagster_tests/storage_tests/test_no_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_no_io_manager.py
@@ -1,0 +1,88 @@
+from dagster import AssetOut, IOManager, Output, asset, materialize, multi_asset
+
+
+class TestIOManager(IOManager):
+    def handle_output(self, context, obj) -> None:
+        # the I/O manager should not be invoked in these tests
+        assert False
+
+    def load_input(self, context):
+        # the I/O manager should not be invoked in these tests
+        assert False
+
+
+def test_return_none_no_type_annotation():
+    @asset
+    def returns_none():
+        return None
+
+    materialize([returns_none], resources={"io_manager": TestIOManager()})
+
+
+def test_return_none_with_type_annotation():
+    @asset
+    def returns_none() -> None:
+        return None
+
+    materialize([returns_none], resources={"io_manager": TestIOManager()})
+
+
+def test_downstream_deps():
+    @asset
+    def returns_none():
+        return None
+
+    @asset(deps=[returns_none])
+    def downstream():
+        return None
+
+    materialize([returns_none, downstream], resources={"io_manager": TestIOManager()})
+
+
+def test_downstream_managed_deps():
+    @asset
+    def returns_none():
+        return None
+
+    @asset
+    def downstream(returns_none):
+        assert returns_none is None
+
+    materialize([returns_none, downstream], resources={"io_manager": TestIOManager()})
+
+
+def test_conditional_materialization():
+    # not totally sure what this should test for yet...
+    should_return = False
+
+    @asset(output_required=False)
+    def conditional_asset():
+        if should_return:
+            yield Output(1)
+
+    @asset
+    def downstream(conditional_asset):
+        return conditional_asset + 1
+
+    result = materialize([conditional_asset, downstream], resources={"io_manager": TestIOManager()})
+    assert result.success
+
+    should_return = True
+    result = materialize([conditional_asset, downstream])
+    assert result.success
+
+
+def test_multi_asset():
+    @multi_asset(outs={"out1": AssetOut(), "out2": AssetOut()})
+    def returns_nones():
+        return None, None
+
+    @asset(deps=["out1", "out2"])
+    def downstream():
+        return None
+
+    materialize([returns_nones, downstream], resources={"io_manager": TestIOManager()})
+
+
+# test partitions
+# test multi assets

--- a/python_modules/dagster/dagster_tests/storage_tests/test_no_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_no_io_manager.py
@@ -126,7 +126,7 @@ def test_deps_unit_test_flow():
 
     asset_context = build_asset_context()
 
-    assert downstream(asset_context) is None
+    assert downstream(asset_context) == 1
 
 
 def test_io_unit_test_flow():

--- a/python_modules/dagster/dagster_tests/storage_tests/test_no_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_no_io_manager.py
@@ -1,4 +1,4 @@
-from dagster import AssetOut, IOManager, Output, asset, materialize, multi_asset
+from dagster import AssetOut, IOManager, Output, asset, job, materialize, multi_asset, op
 
 
 class TestIOManager(IOManager):
@@ -82,6 +82,23 @@ def test_multi_asset():
         return None
 
     materialize([returns_nones, downstream], resources={"io_manager": TestIOManager()})
+
+
+def test_ops():
+    # TODO - fails because the op case for loading inputs is not handled
+    @op
+    def returns_none():
+        return None
+
+    @op
+    def asserts_none(x):
+        assert x is None
+
+    @job
+    def return_none_job():
+        asserts_none(returns_none())
+
+    return_none_job.execute_in_process(resources={"io_manager": TestIOManager()})
 
 
 # test partitions

--- a/python_modules/dagster/dagster_tests/storage_tests/test_no_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_no_io_manager.py
@@ -85,7 +85,6 @@ def test_multi_asset():
 
 
 def test_ops():
-    # TODO - fails because the op case for loading inputs is not handled
     @op
     def returns_none():
         return None
@@ -98,7 +97,8 @@ def test_ops():
     def return_none_job():
         asserts_none(returns_none())
 
-    return_none_job.execute_in_process(resources={"io_manager": TestIOManager()})
+    result = return_none_job.execute_in_process()
+    assert result.success
 
 
 # test partitions


### PR DESCRIPTION
## Summary & Motivation

resolves #15590

In order to "bypass" I/O managers, you need to have a return type annotation of `None` on your asset 
```python
@asset 
def my_asset_stores_its_own_data() -> None:
    make_the_table()
```

In this case, the I/O manger will hit the case where we check the return type annotation and immediately return from the `handle_output` function.

If you omit the `-> None` type the full `handle_output` logic will be run on a `None` output. For some I/O managers this results in a `None` object being pickled and stored (ie fs io manager), for others, it causes errors (ie snowflake io manager). 

Requiring that users remember the `-> None` type annotation adds an additional layer of friction and confusion for the non-IO manager path, and ideally we should remove it so that the asset 

```python
@asset 
def my_asset_stores_its_own_data():
    make_the_table()
```

does not invoke the I/O manager. 

Additionally, this gets us closer to being able  to remove all of the 

```python
if output is None:
   return
```

from our built in IO managers, which is a code smell and would be awesome to delete

This PR presents one possible approach where we check if the return value is None when generating the `_store_output` step in execute_step. If it is None, we bypass the I/O manager. In order to do this we need to provide a no-op function to be run in place of the I/O manager's `handle_output` function. 

Loading data in a downstream asset presents challenges. There is a possibility that the user wants a `None` value to be loaded - ie they write the assets 

```python
@asset 
def returns_none():
    return None

@asset 
def expects_none(returns_none):
    assert returns_none is None
```

In this case we either need 1.) a way for the user to indicate that they want the returned None to be stored using the I/O manager, or 2.) we need to determine that a `None` should be supplied by the I/O manager in the `load_input` step. 

Option 1 puts more burden on the user to remember to annotate their asset when they want the `None` to be stored. Alternatively we could enforce that all assets that use an IO manager need to be be annotated as such, but that would be a huge change. Option 2 has us handle all the complexity on our side, which would result in a nicer user experience, so I'm going ahead with that option until we run into any unsolvable issues. 

I've sketched this approach out by adding metadata to outputs that do not IO managers specifying that the IO manager was not used (this isn't ideal, but works for a POC) and then when loading the downstream asset, if the asset has a prior materialization AND has metadata indicating no IO manager was used, we know it was a None output that the user intended to store with an I/O manager, so we return a None for that input. 

A couple issues with this approach:
1) attaching metadata about if an IO manager was used doesn't feel like a great pattern. The metadata would be visible in the UI, and i think it would be weird to see `used_io_manager=False` in the side panel. I considered instead adding metadata about which IO manager key was used to store data to assets that use the IO manager and then looking for that metadata to determine if we should return a None value or not, but assets with older materializations wouldn't have this metadata attached and would then be confused for `None`s.  I think a better solution would be to use something other than metadata to record this information, but i'm not sure what the right place for it is. maybe tags?

2) this requires access to the instance when loading inputs. So far this doesn't seem like an issue in unit testing, but i'm not sure if there are any gotchas i'm missing

3) Not sure how common this is, but theoretically a user could have an external tool that depends on the stored `None` values. If we feel that this is a common use case we'll need to explore option 1 above, or come up with another work around for those users

## How I Tested These Changes
