### PR TITLE
feat(helm): allow templatable strings in docker image and tag definitions

### DIFF
--- a/helm/dagster/charts/dagster-user-deployments/templates/helpers/_helpers.tpl
+++ b/helm/dagster/charts/dagster-user-deployments/templates/helpers/_helpers.tpl
@@ -33,8 +33,8 @@ If release name contains chart name it will be used as a full name.
 
   {{- with index . 1 }}
     {{- /* Filter the tag to parse strings, string integers, and string floats. */}}
-    {{- $tag := .tag | default $.Chart.Version | toYaml | trimAll "\"" }}
-    {{- printf "%s:%s" .repository $tag }}
+    {{- $tag := tpl (.tag | default $.Chart.Version | toYaml | trimAll "\"") $ }}
+    {{- printf "%s:%s" (tpl .repository $) $tag }}
   {{- end }}
 {{- end }}
 

--- a/helm/dagster/templates/helpers/_helpers.tpl
+++ b/helm/dagster/templates/helpers/_helpers.tpl
@@ -35,8 +35,8 @@ If release name contains chart name it will be used as a full name.
 
   {{- with index . 1 }}
     {{- /* Filter the tag to parse strings, string integers, and string floats. */}}
-    {{- $tag := .tag | default $.Chart.Version | toYaml | trimAll "\"" }}
-    {{- printf "%s:%s" .repository $tag }}
+    {{- $tag := tpl (.tag | default $.Chart.Version | toYaml | trimAll "\"") $ }}
+    {{- printf "%s:%s" (tpl .repository $) $tag }}
   {{- end }}
 {{- end }}
 


### PR DESCRIPTION
## Summary & Motivation
This PR adds the rending of the docker image parameters (tag and repository), in order to allow people to use variables in the image/tag definitions when setting their values.yaml

## How I Tested These Changes
Mainly using different values.yaml definition with literals and variables and testing the templating using `helm template .` command, the helm version used being 
`version.BuildInfo{Version:"v3.12.2", GitCommit:"1e210a2c8cc5117d1055bfaa5d40f51bbc2e345e", GitTreeState:"clean", GoVersion:"go1.20.6"}`