### PR TITLE
fix(dbt): add scaffold to `package_data`

### DIFF
--- a/python_modules/libraries/dagster-dbt/setup.py
+++ b/python_modules/libraries/dagster-dbt/setup.py
@@ -32,6 +32,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_dbt_tests*"]),
+    include_package_data=True,
     install_requires=[
         f"dagster{pin}",
         # Follow the version support constraints for dbt Core: https://docs.getdbt.com/docs/dbt-versions/core


### PR DESCRIPTION
## Summary & Motivation
A `MANIFEST.in` was included, but `include_package_data` was not set. Fix that.

https://setuptools.pypa.io/en/latest/userguide/datafiles.html#include-package-data

## How I Tested These Changes
```
cd python_modules/libraries/dagster-dbt
pip install --no-deps .
``` 

Then, run scaffold on jaffle shop, see scaffold created successfully.
