### PR TITLE
[docs] - Use correct example for GCSComputeLogMananger

### DIFF
--- a/docs/content/deployment/dagster-instance.mdx
+++ b/docs/content/deployment/dagster-instance.mdx
@@ -618,33 +618,24 @@ compute_logs:
 
 The <PyObject module="dagster_gcp.gcs" object="GCSComputeLogManager" /> writes `stdout` and `stderr` to Google Cloud Storage.
 
-```yaml file=/deploying/dagster_instance/dagster.yaml startafter=start_marker_compute_log_storage_blob endbefore=end_marker_compute_log_storage_blob
-# there are multiple ways to configure the AzureBlobComputeLogManager
+```yaml file=/deploying/dagster_instance/dagster.yaml startafter=start_marker_compute_log_storage_gcs endbefore=end_marker_compute_log_storage_gcs
+# there are multiple ways to configure the GCSComputeLogManager
 
 # you can set the necessary configuration values directly:
 compute_logs:
-  module: dagster_azure.blob.compute_log_manager
-  class: AzureBlobComputeLogManager
+  module: dagster_gcp.gcs.compute_log_manager
+  class: GCSComputeLogManager
   config:
-    storage_account: mycorp-dagster
-    container: compute-logs
-    secret_key: foo
-    local_dir: /tmp/bar
+    bucket: mycorp-dagster-compute-logs
     prefix: dagster-test-
 
 # alternatively, you can obtain any of these config values from environment variables
 compute_logs:
-  module: dagster_azure.blob.compute_log_manager
-  class: AzureBlobComputeLogManager
+  module: dagster_gcp.gcs.compute_log_manager
+  class: GCSComputeLogManager
   config:
-    storage_account:
-      env: MYCORP_DAGSTER_STORAGE_ACCOUNT_NAME
-    container:
-      env: CONTAINER_NAME
-    secret_key:
-      env: SECRET_KEY
-    local_dir:
-      env: LOCAL_DIR_PATH
+    bucket:
+      env: MYCORP_DAGSTER_COMPUTE_LOGS_BUCKET
     prefix:
       env: DAGSTER_COMPUTE_LOG_PREFIX
 ```


### PR DESCRIPTION
## Summary & Motivation

This PR corrects the example used for the `GCSComputeLogManager` in the Dagster Instance reference. Came from [user feedback](https://dagster.slack.com/archives/C01U954MEER/p1691684502331899).

## How I Tested These Changes

👀 