### PR TITLE
[dagster-ssh] always load system known hosts

### DIFF
--- a/python_modules/libraries/dagster-ssh/dagster_ssh/resources.py
+++ b/python_modules/libraries/dagster-ssh/dagster_ssh/resources.py
@@ -59,9 +59,6 @@ class SSHResource:
         self.keepalive_interval = check.opt_int_param(keepalive_interval, "keepalive_interval")
         self.compress = check.opt_bool_param(compress, "compress")
         self.no_host_key_check = check.opt_bool_param(no_host_key_check, "no_host_key_check")
-        self.allow_host_key_change = check.opt_bool_param(
-            allow_host_key_change, "allow_host_key_change"
-        )
         self.log = logger
 
         self.host_proxy = None
@@ -96,12 +93,7 @@ class SSHResource:
         :rtype: paramiko.client.SSHClient
         """
         client = paramiko.SSHClient()
-        if not self.allow_host_key_change:
-            self.log.warning(
-                "Remote Identification Change is not verified. This won't protect against "
-                "Man-In-The-Middle attacks"
-            )
-            client.load_system_host_keys()
+        client.load_system_host_keys()
         if self.no_host_key_check:
             self.log.warning(
                 "No Host Key Verification. This won't protect against Man-In-The-Middle attacks"
@@ -257,7 +249,9 @@ class SSHResource:
         ),
         "compress": Field(BoolSource, is_required=False, default_value=True),
         "no_host_key_check": Field(BoolSource, is_required=False, default_value=True),
-        "allow_host_key_change": Field(BoolSource, is_required=False, default_value=False),
+        "allow_host_key_change": Field(
+            BoolSource, description="[Deprecated]", is_required=False, default_value=False
+        ),
     }
 )
 def ssh_resource(init_context):


### PR DESCRIPTION
I'm confused what `allow_host_key_change` is supposed to configure. I think if we don't load these known hosts, then we always have none.

Alternatively, this lib is a tiny wrapper on the paramiko library and hasn't been updated since Nate wrote it 4 years ago. We could deprecate it

https://dagster.slack.com/archives/C01U954MEER/p1691438069457119