### PR TITLE
docs(dbt-cloud): remove example using `AssetSelection.groups(...)`

### DIFF
--- a/docs/content/integrations/dbt-cloud.mdx
+++ b/docs/content/integrations/dbt-cloud.mdx
@@ -108,11 +108,6 @@ from dagster import (
 # Materialize all assets
 run_everything_job = define_asset_job("run_everything_job", AssetSelection.all())
 
-# Materialize only the staging assets
-run_staging_job = define_asset_job(
-    "run_staging_job", AssetSelection.groups("staging")
-)
-
 defs = Definitions(
     # Use the dbt_cloud_assets defined in Step 2
     assets=[dbt_cloud_assets],
@@ -120,10 +115,6 @@ defs = Definitions(
         ScheduleDefinition(
             job=run_everything_job,
             cron_schedule="@daily",
-        ),
-        ScheduleDefinition(
-            job=run_staging_job,
-            cron_schedule="@hourly",
         ),
     ],
 )

--- a/examples/docs_snippets/docs_snippets/integrations/dbt/dbt_cloud.py
+++ b/examples/docs_snippets/docs_snippets/integrations/dbt/dbt_cloud.py
@@ -46,11 +46,6 @@ def scope_schedule_dbt_cloud_assets(dbt_cloud_assets):
     # Materialize all assets
     run_everything_job = define_asset_job("run_everything_job", AssetSelection.all())
 
-    # Materialize only the staging assets
-    run_staging_job = define_asset_job(
-        "run_staging_job", AssetSelection.groups("staging")
-    )
-
     defs = Definitions(
         # Use the dbt_cloud_assets defined in Step 2
         assets=[dbt_cloud_assets],
@@ -58,10 +53,6 @@ def scope_schedule_dbt_cloud_assets(dbt_cloud_assets):
             ScheduleDefinition(
                 job=run_everything_job,
                 cron_schedule="@daily",
-            ),
-            ScheduleDefinition(
-                job=run_staging_job,
-                cron_schedule="@hourly",
             ),
         ],
     )


### PR DESCRIPTION
## Summary & Motivation
Resolves https://github.com/dagster-io/dagster/issues/15652.

By default, groups are not automatically inferred from dbt, so remove this example that schedules by `AssetSelection.groups`.

## How I Tested These Changes
N/A
