### PR TITLE
[auto-materialize] Use data versions in auto-materialize logic

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -339,8 +339,7 @@ class AssetDaemonContext:
                 parent_asset_partitions,
                 # do a precise check for updated parents, factoring in data versions, as long as
                 # we're within reasonable limits on the number of partitions to check
-                use_asset_versions=len(parent_asset_partitions) < 100
-                and len(has_or_will_update) < 100,
+                use_asset_versions=len(parent_asset_partitions | has_or_will_update) < 100,
             )
             updated_parents = {parent.asset_key for parent in updated_parent_asset_partitions}
             will_update_parents = will_update_parents_by_asset_partition[asset_partition]
@@ -447,8 +446,6 @@ class AssetDaemonContext:
             - The set of AssetKeyPartitionKeys that should be materialized.
             - The expected data time of the asset after this tick.
         """
-        print("===============")
-        print(asset_key)
         auto_materialize_policy = check.not_none(
             self.get_implicit_auto_materialize_policy(asset_key)
         )
@@ -486,7 +483,6 @@ class AssetDaemonContext:
             for condition, asset_partitions in parent_updated_conditions.items():
                 conditions[condition].update(asset_partitions)
                 candidates.update(asset_partitions)
-        print("got new parent data")
 
         # MissingAutoMaterializeCondition
         if auto_materialize_policy.on_missing:
@@ -494,7 +490,6 @@ class AssetDaemonContext:
             for condition, asset_partitions in missing_conditions.items():
                 conditions[condition].update(asset_partitions)
                 candidates.update(asset_partitions)
-        print("got missing")
 
         # These should be conditions, but aren't currently, so we just manually strip out things
         # from our materialization set
@@ -517,7 +512,6 @@ class AssetDaemonContext:
                 for condition, asset_partitions in conditions.items():
                     if candidate in asset_partitions:
                         conditions[condition].remove(candidate)
-        print("filtered")
 
         # ParentOutdatedAutoMaterializeCondition (currently no way to disable this)
         if True:
@@ -527,7 +521,6 @@ class AssetDaemonContext:
             for condition, asset_partitions in parent_outdated_conditions.items():
                 conditions[condition].update(asset_partitions)
                 candidates.difference_update(asset_partitions)
-        print("got parent outdated")
 
         # MaxMaterializationsExceededAutoMaterializeCondition
         if auto_materialize_policy.max_materializations_per_minute is not None:
@@ -540,7 +533,6 @@ class AssetDaemonContext:
                 conditions[condition].update(asset_partitions)
                 candidates.difference_update(asset_partitions)
 
-        print("done")
         return conditions, candidates, expected_data_time
 
     def get_auto_materialize_conditions(

--- a/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
+++ b/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
@@ -577,6 +577,7 @@ def get_and_update_asset_status_cache_value(
         latest_materialization_storage_id=latest_materialization_storage_id,
     )
     if updated_cache_value is not None and updated_cache_value != stored_cache_value:
-        instance.update_asset_cached_status_data(asset_key, updated_cache_value)
+        # instance.update_asset_cached_status_data(asset_key, updated_cache_value)
+        pass
 
     return updated_cache_value

--- a/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
+++ b/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
@@ -577,7 +577,6 @@ def get_and_update_asset_status_cache_value(
         latest_materialization_storage_id=latest_materialization_storage_id,
     )
     if updated_cache_value is not None and updated_cache_value != stored_cache_value:
-        # instance.update_asset_cached_status_data(asset_key, updated_cache_value)
-        pass
+        instance.update_asset_cached_status_data(asset_key, updated_cache_value)
 
     return updated_cache_value

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -728,8 +728,6 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
     ) -> AbstractSet[AssetKeyPartitionKey]:
         # we already know asset partitions are updated after the cursor if they've been updated
         # after a cursor that's greater than or equal to this one
-        print(".")
-        print(asset_key, asset_partitions)
         updated_asset_partitions = {
             ap
             for ap in asset_partitions
@@ -738,7 +736,6 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
         }
         to_query_asset_partitions = asset_partitions - updated_asset_partitions
         if not to_query_asset_partitions:
-            print("no query")
             return updated_asset_partitions
 
         latest_versions = self._asset_partitions_data_versions(
@@ -750,7 +747,6 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
         queryed_updated_asset_partitions = {
             ap for ap, version in latest_versions.items() if previous_versions.get(ap) != version
         }
-        print("query")
         # keep track of the maximum storage id at which an asset partition was updated after
         for asset_partition in queryed_updated_asset_partitions:
             self._max_version_updated_by_asset_partition[asset_partition] = after_cursor

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -69,7 +69,9 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
         self._asset_partition_count_cache: Dict[
             Optional[int], Dict[AssetKey, Mapping[str, int]]
         ] = defaultdict(dict)
-        self._max_version_updated_by_asset_partition: Dict[AssetKeyPartitionKey, int] = {}
+        self._asset_partition_versions_updated_after_cursor_cache: Dict[
+            AssetKeyPartitionKey, int
+        ] = {}
 
         self._dynamic_partitions_cache: Dict[str, Sequence[str]] = {}
 
@@ -731,8 +733,8 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
         updated_asset_partitions = {
             ap
             for ap in asset_partitions
-            if ap in self._max_version_updated_by_asset_partition
-            and self._max_version_updated_by_asset_partition[ap] <= after_cursor
+            if ap in self._asset_partition_versions_updated_after_cursor_cache
+            and self._asset_partition_versions_updated_after_cursor_cache[ap] <= after_cursor
         }
         to_query_asset_partitions = asset_partitions - updated_asset_partitions
         if not to_query_asset_partitions:
@@ -749,7 +751,9 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
         }
         # keep track of the maximum storage id at which an asset partition was updated after
         for asset_partition in queryed_updated_asset_partitions:
-            self._max_version_updated_by_asset_partition[asset_partition] = after_cursor
+            self._asset_partition_versions_updated_after_cursor_cache[asset_partition] = (
+                after_cursor
+            )
         return {*updated_asset_partitions, *queryed_updated_asset_partitions}
 
     def get_asset_partitions_updated_after_cursor(

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -767,7 +767,8 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
                 the set of checked partitions to the given partitions.
             after_cursor (Optional[int]): The cursor after which to look for updates.
             use_asset_versions (bool): If True, will use data versions to filter out asset
-                partitions which were materialized, but not updated after the cursor.
+                partitions which were materialized, but not have not had their data versions
+                cahnged since the given cursor.
         """
         if not self.asset_partition_has_materialization_or_observation(
             AssetKeyPartitionKey(asset_key), after_cursor=after_cursor
@@ -786,10 +787,7 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
         if not updated_after_cursor:
             return set()
         if after_cursor is None or (
-            # for non-source assets, only examine asset version information if use_asset_versions
-            # is True
-            not self.asset_graph.is_source(asset_key)
-            and not use_asset_versions
+            not self.asset_graph.is_source(asset_key) and not use_asset_versions
         ):
             return updated_after_cursor
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
@@ -421,6 +421,7 @@ def asset_def(
     partitions_def: Optional[PartitionsDefinition] = None,
     freshness_policy: Optional[FreshnessPolicy] = None,
     auto_materialize_policy: Optional[AutoMaterializePolicy] = None,
+    code_version: Optional[str] = None,
 ) -> AssetsDefinition:
     if deps is None:
         non_argument_deps = None
@@ -443,6 +444,7 @@ def asset_def(
         config_schema={"fail": Field(bool, default_value=False)},
         freshness_policy=freshness_policy,
         auto_materialize_policy=auto_materialize_policy,
+        code_version=code_version,
     )
     def _asset(context, **kwargs):
         del kwargs

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/scenarios.py
@@ -11,6 +11,7 @@ from .freshness_policy_scenarios import freshness_policy_scenarios
 from .multi_code_location_scenarios import multi_code_location_scenarios
 from .observable_source_asset_scenarios import observable_source_asset_scenarios
 from .partition_scenarios import partition_scenarios
+from .version_scenarios import version_scenarios
 
 ASSET_RECONCILIATION_SCENARIOS = {
     **exotic_partition_mapping_scenarios,
@@ -21,6 +22,7 @@ ASSET_RECONCILIATION_SCENARIOS = {
     **observable_source_asset_scenarios,
     **definition_change_scenarios,
     **active_run_scenarios,
+    **version_scenarios,
 }
 
 DAEMON_ONLY_SCENARIOS = {

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/version_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/version_scenarios.py
@@ -1,0 +1,150 @@
+from dagster._core.definitions.partition import StaticPartitionsDefinition
+
+from ..base_scenario import (
+    AssetReconciliationScenario,
+    asset_def,
+    run,
+    run_request,
+)
+
+three_partitions_def = StaticPartitionsDefinition(["a", "b", "c"])
+
+# A code version is not set on the root asset so that rematerializing it will be guaranteed to
+# produce a new data version.
+all_unpartitioned = [
+    asset_def("one"),
+    asset_def("two", ["one"], code_version="0"),
+    asset_def("three", ["two"], code_version="0"),
+]
+
+partitioned_to_unpartitioned = [
+    asset_def("one", partitions_def=three_partitions_def),
+    asset_def("two", ["one"], partitions_def=three_partitions_def, code_version="0"),
+    asset_def("three", ["two"], code_version="0"),
+]
+
+unpartitioned_to_partitioned = [
+    asset_def("one"),
+    asset_def("two", ["one"], code_version="0"),
+    asset_def("three", ["two"], partitions_def=three_partitions_def, code_version="0"),
+]
+
+partitioned_to_partitioned = [
+    asset_def("one", partitions_def=three_partitions_def),
+    asset_def("two", ["one"], partitions_def=three_partitions_def, code_version="0"),
+    asset_def("three", ["two"], partitions_def=three_partitions_def, code_version="0"),
+]
+
+version_scenarios = {
+    "all_unpartitioned_version_updated": AssetReconciliationScenario(
+        assets=all_unpartitioned,
+        cursor_from=AssetReconciliationScenario(
+            assets=all_unpartitioned, unevaluated_runs=[run(["one", "two", "three"])]
+        ),
+        unevaluated_runs=[run(["one", "two"])],
+        expected_run_requests=[run_request(["three"])],
+    ),
+    "all_unpartitioned_version_not_updated": AssetReconciliationScenario(
+        assets=all_unpartitioned,
+        cursor_from=AssetReconciliationScenario(
+            assets=all_unpartitioned, unevaluated_runs=[run(["one", "two", "three"])]
+        ),
+        unevaluated_runs=[run(["two"])],
+        expected_run_requests=[],
+    ),
+    "partitioned_to_unpartitioned_version_updated": AssetReconciliationScenario(
+        assets=partitioned_to_unpartitioned,
+        cursor_from=AssetReconciliationScenario(
+            assets=partitioned_to_unpartitioned,
+            unevaluated_runs=[
+                run(["one", "two"], partition_key="a"),
+                run(["one", "two"], partition_key="b"),
+                run(["one", "two"], partition_key="c"),
+                run(["three"]),
+            ],
+        ),
+        unevaluated_runs=[run(["one", "two"], partition_key="b")],
+        expected_run_requests=[run_request(["three"])],
+    ),
+    "partitioned_to_unpartitioned_version_not_updated": AssetReconciliationScenario(
+        assets=partitioned_to_unpartitioned,
+        cursor_from=AssetReconciliationScenario(
+            assets=partitioned_to_unpartitioned,
+            unevaluated_runs=[
+                run(["one", "two"], partition_key="a"),
+                run(["one", "two"], partition_key="b"),
+                run(["one", "two"], partition_key="c"),
+                run(["three"]),
+            ],
+        ),
+        unevaluated_runs=[run(["two"], partition_key="c")],
+        expected_run_requests=[],
+    ),
+    "unpartitioned_to_partitioned_version_updated": AssetReconciliationScenario(
+        assets=unpartitioned_to_partitioned,
+        cursor_from=AssetReconciliationScenario(
+            assets=unpartitioned_to_partitioned,
+            unevaluated_runs=[
+                run(["one", "two"]),
+                run(["three"], partition_key="a"),
+                run(["three"], partition_key="b"),
+                run(["three"], partition_key="c"),
+            ],
+        ),
+        unevaluated_runs=[run(["one", "two"])],
+        expected_run_requests=[
+            run_request(["three"], partition_key="a"),
+            run_request(["three"], partition_key="b"),
+            run_request(["three"], partition_key="c"),
+        ],
+    ),
+    "unpartitioned_to_partitioned_version_not_updated": AssetReconciliationScenario(
+        assets=unpartitioned_to_partitioned,
+        cursor_from=AssetReconciliationScenario(
+            assets=unpartitioned_to_partitioned,
+            unevaluated_runs=[
+                run(["one", "two"]),
+                run(["three"], partition_key="a"),
+                run(["three"], partition_key="b"),
+                run(["three"], partition_key="c"),
+            ],
+        ),
+        unevaluated_runs=[run(["two"])],
+        expected_run_requests=[],
+    ),
+    "partitioned_to_partitioned_version_updated": AssetReconciliationScenario(
+        assets=partitioned_to_partitioned,
+        cursor_from=AssetReconciliationScenario(
+            assets=partitioned_to_partitioned,
+            unevaluated_runs=[
+                run(["one", "two", "three"], partition_key="a"),
+                run(["one", "two", "three"], partition_key="b"),
+                run(["one", "two", "three"], partition_key="c"),
+            ],
+        ),
+        unevaluated_runs=[
+            run(["one", "two"], partition_key="b"),
+            run(["one", "two"], partition_key="c"),
+        ],
+        expected_run_requests=[
+            run_request(["three"], partition_key="b"),
+            run_request(["three"], partition_key="c"),
+        ],
+    ),
+    "partitioned_to_partitioned_version_not_updated": AssetReconciliationScenario(
+        assets=partitioned_to_partitioned,
+        cursor_from=AssetReconciliationScenario(
+            assets=partitioned_to_partitioned,
+            unevaluated_runs=[
+                run(["one", "two", "three"], partition_key="a"),
+                run(["one", "two", "three"], partition_key="b"),
+                run(["one", "two", "three"], partition_key="c"),
+            ],
+        ),
+        unevaluated_runs=[
+            run(["two"], partition_key="b"),
+            run(["two"], partition_key="c"),
+        ],
+        expected_run_requests=[],
+    ),
+}


### PR DESCRIPTION
## Summary & Motivation

If a new materialization happens, but it has the same data version as the previous materialization, then it shouldn't kick off a downstream run.

## How I Tested These Changes

Added unit tests.