### PR TITLE
join against run tags instead of in query

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -273,22 +273,6 @@ class SqlRunStorage(RunStorage):
         if filters.created_before:
             query = query.where(RunsTable.c.create_timestamp < filters.created_before)
 
-        if filters.tags and self.supports_intersect:
-            intersections = [
-                db_select([RunTagsTable.c.run_id]).where(
-                    db.and_(
-                        RunTagsTable.c.key == key,
-                        (
-                            RunTagsTable.c.value == value
-                            if isinstance(value, str)
-                            else RunTagsTable.c.value.in_(value)
-                        ),
-                    )
-                )
-                for key, value in filters.tags.items()
-            ]
-
-            query = query.where(RunsTable.c.run_id.in_(db.intersect(*intersections)))
         return query
 
     def _runs_query(
@@ -316,7 +300,7 @@ class SqlRunStorage(RunStorage):
                 check.failed("cannot specify bucket_by and limit/cursor at the same time")
             return self._bucketed_runs_query(bucket_by, filters, columns, order_by, ascending)
 
-        if filters.tags and not self.supports_intersect:
+        if filters.tags:
             table = self._apply_tags_table_joins(RunsTable, filters.tags)
         else:
             table = RunsTable
@@ -357,7 +341,7 @@ class SqlRunStorage(RunStorage):
         query_columns = [getattr(RunsTable.c, column) for column in columns] + [bucket_rank]
 
         if isinstance(bucket_by, JobBucket):
-            if filters.tags and not self.supports_intersect:
+            if filters.tags:
                 table = self._apply_tags_table_joins(RunsTable, filters.tags)
             else:
                 table = RunsTable
@@ -387,13 +371,9 @@ class SqlRunStorage(RunStorage):
         else:
             # there are tag filters as well as tag buckets, so we have to apply the tag filters in
             # a separate join
-            if self.supports_intersect:
-                filtered_query = db_select([RunsTable.c.run_id])
-            else:
-                filtered_query = db_select([RunsTable.c.run_id]).select_from(
-                    self._apply_tags_table_joins(RunsTable, filters.tags)
-                )
-
+            filtered_query = db_select([RunsTable.c.run_id]).select_from(
+                self._apply_tags_table_joins(RunsTable, filters.tags)
+            )
             filtered_query = db_subquery(
                 self._add_filters_to_query(filtered_query, filters), "filtered_query"
             )


### PR DESCRIPTION
## Summary & Motivation
The join should be faster than the intersection subquery.  This is now reconciled with changes made to Cloud, and should result in better perf across a range of queries.

GH issue tracked here: https://github.com/dagster-io/dagster/issues/12122

## How I Tested These Changes
BK