### PR TITLE
Hide partition status for observable source assets since we don't have the data

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/SidebarAssetInfo.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/SidebarAssetInfo.tsx
@@ -160,7 +160,7 @@ export const SidebarAssetInfo: React.FC<{
 
       {assetType && <TypeSidebarSection assetType={assetType} />}
 
-      {asset.partitionDefinition && (
+      {asset.partitionDefinition && !definition.isSource && (
         <SidebarSection title="Partitions">
           <Box padding={{vertical: 16, horizontal: 24}} flex={{direction: 'column', gap: 16}}>
             <p>{asset.partitionDefinition.description}</p>


### PR DESCRIPTION
## Summary & Motivation
https://elementl-workspace.slack.com/archives/C03CCE471E0/p1690913352869479

## How I Tested These Changes

<img width="892" alt="Screenshot 2023-08-01 at 7 36 37 PM" src="https://github.com/dagster-io/dagster/assets/2286579/83116c01-3266-411f-b25f-7b51864d6df2">
