### PR TITLE
Update .gitignore with js_modules/dagit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,9 +120,11 @@ python_modules/libraries/dagster-aws/dagster_aws/ecs/config.yaml
 
 python_modules/dagster-webserver/node_modules/
 python_modules/dagster-webserver/yarn.lock
+
+# old dagit stuff
 python_modules/dagit/node_modules/
 python_modules/dagit/yarn.lock
-
+js_modules/dagit
 
 # Gatsby stuff
 docs/gatsby/**/node_modules/


### PR DESCRIPTION
Prevent inadvertent commit of `js_modules/dagit` after rename to `dagster-ui`