### PR TITLE
[ui] Migrate localStorage keys for dagit -> dagster

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppProvider.tsx
@@ -39,6 +39,7 @@ import {PermissionsProvider} from './Permissions';
 import {patchCopyToRemoveZeroWidthUnderscores} from './Util';
 import {WebSocketProvider} from './WebSocketProvider';
 import {AnalyticsContext, dummyAnalytics} from './analytics';
+import {migrateLocalStorageKeys} from './migrateLocalStorageKeys';
 import {TimeProvider} from './time/TimeContext';
 
 import './blueprint.css';
@@ -120,6 +121,12 @@ export const AppProvider: React.FC<AppProviderProps> = (props) => {
     telemetryEnabled = false,
     statusPolling,
   } = config;
+
+  React.useEffect(() => {
+    migrateLocalStorageKeys({from: /DAGIT_FLAGS/g, to: 'DAGSTER_FLAGS'});
+    migrateLocalStorageKeys({from: /:dagit/gi, to: ':dagster'});
+    migrateLocalStorageKeys({from: /^dagit(\.v2)?/gi, to: 'dagster'});
+  }, []);
 
   const graphqlPath = `${basePath}/graphql`;
   const rootServerURI = `${origin}${basePath}`;

--- a/js_modules/dagster-ui/packages/ui-core/src/app/__tests__/migrateLocalStorageKeys.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/__tests__/migrateLocalStorageKeys.test.tsx
@@ -1,0 +1,42 @@
+import {migrateLocalStorageKeys} from '../migrateLocalStorageKeys';
+
+describe('migrateLocalStorageKeys', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('moves an existing value', () => {
+    window.localStorage.setItem('foo', 'hello');
+    expect(window.localStorage.getItem('foo')).toBe('hello');
+    migrateLocalStorageKeys({from: /foo/gi, to: 'bar'});
+    expect(window.localStorage.getItem('foo')).toBeNull();
+    expect(window.localStorage.getItem('bar')).toBe('hello');
+  });
+
+  it('does not affect non-matching keys', () => {
+    window.localStorage.setItem('foo', 'hello');
+    expect(window.localStorage.getItem('foo')).toBe('hello');
+    migrateLocalStorageKeys({from: /baz/gi, to: 'bar'});
+    expect(window.localStorage.getItem('foo')).toBe('hello');
+  });
+
+  it('moves keys of various capitalization', () => {
+    window.localStorage.setItem('FOO-COOL', 'lorem');
+    window.localStorage.setItem('fOo-cOoL', 'ipsum');
+    migrateLocalStorageKeys({from: /foo/gi, to: 'bar'});
+    expect(window.localStorage.getItem('FOO-COOL')).toBeNull();
+    expect(window.localStorage.getItem('fOo-cOoL')).toBeNull();
+    expect(window.localStorage.getItem('bar-COOL')).toBe('lorem');
+    expect(window.localStorage.getItem('bar-cOoL')).toBe('ipsum');
+  });
+
+  it('does not affect keys where the matching string is in the value', () => {
+    window.localStorage.setItem('bar', 'foo');
+    migrateLocalStorageKeys({from: /foo/gi, to: 'baz'});
+    expect(window.localStorage.getItem('bar')).toBe('foo');
+  });
+});

--- a/js_modules/dagster-ui/packages/ui-core/src/app/migrateLocalStorageKeys.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/migrateLocalStorageKeys.tsx
@@ -1,0 +1,9 @@
+export const migrateLocalStorageKeys = ({from, to}: {from: RegExp; to: string}) => {
+  Object.entries(window.localStorage).forEach(([key, value]) => {
+    if (from.test(key)) {
+      const newKey = key.replaceAll(from, to);
+      window.localStorage.setItem(newKey, value);
+      window.localStorage.removeItem(key);
+    }
+  });
+};


### PR DESCRIPTION
## Summary & Motivation

To be used in conjunction with @smackesey's dagit renames.

We use the string `dagit` pretty often in our localStorage keys. We don't want to migrate the `dagit` string to `dagster` in these key strings and risk users losing all of the localStorage state.

To avoid losing any LS state, explicitly migrate from old keys to new when AppProvider is rendered, using regex find-replace and iterating across the whole of LS.

## How I Tested These Changes

Jest.

Log migrated keys to console, with set/remove code commented out. Verify that the migrations look correct.
