### PR TITLE
Skip integration tests in unit test builds

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/aws_credential_test_utils.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/aws_credential_test_utils.py
@@ -26,6 +26,10 @@ def get_aws_creds():
         return creds
 
     except Exception as e:
+        if os.getenv("BUILDKITE"):
+            import pytest
+            pytest.skip("Integration test")
+
         raise Exception(
             "Must have AWS credentials set to be able to run tests locally. Run "
             f"'aws sso login' to authenticate. Original error: {e}"


### PR DESCRIPTION
Over time, our test suite has evolved to have a mix of both unit and integration tests. This represents a blocker to running unit tests on contributor PRs because we don't want to expose the ability to interact with authenticated 3rd party systems.

This build shows what fails if we don't provide any secrets or IAM credentials to buildkite:

https://buildkite.com/dagster/isolated-dagster/builds/18

A lot of these source back to this `get_aws_creds()` function. For now, I'm going to annotate with a pytest skip. Eventually, we might want to explicitly pull these out into their own integration build or rewrite them to not integrate with real systems.