### PR TITLE
move "dbt models and Dagster software-defined assets" from tutorial t…

### DIFF
--- a/docs/content/integrations/dbt/reference.mdx
+++ b/docs/content/integrations/dbt/reference.mdx
@@ -16,6 +16,12 @@ For a step-by-step implementation walkthrough, refer to the [Using dbt with Dags
 
 ---
 
+## dbt models and Dagster software-defined assets
+
+<DbtModelAssetExplanation />
+
+---
+
 ## Loading dbt models from a dbt project
 
 The `dagster-dbt` library offers two methods of loading dbt models from a project into Dagster:

--- a/docs/content/integrations/dbt/using-dbt-with-dagster.mdx
+++ b/docs/content/integrations/dbt/using-dbt-with-dagster.mdx
@@ -14,17 +14,10 @@ In this tutorial, we'll walk you through integrating dbt with Dagster using a sm
 
 By the end of this tutorial, you will:
 
-- Understand how dbt models and Dagster [software-defined assets](/concepts/assets/software-defined-assets) (or SDAs) work together
 - [Set up a dbt project](/integrations/dbt/using-dbt-with-dagster/set-up-dbt-project)
 - [Load the dbt models into Dagster as assets](/integrations/dbt/using-dbt-with-dagster/load-dbt-models)
 - [Create and materialize upstream Dagster assets](/integrations/dbt/using-dbt-with-dagster/upstream-assets)
 - [Create and materialize a downstream asset](/integrations/dbt/using-dbt-with-dagster/downstream-assets) that outputs a plotly chart
-
----
-
-## dbt models and Dagster software-defined assets
-
-<DbtModelAssetExplanation />
 
 ---
 

--- a/docs/content/integrations/dbt/using-dbt-with-dagster.mdx
+++ b/docs/content/integrations/dbt/using-dbt-with-dagster.mdx
@@ -12,7 +12,20 @@ description: Dagster can orchestrate dbt alongside other technologies.
 
 In this tutorial, we'll walk you through integrating dbt with Dagster using a smaller version of dbt's example [jaffle shop project](https://github.com/dbt-labs/jaffle_shop), the [dagster-dbt library](/\_apidocs/libraries/dagster-dbt), and a data warehouse, such as [DuckDB](https://duckdb.org/).
 
-By the end of this tutorial, you will:
+By the end of this tutorial, you'll have your dbt models represented in Dagster along with other [Dagster Software-defined Assets](/integrations/dbt/reference#dbt-models-and-dagster-software-defined-assets) upstream and downstream of them:
+
+<!--
+![Asset group with dbt models and Python asset](/images/integrations/dbt/using-dbt-with-dagster/downstream-assets/asset-group.png)
+-->
+
+<Image
+alt="Asset group with dbt models and Python asset"
+src="/images/integrations/dbt/using-dbt-with-dagster/downstream-assets/asset-group.png"
+width={2992}
+height={1706}
+/>
+
+To get there, you will:
 
 - [Set up a dbt project](/integrations/dbt/using-dbt-with-dagster/set-up-dbt-project)
 - [Load the dbt models into Dagster as assets](/integrations/dbt/using-dbt-with-dagster/load-dbt-models)

--- a/docs/content/integrations/dbt/using-dbt-with-dagster/upstream-assets.mdx
+++ b/docs/content/integrations/dbt/using-dbt-with-dagster/upstream-assets.mdx
@@ -17,7 +17,7 @@ By this point, you've [set up a dbt project](/integrations/dbt/using-dbt-with-da
 
 However, the tables at the root of the pipeline are static: they're [dbt seeds](https://docs.getdbt.com/docs/build/seeds), CSVs that are hardcoded into the dbt project. In a more realistic data pipeline, these tables would typically be ingested from some external data source, for example by using a tool like Airbyte or Fivetran, or by Python code.
 
-These ingestion steps in the pipeline often don't make sense to define inside dbt, but they often still do make sense to define as Dagster software-defined assets. You can think of a Dagster software-defined asset as a more general version of a dbt model. A dbt model is one kind of asset, but another kind is one that's defined in Python, using Dagster's Python API.
+These ingestion steps in the pipeline often don't make sense to define inside dbt, but they often still do make sense to define as Dagster software-defined assets. You can think of a Dagster software-defined asset as a more general version of a dbt model. A dbt model is one kind of asset, but another kind is one that's defined in Python, using Dagster's Python API. The dbt integration reference page includes a [section](/integrations/dbt/reference#dbt-models-and-dagster-software-defined-assets) that outlines the parallels between dbt models and Dagster Software-defined Assets.
 
 In this section, you'll replace the `raw_customers` dbt seed with a Dagster asset that represents it. You'll write Python code that populates this table by fetching data from the web. This will allow you to launch runs that first execute Python code to populate the `raw_customers` table and then invoke dbt to populate the downstream tables.
 

--- a/docs/next/components/mdx/includes/dagster/integrations/DbtModelAssetExplanation.mdx
+++ b/docs/next/components/mdx/includes/dagster/integrations/DbtModelAssetExplanation.mdx
@@ -1,4 +1,4 @@
-Dagster’s [software-defined assets](/concepts/assets/software-defined-assets) (SDAs) bear several similarities to dbt models. A software-defined asset contains an asset key, a set of upstream asset keys, and an operation that is responsible for computing the asset from its upstream dependencies. Models defined in a dbt project are similar to Dagster SDAs in that:
+Dagster’s [software-defined assets](/concepts/assets/software-defined-assets) (SDAs) bear several similarities to dbt models. A software-defined asset contains an asset key, a set of upstream asset keys, and an operation that is responsible for computing the asset from its upstream dependencies. Models defined in a dbt project can be interpreted as Dagster SDAs:
 
 - The asset key for a dbt model is (by default) the name of the model.
 - The upstream dependencies of a dbt model are defined with `ref` or `source` calls within the model's definition.


### PR DESCRIPTION
…o reference

## Summary & Motivation

The beginning of the dbt tutorial currently includes a section titled "dbt models and Dagster software-defined assets", which explains the parallels between dbt models and SDAs. This is great content, but I think it's a lot to digest at once for someone who's opted for the tutorial because they want a gentle walkthrough. It exposes them to these in a short span: the Python API for defining an asset, the term "Software-defined asset", the term "operation", and the term "asset dependency".

This PR proposes moving this content to the reference section of the dbt docs.

## How I Tested These Changes
