### PR TITLE
[docs-no-version] 1/ version dropdown points to static link

### DIFF
--- a/docs/next/.versioned_content/_versions_with_static_links.json
+++ b/docs/next/.versioned_content/_versions_with_static_links.json
@@ -1,11 +1,298 @@
 [
-  {"version": "1.3.11", "url": "https://docs.dagster.io"},
-  {"version": "1.3.12", "url": "https://docs.dagster.io"},
-  {"version": "1.3.13", "url": "https://docs.dagster.io"},
-  {"version": "1.3.14", "url": "https://docs.dagster.io"},
-  {"version": "1.4.0", "url": "https://docs.dagster.io"},
-  {"version": "1.4.1", "url": "https://docs.dagster.io"},
-  {"version": "1.4.2", "url": "https://docs.dagster.io"},
-  {"version": "1.4.3", "url": "https://docs.dagster.io"},
-  {"version": "1.4.4", "url": "https://release-1-4-5.dagster.dagster-docs.io/"}
+  {
+    "url": "https://dagster-git-release-01420-elementl.vercel.app",
+    "version": "0.14.20"
+  },
+  {
+    "url": "https://dagster-git-release-0150-elementl.vercel.app",
+    "version": "0.15.0"
+  },
+  {
+    "url": "https://dagster-git-release-0151-elementl.vercel.app",
+    "version": "0.15.1"
+  },
+  {
+    "url": "https://dagster-git-release-0152-elementl.vercel.app",
+    "version": "0.15.2"
+  },
+  {
+    "url": "https://dagster-git-release-0153-elementl.vercel.app",
+    "version": "0.15.3"
+  },
+  {
+    "url": "https://dagster-git-release-0154-elementl.vercel.app",
+    "version": "0.15.4"
+  },
+  {
+    "url": "https://dagster-git-release-0155-elementl.vercel.app",
+    "version": "0.15.5"
+  },
+  {
+    "url": "https://dagster-git-release-0156-elementl.vercel.app",
+    "version": "0.15.6"
+  },
+  {
+    "url": "https://dagster-git-release-0157-elementl.vercel.app",
+    "version": "0.15.7"
+  },
+  {
+    "url": "https://dagster-git-release-0158-elementl.vercel.app",
+    "version": "0.15.8"
+  },
+  {
+    "url": "https://dagster-git-release-0159-elementl.vercel.app",
+    "version": "0.15.9"
+  },
+  {
+    "url": "https://dagster-git-release-100-elementl.vercel.app",
+    "version": "1.0.0"
+  },
+  {
+    "url": "https://dagster-git-release-101-elementl.vercel.app",
+    "version": "1.0.1"
+  },
+  {
+    "url": "https://dagster-git-release-102-elementl.vercel.app",
+    "version": "1.0.2"
+  },
+  {
+    "url": "https://dagster-git-release-103-elementl.vercel.app",
+    "version": "1.0.3"
+  },
+  {
+    "url": "https://dagster-git-release-104-elementl.vercel.app",
+    "version": "1.0.4"
+  },
+  {
+    "url": "https://dagster-git-release-106-elementl.vercel.app",
+    "version": "1.0.6"
+  },
+  {
+    "url": "https://dagster-git-release-107-elementl.vercel.app",
+    "version": "1.0.7"
+  },
+  {
+    "url": "https://dagster-git-release-108-elementl.vercel.app",
+    "version": "1.0.8"
+  },
+  {
+    "url": "https://dagster-git-release-109-elementl.vercel.app",
+    "version": "1.0.9"
+  },
+  {
+    "url": "https://dagster-git-release-1010-elementl.vercel.app",
+    "version": "1.0.10"
+  },
+  {
+    "url": "https://dagster-git-release-1011-elementl.vercel.app",
+    "version": "1.0.11"
+  },
+  {
+    "url": "https://dagster-git-release-1012-elementl.vercel.app",
+    "version": "1.0.12"
+  },
+  {
+    "url": "https://dagster-git-release-1013-elementl.vercel.app",
+    "version": "1.0.13"
+  },
+  {
+    "url": "https://dagster-git-release-1014-elementl.vercel.app",
+    "version": "1.0.14"
+  },
+  {
+    "url": "https://dagster-git-release-1015-elementl.vercel.app",
+    "version": "1.0.15"
+  },
+  {
+    "url": "https://dagster-git-release-1016-elementl.vercel.app",
+    "version": "1.0.16"
+  },
+  {
+    "url": "https://dagster-git-release-1017-elementl.vercel.app",
+    "version": "1.0.17"
+  },
+  {
+    "url": "https://dagster-git-release-111-elementl.vercel.app",
+    "version": "1.1.1"
+  },
+  {
+    "url": "https://dagster-git-release-112-elementl.vercel.app",
+    "version": "1.1.2"
+  },
+  {
+    "url": "https://dagster-git-release-113-elementl.vercel.app",
+    "version": "1.1.3"
+  },
+  {
+    "url": "https://dagster-git-release-114-elementl.vercel.app",
+    "version": "1.1.4"
+  },
+  {
+    "url": "https://dagster-git-release-115-elementl.vercel.app",
+    "version": "1.1.5"
+  },
+  {
+    "url": "https://dagster-git-release-116-elementl.vercel.app",
+    "version": "1.1.6"
+  },
+  {
+    "url": "https://dagster-git-release-117-elementl.vercel.app",
+    "version": "1.1.7"
+  },
+  {
+    "url": "https://dagster-git-release-118-elementl.vercel.app",
+    "version": "1.1.8"
+  },
+  {
+    "url": "https://dagster-git-release-119-elementl.vercel.app",
+    "version": "1.1.9"
+  },
+  {
+    "url": "https://dagster-git-release-1110-elementl.vercel.app",
+    "version": "1.1.10"
+  },
+  {
+    "url": "https://dagster-git-release-1111-elementl.vercel.app",
+    "version": "1.1.11"
+  },
+  {
+    "url": "https://dagster-git-release-1113-elementl.vercel.app",
+    "version": "1.1.13"
+  },
+  {
+    "url": "https://dagster-git-release-1114-elementl.vercel.app",
+    "version": "1.1.14"
+  },
+  {
+    "url": "https://dagster-git-release-1115-elementl.vercel.app",
+    "version": "1.1.15"
+  },
+  {
+    "url": "https://dagster-git-release-1117-elementl.vercel.app",
+    "version": "1.1.17"
+  },
+  {
+    "url": "https://dagster-git-release-1118-elementl.vercel.app",
+    "version": "1.1.18"
+  },
+  {
+    "url": "https://dagster-git-release-1119-elementl.vercel.app",
+    "version": "1.1.19"
+  },
+  {
+    "url": "https://dagster-git-release-1120-elementl.vercel.app",
+    "version": "1.1.20"
+  },
+  {
+    "url": "https://dagster-git-release-1121-elementl.vercel.app",
+    "version": "1.1.21"
+  },
+  {
+    "url": "https://dagster-git-release-120-elementl.vercel.app",
+    "version": "1.2.0"
+  },
+  {
+    "url": "https://dagster-git-release-121-elementl.vercel.app",
+    "version": "1.2.1"
+  },
+  {
+    "url": "https://dagster-git-release-122-elementl.vercel.app",
+    "version": "1.2.2"
+  },
+  {
+    "url": "https://dagster-git-release-123-elementl.vercel.app",
+    "version": "1.2.3"
+  },
+  {
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.2.4/getting-started",
+    "version": "1.2.4"
+  },
+  {
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.2.6/getting-started",
+    "version": "1.2.6"
+  },
+  {
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.2.7/getting-started",
+    "version": "1.2.7"
+  },
+  {
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.3.0/getting-started",
+    "version": "1.3.0"
+  },
+  {
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.3.1/getting-started",
+    "version": "1.3.1"
+  },
+  {
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.3.2/getting-started",
+    "version": "1.3.2"
+  },
+  {
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.3.3/getting-started",
+    "version": "1.3.3"
+  },
+  {
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.3.4/getting-started",
+    "version": "1.3.4"
+  },
+  {
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.3.5/getting-started",
+    "version": "1.3.5"
+  },
+  {
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.3.6/getting-started",
+    "version": "1.3.6"
+  },
+  {
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.3.7/getting-started",
+    "version": "1.3.7"
+  },
+  {
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.3.8/getting-started",
+    "version": "1.3.8"
+  },
+  {
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.3.9/getting-started",
+    "version": "1.3.9"
+  },
+  {
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.3.10/getting-started",
+    "version": "1.3.10"
+  },
+  {
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.3.11/getting-started",
+    "version": "1.3.11"
+  },
+  {
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.3.12/getting-started",
+    "version": "1.3.12"
+  },
+  {
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.3.13/getting-started",
+    "version": "1.3.13"
+  },
+  {
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.3.14/getting-started",
+    "version": "1.3.14"
+  },
+  {
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.4.0/getting-started",
+    "version": "1.4.0"
+  },
+  {
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.4.1/getting-started",
+    "version": "1.4.1"
+  },
+  {
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.4.2/getting-started",
+    "version": "1.4.2"
+  },
+  {
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.4.3/getting-started",
+    "version": "1.4.3"
+  },
+  {
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.4.4/getting-started",
+    "version": "1.4.4"
+  }
 ]

