### PR TITLE
[auto-materialize][bug] Fix unpartitioned to partitioned rematerialization logic

### DIFF
--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
@@ -153,7 +153,12 @@ scenarios = {
         (
             "partitioned_after_non_partitioned",
             ["2022-01-01", "2022-01-02"],
-            [("asset1", None), ("asset2", "2022-01-01"), ("asset2", "2022-01-02")],
+            [
+                ("asset1", None),
+                ("asset2", None),
+                ("asset3", "2022-01-01"),
+                ("asset3", "2022-01-02"),
+            ],
         ),
     ],
 )

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/partition_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/partition_scenarios.py
@@ -87,7 +87,7 @@ time_multipartitioned_asset = [
 static_multipartitioned_asset = [asset_def("asset1", partitions_def=static_multipartitions_def)]
 
 
-partitioned_after_unpartitioned = [
+partitioned_after_non_partitioned = [
     asset_def("asset1"),
     asset_def("asset2"),
     asset_def(
@@ -358,10 +358,10 @@ partition_scenarios = {
             for partition_key in static_multipartitions_def.get_partition_keys()
         ],
     ),
-    "partitioned_after_unpartitioned_multiple_updates": AssetReconciliationScenario(
-        assets=partitioned_after_unpartitioned,
+    "partitioned_after_non_partitioned_multiple_updates": AssetReconciliationScenario(
+        assets=partitioned_after_non_partitioned,
         cursor_from=AssetReconciliationScenario(
-            assets=partitioned_after_unpartitioned,
+            assets=partitioned_after_non_partitioned,
             unevaluated_runs=[
                 run(["asset1", "asset2"]),
                 run(["asset3"], partition_key="2020-01-02"),

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/partition_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/partition_scenarios.py
@@ -87,11 +87,12 @@ time_multipartitioned_asset = [
 static_multipartitioned_asset = [asset_def("asset1", partitions_def=static_multipartitions_def)]
 
 
-partitioned_after_non_partitioned = [
+partitioned_after_unpartitioned = [
     asset_def("asset1"),
+    asset_def("asset2"),
     asset_def(
-        "asset2",
-        ["asset1"],
+        "asset3",
+        ["asset1", "asset2"],
         partitions_def=DailyPartitionsDefinition(start_date="2020-01-01"),
     ),
 ]
@@ -356,5 +357,21 @@ partition_scenarios = {
             run_request(asset_keys=["asset1"], partition_key=partition_key)
             for partition_key in static_multipartitions_def.get_partition_keys()
         ],
+    ),
+    "partitioned_after_unpartitioned_multiple_updates": AssetReconciliationScenario(
+        assets=partitioned_after_unpartitioned,
+        cursor_from=AssetReconciliationScenario(
+            assets=partitioned_after_unpartitioned,
+            unevaluated_runs=[
+                run(["asset1", "asset2"]),
+                run(["asset3"], partition_key="2020-01-02"),
+                run(["asset1"]),
+            ],
+            current_time=create_pendulum_time(year=2020, month=1, day=3, hour=1),
+            expected_run_requests=[run(["asset3"], partition_key="2020-01-02")],
+        ),
+        current_time=create_pendulum_time(year=2020, month=1, day=3, hour=1),
+        unevaluated_runs=[run(["asset2"])],
+        expected_run_requests=[run_request(["asset3"], partition_key="2020-01-02")],
     ),
 }


### PR DESCRIPTION
## Summary & Motivation

Previously, rematerializing an unpartitioned asset upstream of a time (or dynamic) partitioned asset would not result in the latest partition of that asset being rematerialized, as we would never register that unpartitioned as "updated" with respect to its parents. Due to this, we would only ever materialize the new partition of the upstream asset when it was missing.

## How I Tested These Changes

Added a new test, and updated two old ones to reflect this corrected behavior.
