### PR TITLE
[docs] Adding dbt-duckdb as a dependency in the dbt tutorial

### DIFF
--- a/docs/content/integrations/dbt/using-dbt-with-dagster.mdx
+++ b/docs/content/integrations/dbt/using-dbt-with-dagster.mdx
@@ -37,10 +37,10 @@ To complete this tutorial, you'll need:
 - **To install dbt, Dagster, and the Dagster webserver/UI**. Run the following to install everything using pip:
 
   ```shell
-  pip install dagster-dbt dagster-webserver
+  pip install dagster-dbt dagster-webserver dbt-duckdb
   ```
 
-  The `dagster-dbt` library installs both `dbt-core` and `dagster` as dependencies. Refer to the [dbt](https://docs.getdbt.com/dbt-cli/install/overview) and [Dagster](/getting-started/install) installation docs for more info.
+  The `dagster-dbt` library installs both `dbt-core` and `dagster` as dependencies. `dbt-duckdb` is installed as you'll be using [DuckDB](https://duckdb.org/) as a database during this tutorial. Refer to the [dbt](https://docs.getdbt.com/dbt-cli/install/overview) and [Dagster](/getting-started/install) installation docs for more info.
 
 ---
 


### PR DESCRIPTION
## Summary & Motivation

Users need to install the `dbt-duckdb` adapter to go through the dagster + jaffle-shop tutorial

## How I Tested These Changes
