### PR TITLE
[ui] Allow searching jobs by Run ID

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/components/Icon.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/Icon.tsx
@@ -78,6 +78,7 @@ import graph_upstream from '../icon-svgs/graph_upstream.svg';
 import history from '../icon-svgs/history.svg';
 import history_toggle_off from '../icon-svgs/history_toggle_off.svg';
 import hourglass_bottom from '../icon-svgs/hourglass_bottom.svg';
+import id from '../icon-svgs/id.svg';
 import infinity from '../icon-svgs/infinity.svg';
 import info from '../icon-svgs/info.svg';
 import job from '../icon-svgs/job.svg';
@@ -219,6 +220,7 @@ export const Icons = {
   youtube,
   arrow_indent,
   editor_role,
+  id,
 
   graph,
   graph_downstream,

--- a/js_modules/dagster-ui/packages/ui-components/src/icon-svgs/id.svg
+++ b/js_modules/dagster-ui/packages/ui-components/src/icon-svgs/id.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>id</title>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" font-family="Helvetica-Bold, Helvetica" font-size="19" font-weight="bold">
+        <text id="ID" fill="#000000">
+            <tspan x="3" y="19">ID</tspan>
+        </text>
+    </g>
+</svg>

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelineRunsRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelineRunsRoot.tsx
@@ -50,6 +50,7 @@ const PAGE_SIZE = 25;
 const ENABLED_FILTERS: RunFilterTokenType[] = [
   'status',
   'tag',
+  'id',
   'created_date_before',
   'created_date_after',
 ];

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFilterInput.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFilterInput.tsx
@@ -218,8 +218,10 @@ export const useRunsFilterInput = ({tokens, onChange, enabledFilters}: RunsFilte
   const [fetchBackfillValues, backfillValues] = useTagDataFilterValues(DagsterTag.Backfill);
   const [fetchPartitionValues, partitionValues] = useTagDataFilterValues(DagsterTag.Partition);
 
+  const isStatusFilterEnabled = !enabledFilters || enabledFilters?.includes('status');
   const isBackfillsFilterEnabled = !enabledFilters || enabledFilters?.includes('backfill');
   const isPartitionsFilterEnabled = !enabledFilters || enabledFilters?.includes('partition');
+  const isJobFilterEnabled = !enabledFilters || enabledFilters?.includes('job');
 
   const onFocus = React.useCallback(() => {
     fetchTagKeys();
@@ -249,8 +251,6 @@ export const useRunsFilterInput = ({tokens, onChange, enabledFilters}: RunsFilte
     ],
     [sensorValues, scheduleValues, userValues],
   );
-
-  const isJobFilterEnabled = !enabledFilters || enabledFilters?.includes('job');
 
   const {pipelines, jobs} = React.useMemo(() => {
     const pipelineNames = [];
@@ -438,173 +438,176 @@ export const useRunsFilterInput = ({tokens, onChange, enabledFilters}: RunsFilte
     },
   });
 
+  const launchedByFilter = useStaticSetFilter({
+    name: 'Launched by',
+    allowMultipleSelections: false,
+    icon: 'add_circle',
+    allValues: createdByValues,
+    renderLabel: ({value}) => {
+      let icon;
+      let labelValue = value.value;
+      if (value.type === DagsterTag.SensorName) {
+        icon = <Icon name="sensors" />;
+      } else if (value.type === DagsterTag.ScheduleName) {
+        icon = <Icon name="schedule" />;
+      } else if (value.type === DagsterTag.User) {
+        return <UserDisplay email={value.value!} isFilter />;
+      } else if (value.type === DagsterTag.Automaterialize) {
+        icon = <Icon name="auto_materialize_policy" />;
+        labelValue = 'Auto-materialize policy';
+      }
+      return (
+        <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
+          {icon}
+          <TruncatedTextWithFullTextOnHover text={labelValue!} />
+        </Box>
+      );
+    },
+    getStringValue: (x) => {
+      if (x.type === DagsterTag.Automaterialize) {
+        return 'Auto-materialize policy';
+      }
+      return x.value!;
+    },
+    initialState: React.useMemo(() => {
+      return new Set(
+        tokens
+          .filter(
+            ({token, value}) =>
+              token === 'tag' && CREATED_BY_TAGS.includes(value.split('=')[0] as DagsterTag),
+          )
+          .map(({value}) => tagValueToFilterObject(value)),
+      );
+    }, [tokens]),
+    onStateChanged: (values) => {
+      onChange([
+        ...tokens.filter((token) => {
+          if (token.token !== 'tag') {
+            return true;
+          }
+          return !CREATED_BY_TAGS.includes(token.value.split('=')[0] as DagsterTag);
+        }),
+        ...Array.from(values).map((value) => ({
+          token: 'tag' as const,
+          value: `${value.type}=${value.value}`,
+        })),
+      ]);
+    },
+  });
+
+  const createdDateFilter = useTimeRangeFilter({
+    name: 'Created date',
+    icon: 'date',
+    initialState: React.useMemo(() => {
+      const before = tokens.find((token) => token.token === 'created_date_before');
+      const after = tokens.find((token) => token.token === 'created_date_after');
+      return [
+        after ? parseInt(after.value) * 1000 : null,
+        before ? parseInt(before.value) * 1000 : null,
+      ] as TimeRangeState;
+    }, [tokens]),
+    onStateChanged: (values) => {
+      onChange([
+        ...tokens.filter(
+          (token) => !['created_date_before', 'created_date_after'].includes(token.token ?? ''),
+        ),
+        ...([
+          values[0] != null ? {token: 'created_date_after', value: `${values[0] / 1000}`} : null,
+          values[1] != null ? {token: 'created_date_before', value: `${values[1] / 1000}`} : null,
+        ].filter((x) => x) as RunFilterToken[]),
+      ]);
+    },
+  });
+
+  const tagFilter = useSuggestionFilter({
+    name: 'Tag',
+    icon: 'tag',
+    initialSuggestions: tagSuggestions,
+
+    freeformSearchResult: React.useCallback(
+      (
+        query: string,
+        path: {
+          value: string;
+          key?: string | undefined;
+        }[],
+      ) => {
+        return {
+          ...tagSuggestionValueObject(path[0] ? path[0].value : '', query),
+          final: !!path.length,
+        };
+      },
+      [],
+    ),
+
+    state: React.useMemo(() => {
+      return tokens
+        .filter(({token, value}) => {
+          if (token !== 'tag') {
+            return false;
+          }
+          return !tagsToExclude.includes(value.split('=')[0] as DagsterTag);
+        })
+        .map((token) => {
+          const [key, value] = token.value.split('=');
+          return tagSuggestionValueObject(key!, value!).value;
+        });
+    }, [tokens]),
+
+    setState: (nextState) => {
+      onChange([
+        ...tokens.filter(({token, value}) => {
+          if (token !== 'tag') {
+            return true;
+          }
+          return tagsToExclude.includes(value.split('=')[0] as DagsterTag);
+        }),
+        ...nextState.map(({key, value}) => {
+          return {
+            token: 'tag' as const,
+            value: `${key}=${value}`,
+          };
+        }),
+      ]);
+    },
+    onSuggestionClicked: async ({value}) => {
+      return await fetchTagValues(value);
+    },
+    getStringValue: ({key, value}) => `${key}=${value}`,
+    getKey: ({key, value}) => `${key}: ${value}`,
+    renderLabel: ({value}) => (
+      <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
+        <Icon name="tag" />
+        <TruncatedTextWithFullTextOnHover text={value.value} />
+      </Box>
+    ),
+    renderActiveStateLabel: ({value}) => (
+      <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
+        <Icon name="tag" />
+        <TruncatedTextWithFullTextOnHover text={`${value.key}=${value.value}`} />
+        {value.key}={value.value}
+      </Box>
+    ),
+    isMatch: ({value}, query) => value.toLowerCase().includes(query.toLowerCase()),
+    matchType: 'all-of',
+  });
+
   const {button, activeFiltersJsx} = useFilters({
     filters: [
-      !enabledFilters || enabledFilters?.includes('status') ? statusFilter : null,
-      useStaticSetFilter({
-        name: 'Launched by',
-        allowMultipleSelections: false,
-        icon: 'add_circle',
-        allValues: createdByValues,
-        renderLabel: ({value}) => {
-          let icon;
-          let labelValue = value.value;
-          if (value.type === DagsterTag.SensorName) {
-            icon = <Icon name="sensors" />;
-          } else if (value.type === DagsterTag.ScheduleName) {
-            icon = <Icon name="schedule" />;
-          } else if (value.type === DagsterTag.User) {
-            return <UserDisplay email={value.value!} isFilter />;
-          } else if (value.type === DagsterTag.Automaterialize) {
-            icon = <Icon name="auto_materialize_policy" />;
-            labelValue = 'Auto-materialize policy';
-          }
-          return (
-            <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
-              {icon}
-              <TruncatedTextWithFullTextOnHover text={labelValue!} />
-            </Box>
-          );
-        },
-        getStringValue: (x) => {
-          if (x.type === DagsterTag.Automaterialize) {
-            return 'Auto-materialize policy';
-          }
-          return x.value!;
-        },
-        initialState: React.useMemo(() => {
-          return new Set(
-            tokens
-              .filter(
-                ({token, value}) =>
-                  token === 'tag' && CREATED_BY_TAGS.includes(value.split('=')[0] as DagsterTag),
-              )
-              .map(({value}) => tagValueToFilterObject(value)),
-          );
-        }, [tokens]),
-        onStateChanged: (values) => {
-          onChange([
-            ...tokens.filter((token) => {
-              if (token.token !== 'tag') {
-                return true;
-              }
-              return !CREATED_BY_TAGS.includes(token.value.split('=')[0] as DagsterTag);
-            }),
-            ...Array.from(values).map((value) => ({
-              token: 'tag' as const,
-              value: `${value.type}=${value.value}`,
-            })),
-          ]);
-        },
-      }),
-      useTimeRangeFilter({
-        name: 'Created date',
-        icon: 'date',
-        initialState: React.useMemo(() => {
-          const before = tokens.find((token) => token.token === 'created_date_before');
-          const after = tokens.find((token) => token.token === 'created_date_after');
-          return [
-            after ? parseInt(after.value) * 1000 : null,
-            before ? parseInt(before.value) * 1000 : null,
-          ] as TimeRangeState;
-        }, [tokens]),
-        onStateChanged: (values) => {
-          onChange([
-            ...tokens.filter(
-              (token) => !['created_date_before', 'created_date_after'].includes(token.token ?? ''),
-            ),
-            ...([
-              values[0] != null
-                ? {token: 'created_date_after', value: `${values[0] / 1000}`}
-                : null,
-              values[1] != null
-                ? {token: 'created_date_before', value: `${values[1] / 1000}`}
-                : null,
-            ].filter((x) => x) as RunFilterToken[]),
-          ]);
-        },
-      }),
+      isStatusFilterEnabled ? statusFilter : null,
+      launchedByFilter,
+      createdDateFilter,
       isJobFilterEnabled ? jobFilter : null,
       isPipelineFilterEnabled ? pipelinesFilter : null,
       isBackfillsFilterEnabled ? backfillsFilter : null,
       isPartitionsFilterEnabled ? partitionsFilter : null,
-      useSuggestionFilter({
-        name: 'Tag',
-        icon: 'tag',
-        initialSuggestions: tagSuggestions,
-
-        freeformSearchResult: React.useCallback(
-          (
-            query: string,
-            path: {
-              value: string;
-              key?: string | undefined;
-            }[],
-          ) => {
-            return {
-              ...tagSuggestionValueObject(path[0] ? path[0].value : '', query),
-              final: !!path.length,
-            };
-          },
-          [],
-        ),
-
-        state: React.useMemo(() => {
-          return tokens
-            .filter(({token, value}) => {
-              if (token !== 'tag') {
-                return false;
-              }
-              return !tagsToExclude.includes(value.split('=')[0] as DagsterTag);
-            })
-            .map((token) => {
-              const [key, value] = token.value.split('=');
-              return tagSuggestionValueObject(key!, value!).value;
-            });
-        }, [tokens]),
-
-        setState: (nextState) => {
-          onChange([
-            ...tokens.filter(({token, value}) => {
-              if (token !== 'tag') {
-                return true;
-              }
-              return tagsToExclude.includes(value.split('=')[0] as DagsterTag);
-            }),
-            ...nextState.map(({key, value}) => {
-              return {
-                token: 'tag' as const,
-                value: `${key}=${value}`,
-              };
-            }),
-          ]);
-        },
-        onSuggestionClicked: async ({value}) => {
-          return await fetchTagValues(value);
-        },
-        getStringValue: ({key, value}) => `${key}=${value}`,
-        getKey: ({key, value}) => `${key}: ${value}`,
-        renderLabel: ({value}) => (
-          <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
-            <Icon name="tag" />
-            <TruncatedTextWithFullTextOnHover text={value.value} />
-          </Box>
-        ),
-        renderActiveStateLabel: ({value}) => (
-          <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
-            <Icon name="tag" />
-            <TruncatedTextWithFullTextOnHover text={`${value.key}=${value.value}`} />
-            {value.key}={value.value}
-          </Box>
-        ),
-        isMatch: ({value}, query) => value.toLowerCase().includes(query.toLowerCase()),
-        matchType: 'all-of',
-      }),
+      tagFilter,
     ].filter((x) => x) as FilterObject[],
   });
 
   return {button: <span onClick={onFocus}>{button}</span>, activeFiltersJsx};
 };
+
 export function useTagDataFilterValues(tagKey?: DagsterTag) {
   const [fetch, {data}] = useLazyQuery<RunTagValuesQuery, RunTagValuesQueryVariables>(
     RUN_TAG_VALUES_QUERY,

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFilterInput.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFilterInput.tsx
@@ -596,7 +596,8 @@ export const useRunsFilterInput = ({tokens, onChange, enabledFilters}: RunsFilte
   const idFilter = useSuggestionFilter({
     name: 'Run ID',
     icon: 'id',
-    initialSuggestions: [{final: true, value: ID_EMPTY}],
+    initialSuggestions: [],
+    getNoSuggestionsPlaceholder: (query) => (!query ? ID_EMPTY : ID_TOO_SHORT),
     state: React.useMemo(() => {
       return tokens.filter(({token}) => token === 'id').map((token) => token.value);
     }, [tokens]),
@@ -606,11 +607,9 @@ export const useRunsFilterInput = ({tokens, onChange, enabledFilters}: RunsFilte
     setState: (nextState) => {
       onChange([
         ...tokens.filter(({token}) => token !== 'id'),
-        ...nextState
-          .filter((value) => value !== ID_EMPTY && value !== ID_TOO_SHORT)
-          .map((value) => {
-            return {token: 'id' as const, value};
-          }),
+        ...nextState.map((value) => {
+          return {token: 'id' as const, value};
+        }),
       ]);
     },
     getStringValue: (value) => value,

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/FilterDropdown.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/FilterDropdown.tsx
@@ -266,7 +266,9 @@ export const FilterDropdown = ({filters, setIsOpen, setPortaledElements}: Filter
               </Inner>
             </Container>
           ) : (
-            <Box padding={{vertical: 12, horizontal: 16}}>No results</Box>
+            <Box padding={{vertical: 12, horizontal: 12}} style={{color: Colors.Gray500}}>
+              {selectedFilter?.getNoResultsPlaceholder?.(search) || 'No results'}
+            </Box>
           )}
         </DropdownMenuContainer>
       </Menu>

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/FilterDropdown.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/FilterDropdown.tsx
@@ -126,7 +126,7 @@ export const FilterDropdown = ({filters, setIsOpen, setPortaledElements}: Filter
               setFocusedItemIndex(-1);
             }}
             text={
-              <Box flex={{direction: 'row', gap: 12}}>
+              <Box flex={{direction: 'row', gap: 4}}>
                 <Icon name={filter.icon} />
                 {filter.name}
               </Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/useFilter.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/useFilter.tsx
@@ -10,6 +10,7 @@ export type FilterObject<T = any> = {
   icon: IconName;
   name: string;
   getResults: (query: string) => {label: JSX.Element; key: string; value: any}[];
+  getNoResultsPlaceholder?: (query: string) => string;
   onSelect: (selectArg: {
     value: T;
     close: () => void;

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/useStaticSetFilter.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/useStaticSetFilter.tsx
@@ -258,12 +258,12 @@ export function SetFilterLabel(props: SetFilterLabelProps) {
   const labelRef = React.useRef<HTMLDivElement>(null);
 
   return (
-    // 4 px of margin to compensate for weird Checkbox CSS whose bounding box is smaller than the actual
+    // 2px of margin to compensate for weird Checkbox CSS whose bounding box is smaller than the actual
     // SVG it contains with size="small"
     <Box
       flex={{direction: 'row', gap: 6, alignItems: 'center'}}
       ref={labelRef}
-      margin={{left: 4}}
+      margin={allowMultipleSelections ? {left: 2} : {}}
       style={{maxWidth: '500px'}}
     >
       {allowMultipleSelections ? <Checkbox checked={isActive} size="small" readOnly /> : null}

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/useSuggestionFilter.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/useSuggestionFilter.tsx
@@ -16,7 +16,7 @@ type Args<TValue> = {
   freeformSearchResult?: (
     query: string,
     suggestionPath: TValue[],
-  ) => SuggestionFilterSuggestion<TValue>;
+  ) => SuggestionFilterSuggestion<TValue> | null;
 
   state: TValue[]; // Active suggestions
   setState: (state: TValue[]) => void;
@@ -116,17 +116,19 @@ export function useSuggestionFilter<TValue>({
         }
         if (!hasExactMatch && freeformSearchResult && query.length) {
           const suggestion = freeformSearchResult(query, suggestionPath);
-          results.unshift({
-            label: (
-              <SuggestionFilterLabel
-                value={suggestion.value}
-                renderLabel={renderLabel}
-                filter={filterObjRef.current}
-              />
-            ),
-            key: getKey?.(suggestion.value) || 'freeform',
-            value: suggestion,
-          });
+          if (suggestion) {
+            results.unshift({
+              label: (
+                <SuggestionFilterLabel
+                  value={suggestion.value}
+                  renderLabel={renderLabel}
+                  filter={filterObjRef.current}
+                />
+              ),
+              key: getKey?.(suggestion.value) || 'freeform',
+              value: suggestion,
+            });
+          }
         }
         return results;
       },

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/useSuggestionFilter.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/useSuggestionFilter.tsx
@@ -20,9 +20,11 @@ type Args<TValue> = {
 
   state: TValue[]; // Active suggestions
   setState: (state: TValue[]) => void;
-  initialSuggestions: SuggestionFilterSuggestion<TValue>[];
 
+  initialSuggestions: SuggestionFilterSuggestion<TValue>[];
+  getNoSuggestionsPlaceholder?: (query: string) => string;
   onSuggestionClicked: (value: TValue) => Promise<SuggestionFilterSuggestion<TValue>[]> | void;
+
   getStringValue: (value: TValue) => string;
   getKey: (value: TValue) => string;
   renderLabel: ({value, isActive}: {value: TValue; isActive: boolean}) => JSX.Element;
@@ -44,6 +46,7 @@ export function useSuggestionFilter<TValue>({
   setState,
   initialSuggestions,
   onSuggestionClicked,
+  getNoSuggestionsPlaceholder,
   getStringValue,
   getKey,
   renderLabel,
@@ -71,6 +74,7 @@ export function useSuggestionFilter<TValue>({
         setSuggestionPath([]);
       },
       isLoadingFilters: nextSuggestionsLoading,
+      getNoResultsPlaceholder: getNoSuggestionsPlaceholder,
       getResults: (query: string) => {
         let results;
         let hasExactMatch = false;
@@ -175,6 +179,7 @@ export function useSuggestionFilter<TValue>({
       state,
       nextSuggestionsLoading,
       getStringValue,
+      getNoSuggestionsPlaceholder,
       renderActiveStateLabel,
       renderLabel,
       matchType,

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/useSuggestionFilter.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/useSuggestionFilter.tsx
@@ -214,12 +214,12 @@ function SuggestionFilterLabel(props: SuggestionFilterLabelProps) {
   const labelRef = React.useRef<HTMLDivElement>(null);
 
   return (
-    // 4 px of margin to compensate for weird Checkbox CSS whose bounding box is smaller than the actual
+    // 2px of margin to compensate for weird Checkbox CSS whose bounding box is smaller than the actual
     // SVG it contains with size="small"
     <Box
       flex={{direction: 'row', gap: 6, alignItems: 'center'}}
       ref={labelRef}
-      margin={{left: 4}}
+      margin={{left: 2}}
       style={{maxWidth: '500px', overflow: 'hidden'}}
     >
       <div style={{overflow: 'hidden'}}>{renderLabel({value, isActive})}</div>

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/useTimeRangeFilter.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/useTimeRangeFilter.tsx
@@ -171,7 +171,7 @@ export function useTimeRangeFilter({
 
 function TimeRangeResult({range}: {range: string}) {
   return (
-    <Box flex={{direction: 'row', gap: 12, alignItems: 'center'}}>
+    <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
       <Icon name="date" color={Colors.Dark} />
       {range}
     </Box>


### PR DESCRIPTION
## Summary & Motivation

This is a small PR that makes it possible to filter runs by Run ID (Fixes #15260).

We mostly already supported this, but there wasn't dropdown UI for the filter.  This filter only allows you to enter 36-character Run IDs in the UUID format, which is unfortunate because the UI shows the 8 character version. It seems like it'd actually take a significant amount of work to allow "prefix-" matching against the 8-character display IDs because this filter goes all the way down to the RunStorage interface and there are multiple implementations.

To make this limitation more clear, I hacked in an "empty state" which explains what you need to provide. (Screenshot 2), and changed the `freeformSearchResult` callback so that it can return null to offer no completion if the user's input is not a valid value.

While I was in here, I also created local vars in the RunsFilterInput for some of the fillers that were inlined so the code is a bit more consistent. 

<img width="432" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/e82f6393-b7fa-4da1-b006-b4f972115fba">

<img width="436" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/c1f8a8c9-5414-4853-a46f-f42c50b0c2c7">

<img width="613" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/3f1e9fd9-4bb3-49cd-85e1-c3eb858b7a7d">

## How I Tested These Changes

I tested this by filtering for run IDs, pasting / typing various text and reloading the pages to make sure the filter persists. 