### PR TITLE
Pin universal-pathlib

### DIFF
--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -98,7 +98,7 @@ setup(
         # https://github.com/mhammond/pywin32/issues/1439
         'pywin32 != 226; platform_system=="Windows"',
         "docstring-parser",
-        "universal_pathlib",
+        "universal_pathlib < 0.1.0",
         # https://github.com/pydantic/pydantic/issues/5821
         "pydantic != 1.10.7,<2.0.0",
     ],


### PR DESCRIPTION
Some of our upath io manager tests are breaking since the 0.1.0 release of universal-pathlib this morning.

Temporarily pinning in anticipation of our own 1.4.4 release while we figure out the root cause or the fix we need to apply.
