### PR TITLE
docs(dbt): fix custom asset key example

### DIFF
--- a/docs/content/integrations/dbt/reference.mdx
+++ b/docs/content/integrations/dbt/reference.mdx
@@ -216,7 +216,7 @@ manifest_path = Path("path/to/dbt_project/target/manifest.json")
 
 class CustomDagsterDbtTranslator(DagsterDbtTranslator):
     def get_asset_key(self, dbt_resource_props: Mapping[str, Any]) -> AssetKey:
-        return self.get_asset_key(dbt_resource_props).with_prefix("snowflake")
+        return super().get_asset_key(dbt_resource_props).with_prefix("snowflake")
 
 @dbt_assets(
     manifest=manifest_path,

--- a/examples/docs_snippets/docs_snippets/integrations/dbt/dbt.py
+++ b/examples/docs_snippets/docs_snippets/integrations/dbt/dbt.py
@@ -236,7 +236,7 @@ def scope_custom_asset_key_dagster_dbt_translator():
 
     class CustomDagsterDbtTranslator(DagsterDbtTranslator):
         def get_asset_key(self, dbt_resource_props: Mapping[str, Any]) -> AssetKey:
-            return self.get_asset_key(dbt_resource_props).with_prefix("snowflake")
+            return super().get_asset_key(dbt_resource_props).with_prefix("snowflake")
 
     @dbt_assets(
         manifest=manifest_path,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
@@ -55,7 +55,25 @@ class DagsterDbtTranslator:
                 class CustomDagsterDbtTranslator(DagsterDbtTranslator):
                     @classmethod
                     def get_asset_key(cls, dbt_resource_props: Mapping[str, Any]) -> AssetKey:
-                        return AssetKey([dbt_resource_props["alias"]]).with_prefix("prefix")
+                        return super().get_asset_key(dbt_resource_props).with_prefix("prefix")
+
+            .. code-block:: python
+
+                from typing import Any, Mapping
+
+                from dagster import AssetKey
+                from dagster_dbt import DagsterDbtTranslator
+
+
+                class CustomDagsterDbtTranslator(DagsterDbtTranslator):
+                    @classmethod
+                    def get_asset_key(cls, dbt_resource_props: Mapping[str, Any]) -> AssetKey:
+                        asset_key = super().get_asset_key(dbt_resource_props)
+
+                        if dbt_resource_props["resource_type"] == "source":
+                            asset_key = asset_key.with_prefix("my_prefix")
+
+                        return asset_key
         """
         return default_asset_key_fn(dbt_resource_props)
 


### PR DESCRIPTION
## Summary & Motivation
Use `super()` instead of `self` to prevent recursive spiral.

Also add another example in the API docs to show how to add custom asset keys for only sources.

## How I Tested These Changes
N/A
