### PR TITLE
[asset backfill 1/n] Add get_run_ids storage method

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -1653,8 +1653,10 @@ class DagsterInstance(DynamicPartitionsStore):
         return self._run_storage.get_runs(filters, cursor, limit, bucket_by)
 
     @traced
-    def get_run_ids(self, filters: Optional[RunsFilter] = None) -> Sequence[str]:
-        return self._run_storage.get_run_ids(filters)
+    def get_run_ids(
+        self, filters: Optional[RunsFilter] = None, limit: Optional[int] = None
+    ) -> Sequence[str]:
+        return self._run_storage.get_run_ids(filters, limit=limit)
 
     @traced
     def get_runs_count(self, filters: Optional[RunsFilter] = None) -> int:

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -1653,6 +1653,10 @@ class DagsterInstance(DynamicPartitionsStore):
         return self._run_storage.get_runs(filters, cursor, limit, bucket_by)
 
     @traced
+    def get_run_ids(self, filters: Optional[RunsFilter] = None) -> Sequence[str]:
+        return self._run_storage.get_run_ids(filters)
+
+    @traced
     def get_runs_count(self, filters: Optional[RunsFilter] = None) -> int:
         return self._run_storage.get_runs_count(filters)
 

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -1654,9 +1654,12 @@ class DagsterInstance(DynamicPartitionsStore):
 
     @traced
     def get_run_ids(
-        self, filters: Optional[RunsFilter] = None, limit: Optional[int] = None
+        self,
+        filters: Optional[RunsFilter] = None,
+        cursor: Optional[str] = None,
+        limit: Optional[int] = None,
     ) -> Sequence[str]:
-        return self._run_storage.get_run_ids(filters, limit=limit)
+        return self._run_storage.get_run_ids(filters, cursor=cursor, limit=limit)
 
     @traced
     def get_runs_count(self, filters: Optional[RunsFilter] = None) -> int:

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -204,9 +204,10 @@ class LegacyRunStorage(RunStorage, ConfigurableClass):
     def get_run_ids(
         self,
         filters: Optional["RunsFilter"] = None,
+        cursor: Optional[str] = None,
         limit: Optional[int] = None,
     ) -> Iterable[str]:
-        return self._storage.run_storage.get_run_ids(filters, limit=limit)
+        return self._storage.run_storage.get_run_ids(filters, cursor=cursor, limit=limit)
 
     def get_runs_count(self, filters: Optional["RunsFilter"] = None) -> int:
         return self._storage.run_storage.get_runs_count(filters)

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -201,6 +201,12 @@ class LegacyRunStorage(RunStorage, ConfigurableClass):
     ) -> Iterable["DagsterRun"]:
         return self._storage.run_storage.get_runs(filters, cursor, limit, bucket_by)
 
+    def get_run_ids(
+        self,
+        filters: Optional["RunsFilter"] = None,
+    ) -> Iterable[str]:
+        return self._storage.run_storage.get_run_ids(filters)
+
     def get_runs_count(self, filters: Optional["RunsFilter"] = None) -> int:
         return self._storage.run_storage.get_runs_count(filters)
 

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -204,8 +204,9 @@ class LegacyRunStorage(RunStorage, ConfigurableClass):
     def get_run_ids(
         self,
         filters: Optional["RunsFilter"] = None,
+        limit: Optional[int] = None,
     ) -> Iterable[str]:
-        return self._storage.run_storage.get_run_ids(filters)
+        return self._storage.run_storage.get_run_ids(filters, limit=limit)
 
     def get_runs_count(self, filters: Optional["RunsFilter"] = None) -> int:
         return self._storage.run_storage.get_runs_count(filters)

--- a/python_modules/dagster/dagster/_core/storage/runs/base.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/base.py
@@ -84,6 +84,22 @@ class RunStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance], DaemonCursorSto
         """
 
     @abstractmethod
+    def get_run_ids(
+        self,
+        filters: Optional[RunsFilter] = None,
+    ) -> Sequence[str]:
+        """Return all the run IDs for runs present in the storage that match the given filters.
+
+        Args:
+            filters (Optional[RunsFilter]) -- The
+                :py:class:`~dagster._core.storage.pipeline_run.RunsFilter` by which to filter
+                runs
+
+        Returns:
+            Sequence[str]
+        """
+
+    @abstractmethod
     def get_runs_count(self, filters: Optional[RunsFilter] = None) -> int:
         """Return the number of runs present in the storage that match the given filters.
 

