### PR TITLE
[ui] Leave existing LS keys in place

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/__tests__/migrateLocalStorageKeys.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/__tests__/migrateLocalStorageKeys.test.tsx
@@ -9,11 +9,11 @@ describe('migrateLocalStorageKeys', () => {
     window.localStorage.clear();
   });
 
-  it('moves an existing value', () => {
+  it('copies an existing value', () => {
     window.localStorage.setItem('foo', 'hello');
     expect(window.localStorage.getItem('foo')).toBe('hello');
     migrateLocalStorageKeys({from: /foo/gi, to: 'bar'});
-    expect(window.localStorage.getItem('foo')).toBeNull();
+    expect(window.localStorage.getItem('foo')).toBe('hello');
     expect(window.localStorage.getItem('bar')).toBe('hello');
   });
 
@@ -24,12 +24,10 @@ describe('migrateLocalStorageKeys', () => {
     expect(window.localStorage.getItem('foo')).toBe('hello');
   });
 
-  it('moves keys of various capitalization', () => {
+  it('copies values of various key capitalization', () => {
     window.localStorage.setItem('FOO-COOL', 'lorem');
     window.localStorage.setItem('fOo-cOoL', 'ipsum');
     migrateLocalStorageKeys({from: /foo/gi, to: 'bar'});
-    expect(window.localStorage.getItem('FOO-COOL')).toBeNull();
-    expect(window.localStorage.getItem('fOo-cOoL')).toBeNull();
     expect(window.localStorage.getItem('bar-COOL')).toBe('lorem');
     expect(window.localStorage.getItem('bar-cOoL')).toBe('ipsum');
   });

--- a/js_modules/dagster-ui/packages/ui-core/src/app/migrateLocalStorageKeys.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/migrateLocalStorageKeys.tsx
@@ -3,7 +3,6 @@ export const migrateLocalStorageKeys = ({from, to}: {from: RegExp; to: string}) 
     if (from.test(key)) {
       const newKey = key.replaceAll(from, to);
       window.localStorage.setItem(newKey, value);
-      window.localStorage.removeItem(key);
     }
   });
 };


### PR DESCRIPTION
## Summary & Motivation

Don't delete the localStorage keys we're migrating away from, just to be safe. OSS users may need to revert to an older version, or we may have to roll back a Cloud deploy for some reason. In either case, users who load the app will have lost their old state, which would be an unfortunate experience.

We can always clean these up later if we want, but in the meantime they'll just be orphaned keys on the user's localStorage.

## How I Tested These Changes

Buildkite
