### PR TITLE
add a code location label to k8s run jobs, when available

### DIFF
--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/executor.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/executor.py
@@ -360,6 +360,15 @@ def create_k8s_job_task(celery_app, **task_kwargs):
 
         args = execute_step_args.get_command_args()
 
+        labels = {
+            "dagster/job": dagster_run.job_name,
+            "dagster/op": step_key,
+            "dagster/run-id": execute_step_args.run_id,
+        }
+        if dagster_run.external_job_origin:
+            labels["dagster/code-location"] = (
+                dagster_run.external_job_origin.external_repository_origin.code_location_origin.location_name
+            )
         job = construct_dagster_k8s_job(
             job_config,
             args,
@@ -367,11 +376,7 @@ def create_k8s_job_task(celery_app, **task_kwargs):
             user_defined_k8s_config,
             pod_name,
             component="step_worker",
-            labels={
-                "dagster/job": dagster_run.job_name,
-                "dagster/op": step_key,
-                "dagster/run-id": execute_step_args.run_id,
-            },
+            labels=labels,
             env_vars=[
                 {
                     "name": "DAGSTER_RUN_JOB_NAME",

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/launcher.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/launcher.py
@@ -207,6 +207,15 @@ class CeleryK8sRunLauncher(RunLauncher, ConfigurableClass):
             set_exit_code_on_failure=self._fail_pod_on_run_failure,
         ).get_command_args()
 
+        labels = {
+            "dagster/job": job_origin.job_name,
+            "dagster/run-id": run.run_id,
+        }
+        if run.external_job_origin:
+            labels["dagster/code-location"] = (
+                run.external_job_origin.external_repository_origin.code_location_origin.location_name
+            )
+
         job = construct_dagster_k8s_job(
             job_config,
             args=run_args,
@@ -214,10 +223,7 @@ class CeleryK8sRunLauncher(RunLauncher, ConfigurableClass):
             pod_name=pod_name,
             component="run_worker",
             user_defined_k8s_config=user_defined_k8s_config,
-            labels={
-                "dagster/job": job_origin.job_name,
-                "dagster/run-id": run.run_id,
-            },
+            labels=labels,
             env_vars=[{"name": "DAGSTER_RUN_JOB_NAME", "value": job_origin.job_name}],
         )
 

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s_tests/test_launcher.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s_tests/test_launcher.py
@@ -377,6 +377,9 @@ def test_user_defined_k8s_config_in_run_tags(kubeconfig_file):
 
             labels = kwargs["body"].spec.template.metadata.labels
             assert labels["foo_label_key"] == "bar_label_value"
+            assert labels["dagster/code-location"] == "in_process"
+            assert labels["dagster/job"] == "fake_job"
+            assert labels["dagster/run-id"] == run.run_id
 
             args = container.args
             assert (

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
@@ -256,6 +256,16 @@ class K8sStepHandler(StepHandler):
         if not job_config.job_image:
             raise Exception("No image included in either executor config or the job")
 
+        run = step_handler_context.dagster_run
+        labels = {
+            "dagster/job": run.job_name,
+            "dagster/op": step_key,
+            "dagster/run-id": step_handler_context.execute_step_args.run_id,
+        }
+        if run.external_job_origin:
+            labels["dagster/code-location"] = (
+                run.external_job_origin.external_repository_origin.code_location_origin.location_name
+            )
         job = construct_dagster_k8s_job(
             job_config=job_config,
             args=args,
@@ -263,16 +273,12 @@ class K8sStepHandler(StepHandler):
             pod_name=pod_name,
             component="step_worker",
             user_defined_k8s_config=container_context.get_run_user_defined_k8s_config(),
-            labels={
-                "dagster/job": step_handler_context.dagster_run.job_name,
-                "dagster/op": step_key,
-                "dagster/run-id": step_handler_context.execute_step_args.run_id,
-            },
+            labels=labels,
             env_vars=[
                 *step_handler_context.execute_step_args.get_command_env(),
                 {
                     "name": "DAGSTER_RUN_JOB_NAME",
-                    "value": step_handler_context.dagster_run.job_name,
+                    "value": run.job_name,
                 },
                 {"name": "DAGSTER_RUN_STEP_KEY", "value": step_key},
                 *container_context.env,

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
@@ -217,6 +217,14 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
             run.run_id,
             {DOCKER_IMAGE_TAG: job_config.job_image},
         )
+        labels = {
+            "dagster/job": job_origin.job_name,
+            "dagster/run-id": run.run_id,
+        }
+        if run.external_job_origin:
+            labels["dagster/code-location"] = (
+                run.external_job_origin.external_repository_origin.code_location_origin.location_name
+            )
 
         job = construct_dagster_k8s_job(
             job_config=job_config,
@@ -225,10 +233,7 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
             pod_name=pod_name,
             component="run_worker",
             user_defined_k8s_config=user_defined_k8s_config,
-            labels={
-                "dagster/job": job_origin.job_name,
-                "dagster/run-id": run.run_id,
-            },
+            labels=labels,
             env_vars=[
                 {
                     "name": "DAGSTER_RUN_JOB_NAME",

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
@@ -261,6 +261,16 @@ def execute_k8s_job(
     if retry_number > 0:
         job_name = f"{job_name}-{retry_number}"
 
+    labels = {
+        "dagster/job": context.dagster_run.job_name,
+        "dagster/op": context.op.name,
+        "dagster/run-id": context.dagster_run.run_id,
+    }
+    if context.dagster_run.external_job_origin:
+        labels["dagster/code-location"] = (
+            context.dagster_run.external_job_origin.external_repository_origin.code_location_origin.location_name
+        )
+
     job = construct_dagster_k8s_job(
         job_config=k8s_job_config,
         args=args,
@@ -268,11 +278,7 @@ def execute_k8s_job(
         pod_name=job_name,
         component="k8s_job_op",
         user_defined_k8s_config=user_defined_k8s_config,
-        labels={
-            "dagster/job": context.dagster_run.job_name,
-            "dagster/op": context.op.name,
-            "dagster/run-id": context.dagster_run.run_id,
-        },
+        labels=labels,
     )
 
     if load_incluster_config:

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_launcher.py
@@ -272,6 +272,12 @@ def test_launcher_with_k8s_config(kubeconfig_file):
         # config from run tags applied
         assert container.working_dir == "my_working_dir"
 
+        # appropriate labels applied
+        labels = kwargs["body"].spec.template.metadata.labels
+        assert labels["dagster/code-location"] == "in_process"
+        assert labels["dagster/job"] == "fake_job"
+        assert labels["dagster/run-id"] == run.run_id
+
 
 def test_user_defined_k8s_config_in_run_tags(kubeconfig_file):
     labels = {"foo_label_key": "bar_label_value"}


### PR DESCRIPTION
## Summary & Motivation
`dagster/job` might not be useful in a world where most runs are asset-based jobs.

Adding code location as a label will at least segment certain runs into different code locations, enabling triage of certain k8s pods by team/owner.


## How I Tested These Changes
BK
