### PR TITLE
Minor pyproject.toml fixes

### DIFF
--- a/examples/docs_snippets/pyproject.toml
+++ b/examples/docs_snippets/pyproject.toml
@@ -8,7 +8,7 @@
 line-length = 88
 preview = true
 required-version = "22.12.0"
-target-version = ['py38', 'py39', 'py310', 'py311']
+target-versions = ['py38', 'py39', 'py310', 'py311']
 
 [tool.ruff]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ preview = true
 required-version = "22.12.0"
 
 # Ensure black's output will be compatible with all listed versions.
-target-version = ['py38', 'py39', 'py310', 'py311']
+target-versions = ['py38', 'py39', 'py310', 'py311']
 
 # ########################
 # ##### PYRIGHT
@@ -117,6 +117,8 @@ filterwarnings = [
 # README.
 
 [tool.ruff]
+
+target-version = "py38"
 
 extend-exclude = [
   "*/__generated__/*",


### PR DESCRIPTION
## Summary & Motivation

- Fix black `target-version` setting (was missing an "s" and not being respected)
- Bump `ruff` target version to 3.8. Now we can use the almighty walrus: `:=`

## How I Tested These Changes

BK