### PR TITLE
GQL stale status partition resolvers

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__fixtures__/AssetNode.fixtures.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__fixtures__/AssetNode.fixtures.ts
@@ -8,12 +8,14 @@ export const MockStaleReasonData: StaleCause = {
     path: ['asset0'],
     __typename: 'AssetKey',
   },
+  partitionKey: null,
   reason: 'updated data version',
   category: StaleCauseCategory.DATA,
   dependency: {
     path: ['asset0'],
     __typename: 'AssetKey',
   },
+  dependencyPartitionKey: null,
 };
 
 export const MockStaleReasonCode: StaleCause = {
@@ -22,12 +24,14 @@ export const MockStaleReasonCode: StaleCause = {
     path: ['asset1'],
     __typename: 'AssetKey',
   },
+  partitionKey: null,
   reason: 'code version changed',
   category: StaleCauseCategory.CODE,
   dependency: {
     path: ['asset1'],
     __typename: 'AssetKey',
   },
+  dependencyPartitionKey: null,
 };
 
 const TIMESTAMP = `${new Date('2023-02-12 00:00:00').getTime()}`;

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -646,7 +646,8 @@ type AssetNode {
   ): [ObservationEvent!]!
   computeKind: String
   configField: ConfigTypeField
-  currentDataVersion: String
+  dataVersion(partition: String): String
+  dataVersionByPartition(partitions: [String!]): [String]!
   dependedBy: [AssetDependency!]!
   dependedByKeys: [AssetKey!]!
   dependencies: [AssetDependency!]!
@@ -677,8 +678,10 @@ type AssetNode {
   partitionKeysByDimension(startIdx: Int, endIdx: Int): [DimensionPartitionKeys!]!
   repository: Repository!
   requiredResources: [ResourceRequirement!]!
-  staleStatus: StaleStatus
-  staleCauses: [StaleCause!]!
+  staleStatus(partition: String): StaleStatus
+  staleStatusByPartition(partitions: [String!]): [StaleStatus!]!
+  staleCauses(partition: String): [StaleCause!]!
+  staleCausesByPartition(partitions: [String!]): [[StaleCause!]!]
   type: DagsterType
   hasMaterializePermission: Boolean!
 }