--- a/python_modules/dagster/dagster/_core/storage/runs/base.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/base.py
@@ -87,6 +87,7 @@ class RunStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance], DaemonCursorSto
     def get_run_ids(
         self,
         filters: Optional[RunsFilter] = None,
+        limit: Optional[int] = None,
     ) -> Sequence[str]:
         """Return all the run IDs for runs present in the storage that match the given filters.
 
@@ -94,6 +95,7 @@ class RunStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance], DaemonCursorSto
             filters (Optional[RunsFilter]) -- The
                 :py:class:`~dagster._core.storage.pipeline_run.RunsFilter` by which to filter
                 runs
+            limit (Optional[int]): Number of results to get. Defaults to infinite.
 
         Returns:
             Sequence[str]

--- a/python_modules/dagster/dagster/_core/storage/runs/base.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/base.py
@@ -87,6 +87,7 @@ class RunStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance], DaemonCursorSto
     def get_run_ids(
         self,
         filters: Optional[RunsFilter] = None,
+        cursor: Optional[str] = None,
         limit: Optional[int] = None,
     ) -> Sequence[str]:
         """Return all the run IDs for runs present in the storage that match the given filters.
@@ -95,6 +96,7 @@ class RunStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance], DaemonCursorSto
             filters (Optional[RunsFilter]) -- The
                 :py:class:`~dagster._core.storage.pipeline_run.RunsFilter` by which to filter
                 runs
+            cursor (Optional[str]): Starting cursor (run_id) of range of runs
             limit (Optional[int]): Number of results to get. Defaults to infinite.
 
         Returns:

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -347,8 +347,9 @@ class SqlRunStorage(RunStorage):
     def get_run_ids(
         self,
         filters: Optional[RunsFilter] = None,
+        limit: Optional[int] = None,
     ) -> Sequence[str]:
-        query = self._runs_query(filters=filters, columns=["run_id"])
+        query = self._runs_query(filters=filters, limit=limit, columns=["run_id"])
         rows = self.fetchall(query)
         return [row["run_id"] for row in rows]
 

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -347,9 +347,10 @@ class SqlRunStorage(RunStorage):
     def get_run_ids(
         self,
         filters: Optional[RunsFilter] = None,
+        cursor: Optional[str] = None,
         limit: Optional[int] = None,
     ) -> Sequence[str]:
-        query = self._runs_query(filters=filters, limit=limit, columns=["run_id"])
+        query = self._runs_query(filters=filters, cursor=cursor, limit=limit, columns=["run_id"])
         rows = self.fetchall(query)
         return [row["run_id"] for row in rows]
 

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -344,6 +344,14 @@ class SqlRunStorage(RunStorage):
         rows = self.fetchall(query)
         return self._rows_to_runs(rows)
 
+    def get_run_ids(
+        self,
+        filters: Optional[RunsFilter] = None,
+    ) -> Sequence[str]:
+        query = self._runs_query(filters=filters, columns=["run_id"])
+        rows = self.fetchall(query)
+        return [row["run_id"] for row in rows]
+
     def get_runs_count(self, filters: Optional[RunsFilter] = None) -> int:
         subquery = db_subquery(self._runs_query(filters=filters))
         query = db_select([db.func.count().label("count")]).select_from(subquery)

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
@@ -412,102 +412,111 @@ class TestRunStorage:
 
         assert len(storage.get_runs()) == 4
 
-        some_runs = storage.get_runs(RunsFilter(run_ids=[one]))
-        count = storage.get_runs_count(RunsFilter(run_ids=[one]))
+        run_ids_filter = RunsFilter(run_ids=[one])
+        some_runs = storage.get_runs(run_ids_filter)
+        count = storage.get_runs_count(run_ids_filter)
+        ids = storage.get_run_ids(run_ids_filter)
         assert len(some_runs) == 1
         assert count == 1
         assert some_runs[0].run_id == one
+        assert ids == [one]
 
-        some_runs = storage.get_runs(RunsFilter(job_name="some_pipeline"))
-        count = storage.get_runs_count(RunsFilter(job_name="some_pipeline"))
+        job_name_filter = RunsFilter(job_name="some_pipeline")
+        some_runs = storage.get_runs(job_name_filter)
+        count = storage.get_runs_count(job_name_filter)
+        ids = storage.get_run_ids(job_name_filter)
         assert len(some_runs) == 2
         assert count == 2
         assert some_runs[0].run_id == two
         assert some_runs[1].run_id == one
+        assert ids == [two, one]
 
