### PR TITLE
Fix BK automation pkg

### DIFF
--- a/python_modules/automation/tox.ini
+++ b/python_modules/automation/tox.ini
@@ -53,6 +53,12 @@ deps =
   -e ../libraries/dagster-snowflake-pyspark
   -e ../libraries/dagster-pandera
   -e .
+
+  # This is a temporary pin due to version conflicts between dbt 1.6 and some higher-order
+  # dependencies of other integration libs. It is not important that this particular testenv support
+  # dbt 1.6, so we can pin. The pin can be removed at any time in the future so long as the env builds
+  # successfully.
+  dbt-core<1.6
 allowlist_externals =
   /bin/bash
 commands =


### PR DESCRIPTION
## Summary & Motivation

Add temporary dbt-core pin to `automation` testenv to prevent version conflicts of higher-order deps in builds.
