### PR TITLE
[docs] - Add callouts to Branch Deps guides

### DIFF
--- a/docs/content/dagster-cloud/managing-deployments/branch-deployments/using-branch-deployments-with-github.mdx
+++ b/docs/content/dagster-cloud/managing-deployments/branch-deployments/using-branch-deployments-with-github.mdx
@@ -36,6 +36,14 @@ To complete the steps in this guide, you'll need:
 
 ## Step 2: Create and configure an agent
 
+<Note>
+  <strong>
+    If using{" "}
+    <a href="/dagster-cloud/deployment/serverless">Serverless deployment</a>
+  </strong>
+  , this step isn't required.
+</Note>
+
 <BDCreateConfigureAgent />
 
 ---

--- a/docs/content/dagster-cloud/managing-deployments/branch-deployments/using-branch-deployments-with-gitlab.mdx
+++ b/docs/content/dagster-cloud/managing-deployments/branch-deployments/using-branch-deployments-with-gitlab.mdx
@@ -36,6 +36,14 @@ To complete the steps in this guide, you'll need:
 
 ## Step 2: Create and configure an agent
 
+<Note>
+  <strong>
+    If using{" "}
+    <a href="/dagster-cloud/deployment/serverless">Serverless deployment</a>
+  </strong>
+  , this step isn't required.
+</Note>
+
 <BDCreateConfigureAgent />
 
 ---


### PR DESCRIPTION
## Summary & Motivation

This PR clarifies in the Branch Deps guides that creating an agent is optional for Serverless. Came from [user feedback](https://www.notion.so/dagster/docs-feedback-From-yang015-in-dagster-support-dbcadfe6080942efabdb7a61940f0796?pvs=4#9d6065962c2f4a2dbd67765d1aebf6e8).

## How I Tested These Changes

👀 , local