-        some_runs = storage.get_runs(RunsFilter(statuses=[DagsterRunStatus.SUCCESS]))
-        count = storage.get_runs_count(RunsFilter(statuses=[DagsterRunStatus.SUCCESS]))
+        run_status_filter = RunsFilter(statuses=[DagsterRunStatus.SUCCESS])
+        some_runs = storage.get_runs(run_status_filter)
+        count = storage.get_runs_count(run_status_filter)
+        run_ids = storage.get_run_ids(run_status_filter)
         assert len(some_runs) == 2
         assert count == 2
         assert some_runs[0].run_id == three
         assert some_runs[1].run_id == one
+        assert run_ids == [three, one]
 
-        some_runs = storage.get_runs(RunsFilter(tags={"tag": "hello"}))
-        count = storage.get_runs_count(RunsFilter(tags={"tag": "hello"}))
+        run_tags_filter = RunsFilter(tags={"tag": "hello"})
+        some_runs = storage.get_runs(run_tags_filter)
+        count = storage.get_runs_count(run_tags_filter)
+        run_ids = storage.get_run_ids(run_tags_filter)
         assert len(some_runs) == 2
         assert count == 2
         assert some_runs[0].run_id == two
         assert some_runs[1].run_id == one
+        assert run_ids == [two, one]
 
-        some_runs = storage.get_runs(RunsFilter(tags={"tag": "hello", "tag2": "world"}))
-        count = storage.get_runs_count(RunsFilter(tags={"tag": "hello", "tag2": "world"}))
+        two_run_tags_filter = RunsFilter(tags={"tag": "hello", "tag2": "world"})
+        some_runs = storage.get_runs(two_run_tags_filter)
+        count = storage.get_runs_count(two_run_tags_filter)
+        run_ids = storage.get_run_ids(two_run_tags_filter)
         assert len(some_runs) == 1
         assert count == 1
         assert some_runs[0].run_id == one
+        assert run_ids == [one]
 
-        some_runs = storage.get_runs(RunsFilter(job_name="some_pipeline", tags={"tag": "hello"}))
-        count = storage.get_runs_count(RunsFilter(job_name="some_pipeline", tags={"tag": "hello"}))
+        job_and_tags_filter = RunsFilter(job_name="some_pipeline", tags={"tag": "hello"})
+        some_runs = storage.get_runs(job_and_tags_filter)
+        count = storage.get_runs_count(job_and_tags_filter)
+        run_ids = storage.get_run_ids(job_and_tags_filter)
         assert len(some_runs) == 2
         assert count == 2
         assert some_runs[0].run_id == two
         assert some_runs[1].run_id == one
+        assert run_ids == [two, one]
 
-        runs_with_multiple_tag_values = storage.get_runs(
-            RunsFilter(tags={"tag": ["hello", "goodbye", "farewell"]})
-        )
+        multiple_tag_values_filter = RunsFilter(tags={"tag": ["hello", "goodbye", "farewell"]})
+        runs_with_multiple_tag_values = storage.get_runs(multiple_tag_values_filter)
         assert len(runs_with_multiple_tag_values) == 3
         assert runs_with_multiple_tag_values[0].run_id == four
         assert runs_with_multiple_tag_values[1].run_id == two
         assert runs_with_multiple_tag_values[2].run_id == one
 
-        count_with_multiple_tag_values = storage.get_runs_count(
-            RunsFilter(tags={"tag": ["hello", "goodbye", "farewell"]})
-        )
+        count_with_multiple_tag_values = storage.get_runs_count(multiple_tag_values_filter)
         assert count_with_multiple_tag_values == 3
 
