### PR TITLE
[docs] Update bigquery tutorial to use resource and deps in addition to io manager

### DIFF
--- a/docs/content/integrations/bigquery/using-bigquery-with-dagster.mdx
+++ b/docs/content/integrations/bigquery/using-bigquery-with-dagster.mdx
@@ -8,7 +8,8 @@ description: Store your Dagster assets in BigQuery
 This tutorial focuses on creating and interacting with BigQuery tables using Dagster's [software-defined assets (SDAs)](/concepts/assets/software-defined-assets).
 
 The `dagster-gcp` library provides two ways to interact with BigQuery tables:
-- [Resource](/concepts/resources): The resource allows you to directly run SQL queries against tables within an asset's compute function. Available resources: `BigQueryResource `
+
+- [Resource](/concepts/resources): The resource allows you to directly run SQL queries against tables within an asset's compute function. Available resources: ` BigQueryResource  `
 - [I/O manager](/concepts/io-management/io-managers): The I/O manager transfers the responsibility of storing and loading DataFrames as BigQuery tables to Dagster. Available I/O managers: `BigQueryPandasIOManager`, `BigQueryPySparkIOManager`
 
 This tutorial is divided into two sections to demonstrate the differences between the BigQuery resource and the BigQuery I/O manager. Each section will create the same assets, but the first section will use the BigQuery resource to store data in BigQuery, whereas the second section will use the BigQuery I/O manager. When writing your own assets, you may choose one or the other (or both) approaches depending on your storage requirements. See [When to use I/O managers](/concepts/io-management/io-managers#when-to-use-io-managers) to learn more about when to use I/O managers and when to use resources.
@@ -24,7 +25,6 @@ In [Option 2](#option-2-using-the-bigquery-io-manager) you will:
 - Set up and configure the BigQuery I/O manager.
 - Use Pandas to create a DataFrame, then delegate responsibility creating a table to the BigQuery I/O manager.
 - Use the BigQuery I/O manager to load the table into memory so that you can interact with it using the Pandas library.
-
 
 By the end of the tutorial, you will:
 
@@ -54,7 +54,7 @@ To complete this tutorial, you'll need:
 
 ---
 
-# Option 1: Using the BigQuery resource
+## Option 1: Using the BigQuery resource
 
 ### Step 1: Configure the BigQuery resource
 
@@ -228,8 +228,9 @@ defs = Definitions(
 ## Option 2: Using the BigQuery I/O manager
 
 You may want to use an I/O manager to handle storing DataFrames as tables in BigQuery and loading BigQuery tables as DataFrames in downstream assets. You may want to use an I/O manager if:
+
 - You want your data to be loaded in memory so that you can interact with it using Python.
-- You'd like to have Dagster manage how you store the data and load it as an input in downstream assets. 
+- You'd like to have Dagster manage how you store the data and load it as an input in downstream assets.
 
 Using an I/O manager is not required, and you can reference [When to use I/O managers](/concepts/io-management/io-managers#when-to-use-io-managers) to learn more.
 

--- a/docs/content/integrations/bigquery/using-bigquery-with-dagster.mdx
+++ b/docs/content/integrations/bigquery/using-bigquery-with-dagster.mdx
@@ -7,21 +7,24 @@ description: Store your Dagster assets in BigQuery
 
 This tutorial focuses on creating and interacting with BigQuery tables using Dagster's [software-defined assets (SDAs)](/concepts/assets/software-defined-assets).
 
-The `dagster-gcp` library provides two ways to interact with BigQuery tables. The [resource](/concepts/resources) allows you to directly run SQL queries against tables within an asset's compute function. The [I/O manager](/concepts/io-management/io-managers) transfers the responsibility of storing and loading DataFrames as BigQuery tables to Dagster.
+The `dagster-gcp` library provides two ways to interact with BigQuery tables:
+- [Resource](/concepts/resources): The resource allows you to directly run SQL queries against tables within an asset's compute function. Available resources: `BigQueryResource `
+- [I/O manager](/concepts/io-management/io-managers): The I/O manager transfers the responsibility of storing and loading DataFrames as BigQuery tables to Dagster. Available I/O managers: `BigQueryPandasIOManager`, `BigQueryPySparkIOManager`
 
-This tutorial is divided in two parts. Both parts will create the same assets, but how the data is stored in BigQuery will differ. In [Part 1](#part-1-using-the-bigquery-resource) you will:
+This tutorial is divided into two sections to demonstrate the differences between the BigQuery resource and the BigQuery I/O manager. Each section will create the same assets, but the first section will use the BigQuery resource to store data in BigQuery, whereas the second section will use the BigQuery I/O manager. When writing your own assets, you may choose one or the other (or both) approaches depending on your storage requirements. See [When to use I/O managers](/concepts/io-management/io-managers#when-to-use-io-managers) to learn more about when to use I/O managers and when to use resources.
+
+In [Option 1](#option-1-using-the-bigquery-resource) you will:
 
 - Set up and configure the BigQuery resource.
 - Use the BigQuery resource to execute a SQL query to create a table.
 - Use the BigQuery resource to execute a SQL query to interact with the table.
 
-In [Part 2](#part-2-using-the-bigquery-io-manager) you will:
+In [Option 2](#option-2-using-the-bigquery-io-manager) you will:
 
 - Set up and configure the BigQuery I/O manager.
 - Use Pandas to create a DataFrame, then delegate responsibility creating a table to the BigQuery I/O manager.
 - Use the BigQuery I/O manager to load the table into memory so that you can interact with it using the Pandas library.
 
-When writing your own assets, you may choose one or the other (or both) approaches depending on your storage requirements. See [When to use I/O managers](/concepts/io-management/io-managers#when-to-use-io-managers) to learn more.
 
 By the end of the tutorial, you will:
 
@@ -51,7 +54,7 @@ To complete this tutorial, you'll need:
 
 ---
 
-# Part 1: Using the BigQuery resource
+# Option 1: Using the BigQuery resource
 
 ### Step 1: Configure the BigQuery resource
 
@@ -122,11 +125,11 @@ Now you can run `dagster dev` and materialize the `iris_data` asset from the Dag
 
 </TabItem>
 
-<TabItem name="Make existing tables available in Dagster">
+<TabItem name="Making Dagster aware of existing tables">
 
-#### Make existing tables available in Dagster
+#### Making Dagster aware of existing tables
 
-If you already have tables in BigQuery, you may want to have other assets in Dagster depend on those tables. You can accomplish this by creating [source assets](/concepts/assets/software-defined-assets#defining-external-asset-dependencies) for these tables.
+If you already have existing tables in BigQuery and other assets defined in Dagster depend on those tables, you may want Dagster to be aware of those upstream dependencies. Making Dagster aware of these tables will allow you to track the full data lineage in Dagster. You can accomplish this by creating [source assets](/concepts/assets/software-defined-assets#defining-external-asset-dependencies) for these tables.
 
 ```python file=/integrations/bigquery/tutorial/resource/source_asset.py
 from dagster import SourceAsset
@@ -142,7 +145,7 @@ In this example, you're creating a <PyObject object="SourceAsset" /> for a pre-e
 
 ### Step 3: Define downstream assets
 
-Once you have created an asset or source asset that represents a table in BigQuery, you will likely want to create additional assets that work with the data.
+Once you have created an asset that represents a table in BigQuery, you will likely want to create additional assets that work with the data.
 
 ```python file=/integrations/bigquery/tutorial/resource/downstream.py startafter=start_example endbefore=end_example
 from dagster import asset
@@ -222,9 +225,13 @@ defs = Definitions(
 
 ---
 
-## Part 2: Using the BigQuery I/O manager
+## Option 2: Using the BigQuery I/O manager
 
-You may want to use an I/O manager to handle storing DataFrames as tables in BigQuery and loading BigQuery tables as DataFrames in downstream assets. Using an I/O manager is not required, and you can reference [When to use I/O managers](/concepts/io-management/io-managers#when-to-use-io-managers) to learn more.
+You may want to use an I/O manager to handle storing DataFrames as tables in BigQuery and loading BigQuery tables as DataFrames in downstream assets. You may want to use an I/O manager if:
+- You want your data to be loaded in memory so that you can interact with it using Python.
+- You'd like to have Dagster manage how you store the data and load it as an input in downstream assets. 
+
+Using an I/O manager is not required, and you can reference [When to use I/O managers](/concepts/io-management/io-managers#when-to-use-io-managers) to learn more.
 
 This section of the guide focuses on storing and loading Pandas DataFrames in BigQuery, but Dagster also supports using PySpark DataFrames with BigQuery. The concepts from this guide apply to working with PySpark DataFrames, and you can learn more about setting up and using the BigQuery I/O manager with PySpark DataFrames in the [reference guide](/integrations/bigquery/reference).
 
@@ -299,11 +306,11 @@ When Dagster materializes the `iris_data` asset using the configuration from [St
 
 </TabItem>
 
-<TabItem name="Make existing tables available in Dagster">
+<TabItem name="Making Dagster aware of existing tables">
 
-#### Make an existing table available in Dagster
+#### Making Dagster aware of existing tables
 
-You may already have tables in BigQuery that you want to make available to other Dagster assets. You can create [source assets](/concepts/assets/software-defined-assets#defining-external-asset-dependencies) for these tables. By creating a source asset for the existing table, you tell Dagster how to find the table so it can be fetched for downstream assets.
+If you already have existing tables in BigQuery and other assets defined in Dagster depend on those tables, you may want Dagster to be aware of those upstream dependencies. Making Dagster aware of these tables will allow you to track the full data lineage in Dagster. You can create [source assets](/concepts/assets/software-defined-assets#defining-external-asset-dependencies) for these tables. When using an I/O manager, creating a source asset for an existing table also allows you to tell Dagster how to find the table so it can be fetched for downstream assets.
 
 ```python file=/integrations/bigquery/tutorial/io_manager/source_asset.py
 from dagster import SourceAsset
@@ -320,7 +327,7 @@ Because you already supplied the project and dataset in the I/O manager configur
 
 ### Step 3: Load BigQuery tables in downstream assets
 
-Once you have created an asset or source asset that represents a table in BigQuery, you will likely want to create additional assets that work with the data. Dagster and the BigQuery I/O manager allow you to load the data stored in BigQuery tables into downstream assets.
+Once you have created an asset that represents a table in BigQuery, you will likely want to create additional assets that work with the data. Dagster and the BigQuery I/O manager allow you to load the data stored in BigQuery tables into downstream assets.
 
 ```python file=/integrations/bigquery/tutorial/io_manager/load_downstream.py startafter=start_example endbefore=end_example
 import pandas as pd

--- a/docs/content/integrations/bigquery/using-bigquery-with-dagster.mdx
+++ b/docs/content/integrations/bigquery/using-bigquery-with-dagster.mdx
@@ -118,6 +118,8 @@ def iris_data(bigquery: BigQueryResource) -> None:
 
 In this example, you're defining an asset that fetches the Iris dataset as a Pandas DataFrame and renames the columns. Then, using the BigQuery resource, the DataFrame is stored in BigQuery as the `iris.iris_data` table.
 
+Now you can run `dagster dev` and materialize the `iris_data` asset from the Dagster UI.
+
 </TabItem>
 
 <TabItem name="Make existing tables available in Dagster">
@@ -138,7 +140,6 @@ In this example, you're creating a <PyObject object="SourceAsset" /> for a pre-e
 
 </TabGroup>
 
-Now you can run `dagster dev` and materialize the `iris_data` asset from the Dagster UI.
 
 ### Step 3: Define downstream assets
 
@@ -235,7 +236,7 @@ To use the BigQuery I/O manager, you'll need to add it to your `Definitions` obj
 - A `project`
 - One method of authentication. You can follow the GCP authentication instructions [here](https://cloud.google.com/docs/authentication/provide-credentials-adc), or see [Providing credentials as configuration](/integrations/bigquery/reference#providing-credentials-as-configuration) in the BigQuery reference guide.
 
-You can also specify a `location` where data should be stored and processed and `dataset` that should hold the created tables. You can also set a `timeout` and number of `retries` when working with Pandas DataFrames.
+You can also specify a `location` where data should be stored and processed and `dataset` that should hold the created tables. You can also set a `timeout` when working with Pandas DataFrames.
 
 ```python file=/integrations/bigquery/tutorial/io_manager/configuration.py startafter=start_example endbefore=end_example
 from dagster_gcp_pandas import BigQueryPandasIOManager

--- a/docs/content/integrations/bigquery/using-bigquery-with-dagster.mdx
+++ b/docs/content/integrations/bigquery/using-bigquery-with-dagster.mdx
@@ -140,7 +140,6 @@ In this example, you're creating a <PyObject object="SourceAsset" /> for a pre-e
 
 </TabGroup>
 
-
 ### Step 3: Define downstream assets
 
 Once you have created an asset or source asset that represents a table in BigQuery, you will likely want to create additional assets that work with the data.
@@ -272,7 +271,7 @@ The BigQuery I/O manager can create and update tables for your Dagster defined a
 
 #### Store a Dagster asset as a table in BigQuery
 
-To store data in BigQuery using the BigQuery I/O manager,you can simply return a Pandas DataFrame from your asset. Dagster will handle storing and loading your assets in BigQuery.
+To store data in BigQuery using the BigQuery I/O manager, you can simply return a Pandas DataFrame from your asset. Dagster will handle storing and loading your assets in BigQuery.
 
 ```python file=/integrations/bigquery/tutorial/io_manager/basic_example.py
 import pandas as pd

--- a/docs/content/integrations/bigquery/using-bigquery-with-dagster.mdx
+++ b/docs/content/integrations/bigquery/using-bigquery-with-dagster.mdx
@@ -5,16 +5,29 @@ description: Store your Dagster assets in BigQuery
 
 # Using Dagster with Google BigQuery
 
-This tutorial focuses on how to store and load Dagster's [software-defined assets (SDAs)](/concepts/assets/software-defined-assets) in BigQuery.
+This tutorial focuses on creating and interacting with BigQuery tables using Dagster's [software-defined assets (SDAs)](/concepts/assets/software-defined-assets).
+
+The `dagster-gcp` library provides two ways to interact with BigQuery tables. The [resource](/concepts/resources) allows you to directly run SQL queries against tables within an asset's compute function. The [I/O manager](/concepts/io-management/io-managers) transfers the responsibility of storing and loading DataFrames as BigQuery tables to Dagster.
+
+This tutorial is divided in two parts. Both parts will create the same assets, but how the data is stored in BigQuery will differ. In [Part 1](#part-1-using-the-bigquery-resource) you will:
+
+- Set up and configure the BigQuery resource.
+- Use the BigQuery resource to execute a SQL query to create a table.
+- Use the BigQuery resource to execute a SQL query to interact with the table.
+
+In [Part 2](#part-2-using-the-bigquery-io-manager) you will:
+
+- Set up and configure the BigQuery I/O manager.
+- Use Pandas to create a DataFrame, then delegate responsibility creating a table to the BigQuery I/O manager.
+- Use the BigQuery I/O manager to load the table into memory so that you can interact with it using the Pandas library.
+
+When writing your own assets, you may choose one or the other (or both) approaches depending on your storage requirements. See [When to use I/O managers](/concepts/io-management/io-managers#when-to-use-io-managers) to learn more.
 
 By the end of the tutorial, you will:
 
-- Configure a BigQuery I/O manager
-- Create a table in BigQuery using a Dagster asset
-- Make a BigQuery table available in Dagster
-- Load BigQuery tables in downstream assets
-
-This guide focuses on storing and loading Pandas DataFrames in BigQuery. Dagster also supports using PySpark DataFrames with BigQuery. The concepts from this guide apply to working with PySpark DataFrames, and you can learn more about setting up and using the BigQuery I/O manager with PySpark DataFrames in the [reference guide](/integrations/bigquery/reference).
+- Understand how to interact with a BigQuery database using the BigQuery resource.
+- Understand how to use the BigQuery I/O manager to store and load DataFrames as BigQuery tables.
+- Understand how to define dependencies between assets corresponding to tables in a BigQuery database.
 
 ---
 
@@ -34,13 +47,190 @@ To complete this tutorial, you'll need:
 
   - **GCP credentials**: You can authenticate with GCP two ways: by following GCP authentication instructions [here](https://cloud.google.com/docs/authentication/provide-credentials-adc), or by providing credentials directly to the BigQuery I/O manager.
 
-    In this guide, we assume that you have run one of the `gcloud auth` commands or have set `GOOGLE_APPLICATION_CREDENTIALS` as specified in the linked instructions. For more information on providing credentials directly to the BigQuery I/O manager, see [Providing credentials as configuration](/integrations/bigquery/reference#providing-credentials-as-configuration) in the BigQuery reference guide.
+    In this guide, we assume that you have run one of the `gcloud auth` commands or have set `GOOGLE_APPLICATION_CREDENTIALS` as specified in the linked instructions. For more information on providing credentials directly to the BigQuery resource and I/O manager, see [Providing credentials as configuration](/integrations/bigquery/reference#providing-credentials-as-configuration) in the BigQuery reference guide.
 
 ---
 
-## Step 1: Configure the BigQuery I/O manager
+# Part 1: Using the BigQuery resource
 
-The BigQuery I/O manager requires some configuration to connect to your Bigquery instance:
+### Step 1: Configure the BigQuery resource
+
+To use the BigQuery resource, you'll need to add it to your `Definitions` object. The BigQuery resource requires some configuration:
+
+- A `project`
+- One method of authentication. You can follow the GCP authentication instructions [here](https://cloud.google.com/docs/authentication/provide-credentials-adc), or see [Providing credentials as configuration](/integrations/bigquery/reference#providing-credentials-as-configuration) in the BigQuery reference guide.
+
+You can also specify a `location` where computation should take place.
+
+```python file=/integrations/bigquery/tutorial/resource/configuration.py startafter=start_example endbefore=end_example
+from dagster_gcp import BigQueryResource
+
+from dagster import Definitions
+
+defs = Definitions(
+    assets=[iris_data],
+    resources={
+        "bigquery": BigQueryResource(
+            project="my-gcp-project",  # required
+            location="us-east5",  # optional, defaults to the default location for the project - see https://cloud.google.com/bigquery/docs/locations for a list of locations
+        )
+    },
+)
+```
+
+### Step 2: Create tables in BigQuery
+
+<TabGroup>
+
+<TabItem name="Create BigQuery tables in Dagster">
+
+#### Create BigQuery tables in Dagster
+
+Using the BigQuery resource, you can create BigQuery tables using the BigQuery Python API:
+
+```python file=/integrations/bigquery/tutorial/resource/create_table.py startafter=start_example endbefore=end_example
+import pandas as pd
+from dagster_gcp import BigQueryResource
+
+from dagster import asset
+
+
+@asset
+def iris_data(bigquery: BigQueryResource) -> None:
+    iris_df = pd.read_csv(
+        "https://docs.dagster.io/assets/iris.csv",
+        names=[
+            "sepal_length_cm",
+            "sepal_width_cm",
+            "petal_length_cm",
+            "petal_width_cm",
+            "species",
+        ],
+    )
+
+    with bigquery.get_client() as client:
+        job = client.load_table_from_dataframe(
+            dataframe=iris_df,
+            destination="iris.iris_data",
+        )
+        job.result()
+```
+
+In this example, you're defining an asset that fetches the Iris dataset as a Pandas DataFrame and renames the columns. Then, using the BigQuery resource, the DataFrame is stored in BigQuery as the `iris.iris_data` table.
+
+</TabItem>
+
+<TabItem name="Make existing tables available in Dagster">
+
+#### Make existing tables available in Dagster
+
+If you already have tables in BigQuery, you may want to have other assets in Dagster depend on those tables. You can accomplish this by creating [source assets](/concepts/assets/software-defined-assets#defining-external-asset-dependencies) for these tables.
+
+```python file=/integrations/bigquery/tutorial/resource/source_asset.py
+from dagster import SourceAsset
+
+iris_harvest_data = SourceAsset(key="iris_harvest_data")
+```
+
+In this example, you're creating a <PyObject object="SourceAsset" /> for a pre-existing table called `iris_harvest_data`.
+
+</TabItem>
+
+</TabGroup>
+
+Now you can run `dagster dev` and materialize the `iris_data` asset from the Dagster UI.
+
+### Step 3: Define downstream assets
+
+Once you have created an asset or source asset that represents a table in BigQuery, you will likely want to create additional assets that work with the data.
+
+```python file=/integrations/bigquery/tutorial/resource/downstream.py startafter=start_example endbefore=end_example
+from dagster import asset
+
+from .create_table import iris_data
+
+# this example uses the iris_dataset asset from Step 2
+
+
+@asset(deps=[iris_data])
+def iris_setosa(bigquery: BigQueryResource) -> None:
+    job_config = bq.QueryJobConfig(destination="iris.iris_setosa")
+    sql = "SELECT * FROM iris.iris_data WHERE species = 'Iris-setosa'"
+
+    with bigquery.get_client() as client:
+        job = client.query(sql, job_config=job_config)
+        job.result()
+```
+
+In this asset, you're creating second table that only contains the data for the _Iris Setosa_ species. This asset has a dependency on the `iris_data` asset. To define this dependency, you provide the `iris_data` asset as the `deps` parameter to the `iris_setosa` asset. You can then run the SQL query to create the table of _Iris Setosa_ data.
+
+### Completed code example
+
+When finished, your code should look like the following:
+
+```python file=/integrations/bigquery/tutorial/resource/full_example.py
+import pandas as pd
+from dagster_gcp import BigQueryResource
+from google.cloud import bigquery as bq
+
+from dagster import Definitions, SourceAsset, asset
+
+iris_harvest_data = SourceAsset(key="iris_harvest_data")
+
+
+@asset
+def iris_data(bigquery: BigQueryResource) -> None:
+    iris_df = pd.read_csv(
+        "https://docs.dagster.io/assets/iris.csv",
+        names=[
+            "sepal_length_cm",
+            "sepal_width_cm",
+            "petal_length_cm",
+            "petal_width_cm",
+            "species",
+        ],
+    )
+
+    with bigquery.get_client() as client:
+        job = client.load_table_from_dataframe(
+            dataframe=iris_df,
+            destination="iris.iris_data",
+        )
+        job.result()
+
+
+@asset(deps=[iris_data])
+def iris_setosa(bigquery: BigQueryResource) -> None:
+    job_config = bq.QueryJobConfig(destination="iris.iris_setosa")
+    sql = "SELECT * FROM iris.iris_data WHERE species = 'Iris-setosa'"
+
+    with bigquery.get_client() as client:
+        job = client.query(sql, job_config=job_config)
+        job.result()
+
+
+defs = Definitions(
+    assets=[iris_data, iris_setosa, iris_harvest_data],
+    resources={
+        "bigquery": BigQueryResource(
+            project="my-gcp-project",
+            location="us-east5",
+        )
+    },
+)
+```
+
+---
+
+## Part 2: Using the BigQuery I/O manager
+
+You may want to use an I/O manager to handle storing DataFrames as tables in BigQuery and loading BigQuery tables as DataFrames in downstream assets. Using an I/O manager is not required, and you can reference [When to use I/O managers](/concepts/io-management/io-managers#when-to-use-io-managers) to learn more.
+
+This section of the guide focuses on storing and loading Pandas DataFrames in BigQuery, but Dagster also supports using PySpark DataFrames with BigQuery. The concepts from this guide apply to working with PySpark DataFrames, and you can learn more about setting up and using the BigQuery I/O manager with PySpark DataFrames in the [reference guide](/integrations/bigquery/reference).
+
+### Step 1: Configure the BigQuery I/O manager
+
+To use the BigQuery I/O manager, you'll need to add it to your `Definitions` object. The BigQuery I/O manager requires some configuration to connect to your Bigquery instance:
 
 - A `project`
 - One method of authentication. You can follow the GCP authentication instructions [here](https://cloud.google.com/docs/authentication/provide-credentials-adc), or see [Providing credentials as configuration](/integrations/bigquery/reference#providing-credentials-as-configuration) in the BigQuery reference guide.
@@ -71,9 +261,7 @@ Finally, in the <PyObject object="Definitions" /> object, we assign the <PyObjec
 
 For more info about each of the configuration values, refer to the <PyObject module="dagster_gcp_pandas" object="BigQueryPandasIOManager" /> API documentation.
 
----
-
-## Step 2: Create tables in BigQuery
+### Step 2: Create tables in BigQuery
 
 The BigQuery I/O manager can create and update tables for your Dagster defined assets, but you can also make existing BigQuery tables available to Dagster.
 
@@ -81,9 +269,9 @@ The BigQuery I/O manager can create and update tables for your Dagster defined a
 
 <TabItem name="Create tables in BigQuery from Dagster assets">
 
-### Store a Dagster asset as a table in BigQuery
+#### Store a Dagster asset as a table in BigQuery
 
-To store data in BigQuery using the BigQuery I/O manager, the definitions of your assets don't need to change. You can tell Dagster to use the BigQuery I/O manager, like in [Step 1: Configure the BigQuery I/O manager](#step-1-configure-the-bigquery-io-manager), and Dagster will handle storing and loading your assets in BigQuery.
+To store data in BigQuery using the BigQuery I/O manager,you can simply return a Pandas DataFrame from your asset. Dagster will handle storing and loading your assets in BigQuery.
 
 ```python file=/integrations/bigquery/tutorial/io_manager/basic_example.py
 import pandas as pd
@@ -105,7 +293,7 @@ def iris_data() -> pd.DataFrame:
     )
 ```
 
-In this example, we first define our [asset](/concepts/assets/software-defined-assets). Here, we are fetching the Iris dataset as a Pandas DataFrame and renaming the columns. The type signature of the function tells the I/O manager what data type it is working with, so it is important to include the return type `pd.DataFrame`.
+In this example, you're defining an [asset](/concepts/assets/software-defined-assets) that fetches the Iris dataset as a Pandas DataFrame, renames the columns, then returns the DataFrame. The type signature of the function tells the I/O manager what data type it is working with, so it is important to include the return type `pd.DataFrame`.
 
 When Dagster materializes the `iris_data` asset using the configuration from [Step 1: Configure the BigQuery I/O manager](#step-1-configure-the-bigquery-io-manager), the BigQuery I/O manager will create the table `IRIS.IRIS_DATA` if it does not exist and replace the contents of the table with the value returned from the `iris_data` asset.
 
@@ -113,7 +301,7 @@ When Dagster materializes the `iris_data` asset using the configuration from [St
 
 <TabItem name="Make existing tables available in Dagster">
 
-### Make an existing table available in Dagster
+#### Make an existing table available in Dagster
 
 You may already have tables in BigQuery that you want to make available to other Dagster assets. You can create [source assets](/concepts/assets/software-defined-assets#defining-external-asset-dependencies) for these tables. By creating a source asset for the existing table, you tell Dagster how to find the table so it can be fetched for downstream assets.
 
@@ -123,16 +311,14 @@ from dagster import SourceAsset
 iris_harvest_data = SourceAsset(key="iris_harvest_data")
 ```
 
-In this example, we create a <PyObject object="SourceAsset" /> for a pre-existing table - perhaps created by an external data ingestion tool - that contains data about iris harvests. To make the data available to other Dagster assets, we need to tell the BigQuery I/O manager how to find the data.
+In this example, you're creating a <PyObject object="SourceAsset" /> for a pre-existing table - perhaps created by an external data ingestion tool - that contains data about iris harvests. To make the data available to other Dagster assets, you need to tell the BigQuery I/O manager how to find the data, so that the I/O manager can load the data into memory.
 
-Since we supply the project and dataset in the I/O manager configuration in [Step 1: Configure the BigQuery I/O manager](#step-1-configure-the-bigquery-io-manager), we only need to provide the table name. We do this with the `key` parameter in `SourceAsset`. When the I/O manager needs to load the `iris_harvest_data` in a downstream asset, it will select the data in the `IRIS.IRIS_HARVEST_DATA` table as a Pandas DataFrame and provide it to the downstream asset.
+Because you already supplied the project and dataset in the I/O manager configuration in [Step 1: Configure the BigQuery I/O manager](#step-1-configure-the-bigquery-io-manager), you only need to provide the table name. This is done with the `key` parameter in `SourceAsset`. When the I/O manager needs to load the `iris_harvest_data` in a downstream asset, it will select the data in the `IRIS.IRIS_HARVEST_DATA` table as a Pandas DataFrame and provide it to the downstream asset.
 
 </TabItem>
 </TabGroup>
 
----
-
-## Step 3: Load BigQuery tables in downstream assets
+### Step 3: Load BigQuery tables in downstream assets
 
 Once you have created an asset or source asset that represents a table in BigQuery, you will likely want to create additional assets that work with the data. Dagster and the BigQuery I/O manager allow you to load the data stored in BigQuery tables into downstream assets.
 
@@ -145,19 +331,15 @@ from dagster import asset
 
 
 @asset
-def iris_cleaned(iris_data: pd.DataFrame) -> pd.DataFrame:
-    return iris_data.dropna().drop_duplicates()
+def iris_setosa(iris_data: pd.DataFrame) -> pd.DataFrame:
+    return iris_data[iris_data["species"] == "Iris-setosa"]
 ```
 
-In this example, we want to provide the `iris_data` asset from the [Store a Dagster asset as a table in BigQuery](#store-a-dagster-asset-as-a-table-in-bigquery) example to the `iris_cleaned` asset.
+In this asset, you're providing the `iris_data` asset from the [Store a Dagster asset as a table in BigQuery](#store-a-dagster-asset-as-a-table-in-bigquery) example to the `iris_setosa` asset.
 
-In `iris_cleaned`, the `iris_data` parameter tells Dagster that the value for the `iris_data` asset should be provided as input to `iris_cleaned`. If this feels too magical for you, refer to the [docs for explicitly specifying dependencies](/concepts/assets/software-defined-assets#defining-explicit-managed-loading-dependencies).
+In this asset, you're providing the `iris_data` asset as a dependency to `iris_setosa`. By supplying `iris_data` as a parameter to `iris_setosa`, Dagster knows to use the `BigQueryPandasIOManager` to load this asset into memory as a Pandas DataFrame and pass it as an argument to `iris_setosa`. Next, a DataFrame that only contains the data for the _Iris Setosa_ species is created and returned. Then the `BigQueryPandasIOManager` will store the DataFrame as the `IRIS.IRIS_SETOSA` table in BigQuery.
 
-When materializing these assets, Dagster will use the `BigQueryPandasIOManager` to fetch the `IRIS.IRIS_DATA` as a Pandas DataFrame and pass this DataFrame as the `iris_data` parameter to `iris_cleaned`. When `iris_cleaned` returns a Pandas DataFrame, Dagster will use the `BigQueryPandasIOManager` to store the DataFrame as the `IRIS.IRIS_CLEANED` table in BigQuery.
-
----
-
-## Completed code example
+### Completed code example
 
 When finished, your code should look like the following:
 
@@ -185,12 +367,12 @@ def iris_data() -> pd.DataFrame:
 
 
 @asset
-def iris_cleaned(iris_data: pd.DataFrame) -> pd.DataFrame:
-    return iris_data.dropna().drop_duplicates()
+def iris_setosa(iris_data: pd.DataFrame) -> pd.DataFrame:
+    return iris_data[iris_data["species"] == "Iris-setosa"]
 
 
 defs = Definitions(
-    assets=[iris_data, iris_harvest_data, iris_cleaned],
+    assets=[iris_data, iris_harvest_data, iris_setosa],
     resources={
         "io_manager": BigQueryPandasIOManager(
             project="my-gcp-project",

--- a/examples/docs_snippets/docs_snippets/integrations/bigquery/tutorial/io_manager/full_example.py
+++ b/examples/docs_snippets/docs_snippets/integrations/bigquery/tutorial/io_manager/full_example.py
@@ -21,12 +21,12 @@ def iris_data() -> pd.DataFrame:
 
 
 @asset
-def iris_cleaned(iris_data: pd.DataFrame) -> pd.DataFrame:
-    return iris_data.dropna().drop_duplicates()
+def iris_setosa(iris_data: pd.DataFrame) -> pd.DataFrame:
+    return iris_data[iris_data["species"] == "Iris-setosa"]
 
 
 defs = Definitions(
-    assets=[iris_data, iris_harvest_data, iris_cleaned],
+    assets=[iris_data, iris_harvest_data, iris_setosa],
     resources={
         "io_manager": BigQueryPandasIOManager(
             project="my-gcp-project",

--- a/examples/docs_snippets/docs_snippets/integrations/bigquery/tutorial/io_manager/load_downstream.py
+++ b/examples/docs_snippets/docs_snippets/integrations/bigquery/tutorial/io_manager/load_downstream.py
@@ -10,8 +10,8 @@ from dagster import asset
 
 
 @asset
-def iris_cleaned(iris_data: pd.DataFrame) -> pd.DataFrame:
-    return iris_data.dropna().drop_duplicates()
+def iris_setosa(iris_data: pd.DataFrame) -> pd.DataFrame:
+    return iris_data[iris_data["species"] == "Iris-setosa"]
 
 
 # end_example

--- a/examples/docs_snippets/docs_snippets/integrations/bigquery/tutorial/resource/configuration.py
+++ b/examples/docs_snippets/docs_snippets/integrations/bigquery/tutorial/resource/configuration.py
@@ -1,0 +1,26 @@
+from dagster import asset
+
+
+@asset
+def iris_data():
+    return None
+
+
+# start_example
+
+from dagster_gcp import BigQueryResource
+
+from dagster import Definitions
+
+defs = Definitions(
+    assets=[iris_data],
+    resources={
+        "bigquery": BigQueryResource(
+            project="my-gcp-project",  # required
+            location="us-east5",  # optional, defaults to the default location for the project - see https://cloud.google.com/bigquery/docs/locations for a list of locations
+        )
+    },
+)
+
+
+# end_example

--- a/examples/docs_snippets/docs_snippets/integrations/bigquery/tutorial/resource/create_table.py
+++ b/examples/docs_snippets/docs_snippets/integrations/bigquery/tutorial/resource/create_table.py
@@ -1,0 +1,29 @@
+# start_example
+import pandas as pd
+from dagster_gcp import BigQueryResource
+
+from dagster import asset
+
+
+@asset
+def iris_data(bigquery: BigQueryResource) -> None:
+    iris_df = pd.read_csv(
+        "https://docs.dagster.io/assets/iris.csv",
+        names=[
+            "sepal_length_cm",
+            "sepal_width_cm",
+            "petal_length_cm",
+            "petal_width_cm",
+            "species",
+        ],
+    )
+
+    with bigquery.get_client() as client:
+        job = client.load_table_from_dataframe(
+            dataframe=iris_df,
+            destination="iris.iris_data",
+        )
+        job.result()
+
+
+# end_example

--- a/examples/docs_snippets/docs_snippets/integrations/bigquery/tutorial/resource/downstream.py
+++ b/examples/docs_snippets/docs_snippets/integrations/bigquery/tutorial/resource/downstream.py
@@ -1,0 +1,22 @@
+from dagster_gcp import BigQueryResource
+from google.cloud import bigquery as bq
+
+# start_example
+from dagster import asset
+
+from .create_table import iris_data
+
+# this example uses the iris_dataset asset from Step 2
+
+
+@asset(deps=[iris_data])
+def iris_setosa(bigquery: BigQueryResource) -> None:
+    job_config = bq.QueryJobConfig(destination="iris.iris_setosa")
+    sql = "SELECT * FROM iris.iris_data WHERE species = 'Iris-setosa'"
+
+    with bigquery.get_client() as client:
+        job = client.query(sql, job_config=job_config)
+        job.result()
+
+
+# end_example

--- a/examples/docs_snippets/docs_snippets/integrations/bigquery/tutorial/resource/full_example.py
+++ b/examples/docs_snippets/docs_snippets/integrations/bigquery/tutorial/resource/full_example.py
@@ -1,0 +1,49 @@
+import pandas as pd
+from dagster_gcp import BigQueryResource
+from google.cloud import bigquery as bq
+
+from dagster import Definitions, SourceAsset, asset
+
+iris_harvest_data = SourceAsset(key="iris_harvest_data")
+
+
+@asset
+def iris_data(bigquery: BigQueryResource) -> None:
+    iris_df = pd.read_csv(
+        "https://docs.dagster.io/assets/iris.csv",
+        names=[
+            "sepal_length_cm",
+            "sepal_width_cm",
+            "petal_length_cm",
+            "petal_width_cm",
+            "species",
+        ],
+    )
+
+    with bigquery.get_client() as client:
+        job = client.load_table_from_dataframe(
+            dataframe=iris_df,
+            destination="iris.iris_data",
+        )
+        job.result()
+
+
+@asset(deps=[iris_data])
+def iris_setosa(bigquery: BigQueryResource) -> None:
+    job_config = bq.QueryJobConfig(destination="iris.iris_setosa")
+    sql = "SELECT * FROM iris.iris_data WHERE species = 'Iris-setosa'"
+
+    with bigquery.get_client() as client:
+        job = client.query(sql, job_config=job_config)
+        job.result()
+
+
+defs = Definitions(
+    assets=[iris_data, iris_setosa, iris_harvest_data],
+    resources={
+        "bigquery": BigQueryResource(
+            project="my-gcp-project",
+            location="us-east5",
+        )
+    },
+)

--- a/examples/docs_snippets/docs_snippets/integrations/bigquery/tutorial/resource/source_asset.py
+++ b/examples/docs_snippets/docs_snippets/integrations/bigquery/tutorial/resource/source_asset.py
@@ -1,0 +1,3 @@
+from dagster import SourceAsset
+
+iris_harvest_data = SourceAsset(key="iris_harvest_data")


### PR DESCRIPTION
## Summary & Motivation
Updates the BigQuery tutorial to introduce the non-io manager workflow (a la the duckdb tutorial rework in #15531) 

## How I Tested These Changes
