### PR TITLE
in upstream assets section of dbt tutorial, use list for asset key

### DIFF
--- a/docs/content/integrations/dbt/using-dbt-with-dagster/upstream-assets.mdx
+++ b/docs/content/integrations/dbt/using-dbt-with-dagster/upstream-assets.mdx
@@ -118,7 +118,7 @@ defs = Definitions(
          - name: raw_customers
            meta:
              dagster:
-               asset_key: raw_customers
+               asset_key: ["raw_customers"]
    ```
 
 This is a standard dbt source definition, with one addition: it includes metadata, under the `meta` property, that specifies the Dagster asset that it corresponds to. When Dagster reads the contents of the dbt project, it reads this metadata and infers the correspondence. For any dbt model that depends on this dbt source, Dagster then knows that the Dagster asset corresponding to the dbt model should depend on the Dagster asset corresponding to the source.


### PR DESCRIPTION
## Summary & Motivation

When users want to use asset keys with prefixes, this makes it more clear how to do so.

## How I Tested These Changes
