### PR TITLE
fix metadata on to_source_assets

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -1130,7 +1130,7 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
 
             return SourceAsset(
                 key=key,
-                metadata=output_def.metadata,
+                metadata=self.metadata_by_key.get(key),
                 io_manager_key=output_def.io_manager_key,
                 description=output_def.description,
                 resource_defs=self.resource_defs,

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -497,6 +497,15 @@ def test_to_source_assets():
     assert my_multi_asset.to_source_asset("my_other_asset") == my_other_asset_source_asset
 
 
+def test_to_source_asset_with_attributes_metadata():
+    @asset
+    def asset1():
+        ...
+
+    asset1_with_metadata = asset1.with_attributes(metadata_by_key={asset1.key: {"a": "b"}})
+    assert asset1_with_metadata.to_source_asset().raw_metadata == {"a": "b"}
+
+
 def test_coerced_asset_keys():
     @asset(ins={"input1": AssetIn(key=["Asset", "1"])})
     def asset1(input1):


### PR DESCRIPTION
## Summary & Motivation

Sometimes, we construct a SourceAsset from an AssetsDefinition. When we did that, we were determining the metadata by looking at the `Out` inside of the asset's op.

But AssetsDefinitions don't always have all their metadata on their `Out`. E.g. if `with_attributes` is used.  This PR uses the metadata on the `AssetsDefinition` itself.

This fixes from strange behavior that @slopp was observing.

## How I Tested These Changes
