### PR TITLE
MultiPartitioned key format fix in UPathIOManager

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
@@ -189,16 +189,16 @@ class UPathIOManager(MemoizableIOManager):
                 "but the asset is not partitioned"
             )
 
-        def _formatted_multipartitioned_path(partition_key: MultiPartitionKey) -> str:
+        def _formatted_multipartitioned_key(partition_key: MultiPartitionKey) -> str:
             ordered_dimension_keys = [
                 key[1]
                 for key in sorted(partition_key.keys_by_dimension.items(), key=lambda x: x[0])
             ]
-            return "/".join(ordered_dimension_keys)
+            return "|".join(ordered_dimension_keys)
 
         formatted_partition_keys = {
             partition_key: (
-                _formatted_multipartitioned_path(partition_key)
+                _formatted_multipartitioned_key(partition_key)
                 if isinstance(partition_key, MultiPartitionKey)
                 else partition_key
             )


### PR DESCRIPTION
## Summary & Motivation

Having an asset that depends on a Multipartitioned one, raise an error in UPathManager
It tries to create key with a separator "/" instead of a "|" (Raising a keyError because the key doesn't exist in the available partitions dict)
See #15600 for more details about the error

## How I Tested These Changes
By changing this, dagster was able to load all partitions and send them to my other asset