--- a/docs/next/.versioned_content/_versions_with_static_links.json
+++ b/docs/next/.versioned_content/_versions_with_static_links.json
@@ -1,0 +1,11 @@
+[
+  {"version": "1.3.11", "url": "https://docs.dagster.io"},
+  {"version": "1.3.12", "url": "https://docs.dagster.io"},
+  {"version": "1.3.13", "url": "https://docs.dagster.io"},
+  {"version": "1.3.14", "url": "https://docs.dagster.io"},
+  {"version": "1.4.0", "url": "https://docs.dagster.io"},
+  {"version": "1.4.1", "url": "https://docs.dagster.io"},
+  {"version": "1.4.2", "url": "https://docs.dagster.io"},
+  {"version": "1.4.3", "url": "https://docs.dagster.io"},
+  {"version": "1.4.4", "url": "https://release-1-4-5.dagster.dagster-docs.io/"}
+]

--- a/docs/next/.versioned_content/_versions_with_static_links.json
+++ b/docs/next/.versioned_content/_versions_with_static_links.json
@@ -294,5 +294,13 @@
   {
     "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.4.4/getting-started",
     "version": "1.4.4"
+  },
+  {
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.4.5/getting-started",
+    "version": "1.4.5"
+  },
+  {
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.4.6/getting-started",
+    "version": "1.4.6"
   }
 ]

