### PR TITLE
[docs-no-version] 2.1/ eliminate useVersion part 1

### DIFF
--- a/docs/content/_navigation.json
+++ b/docs/content/_navigation.json
@@ -100,7 +100,7 @@
           }
         ]
       },
-      
+
       {
         "title": "Schedules & Sensors",
         "children": [
@@ -794,7 +794,7 @@
       {
         "title": "Version migration",
         "path": "/migration",
-        "isUnversioned": true
+        "isNotDynamic": true
       },
       {
         "title": "Migrating to Dagster",
@@ -1155,7 +1155,7 @@
   {
     "title": "About",
     "icon": "About",
-    "isUnversioned": true,
+    "isNotDynamic": true,
     "children": [
       {
         "title": "Community",
@@ -1188,7 +1188,7 @@
       {
         "title": "Changelog",
         "path": "/changelog",
-        "isUnversioned": true
+        "isNotDynamic": true
       }
     ]
   }

--- a/docs/next/__tests__/mdxInternalLinks.test.ts
+++ b/docs/next/__tests__/mdxInternalLinks.test.ts
@@ -37,7 +37,7 @@ test('No dead navs', async () => {
       elem.path &&
       !fileExists(path.join(DOCS_DIR, elem.path) + '.mdx') &&
       !elem.isExternalLink &&
-      !elem.isUnversioned
+      !elem.isNotDynamic
     ) {
       deadNavLinks.push({
         title: elem.title,

--- a/docs/next/components/mdx/MDXComponents.tsx
+++ b/docs/next/components/mdx/MDXComponents.tsx
@@ -677,7 +677,6 @@ const Image = ({children, ...props}) => {
    * - on non-master version
    * - in public/images/ dir
    */
-  const {version} = useVersion();
   const {src} = props;
   if (!src.startsWith('/images/')) {
     return (
@@ -686,19 +685,10 @@ const Image = ({children, ...props}) => {
       </span>
     );
   }
-
-  const resolvedPath =
-    version === 'master'
-      ? src
-      : new URL(
-          path.join('versioned_images', version, src.replace('/images/', '')),
-          'https://dagster-docs-versioned-content.s3.us-west-1.amazonaws.com',
-        ).href;
-
   return (
     <Zoom wrapElement="span" wrapStyle={{display: 'block'}}>
       <span className="block mx-auto">
-        <NextImage src={resolvedPath} width={props.width} height={props.height} alt={props.alt} />
+        <NextImage src={src} width={props.width} height={props.height} alt={props.alt} />
       </span>
     </Zoom>
   );

--- a/docs/next/components/mdx/MDXComponents.tsx
+++ b/docs/next/components/mdx/MDXComponents.tsx
@@ -5,8 +5,6 @@
 // For example, if you need to update `PyObject`, rename the existing component to `PyObjectLegacy`
 // and update all existing usage of it
 
-import path from 'path';
-
 import {Tab, Transition} from '@headlessui/react';
 import cx from 'classnames';
 import {PersistentTabContext} from 'components/PersistentTabContext';

--- a/docs/next/components/mdx/MDXRenderer.tsx
+++ b/docs/next/components/mdx/MDXRenderer.tsx
@@ -1,9 +1,8 @@
 import {useNavigation} from 'util/useNavigation';
-import {useVersion} from 'util/useVersion';
+import {useVersion, showVersionNotice} from 'util/useVersion';
 
 import cx from 'classnames';
 import Icons from 'components/Icons';
-import Link from 'components/Link';
 import VersionDropdown from 'components/VersionDropdown';
 import MDXComponents, {SearchIndexContext} from 'components/mdx/MDXComponents';
 import SidebarNavigation from 'components/mdx/SidebarNavigation';
@@ -30,9 +29,7 @@ export type MDXData = {
 };
 
 export const VersionNotice = () => {
-  const {asPath, version, defaultVersion} = useVersion();
-
-  if (version === defaultVersion) {
+  if (!showVersionNotice) {
     return null;
   }
 
@@ -40,31 +37,15 @@ export const VersionNotice = () => {
     <div className="bg-yellow-100 mb-10 mt-6 mx-4 shadow sm:rounded-lg">
       <div className="px-4 py-5 sm:p-6">
         <h3 className="text-lg leading-6 font-medium text-gray-900">
-          {version === 'master'
-            ? 'You are viewing an unreleased version of the documentation.'
-            : 'You are viewing an outdated version of the documentation.'}
+          You are viewing an unreleased or outdated version of the documentation
         </h3>
-        <div className="mt-2 text-sm text-gray-500">
-          {version === 'master' ? (
-            <p>
-              This documentation is for an unreleased version ({version}) of Dagster. The content
-              here is not guaranteed to be correct or stable. You can view the version of this page
-              from our latest release below.
-            </p>
-          ) : (
-            <p>
-              This documentation is for an older version ({version}) of Dagster. You can view the
-              version of this page from our latest release below.
-            </p>
-          )}
-        </div>
         <div className="mt-3 text-sm">
-          <Link href={asPath} version={defaultVersion}>
-            <a className="font-medium text-indigo-600 hover:text-indigo-500">
-              {' '}
-              View Latest Documentation <span aria-hidden="true">→</span>
-            </a>
-          </Link>
+          <a
+            href="https://docs.dagster.io"
+            className="font-medium text-indigo-600 hover:text-indigo-500"
+          >
+            View Latest Documentation <span aria-hidden="true">→</span>
+          </a>
         </div>
       </div>
     </div>

--- a/docs/next/pages/sitemap.xml.tsx
+++ b/docs/next/pages/sitemap.xml.tsx
@@ -1,4 +1,4 @@
-import {latestAllVersionedPaths} from 'util/useNavigation';
+import {latestAllPaths} from 'util/useNavigation';
 
 const toUrl = (host, route) => `<url><loc>http://${host}${route}</loc></url>`;
 
@@ -11,7 +11,7 @@ const createSitemap = (host, routes) =>
 const Sitemap = () => {};
 
 Sitemap.getInitialProps = ({res, req}) => {
-  const routes = latestAllVersionedPaths().map(({params}) => '/' + params.page.join('/'));
+  const routes = latestAllPaths().map(({params}) => '/' + params.page.join('/'));
   const sitemap = createSitemap(req.headers.host, routes);
 
   res.setHeader('Content-Type', 'text/xml');

--- a/docs/next/util/useVersion.ts
+++ b/docs/next/util/useVersion.ts
@@ -12,6 +12,18 @@ export function getOlderVersions() {
   return MAP_VERSION_TO_LINK.slice(0, -1).sort((a, b) => (a.version < b.version ? 1 : -1));
 }
 
+// only hide version notice in production
+export let showVersionNotice = true;
+if (process.env.NEXT_PUBLIC_VERCEL_ENV === 'production') {
+  // We use NEXT_PUBLIC_VERCEL_ENV to tell whether it's in production or not
+  // * NEXT_PUBLIC_VERCEL_ENV is exposed to the browser
+  // * Vercel previews have NODE_ENV === "production"
+  showVersionNotice = false;
+} else if (process.env.NODE_ENV === 'production') {
+  // for testing
+  showVersionNotice = false;
+}
+
 export function normalizeVersionPath(
   asPath: string,
   versions?: string[],
@@ -54,14 +66,6 @@ export function normalizeVersionPath(
     defaultVersion,
     latestVersion,
   };
-}
-
-export function versionFromPage(page: string | string[]) {
-  if (Array.isArray(page)) {
-    return normalizeVersionPath('/' + page.join('/'), ALL_VERSIONS);
-  }
-
-  return normalizeVersionPath(page, ALL_VERSIONS);
 }
 
 export const useVersion = () => {


### PR DESCRIPTION
## Summary & Motivation
remove version logic from:
- navigation: only use master nav
- version banner: default to show version warning banner. hide the banner in production. so all previews get the banner. see result in part 2.
- image
- getContent: we used to load versioned content from s3 when dynamically generating the page. now we no longer need to do so.

the remaining ones are:
1. necessary version info:
  - current version so when filing github issue or rendering github link we are still aware of version
  - showVersionBanner: whether or not to show the version notice banner at the top

2. `asPath` and `asPathWithoutAnchor`: in part 2

## How I Tested These Changes
https://yuhan--docs-no-version-eliminate-usevers.dagster.dagster-docs.io/