### PR TITLE
Tweak check.opt_mapping_param overloads

### DIFF
--- a/python_modules/dagster/dagster/_check/__init__.py
+++ b/python_modules/dagster/dagster/_check/__init__.py
@@ -275,7 +275,6 @@ def opt_dict_param(
     return _check_mapping_entries(obj, key_type, value_type, mapping_type=dict)
 
 
-# pyright understands this overload but not mypy
 @overload
 def opt_nullable_dict_param(
     obj: None,
@@ -629,7 +628,7 @@ def opt_int_elem(
 # ##### INST
 # ########################
 
-# mypy note: Attempting to use the passed type (Type[T] -> T) to infer the output type has
+# type-checking note: Attempting to use the passed type (Type[T] -> T) to infer the output type has
 # issues with abstract classes, so here we count on the incoming object to be typed before
 # this runtime validation check.
 
@@ -711,29 +710,11 @@ def opt_inst(
 # ########################
 
 
-@overload
 def iterator_param(
     obj: Iterator[T],
     param_name: str,
-    additional_message: Optional[str] = ...,
-) -> Iterator[T]:
-    ...
-
-
-@overload
-def iterator_param(
-    obj: object,
-    param_name: str,
-    additional_message: Optional[str] = ...,
-) -> Iterator[Any]:
-    ...
-
-
-def iterator_param(
-    obj: Any,
-    param_name: str,
     additional_message: Optional[str] = None,
-) -> Iterator[Any]:
+) -> Iterator[T]:
     if not isinstance(obj, Iterator):
         raise _param_type_mismatch_exception(obj, Iterator, param_name, additional_message)
     return obj
@@ -782,7 +763,6 @@ def opt_list_param(
     return _check_iterable_items(obj, of_type, "list")
 
 
-# pyright understands this overload but not mypy
 @overload
 def opt_nullable_list_param(
     obj: None,
@@ -907,7 +887,6 @@ def is_list(
 # ########################
 
 
-@overload
 def mapping_param(
     obj: Mapping[T, U],
     param_name: str,
@@ -915,27 +894,6 @@ def mapping_param(
     value_type: Optional[TypeOrTupleOfTypes] = None,
     additional_message: Optional[str] = None,
 ) -> Mapping[T, U]:
-    ...
-
-
-@overload
-def mapping_param(
-    obj: object,
-    param_name: str,
-    key_type: Optional[TypeOrTupleOfTypes] = ...,
-    value_type: Optional[TypeOrTupleOfTypes] = ...,
-    additional_message: Optional[str] = ...,
-) -> Mapping[object, object]:
-    ...
-
-
-def mapping_param(
-    obj: object,
-    param_name: str,
-    key_type: Optional[TypeOrTupleOfTypes] = None,
-    value_type: Optional[TypeOrTupleOfTypes] = None,
-    additional_message: Optional[str] = None,
-) -> Mapping[Any, Any]:
     if not isinstance(obj, collections.abc.Mapping):
         raise _param_type_mismatch_exception(
             obj, (collections.abc.Mapping,), param_name, additional_message=additional_message
@@ -947,42 +905,19 @@ def mapping_param(
     return _check_mapping_entries(obj, key_type, value_type, mapping_type=collections.abc.Mapping)
 
 
-@overload
 def opt_mapping_param(
     obj: Optional[Mapping[T, U]],
-    param_name: str,
-    key_type: Optional[TypeOrTupleOfTypes] = ...,
-    value_type: Optional[TypeOrTupleOfTypes] = ...,
-    additional_message: Optional[str] = ...,
-) -> Mapping[T, U]:
-    ...
-
-
-@overload
-def opt_mapping_param(
-    obj: object,
-    param_name: str,
-    key_type: Optional[TypeOrTupleOfTypes] = ...,
-    value_type: Optional[TypeOrTupleOfTypes] = ...,
-    additional_message: Optional[str] = ...,
-) -> Mapping[object, object]:
-    ...
-
-
-def opt_mapping_param(
-    obj: Optional[object],
     param_name: str,
     key_type: Optional[TypeOrTupleOfTypes] = None,
     value_type: Optional[TypeOrTupleOfTypes] = None,
     additional_message: Optional[str] = None,
-) -> Mapping[Any, Any]:
+) -> Mapping[T, U]:
     if obj is None:
         return dict()
     else:
         return mapping_param(obj, param_name, key_type, value_type, additional_message)
 
 
-# pyright understands this overload but not mypy
 @overload
 def opt_nullable_mapping_param(
     obj: None,

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -559,7 +559,7 @@ def multi_asset(
     )
 
     _config_schema = check.opt_mapping_param(
-        config_schema,
+        config_schema,  # type: ignore
         "config_schema",
         additional_message="Only dicts are supported for asset config_schema.",
     )


### PR DESCRIPTION
## Summary & Motivation

Minor tweaks to signature of `get_opt_mapping_param` and `get_opt_iterable_param` for cleaner type-checking.

## How I Tested These Changes

Existing test suite.
