### PR TITLE
Avoid O(n^2) check when loading StaticPartitionsDefinitions

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -312,12 +312,12 @@ def raise_error_on_duplicate_partition_keys(partition_keys: Sequence[str]) -> No
     counts: Dict[str, int] = defaultdict(lambda: 0)
     for partition_key in partition_keys:
         counts[partition_key] += 1
-        found_duplicates = [key for key in counts.keys() if counts[key] > 1]
-        if found_duplicates:
-            raise DagsterInvalidDefinitionError(
-                "Partition keys must be unique. Duplicate instances of partition keys:"
-                f" {found_duplicates}."
-            )
+    found_duplicates = [key for key in counts.keys() if counts[key] > 1]
+    if found_duplicates:
+        raise DagsterInvalidDefinitionError(
+            "Partition keys must be unique. Duplicate instances of partition keys:"
+            f" {found_duplicates}."
+        )
 
 
 class StaticPartitionsDefinition(PartitionsDefinition[str]):


### PR DESCRIPTION
## Summary & Motivation

On closer inspection, it seems like this is a case of an accidental indent, as the original logic would not actually work in cases where there were multiple duplicate keys. 

## How I Tested These Changes
