### PR TITLE
[docs] add return for multi_asset api doc example

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -529,13 +529,14 @@ def multi_asset(
                     "asset1": AssetOut(),
                     "asset2": AssetOut(),
                 },
-                deps={"asset0"},
+                deps=["asset0"],
             )
             def my_function():
                 asset0_value = load(path="asset0")
                 asset1_result, asset2_result = do_some_transformation(asset0_value)
                 write(asset1_result, path="asset1")
                 write(asset2_result, path="asset2")
+                return None, None
     """
     from dagster._core.execution.build_resources import wrap_resources_for_execution
 


### PR DESCRIPTION
The example as is doesn't work currently, you would get
```
dagster._core.errors.DagsterInvariantViolationError: op "my_function" has multiple outputs, but only one output was returned of type <class 'NoneType'>. When using multiple outputs, either yield each output, or return a tuple containing a value for each output. Check out the documentation on outputs for more: https://docs.dagster.io/concepts/ops-jobs-graphs/ops#outputs.
```

This change just updates the example to a working state.

An alternative path is make the current code work by treating a returned `None` as "assume everything was materialized correctly" which is explored in stacked PR https://github.com/dagster-io/dagster/pull/15622

## How I Tested These Changes

execute the example before and after