### PR TITLE
[docs-no-version] 2.2/ only keep necessary useVersion and remove all others

### DIFF
--- a/docs/content/_navigation.json
+++ b/docs/content/_navigation.json
@@ -782,7 +782,7 @@
           },
           {
             "title": "Migrating to graphs, jobs, ops",
-            "path": "https://docs.dagster.io/0.15.7/guides/dagster/graph_job_op",
+            "path": "https://legacy-versioned-docs.dagster.dagster-docs.io/0.15.7/guides/dagster/graph_job_op",
             "isExternalLink": true
           },
           {

--- a/docs/next/__tests__/mdxInternalLinks.test.ts
+++ b/docs/next/__tests__/mdxInternalLinks.test.ts
@@ -12,7 +12,7 @@ import visit from 'unist-util-visit';
 
 import masterNavigation from '../../content/_navigation.json';
 import {getItems, getIds} from '../components/mdx/SidebarNavigation';
-import {flatten} from '../util/useNavigation';
+import {flatten} from '../util/navigation';
 
 // remark
 

--- a/docs/next/components/FeedbackModal.tsx
+++ b/docs/next/components/FeedbackModal.tsx
@@ -3,11 +3,11 @@ import newGithubIssueUrl from 'new-github-issue-url';
 import React, {useEffect, useState} from 'react';
 
 import {usePath} from '../util/usePath';
-import {useVersion} from '../util/useVersion';
+import {LATEST_VERSION} from '../util/version';
 
 const FeedbackModal = ({isOpen, closeFeedback}: {isOpen: boolean; closeFeedback: () => void}) => {
   const {asPath} = usePath();
-  const {version} = useVersion();
+  const version = LATEST_VERSION;
   const [currentPage, setCurrentPage] = useState<string>(asPath);
   const [currentVersion, setCurrentVersion] = useState<string>(version);
   const [description, setDescription] = useState<string>('');

--- a/docs/next/components/FeedbackModal.tsx
+++ b/docs/next/components/FeedbackModal.tsx
@@ -2,10 +2,12 @@ import {Transition} from '@headlessui/react';
 import newGithubIssueUrl from 'new-github-issue-url';
 import React, {useEffect, useState} from 'react';
 
+import {usePath} from '../util/usePath';
 import {useVersion} from '../util/useVersion';
 
 const FeedbackModal = ({isOpen, closeFeedback}: {isOpen: boolean; closeFeedback: () => void}) => {
-  const {asPath, version} = useVersion();
+  const {asPath} = usePath();
+  const {version} = useVersion();
   const [currentPage, setCurrentPage] = useState<string>(asPath);
   const [currentVersion, setCurrentVersion] = useState<string>(version);
   const [description, setDescription] = useState<string>('');

--- a/docs/next/components/Link.tsx
+++ b/docs/next/components/Link.tsx
@@ -1,51 +1,21 @@
-import path from 'path';
-
 import NextLink from 'next/link';
 import React from 'react';
-
-import {normalizeVersionPath, useVersion} from '../util/useVersion';
 
 interface LinkProps {
   href: string;
   children: React.ReactNode;
-  version?: string;
   passHref?: boolean;
 }
 
 {
   /*
   <Link href="/abcd"></Link>
-  <Link href="/abcd" version={newVersion}></Link>
-  <Link href="/version/abcd" version={newVersion}></Link>
 */
 }
 
-const Link = ({href, children, version, passHref = false}: LinkProps) => {
-  const {asPath} = normalizeVersionPath(href);
-  const {version: currentVersion, defaultVersion} = useVersion();
-
-  if (version) {
-    const versionedHref =
-      version === defaultVersion ? path.join('/', asPath) : path.join('/', version, asPath);
-    return (
-      <NextLink href={versionedHref} passHref={passHref}>
-        {children}
-      </NextLink>
-    );
-  }
-
-  if (currentVersion === defaultVersion) {
-    const versionedHref = path.join('/', href);
-    return (
-      <NextLink href={versionedHref} passHref={passHref}>
-        {children}
-      </NextLink>
-    );
-  }
-
-  const versionedHref = path.join('/', currentVersion, href);
+const Link = ({href, children, passHref = false}: LinkProps) => {
   return (
-    <NextLink href={versionedHref} passHref={passHref}>
+    <NextLink href={href} passHref={passHref}>
       {children}
     </NextLink>
   );

--- a/docs/next/components/Pagination.tsx
+++ b/docs/next/components/Pagination.tsx
@@ -2,12 +2,12 @@ import {flatten, useNavigation} from 'util/useNavigation';
 
 import React from 'react';
 
-import {useVersion} from '../util/useVersion';
+import {usePath} from '../util/usePath';
 
 import Link from './Link';
 
 const Pagination = () => {
-  const {asPath} = useVersion();
+  const {asPath} = usePath();
   const navigation = useNavigation();
   const flattenedNavigation = flatten(navigation).filter((n: {path: any}) => n.path);
 

--- a/docs/next/components/Pagination.tsx
+++ b/docs/next/components/Pagination.tsx
@@ -1,4 +1,4 @@
-import {flatten, useNavigation} from 'util/useNavigation';
+import navigation, {flatten} from 'util/navigation';
 
 import React from 'react';
 
@@ -8,7 +8,6 @@ import Link from './Link';
 
 const Pagination = () => {
   const {asPath} = usePath();
-  const navigation = useNavigation();
   const flattenedNavigation = flatten(navigation).filter((n: {path: any}) => n.path);
 
   const currentIndex = flattenedNavigation.findIndex((n: {path: string}) => n.path === asPath);

--- a/docs/next/components/Sidebar.tsx
+++ b/docs/next/components/Sidebar.tsx
@@ -5,7 +5,7 @@ import NextLink from 'next/link';
 import React, {useState} from 'react';
 
 import Icons from '../components/Icons';
-import {useNavigation, flatten, getNavKey, getNavLvl} from '../util/useNavigation';
+import navigation, {flatten, getNavKey, getNavLvl} from '../util/navigation';
 import {usePath} from '../util/usePath';
 
 const useCurrentSection = (navigation) => {
@@ -177,7 +177,6 @@ const RecursiveNavigation = ({
   setNavKeysToExpanded,
 }) => {
   const {asPathWithoutAnchor} = usePath();
-  const navigation = useNavigation();
   const currentSection = useCurrentSection(navigation);
   const navKey = getNavKey(parentKey, idx);
   const lvl = getNavLvl(navKey);
@@ -247,8 +246,6 @@ const RecursiveNavigation = ({
 };
 
 const TopLevelNavigation = () => {
-  const navigation = useNavigation();
-
   const map = {};
   const [navKeysToExpanded, setNavKeysToExpanded] = useState<{
     [key: string]: boolean;

--- a/docs/next/components/Sidebar.tsx
+++ b/docs/next/components/Sidebar.tsx
@@ -6,12 +6,10 @@ import React, {useState} from 'react';
 
 import Icons from '../components/Icons';
 import {useNavigation, flatten, getNavKey, getNavLvl} from '../util/useNavigation';
-import {useVersion} from '../util/useVersion';
-
-import Link from './Link';
+import {usePath} from '../util/usePath';
 
 const useCurrentSection = (navigation) => {
-  const {asPath} = useVersion();
+  const {asPath} = usePath();
   const match = navigation.find((item) => item.path !== '/' && asPath.startsWith(item.path));
   return match || navigation.find((item) => item.path === '/');
 };
@@ -108,19 +106,10 @@ const MenuItem = React.forwardRef<HTMLAnchorElement, React.PropsWithChildren<Men
       return linkElement;
     }
 
-    if (item.isUnversioned) {
-      return (
-        <NextLink href={item.path} passHref>
-          {linkElement}
-        </NextLink>
-      );
-    }
-
-    // Versioned link
     return (
-      <Link href={item.path} passHref>
+      <NextLink href={item.path} passHref>
         {linkElement}
-      </Link>
+      </NextLink>
     );
   },
 );
@@ -187,7 +176,7 @@ const RecursiveNavigation = ({
   navKeysToExpanded,
   setNavKeysToExpanded,
 }) => {
-  const {asPathWithoutAnchor} = useVersion();
+  const {asPathWithoutAnchor} = usePath();
   const navigation = useNavigation();
   const currentSection = useCurrentSection(navigation);
   const navKey = getNavKey(parentKey, idx);

--- a/docs/next/components/VersionDropdown.tsx
+++ b/docs/next/components/VersionDropdown.tsx
@@ -2,7 +2,7 @@ import {Menu, Transition} from '@headlessui/react';
 import React from 'react';
 
 import Icons from '../components/Icons';
-import {useVersion, getOlderVersions} from '../util/useVersion';
+import {LATEST_VERSION, SHOW_VERSION_NOTICE, getOlderVersions} from '../util/version';
 
 import Link from './Link';
 
@@ -19,8 +19,7 @@ function getLibraryVersionText(coreVersion) {
 }
 
 export default function VersionDropdown() {
-  const {version: currentVersion, showVersionNotice} = useVersion();
-  const libraryVersionText = getLibraryVersionText(currentVersion);
+  const libraryVersionText = getLibraryVersionText(LATEST_VERSION);
   const olderVersions = getOlderVersions();
   return (
     <div className="z-20 relative inline-flex text-left w-full">
@@ -34,10 +33,10 @@ export default function VersionDropdown() {
                     <span className="flex min-w-0 items-center justify-between space-x-3">
                       <span className="flex-1 min-w-0 text-gable-green dark:text-gray-300 text-xs lg:text-sm truncate space-x-1">
                         <span>
-                          {currentVersion} {libraryVersionText}
+                          {LATEST_VERSION} {libraryVersionText}
                         </span>
                         {/* When show version notice, do not show the "latest" tag to avoid confusion */}
-                        {!showVersionNotice ? (
+                        {!SHOW_VERSION_NOTICE ? (
                           <span className="bg-lavender rounded-full px-2 py-1">latest</span>
                         ) : null}
                       </span>
@@ -74,7 +73,7 @@ export default function VersionDropdown() {
                     <p className="text-sm leading-5">
                       You&apos;re currently viewing the docs for Dagster{' '}
                       <span className="text-sm font-medium leading-5 text-gray-900">
-                        {currentVersion}
+                        {LATEST_VERSION}
                       </span>
                       . Select a different version below. Note that prior to 1.0, all Dagster
                       packages shared the same version. After 1.0, we adopted separate version

--- a/docs/next/components/VersionDropdown.tsx
+++ b/docs/next/components/VersionDropdown.tsx
@@ -19,7 +19,7 @@ function getLibraryVersionText(coreVersion) {
 }
 
 export default function VersionDropdown() {
-  const {latestVersion, version: currentVersion} = useVersion();
+  const {version: currentVersion, showVersionNotice} = useVersion();
   const libraryVersionText = getLibraryVersionText(currentVersion);
   const olderVersions = getOlderVersions();
   return (
@@ -36,7 +36,8 @@ export default function VersionDropdown() {
                         <span>
                           {currentVersion} {libraryVersionText}
                         </span>
-                        {currentVersion === latestVersion ? (
+                        {/* When show version notice, do not show the "latest" tag to avoid confusion */}
+                        {!showVersionNotice ? (
                           <span className="bg-lavender rounded-full px-2 py-1">latest</span>
                         ) : null}
                       </span>

--- a/docs/next/components/mdx/MDXComponents.tsx
+++ b/docs/next/components/mdx/MDXComponents.tsx
@@ -13,7 +13,6 @@ import NextLink from 'next/link';
 import React, {ReactElement, useCallback, useContext, useEffect, useRef, useState} from 'react';
 import Zoom from 'react-medium-image-zoom';
 
-import {useVersion} from '../../util/useVersion';
 import Icons from '../Icons';
 import Link from '../Link';
 
@@ -282,8 +281,7 @@ const Warning = ({children}) => {
 };
 
 const CodeReferenceLink = ({filePath, isInline, children}) => {
-  const {version} = useVersion();
-  const url = `https://github.com/dagster-io/dagster/tree/${version}/${filePath}`;
+  const url = `https://github.com/dagster-io/dagster/tree/${LATEST_VERSION}/${filePath}`;
 
   if (isInline) {
     return <a href={url}>{children}</a>;

--- a/docs/next/components/mdx/MDXComponents.tsx
+++ b/docs/next/components/mdx/MDXComponents.tsx
@@ -4,6 +4,7 @@
 
 // For example, if you need to update `PyObject`, rename the existing component to `PyObjectLegacy`
 // and update all existing usage of it
+import {LATEST_VERSION} from 'util/version';
 
 import {Tab, Transition} from '@headlessui/react';
 import cx from 'classnames';

--- a/docs/next/components/mdx/MDXRenderer.tsx
+++ b/docs/next/components/mdx/MDXRenderer.tsx
@@ -1,6 +1,6 @@
-import {useNavigation} from 'util/useNavigation';
+import navigation from 'util/navigation';
 import {usePath} from 'util/usePath';
-import {useVersion} from 'util/useVersion';
+import {SHOW_VERSION_NOTICE} from 'util/version';
 
 import cx from 'classnames';
 import Icons from 'components/Icons';
@@ -30,8 +30,7 @@ export type MDXData = {
 };
 
 export const VersionNotice = () => {
-  const {showVersionNotice} = useVersion();
-  if (!showVersionNotice) {
+  if (!SHOW_VERSION_NOTICE) {
     return null;
   }
 
@@ -57,8 +56,6 @@ export const VersionNotice = () => {
 const BreadcrumbNav = ({asPath}) => {
   const {asPathWithoutAnchor} = usePath();
   const pagePath = asPath ? asPath : asPathWithoutAnchor;
-
-  const navigation = useNavigation();
 
   function traverse(currNode, path, stack) {
     if (currNode.path === path) {

--- a/docs/next/components/mdx/MDXRenderer.tsx
+++ b/docs/next/components/mdx/MDXRenderer.tsx
@@ -1,5 +1,6 @@
 import {useNavigation} from 'util/useNavigation';
-import {useVersion, showVersionNotice} from 'util/useVersion';
+import {usePath} from 'util/usePath';
+import {useVersion} from 'util/useVersion';
 
 import cx from 'classnames';
 import Icons from 'components/Icons';
@@ -29,6 +30,7 @@ export type MDXData = {
 };
 
 export const VersionNotice = () => {
+  const {showVersionNotice} = useVersion();
   if (!showVersionNotice) {
     return null;
   }
@@ -53,7 +55,7 @@ export const VersionNotice = () => {
 };
 
 const BreadcrumbNav = ({asPath}) => {
-  const {asPathWithoutAnchor} = useVersion();
+  const {asPathWithoutAnchor} = usePath();
   const pagePath = asPath ? asPath : asPathWithoutAnchor;
 
   const navigation = useNavigation();

--- a/docs/next/pages/[...page].tsx
+++ b/docs/next/pages/[...page].tsx
@@ -1,6 +1,6 @@
 import {promises as fs} from 'fs';
 import path from 'path';
-import {latestAllDynamicPaths} from 'util/useNavigation';
+import {latestAllDynamicPaths} from 'util/navigation';
 
 import FeedbackModal from 'components/FeedbackModal';
 import {Shimmer} from 'components/Shimmer';

--- a/docs/next/pages/_app.tsx
+++ b/docs/next/pages/_app.tsx
@@ -1,7 +1,7 @@
 import '/styles/fonts.css';
 import '/styles/globals.css';
 import '/styles/prism.css';
-import {useVersion} from 'util/useVersion';
+import {usePath} from 'util/usePath';
 
 import {PersistentTabProvider} from 'components/PersistentTabContext';
 import {DefaultSeo} from 'next-seo';
@@ -41,7 +41,7 @@ const MyApp = ({Component, pageProps}: AppProps) => {
   const router = useRouter();
   const asPathFromPageProps = pageProps?.data?.asPath;
 
-  const {asPath} = useVersion();
+  const {asPath} = usePath();
 
   const canonicalUrl = `${BASE_URL}${asPathFromPageProps ?? asPath}`;
 

--- a/docs/next/pages/migration.tsx
+++ b/docs/next/pages/migration.tsx
@@ -93,7 +93,7 @@ export const getStaticProps: GetStaticProps = async () => {
   const pathToMdxFile = path.resolve('../../MIGRATION.md');
 
   try {
-    // 2. Read and parse versioned MDX content
+    // 2. Read and parse MDX content
     const source = await fs.readFile(pathToMdxFile);
     const {content, data} = matter(source);
 

--- a/docs/next/pages/sitemap.xml.tsx
+++ b/docs/next/pages/sitemap.xml.tsx
@@ -1,4 +1,4 @@
-import {latestAllPaths} from 'util/useNavigation';
+import {latestAllPaths} from 'util/navigation';
 
 const toUrl = (host, route) => `<url><loc>http://${host}${route}</loc></url>`;
 

--- a/docs/next/util/navigation.ts
+++ b/docs/next/util/navigation.ts
@@ -1,4 +1,4 @@
-import masterNavigation from '../../content/_navigation.json';
+import navigation from '../../content/_navigation.json';
 
 type NavEntry = {
   title: string;
@@ -32,13 +32,9 @@ export function flatten(yx: any, parentKey = '') {
   }, []);
 }
 
-export const useNavigation = () => {
-  return masterNavigation;
-};
-
 export const latestAllPaths = () => {
   // include path like /changelog which doesn't go through the markdoc renderer
-  return flatten(masterNavigation)
+  return flatten(navigation)
     .filter((n: {path: any}) => n.path)
     .map(({path}) => path.split('/').splice(1))
     .map((page: string[]) => {
@@ -52,7 +48,7 @@ export const latestAllPaths = () => {
 
 export const latestAllDynamicPaths = () => {
   // only include paths that will be dynamically generated
-  return flatten(masterNavigation)
+  return flatten(navigation)
     .filter((n: NavEntry) => n.path && !n.isExternalLink && !n.isNotDynamic)
     .map(({path}) => path.split('/').splice(1))
     .map((page: string[]) => {
@@ -64,6 +60,4 @@ export const latestAllDynamicPaths = () => {
     });
 };
 
-export const navigations = {
-  masterNavigation,
-};
+export default navigation;

--- a/docs/next/util/usePath.ts
+++ b/docs/next/util/usePath.ts
@@ -1,0 +1,24 @@
+import {useRouter} from 'next/router';
+import {useState, useEffect} from 'react';
+
+export const usePath = () => {
+  const router = useRouter();
+
+  const [asPath, setAsPath] = useState('/');
+
+  useEffect(() => {
+    if (router.isReady) {
+      setAsPath(router.asPath);
+    }
+  }, [router]);
+
+  let asPathWithoutAnchor = asPath;
+  if (asPathWithoutAnchor.indexOf('#') > 0) {
+    asPathWithoutAnchor = asPath.substring(0, asPath.indexOf('#'));
+  }
+
+  return {
+    asPath,
+    asPathWithoutAnchor,
+  };
+};

--- a/docs/next/util/useVersion.ts
+++ b/docs/next/util/useVersion.ts
@@ -30,9 +30,11 @@ if (process.env.NEXT_PUBLIC_VERCEL_ENV === 'production') {
   // * NEXT_PUBLIC_VERCEL_ENV is exposed to the browser
   // * Vercel previews have NODE_ENV === "production"
   showVersionNotice = false;
+  console.log('process.env.NEXT_PUBLIC_VERCEL_ENV', process.env.NEXT_PUBLIC_VERCEL_ENV);
 } else if (process.env.NODE_ENV === 'production') {
   // for testing
   showVersionNotice = false;
+  console.log('process.env.NODE_ENV', process.env.NODE_ENV);
 }
 
 export const useVersion = () => {

--- a/docs/next/util/useVersion.ts
+++ b/docs/next/util/useVersion.ts
@@ -10,6 +10,7 @@ export const defaultVersion = latestVersion; // always point the default version
 export function getOlderVersions() {
   // exclude latest version which will be the current site. sort by version desc
   return MAP_VERSION_TO_LINK.slice(0, -1).sort((a, b) => (a.version < b.version ? 1 : -1));
+<<<<<<< HEAD
 }
 
 // only hide version notice in production
@@ -22,6 +23,8 @@ if (process.env.NEXT_PUBLIC_VERCEL_ENV === 'production') {
 } else if (process.env.NODE_ENV === 'production') {
   // for testing
   showVersionNotice = false;
+=======
+>>>>>>> 6dc1a92f2b ([docs-no-version] 1/ version dropdown points to static link)
 }
 
 export function normalizeVersionPath(

--- a/docs/next/util/useVersion.ts
+++ b/docs/next/util/useVersion.ts
@@ -1,11 +1,7 @@
-import {useRouter} from 'next/router';
-import {useState, useEffect} from 'react';
-
 import ALL_VERSIONS from '../.versioned_content/_versions.json';
 import MAP_VERSION_TO_LINK from '../.versioned_content/_versions_with_static_links.json';
 
 export const latestVersion = ALL_VERSIONS[ALL_VERSIONS.length - 1];
-export const defaultVersion = latestVersion; // always point the default version to master
 
 export function getOlderVersions() {
   // exclude latest version which will be the current site. sort by version desc
@@ -28,7 +24,7 @@ if (process.env.NEXT_PUBLIC_VERCEL_ENV === 'production') {
 }
 
 // only hide version notice in production
-export let showVersionNotice = true;
+let showVersionNotice = true;
 if (process.env.NEXT_PUBLIC_VERCEL_ENV === 'production') {
   // We use NEXT_PUBLIC_VERCEL_ENV to tell whether it's in production or not
   // * NEXT_PUBLIC_VERCEL_ENV is exposed to the browser
@@ -39,59 +35,6 @@ if (process.env.NEXT_PUBLIC_VERCEL_ENV === 'production') {
   showVersionNotice = false;
 }
 
-export function normalizeVersionPath(
-  asPath: string,
-  versions?: string[],
-): {
-  version?: string;
-  asPath: string;
-  asPathWithoutAnchor: string;
-  versions: string[];
-  defaultVersion: string;
-  latestVersion: string;
-} {
-  let detectedVersion: string = defaultVersion;
-  // first item will be empty string from splitting at first char
-  const pathnameParts = asPath.split('/');
-
-  (versions || []).some((version) => {
-    if (pathnameParts[1].toLowerCase() === version.toLowerCase()) {
-      detectedVersion = version;
-      pathnameParts.splice(1, 1);
-      asPath = pathnameParts.join('/') || '/';
-      return true;
-    }
-    return false;
-  });
-
-  let asPathWithoutAnchor = asPath;
-  if (asPathWithoutAnchor.indexOf('#') > 0) {
-    asPathWithoutAnchor = asPath.substring(0, asPath.indexOf('#'));
-  }
-
-  // sort release versions by latest - we assume `ALL_VERSIONS` starts with master, and then
-  // the following versions are sorted from oldest to latest.
-  const sortedVersions = ALL_VERSIONS.slice(0, 1).concat(ALL_VERSIONS.slice(1).reverse());
-
-  return {
-    asPath,
-    asPathWithoutAnchor,
-    version: detectedVersion,
-    versions: sortedVersions,
-    defaultVersion,
-    latestVersion,
-  };
-}
-
 export const useVersion = () => {
-  const router = useRouter();
-
-  const [asPath, setAsPath] = useState('/');
-
-  useEffect(() => {
-    if (router.isReady) {
-      setAsPath(router.asPath);
-    }
-  }, [router]);
-  return normalizeVersionPath(asPath, ALL_VERSIONS);
+  return {version: latestVersion, showVersionNotice};
 };

--- a/docs/next/util/useVersion.ts
+++ b/docs/next/util/useVersion.ts
@@ -26,15 +26,13 @@ if (process.env.NEXT_PUBLIC_VERCEL_ENV === 'production') {
 // only hide version notice in production
 let showVersionNotice = true;
 if (process.env.NEXT_PUBLIC_VERCEL_ENV === 'production') {
-  // We use NEXT_PUBLIC_VERCEL_ENV to tell whether it's in production or not
+  // We use NEXT_PUBLIC_VERCEL_ENV to tell whether it's in production or not, because:
   // * NEXT_PUBLIC_VERCEL_ENV is exposed to the browser
-  // * Vercel previews have NODE_ENV === "production"
+  // * Vercel previews have NODE_ENV === "production", so we can't rely on that.
+  //     As going forward, we are relying on Vercel's previews to version the older docs, we need to
+  //     make sure that when a user lands on the older docs (aka previews), we have the version
+  //     notice as reminder that they are looking at older docs.
   showVersionNotice = false;
-  console.log('process.env.NEXT_PUBLIC_VERCEL_ENV', process.env.NEXT_PUBLIC_VERCEL_ENV);
-} else if (process.env.NODE_ENV === 'production') {
-  // for testing
-  showVersionNotice = false;
-  console.log('process.env.NODE_ENV', process.env.NODE_ENV);
 }
 
 export const useVersion = () => {

--- a/docs/next/util/useVersion.ts
+++ b/docs/next/util/useVersion.ts
@@ -27,6 +27,18 @@ if (process.env.NEXT_PUBLIC_VERCEL_ENV === 'production') {
 >>>>>>> 6dc1a92f2b ([docs-no-version] 1/ version dropdown points to static link)
 }
 
+// only hide version notice in production
+export let showVersionNotice = true;
+if (process.env.NEXT_PUBLIC_VERCEL_ENV === 'production') {
+  // We use NEXT_PUBLIC_VERCEL_ENV to tell whether it's in production or not
+  // * NEXT_PUBLIC_VERCEL_ENV is exposed to the browser
+  // * Vercel previews have NODE_ENV === "production"
+  showVersionNotice = false;
+} else if (process.env.NODE_ENV === 'production') {
+  // for testing
+  showVersionNotice = false;
+}
+
 export function normalizeVersionPath(
   asPath: string,
   versions?: string[],

--- a/docs/next/util/version.ts
+++ b/docs/next/util/version.ts
@@ -1,7 +1,7 @@
 import ALL_VERSIONS from '../.versioned_content/_versions.json';
 import MAP_VERSION_TO_LINK from '../.versioned_content/_versions_with_static_links.json';
 
-export const latestVersion = ALL_VERSIONS[ALL_VERSIONS.length - 1];
+export const LATEST_VERSION = ALL_VERSIONS[ALL_VERSIONS.length - 1];
 
 export function getOlderVersions() {
   // exclude latest version which will be the current site. sort by version desc
@@ -24,7 +24,7 @@ if (process.env.NEXT_PUBLIC_VERCEL_ENV === 'production') {
 }
 
 // only hide version notice in production
-let showVersionNotice = true;
+export let SHOW_VERSION_NOTICE = true;
 if (process.env.NEXT_PUBLIC_VERCEL_ENV === 'production') {
   // We use NEXT_PUBLIC_VERCEL_ENV to tell whether it's in production or not, because:
   // * NEXT_PUBLIC_VERCEL_ENV is exposed to the browser
@@ -32,9 +32,5 @@ if (process.env.NEXT_PUBLIC_VERCEL_ENV === 'production') {
   //     As going forward, we are relying on Vercel's previews to version the older docs, we need to
   //     make sure that when a user lands on the older docs (aka previews), we have the version
   //     notice as reminder that they are looking at older docs.
-  showVersionNotice = false;
+  SHOW_VERSION_NOTICE = false;
 }
-
-export const useVersion = () => {
-  return {version: latestVersion, showVersionNotice};
-};

--- a/docs/next/util/version.ts
+++ b/docs/next/util/version.ts
@@ -6,21 +6,6 @@ export const LATEST_VERSION = ALL_VERSIONS[ALL_VERSIONS.length - 1];
 export function getOlderVersions() {
   // exclude latest version which will be the current site. sort by version desc
   return MAP_VERSION_TO_LINK.slice(0, -1).sort((a, b) => (a.version < b.version ? 1 : -1));
-<<<<<<< HEAD
-}
-
-// only hide version notice in production
-export let showVersionNotice = true;
-if (process.env.NEXT_PUBLIC_VERCEL_ENV === 'production') {
-  // We use NEXT_PUBLIC_VERCEL_ENV to tell whether it's in production or not
-  // * NEXT_PUBLIC_VERCEL_ENV is exposed to the browser
-  // * Vercel previews have NODE_ENV === "production"
-  showVersionNotice = false;
-} else if (process.env.NODE_ENV === 'production') {
-  // for testing
-  showVersionNotice = false;
-=======
->>>>>>> 6dc1a92f2b ([docs-no-version] 1/ version dropdown points to static link)
 }
 
 // only hide version notice in production


### PR DESCRIPTION
## Summary & Motivation
depends on https://github.com/dagster-io/dagster/pull/15777

this completes the `useVersion` clean up.
- it keeps necessary version info in useVersion: `version` shows the latest version, `showVersionBanner` indicates whether or not to show the version notice banner
  * note: this is useful in previews because going forward we're going to rely on previews to show docs of older version. when a user lands on a older version (preview), we'd always show the warning banner to remind them that the site is an outdated site.
- it moves path info to a separate `usePath` file/function. previously, because version has been part of the path, we derive the normalized path from useVersion. now, as we only render latest version (master), we no longer need that derived logic.
  * this also results in removing useVersion usage in a few places: Link, Sidebar, Pagination (we aren't actively using it anyways)

Next:
- update release pipeline
- more cleanups such as func names

## How I Tested These Changes
click around in preview: internal links and sidebar links all work
