### PR TITLE
[ui] Display stale status / causes on individual asset partitions

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEvents.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEvents.tsx
@@ -9,7 +9,7 @@ import {
 import * as React from 'react';
 
 import {LiveDataForNode, stepKeyForAsset} from '../asset-graph/Utils';
-import {RepositorySelector, StaleStatus} from '../graphql/types';
+import {RepositorySelector} from '../graphql/types';
 
 import {AssetEventDetail, AssetEventDetailEmpty} from './AssetEventDetail';
 import {AssetEventList} from './AssetEventList';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEvents.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEvents.tsx
@@ -9,7 +9,7 @@ import {
 import * as React from 'react';
 
 import {LiveDataForNode, stepKeyForAsset} from '../asset-graph/Utils';
-import {RepositorySelector} from '../graphql/types';
+import {RepositorySelector, StaleStatus} from '../graphql/types';
 
 import {AssetEventDetail, AssetEventDetailEmpty} from './AssetEventDetail';
 import {AssetEventList} from './AssetEventList';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitionDetail.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitionDetail.tsx
@@ -60,13 +60,9 @@ export const AssetPartitionDetailLoader: React.FC<{assetKey: AssetKey; partition
 
     return {
       stepKey: stepKeyForAsset(result.data.assetNodeOrError),
-
       staleStatus: result.data.assetNodeOrError.staleStatus,
-
       staleCauses: result.data.assetNodeOrError.staleCauses,
-
       latestRunForPartition: result.data.assetNodeOrError.latestRunForPartition,
-
       materializations: [...result.data.assetNodeOrError.assetMaterializations].sort(
         (a, b) => Number(b.timestamp) - Number(a.timestamp),
       ),

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/Stale.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/Stale.tsx
@@ -20,10 +20,12 @@ import {AssetKeyInput, StaleCauseCategory, StaleStatus} from '../graphql/types';
 
 import {assetDetailsPathForKey} from './assetDetailsPathForKey';
 
-export const isAssetMissing = (liveData?: LiveDataForNode) =>
+type StaleDataForNode = Pick<LiveDataForNode, 'staleCauses' | 'staleStatus'>;
+
+export const isAssetMissing = (liveData?: StaleDataForNode) =>
   liveData && liveData.staleStatus === StaleStatus.MISSING;
 
-export const isAssetStale = (liveData?: LiveDataForNode) =>
+export const isAssetStale = (liveData?: StaleDataForNode) =>
   liveData && liveData.staleStatus === StaleStatus.STALE;
 
 const LABELS = {
@@ -42,7 +44,7 @@ const LABELS = {
 export const StaleReasonsLabel: React.FC<{
   assetKey: AssetKeyInput;
   include: 'all' | 'upstream' | 'self';
-  liveData?: LiveDataForNode;
+  liveData?: StaleDataForNode;
 }> = ({liveData, include, assetKey}) => {
   if (!isAssetStale(liveData) || !liveData?.staleCauses.length) {
     return null;
@@ -65,7 +67,7 @@ export const StaleReasonsLabel: React.FC<{
 export const StaleReasonsTags: React.FC<{
   assetKey: AssetKeyInput;
   include: 'all' | 'upstream' | 'self';
-  liveData?: LiveDataForNode;
+  liveData?: StaleDataForNode;
   onClick?: () => void;
 }> = ({liveData, include, assetKey, onClick}) => {
   if (!isAssetStale(liveData) || !liveData?.staleCauses.length) {
@@ -106,7 +108,7 @@ export const StaleReasonsTags: React.FC<{
 function groupedCauses(
   assetKey: AssetKeyInput,
   include: 'all' | 'upstream' | 'self',
-  liveData?: LiveDataForNode,
+  liveData?: StaleDataForNode,
 ) {
   const all = (liveData?.staleCauses || [])
     .map((cause) => {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__fixtures__/AssetEventDetail.fixtures.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__fixtures__/AssetEventDetail.fixtures.ts
@@ -1,6 +1,6 @@
 import {MockedResponse} from '@apollo/client/testing';
 
-import {RunStatus} from '../../graphql/types';
+import {RunStatus, StaleStatus} from '../../graphql/types';
 import {ASSET_MATERIALIZATION_UPSTREAM_QUERY} from '../AssetMaterializationUpstreamData';
 import {ASSET_PARTITION_DETAIL_QUERY} from '../AssetPartitionDetail';
 import {AssetMaterializationUpstreamQuery} from '../types/AssetMaterializationUpstreamData.types';
@@ -275,6 +275,10 @@ export const MaterializationUpstreamDataEmptyMock: MockedResponse<AssetMateriali
 
 export const buildAssetPartitionDetailMock = (
   currentRunStatus?: RunStatus,
+  staleCauses: Extract<
+    AssetPartitionDetailQuery['assetNodeOrError'],
+    {__typename: 'AssetNode'}
+  >['staleCauses'] = [],
 ): MockedResponse<AssetPartitionDetailQuery> => ({
   request: {
     operationName: 'AssetPartitionDetailQuery',
@@ -297,6 +301,8 @@ export const buildAssetPartitionDetailMock = (
             timestamp: `${Number(BasicObservationEvent.timestamp) + 2 * 60 * 1000}`,
           },
         ],
+        staleCauses,
+        staleStatus: staleCauses.length ? StaleStatus.STALE : StaleStatus.FRESH,
         latestRunForPartition: currentRunStatus
           ? {
               __typename: 'Run',

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__stories__/AssetPartitionDetail.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__stories__/AssetPartitionDetail.stories.tsx
@@ -3,7 +3,7 @@ import {Box} from '@dagster-io/ui-components';
 import React from 'react';
 
 import {createAppCache} from '../../app/AppCache';
-import {RunStatus} from '../../graphql/types';
+import {RunStatus, buildStaleCause} from '../../graphql/types';
 import {WorkspaceProvider} from '../../workspace/WorkspaceContext';
 import {
   AssetPartitionDetail,
@@ -47,7 +47,7 @@ export const MaterializationWithRecentFailure = () => {
   return (
     <MockedProvider
       mocks={[
-        buildAssetPartitionDetailMock(RunStatus.FAILURE),
+        buildAssetPartitionDetailMock(RunStatus.FAILURE, [buildStaleCause()]),
         MaterializationUpstreamDataFullMock,
       ]}
       cache={createAppCache()}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetPartitionDetail.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetPartitionDetail.types.ts
@@ -14,6 +14,14 @@ export type AssetPartitionDetailQuery = {
         __typename: 'AssetNode';
         id: string;
         opNames: Array<string>;
+        staleStatus: Types.StaleStatus | null;
+        staleCauses: Array<{
+          __typename: 'StaleCause';
+          reason: string;
+          category: Types.StaleCauseCategory;
+          key: {__typename: 'AssetKey'; path: Array<string>};
+          dependency: {__typename: 'AssetKey'; path: Array<string>} | null;
+        }>;
         latestRunForPartition: {
           __typename: 'Run';
           id: string;


### PR DESCRIPTION
## Summary & Motivation

This PR stacks on https://github.com/dagster-io/dagster/pull/15657 and adds Stale tags to the Asset > Partition details view. This allows you to see if a specific partition needs to be re-materialized after the upstream partitions it incorporates were changed.

Right now, this value is fetched for the specific partition shown and is shown next to the green "Materialized" tag. We want to keep "Green" in this UI for now, since we can't fetch this info in bulk fast enough to put filterable stale / yellow dots in the left sidebar or asset health bar.

## How I Tested These Changes

I updated the storybooks for this to show a stale cause.

I also took a partition mapped asset, materialized a partition, re-materialized one of it's upstreams, and observed that the partition appeared "Stale" while others did not.

I also fixed a small bug I discovered where the UI would stick in a loading state if the only attempted run for a partition failed to materialize and there is no `latest` event.


![image](https://github.com/dagster-io/dagster/assets/1037212/e9bb2d14-617f-4315-a3ed-796360e18d35)