-        some_runs = storage.get_runs(
-            RunsFilter(
-                job_name="some_pipeline",
-                tags={"tag": "hello"},
-                statuses=[DagsterRunStatus.SUCCESS],
-            )
+        assert storage.get_run_ids(multiple_tag_values_filter) == [four, two, one]
+
+        multiple_filters = RunsFilter(
+            job_name="some_pipeline",
+            tags={"tag": "hello"},
+            statuses=[DagsterRunStatus.SUCCESS],
         )
-        count = storage.get_runs_count(
-            RunsFilter(
-                job_name="some_pipeline",
-                tags={"tag": "hello"},
-                statuses=[DagsterRunStatus.SUCCESS],
-            )
-        )
+        some_runs = storage.get_runs(multiple_filters)
+        count = storage.get_runs_count(multiple_filters)
+        run_ids = storage.get_run_ids(multiple_filters)
         assert len(some_runs) == 1
         assert count == 1
         assert some_runs[0].run_id == one
+        assert run_ids == [one]
 
         # All filters
-        some_runs = storage.get_runs(
-            RunsFilter(
-                run_ids=[one],
-                job_name="some_pipeline",
-                tags={"tag": "hello"},
-                statuses=[DagsterRunStatus.SUCCESS],
-            )
+        all_filters = RunsFilter(
+            run_ids=[one],
+            job_name="some_pipeline",
+            tags={"tag": "hello"},
+            statuses=[DagsterRunStatus.SUCCESS],
         )
-        count = storage.get_runs_count(
-            RunsFilter(
-                run_ids=[one],
-                job_name="some_pipeline",
-                tags={"tag": "hello"},
-                statuses=[DagsterRunStatus.SUCCESS],
-            )
-        )
+        some_runs = storage.get_runs(all_filters)
+        count = storage.get_runs_count(all_filters)
+        run_ids = storage.get_run_ids(all_filters)
         assert len(some_runs) == 1
         assert count == 1
         assert some_runs[0].run_id == one
+        assert run_ids == [one]
 
-        some_runs = storage.get_runs(RunsFilter())
-        count = storage.get_runs_count(RunsFilter())
+        empty_filter = RunsFilter()
+        some_runs = storage.get_runs(empty_filter)
+        count = storage.get_runs_count(empty_filter)
+        run_ids = storage.get_run_ids(empty_filter)
         assert len(some_runs) == 4
         assert count == 4
+        assert run_ids == [four, three, two, one]
 
     def test_fetch_count_by_tag(self, storage):
         assert storage

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
@@ -605,21 +605,31 @@ class TestRunStorage:
 
         all_runs = storage.get_runs()
         assert len(all_runs) == 3
+        assert storage.get_run_ids() == [three, two, one]
         sliced_runs = storage.get_runs(cursor=three, limit=1)
         assert len(sliced_runs) == 1
         assert sliced_runs[0].run_id == two
+        assert storage.get_run_ids(cursor=three, limit=1) == [two]
 
         all_runs = storage.get_runs(RunsFilter(job_name="some_pipeline"))
         assert len(all_runs) == 3
+        assert storage.get_run_ids(RunsFilter(job_name="some_pipeline")) == [three, two, one]
         sliced_runs = storage.get_runs(RunsFilter(job_name="some_pipeline"), cursor=three, limit=1)
         assert len(sliced_runs) == 1
         assert sliced_runs[0].run_id == two
+        assert storage.get_run_ids(RunsFilter(job_name="some_pipeline"), cursor=three, limit=1) == [
+            two
+        ]
 
         all_runs = storage.get_runs(RunsFilter(tags={"mytag": "hello"}))
         assert len(all_runs) == 3
+        assert storage.get_run_ids(RunsFilter(tags={"mytag": "hello"})) == [three, two, one]
         sliced_runs = storage.get_runs(RunsFilter(tags={"mytag": "hello"}), cursor=three, limit=1)
         assert len(sliced_runs) == 1
         assert sliced_runs[0].run_id == two
+        assert storage.get_run_ids(RunsFilter(tags={"mytag": "hello"}), cursor=three, limit=1) == [
+            two
+        ]
 
     def test_get_run_ids(self, storage):
         assert storage

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
@@ -621,6 +621,25 @@ class TestRunStorage:
         assert len(sliced_runs) == 1
         assert sliced_runs[0].run_id == two
 
+    def test_get_run_ids(self, storage):
+        assert storage
+
+        one, two, three = [make_new_run_id(), make_new_run_id(), make_new_run_id()]
+        storage.add_run(
+            TestRunStorage.build_run(run_id=one, job_name="some_pipeline", tags={"mytag": "hello"})
+        )
+        storage.add_run(
+            TestRunStorage.build_run(run_id=two, job_name="some_pipeline", tags={"mytag": "hello"})
+        )
+        storage.add_run(
+            TestRunStorage.build_run(
+                run_id=three, job_name="some_pipeline", tags={"mytag": "hello"}
+            )
+        )
+
+        assert storage.get_run_ids(RunsFilter(job_name="some_pipeline")) == [three, two, one]
+        assert storage.get_run_ids(RunsFilter(job_name="some_pipeline"), limit=1) == [three]
+
     def test_fetch_by_status(self, storage):
         assert storage
         one = make_new_run_id()


### PR DESCRIPTION
This PR adds a `get_run_ids` call to performantly fetch for the run IDs of cancellable backfill runs.
- The previous `get_runs` call is slow because it deserializes all of the runs, this PR replaces it with a `get_run_ids` method that does not deserialize the run body.
- Now, it takes ~4 seconds on cloud to fetch 100K run IDs. This previously timed out on cloud.

Corresponding internal diff: https://github.com/dagster-io/internal/pull/6434
