### PR TITLE
infra(helm): make Values.ingress.apiVersion take precedence

### DIFF
--- a/helm/dagster/templates/ingress-v1beta1.yaml
+++ b/helm/dagster/templates/ingress-v1beta1.yaml
@@ -2,7 +2,8 @@
 {{- $apiVersion := .Values.ingress.apiVersion | default "" }}
 {{- $hasApiVersion := (not (.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress")) }}
 {{- $hasOverrideApiVersion := eq $apiVersion "extensions/v1beta1/Ingress" }}
-{{- if and (.Values.ingress.enabled) (or $hasApiVersion $hasOverrideApiVersion) }}
+{{- $hasOverrideV1ApiVersion := eq $apiVersion "networking.k8s.io/v1/Ingress" }}
+{{- if and (.Values.ingress.enabled) (not $hasOverrideV1ApiVersion) (or $hasApiVersion $hasOverrideApiVersion) }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:

--- a/helm/dagster/templates/ingress.yaml
+++ b/helm/dagster/templates/ingress.yaml
@@ -2,7 +2,8 @@
 {{- $apiVersion := .Values.ingress.apiVersion | default "" }}
 {{- $hasApiVersion := (.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress") }}
 {{- $hasOverrideApiVersion := eq $apiVersion "networking.k8s.io/v1/Ingress" }}
-{{- if and (.Values.ingress.enabled) (or $hasApiVersion $hasOverrideApiVersion) }}
+{{- $hasOverrideBetaApiVersion := eq $apiVersion "extensions/v1beta1/Ingress" }}
+{{- if and (.Values.ingress.enabled) (not $hasOverrideBetaApiVersion) (or $hasApiVersion $hasOverrideApiVersion) }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:


### PR DESCRIPTION
## Summary & Motivation
I _believe_ the evaluation rules in https://github.com/dagster-io/dagster/blob/master/helm/dagster/templates/ingress-v1beta1.yaml are incorrect in certain circumstances.

```yaml
{{- $_ := include "dagster.backcompat" . | mustFromJson -}}
{{- $apiVersion := .Values.ingress.apiVersion | default "" }}
{{- $hasApiVersion := (not (.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress")) }}
{{- $hasOverrideApiVersion := eq $apiVersion "extensions/v1beta1/Ingress" }}
{{- if and (.Values.ingress.enabled) (or $hasApiVersion $hasOverrideApiVersion) }}
```

Setting `.Values.ingress.apiVersion` **explicitly** to `networking.k8s.io/v1/Ingress` should, IMO, _never_ render `ingress-v1beta1` (or vice versa), since they should be mutually exclusive and the explicitly set version should take precedence. A cluster failing to execute the rendered manifest is fine if a user sets this explicitly, as far as I'm concerned.

For instance, when `kubectl get --raw /apis | jq | grep -i ingress -B 3 -A2` doesn't return a result, but  `.Values.ingress.apiVersion` is set explicitly, the above evaluates to

```yaml
{{- $_ := include "dagster.backcompat" . | mustFromJson -}}
{{- $apiVersion := "networking.k8s.io/v1/Ingress" }}
{{- $hasApiVersion := (not (false)) }} // aka true
{{- $hasOverrideApiVersion := false }}
{{- if and (true) (or true false) }} // true and (true or false) == true
```

Which renders both templates.

## Change
This change makes them mutually exclusive. 

```yml
// ingress-v1beta1.yml
{{- $apiVersion := .Values.ingress.apiVersion | default "" }}
{{- $hasApiVersion := (not (.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress")) }}
{{- $hasOverrideApiVersion := eq $apiVersion "extensions/v1beta1/Ingress" }}
{{- $hasOverrideV1ApiVersion := eq $apiVersion "networking.k8s.io/v1/Ingress" }}
{{- if and (.Values.ingress.enabled) (not $hasOverrideV1ApiVersion) (or $hasApiVersion $hasOverrideApiVersion) }}
```

i.e.

```yml
{{- $apiVersion := "networking.k8s.io/v1/Ingress" }}
{{- $hasApiVersion := (not (false)) }} // aka true
{{- $hasOverrideApiVersion := false }}
{{- $hasOverrideV1ApiVersion := true }}
{{- if and (true) (not true) (or true false) }} // => true & false & true == false
```

Meanwhile, `ingress.yml` evalutes to `true`

If the flag isn't set explicitly and the capabilities aren't set, it will still render the `v1beta`, but not the regular `ingress.yml`

```yml
{{- $apiVersion := "networking.k8s.io/v1/Ingress" }}
{{- $hasApiVersion := (not (false)) }} // aka true
{{- $hasOverrideApiVersion := false }}
{{- $hasOverrideV1ApiVersion := false }}
{{- if and (true) (not false) (or true false) }} // => true & true & true == true
```

```yml
// ingress.yml
{{- $apiVersion := "" }} // unset
{{- $hasApiVersion := false }}
{{- $hasOverrideApiVersion := false }}
{{- $hasOverrideBetaApiVersion := false }}
{{- if and (true) (not true) (or true false) }} // => true & false & true == false
```

Somebody please double check me here 😬

## How I Tested These Changes
```bash 
kubectl get --raw /apis | jq | grep -i ingress -B 3 -A2 # empty - 
helm show values dagster/dagster > values.yaml
vim values.yaml
cat values.yaml|yq '.ingress.enabled'
# true
cat values.yaml|yq '.ingress.apiVersion'
# networking.k8s.io/v1/Ingress
helm template test ~/workspace/dagster/helm/dagster/ -f ./values.yaml | grep /templates/ingress
# Source: dagster/templates/ingress.yaml
```

To compare, otherwise we get both:

```bash
helm template test dagster/dagster  -f ./values.yaml | grep /templates/ingress
# Source: dagster/templates/ingress-v1beta1.yaml
# Source: dagster/templates/ingress.yaml
```