@@ -804,9 +807,11 @@ enum StaleStatus {
 
 type StaleCause {
   key: AssetKey!
+  partitionKey: String
   category: StaleCauseCategory!
   reason: String!
   dependency: AssetKey
+  dependencyPartitionKey: String
 }
 
 enum StaleCauseCategory {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -199,7 +199,8 @@ export type AssetNode = {
   autoMaterializePolicy: Maybe<AutoMaterializePolicy>;
   computeKind: Maybe<Scalars['String']>;
   configField: Maybe<ConfigTypeField>;
-  currentDataVersion: Maybe<Scalars['String']>;
+  dataVersion: Maybe<Scalars['String']>;
+  dataVersionByPartition: Array<Maybe<Scalars['String']>>;
   dependedBy: Array<AssetDependency>;
   dependedByKeys: Array<AssetKey>;
   dependencies: Array<AssetDependency>;
@@ -230,7 +231,9 @@ export type AssetNode = {
   repository: Repository;
   requiredResources: Array<ResourceRequirement>;
   staleCauses: Array<StaleCause>;
+  staleCausesByPartition: Maybe<Array<Array<StaleCause>>>;
   staleStatus: Maybe<StaleStatus>;
+  staleStatusByPartition: Array<StaleStatus>;
   type: Maybe<DagsterType>;
 };
 
@@ -250,6 +253,14 @@ export type AssetNodeAssetObservationsArgs = {
   partitions?: InputMaybe<Array<Scalars['String']>>;
 };
 
+export type AssetNodeDataVersionArgs = {
+  partition?: InputMaybe<Scalars['String']>;
+};
+
+export type AssetNodeDataVersionByPartitionArgs = {
+  partitions?: InputMaybe<Array<Scalars['String']>>;
+};
+
 export type AssetNodeLatestMaterializationByPartitionArgs = {
   partitions?: InputMaybe<Array<Scalars['String']>>;
 };
@@ -261,6 +272,22 @@ export type AssetNodeLatestRunForPartitionArgs = {
 export type AssetNodePartitionKeysByDimensionArgs = {
   endIdx?: InputMaybe<Scalars['Int']>;
   startIdx?: InputMaybe<Scalars['Int']>;
+};
+
+export type AssetNodeStaleCausesArgs = {
+  partition?: InputMaybe<Scalars['String']>;
+};
+
+export type AssetNodeStaleCausesByPartitionArgs = {
+  partitions?: InputMaybe<Array<Scalars['String']>>;
+};
+
+export type AssetNodeStaleStatusArgs = {
+  partition?: InputMaybe<Scalars['String']>;
+};
+
+export type AssetNodeStaleStatusByPartitionArgs = {
+  partitions?: InputMaybe<Array<Scalars['String']>>;
 };
 
 export type AssetNodeDefinitionCollision = {
@@ -3751,7 +3778,9 @@ export type StaleCause = {
   __typename: 'StaleCause';
   category: StaleCauseCategory;
   dependency: Maybe<AssetKey>;
+  dependencyPartitionKey: Maybe<Scalars['String']>;
   key: AssetKey;
+  partitionKey: Maybe<Scalars['String']>;
   reason: Scalars['String'];
 };
 
@@ -4534,10 +4563,12 @@ export const buildAssetNode = (
         : relationshipsToOmit.has('ConfigTypeField')
         ? ({} as ConfigTypeField)
         : buildConfigTypeField({}, relationshipsToOmit),
-    currentDataVersion:
-      overrides && overrides.hasOwnProperty('currentDataVersion')
-        ? overrides.currentDataVersion!
-        : 'aperiam',
+    dataVersion:
+      overrides && overrides.hasOwnProperty('dataVersion') ? overrides.dataVersion! : 'a',
+    dataVersionByPartition:
+      overrides && overrides.hasOwnProperty('dataVersionByPartition')
+        ? overrides.dataVersionByPartition!
+        : [],
     dependedBy: overrides && overrides.hasOwnProperty('dependedBy') ? overrides.dependedBy! : [],
     dependedByKeys:
       overrides && overrides.hasOwnProperty('dependedByKeys') ? overrides.dependedByKeys! : [],
@@ -4628,10 +4659,18 @@ export const buildAssetNode = (
         ? overrides.requiredResources!
         : [],
     staleCauses: overrides && overrides.hasOwnProperty('staleCauses') ? overrides.staleCauses! : [],
+    staleCausesByPartition:
+      overrides && overrides.hasOwnProperty('staleCausesByPartition')
+        ? overrides.staleCausesByPartition!
+        : [],
     staleStatus:
       overrides && overrides.hasOwnProperty('staleStatus')
         ? overrides.staleStatus!
         : StaleStatus.FRESH,
+    staleStatusByPartition:
+      overrides && overrides.hasOwnProperty('staleStatusByPartition')
+        ? overrides.staleStatusByPartition!
+        : [],
     type:
       overrides && overrides.hasOwnProperty('type')
         ? overrides.type!
@@ -11314,12 +11353,18 @@ export const buildStaleCause = (
         : relationshipsToOmit.has('AssetKey')
         ? ({} as AssetKey)
         : buildAssetKey({}, relationshipsToOmit),
+    dependencyPartitionKey:
+      overrides && overrides.hasOwnProperty('dependencyPartitionKey')
+        ? overrides.dependencyPartitionKey!
+        : 'nisi',
     key:
       overrides && overrides.hasOwnProperty('key')
         ? overrides.key!
         : relationshipsToOmit.has('AssetKey')
         ? ({} as AssetKey)
         : buildAssetKey({}, relationshipsToOmit),
+    partitionKey:
+      overrides && overrides.hasOwnProperty('partitionKey') ? overrides.partitionKey! : 'autem',
     reason: overrides && overrides.hasOwnProperty('reason') ? overrides.reason! : 'et',
   };
 };

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -12,7 +12,7 @@ from dagster._core.definitions.data_version import (
     StaleStatus,
 )
 from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
-from dagster._core.definitions.partition import CachingDynamicPartitionsLoader
+from dagster._core.definitions.partition import CachingDynamicPartitionsLoader, PartitionsDefinition
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.event_api import EventRecordsFilter
 from dagster._core.events import DagsterEventType
@@ -93,9 +93,11 @@ GrapheneAssetStaleCauseCategory = graphene.Enum.from_enum(
 
 class GrapheneAssetStaleCause(graphene.ObjectType):
     key = graphene.NonNull(GrapheneAssetKey)
+    partition_key = graphene.String()
     category = graphene.NonNull(GrapheneAssetStaleCauseCategory)
     reason = graphene.NonNull(graphene.String)
     dependency = graphene.Field(GrapheneAssetKey)
+    dependency_partition_key = graphene.String()
 
     class Meta:
         name = "StaleCause"
@@ -203,7 +205,11 @@ class GrapheneAssetNode(graphene.ObjectType):
     )
     computeKind = graphene.String()
     configField = graphene.Field(GrapheneConfigTypeField)
-    currentDataVersion = graphene.String()
+    dataVersion = graphene.Field(graphene.String(), partition=graphene.String())
+    dataVersionByPartition = graphene.Field(
+        graphene.NonNull(graphene.List(graphene.String)),
+        partitions=graphene.List(graphene.NonNull(graphene.String)),
+    )
     dependedBy = non_null_list(GrapheneAssetDependency)
     dependedByKeys = non_null_list(GrapheneAssetKey)
     dependencies = non_null_list(GrapheneAssetDependency)
@@ -241,8 +247,18 @@ class GrapheneAssetNode(graphene.ObjectType):
     )
     repository = graphene.NonNull(lambda: external.GrapheneRepository)
     required_resources = non_null_list(GrapheneResourceRequirement)
-    staleStatus = graphene.Field(GrapheneAssetStaleStatus)
-    staleCauses = non_null_list(GrapheneAssetStaleCause)
+    staleStatus = graphene.Field(GrapheneAssetStaleStatus, partition=graphene.String())
+    staleStatusByPartition = graphene.Field(
+        non_null_list(GrapheneAssetStaleStatus),
+        partitions=graphene.List(graphene.NonNull(graphene.String)),
+    )
+    staleCauses = graphene.Field(
+        non_null_list(GrapheneAssetStaleCause), partition=graphene.String()
+    )
+    staleCausesByPartition = graphene.Field(
+        graphene.List((non_null_list(GrapheneAssetStaleCause))),
+        partitions=graphene.List(graphene.NonNull(graphene.String)),
+    )
     type = graphene.Field(GrapheneDagsterType)
     hasMaterializePermission = graphene.NonNull(graphene.Boolean)
 
@@ -574,14 +590,57 @@ class GrapheneAssetNode(graphene.ObjectType):
     def resolve_computeKind(self, _graphene_info: ResolveInfo) -> Optional[str]:
         return self._external_asset_node.compute_kind
 
-    def resolve_staleStatus(self, graphene_info: ResolveInfo) -> Any:  # (GrapheneAssetStaleStatus)
-        return self.stale_status_loader.get_status(self._external_asset_node.asset_key)
+    def resolve_staleStatus(
+        self, graphene_info: ResolveInfo, partition: Optional[str] = None
+    ) -> Any:  # (GrapheneAssetStaleStatus)
+        if partition:
+            self._validate_partitions_existence()
+        # The status loader does not support querying for the stale status of a
+        # partitioned asset without specifying a partition, so we return here.
+        return self.stale_status_loader.get_status(self._external_asset_node.asset_key, partition)
 
-    def resolve_staleCauses(self, graphene_info: ResolveInfo) -> Sequence[GrapheneAssetStaleCause]:
-        causes = self.stale_status_loader.get_stale_root_causes(self._external_asset_node.asset_key)
+    def resolve_staleStatusByPartition(
+        self,
+        graphene_info: ResolveInfo,
+        partitions: Optional[Sequence[str]] = None,
+    ) -> Sequence[Any]:  # (GrapheneAssetStaleStatus)
+        if partitions is None:
+            partitions = self._get_partitions_def().get_partition_keys()
+        else:
+            self._validate_partitions_existence()
+        return [
+            self.stale_status_loader.get_status(self._external_asset_node.asset_key, partition)
+            for partition in partitions
+        ]
+
+    def resolve_staleCauses(
+        self, graphene_info: ResolveInfo, partition: Optional[str] = None
+    ) -> Sequence[GrapheneAssetStaleCause]:
+        if partition:
+            self._validate_partitions_existence()
+        return self._get_staleCauses(partition)
+
+    def resolve_staleCausesByPartition(
+        self,
+        graphene_info: ResolveInfo,
+        partitions: Optional[Sequence[str]] = None,
+    ) -> Sequence[Sequence[GrapheneAssetStaleCause]]:
+        if partitions is None:
+            partitions = self._get_partitions_def().get_partition_keys()
+        else:
+            self._validate_partitions_existence()
+        return [self._get_staleCauses(partition) for partition in partitions]
+
+    def _get_staleCauses(
+        self, partition: Optional[str] = None
+    ) -> Sequence[GrapheneAssetStaleCause]:
+        causes = self.stale_status_loader.get_stale_root_causes(
+            self._external_asset_node.asset_key, partition
+        )
         return [
             GrapheneAssetStaleCause(
                 GrapheneAssetKey(path=cause.asset_key.path),
+                cause.partition_key,
                 cause.category,
                 cause.reason,
                 (
@@ -589,15 +648,37 @@ class GrapheneAssetNode(graphene.ObjectType):
                     if cause.dependency
                     else None
                 ),
+                cause.dependency_partition_key,
             )
             for cause in causes
         ]
 
-    def resolve_currentDataVersion(self, graphene_info: ResolveInfo) -> Optional[str]:
+    def resolve_dataVersion(
+        self, graphene_info: ResolveInfo, partition: Optional[str] = None
+    ) -> Optional[str]:
+        if partition:
+            self._validate_partitions_existence()
         version = self.stale_status_loader.get_current_data_version(
-            self._external_asset_node.asset_key
+            self._external_asset_node.asset_key, partition
         )
         return None if version == NULL_DATA_VERSION else version.value
+
+    def resolve_dataVersionByPartition(
+        self, graphene_info: ResolveInfo, partitions: Optional[Sequence[str]] = None
+    ) -> Sequence[Optional[str]]:
+        if partitions is None:
+            partitions = self._get_partitions_def().get_partition_keys()
+        else:
+            self._validate_partitions_existence()
+        data_versions = [
+            self.stale_status_loader.get_current_data_version(
+                self._external_asset_node.asset_key, partition
+            )
+            for partition in partitions
+        ]
+        return [
+            None if version == NULL_DATA_VERSION else version.value for version in data_versions
+        ]
 
     def resolve_dependedBy(self, graphene_info: ResolveInfo) -> List[GrapheneAssetDependency]:
         # CrossRepoAssetDependedByLoader class loads cross-repo asset dependencies workspace-wide.
@@ -993,6 +1074,15 @@ class GrapheneAssetNode(graphene.ObjectType):
                         output_def.dagster_type_key,
                     )
         return None
+
+    def _get_partitions_def(self) -> PartitionsDefinition:
+        if not self._external_asset_node.partitions_def_data:
+            check.failed("Asset node has no partitions definition")
+        return self._external_asset_node.partitions_def_data.get_partitions_definition()
+
+    def _validate_partitions_existence(self) -> None:
+        if not self._external_asset_node.partitions_def_data:
+            check.failed("Asset node has no partitions definition")
 
 
 class GrapheneAssetGroup(graphene.ObjectType):

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
@@ -153,7 +153,7 @@ GET_ASSET_DATA_VERSIONS = """
             assetKey {
               path
             }
-            currentDataVersion
+            dataVersion
             staleStatus
             staleCauses {
                 key { path }
@@ -165,6 +165,45 @@ GET_ASSET_DATA_VERSIONS = """
                 tags {
                     key
                     value
+                }
+            }
+        }
+    }
+"""
+
+GET_ASSET_DATA_VERSIONS_BY_PARTITION = """
+    query AssetNodeQuery($assetKey: AssetKeyInput!, $partition: String, $partitions: [String!]) {
+        assetNodeOrError(assetKey: $assetKey) {
+            ... on AssetNode {
+                id
+                assetKey {
+                  path
+                }
+                dataVersion(partition: $partition)
+                dataVersionByPartition(partitions: $partitions)
+                staleStatus(partition: $partition)
+                staleCauses(partition: $partition) {
+                    key { path }
+                    partitionKey
+                    category
+                    reason
+                    dependency { path }
+                    dependencyPartitionKey
+                }
+                staleStatusByPartition(partitions: $partitions)
+                staleCausesByPartition(partitions: $partitions) {
+                    key { path }
+                    partitionKey
+                    category
+                    reason
+                    dependency { path }
+                    dependencyPartitionKey
+                }
+                assetMaterializations {
+                    tags {
+                        key
+                        value
+                    }
                 }
             }
         }

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_data_versions.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_data_versions.py
@@ -1,8 +1,9 @@
-from typing import Any, Mapping, Optional, Sequence, cast
+from typing import Any, Mapping, Optional, Sequence, Union, cast
 
 from dagster import (
     AssetIn,
     DailyPartitionsDefinition,
+    OpExecutionContext,
     RepositoryDefinition,
     TimeWindowPartitionMapping,
     asset,
@@ -10,15 +11,18 @@ from dagster import (
     op,
     repository,
 )
+from dagster._config.pythonic_config import Config
 from dagster._core.definitions.data_version import DATA_VERSION_TAG, DataVersion
 from dagster._core.definitions.decorators.source_asset_decorator import observable_source_asset
 from dagster._core.definitions.definitions_class import Definitions
-from dagster._core.definitions.events import AssetKey
+from dagster._core.definitions.events import AssetKey, Output
 from dagster._core.definitions.partition import StaticPartitionsDefinition
 from dagster._core.definitions.unresolved_asset_job_definition import define_asset_job
 from dagster._core.test_utils import instance_for_test, wait_for_runs_to_finish
 from dagster._core.workspace.context import WorkspaceRequestContext
-from dagster_graphql.client.query import LAUNCH_PIPELINE_EXECUTION_MUTATION
+from dagster_graphql.client.query import (
+    LAUNCH_PIPELINE_EXECUTION_MUTATION,
+)
 from dagster_graphql.test.utils import (
     GqlAssetKey,
     GqlResult,
@@ -28,7 +32,11 @@ from dagster_graphql.test.utils import (
     infer_repository_selector,
 )
 
-from dagster_graphql_tests.graphql.test_assets import GET_ASSET_DATA_VERSIONS, GET_ASSET_JOB_NAMES
+from dagster_graphql_tests.graphql.test_assets import (
+    GET_ASSET_DATA_VERSIONS,
+    GET_ASSET_DATA_VERSIONS_BY_PARTITION,
+    GET_ASSET_JOB_NAMES,
+)
 
 
 def get_repo_v1():
@@ -77,8 +85,8 @@ def test_stale_status():
     with instance_for_test() as instance:
         with define_out_of_process_context(__file__, "get_repo_v1", instance) as context:
             result = _fetch_data_versions(context, repo)
-            foo = _get_asset_node("foo", result)
-            assert foo["currentDataVersion"] is None
+            foo = _get_asset_node(result, "foo")
+            assert foo["dataVersion"] is None
             assert foo["staleStatus"] == "MISSING"
             assert foo["staleCauses"] == []
 
@@ -86,8 +94,8 @@ def test_stale_status():
             wait_for_runs_to_finish(context.instance)
 
             result = _fetch_data_versions(context, repo)
-            foo = _get_asset_node("foo", result)
-            assert foo["currentDataVersion"] is not None
+            foo = _get_asset_node(result, "foo")
+            assert foo["dataVersion"] is not None
             assert foo["staleStatus"] == "FRESH"
             assert foo["staleCauses"] == []
 
@@ -95,8 +103,8 @@ def test_stale_status():
             wait_for_runs_to_finish(context.instance)
 
             result = _fetch_data_versions(context, repo)
-            bar = _get_asset_node("bar", result)
-            assert bar["currentDataVersion"] is not None
+            bar = _get_asset_node(result, "bar")
+            assert bar["dataVersion"] is not None
             assert bar["staleStatus"] == "STALE"
             assert bar["staleCauses"] == [
                 {
@@ -105,6 +113,111 @@ def test_stale_status():
                     "reason": "has a new materialization",
                     "dependency": None,
                 }
+            ]
+
+
+def get_repo_partitioned():
+    partitions_def = StaticPartitionsDefinition(["alpha", "beta"])
+
+    class FooConfig(Config):
+        prefix: str = "ok"
+
+    @asset(partitions_def=partitions_def)
+    def foo(context: OpExecutionContext, config: FooConfig) -> Output[bool]:
+        return Output(
+            True, data_version=DataVersion(f"{config.prefix}_foo_{context.partition_key}")
+        )
+
+    @asset(partitions_def=partitions_def)
+    def bar(context: OpExecutionContext, foo) -> Output[bool]:
+        return Output(True, data_version=DataVersion(f"ok_bar_{context.partition_key}"))
+
+    @repository
+    def repo():
+        return [foo, bar]
+
+    return repo
+
+
+def test_stale_status_partitioned():
+    repo = get_repo_partitioned()
+
+    with instance_for_test() as instance:
+        with define_out_of_process_context(__file__, "get_repo_partitioned", instance) as context:
+            for key in ["foo", "bar"]:
+                result = _fetch_partition_data_versions(context, AssetKey([key]))
+                node = _get_asset_node(result)
+                assert node["dataVersion"] is None
+                assert node["dataVersionByPartition"] == [None, None]
+                assert node["staleStatus"] == "MISSING"
+                assert node["staleStatusByPartition"] == ["MISSING", "MISSING"]
+                assert node["staleCauses"] == []
+                assert node["staleCausesByPartition"] == [[], []]
+
+            assert _materialize_assets(
+                context, repo, [AssetKey(["foo"]), AssetKey(["bar"])], ["alpha", "beta"]
+            )
+            wait_for_runs_to_finish(context.instance)
+
+            for key in ["foo", "bar"]:
+                result = _fetch_partition_data_versions(context, AssetKey([key]), "alpha")
+                node = _get_asset_node(result)
+                assert node["dataVersion"] == f"ok_{key}_alpha"
+                assert node["dataVersionByPartition"] == [f"ok_{key}_alpha", f"ok_{key}_beta"]
+                assert node["staleStatus"] == "FRESH"
+                assert node["staleStatusByPartition"] == ["FRESH", "FRESH"]
+                assert node["staleCauses"] == []
+                assert node["staleCausesByPartition"] == [[], []]
+
+            assert _materialize_assets(
+                context,
+                repo,
+                [AssetKey(["foo"])],
+                ["alpha", "beta"],
+                run_config_data={"ops": {"foo": {"config": {"prefix": "from_config"}}}},
+            )
+            wait_for_runs_to_finish(context.instance)
+
+            result = _fetch_partition_data_versions(context, AssetKey(["foo"]), "alpha")
+            foo = _get_asset_node(result, "foo")
+            assert foo["dataVersion"] == "from_config_foo_alpha"
+            assert foo["dataVersionByPartition"] == [
+                "from_config_foo_alpha",
+                "from_config_foo_beta",
+            ]
+            assert foo["staleStatus"] == "FRESH"
+            assert foo["staleStatusByPartition"] == ["FRESH", "FRESH"]
+
+            result = _fetch_partition_data_versions(
+                context, AssetKey(["bar"]), "alpha", ["beta", "alpha"]
+            )
+            bar = _get_asset_node(result, "bar")
+            assert bar["dataVersion"] == "ok_bar_alpha"
+            assert bar["dataVersionByPartition"] == ["ok_bar_beta", "ok_bar_alpha"]
+            assert bar["staleStatus"] == "STALE"
+            assert bar["staleStatusByPartition"] == ["STALE", "STALE"]
+            assert bar["staleCauses"] == [
+                {
+                    "key": {"path": ["foo"]},
+                    "partitionKey": "alpha",
+                    "category": "DATA",
+                    "reason": "has a new data version",
+                    "dependency": None,
+                    "dependencyPartitionKey": None,
+                }
+            ]
+            assert bar["staleCausesByPartition"] == [
+                [
+                    {
+                        "key": {"path": ["foo"]},
+                        "partitionKey": key,
+                        "category": "DATA",
+                        "reason": "has a new data version",
+                        "dependency": None,
+                        "dependencyPartitionKey": None,
+                    }
+                ]
+                for key in ["beta", "alpha"]
             ]
 
 
@@ -117,7 +230,7 @@ def test_data_version_from_tags():
             result = _fetch_data_versions(context_v1, repo_v1)
             tags = result.data["assetNodes"][0]["assetMaterializations"][0]["tags"]
             dv_tag = next(tag for tag in tags if tag["key"] == DATA_VERSION_TAG)
-            assert dv_tag["value"] == result.data["assetNodes"][0]["currentDataVersion"]
+            assert dv_tag["value"] == result.data["assetNodes"][0]["dataVersion"]
 
 
 def get_repo_with_partitioned_self_dep_asset():
@@ -153,8 +266,8 @@ def test_partitioned_self_dep():
             result = _fetch_data_versions(context, repo)
             assert result
             assert result.data
-            assert _get_asset_node("a", result)["staleStatus"] == "MISSING"
-            assert _get_asset_node("b", result)["staleStatus"] == "MISSING"
+            assert _get_asset_node(result, "a")["staleStatus"] == "MISSING"
+            assert _get_asset_node(result, "b")["staleStatus"] == "MISSING"
 
 
 def get_observable_source_asset_repo():
@@ -204,9 +317,9 @@ def test_source_asset_job_name():
                 },
             )
             assert result and result.data
-            foo_jobs = _get_asset_node("foo", result.data["repositoryOrError"])["jobNames"]
-            bar_jobs = _get_asset_node("bar", result.data["repositoryOrError"])["jobNames"]
-            baz_jobs = _get_asset_node("baz", result.data["repositoryOrError"])["jobNames"]
+            foo_jobs = _get_asset_node(result.data["repositoryOrError"], "foo")["jobNames"]
+            bar_jobs = _get_asset_node(result.data["repositoryOrError"], "bar")["jobNames"]
+            baz_jobs = _get_asset_node(result.data["repositoryOrError"], "baz")["jobNames"]
 
             # All nodes should have separate job sets since there are two different partitions defs
             # and a non-partitioned observable.
@@ -230,7 +343,9 @@ def _materialize_assets(
     context: WorkspaceRequestContext,
     repo: RepositoryDefinition,
     asset_selection: Optional[Sequence[AssetKey]] = None,
-) -> GqlResult:
+    partition_keys: Optional[Sequence[str]] = None,
+    run_config_data: Optional[Mapping[str, Any]] = None,
+) -> Union[GqlResult, Sequence[GqlResult]]:
     gql_asset_selection = (
         cast(Sequence[GqlAssetKey], [key.to_graphql_input() for key in asset_selection])
         if asset_selection
@@ -239,15 +354,39 @@ def _materialize_assets(
     selector = infer_job_or_pipeline_selector(
         context, repo.get_implicit_asset_job_names()[0], asset_selection=gql_asset_selection
     )
-    return execute_dagster_graphql(
-        context,
-        LAUNCH_PIPELINE_EXECUTION_MUTATION,
-        variables={
-            "executionParams": {
-                "selector": selector,
-            }
-        },
-    )
+    if partition_keys:
+        results = []
+        for key in partition_keys:
+            results.append(
+                execute_dagster_graphql(
+                    context,
+                    LAUNCH_PIPELINE_EXECUTION_MUTATION,
+                    variables={
+                        "executionParams": {
+                            "selector": selector,
+                            "executionMetadata": {
+                                "tags": [{"key": "dagster/partition", "value": key}]
+                            },
+                            "runConfigData": run_config_data,
+                        }
+                    },
+                )
+            )
+        return results
+    else:
+        selector = infer_job_or_pipeline_selector(
+            context, repo.get_implicit_asset_job_names()[0], asset_selection=gql_asset_selection
+        )
+        return execute_dagster_graphql(
+            context,
+            LAUNCH_PIPELINE_EXECUTION_MUTATION,
+            variables={
+                "executionParams": {
+                    "selector": selector,
+                    "runConfigData": run_config_data,
+                }
+            },
+        )
 
 
 def _fetch_data_versions(context: WorkspaceRequestContext, repo: RepositoryDefinition):
@@ -261,6 +400,32 @@ def _fetch_data_versions(context: WorkspaceRequestContext, repo: RepositoryDefin
     )
 
 
-def _get_asset_node(key: str, result: Any) -> Mapping[str, Any]:
+def _fetch_partition_data_versions(
+    context: WorkspaceRequestContext,
+    asset_key: AssetKey,
+    partition: Optional[str] = None,
+    partitions: Optional[Sequence[str]] = None,
+):
+    return execute_dagster_graphql(
+        context,
+        GET_ASSET_DATA_VERSIONS_BY_PARTITION,
+        variables={
+            "assetKey": asset_key.to_graphql_input(),
+            "partition": partition,
+            "partitions": partitions,
+        },
+    )
+
+
+def _get_asset_node(result: Any, key: Optional[str] = None) -> Mapping[str, Any]:
     to_check = result if isinstance(result, dict) else result.data  # GqlResult
-    return next((node for node in to_check["assetNodes"] if node["assetKey"]["path"] == [key]))
+    if key is None:  # assume we are dealing with a single-node query
+        return to_check["assetNodeOrError"]
+    else:
+        return (
+            to_check["assetNodeOrError"]
+            if "assetNodeOrError" in to_check
+            else next(
+                (node for node in to_check["assetNodes"] if node["assetKey"]["path"] == [key])
+            )
+        )


### PR DESCRIPTION
## Summary & Motivation

- Rename `AssetNode.currentDataVersion` -> `dataVersion`. (This field is not currently being called from Dagster UI so its a safe rename).
- Make `CachingStaleStatusResolver` return an `StaleStatus.FRESH`/`[]` when requesting the status/causes for a partitioned asset without specifying a partition key (status quo throws an error)
- Add partition-scoped resolution for GQL `AssetNode` fields:
    - `staleStatus`
    - `staleStatusCauses`
    - `dataVersion`

Two changes for each of the above fields:

- The singular resolver (e.g. `resolve_staleStatus`) now takes an optional `partition` argument specifying a single partition key. An error is thrown if this is specified for a non-partitioned asset.
- A new `XByPartition` field(e.g. `staleStatusByPartition`) field is added that takes on optional `partitions` argument, which is a list of partition keys. It returns the requested field in a list corresponding to the order of the passed partition keys. If no list of partition keys is specified, the result for all partition keys is returned (note that this form requires you to know in advance the order of all partition keys to be interpretable).

## How I Tested These Changes

New unit test
