### PR TITLE
[auto-materialize] Partial revert of data version logic

### DIFF
--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -773,6 +773,7 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
             use_asset_versions (bool): If True, will use data versions to filter out asset
                 partitions which were materialized, but not have not had their data versions
                 cahnged since the given cursor.
+                NOTE: This boolean has been temporarily disabled
         """
         if not self.asset_partition_has_materialization_or_observation(
             AssetKeyPartitionKey(asset_key), after_cursor=after_cursor
@@ -790,9 +791,7 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
 
         if not updated_after_cursor:
             return set()
-        if after_cursor is None or (
-            not self.asset_graph.is_source(asset_key) and not use_asset_versions
-        ):
+        if after_cursor is None or (not self.asset_graph.is_source(asset_key)):
             return updated_after_cursor
 
         # more expensive check to explicitly handle data versions

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/version_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/version_scenarios.py
@@ -35,6 +35,7 @@ partitioned_to_partitioned = [
     asset_def("three", ["two"], partitions_def=three_partitions_def, code_version="0"),
 ]
 
+"""
 version_scenarios = {
     "all_unpartitioned_version_updated": AssetReconciliationScenario(
         assets=all_unpartitioned,
@@ -148,3 +149,5 @@ version_scenarios = {
         expected_run_requests=[],
     ),
 }
+"""
+version_scenarios = {}


### PR DESCRIPTION
## Summary & Motivation

In some cases, data versions are not accurately calculated, leading to materializations not firing when they should.

## How I Tested These Changes
