### PR TITLE
Pass CI_* into build containers

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/step_builder.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/step_builder.py
@@ -72,8 +72,12 @@ class CommandStepBuilder:
         settings["volumes"] = ["/var/run/docker.sock:/var/run/docker.sock", "/tmp:/tmp"]
         settings["network"] = "kind"
 
-        # Pass through all BUILDKITE* envvars so our test analytics are properly tagged
-        buildkite_envvars = [env for env in list(os.environ.keys()) if env.startswith("BUILDKITE")]
+        # Pass through all BUILDKITE* and CI* envvars so our test analytics are properly tagged
+        buildkite_envvars = [
+            env
+            for env in list(os.environ.keys())
+            if env.startswith("BUILDKITE") or env.startswith("CI_")
+        ]
 
         # Set PYTEST_DEBUG_TEMPROOT to our mounted /tmp volume. Any time the
         # pytest `tmp_path` or `tmpdir` fixtures are used used, the temporary


### PR DESCRIPTION
I made sure that the env var gets passed from the container into tox in: https://github.com/dagster-io/dagster/pull/15774

I neglected to make sure that the env var gets passed from the buildkite host into the container. This commit fixes that.