### PR TITLE
chore: remove `contextvars` installation

### DIFF
--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -70,7 +70,6 @@ setup(
         # cli
         "click>=5.0",
         "coloredlogs>=6.1, <=14.0",
-        "contextvars; python_version < '3.7'",
         "Jinja2",
         "PyYAML>=5.1",
         # core (not explicitly expressed atm)


### PR DESCRIPTION
## Summary & Motivation
Not necessary since Dagster dropped support for py3.6.

## How I Tested These Changes
bk
