### PR TITLE
[ui] LS key migration fixes

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppProvider.tsx
@@ -122,10 +122,11 @@ export const AppProvider: React.FC<AppProviderProps> = (props) => {
     statusPolling,
   } = config;
 
+  // todo dish: Change `deleteExisting` to true soon. (Current: 1.4.5)
   React.useEffect(() => {
-    migrateLocalStorageKeys({from: /DAGIT_FLAGS/g, to: 'DAGSTER_FLAGS'});
-    migrateLocalStorageKeys({from: /:dagit/gi, to: ':dagster'});
-    migrateLocalStorageKeys({from: /^dagit(\.v2)?/gi, to: 'dagster'});
+    migrateLocalStorageKeys({from: /DAGIT_FLAGS/g, to: 'DAGSTER_FLAGS', deleteExisting: false});
+    migrateLocalStorageKeys({from: /:dagit/gi, to: ':dagster', deleteExisting: false});
+    migrateLocalStorageKeys({from: /^dagit(\.v2)?/gi, to: 'dagster', deleteExisting: false});
   }, []);
 
   const graphqlPath = `${basePath}/graphql`;

--- a/js_modules/dagster-ui/packages/ui-core/src/app/__tests__/migrateLocalStorageKeys.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/__tests__/migrateLocalStorageKeys.test.tsx
@@ -37,4 +37,28 @@ describe('migrateLocalStorageKeys', () => {
     migrateLocalStorageKeys({from: /foo/gi, to: 'baz'});
     expect(window.localStorage.getItem('bar')).toBe('foo');
   });
+
+  it('does not overwrite newly written keys with old values', () => {
+    window.localStorage.setItem('foo', 'hello');
+    expect(window.localStorage.getItem('foo')).toBe('hello');
+    migrateLocalStorageKeys({from: /foo/gi, to: 'bar'});
+    expect(window.localStorage.getItem('foo')).toBe('hello');
+    expect(window.localStorage.getItem('bar')).toBe('hello');
+
+    window.localStorage.setItem('foo', 'updated old key');
+    migrateLocalStorageKeys({from: /foo/gi, to: 'bar'});
+
+    // Old key is updated
+    expect(window.localStorage.getItem('foo')).toBe('updated old key');
+    // New key already existed, remains unchanged
+    expect(window.localStorage.getItem('bar')).toBe('hello');
+  });
+
+  it('deletes existing key, if option is used', () => {
+    window.localStorage.setItem('foo', 'hello');
+    expect(window.localStorage.getItem('foo')).toBe('hello');
+    migrateLocalStorageKeys({from: /foo/gi, to: 'bar', deleteExisting: true});
+    expect(window.localStorage.getItem('foo')).toBe(null);
+    expect(window.localStorage.getItem('bar')).toBe('hello');
+  });
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/app/migrateLocalStorageKeys.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/migrateLocalStorageKeys.tsx
@@ -1,8 +1,26 @@
-export const migrateLocalStorageKeys = ({from, to}: {from: RegExp; to: string}) => {
+type Input = {
+  from: RegExp;
+  to: string;
+  deleteExisting?: boolean;
+};
+
+export const migrateLocalStorageKeys = ({from, to, deleteExisting = false}: Input) => {
   Object.entries(window.localStorage).forEach(([key, value]) => {
     if (from.test(key)) {
       const newKey = key.replaceAll(from, to);
-      window.localStorage.setItem(newKey, value);
+
+      // If the new key doesn't exist yet, write it.
+      if (window.localStorage.getItem(newKey) === null) {
+        try {
+          window.localStorage.setItem(newKey, value);
+        } catch (e) {
+          // Failed to write. Probably a QuotaExceededError.
+        }
+      }
+
+      if (deleteExisting) {
+        window.localStorage.removeItem(key);
+      }
     }
   });
 };


### PR DESCRIPTION
## Summary & Motivation

Try to fix a couple of possible issues with localStorage key migration.

- Since we're not deleting old keys (because the user might revert to an old version, or if we were to have to revert on Cloud), we're effectively doubling the storage used by the affected key-value pairs. This means users might hit quota errors on write. Wrap the `setItem` in a try-catch so that these are less noisy.
- If the new key already exists, we're already done -- don't waste time writing it again. (I was thinking that this could be an issue in the revert case, since the revert state could end up overwriting the new-key state. But I think that's not actually a problem, since anything being done in the revert state is probably intended and *should* overwrite any new keys once the user is able to move forward with the new version.)
- Add a `deleteExisting` flag to the migration function. This gives me a switch to flip once we're ready to clean up old keys.

## How I Tested These Changes

Jest
