### PR TITLE
Remove universal-pathlib<0.1.0 pin

### DIFF
--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -101,7 +101,7 @@ setup(
         # https://github.com/mhammond/pywin32/issues/1439
         'pywin32 != 226; platform_system=="Windows"',
         "docstring-parser",
-        "universal_pathlib < 0.1.0",
+        "universal_pathlib",
         # https://github.com/pydantic/pydantic/issues/5821
         "pydantic != 1.10.7,<2.0.0",
     ],


### PR DESCRIPTION
## Summary & Motivation

`universal-pathlib` dev has released an updated version that lets us lift the pin with some minor code changes: https://github.com/dagster-io/dagster/pull/15017#issuecomment-1668578876

## How I Tested These Changes

Existing test suite.
