### PR TITLE
refactor(dbt): prefer `.joinpath(.., ...).resolve()` over `.parent.joinpath(...)`

### DIFF
--- a/docs/content/integrations/dbt/using-dbt-with-dagster/load-dbt-models.mdx
+++ b/docs/content/integrations/dbt/using-dbt-with-dagster/load-dbt-models.mdx
@@ -111,7 +111,7 @@ The most important file is the Python file that contains the set of definitions 
 To return a Dagster asset for each dbt model, the code in this file needs to know what dbt models you have. It finds out what models you have by reading a file called a `manifest.json`, which is a file that dbt can generate for any dbt project and contains information about every model, seed, snapshot, test, etc. in the project. The following code, already in your project's `definitions.py`, does this:
 
 ```python file=integrations/dbt/tutorial/load_dbt_models/definitions.py startafter=start_load_manifest endbefore=end_load_manifest
-dbt_project_dir = Path(__file__).parent.joinpath("..", "..")
+dbt_project_dir = Path(__file__).joinpath("..", "..", "..").resolve()
 dbt = DbtCliResource(project_dir=os.fspath(dbt_project_dir))
 
 # If DAGSTER_DBT_PARSE_PROJECT_ON_LOAD is set, a manifest will be created at runtime.

--- a/docs/content/integrations/dbt/using-dbt-with-dagster/upstream-assets.mdx
+++ b/docs/content/integrations/dbt/using-dbt-with-dagster/upstream-assets.mdx
@@ -54,7 +54,7 @@ from dagster_dbt import DbtCliResource, build_schedule_from_dbt_selection, dbt_a
 
 from dagster import Definitions, OpExecutionContext, asset
 
-dbt_project_dir = Path(__file__).parent.joinpath("..", "..")
+dbt_project_dir = Path(__file__).joinpath("..", "..", "..").resolve()
 duckdb_database_path = dbt_project_dir.joinpath("tutorial.duckdb")
 
 

--- a/examples/docs_snippets/docs_snippets/integrations/dbt/tutorial/downstream_assets/definitions.py
+++ b/examples/docs_snippets/docs_snippets/integrations/dbt/tutorial/downstream_assets/definitions.py
@@ -17,7 +17,7 @@ from dagster import Definitions, MetadataValue, OpExecutionContext, asset
 # end_imports
 
 
-dbt_project_dir = Path(__file__).parent.joinpath("..", "..")
+dbt_project_dir = Path(__file__).joinpath("..", "..", "..").resolve()
 duckdb_database_path = dbt_project_dir.joinpath("tutorial.duckdb")
 
 

--- a/examples/docs_snippets/docs_snippets/integrations/dbt/tutorial/load_dbt_models/definitions.py
+++ b/examples/docs_snippets/docs_snippets/integrations/dbt/tutorial/load_dbt_models/definitions.py
@@ -6,7 +6,7 @@ from dagster_dbt import DbtCliResource, build_schedule_from_dbt_selection, dbt_a
 from dagster import Definitions, OpExecutionContext
 
 # start_load_manifest
-dbt_project_dir = Path(__file__).parent.joinpath("..", "..")
+dbt_project_dir = Path(__file__).joinpath("..", "..", "..").resolve()
 dbt = DbtCliResource(project_dir=os.fspath(dbt_project_dir))
 
 # If DAGSTER_DBT_PARSE_PROJECT_ON_LOAD is set, a manifest will be created at runtime.

--- a/examples/docs_snippets/docs_snippets/integrations/dbt/tutorial/upstream_assets/definitions.py
+++ b/examples/docs_snippets/docs_snippets/integrations/dbt/tutorial/upstream_assets/definitions.py
@@ -8,7 +8,7 @@ from dagster_dbt import DbtCliResource, build_schedule_from_dbt_selection, dbt_a
 
 from dagster import Definitions, OpExecutionContext, asset
 
-dbt_project_dir = Path(__file__).parent.joinpath("..", "..")
+dbt_project_dir = Path(__file__).joinpath("..", "..", "..").resolve()
 duckdb_database_path = dbt_project_dir.joinpath("tutorial.duckdb")
 
 

--- a/examples/docs_snippets/docs_snippets_tests/integrations_tests/test_dbt.py
+++ b/examples/docs_snippets/docs_snippets_tests/integrations_tests/test_dbt.py
@@ -21,7 +21,7 @@ from docs_snippets.integrations.dbt.dbt_cloud import (
 
 
 def test_scope_schedule_assets_can_load():
-    MANIFEST_PATH = Path(__file__).parent / "manifest.json"
+    MANIFEST_PATH = Path(__file__).joinpath("..", "manifest.json").resolve()
     manifest = json.loads(MANIFEST_PATH.read_bytes())
 
     scope_schedule_assets_dbt_only(manifest)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/app.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/app.py
@@ -97,7 +97,7 @@ def copy_scaffold(
     dbt_project_dir_relative_path = Path(
         os.path.relpath(
             dbt_project_dir,
-            start=dagster_project_dir.joinpath(project_name),
+            start=dagster_project_dir.joinpath(project_name, "definitions.py"),
         )
     )
     dbt_project_dir_relative_path_parts = [

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/include/__init__.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/include/__init__.py
@@ -1,3 +1,3 @@
 from pathlib import Path
 
-STARTER_PROJECT_PATH = Path(__file__).parent
+STARTER_PROJECT_PATH = Path(__file__).joinpath("..").resolve()

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/include/scaffold/definitions.py.jinja
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/include/scaffold/definitions.py.jinja
@@ -8,7 +8,7 @@ from dagster_dbt import DbtCliResource, build_schedule_from_dbt_selection, dbt_a
 # We expect the dbt project to be installed as package data.
 # For details, see https://docs.python.org/3/distutils/setupscript.html#installing-package-data.
 {%- endif %}
-dbt_project_dir = Path(__file__).parent.joinpath({{ dbt_project_dir_relative_path_parts | join(', ')}})
+dbt_project_dir = Path(__file__).joinpath({{ dbt_project_dir_relative_path_parts | join(', ')}}).resolve()
 dbt = DbtCliResource(project_dir=os.fspath(dbt_project_dir))
 
 # If DAGSTER_DBT_PARSE_PROJECT_ON_LOAD is set, a manifest will be created at runtime.

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_app.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_app.py
@@ -15,8 +15,8 @@ if TYPE_CHECKING:
 
 pytest.importorskip("dbt.version", minversion="1.4")
 
-test_dagster_metadata_dbt_project_path = Path(__file__).parent.joinpath(
-    "..", "dbt_projects", "test_dagster_metadata"
+test_dagster_metadata_dbt_project_path = (
+    Path(__file__).joinpath("..", "..", "dbt_projects", "test_dagster_metadata").resolve()
 )
 
 runner = CliRunner()

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_selection.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_selection.py
@@ -8,7 +8,7 @@ from dagster._core.definitions.events import AssetKey
 from dagster_dbt import build_dbt_asset_selection
 from dagster_dbt.asset_decorator import dbt_assets
 
-manifest_path = Path(__file__).parent.joinpath("..", "sample_manifest.json")
+manifest_path = Path(__file__).joinpath("..", "..", "sample_manifest.json").resolve()
 
 with open(manifest_path, "r") as f:
     manifest = json.load(f)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_schedules.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_schedules.py
@@ -7,7 +7,7 @@ from dagster import RunConfig
 from dagster._core.definitions.unresolved_asset_job_definition import UnresolvedAssetJobDefinition
 from dagster_dbt import DbtManifestAssetSelection, build_schedule_from_dbt_selection, dbt_assets
 
-manifest_path = Path(__file__).parent.joinpath("..", "sample_manifest.json")
+manifest_path = Path(__file__).joinpath("..", "..", "sample_manifest.json").resolve()
 with open(manifest_path, "r") as f:
     manifest = json.load(f)
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_decorator.py
@@ -18,15 +18,15 @@ from dagster_dbt import DbtCliResource
 from dagster_dbt.asset_decorator import dbt_assets
 from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator
 
-manifest_path = Path(__file__).parent.joinpath("sample_manifest.json")
-with open(manifest_path, "r") as f:
-    manifest = json.load(f)
+manifest_path = Path(__file__).joinpath("..", "sample_manifest.json").resolve()
+manifest = json.loads(manifest_path.read_bytes())
 
-test_dagster_metadata_manifest_path = Path(__file__).parent.joinpath(
-    "dbt_projects", "test_dagster_metadata", "manifest.json"
+test_dagster_metadata_manifest_path = (
+    Path(__file__)
+    .joinpath("..", "dbt_projects", "test_dagster_metadata", "manifest.json")
+    .resolve()
 )
-with open(test_dagster_metadata_manifest_path, "r") as f:
-    test_dagster_metadata_manifest = json.load(f)
+test_dagster_metadata_manifest = json.loads(test_dagster_metadata_manifest_path.read_bytes())
 
 
 def test_materialize(test_project_dir):
@@ -39,7 +39,7 @@ def test_materialize(test_project_dir):
     ).success
 
 
-@pytest.mark.parametrize("manifest", [json.load(manifest_path.open()), manifest_path])
+@pytest.mark.parametrize("manifest", [manifest, manifest_path])
 def test_manifest_argument(manifest):
     @dbt_assets(manifest=manifest)
     def my_dbt_assets():

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
@@ -41,6 +41,9 @@ from pandas import read_csv
 
 from .utils import assert_assets_match_project
 
+manifest_path = Path(__file__).joinpath("..", "sample_manifest.json").resolve()
+manifest_json = json.loads(manifest_path.read_bytes())
+
 
 def test_custom_resource_key_asset_load(
     dbt_seed, dbt_cli_resource_factory, test_project_dir, dbt_config_dir
@@ -72,10 +75,6 @@ def test_custom_resource_key_asset_load(
     ],
 )
 def test_load_from_manifest_json(prefix):
-    manifest_path = file_relative_path(__file__, "sample_manifest.json")
-    with open(manifest_path, "r", encoding="utf8") as f:
-        manifest_json = json.load(f)
-
     run_results_path = file_relative_path(__file__, "sample_run_results.json")
     with open(run_results_path, "r", encoding="utf8") as f:
         run_results_json = json.load(f)
@@ -97,10 +96,7 @@ def test_load_from_manifest_json(prefix):
     assert assets_job.execute_in_process().success
 
 
-manifest_path = Path(__file__).parent.joinpath("sample_manifest.json")
-
-
-@pytest.mark.parametrize("manifest", [json.load(manifest_path.open()), manifest_path])
+@pytest.mark.parametrize("manifest", [json.loads(manifest_path.read_bytes()), manifest_path])
 def test_manifest_argument(manifest):
     my_dbt_assets = load_assets_from_dbt_manifest(manifest)
 
@@ -123,10 +119,6 @@ def test_runtime_metadata_fn(
     test_project_dir,
     dbt_config_dir,
 ):
-    manifest_path = file_relative_path(__file__, "sample_manifest.json")
-    with open(manifest_path, "r", encoding="utf8") as f:
-        manifest_json = json.load(f)
-
     def runtime_metadata_fn(context, node_info):
         return {"op_name": context.op_def.name, "dbt_model": node_info["name"]}
 
@@ -328,10 +320,6 @@ def test_custom_groups(dbt_seed, test_project_dir, dbt_config_dir):
 
 
 def test_custom_freshness_policy():
-    manifest_path = file_relative_path(__file__, "sample_manifest.json")
-    with open(manifest_path, "r", encoding="utf8") as f:
-        manifest_json = json.load(f)
-
     dbt_assets = load_assets_from_dbt_manifest(
         manifest_json=manifest_json,
         node_info_to_freshness_policy_fn=lambda node_info: FreshnessPolicy(
@@ -345,10 +333,6 @@ def test_custom_freshness_policy():
 
 
 def test_custom_auto_materialize_policy():
-    manifest_path = file_relative_path(__file__, "sample_manifest.json")
-    with open(manifest_path, "r", encoding="utf8") as f:
-        manifest_json = json.load(f)
-
     dbt_assets = load_assets_from_dbt_manifest(
         manifest_json=manifest_json,
         node_info_to_auto_materialize_policy_fn=lambda _: AutoMaterializePolicy.lazy(),
@@ -360,10 +344,6 @@ def test_custom_auto_materialize_policy():
 
 
 def test_custom_definition_metadata():
-    manifest_path = file_relative_path(__file__, "sample_manifest.json")
-    with open(manifest_path, "r", encoding="utf8") as f:
-        manifest_json = json.load(f)
-
     dbt_assets_custom = load_assets_from_dbt_manifest(
         manifest_json=manifest_json,
         node_info_to_definition_metadata_fn=lambda node_info: {
@@ -510,9 +490,6 @@ def test_dbt_ls_fail_fast():
 def test_select_from_manifest(
     dbt_seed, dbt_cli_resource_factory, test_project_dir, dbt_config_dir, use_build
 ):
-    manifest_path = file_relative_path(__file__, "sample_manifest.json")
-    with open(manifest_path, "r", encoding="utf8") as f:
-        manifest_json = json.load(f)
     dbt_assets = load_assets_from_dbt_manifest(
         manifest_json,
         selected_unique_ids={
@@ -744,9 +721,6 @@ def test_op_config(
             "sort_by_calories,cold_schema/sort_cold_cereals_by_calories,"
             "sort_hot_cereals_by_calories,subdir_schema/least_caloric,cereals,orders_snapshot"
         )
-    manifest_path = file_relative_path(__file__, "sample_manifest.json")
-    with open(manifest_path, "r", encoding="utf8") as f:
-        manifest_json = json.load(f)
 
     dbt_assets = load_assets_from_dbt_manifest(manifest_json)
     result = materialize_to_memory(
@@ -770,18 +744,16 @@ def test_op_config(
 
 def test_op_custom_name():
     instances = [{"target": "target_a"}, {"target": "target_b"}]
-    manifest_path = file_relative_path(__file__, "sample_manifest.json")
     dbt_assets = []
     for instance in instances:
-        with open(manifest_path) as manifest_json:
-            dbt_assets.extend(
-                load_assets_from_dbt_manifest(
-                    manifest_json=json.load(manifest_json),
-                    key_prefix=[instance["target"], "duckdb", "test-schema"],
-                    op_name=f"{instance['target']}_dbt_op",
-                    select="fqn:* fqn:*",  # just a non-default selection
-                )
+        dbt_assets.extend(
+            load_assets_from_dbt_manifest(
+                manifest_json=manifest_json,
+                key_prefix=[instance["target"], "duckdb", "test-schema"],
+                op_name=f"{instance['target']}_dbt_op",
+                select="fqn:* fqn:*",  # just a non-default selection
             )
+        )
     op_names = [asset_group.op.name for asset_group in dbt_assets]
     assert len(op_names) == len(set(op_names)), (
         "Multiple instances of a dbt project cannot have the same op name.\n"
@@ -891,10 +863,6 @@ def test_dbt_selections(
     expected_asset_names,
 ):
     if load_from_manifest:
-        manifest_path = file_relative_path(__file__, "sample_manifest.json")
-        with open(manifest_path, "r", encoding="utf8") as f:
-            manifest_json = json.load(f)
-
         dbt_assets = load_assets_from_dbt_manifest(manifest_json, select=select, exclude=exclude)
     else:
         dbt_assets = load_assets_from_dbt_project(
@@ -938,10 +906,6 @@ def test_dbt_selections(
     ],
 )
 def test_static_select_invalid_selection(select, error_match):
-    manifest_path = file_relative_path(__file__, "sample_manifest.json")
-    with open(manifest_path, "r", encoding="utf8") as f:
-        manifest_json = json.load(f)
-
     with pytest.raises(Exception, match=error_match):
         load_assets_from_dbt_manifest(manifest_json, select=select)
 
@@ -975,11 +939,11 @@ def test_source_tag_selection(test_python_project_dir, dbt_python_config_dir):
 
     assert len(dbt_assets[0].keys) == 2
 
-    manifest_path = os.path.join(test_python_project_dir, "target", "manifest.json")
-    with open(manifest_path, "r", encoding="utf8") as f:
-        manifest_json = json.load(f)
+    test_python_manifest_path = os.path.join(test_python_project_dir, "target", "manifest.json")
+    with open(test_python_manifest_path, "r", encoding="utf8") as f:
+        test_python_manifest_json = json.load(f)
 
-    dbt_assets = load_assets_from_dbt_manifest(manifest_json, select="tag:events")
+    dbt_assets = load_assets_from_dbt_manifest(test_python_manifest_json, select="tag:events")
 
     assert len(dbt_assets[0].keys) == 2
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_dependencies.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_dependencies.py
@@ -6,11 +6,12 @@ from dagster import AssetKey, asset
 from dagster_dbt import get_asset_key_for_model, get_asset_keys_by_output_name_for_source
 from dagster_dbt.asset_decorator import dbt_assets
 
-manifest_path = Path(__file__).parent.joinpath(
-    "dbt_projects", "test_dagster_metadata", "manifest.json"
+manifest_path = (
+    Path(__file__)
+    .joinpath("..", "dbt_projects", "test_dagster_metadata", "manifest.json")
+    .resolve()
 )
-with open(manifest_path, "r") as f:
-    manifest = json.load(f)
+manifest = json.loads(manifest_path.read_bytes())
 
 
 @dbt_assets(manifest=manifest)


### PR DESCRIPTION
## Summary & Motivation
Resolves https://github.com/dagster-io/dagster/issues/15602.

Pathlib's `.parent` is just [syntatic sugar for `..`](https://docs.python.org/3/library/pathlib.html#pathlib.PurePath.parent). So to eliminate any confusion, just use the latter.

Because `Path(__file__)` returns the path to the file, appending `..` will give an incoherent looking path at first (e.g. `/users/rexledesma/definitions.py/..`). So call `.resolve()` on it after adding the traversals (e.g. we'll receive `/users/rexledesma`).

## How I Tested These Changes
pytest
