### PR TITLE
[ui] Tiny fix for pressing an arrow key without a selection in the asset graph

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -255,7 +255,7 @@ const AssetGraphExplorerWithData: React.FC<WithDataProps> = ({
     );
 
   const onArrowKeyDown = (e: React.KeyboardEvent<any>, dir: string) => {
-    if (!layout) {
+    if (!layout || !lastSelectedNode) {
       return;
     }
     const hasDefinition = (node: {id: string}) => !!assetGraphData.nodes[node.id]?.definition;


### PR DESCRIPTION
Was able to reproduce this after @hellendag flagged https://app.datadoghq.com/rum/error-tracking/issue/bf22bfa4-393c-11ed-8bbc-da7ad0900002?query=%40application.id%3A7edc09bb-51d0-4555-90cd-b19ca483d1fe&from_ts=1689806194775&to_ts=1691015769107&live=true, also verified it does not happen in the op graph

## Summary & Motivation

## How I Tested These Changes
