### PR TITLE
[dagster-dbt][dagster-airbyte] Safer generation of output names

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
@@ -44,6 +44,7 @@ def input_name_fn(dbt_resource_props: Mapping[str, Any]) -> str:
 
 
 def output_name_fn(dbt_resource_props: Mapping[str, Any]) -> str:
+    # hyphens are valid in dbt model names, but not in output names
     return dbt_resource_props["unique_id"].split(".")[-1].replace("-", "_")
 
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
@@ -44,7 +44,7 @@ def input_name_fn(dbt_resource_props: Mapping[str, Any]) -> str:
 
 
 def output_name_fn(dbt_resource_props: Mapping[str, Any]) -> str:
-    return dbt_resource_props["unique_id"].split(".")[-1]
+    return dbt_resource_props["unique_id"].split(".")[-1].replace("-", "_")
 
 
 def _node_result_to_metadata(node_result: Mapping[str, Any]) -> Mapping[str, RawMetadataValue]:


### PR DESCRIPTION
## Summary & Motivation

Output names must be valid python identifiers. It's possible to have dbt models or airbyte assets with hyphens in their names. If users had such models in the past, we would error when attempting to generate an asset. Now, we sanitize the identifiers.

Resolves: https://github.com/dagster-io/dagster/issues/15607

## How I Tested These Changes
