### PR TITLE
Validate asset keys with partition mappings in direct AssetsDefinition construction

### DIFF
--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -14,6 +14,7 @@ from dagster import (
     EventRecordsFilter,
     FreshnessPolicy,
     GraphOut,
+    IdentityPartitionMapping,
     IOManager,
     IOManagerDefinition,
     LastPartitionMapping,
@@ -1653,3 +1654,17 @@ def test_multi_asset_return_none():
         match="has multiple outputs, but only one output was returned",
     ):
         untyped()
+
+
+def test_direct_instantiation_invalid_partition_mapping():
+    @op
+    def my_op():
+        return 1
+
+    with pytest.raises(CheckError, match="received a partition mapping"):
+        AssetsDefinition(
+            keys_by_input_name={},
+            keys_by_output_name={"my_output": AssetKey("foo")},
+            node_def=my_op,
+            partition_mappings={AssetKey("nonexistent_asset"): IdentityPartitionMapping()},
+        )


### PR DESCRIPTION
This PR adds a check for directly instantiated `AssetsDefinition`s, checking that the keys provided for partition mappings truly correspond to input assets. This check was requested by Discord (message below):

> Playing around with partition mappings. I've noticed that `AssetsDefinition.from_graph()` has a validation step for the passed in partitions mapping (which is of type `Dict[str, PartitionMapping]`). It validates that keys in the partitions mapping are valid compared to the op input names. But using the AssetsDefinition constructor directly, does not validate the partitions mapping parameter (which has a different type, `Dict[Assetkey, PartitionMapping]`)
> 
> I would expect the direct construction to validate that each key in the partitions_mapping param exists in the keys_by_input_name . The implication is that user specified partition mappings (that come from a dbt config for instance), might be incorrect and silently materialize incorrectly