### PR TITLE
feat(dbt): add support for configuring `profiles_dir`

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -357,6 +357,9 @@ class DbtCliResource(ConfigurableResource):
         global_config_flags (List[str]): A list of global flags configuration to pass to the dbt CLI
             invocation. See https://docs.getdbt.com/reference/global-configs for a full list of
             configuration.
+        profiles_dir (Optional[str]): The path to the directory containing your dbt `profiles.yml`.
+            See https://docs.getdbt.com/docs/core/connect-data-platform/connection-profiles for more
+            information.
         profile (Optional[str]): The profile from your dbt `profiles.yml` to use for execution. See
             https://docs.getdbt.com/docs/core/connect-data-platform/connection-profiles for more
             information.
@@ -390,6 +393,14 @@ class DbtCliResource(ConfigurableResource):
         description=(
             "A list of global flags configuration to pass to the dbt CLI invocation. See"
             " https://docs.getdbt.com/reference/global-configs for a full list of configuration."
+        ),
+    )
+    profiles_dir: Optional[str] = Field(
+        default=None,
+        description=(
+            "The path to the directory containing your dbt `profiles.yml`. See"
+            " https://docs.getdbt.com/docs/core/connect-data-platform/connection-profiles for more"
+            " information."
         ),
     )
     profile: Optional[str] = Field(
@@ -476,6 +487,11 @@ class DbtCliResource(ConfigurableResource):
             # See https://discourse.getdbt.com/t/multiple-run-results-json-and-manifest-json-files/7555
             # for more information.
             "DBT_TARGET_PATH": target_path,
+            # The DBT_PROFILES_DIR environment variable is set to the path containing the dbt
+            # profiles.yml file.
+            # See https://docs.getdbt.com/docs/core/connect-data-platform/connection-profiles#advanced-customizing-a-profile-directory
+            # for more information.
+            **({"DBT_PROFILES_DIR": self.profiles_dir} if self.profiles_dir else {}),
         }
 
         assets_def: Optional[AssetsDefinition] = None

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resources_v2.py
@@ -29,8 +29,7 @@ pytest.importorskip("dbt.version", minversion="1.4")
 
 
 manifest_path = Path(TEST_PROJECT_DIR).joinpath("manifest.json")
-with open(manifest_path, "r") as f:
-    manifest = json.load(f)
+manifest = json.loads(manifest_path.read_bytes())
 
 
 @pytest.mark.parametrize("global_config_flags", [[], ["--quiet"]])
@@ -95,6 +94,22 @@ def test_dbt_profile_configuration() -> None:
         "dev",
     ]
     assert dbt_cli_invocation.is_successful()
+
+
+def test_dbt_profile_dir_configuration() -> None:
+    dbt = DbtCliResource(project_dir=TEST_PROJECT_DIR, profiles_dir=TEST_PROJECT_DIR)
+
+    dbt_cli_invocation = dbt.cli(["parse"], manifest=manifest).wait()
+
+    assert dbt_cli_invocation.process.args == ["dbt", "parse"]
+    assert dbt_cli_invocation.is_successful()
+
+    dbt = DbtCliResource(
+        project_dir=TEST_PROJECT_DIR, profiles_dir=f"{TEST_PROJECT_DIR}/nonexistent"
+    )
+
+    with pytest.raises(DagsterDbtCliRuntimeError):
+        dbt.cli(["parse"], manifest=manifest).wait()
 
 
 def test_dbt_without_partial_parse() -> None:


### PR DESCRIPTION
## Summary & Motivation
We give an escape for users who were previously hosting their `profiles.yml` in a non-root directory. Users do not have to specify `--profiles-dir` manually each time when they invoke `DbtCliResource`.

## How I Tested These Changes
pytest
