### PR TITLE
[ui] Add an “event type” filter to the Asset > Events tab

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/LogFilterSelect.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/LogFilterSelect.tsx
@@ -56,10 +56,11 @@ export const LogFilterSelect: React.FC<Props> = ({options, onSetFilter}) => {
                 tagName="div"
                 shouldDismissPopover={false}
                 text={
-                  <Box flex={{direction: 'row', alignItems: 'center'}}>
+                  <Box flex={{direction: 'row', alignItems: 'center'}} padding={{horizontal: 2}}>
                     <MenuCheckbox
                       id={`menu-check-${level}`}
                       checked={enabled}
+                      size="small"
                       onChange={onChange(level)}
                       label={
                         <Box
@@ -102,4 +103,5 @@ const FilterButton = styled(Button)`
 const MenuCheckbox = styled(Checkbox)`
   display: flex;
   flex: 1;
+  align-items: center;
 `;


### PR DESCRIPTION
## Summary & Motivation
Fixes #15520

This PR adds a new "Event Type" filter to the Asset > Events page for non-source assets. State is synced to local storage so it's consistent as you move between assets. The filtering + UI is skipped for source assets, since in the typical case (hiding observations), you would see nothing.

This PR also shrinks the checkboxes in the log filter dropdown to match this dropdown. I noticed that the fancy new RunsFilter UI is using small checkboxes and i think we should use those in all dropdown menus!

<img width="757" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/d81b840d-3fb9-42da-aff4-6919be42b6b4">


## How I Tested These Changes

I viewed assets and source assets with and without observations / materializations. I also opened the inspector, deleted the local storage and reloaded the page to verify that it defaults properly when no stored state is present.