--- a/docs/next/.versioned_content/_versions_with_static_links.json
+++ b/docs/next/.versioned_content/_versions_with_static_links.json
@@ -1,206 +1,206 @@
 [
   {
-    "url": "https://dagster-git-release-01420-elementl.vercel.app",
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/0.14.20/getting-started",
     "version": "0.14.20"
   },
   {
-    "url": "https://dagster-git-release-0150-elementl.vercel.app",
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/0.15.0/getting-started",
     "version": "0.15.0"
   },
   {
-    "url": "https://dagster-git-release-0151-elementl.vercel.app",
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/0.15.1/getting-started",
     "version": "0.15.1"
   },
   {
-    "url": "https://dagster-git-release-0152-elementl.vercel.app",
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/0.15.2/getting-started",
     "version": "0.15.2"
   },
   {
-    "url": "https://dagster-git-release-0153-elementl.vercel.app",
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/0.15.3/getting-started",
     "version": "0.15.3"
   },
   {
-    "url": "https://dagster-git-release-0154-elementl.vercel.app",
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/0.15.4/getting-started",
     "version": "0.15.4"
   },
   {
-    "url": "https://dagster-git-release-0155-elementl.vercel.app",
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/0.15.5/getting-started",
     "version": "0.15.5"
   },
   {
-    "url": "https://dagster-git-release-0156-elementl.vercel.app",
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/0.15.6/getting-started",
     "version": "0.15.6"
   },
   {
-    "url": "https://dagster-git-release-0157-elementl.vercel.app",
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/0.15.7/getting-started",
     "version": "0.15.7"
   },
   {
-    "url": "https://dagster-git-release-0158-elementl.vercel.app",
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/0.15.8/getting-started",
     "version": "0.15.8"
   },
   {
-    "url": "https://dagster-git-release-0159-elementl.vercel.app",
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/0.15.9/getting-started",
     "version": "0.15.9"
   },
   {
-    "url": "https://dagster-git-release-100-elementl.vercel.app",
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.0.0/getting-started",
     "version": "1.0.0"
   },
   {
-    "url": "https://dagster-git-release-101-elementl.vercel.app",
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.0.1/getting-started",
     "version": "1.0.1"
   },
   {
-    "url": "https://dagster-git-release-102-elementl.vercel.app",
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.0.2/getting-started",
     "version": "1.0.2"
   },
   {
-    "url": "https://dagster-git-release-103-elementl.vercel.app",
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.0.3/getting-started",
     "version": "1.0.3"
   },
   {
-    "url": "https://dagster-git-release-104-elementl.vercel.app",
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.0.4/getting-started",
     "version": "1.0.4"
   },
   {
-    "url": "https://dagster-git-release-106-elementl.vercel.app",
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.0.6/getting-started",
     "version": "1.0.6"
   },
   {
-    "url": "https://dagster-git-release-107-elementl.vercel.app",
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.0.7/getting-started",
     "version": "1.0.7"
   },
   {
-    "url": "https://dagster-git-release-108-elementl.vercel.app",
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.0.8/getting-started",
     "version": "1.0.8"
   },
   {
-    "url": "https://dagster-git-release-109-elementl.vercel.app",
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.0.9/getting-started",
     "version": "1.0.9"
   },
   {
-    "url": "https://dagster-git-release-1010-elementl.vercel.app",
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.0.10/getting-started",
     "version": "1.0.10"
   },
   {
-    "url": "https://dagster-git-release-1011-elementl.vercel.app",
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.0.11/getting-started",
     "version": "1.0.11"
   },
   {
-    "url": "https://dagster-git-release-1012-elementl.vercel.app",
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.0.12/getting-started",
     "version": "1.0.12"
   },
   {
-    "url": "https://dagster-git-release-1013-elementl.vercel.app",
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.0.13/getting-started",
     "version": "1.0.13"
   },
   {
-    "url": "https://dagster-git-release-1014-elementl.vercel.app",
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.0.14/getting-started",
     "version": "1.0.14"
   },
   {
-    "url": "https://dagster-git-release-1015-elementl.vercel.app",
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.0.15/getting-started",
     "version": "1.0.15"
   },
   {
-    "url": "https://dagster-git-release-1016-elementl.vercel.app",
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.0.16/getting-started",
     "version": "1.0.16"
   },
   {
-    "url": "https://dagster-git-release-1017-elementl.vercel.app",
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.0.17/getting-started",
     "version": "1.0.17"
   },
   {
-    "url": "https://dagster-git-release-111-elementl.vercel.app",
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.1.1/getting-started",
     "version": "1.1.1"
   },
   {
-    "url": "https://dagster-git-release-112-elementl.vercel.app",
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.1.2/getting-started",
     "version": "1.1.2"
   },
   {
-    "url": "https://dagster-git-release-113-elementl.vercel.app",
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.1.3/getting-started",
     "version": "1.1.3"
   },
   {
-    "url": "https://dagster-git-release-114-elementl.vercel.app",
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.1.4/getting-started",
     "version": "1.1.4"
   },
   {
-    "url": "https://dagster-git-release-115-elementl.vercel.app",
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.1.5/getting-started",
     "version": "1.1.5"
   },
   {
-    "url": "https://dagster-git-release-116-elementl.vercel.app",
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.1.6/getting-started",
     "version": "1.1.6"
   },
   {
-    "url": "https://dagster-git-release-117-elementl.vercel.app",
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.1.7/getting-started",
     "version": "1.1.7"
   },
   {
-    "url": "https://dagster-git-release-118-elementl.vercel.app",
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.1.8/getting-started",
     "version": "1.1.8"
   },
   {
-    "url": "https://dagster-git-release-119-elementl.vercel.app",
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.1.9/getting-started",
     "version": "1.1.9"
   },
   {
-    "url": "https://dagster-git-release-1110-elementl.vercel.app",
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.1.10/getting-started",
     "version": "1.1.10"
   },
   {
-    "url": "https://dagster-git-release-1111-elementl.vercel.app",
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.1.11/getting-started",
     "version": "1.1.11"
   },
   {
-    "url": "https://dagster-git-release-1113-elementl.vercel.app",
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.1.13/getting-started",
     "version": "1.1.13"
   },
   {
-    "url": "https://dagster-git-release-1114-elementl.vercel.app",
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.1.14/getting-started",
     "version": "1.1.14"
   },
   {
-    "url": "https://dagster-git-release-1115-elementl.vercel.app",
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.1.15/getting-started",
     "version": "1.1.15"
   },
   {
-    "url": "https://dagster-git-release-1117-elementl.vercel.app",
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.1.17/getting-started",
     "version": "1.1.17"
   },
   {
-    "url": "https://dagster-git-release-1118-elementl.vercel.app",
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.1.18/getting-started",
     "version": "1.1.18"
   },
   {
-    "url": "https://dagster-git-release-1119-elementl.vercel.app",
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.1.19/getting-started",
     "version": "1.1.19"
   },
   {
-    "url": "https://dagster-git-release-1120-elementl.vercel.app",
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.1.20/getting-started",
     "version": "1.1.20"
   },
   {
-    "url": "https://dagster-git-release-1121-elementl.vercel.app",
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.1.21/getting-started",
     "version": "1.1.21"
   },
   {
-    "url": "https://dagster-git-release-120-elementl.vercel.app",
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.2.0/getting-started",
     "version": "1.2.0"
   },
   {
-    "url": "https://dagster-git-release-121-elementl.vercel.app",
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.2.1/getting-started",
     "version": "1.2.1"
   },
   {
-    "url": "https://dagster-git-release-122-elementl.vercel.app",
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.2.2/getting-started",
     "version": "1.2.2"
   },
   {
-    "url": "https://dagster-git-release-123-elementl.vercel.app",
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.2.3/getting-started",
     "version": "1.2.3"
   },
   {

--- a/docs/next/.versioned_content/_versions_with_static_links.json
+++ b/docs/next/.versioned_content/_versions_with_static_links.json
@@ -302,5 +302,9 @@
   {
     "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.4.6/getting-started",
     "version": "1.4.6"
+  },
+  {
+    "url": "https://legacy-versioned-docs.dagster.dagster-docs.io/1.4.7/getting-started",
+    "version": "1.4.7"
   }
 ]

--- a/docs/next/components/VersionDropdown.tsx
+++ b/docs/next/components/VersionDropdown.tsx
@@ -2,7 +2,7 @@ import {Menu, Transition} from '@headlessui/react';
 import React from 'react';
 
 import Icons from '../components/Icons';
-import {useVersion} from '../util/useVersion';
+import {useVersion, getOlderVersions} from '../util/useVersion';
 
 import Link from './Link';
 
@@ -19,8 +19,9 @@ function getLibraryVersionText(coreVersion) {
 }
 
 export default function VersionDropdown() {
-  const {latestVersion, version: currentVersion, versions, asPath} = useVersion();
+  const {latestVersion, version: currentVersion} = useVersion();
   const libraryVersionText = getLibraryVersionText(currentVersion);
+  const olderVersions = getOlderVersions();
   return (
     <div className="z-20 relative inline-flex text-left w-full">
       <div className="relative block text-left w-full">
@@ -85,22 +86,23 @@ export default function VersionDropdown() {
                   </div>
 
                   <div className="py-1">
-                    {versions.map((version) => {
+                    {olderVersions.map((item) => {
+                      const version = item.version;
+                      const url = item.url;
                       const libraryVersionText = getLibraryVersionText(version);
                       return (
-                        <Link key={version} href={asPath} version={version}>
-                          <Menu.Item>
-                            {({active}) => (
-                              <a
-                                className={`${
-                                  active ? 'bg-gray-100 text-gray-900' : 'text-gray-700'
-                                } flex cursor-pointer justify-between w-full px-4 py-2 text-sm leading-5 text-left`}
-                              >
-                                {version} {libraryVersionText}
-                              </a>
-                            )}
-                          </Menu.Item>
-                        </Link>
+                        <Menu.Item key={version}>
+                          {({active}) => (
+                            <a
+                              href={url}
+                              className={`${
+                                active ? 'bg-gray-100 text-gray-900' : 'text-gray-700'
+                              } flex cursor-pointer justify-between w-full px-4 py-2 text-sm leading-5 text-left`}
+                            >
+                              {version} {libraryVersionText}
+                            </a>
+                          )}
+                        </Menu.Item>
                       );
                     })}
                   </div>

--- a/docs/next/util/useVersion.ts
+++ b/docs/next/util/useVersion.ts
@@ -2,17 +2,14 @@ import {useRouter} from 'next/router';
 import {useState, useEffect} from 'react';
 
 import ALL_VERSIONS from '../.versioned_content/_versions.json';
+import MAP_VERSION_TO_LINK from '../.versioned_content/_versions_with_static_links.json';
 
 export const latestVersion = ALL_VERSIONS[ALL_VERSIONS.length - 1];
+export const defaultVersion = latestVersion; // always point the default version to master
 
-export let defaultVersion = latestVersion;
-if (process.env.NEXT_PUBLIC_VERCEL_ENV !== 'production') {
-  // We use NEXT_PUBLIC_VERCEL_ENV to default Vercel previews to master because
-  // * NEXT_PUBLIC_VERCEL_ENV is exposed to the browser
-  // * Vercel previews have NODE_ENV === "production"
-  defaultVersion = 'master';
-} else if (process.env.NODE_ENV !== 'production') {
-  defaultVersion = 'master';
+export function getOlderVersions() {
+  // exclude latest version which will be the current site. sort by version desc
+  return MAP_VERSION_TO_LINK.slice(0, -1).sort((a, b) => (a.version < b.version ? 1 : -1));
 }
 
 export function normalizeVersionPath(


### PR DESCRIPTION
## Summary & Motivation
This stack of PRs aim to remove the custom versioning scheme from the docs site.

<details><summary>initial approach</summary>
this updates the version dropdown so that every old version points to a previous vercel build. some of the previews urls are ugly urls with hashed values, but most are not!

- prior to 1.2.3, we were using vercel's built-in git integration which generates an ok url, such as `https://dagster-git-release-123-elementl.vercel.app` for branch "release-1.2.3". so they weren't too bad.
  * caveat: i removed versions older than 0.15.0 because they had old layout and assuming no one would look at that many versions ago. but we are keeping some pre-1.0 versions because there are still users who haven't upgraded to 1.x.
- between 1.2.4 and now, we don't get that any more, so i built a separate deployment here: https://github.com/dagster-io/dagster/pull/15780. then, we can use that build's versioning scheme which results in e.g. `https://legacy-versioned-docs.dagster.dagster-docs.io/1.2.6/getting-started` for v1.2.6.
  * alternatively, we can go through [github actions logs](https://github.com/dagster-io/dagster/actions?query=actor%3Aelementl-devtools++) or vercel logs for the older ones to fetch the ugly urls with hashed values.
</details>

per, https://github.com/dagster-io/dagster/pull/15776#discussion_r1290496933 - the updated approach:
- Use https://legacy-versioned-docs.dagster.dagster-docs.io/getting-started for all older versions. This site is built by https://github.com/dagster-io/dagster/pull/15780 and we'll keep this branch around 
- Going forward, as all deployments will only build the master + we started to alias urls again ([pr](https://github.com/dagster-io/dagster/pull/15546)), we can continue leverage branch-based url, such as `https://release-1-4-5.dagster.dagster-docs.io/`
- Later, we can also build a static site from the versioned content and deploy the content to a more user-friendly urls, so the subdomain schema is more consistent. But I feel what this PR presents is not bad (better than we expected).

## How I Tested These Changes
click items in the version dropdown: https://yuhan--docs-no-version-version-dropdown.dagster.dagster-docs.io/getting-started