### PR TITLE
[ui] Allow filtering the global graph by asset group

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -432,6 +432,7 @@ const AssetGraphExplorerWithData: React.FC<WithDataProps> = ({
             {fetchOptionFilters}
 
             <GraphQueryInput
+              width={fetchOptionFilters ? '16vw' : undefined}
               items={graphQueryItems}
               value={explorerPath.opsQuery}
               placeholder="Type an asset subset…"

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetGroupSuggest.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetGroupSuggest.tsx
@@ -14,12 +14,8 @@ type Asset = {
   } | null;
 };
 
-export const AssetGroupSuggest: React.FC<{
-  assets: Asset[];
-  value: AssetGroupSelector | null;
-  onChange: (g: AssetGroupSelector | null) => void;
-}> = ({assets, value, onChange}) => {
-  const assetGroups = React.useMemo(
+export function useAssetGroupSelectorsForAssets(assets: Asset[] | undefined) {
+  return React.useMemo(
     () =>
       uniqBy(
         (assets || []).map(buildAssetGroupSelector).filter((a) => !!a) as AssetGroupSelector[],
@@ -27,7 +23,13 @@ export const AssetGroupSuggest: React.FC<{
       ).sort((a, b) => a.groupName.localeCompare(b.groupName)),
     [assets],
   );
+}
 
+export const AssetGroupSuggest: React.FC<{
+  assetGroups: AssetGroupSelector[];
+  value: AssetGroupSelector | null;
+  onChange: (g: AssetGroupSelector | null) => void;
+}> = ({assetGroups, value, onChange}) => {
   const repoContextNeeded = React.useMemo(() => {
     // This is a bit tricky - the first time we find a groupName it sets the key to `false`.
     // The second time, it sets the value to `true` + tells use we need to show the repo name
@@ -43,7 +45,7 @@ export const AssetGroupSuggest: React.FC<{
       selectedItem={value}
       items={assetGroups}
       inputProps={{
-        style: {width: 220},
+        style: {width: 200},
         placeholder: 'Filter asset groups…',
         rightElement: value ? (
           <ClearButton onClick={() => onChange(null)} style={{marginTop: 5, marginRight: 4}}>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetGroupSuggest.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetGroupSuggest.tsx
@@ -1,0 +1,93 @@
+import {Icon, MenuItem, Suggest} from '@dagster-io/ui-components';
+import isEqual from 'lodash/isEqual';
+import uniqBy from 'lodash/uniqBy';
+import * as React from 'react';
+
+import {AssetGroupSelector} from '../graphql/types';
+import {ClearButton} from '../ui/ClearButton';
+import {buildRepoPathForHuman} from '../workspace/buildRepoAddress';
+
+type Asset = {
+  definition: {
+    groupName: string | null;
+    repository: {name: string; location: {name: string}};
+  } | null;
+};
+
+export const AssetGroupSuggest: React.FC<{
+  assets: Asset[];
+  value: AssetGroupSelector | null;
+  onChange: (g: AssetGroupSelector | null) => void;
+}> = ({assets, value, onChange}) => {
+  const assetGroups = React.useMemo(
+    () =>
+      uniqBy(
+        (assets || []).map(buildAssetGroupSelector).filter((a) => !!a) as AssetGroupSelector[],
+        (a) => JSON.stringify(a),
+      ).sort((a, b) => a.groupName.localeCompare(b.groupName)),
+    [assets],
+  );
+
+  const repoContextNeeded = React.useMemo(() => {
+    // This is a bit tricky - the first time we find a groupName it sets the key to `false`.
+    // The second time, it sets the value to `true` + tells use we need to show the repo name
+    const result: {[groupName: string]: boolean} = {};
+    assetGroups.forEach(
+      (group) => (result[group.groupName] = result.hasOwnProperty(group.groupName)),
+    );
+    return result;
+  }, [assetGroups]);
+
+  return (
+    <Suggest<AssetGroupSelector>
+      selectedItem={value}
+      items={assetGroups}
+      inputProps={{
+        style: {width: 220},
+        placeholder: 'Filter asset groups…',
+        rightElement: value ? (
+          <ClearButton onClick={() => onChange(null)} style={{marginTop: 5, marginRight: 4}}>
+            <Icon name="cancel" />
+          </ClearButton>
+        ) : undefined,
+      }}
+      inputValueRenderer={(partition) => partition.groupName}
+      itemPredicate={(query, partition) =>
+        query.length === 0 || partition.groupName.includes(query)
+      }
+      itemsEqual={isEqual}
+      itemRenderer={(assetGroup, props) => (
+        <MenuItem
+          active={props.modifiers.active}
+          onClick={props.handleClick}
+          key={JSON.stringify(assetGroup)}
+          text={
+            <>
+              {assetGroup.groupName}
+              {repoContextNeeded[assetGroup.groupName] ? (
+                <span style={{opacity: 0.5, paddingLeft: 4}}>
+                  {buildRepoPathForHuman(
+                    assetGroup.repositoryName,
+                    assetGroup.repositoryLocationName,
+                  )}
+                </span>
+              ) : undefined}
+            </>
+          }
+        />
+      )}
+      noResults={<MenuItem disabled={true} text="No asset groups" />}
+      onItemSelect={onChange}
+    />
+  );
+};
+
+export function buildAssetGroupSelector(a: Asset) {
+  return a.definition && a.definition.groupName
+    ? {
+        groupName: a.definition.groupName,
+        repositoryName: a.definition.repository.name,
+        repositoryLocationName: a.definition.repository.location.name,
+      }
+    : null;
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetTable.tsx
@@ -37,7 +37,7 @@ interface Props {
   displayPathForAsset: (asset: Asset) => string[];
   requery?: RefetchQueriesFunction;
   searchPath: string;
-  searchGroup: AssetGroupSelector | null;
+  searchGroups: AssetGroupSelector[];
 }
 
 export const AssetTable: React.FC<Props> = ({
@@ -48,7 +48,7 @@ export const AssetTable: React.FC<Props> = ({
   displayPathForAsset,
   requery,
   searchPath,
-  searchGroup,
+  searchGroups,
   view,
 }) => {
   const [toWipe, setToWipe] = React.useState<AssetKeyInput[] | undefined>();
@@ -76,10 +76,14 @@ export const AssetTable: React.FC<Props> = ({
               icon="search"
               title="No matching assets"
               description={
-                searchGroup ? (
+                searchGroups.length ? (
                   <div>
                     No assets matching <strong>{searchPath}</strong> were found in{' '}
-                    <strong>{searchGroup.groupName}</strong>
+                    {searchGroups.length === 1 ? (
+                      <strong>{searchGroups[0]?.groupName}</strong>
+                    ) : (
+                      'the selected asset groups'
+                    )}
                   </div>
                 ) : (
                   <div>
@@ -98,9 +102,14 @@ export const AssetTable: React.FC<Props> = ({
             icon="search"
             title="No assets"
             description={
-              searchGroup ? (
+              searchGroups.length ? (
                 <div>
-                  No assets were found in <strong>{searchGroup.groupName}</strong>
+                  No assets were found in{' '}
+                  {searchGroups.length === 1 ? (
+                    <strong>{searchGroups[0]?.groupName}</strong>
+                  ) : (
+                    'the selected asset groups'
+                  )}
                 </div>
               ) : (
                 'No assets were found'

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
@@ -11,7 +11,11 @@ import {AssetGroupSelector} from '../graphql/types';
 import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
 import {LoadingSpinner} from '../ui/Loading';
 
-import {AssetGroupSuggest, buildAssetGroupSelector} from './AssetGroupSuggest';
+import {
+  AssetGroupSuggest,
+  buildAssetGroupSelector,
+  useAssetGroupSelectorsForAssets,
+} from './AssetGroupSuggest';
 import {AssetTable} from './AssetTable';
 import {ASSET_TABLE_DEFINITION_FRAGMENT, ASSET_TABLE_FRAGMENT} from './AssetTableFragment';
 import {AssetsEmptyState} from './AssetsEmptyState';
@@ -95,6 +99,7 @@ export const AssetsCatalogTable: React.FC<AssetCatalogTableProps> = ({
     .trim();
 
   const {assets, query, error} = useAllAssets(groupSelector);
+  const assetGroupOptions = useAssetGroupSelectorsForAssets(assets);
   const pathMatches = useAssetSearch(searchPath, assets || []);
 
   const filtered = React.useMemo(
@@ -162,7 +167,11 @@ export const AssetsCatalogTable: React.FC<AssetCatalogTableProps> = ({
             onChange={(e: React.ChangeEvent<any>) => setSearch(e.target.value)}
           />
           {!groupSelector ? (
-            <AssetGroupSuggest assets={assets} value={searchGroup} onChange={setSearchGroup} />
+            <AssetGroupSuggest
+              assetGroups={assetGroupOptions}
+              value={searchGroup}
+              onChange={setSearchGroup}
+            />
           ) : undefined}
         </>
       }

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
@@ -87,10 +87,10 @@ export const AssetsCatalogTable: React.FC<AssetCatalogTableProps> = ({
 }) => {
   const [view, setView] = useAssetView();
   const [search, setSearch] = useQueryPersistedState<string | undefined>({queryKey: 'q'});
-  const [searchGroup, setSearchGroup] = useQueryPersistedState<AssetGroupSelector | null>({
+  const [searchGroups, setSearchGroups] = useQueryPersistedState<AssetGroupSelector[]>({
     queryKey: 'g',
-    decode: (qs) => (qs.group ? JSON.parse(qs.group) : null),
-    encode: (group) => ({group: group ? JSON.stringify(group) : undefined}),
+    decode: (qs) => (qs.groups ? JSON.parse(qs.groups) : []),
+    encode: (groups) => ({groups: groups.length ? JSON.stringify(groups) : undefined}),
   });
 
   const searchPath = (search || '')
@@ -104,8 +104,11 @@ export const AssetsCatalogTable: React.FC<AssetCatalogTableProps> = ({
 
   const filtered = React.useMemo(
     () =>
-      pathMatches.filter((a) => !searchGroup || isEqual(buildAssetGroupSelector(a), searchGroup)),
-    [pathMatches, searchGroup],
+      pathMatches.filter(
+        (a) =>
+          !searchGroups.length || searchGroups.some((g) => isEqual(buildAssetGroupSelector(a), g)),
+      ),
+    [pathMatches, searchGroups],
   );
 
   const {displayPathForAsset, displayed} =
@@ -169,8 +172,8 @@ export const AssetsCatalogTable: React.FC<AssetCatalogTableProps> = ({
           {!groupSelector ? (
             <AssetGroupSuggest
               assetGroups={assetGroupOptions}
-              value={searchGroup}
-              onChange={setSearchGroup}
+              value={searchGroups}
+              onChange={setSearchGroups}
             />
           ) : undefined}
         </>
@@ -178,7 +181,7 @@ export const AssetsCatalogTable: React.FC<AssetCatalogTableProps> = ({
       refreshState={refreshState}
       prefixPath={prefixPath || []}
       searchPath={searchPath}
-      searchGroup={searchGroup}
+      searchGroups={searchGroups}
       displayPathForAsset={displayPathForAsset}
       requery={(_) => [{query: ASSET_CATALOG_TABLE_QUERY}]}
     />

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
@@ -1,7 +1,6 @@
 import {gql, QueryResult, useQuery} from '@apollo/client';
-import {Box, TextInput, Suggest, MenuItem, Icon, ButtonGroup} from '@dagster-io/ui-components';
+import {Box, TextInput, ButtonGroup} from '@dagster-io/ui-components';
 import isEqual from 'lodash/isEqual';
-import uniqBy from 'lodash/uniqBy';
 import * as React from 'react';
 
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
@@ -10,10 +9,9 @@ import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../app/QueryRefresh';
 import {PythonErrorFragment} from '../app/types/PythonErrorFragment.types';
 import {AssetGroupSelector} from '../graphql/types';
 import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
-import {ClearButton} from '../ui/ClearButton';
 import {LoadingSpinner} from '../ui/Loading';
-import {buildRepoPathForHuman} from '../workspace/buildRepoAddress';
 
+import {AssetGroupSuggest, buildAssetGroupSelector} from './AssetGroupSuggest';
 import {AssetTable} from './AssetTable';
 import {ASSET_TABLE_DEFINITION_FRAGMENT, ASSET_TABLE_FRAGMENT} from './AssetTableFragment';
 import {AssetsEmptyState} from './AssetsEmptyState';
@@ -178,74 +176,6 @@ export const AssetsCatalogTable: React.FC<AssetCatalogTableProps> = ({
   );
 };
 
-export const AssetGroupSuggest: React.FC<{
-  assets: Asset[];
-  value: AssetGroupSelector | null;
-  onChange: (g: AssetGroupSelector | null) => void;
-}> = ({assets, value, onChange}) => {
-  const assetGroups = React.useMemo(
-    () =>
-      uniqBy(
-        (assets || []).map(buildAssetGroupSelector).filter((a) => !!a) as AssetGroupSelector[],
-        (a) => JSON.stringify(a),
-      ).sort((a, b) => a.groupName.localeCompare(b.groupName)),
-    [assets],
-  );
-
-  const repoContextNeeded = React.useMemo(() => {
-    // This is a bit tricky - the first time we find a groupName it sets the key to `false`.
-    // The second time, it sets the value to `true` + tells use we need to show the repo name
-    const result: {[groupName: string]: boolean} = {};
-    assetGroups.forEach(
-      (group) => (result[group.groupName] = result.hasOwnProperty(group.groupName)),
-    );
-    return result;
-  }, [assetGroups]);
-
-  return (
-    <Suggest<AssetGroupSelector>
-      selectedItem={value}
-      items={assetGroups}
-      inputProps={{
-        style: {width: 220},
-        placeholder: 'Filter asset groups…',
-        rightElement: value ? (
-          <ClearButton onClick={() => onChange(null)} style={{marginTop: 5, marginRight: 4}}>
-            <Icon name="cancel" />
-          </ClearButton>
-        ) : undefined,
-      }}
-      inputValueRenderer={(partition) => partition.groupName}
-      itemPredicate={(query, partition) =>
-        query.length === 0 || partition.groupName.includes(query)
-      }
-      itemsEqual={isEqual}
-      itemRenderer={(assetGroup, props) => (
-        <MenuItem
-          active={props.modifiers.active}
-          onClick={props.handleClick}
-          key={JSON.stringify(assetGroup)}
-          text={
-            <>
-              {assetGroup.groupName}
-              {repoContextNeeded[assetGroup.groupName] ? (
-                <span style={{opacity: 0.5, paddingLeft: 4}}>
-                  {buildRepoPathForHuman(
-                    assetGroup.repositoryName,
-                    assetGroup.repositoryLocationName,
-                  )}
-                </span>
-              ) : undefined}
-            </>
-          }
-        />
-      )}
-      noResults={<MenuItem disabled={true} text="No asset groups" />}
-      onItemSelect={onChange}
-    />
-  );
-};
-
 export const ASSET_CATALOG_TABLE_QUERY = gql`
   query AssetCatalogTableQuery {
     assetsOrError {
@@ -287,16 +217,6 @@ export const ASSET_CATALOG_GROUP_TABLE_QUERY = gql`
 // AssetCatalogTableQuery results.
 function definitionToAssetTableFragment(definition: AssetCatalogGroupTableNodeFragment): Asset {
   return {__typename: 'Asset', id: definition.id, key: definition.assetKey, definition};
-}
-
-function buildAssetGroupSelector(a: Asset) {
-  return a.definition && a.definition.groupName
-    ? {
-        groupName: a.definition.groupName,
-        repositoryName: a.definition.repository.name,
-        repositoryLocationName: a.definition.repository.location.name,
-      }
-    : null;
 }
 
 function buildFlatProps(assets: Asset[], _: string[]) {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsGroupsGlobalGraphRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsGroupsGlobalGraphRoot.tsx
@@ -107,10 +107,8 @@ export const AssetsGroupsGlobalGraphRoot: React.FC = () => {
             {allRepos.length > 1 && <RepoFilterButton />}
             <AssetGroupSuggest
               assetGroups={assetGroups}
-              value={filters.groups?.[0] || null}
-              onChange={(g: AssetGroupSelector | null) => {
-                setFilters({...filters, groups: g ? [g] : []});
-              }}
+              value={filters.groups || []}
+              onChange={(groups) => setFilters({...filters, groups})}
             />
           </>
         }

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsGroupsGlobalGraphRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsGroupsGlobalGraphRoot.tsx
@@ -1,11 +1,14 @@
 import {Page, PageHeader, Heading} from '@dagster-io/ui-components';
+import isEqual from 'lodash/isEqual';
 import * as React from 'react';
 import {useHistory, useParams} from 'react-router-dom';
 
 import {AssetGraphExplorer} from '../asset-graph/AssetGraphExplorer';
 import {AssetGraphFetchScope} from '../asset-graph/useAssetGraphData';
 import {AssetLocation} from '../asset-graph/useFindAssetLocation';
+import {AssetGroupSelector} from '../graphql/types';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
+import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
 import {RepoFilterButton} from '../instance/RepoFilterButton';
 import {
   ExplorerPath,
@@ -15,6 +18,7 @@ import {
 import {ReloadAllButton} from '../workspace/ReloadAllButton';
 import {WorkspaceContext} from '../workspace/WorkspaceContext';
 
+import {AssetGroupSuggest, buildAssetGroupSelector} from './AssetGroupSuggest';
 import {assetDetailsPathForKey} from './assetDetailsPathForKey';
 
 interface AssetGroupRootParams {
@@ -28,16 +32,17 @@ export const AssetsGroupsGlobalGraphRoot: React.FC = () => {
   const {allRepos, visibleRepos} = React.useContext(WorkspaceContext);
   const history = useHistory();
 
+  const [filters, setFilters] = useQueryPersistedState<{groups: AssetGroupSelector[]}>({
+    encode: ({groups}) => ({groups: JSON.stringify(groups)}),
+    decode: (qs) => ({groups: qs.groups ? JSON.parse(qs.groups) : []}),
+  });
+
   useDocumentTitle(`Global Asset Lineage`);
 
   const onChangeExplorerPath = React.useCallback(
     (path: ExplorerPath, mode: 'push' | 'replace') => {
-      history[mode](
-        `/asset-groups${explorerPathToString({...path, pipelineName: __GLOBAL__}).replace(
-          __GLOBAL__,
-          '',
-        )}`,
-      );
+      const str = explorerPathToString({...path, pipelineName: __GLOBAL__}).replace(__GLOBAL__, '');
+      history[mode]({pathname: `/asset-groups${str}`, search: history.location.search});
     },
     [history],
   );
@@ -53,14 +58,36 @@ export const AssetsGroupsGlobalGraphRoot: React.FC = () => {
     const options: AssetGraphFetchScope = {
       hideEdgesToNodesOutsideQuery: false,
       hideNodesMatching: (node) => {
-        return !visibleRepos.some(
-          (repo) =>
-            repo.repositoryLocation.name === node.repository.location.name &&
-            repo.repository.name === node.repository.name,
-        );
+        if (
+          !visibleRepos.some(
+            (repo) =>
+              repo.repositoryLocation.name === node.repository.location.name &&
+              repo.repository.name === node.repository.name,
+          )
+        ) {
+          return true;
+        }
+        if (filters.groups?.length) {
+          const nodeGroup = buildAssetGroupSelector({definition: node});
+          if (!filters.groups.some((g) => isEqual(g, nodeGroup))) {
+            return true;
+          }
+        }
+
+        return false;
       },
     };
     return options;
+  }, [filters.groups, visibleRepos]);
+
+  const assetGroups: AssetGroupSelector[] = React.useMemo(() => {
+    return visibleRepos.flatMap((repo) =>
+      repo.repository.assetGroups.map((g) => ({
+        groupName: g.groupName,
+        repositoryLocationName: repo.repositoryLocation.name,
+        repositoryName: repo.repository.name,
+      })),
+    );
   }, [visibleRepos]);
 
   return (
@@ -75,7 +102,18 @@ export const AssetsGroupsGlobalGraphRoot: React.FC = () => {
       />
       <AssetGraphExplorer
         fetchOptions={fetchOptions}
-        fetchOptionFilters={<>{allRepos.length > 1 && <RepoFilterButton />}</>}
+        fetchOptionFilters={
+          <>
+            {allRepos.length > 1 && <RepoFilterButton />}
+            <AssetGroupSuggest
+              assetGroups={assetGroups}
+              value={filters.groups?.[0] || null}
+              onChange={(g: AssetGroupSelector | null) => {
+                setFilters({...filters, groups: g ? [g] : []});
+              }}
+            />
+          </>
+        }
         options={{preferAssetRendering: true, explodeComposites: true}}
         explorerPath={explorerPathFromString(__GLOBAL__ + path || '/')}
         onChangeExplorerPath={onChangeExplorerPath}


### PR DESCRIPTION
## Summary & Motivation

Fixes: https://github.com/dagster-io/dagster/issues/15355

This PR enables filtering the global asset graph by asset group, and brings asset group multi-selection to the global asset catalog.

<img width="657" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/37f90294-35c2-4ab0-b598-f43f4f596f97">

I considered porting the fancy RunsFilter UI over to the asset catalog, but at the moment group is the only available filter, and the RunsFilter UI exposes a "Filter" button and a separate list of "filter tags", which we don't have a great place to show in the asset graph.  I think that having a single component with typeahead filtering and multi-selection may be best until we redesign this UI a bit more significantly.

## How I Tested These Changes

I tested this in both the global asset graph and the asset catalog in a repo that contains many groups, some of which have overlapping names. I also verified that clicking around the global graph does not clear your filter, and that reloading the pages preserves / rehydrates the filter state correctly.