### PR TITLE
Remove styled-components/macro imports

### DIFF
--- a/js_modules/dagit/packages/core/src/app/App.tsx
+++ b/js_modules/dagit/packages/core/src/app/App.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {LeftNav, LEFT_NAV_WIDTH} from '../nav/LeftNav';
 

--- a/js_modules/dagit/packages/core/src/app/AppProvider.tsx
+++ b/js_modules/dagit/packages/core/src/app/AppProvider.tsx
@@ -23,7 +23,7 @@ import {
 import * as React from 'react';
 import {BrowserRouter} from 'react-router-dom';
 import {CompatRouter} from 'react-router-dom-v5-compat';
-import {createGlobalStyle} from 'styled-components/macro';
+import {createGlobalStyle} from 'styled-components';
 import {SubscriptionClient} from 'subscriptions-transport-ws';
 
 import {AssetRunLogObserver} from '../asset-graph/AssetRunLogObserver';

--- a/js_modules/dagit/packages/core/src/app/AppTopNav.tsx
+++ b/js_modules/dagit/packages/core/src/app/AppTopNav.tsx
@@ -1,7 +1,7 @@
 import {Box, Colors, Icon, IconWrapper, Tooltip} from '@dagster-io/ui';
 import * as React from 'react';
 import {Link, NavLink, useHistory} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {DeploymentStatusIcon} from '../nav/DeploymentStatusIcon';
 import {VersionNumber} from '../nav/VersionNumber';

--- a/js_modules/dagit/packages/core/src/app/CustomAlertProvider.tsx
+++ b/js_modules/dagit/packages/core/src/app/CustomAlertProvider.tsx
@@ -1,6 +1,6 @@
 import {Button, Dialog, DialogBody, DialogFooter, FontFamily} from '@dagster-io/ui';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {testId} from '../testing/testId';
 

--- a/js_modules/dagit/packages/core/src/app/PythonErrorInfo.tsx
+++ b/js_modules/dagit/packages/core/src/app/PythonErrorInfo.tsx
@@ -1,7 +1,7 @@
 import {gql} from '@apollo/client';
 import {Button, Icon, FontFamily, Colors} from '@dagster-io/ui';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {ErrorSource} from '../graphql/types';
 import {useLaunchPadHooks} from '../launchpad/LaunchpadHooksContext';

--- a/js_modules/dagit/packages/core/src/app/ShortcutHandler.tsx
+++ b/js_modules/dagit/packages/core/src/app/ShortcutHandler.tsx
@@ -1,7 +1,7 @@
 import {Colors} from '@dagster-io/ui';
 import * as React from 'react';
 import ReactDOM from 'react-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {getJSONForKey} from '../hooks/useStateWithStorage';
 

--- a/js_modules/dagit/packages/core/src/app/UserSettingsButton.tsx
+++ b/js_modules/dagit/packages/core/src/app/UserSettingsButton.tsx
@@ -1,6 +1,6 @@
 import {IconWrapper, Colors, Icon} from '@dagster-io/ui';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {UserSettingsDialog} from './UserSettingsDialog';
 import {getVisibleFeatureFlagRows} from './getVisibleFeatureFlagRows';

--- a/js_modules/dagit/packages/core/src/app/WebSocketProvider.tsx
+++ b/js_modules/dagit/packages/core/src/app/WebSocketProvider.tsx
@@ -1,7 +1,7 @@
 import {Colors} from '@dagster-io/ui';
 import debounce from 'lodash/debounce';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 import {SubscriptionClient} from 'subscriptions-transport-ws';
 
 import {useFeatureFlags} from './Flags';

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
@@ -10,7 +10,7 @@ import pickBy from 'lodash/pickBy';
 import uniq from 'lodash/uniq';
 import without from 'lodash/without';
 import React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {useFeatureFlags} from '../app/Flags';
 import {QueryRefreshCountdown, QueryRefreshState} from '../app/QueryRefresh';

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetGroupNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetGroupNode.tsx
@@ -1,7 +1,7 @@
 import {Box, Colors, FontFamily, Icon, Mono} from '@dagster-io/ui';
 import React from 'react';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {withMiddleTruncation} from '../app/Util';
 import {buildRepoPathForHuman} from '../workspace/buildRepoAddress';

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
@@ -3,7 +3,7 @@ import {Body, Box, Colors, FontFamily, Icon, Spinner, Tooltip} from '@dagster-io
 import isEqual from 'lodash/isEqual';
 import React from 'react';
 import {Link} from 'react-router-dom';
-import styled, {CSSObject} from 'styled-components/macro';
+import styled, {CSSObject} from 'styled-components';
 
 import {withMiddleTruncation} from '../app/Util';
 import {

--- a/js_modules/dagit/packages/core/src/asset-graph/ForeignNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/ForeignNode.tsx
@@ -1,6 +1,6 @@
 import {Colors, Icon, FontFamily} from '@dagster-io/ui';
 import React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {withMiddleTruncation} from '../app/Util';
 

--- a/js_modules/dagit/packages/core/src/asset-graph/SidebarAssetInfo.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/SidebarAssetInfo.tsx
@@ -2,7 +2,7 @@ import {gql, useQuery} from '@apollo/client';
 import {Box, Colors, ConfigTypeSchema, Icon, Spinner} from '@dagster-io/ui';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {ASSET_NODE_CONFIG_FRAGMENT} from '../assets/AssetConfig';
 import {AssetDefinedInMultipleReposNotice} from '../assets/AssetDefinedInMultipleReposNotice';

--- a/js_modules/dagit/packages/core/src/assets/AllIndividualEventsLink.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AllIndividualEventsLink.tsx
@@ -14,7 +14,7 @@ import {
 import dayjs from 'dayjs';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {Timestamp} from '../app/time/Timestamp';
 import {isHiddenAssetGroupJob} from '../asset-graph/Utils';

--- a/js_modules/dagit/packages/core/src/assets/AssetEventList.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetEventList.tsx
@@ -1,7 +1,7 @@
 import {Box, Caption, Colors, Icon, Tag} from '@dagster-io/ui';
 import {useVirtualizer} from '@tanstack/react-virtual';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {Timestamp} from '../app/time/Timestamp';
 import {AssetRunLink} from '../asset-graph/AssetRunLinking';

--- a/js_modules/dagit/packages/core/src/assets/AssetEventMetadataEntriesTable.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetEventMetadataEntriesTable.tsx
@@ -3,7 +3,7 @@ import dayjs from 'dayjs';
 import uniqBy from 'lodash/uniqBy';
 import React from 'react';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {MetadataEntry} from '../metadata/MetadataEntry';
 import {titleForRun} from '../runs/RunUtils';

--- a/js_modules/dagit/packages/core/src/assets/AssetEventSystemTags.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetEventSystemTags.tsx
@@ -1,6 +1,6 @@
 import {Box, ButtonLink, Caption, Colors, Icon, Mono} from '@dagster-io/ui';
 import React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {useStateWithStorage} from '../hooks/useStateWithStorage';
 import {DagsterTag} from '../runs/RunTag';

--- a/js_modules/dagit/packages/core/src/assets/AssetMaterializationUpstreamData.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetMaterializationUpstreamData.tsx
@@ -4,7 +4,7 @@ import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import React from 'react';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {Timestamp} from '../app/time/Timestamp';
 import {displayNameForAssetKey} from '../asset-graph/Utils';

--- a/js_modules/dagit/packages/core/src/assets/AssetNodeLineage.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodeLineage.tsx
@@ -1,6 +1,6 @@
 import {Box, Button, ButtonGroup, Colors, Icon, JoinedButtons, TextInput} from '@dagster-io/ui';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {GraphData, LiveData} from '../asset-graph/Utils';
 import {AssetGraphQueryItem, calculateGraphDistances} from '../asset-graph/useAssetGraphData';

--- a/js_modules/dagit/packages/core/src/assets/AssetNodeLineageGraph.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodeLineageGraph.tsx
@@ -1,7 +1,7 @@
 import {Box, Spinner} from '@dagster-io/ui';
 import React from 'react';
 import {useHistory} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {AssetEdges} from '../asset-graph/AssetEdges';
 import {MINIMAL_SCALE} from '../asset-graph/AssetGraphExplorer';

--- a/js_modules/dagit/packages/core/src/assets/AssetNodeList.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodeList.tsx
@@ -1,7 +1,7 @@
 import {Box, Spinner} from '@dagster-io/ui';
 import React from 'react';
 import {useHistory} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {AssetNode} from '../asset-graph/AssetNode';
 import {LiveData, toGraphId} from '../asset-graph/Utils';

--- a/js_modules/dagit/packages/core/src/assets/AssetNodePartitionCounts.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodePartitionCounts.tsx
@@ -1,6 +1,6 @@
 import {Colors, Icon, Box, Tooltip, IconName} from '@dagster-io/ui';
 import React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {LiveDataForNode} from '../asset-graph/Utils';
 import {AssetNodeFragment} from '../asset-graph/types/AssetNode.types';

--- a/js_modules/dagit/packages/core/src/assets/AssetPageHeader.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetPageHeader.tsx
@@ -3,7 +3,7 @@ import {BreadcrumbProps, Breadcrumbs} from '@blueprintjs/core';
 import {Box, Colors, PageHeader, Heading, Icon, Tooltip, IconWrapper} from '@dagster-io/ui';
 import React from 'react';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {showSharedToaster} from '../app/DomUtils';
 import {useCopyToClipboard} from '../app/browser';

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AssetAutomaterializePolicyPage.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AssetAutomaterializePolicyPage.tsx
@@ -1,6 +1,6 @@
 import {Box, Colors, Subheading} from '@dagster-io/ui';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../../app/QueryRefresh';
 import {useQueryPersistedState} from '../../hooks/useQueryPersistedState';

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AutomaterializeLeftPanel.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AutomaterializeLeftPanel.tsx
@@ -1,6 +1,6 @@
 import {Box, Caption, Colors, CursorPaginationControls} from '@dagster-io/ui';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {TimestampDisplay} from '../../schedules/TimestampDisplay';
 import {compactNumber} from '../../ui/formatters';

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AutomaterializeRequestedPartitionsLink.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/AutomaterializeRequestedPartitionsLink.tsx
@@ -15,7 +15,7 @@ import {
 import {useVirtualizer} from '@tanstack/react-virtual';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {showCustomAlert} from '../../app/CustomAlertProvider';
 import {PYTHON_ERROR_FRAGMENT} from '../../app/PythonErrorFragment';

--- a/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/CollapsibleSection.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutoMaterializePolicyPage/CollapsibleSection.tsx
@@ -1,6 +1,6 @@
 import {Box, Colors, Icon, Subheading, Tooltip} from '@dagster-io/ui';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 interface Props {
   header: React.ReactNode;

--- a/js_modules/dagit/packages/core/src/assets/LastMaterializationMetadata.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LastMaterializationMetadata.tsx
@@ -1,7 +1,7 @@
 import {Box, Colors, Group, Icon, Mono, NonIdealState, Table} from '@dagster-io/ui';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {Timestamp} from '../app/time/Timestamp';
 import {isHiddenAssetGroupJob, LiveDataForNode} from '../asset-graph/Utils';

--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -19,7 +19,7 @@ import {
 import reject from 'lodash/reject';
 import React from 'react';
 import {useHistory} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {showCustomAlert} from '../app/CustomAlertProvider';
 import {PipelineRunTag} from '../app/ExecutionSessionStorage';

--- a/js_modules/dagit/packages/core/src/assets/Version.tsx
+++ b/js_modules/dagit/packages/core/src/assets/Version.tsx
@@ -1,5 +1,5 @@
 import {FontFamily} from '@dagster-io/ui';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 export const Version = styled.div`
   font-family: ${FontFamily.monospace};

--- a/js_modules/dagit/packages/core/src/dagstertype/DagsterType.tsx
+++ b/js_modules/dagit/packages/core/src/dagstertype/DagsterType.tsx
@@ -2,7 +2,7 @@ import {gql} from '@apollo/client';
 import {Box, Colors, FontFamily} from '@dagster-io/ui';
 import {Spacing} from '@dagster-io/ui/src/components/types';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {gqlTypePredicate} from '../app/Util';
 import {METADATA_ENTRY_FRAGMENT} from '../metadata/MetadataEntry';

--- a/js_modules/dagit/packages/core/src/gantt/GanttChart.tsx
+++ b/js_modules/dagit/packages/core/src/gantt/GanttChart.tsx
@@ -14,7 +14,7 @@ import {
 import isEqual from 'lodash/isEqual';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {AppContext} from '../app/AppContext';
 import {filterByQuery, GraphQueryItem} from '../app/GraphQueryImpl';

--- a/js_modules/dagit/packages/core/src/gantt/GanttChartTimescale.tsx
+++ b/js_modules/dagit/packages/core/src/gantt/GanttChartTimescale.tsx
@@ -1,6 +1,6 @@
 import {Colors, FontFamily} from '@dagster-io/ui';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {formatElapsedTime} from '../app/Util';
 

--- a/js_modules/dagit/packages/core/src/gantt/GanttStatusPanel.tsx
+++ b/js_modules/dagit/packages/core/src/gantt/GanttStatusPanel.tsx
@@ -1,6 +1,6 @@
 import {Colors, Spinner, Tooltip} from '@dagster-io/ui';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {GraphQueryItem} from '../app/GraphQueryImpl';
 import {formatElapsedTime} from '../app/Util';

--- a/js_modules/dagit/packages/core/src/gantt/RunGroupPanel.tsx
+++ b/js_modules/dagit/packages/core/src/gantt/RunGroupPanel.tsx
@@ -2,7 +2,7 @@ import {gql, useQuery} from '@apollo/client';
 import {Box, ButtonLink, Colors, Group, Icon, FontFamily} from '@dagster-io/ui';
 import React from 'react';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {showCustomAlert} from '../app/CustomAlertProvider';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';

--- a/js_modules/dagit/packages/core/src/gantt/VizComponents.tsx
+++ b/js_modules/dagit/packages/core/src/gantt/VizComponents.tsx
@@ -1,5 +1,5 @@
 import {Colors, CursorControlsContainer} from '@dagster-io/ui';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 export const OptionsContainer = styled.div`
   min-height: 56px;

--- a/js_modules/dagit/packages/core/src/gantt/ZoomSlider.tsx
+++ b/js_modules/dagit/packages/core/src/gantt/ZoomSlider.tsx
@@ -1,6 +1,6 @@
 import {Colors, SliderStyles} from '@dagster-io/ui';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 /**
  * Renders a horizontal slider that lets you adjust the graph's relative zoom from 1-100.

--- a/js_modules/dagit/packages/core/src/graph/ExternalConnectionNode.tsx
+++ b/js_modules/dagit/packages/core/src/graph/ExternalConnectionNode.tsx
@@ -1,7 +1,7 @@
 import {Colors} from '@dagster-io/ui';
 import {LinkVertical as Link} from '@vx/shape';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {Edge} from './OpEdges';
 import {SVGMonospaceText} from './SVGComponents';

--- a/js_modules/dagit/packages/core/src/graph/OpEdges.tsx
+++ b/js_modules/dagit/packages/core/src/graph/OpEdges.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {weakmapMemoize} from '../app/Util';
 import {buildSVGPath} from '../asset-graph/Utils';

--- a/js_modules/dagit/packages/core/src/graph/OpGraph.tsx
+++ b/js_modules/dagit/packages/core/src/graph/OpGraph.tsx
@@ -1,7 +1,7 @@
 import {gql} from '@apollo/client';
 import {Colors} from '@dagster-io/ui';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {OpNameOrPath} from '../ops/OpNameOrPath';
 

--- a/js_modules/dagit/packages/core/src/graph/OpIOBox.tsx
+++ b/js_modules/dagit/packages/core/src/graph/OpIOBox.tsx
@@ -1,6 +1,6 @@
 import {Colors, FontFamily} from '@dagster-io/ui';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {DEFAULT_RESULT_NAME, titleOfIO} from '../app/titleOfIO';
 

--- a/js_modules/dagit/packages/core/src/graph/OpNode.tsx
+++ b/js_modules/dagit/packages/core/src/graph/OpNode.tsx
@@ -1,7 +1,7 @@
 import {gql} from '@apollo/client';
 import {Colors, Icon, FontFamily} from '@dagster-io/ui';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {withMiddleTruncation} from '../app/Util';
 import {displayNameForAssetKey} from '../asset-graph/Utils';

--- a/js_modules/dagit/packages/core/src/graph/OpTags.tsx
+++ b/js_modules/dagit/packages/core/src/graph/OpTags.tsx
@@ -1,6 +1,6 @@
 import {Box, Colors, FontFamily, IconWrapper} from '@dagster-io/ui';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import airbyte from './optag-images/airbyte.svg';
 import airflow from './optag-images/airflow.svg';

--- a/js_modules/dagit/packages/core/src/graph/ParentOpNode.tsx
+++ b/js_modules/dagit/packages/core/src/graph/ParentOpNode.tsx
@@ -1,6 +1,6 @@
 import {Colors} from '@dagster-io/ui';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {titleOfIO} from '../app/titleOfIO';
 import {OpNameOrPath} from '../ops/OpNameOrPath';

--- a/js_modules/dagit/packages/core/src/graph/SVGViewport.tsx
+++ b/js_modules/dagit/packages/core/src/graph/SVGViewport.tsx
@@ -3,7 +3,7 @@ import animate from 'amator';
 import * as React from 'react';
 import ReactDOM from 'react-dom';
 import {MemoryRouter} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {IBounds} from './common';
 import {makeSVGPortable} from './makeSVGPortable';

--- a/js_modules/dagit/packages/core/src/instance/BackfillRow.tsx
+++ b/js_modules/dagit/packages/core/src/instance/BackfillRow.tsx
@@ -3,7 +3,7 @@ import {Box, Button, Colors, Icon, MenuItem, Menu, Popover, Tag, Mono} from '@da
 import countBy from 'lodash/countBy';
 import * as React from 'react';
 import {useHistory, Link} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {showCustomAlert} from '../app/CustomAlertProvider';
 import {PythonErrorInfo} from '../app/PythonErrorInfo';

--- a/js_modules/dagit/packages/core/src/instance/InstanceConfig.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceConfig.tsx
@@ -13,7 +13,7 @@ import {
 } from '@dagster-io/ui';
 import * as codemirror from 'codemirror';
 import * as React from 'react';
-import {createGlobalStyle} from 'styled-components/macro';
+import {createGlobalStyle} from 'styled-components';
 
 import {useQueryRefreshAtInterval, FIFTEEN_SECONDS} from '../app/QueryRefresh';
 import {useTrackPageView} from '../app/analytics';

--- a/js_modules/dagit/packages/core/src/instance/backfill/BackfillPage.tsx
+++ b/js_modules/dagit/packages/core/src/instance/backfill/BackfillPage.tsx
@@ -19,7 +19,7 @@ import duration from 'dayjs/plugin/duration';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import React from 'react';
 import {Link, useParams} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {showCustomAlert} from '../../app/CustomAlertProvider';
 import {PYTHON_ERROR_FRAGMENT} from '../../app/PythonErrorFragment';

--- a/js_modules/dagit/packages/core/src/instigation/InstigationTick.tsx
+++ b/js_modules/dagit/packages/core/src/instigation/InstigationTick.tsx
@@ -15,7 +15,7 @@ import {
   Tooltip,
 } from '@dagster-io/ui';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {showCustomAlert} from '../app/CustomAlertProvider';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';

--- a/js_modules/dagit/packages/core/src/instigation/InstigationUtils.tsx
+++ b/js_modules/dagit/packages/core/src/instigation/InstigationUtils.tsx
@@ -2,7 +2,7 @@ import {gql} from '@apollo/client';
 import {Colors, Group, Mono} from '@dagster-io/ui';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {LastRunSummary} from '../instance/LastRunSummary';
 import {RunStatusIndicator} from '../runs/RunStatusDots';

--- a/js_modules/dagit/packages/core/src/instigation/TickHistory.tsx
+++ b/js_modules/dagit/packages/core/src/instigation/TickHistory.tsx
@@ -21,7 +21,7 @@ import {
 import {Chart} from 'chart.js';
 import zoomPlugin from 'chartjs-plugin-zoom';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {showSharedToaster} from '../app/DomUtils';
 import {useFeatureFlags} from '../app/Flags';

--- a/js_modules/dagit/packages/core/src/launchpad/ConfigEditorConfigPicker.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/ConfigEditorConfigPicker.tsx
@@ -15,7 +15,7 @@ import {
   Suggest,
 } from '@dagster-io/ui';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {AppContext} from '../app/AppContext';
 import {showCustomAlert} from '../app/CustomAlertProvider';

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchButton.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchButton.tsx
@@ -10,7 +10,7 @@ import {
   Tooltip,
 } from '@dagster-io/ui';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {useConfirmation} from '../app/CustomConfirmationProvider';
 import {ShortcutHandler} from '../app/ShortcutHandler';

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadSession.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadSession.tsx
@@ -16,7 +16,7 @@ import {
 import merge from 'deepmerge';
 import uniqBy from 'lodash/uniqBy';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 import * as yaml from 'yaml';
 
 import {showCustomAlert} from '../app/CustomAlertProvider';

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadTabs.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadTabs.tsx
@@ -1,6 +1,6 @@
 import {Box, ButtonLink, Colors, Icon, IconWrapper} from '@dagster-io/ui';
 import * as React from 'react';
-import styled, {css} from 'styled-components/macro';
+import styled, {css} from 'styled-components';
 
 import {useConfirmation} from '../app/CustomConfirmationProvider';
 import {

--- a/js_modules/dagit/packages/core/src/launchpad/LoadingOverlay.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LoadingOverlay.tsx
@@ -1,6 +1,6 @@
 import {Group, Spinner} from '@dagster-io/ui';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 export const LoadingOverlay: React.FC<{
   isLoading: boolean;

--- a/js_modules/dagit/packages/core/src/launchpad/OpSelector.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/OpSelector.tsx
@@ -1,7 +1,7 @@
 import {gql, useQuery} from '@apollo/client';
 import {Box, Colors, Popover} from '@dagster-io/ui';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {filterByQuery} from '../app/GraphQueryImpl';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';

--- a/js_modules/dagit/packages/core/src/launchpad/RunPreview.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/RunPreview.tsx
@@ -15,7 +15,7 @@ import {
   FontFamily,
 } from '@dagster-io/ui';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {showCustomAlert} from '../app/CustomAlertProvider';
 import {useConfirmation} from '../app/CustomConfirmationProvider';

--- a/js_modules/dagit/packages/core/src/launchpad/SessionSettingsBar.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/SessionSettingsBar.tsx
@@ -1,5 +1,5 @@
 import {Colors} from '@dagster-io/ui';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 export const SessionSettingsBar = styled.div`
   color: white;

--- a/js_modules/dagit/packages/core/src/launchpad/TagEditor.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/TagEditor.tsx
@@ -10,7 +10,7 @@ import {
   Tooltip,
 } from '@dagster-io/ui';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {PipelineRunTag} from '../app/ExecutionSessionStorage';
 import {ShortcutHandler} from '../app/ShortcutHandler';

--- a/js_modules/dagit/packages/core/src/metadata/MetadataEntry.tsx
+++ b/js_modules/dagit/packages/core/src/metadata/MetadataEntry.tsx
@@ -16,7 +16,7 @@ import {
 } from '@dagster-io/ui';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {copyValue} from '../app/DomUtils';
 import {assertUnreachable} from '../app/Util';

--- a/js_modules/dagit/packages/core/src/metadata/TableSchema.tsx
+++ b/js_modules/dagit/packages/core/src/metadata/TableSchema.tsx
@@ -2,7 +2,7 @@ import {gql} from '@apollo/client';
 import {Box, Colors, Tag, Tooltip} from '@dagster-io/ui';
 import {Spacing} from '@dagster-io/ui/src/components/types';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {TableSchemaFragment, ConstraintsForTableColumnFragment} from './types/TableSchema.types';
 

--- a/js_modules/dagit/packages/core/src/nav/LeftNav.tsx
+++ b/js_modules/dagit/packages/core/src/nav/LeftNav.tsx
@@ -1,6 +1,6 @@
 import {Colors} from '@dagster-io/ui';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {LayoutContext} from '../app/LayoutProvider';
 

--- a/js_modules/dagit/packages/core/src/nav/LeftNavItem.tsx
+++ b/js_modules/dagit/packages/core/src/nav/LeftNavItem.tsx
@@ -1,7 +1,7 @@
 import {Colors, Icon, Tooltip} from '@dagster-io/ui';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {InstigationStatus} from '../graphql/types';
 import {humanCronString} from '../schedules/humanCronString';

--- a/js_modules/dagit/packages/core/src/nav/LeftNavRepositorySection.tsx
+++ b/js_modules/dagit/packages/core/src/nav/LeftNavRepositorySection.tsx
@@ -1,6 +1,6 @@
 import {Body, Box, Colors} from '@dagster-io/ui';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {SectionedLeftNav} from '../ui/SectionedLeftNav';
 import {DagsterRepoOption, WorkspaceContext} from '../workspace/WorkspaceContext';

--- a/js_modules/dagit/packages/core/src/nav/RepoNavItem.tsx
+++ b/js_modules/dagit/packages/core/src/nav/RepoNavItem.tsx
@@ -13,7 +13,7 @@ import {
 } from '@dagster-io/ui';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {ShortcutHandler} from '../app/ShortcutHandler';
 import {buildRepoAddress, DUNDER_REPO_NAME} from '../workspace/buildRepoAddress';

--- a/js_modules/dagit/packages/core/src/nav/RepoSelector.tsx
+++ b/js_modules/dagit/packages/core/src/nav/RepoSelector.tsx
@@ -11,7 +11,7 @@ import {
 } from '@dagster-io/ui';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
 import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';

--- a/js_modules/dagit/packages/core/src/nav/RepositoryContentList.tsx
+++ b/js_modules/dagit/packages/core/src/nav/RepositoryContentList.tsx
@@ -1,6 +1,6 @@
 import {Colors} from '@dagster-io/ui';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 export const Item = styled(Link)<{$active: boolean}>`
   background-color: ${({$active}) => ($active ? Colors.Blue50 : 'transparent')};

--- a/js_modules/dagit/packages/core/src/nav/RepositoryLink.tsx
+++ b/js_modules/dagit/packages/core/src/nav/RepositoryLink.tsx
@@ -1,7 +1,7 @@
 import {Box, Colors, Icon, IconWrapper, MiddleTruncate, Spinner, Tooltip} from '@dagster-io/ui';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
 import {RepoAddress} from '../workspace/types';

--- a/js_modules/dagit/packages/core/src/nav/VersionNumber.tsx
+++ b/js_modules/dagit/packages/core/src/nav/VersionNumber.tsx
@@ -1,6 +1,6 @@
 import {gql, useQuery} from '@apollo/client';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {VersionNumberQuery, VersionNumberQueryVariables} from './types/VersionNumber.types';
 

--- a/js_modules/dagit/packages/core/src/nav/WarningTooltip.tsx
+++ b/js_modules/dagit/packages/core/src/nav/WarningTooltip.tsx
@@ -1,5 +1,5 @@
 import {Tooltip} from '@dagster-io/ui';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 export const WarningTooltip = styled(Tooltip)`
   display: block;

--- a/js_modules/dagit/packages/core/src/nav/getLeftNavItemsForOption.tsx
+++ b/js_modules/dagit/packages/core/src/nav/getLeftNavItemsForOption.tsx
@@ -1,6 +1,6 @@
 import {Colors} from '@dagster-io/ui';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
 import {LegacyPipelineTag} from '../pipelines/LegacyPipelineTag';

--- a/js_modules/dagit/packages/core/src/nav/useCodeLocationsStatus.tsx
+++ b/js_modules/dagit/packages/core/src/nav/useCodeLocationsStatus.tsx
@@ -2,7 +2,7 @@ import {gql, useQuery} from '@apollo/client';
 import {Box, ButtonLink, Colors} from '@dagster-io/ui';
 import * as React from 'react';
 import {useHistory} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {showSharedToaster} from '../app/DomUtils';
 import {useQueryRefreshAtInterval} from '../app/QueryRefresh';

--- a/js_modules/dagit/packages/core/src/ops/OpCard.tsx
+++ b/js_modules/dagit/packages/core/src/ops/OpCard.tsx
@@ -1,7 +1,7 @@
 import {gql} from '@apollo/client';
 import {Box} from '@dagster-io/ui';
 import React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {OpNode, OP_NODE_DEFINITION_FRAGMENT} from '../graph/OpNode';
 import {layoutOp} from '../graph/asyncGraphLayout';

--- a/js_modules/dagit/packages/core/src/ops/OpDetailsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/ops/OpDetailsRoot.tsx
@@ -1,6 +1,6 @@
 import {gql, useQuery} from '@apollo/client';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {
   SidebarOpDefinition,

--- a/js_modules/dagit/packages/core/src/ops/OpTypeSignature.tsx
+++ b/js_modules/dagit/packages/core/src/ops/OpTypeSignature.tsx
@@ -3,7 +3,7 @@ import {gql} from '@apollo/client';
 import {Code} from '@blueprintjs/core';
 import {Colors, FontFamily} from '@dagster-io/ui';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {breakOnUnderscores} from '../app/Util';
 import {DAGSTER_TYPE_WITH_TOOLTIP_FRAGMENT, TypeWithTooltip} from '../typeexplorer/TypeWithTooltip';

--- a/js_modules/dagit/packages/core/src/ops/OpsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/ops/OpsRoot.tsx
@@ -20,7 +20,7 @@ import {
   CellMeasurerCache,
   List as _List,
 } from 'react-virtualized';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {useTrackPageView} from '../app/analytics';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';

--- a/js_modules/dagit/packages/core/src/overview/OverviewAssetsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/overview/OverviewAssetsRoot.tsx
@@ -14,7 +14,7 @@ import {
 import {useVirtualizer} from '@tanstack/react-virtual';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {PythonErrorInfo} from '../app/PythonErrorInfo';
 import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../app/QueryRefresh';

--- a/js_modules/dagit/packages/core/src/partitions/CreatePartitionDialog.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/CreatePartitionDialog.tsx
@@ -13,7 +13,7 @@ import {
   Tooltip,
 } from '@dagster-io/ui';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {showCustomAlert} from '../app/CustomAlertProvider';
 import {PythonErrorInfo} from '../app/PythonErrorInfo';

--- a/js_modules/dagit/packages/core/src/partitions/DimensionRangeWizard.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/DimensionRangeWizard.tsx
@@ -12,7 +12,7 @@ import {
   TagSelectorDropdownItemProps,
 } from '@dagster-io/ui';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {AssetPartitionStatusDot} from '../assets/AssetPartitionList';
 import {partitionStatusAtIndex} from '../assets/usePartitionHealthData';

--- a/js_modules/dagit/packages/core/src/partitions/PartitionGraph.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionGraph.tsx
@@ -1,7 +1,7 @@
 import {Colors} from '@dagster-io/ui';
 import * as React from 'react';
 import {Line} from 'react-chartjs-2';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {colorHash} from '../app/Util';
 

--- a/js_modules/dagit/packages/core/src/partitions/PartitionStatus.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionStatus.tsx
@@ -1,6 +1,6 @@
 import {Box, Tooltip, Colors, useViewport} from '@dagster-io/ui';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {
   assetPartitionStatusToText,

--- a/js_modules/dagit/packages/core/src/partitions/PartitionStepStatus.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionStepStatus.tsx
@@ -12,7 +12,7 @@ import {
   useViewport,
 } from '@dagster-io/ui';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {GraphQueryItem} from '../app/GraphQueryImpl';
 import {tokenForAssetKey} from '../asset-graph/Utils';

--- a/js_modules/dagit/packages/core/src/partitions/RunMatrixUtils.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/RunMatrixUtils.tsx
@@ -1,6 +1,6 @@
 import {Colors} from '@dagster-io/ui';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 export const BOX_SIZE = 32;
 

--- a/js_modules/dagit/packages/core/src/pipelines/Description.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/Description.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {Markdown} from '../ui/Markdown';
 

--- a/js_modules/dagit/packages/core/src/pipelines/GraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/GraphExplorer.tsx
@@ -6,7 +6,7 @@ import Color from 'color';
 import qs from 'qs';
 import * as React from 'react';
 import {Route} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {filterByQuery} from '../app/GraphQueryImpl';
 import {isHiddenAssetGroupJob} from '../asset-graph/Utils';

--- a/js_modules/dagit/packages/core/src/pipelines/GraphNotices.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/GraphNotices.tsx
@@ -1,7 +1,7 @@
 import {Box, Colors, Icon, NonIdealState, Spinner} from '@dagster-io/ui';
 import capitalize from 'lodash/capitalize';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 export const LargeDAGNotice = ({nodeType}: {nodeType: 'op' | 'asset'}) => (
   <LargeDAGContainer>

--- a/js_modules/dagit/packages/core/src/pipelines/LegacyPipelineTag.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/LegacyPipelineTag.tsx
@@ -1,6 +1,6 @@
 import {Colors, Tooltip, FontFamily} from '@dagster-io/ui';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 export const LegacyPipelineTag = () => (
   <Tooltip content="Legacy pipeline" placement="top">

--- a/js_modules/dagit/packages/core/src/pipelines/SidebarComponents.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/SidebarComponents.tsx
@@ -2,7 +2,7 @@
 import {Collapse} from '@blueprintjs/core';
 import {Colors, Icon, FontFamily} from '@dagster-io/ui';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {useStateWithStorage} from '../hooks/useStateWithStorage';
 

--- a/js_modules/dagit/packages/core/src/pipelines/SidebarOpDefinition.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/SidebarOpDefinition.tsx
@@ -2,7 +2,7 @@ import {gql} from '@apollo/client';
 import {Box, Colors, ConfigTypeSchema, FontFamily, Icon} from '@dagster-io/ui';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {breakOnUnderscores} from '../app/Util';
 import {displayNameForAssetKey, isHiddenAssetGroupJob} from '../asset-graph/Utils';

--- a/js_modules/dagit/packages/core/src/pipelines/SidebarOpHelpers.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/SidebarOpHelpers.tsx
@@ -3,7 +3,7 @@ import {Text} from '@blueprintjs/core';
 import {Colors, Group, Icon, IconWrapper, Code, FontFamily} from '@dagster-io/ui';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {titleOfIO} from '../app/titleOfIO';
 import {OpColumn, OpColumnContainer} from '../runs/LogsRowComponents';

--- a/js_modules/dagit/packages/core/src/pipelines/SidebarResourcesSection.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/SidebarResourcesSection.tsx
@@ -1,7 +1,7 @@
 import {gql} from '@apollo/client';
 import {Colors, ConfigTypeSchema, Icon, IconWrapper, Box} from '@dagster-io/ui';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {CONFIG_TYPE_SCHEMA_FRAGMENT} from '../typeexplorer/ConfigTypeSchema';
 

--- a/js_modules/dagit/packages/core/src/resources/ResourceRoot.tsx
+++ b/js_modules/dagit/packages/core/src/resources/ResourceRoot.tsx
@@ -21,7 +21,7 @@ import {
 } from '@dagster-io/ui';
 import * as React from 'react';
 import {Link, useParams, useRouteMatch} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {showCustomAlert} from '../app/CustomAlertProvider';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';

--- a/js_modules/dagit/packages/core/src/resources/VirtualizedResourceRow.tsx
+++ b/js_modules/dagit/packages/core/src/resources/VirtualizedResourceRow.tsx
@@ -1,7 +1,7 @@
 import {Box, Caption, Colors, Icon, MiddleTruncate, Mono, Tooltip} from '@dagster-io/ui';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {HeaderCell, Row, RowCell} from '../ui/VirtualizedTable';
 import {RepoAddress} from '../workspace/types';

--- a/js_modules/dagit/packages/core/src/runs/CellTruncationProvider.tsx
+++ b/js_modules/dagit/packages/core/src/runs/CellTruncationProvider.tsx
@@ -1,6 +1,6 @@
 import {Colors} from '@dagster-io/ui';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {showCustomAlert} from '../app/CustomAlertProvider';
 

--- a/js_modules/dagit/packages/core/src/runs/ExecutionStateDot.tsx
+++ b/js_modules/dagit/packages/core/src/runs/ExecutionStateDot.tsx
@@ -1,5 +1,5 @@
 import {Colors} from '@dagster-io/ui';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {IStepState} from './RunMetadataProvider';
 

--- a/js_modules/dagit/packages/core/src/runs/LogFilterSelect.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogFilterSelect.tsx
@@ -1,6 +1,6 @@
 import {Box, Button, Checkbox, Colors, Icon, Menu, MenuItem, Popover} from '@dagster-io/ui';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {LogLevel} from '../graphql/types';
 import {compactNumber} from '../ui/formatters';

--- a/js_modules/dagit/packages/core/src/runs/LogsFilterInput.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogsFilterInput.tsx
@@ -8,7 +8,7 @@ import {
 } from '@dagster-io/ui';
 import Fuse from 'fuse.js';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {ClearButton} from '../ui/ClearButton';
 

--- a/js_modules/dagit/packages/core/src/runs/LogsRowComponents.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogsRowComponents.tsx
@@ -3,7 +3,7 @@ import memoize from 'lodash/memoize';
 import qs from 'qs';
 import * as React from 'react';
 import {Link, useLocation} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {formatElapsedTimeWithMsec} from '../app/Util';
 import {TimeContext} from '../app/time/TimeContext';

--- a/js_modules/dagit/packages/core/src/runs/LogsScrollingTable.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogsScrollingTable.tsx
@@ -9,7 +9,7 @@ import {
   ListRowProps,
   ScrollParams,
 } from 'react-virtualized';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {LogFilter, LogsProviderLogs} from './LogsProvider';
 import {

--- a/js_modules/dagit/packages/core/src/runs/LogsScrollingTableHeader.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogsScrollingTableHeader.tsx
@@ -1,6 +1,6 @@
 import {Colors} from '@dagster-io/ui';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {getJSONForKey} from '../hooks/useStateWithStorage';
 

--- a/js_modules/dagit/packages/core/src/runs/LogsToolbar.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogsToolbar.tsx
@@ -13,7 +13,7 @@ import {
   Tooltip,
 } from '@dagster-io/ui';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {useCopyToClipboard} from '../app/browser';
 import {OptionsContainer, OptionsDivider} from '../gantt/VizComponents';

--- a/js_modules/dagit/packages/core/src/runs/RawLogContent.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RawLogContent.tsx
@@ -1,7 +1,7 @@
 import {Colors, Group, Icon, Spinner, FontFamily} from '@dagster-io/ui';
 import Ansi from 'ansi-to-react';
 import * as React from 'react';
-import styled, {createGlobalStyle} from 'styled-components/macro';
+import styled, {createGlobalStyle} from 'styled-components';
 
 const MAX_STREAMING_LOG_BYTES = 5242880; // 5 MB
 const TRUNCATE_PREFIX = '\u001b[33m...logs truncated...\u001b[39m\n';

--- a/js_modules/dagit/packages/core/src/runs/RepoSectionHeader.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RepoSectionHeader.tsx
@@ -1,6 +1,6 @@
 import {Box, Colors, Icon, IconWrapper} from '@dagster-io/ui';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {DUNDER_REPO_NAME} from '../workspace/buildRepoAddress';
 

--- a/js_modules/dagit/packages/core/src/runs/Run.tsx
+++ b/js_modules/dagit/packages/core/src/runs/Run.tsx
@@ -6,7 +6,7 @@ import {
   ErrorBoundary,
 } from '@dagster-io/ui';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {showCustomAlert} from '../app/CustomAlertProvider';
 import {filterByQuery} from '../app/GraphQueryImpl';

--- a/js_modules/dagit/packages/core/src/runs/RunActionsMenu.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunActionsMenu.tsx
@@ -18,7 +18,7 @@ import {
 } from '@dagster-io/ui';
 import * as React from 'react';
 import {Link, useHistory} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {AppContext} from '../app/AppContext';
 import {showSharedToaster} from '../app/DomUtils';

--- a/js_modules/dagit/packages/core/src/runs/RunDetails.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunDetails.tsx
@@ -17,7 +17,7 @@ import {
 } from '@dagster-io/ui';
 import * as React from 'react';
 import {useHistory} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {AppContext} from '../app/AppContext';
 import {showSharedToaster} from '../app/DomUtils';

--- a/js_modules/dagit/packages/core/src/runs/RunListTabs.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunListTabs.tsx
@@ -3,7 +3,7 @@ import {Colors, JoinedButtons, TokenizingFieldValue} from '@dagster-io/ui';
 import isEqual from 'lodash/isEqual';
 import * as React from 'react';
 import {useLocation} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {RunStatus, RunsFilter} from '../graphql/types';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';

--- a/js_modules/dagit/packages/core/src/runs/RunStats.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunStats.tsx
@@ -2,7 +2,7 @@ import {gql, useQuery} from '@apollo/client';
 import {Box, Spinner} from '@dagster-io/ui';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {PythonErrorInfo} from '../app/PythonErrorInfo';

--- a/js_modules/dagit/packages/core/src/runs/RunStatusDots.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunStatusDots.tsx
@@ -1,6 +1,6 @@
 import {Popover, Spinner} from '@dagster-io/ui';
 import * as React from 'react';
-import styled, {css, keyframes} from 'styled-components/macro';
+import styled, {css, keyframes} from 'styled-components';
 
 import {RunStatus} from '../graphql/types';
 

--- a/js_modules/dagit/packages/core/src/runs/RunStatusPez.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunStatusPez.tsx
@@ -1,7 +1,7 @@
 import {Box, Colors, FontFamily, Mono, Popover} from '@dagster-io/ui';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {RunStatus} from '../graphql/types';
 import {StepSummaryForRun} from '../instance/StepSummaryForRun';

--- a/js_modules/dagit/packages/core/src/runs/RunTable.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTable.tsx
@@ -17,7 +17,7 @@ import {
 } from '@dagster-io/ui';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {ShortcutHandler} from '../app/ShortcutHandler';
 import {isHiddenAssetGroupJob} from '../asset-graph/Utils';

--- a/js_modules/dagit/packages/core/src/runs/RunTag.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTag.tsx
@@ -1,7 +1,7 @@
 import {Box, Caption, Colors, Popover, Tag} from '@dagster-io/ui';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 export enum DagsterTag {
   Automaterialize = 'dagster/auto_materialize',

--- a/js_modules/dagit/packages/core/src/runs/RunTimeline.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTimeline.tsx
@@ -14,7 +14,7 @@ import {
 import {useVirtualizer} from '@tanstack/react-virtual';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {RunStatus} from '../graphql/types';
 import {OVERVIEW_COLLAPSED_KEY} from '../overview/OverviewExpansionKey';

--- a/js_modules/dagit/packages/core/src/runs/StepLogsDialog.tsx
+++ b/js_modules/dagit/packages/core/src/runs/StepLogsDialog.tsx
@@ -1,7 +1,7 @@
 import {Box, Button, Colors, Dialog, DialogFooter, Icon, Mono, Spinner} from '@dagster-io/ui';
 import React, {useState} from 'react';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {DagsterEventType} from '../graphql/types';
 import {useSupportsCapturedLogs} from '../instance/useSupportsCapturedLogs';

--- a/js_modules/dagit/packages/core/src/schedules/SchedulesNextTicks.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/SchedulesNextTicks.tsx
@@ -22,7 +22,7 @@ import {
 import qs from 'qs';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {showSharedToaster} from '../app/DomUtils';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';

--- a/js_modules/dagit/packages/core/src/schedules/TimestampDisplay.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/TimestampDisplay.tsx
@@ -1,6 +1,6 @@
 import {Colors, Icon, Tooltip} from '@dagster-io/ui';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {TimeContext} from '../app/time/TimeContext';
 import {DEFAULT_TIME_FORMAT, TimeFormat} from '../app/time/TimestampFormat';

--- a/js_modules/dagit/packages/core/src/search/SearchDialog.tsx
+++ b/js_modules/dagit/packages/core/src/search/SearchDialog.tsx
@@ -5,7 +5,7 @@ import Fuse from 'fuse.js';
 import debounce from 'lodash/debounce';
 import * as React from 'react';
 import {useHistory, useLocation} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {ShortcutHandler} from '../app/ShortcutHandler';
 import {useTrackEvent} from '../app/analytics';

--- a/js_modules/dagit/packages/core/src/search/SearchResults.tsx
+++ b/js_modules/dagit/packages/core/src/search/SearchResults.tsx
@@ -2,7 +2,7 @@ import {Colors, IconName, Icon} from '@dagster-io/ui';
 import Fuse from 'fuse.js';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {SearchResult, SearchResultType} from './types';
 

--- a/js_modules/dagit/packages/core/src/ticks/EvaluateScheduleDialog.tsx
+++ b/js_modules/dagit/packages/core/src/ticks/EvaluateScheduleDialog.tsx
@@ -18,7 +18,7 @@ import {
   useViewport,
 } from '@dagster-io/ui';
 import React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {PythonErrorInfo} from '../app/PythonErrorInfo';

--- a/js_modules/dagit/packages/core/src/ticks/SensorDryRunDialog.tsx
+++ b/js_modules/dagit/packages/core/src/ticks/SensorDryRunDialog.tsx
@@ -16,7 +16,7 @@ import {
   TextInput,
 } from '@dagster-io/ui';
 import React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {showCustomAlert} from '../app/CustomAlertProvider';
 import {showSharedToaster} from '../app/DomUtils';

--- a/js_modules/dagit/packages/core/src/typeexplorer/TypeList.tsx
+++ b/js_modules/dagit/packages/core/src/typeexplorer/TypeList.tsx
@@ -1,7 +1,7 @@
 import {gql} from '@apollo/client';
 import {Box, Colors} from '@dagster-io/ui';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {SidebarSection, SidebarSubhead, SidebarTitle} from '../pipelines/SidebarComponents';
 

--- a/js_modules/dagit/packages/core/src/typeexplorer/TypeWithTooltip.tsx
+++ b/js_modules/dagit/packages/core/src/typeexplorer/TypeWithTooltip.tsx
@@ -2,7 +2,7 @@ import {gql} from '@apollo/client';
 import {Colors} from '@dagster-io/ui';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 interface ITypeWithTooltipProps {
   type: {

--- a/js_modules/dagit/packages/core/src/ui/ClearButton.tsx
+++ b/js_modules/dagit/packages/core/src/ui/ClearButton.tsx
@@ -1,5 +1,5 @@
 import {Colors, IconWrapper} from '@dagster-io/ui';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 export const ClearButton = styled.button`
   background: transparent;

--- a/js_modules/dagit/packages/core/src/ui/Filters/FilterDropdown.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Filters/FilterDropdown.tsx
@@ -12,7 +12,7 @@ import {
 } from '@dagster-io/ui';
 import {useVirtualizer} from '@tanstack/react-virtual';
 import React, {useState, useRef} from 'react';
-import styled, {createGlobalStyle} from 'styled-components/macro';
+import styled, {createGlobalStyle} from 'styled-components';
 import {v4 as uuidv4} from 'uuid';
 
 import {ShortcutHandler} from '../../app/ShortcutHandler';

--- a/js_modules/dagit/packages/core/src/ui/Filters/useFilter.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Filters/useFilter.tsx
@@ -1,6 +1,6 @@
 import {BaseTag, Colors, Icon, IconName} from '@dagster-io/ui';
 import React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {TruncatedTextWithFullTextOnHover} from '../../nav/getLeftNavItemsForOption';
 

--- a/js_modules/dagit/packages/core/src/ui/Filters/useTimeRangeFilter.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Filters/useTimeRangeFilter.tsx
@@ -4,7 +4,7 @@ import isEqual from 'lodash/isEqual';
 import moment from 'moment-timezone';
 import React from 'react';
 import {DateRangePicker} from 'react-dates';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {TimeContext} from '../../app/time/TimeContext';
 import {browserTimezone} from '../../app/time/browserTimezone';

--- a/js_modules/dagit/packages/core/src/ui/GraphQueryInput.tsx
+++ b/js_modules/dagit/packages/core/src/ui/GraphQueryInput.tsx
@@ -16,7 +16,7 @@ import isEqual from 'lodash/isEqual';
 import uniq from 'lodash/uniq';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {filterByQuery, GraphQueryItem} from '../app/GraphQueryImpl';
 import {dynamicKeyWithoutIndex, isDynamicStep} from '../gantt/DynamicStepSupport';

--- a/js_modules/dagit/packages/core/src/ui/Markdown.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Markdown.tsx
@@ -4,7 +4,7 @@ import ReactMarkdown from 'react-markdown';
 import rehypeHighlight from 'rehype-highlight';
 import rehypeSanitize, {defaultSchema} from 'rehype-sanitize';
 import gfm from 'remark-gfm';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import 'highlight.js/styles/github.css';
 

--- a/js_modules/dagit/packages/core/src/ui/MenuLink.tsx
+++ b/js_modules/dagit/packages/core/src/ui/MenuLink.tsx
@@ -9,7 +9,7 @@ import {
 } from '@dagster-io/ui';
 import * as React from 'react';
 import {Link, LinkProps} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 interface MenuLinkProps
   extends CommonMenuItemProps,

--- a/js_modules/dagit/packages/core/src/ui/SectionedLeftNav.tsx
+++ b/js_modules/dagit/packages/core/src/ui/SectionedLeftNav.tsx
@@ -2,7 +2,7 @@ import {BaseTag, Box, Colors, Icon, IconWrapper, MiddleTruncate, StyledTag} from
 import {useVirtualizer} from '@tanstack/react-virtual';
 import * as React from 'react';
 import {useRouteMatch} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {AppContext} from '../app/AppContext';
 import {useFeatureFlags} from '../app/Flags';

--- a/js_modules/dagit/packages/core/src/ui/StickyTableContainer.tsx
+++ b/js_modules/dagit/packages/core/src/ui/StickyTableContainer.tsx
@@ -1,5 +1,5 @@
 import {Colors} from '@dagster-io/ui';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 interface Props {
   $top?: number;

--- a/js_modules/dagit/packages/core/src/ui/TabLink.tsx
+++ b/js_modules/dagit/packages/core/src/ui/TabLink.tsx
@@ -1,7 +1,7 @@
 import {TabStyleProps, getTabA11yProps, getTabContent, tabCSS} from '@dagster-io/ui';
 import * as React from 'react';
 import {Link, LinkProps} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 interface TabLinkProps extends TabStyleProps, Omit<LinkProps, 'title'> {
   title?: React.ReactNode;

--- a/js_modules/dagit/packages/core/src/ui/VirtualizedTable.tsx
+++ b/js_modules/dagit/packages/core/src/ui/VirtualizedTable.tsx
@@ -1,6 +1,6 @@
 import {Box, Colors} from '@dagster-io/ui';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 export const HeaderCell = ({children}: {children?: React.ReactNode}) => (
   <CellBox

--- a/js_modules/dagit/packages/core/src/workspace/CodeLocationRowSet.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/CodeLocationRowSet.tsx
@@ -11,7 +11,7 @@ import {
 } from '@dagster-io/ui';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {showSharedToaster} from '../app/DomUtils';
 import {useCopyToClipboard} from '../app/browser';

--- a/js_modules/dagit/packages/core/src/workspace/RepositoryCountTags.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/RepositoryCountTags.tsx
@@ -1,7 +1,7 @@
 import {Box, Tag, Tooltip} from '@dagster-io/ui';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
 

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedAssetRow.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedAssetRow.tsx
@@ -2,7 +2,7 @@ import {gql, useQuery} from '@apollo/client';
 import {Box, Caption, Checkbox, Colors, Icon} from '@dagster-io/ui';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {buildAssetNodeStatusContent} from '../asset-graph/AssetNode';
 import {AssetRunLink} from '../asset-graph/AssetRunLinking';

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedGraphTable.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedGraphTable.tsx
@@ -3,7 +3,7 @@ import {Box, Caption, Colors} from '@dagster-io/ui';
 import {useVirtualizer} from '@tanstack/react-virtual';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {Container, HeaderCell, Inner, Row, RowCell} from '../ui/VirtualizedTable';
 

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedJobRow.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedJobRow.tsx
@@ -2,7 +2,7 @@ import {gql, useLazyQuery} from '@apollo/client';
 import {Box, Colors, MiddleTruncate} from '@dagster-io/ui';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {useQueryRefreshAtInterval, FIFTEEN_SECONDS} from '../app/QueryRefresh';
 import {JobMenu} from '../instance/JobMenu';

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedRepoAssetTable.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedRepoAssetTable.tsx
@@ -3,7 +3,7 @@ import {Box, Colors, Icon, IconWrapper, Tag} from '@dagster-io/ui';
 import {useVirtualizer} from '@tanstack/react-virtual';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {AppContext} from '../app/AppContext';
 import {ASSET_TABLE_DEFINITION_FRAGMENT} from '../assets/AssetTableFragment';

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedScheduleRow.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedScheduleRow.tsx
@@ -13,7 +13,7 @@ import {
 } from '@dagster-io/ui';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {useQueryRefreshAtInterval, FIFTEEN_SECONDS} from '../app/QueryRefresh';
 import {InstigationStatus, InstigationType} from '../graphql/types';

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedSensorRow.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedSensorRow.tsx
@@ -2,7 +2,7 @@ import {gql, useLazyQuery} from '@apollo/client';
 import {Box, Caption, Checkbox, Colors, MiddleTruncate, Tooltip} from '@dagster-io/ui';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {useQueryRefreshAtInterval, FIFTEEN_SECONDS} from '../app/QueryRefresh';
 import {InstigationStatus, InstigationType} from '../graphql/types';

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedWorkspaceTable.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedWorkspaceTable.tsx
@@ -1,7 +1,7 @@
 import {LazyQueryExecFunction, QueryResult} from '@apollo/client';
 import {Caption, Colors} from '@dagster-io/ui';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {RepoSectionHeader} from '../runs/RepoSectionHeader';
 import {Row} from '../ui/VirtualizedTable';

--- a/js_modules/dagit/packages/eslint-config/index.js
+++ b/js_modules/dagit/packages/eslint-config/index.js
@@ -43,7 +43,6 @@ module.exports = {
     'no-restricted-imports': [
       'error',
       {
-        patterns: ['!styled-components/macro'],
         paths: [
           {
             name: '@blueprintjs/core',
@@ -77,10 +76,6 @@ module.exports = {
           {
             name: 'moment-timezone',
             message: 'Please use native Intl APIs for date/time, or dayjs if necessary.',
-          },
-          {
-            name: 'styled-components',
-            message: 'Please import from `styled-components/macro`.',
           },
         ],
       },

--- a/js_modules/dagit/packages/ui/src/components/Alert.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Alert.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {Box} from './Box';
 import {Colors} from './Colors';

--- a/js_modules/dagit/packages/ui/src/components/BaseTag.tsx
+++ b/js_modules/dagit/packages/ui/src/components/BaseTag.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {Colors} from './Colors';
 import {IconWrapper} from './Icon';

--- a/js_modules/dagit/packages/ui/src/components/Box.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Box.tsx
@@ -1,4 +1,4 @@
-import styled, {css} from 'styled-components/macro';
+import styled, {css} from 'styled-components';
 
 import {assertUnreachable} from '../util/assertUnreachable';
 

--- a/js_modules/dagit/packages/ui/src/components/Button.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Button.tsx
@@ -1,7 +1,7 @@
 // eslint-disable-next-line no-restricted-imports
 import {AnchorButton as BlueprintAnchorButton, Button as BlueprintButton} from '@blueprintjs/core';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {BaseButton} from './BaseButton';
 import {Colors} from './Colors';

--- a/js_modules/dagit/packages/ui/src/components/ButtonLink.tsx
+++ b/js_modules/dagit/packages/ui/src/components/ButtonLink.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import styled, {css} from 'styled-components/macro';
+import styled, {css} from 'styled-components';
 
 import {Colors} from './Colors';
 

--- a/js_modules/dagit/packages/ui/src/components/Checkbox.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Checkbox.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {useRef} from 'react';
-import styled, {css} from 'styled-components/macro';
+import styled, {css} from 'styled-components';
 
 import {Colors} from './Colors';
 

--- a/js_modules/dagit/packages/ui/src/components/CodeMirror.tsx
+++ b/js_modules/dagit/packages/ui/src/components/CodeMirror.tsx
@@ -2,7 +2,7 @@ import 'codemirror/lib/codemirror.css';
 
 import * as React from 'react';
 import {Controlled, UnControlled as Uncontrolled} from 'react-codemirror2';
-import {createGlobalStyle} from 'styled-components/macro';
+import {createGlobalStyle} from 'styled-components';
 
 import {Colors} from './Colors';
 import {Icons} from './Icon';

--- a/js_modules/dagit/packages/ui/src/components/ConfigEditor.tsx
+++ b/js_modules/dagit/packages/ui/src/components/ConfigEditor.tsx
@@ -14,7 +14,7 @@ import 'codemirror/keymap/sublime';
 import {Editor} from 'codemirror';
 import debounce from 'lodash/debounce';
 import * as React from 'react';
-import {createGlobalStyle} from 'styled-components/macro';
+import {createGlobalStyle} from 'styled-components';
 import * as yaml from 'yaml';
 
 import {StyledCodeMirror} from './CodeMirror';

--- a/js_modules/dagit/packages/ui/src/components/ConfigEditorWithSchema.tsx
+++ b/js_modules/dagit/packages/ui/src/components/ConfigEditorWithSchema.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {createGlobalStyle} from 'styled-components/macro';
+import {createGlobalStyle} from 'styled-components';
 
 import {Box} from './Box';
 import {ConfigEditor, ConfigSchema} from './ConfigEditor';

--- a/js_modules/dagit/packages/ui/src/components/ConfigTypeSchema.tsx
+++ b/js_modules/dagit/packages/ui/src/components/ConfigTypeSchema.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {Colors} from './Colors';
 import {Popover} from './Popover';

--- a/js_modules/dagit/packages/ui/src/components/CursorControls.tsx
+++ b/js_modules/dagit/packages/ui/src/components/CursorControls.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {Button} from './Button';
 import {Icon} from './Icon';

--- a/js_modules/dagit/packages/ui/src/components/CustomTooltipProvider.tsx
+++ b/js_modules/dagit/packages/ui/src/components/CustomTooltipProvider.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 export const CustomTooltipProvider = () => {
   const [state, setState] = React.useState<null | {

--- a/js_modules/dagit/packages/ui/src/components/Dialog.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Dialog.tsx
@@ -1,7 +1,7 @@
 // eslint-disable-next-line no-restricted-imports
 import {Dialog as BlueprintDialog} from '@blueprintjs/core';
 import * as React from 'react';
-import styled, {createGlobalStyle} from 'styled-components/macro';
+import styled, {createGlobalStyle} from 'styled-components';
 
 import {Box} from './Box';
 import {Colors} from './Colors';

--- a/js_modules/dagit/packages/ui/src/components/ErrorBoundary.tsx
+++ b/js_modules/dagit/packages/ui/src/components/ErrorBoundary.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {Box} from './Box';
 import {Colors} from './Colors';

--- a/js_modules/dagit/packages/ui/src/components/Group.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Group.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import styled, {css} from 'styled-components/macro';
+import styled, {css} from 'styled-components';
 
 import {Box} from './Box';
 import {AlignItems, DirectionalSpacing, FlexProperties, FlexWrap, Spacing} from './types';

--- a/js_modules/dagit/packages/ui/src/components/Icon.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Icon.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import account_circle from '../icon-svgs/account_circle.svg';
 import account_tree from '../icon-svgs/account_tree.svg';

--- a/js_modules/dagit/packages/ui/src/components/MainContent.tsx
+++ b/js_modules/dagit/packages/ui/src/components/MainContent.tsx
@@ -1,4 +1,4 @@
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 export const MainContent = styled.div`
   overflow-y: auto;

--- a/js_modules/dagit/packages/ui/src/components/Menu.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Menu.tsx
@@ -6,7 +6,7 @@ import {
   MenuItem as BlueprintMenuItem,
 } from '@blueprintjs/core';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {Colors} from './Colors';
 import {IconName, Icon, IconWrapper} from './Icon';

--- a/js_modules/dagit/packages/ui/src/components/MetadataTable.tsx
+++ b/js_modules/dagit/packages/ui/src/components/MetadataTable.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {Box} from './Box';
 import {Colors} from './Colors';

--- a/js_modules/dagit/packages/ui/src/components/MiddleTruncate.tsx
+++ b/js_modules/dagit/packages/ui/src/components/MiddleTruncate.tsx
@@ -1,6 +1,6 @@
 import useResizeObserver from '@react-hook/resize-observer';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {calculateMiddleTruncation} from './calculateMiddleTruncation';
 

--- a/js_modules/dagit/packages/ui/src/components/Page.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Page.tsx
@@ -1,4 +1,4 @@
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 export const Page = styled.div`
   height: 100%;

--- a/js_modules/dagit/packages/ui/src/components/PageHeader.tsx
+++ b/js_modules/dagit/packages/ui/src/components/PageHeader.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {Box} from './Box';
 import {Colors} from './Colors';

--- a/js_modules/dagit/packages/ui/src/components/Popover.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Popover.tsx
@@ -3,7 +3,7 @@
 import {Popover2, Popover2Props} from '@blueprintjs/popover2';
 import deepmerge from 'deepmerge';
 import * as React from 'react';
-import {createGlobalStyle} from 'styled-components/macro';
+import {createGlobalStyle} from 'styled-components';
 
 import searchSVG from '../icon-svgs/search.svg';
 

--- a/js_modules/dagit/packages/ui/src/components/ProductTour.tsx
+++ b/js_modules/dagit/packages/ui/src/components/ProductTour.tsx
@@ -1,7 +1,7 @@
 // eslint-disable-next-line no-restricted-imports
 import {Placement} from '@blueprintjs/popover2';
 import React from 'react';
-import styled, {CSSProperties} from 'styled-components/macro';
+import styled, {CSSProperties} from 'styled-components';
 
 import {Box} from './Box';
 import {Button} from './Button';

--- a/js_modules/dagit/packages/ui/src/components/ProgressBar.tsx
+++ b/js_modules/dagit/packages/ui/src/components/ProgressBar.tsx
@@ -1,7 +1,7 @@
 // eslint-disable-next-line no-restricted-imports
 import {ProgressBar as BlueprintProgressBar, ProgressBarProps} from '@blueprintjs/core';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {Colors} from './Colors';
 

--- a/js_modules/dagit/packages/ui/src/components/Radio.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Radio.tsx
@@ -1,4 +1,4 @@
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {Colors} from './Colors';
 import {IconWrapper} from './Icon';

--- a/js_modules/dagit/packages/ui/src/components/RefreshableCountdown.tsx
+++ b/js_modules/dagit/packages/ui/src/components/RefreshableCountdown.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {Colors} from './Colors';
 import {Group} from './Group';

--- a/js_modules/dagit/packages/ui/src/components/Slider.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Slider.tsx
@@ -6,7 +6,7 @@ import {
   MultiSliderProps,
 } from '@blueprintjs/core';
 import * as React from 'react';
-import styled, {css} from 'styled-components/macro';
+import styled, {css} from 'styled-components';
 
 import {Colors} from './Colors';
 

--- a/js_modules/dagit/packages/ui/src/components/Spinner.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Spinner.tsx
@@ -1,7 +1,7 @@
 // eslint-disable-next-line no-restricted-imports
 import {Spinner as BlueprintSpinner} from '@blueprintjs/core';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {Colors} from './Colors';
 

--- a/js_modules/dagit/packages/ui/src/components/SplitPanelContainer.tsx
+++ b/js_modules/dagit/packages/ui/src/components/SplitPanelContainer.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {Button} from './Button';
 import {ButtonGroup} from './ButtonGroup';

--- a/js_modules/dagit/packages/ui/src/components/StyledButton.tsx
+++ b/js_modules/dagit/packages/ui/src/components/StyledButton.tsx
@@ -1,4 +1,4 @@
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {IconWrapper} from './Icon';
 import {SpinnerWrapper} from './Spinner';

--- a/js_modules/dagit/packages/ui/src/components/SubwayDot.tsx
+++ b/js_modules/dagit/packages/ui/src/components/SubwayDot.tsx
@@ -2,7 +2,7 @@
 import {Colors} from '@blueprintjs/core';
 import memoize from 'lodash/memoize';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {Icon, IconName} from './Icon';
 

--- a/js_modules/dagit/packages/ui/src/components/Suggest.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Suggest.tsx
@@ -5,7 +5,7 @@ import {isCreateNewItem, Suggest as BlueprintSuggest, SuggestProps} from '@bluep
 import deepmerge from 'deepmerge';
 import * as React from 'react';
 import {List as _List} from 'react-virtualized';
-import {createGlobalStyle} from 'styled-components/macro';
+import {createGlobalStyle} from 'styled-components';
 
 import {Colors} from './Colors';
 import {IconWrapper} from './Icon';

--- a/js_modules/dagit/packages/ui/src/components/Table.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Table.tsx
@@ -1,6 +1,6 @@
 // eslint-disable-next-line no-restricted-imports
 import {HTMLTable, HTMLTableProps} from '@blueprintjs/core';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {StyledTag} from './BaseTag';
 import {Colors} from './Colors';

--- a/js_modules/dagit/packages/ui/src/components/Tabs.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Tabs.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import styled, {css} from 'styled-components/macro';
+import styled, {css} from 'styled-components';
 
 import {Colors} from './Colors';
 import {IconWrapper} from './Icon';

--- a/js_modules/dagit/packages/ui/src/components/TagSelector.tsx
+++ b/js_modules/dagit/packages/ui/src/components/TagSelector.tsx
@@ -1,6 +1,6 @@
 import {useVirtualizer} from '@tanstack/react-virtual';
 import React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {Box} from './Box';
 import {Checkbox} from './Checkbox';

--- a/js_modules/dagit/packages/ui/src/components/Text.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Text.tsx
@@ -1,4 +1,4 @@
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {Colors} from './Colors';
 import {FontFamily} from './styles';

--- a/js_modules/dagit/packages/ui/src/components/TextInput.tsx
+++ b/js_modules/dagit/packages/ui/src/components/TextInput.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import styled, {css} from 'styled-components/macro';
+import styled, {css} from 'styled-components';
 
 import {Colors} from './Colors';
 import {IconName, Icon, IconWrapper} from './Icon';

--- a/js_modules/dagit/packages/ui/src/components/Toaster.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Toaster.tsx
@@ -1,7 +1,7 @@
 // eslint-disable-next-line no-restricted-imports
 import {IToasterProps, ToasterInstance, ToastProps} from '@blueprintjs/core';
 import React from 'react';
-import {createGlobalStyle} from 'styled-components/macro';
+import {createGlobalStyle} from 'styled-components';
 
 import {Colors} from './Colors';
 import {IconName, Icon} from './Icon';

--- a/js_modules/dagit/packages/ui/src/components/TokenizingField.tsx
+++ b/js_modules/dagit/packages/ui/src/components/TokenizingField.tsx
@@ -1,7 +1,7 @@
 // eslint-disable-next-line no-restricted-imports
 import {TagInput} from '@blueprintjs/core';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {Box} from './Box';
 import {Colors} from './Colors';

--- a/js_modules/dagit/packages/ui/src/components/Tooltip.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Tooltip.tsx
@@ -2,7 +2,7 @@
 import {Tooltip2, Tooltip2Props} from '@blueprintjs/popover2';
 import deepmerge from 'deepmerge';
 import React from 'react';
-import styled, {createGlobalStyle, css} from 'styled-components/macro';
+import styled, {createGlobalStyle, css} from 'styled-components';
 
 import {Colors} from './Colors';
 import {FontFamily} from './styles';

--- a/js_modules/dagit/packages/ui/src/components/Trace.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Trace.tsx
@@ -1,4 +1,4 @@
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {Colors} from './Colors';
 import {FontFamily} from './styles';

--- a/js_modules/dagit/packages/ui/src/components/VirtualizedTable.tsx
+++ b/js_modules/dagit/packages/ui/src/components/VirtualizedTable.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {Box} from './Box';
 import {Colors} from './Colors';

--- a/js_modules/dagit/packages/ui/src/components/Warning.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Warning.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {Colors} from './Colors';
 import {Icon} from './Icon';

--- a/js_modules/dagit/packages/ui/src/components/__stories__/Box.stories.tsx
+++ b/js_modules/dagit/packages/ui/src/components/__stories__/Box.stories.tsx
@@ -1,6 +1,6 @@
 import {Meta} from '@storybook/react';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {Box} from '../Box';
 import {Colors} from '../Colors';

--- a/js_modules/dagit/packages/ui/src/components/__stories__/Group.stories.tsx
+++ b/js_modules/dagit/packages/ui/src/components/__stories__/Group.stories.tsx
@@ -1,6 +1,6 @@
 import {Meta} from '@storybook/react';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {Box} from '../Box';
 import {ButtonLink} from '../ButtonLink';

--- a/js_modules/dagit/packages/ui/src/components/__stories__/Menu.stories.tsx
+++ b/js_modules/dagit/packages/ui/src/components/__stories__/Menu.stories.tsx
@@ -1,6 +1,6 @@
 import {Meta} from '@storybook/react';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {Group} from '../Group';
 import {Menu, MenuItem, MenuDivider} from '../Menu';

--- a/js_modules/dagit/packages/ui/src/components/__stories__/TagSelector.stories.tsx
+++ b/js_modules/dagit/packages/ui/src/components/__stories__/TagSelector.stories.tsx
@@ -1,6 +1,6 @@
 import {Meta} from '@storybook/react';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {Box} from '../Box';
 import {Checkbox} from '../Checkbox';

--- a/js_modules/dagit/packages/ui/src/components/__stories__/TokenizingField.stories.tsx
+++ b/js_modules/dagit/packages/ui/src/components/__stories__/TokenizingField.stories.tsx
@@ -1,6 +1,6 @@
 import {Meta} from '@storybook/react';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {Colors} from '../Colors';
 import {Group} from '../Group';

--- a/js_modules/dagit/packages/ui/src/components/configeditor/ConfigEditorHelp.tsx
+++ b/js_modules/dagit/packages/ui/src/components/configeditor/ConfigEditorHelp.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 
 import {Colors} from '../Colors';
 import {ConfigTypeSchema, TypeData} from '../ConfigTypeSchema';

--- a/js_modules/dagit/packages/ui/src/fonts/GlobalInconsolata.tsx
+++ b/js_modules/dagit/packages/ui/src/fonts/GlobalInconsolata.tsx
@@ -1,4 +1,4 @@
-import {createGlobalStyle} from 'styled-components/macro';
+import {createGlobalStyle} from 'styled-components';
 
 /**
  * `Inter` and `Inconsolata` are encoded as base64 because we can't always guarantee

--- a/js_modules/dagit/packages/ui/src/fonts/GlobalInter.tsx
+++ b/js_modules/dagit/packages/ui/src/fonts/GlobalInter.tsx
@@ -1,4 +1,4 @@
-import {createGlobalStyle} from 'styled-components/macro';
+import {createGlobalStyle} from 'styled-components';
 
 /**
  * `Inter` and `Inconsolata` are encoded as base64 because we can't always guarantee


### PR DESCRIPTION
## Summary & Motivation

We don't actually need to import from styled-components/macro because we're already using babel-plugin-macros

## How I Tested These Changes
buildkite
