### PR TITLE
fix(dbt): use forward slashes when retrieving jinja templates

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/app.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/app.py
@@ -114,7 +114,7 @@ def copy_scaffold(
         if path.suffix == ".jinja":
             relative_path = path.relative_to(Path.cwd())
             destination_path = os.fspath(relative_path.parent.joinpath(relative_path.stem))
-            template_path = os.fspath(path.relative_to(dagster_project_dir))
+            template_path = path.relative_to(dagster_project_dir).as_posix()
 
             env.get_template(template_path).stream(
                 dbt_project_dir_relative_path_parts=dbt_project_dir_relative_path_parts,


### PR DESCRIPTION
## Summary & Motivation
Resolves https://github.com/dagster-io/dagster/issues/15730.

From https://jinja.palletsprojects.com/en/3.0.x/api/#jinja2.Environment.get_template: 

> name (Union[str, jinja2.environment.Template]) – Name of the template to load. When loading templates from the filesystem, “/” is used as the path separator, even on Windows.

So, when invoking `.get_template`, use forward slashes, even when on Windows.

## How I Tested These Changes
N/A
