### PR TITLE
decouple run deletion from asset key deletion

### DIFF
--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -1828,7 +1828,9 @@ class TestEventLogStorage:
 
                     storage.delete_events(two_second_run_id)
                     asset_keys = storage.all_asset_keys()
-                    assert len(asset_keys) == 1
+                    # we now no longer keep the asset catalog keys in sync with the presence of
+                    # asset events in the event log
+                    # assert len(asset_keys) == 1
 
     def test_asset_partition_query(self, storage, instance):
         @op(config_schema={"partition": Field(str, is_required=False)})


### PR DESCRIPTION
## Summary & Motivation
Currently, we have some complicated logic when a run is deleted, to check to see if this will delete an asset materialization from the event log which is the only materialization of that asset.  If so, the asset will be removed from the asset catalog.

This PR decouples the run deletion from the presence of assets in the asset catalog, so the asset will remain in the asset catalog until it is wiped, even if the underlying run is deleted.

This is purely for performance and simplicity.

## How I Tested These Changes
BK