### PR TITLE
[brownfield-essentials] Revision to ExternalExecutionContext

### DIFF
--- a/python_modules/dagster-external/dagster_external/__init__.py
+++ b/python_modules/dagster-external/dagster_external/__init__.py
@@ -3,8 +3,5 @@ from dagster_external.context import (
     init_dagster_external as init_dagster_external,
 )
 from dagster_external.protocol import (
-    ExternalDataProvenance as ExternalDataProvenance,
     ExternalExecutionContextData as ExternalExecutionContextData,
-    ExternalPartitionKeyRange as ExternalPartitionKeyRange,
-    ExternalTimeWindow as ExternalTimeWindow,
 )

--- a/python_modules/dagster-external/dagster_external/protocol.py
+++ b/python_modules/dagster-external/dagster_external/protocol.py
@@ -1,8 +1,8 @@
-from typing import Any, Mapping, Optional
+from typing import Any, Mapping, Optional, Sequence
 
 from typing_extensions import Final, TypeAlias, TypedDict
 
-ExternalExecutionUserdata: TypeAlias = Mapping[str, Any]
+ExternalExecutionExtras: TypeAlias = Mapping[str, Any]
 
 DAGSTER_EXTERNAL_DEFAULT_PORT: Final = 9716
 DAGSTER_EXTERNAL_DEFAULT_INPUT_FILENAME: Final = "dagster_external_input"
@@ -29,17 +29,16 @@ class Notification(TypedDict):
 
 
 class ExternalExecutionContextData(TypedDict):
-    asset_key: str
-    code_version: Optional[str]
-    data_provenance: Optional["ExternalDataProvenance"]
+    asset_keys: Optional[Sequence[str]]
+    code_version_by_asset_key: Optional[Mapping[str, Optional[str]]]
+    provenance_by_asset_key: Optional[Mapping[str, Optional["ExternalDataProvenance"]]]
     partition_key: Optional[str]
     partition_key_range: Optional["ExternalPartitionKeyRange"]
     partition_time_window: Optional["ExternalTimeWindow"]
     run_id: str
-    run_tags: Mapping[str, str]
     job_name: str
     retry_number: int
-    userdata: Mapping[str, Any]
+    extras: Mapping[str, Any]
 
 
 class ExternalPartitionKeyRange(TypedDict):

--- a/python_modules/dagster-external/dagster_external/util.py
+++ b/python_modules/dagster-external/dagster_external/util.py
@@ -1,0 +1,79 @@
+import json
+from typing import Any, Optional, Sequence, TypeVar
+
+from dagster_external.protocol import ExternalExecutionContextData, ExternalExecutionExtras
+
+T = TypeVar("T")
+
+
+class DagsterExternalError(Exception):
+    pass
+
+
+def assert_not_none(value: Optional[T], desc: Optional[str] = None) -> T:
+    if value is None:
+        raise DagsterExternalError(f"Missing required property: {desc}")
+    return value
+
+
+def assert_defined_asset_property(value: Optional[T], key: str) -> T:
+    return assert_not_none(value, f"`{key}` is undefined. Current step does not target an asset.")
+
+
+# This should only be called under the precondition that the current steps targets assets.
+def assert_single_asset(data: ExternalExecutionContextData, key: str) -> None:
+    asset_keys = data["asset_keys"]
+    assert asset_keys is not None
+    if len(asset_keys) != 1:
+        raise DagsterExternalError(f"`{key}` is undefined. Current step targets multiple assets.")
+
+
+def assert_defined_partition_property(value: Optional[T], key: str) -> T:
+    return assert_not_none(
+        value, f"`{key}` is undefined. Current step does not target any partitions."
+    )
+
+
+# This should only be called under the precondition that the current steps targets assets.
+def assert_single_partition(data: ExternalExecutionContextData, key: str) -> None:
+    partition_key_range = data["partition_key_range"]
+    assert partition_key_range is not None
+    if partition_key_range["start"] != partition_key_range["end"]:
+        raise DagsterExternalError(
+            f"`{key}` is undefined. Current step targets multiple partitions."
+        )
+
+
+def assert_defined_extra(extras: ExternalExecutionExtras, key: str) -> Any:
+    if key not in extras:
+        raise DagsterExternalError(f"Extra `{key}` is undefined. Extras must be provided by user.")
+    return extras[key]
+
+
+def assert_param_type(value: T, expected_type: Any, method: str, param: str) -> T:
+    if not isinstance(value, expected_type):
+        raise DagsterExternalError(
+            f"Invalid type for parameter `{param}` of `{method}`. Expected `{expected_type}`, got"
+            f" `{type(value)}`."
+        )
+    return value
+
+
+def assert_param_value(value: T, expected_values: Sequence[T], method: str, param: str) -> T:
+    if value not in expected_values:
+        raise DagsterExternalError(
+            f"Invalid value for parameter `{param}` of `{method}`. Expected one of"
+            f" `{expected_values}`, got `{value}`."
+        )
+    return value
+
+
+def assert_param_json_serializable(value: T, method: str, param: str) -> T:
+    try:
+        json.dumps(value)
+    except (TypeError, OverflowError):
+        raise DagsterExternalError(
+            f"Invalid type for parameter `{param}` of `{method}`. Expected a JSON-serializable"
+            f" type, got `{type(value)}`."
+        )
+    return value

--- a/python_modules/dagster-external/dagster_external_tests/test_context.py
+++ b/python_modules/dagster-external/dagster_external_tests/test_context.py
@@ -1,0 +1,141 @@
+from unittest.mock import MagicMock
+
+import pytest
+from dagster_external.context import ExternalExecutionContext
+from dagster_external.protocol import (
+    ExternalDataProvenance,
+    ExternalExecutionContextData,
+    ExternalPartitionKeyRange,
+    ExternalTimeWindow,
+)
+from dagster_external.util import DagsterExternalError
+
+TEST_EXTERNAL_EXECUTION_CONTEXT_DEFAULTS = ExternalExecutionContextData(
+    asset_keys=None,
+    code_version_by_asset_key=None,
+    provenance_by_asset_key=None,
+    partition_key=None,
+    partition_key_range=None,
+    partition_time_window=None,
+    job_name="foo_job",
+    run_id="123",
+    retry_number=1,
+    extras={},
+)
+
+
+def _make_external_execution_context(**kwargs):
+    kwargs = {**TEST_EXTERNAL_EXECUTION_CONTEXT_DEFAULTS, **kwargs}
+    return ExternalExecutionContext(
+        data=ExternalExecutionContextData(**kwargs),
+        output_stream=MagicMock(),
+    )
+
+
+def _assert_undefined(context, key) -> None:
+    with pytest.raises(DagsterExternalError, match=f"`{key}` is undefined"):
+        getattr(context, key)
+
+
+def test_no_asset_context():
+    context = _make_external_execution_context()
+
+    assert not context.is_asset_step
+    _assert_undefined(context, "asset_key")
+    _assert_undefined(context, "asset_keys")
+    _assert_undefined(context, "code_version")
+    _assert_undefined(context, "code_version_by_asset_key")
+    _assert_undefined(context, "provenance")
+    _assert_undefined(context, "provenance_by_asset_key")
+
+
+def test_single_asset_context():
+    foo_provenance = ExternalDataProvenance(
+        code_version="alpha", input_data_versions={"bar": "baz"}, is_user_provided=False
+    )
+
+    context = _make_external_execution_context(
+        asset_keys=["foo"],
+        code_version_by_asset_key={"foo": "beta"},
+        provenance_by_asset_key={"foo": foo_provenance},
+    )
+
+    assert context.is_asset_step
+    assert context.asset_key == "foo"
+    assert context.asset_keys == ["foo"]
+    assert context.code_version == "beta"
+    assert context.code_version_by_asset_key == {"foo": "beta"}
+    assert context.provenance == foo_provenance
+    assert context.provenance_by_asset_key == {"foo": foo_provenance}
+
+
+def test_multi_asset_context():
+    foo_provenance = ExternalDataProvenance(
+        code_version="alpha", input_data_versions={"bar": "baz"}, is_user_provided=False
+    )
+    bar_provenance = None
+
+    context = _make_external_execution_context(
+        asset_keys=["foo", "bar"],
+        code_version_by_asset_key={"foo": "beta", "bar": "gamma"},
+        provenance_by_asset_key={
+            "foo": foo_provenance,
+            "bar": bar_provenance,
+        },
+    )
+
+    assert context.is_asset_step
+    _assert_undefined(context, "asset_key")
+    assert context.asset_keys == ["foo", "bar"]
+    _assert_undefined(context, "code_version")
+    assert context.code_version_by_asset_key == {"foo": "beta", "bar": "gamma"}
+    _assert_undefined(context, "provenance")
+    assert context.provenance_by_asset_key == {"foo": foo_provenance, "bar": bar_provenance}
+
+
+def test_no_partition_context():
+    context = _make_external_execution_context()
+
+    assert not context.is_partition_step
+    _assert_undefined(context, "partition_key")
+    _assert_undefined(context, "partition_key_range")
+    _assert_undefined(context, "partition_time_window")
+
+
+def test_single_partition_context():
+    partition_key_range = ExternalPartitionKeyRange(start="foo", end="foo")
+
+    context = _make_external_execution_context(
+        partition_key="foo",
+        partition_key_range=partition_key_range,
+        partition_time_window=None,
+    )
+
+    assert context.is_partition_step
+    assert context.partition_key == "foo"
+    assert context.partition_key_range == partition_key_range
+    assert context.partition_time_window is None
+
+
+def test_multiple_partition_context():
+    partition_key_range = ExternalPartitionKeyRange(start="2023-01-01", end="2023-01-02")
+    time_window = ExternalTimeWindow(start="2023-01-01", end="2023-01-02")
+
+    context = _make_external_execution_context(
+        partition_key=None,
+        partition_key_range=partition_key_range,
+        partition_time_window=time_window,
+    )
+
+    assert context.is_partition_step
+    _assert_undefined(context, "partition_key")
+    assert context.partition_key_range == partition_key_range
+    assert context.partition_time_window == time_window
+
+
+def test_extras_context():
+    context = _make_external_execution_context(extras={"foo": "bar"})
+
+    assert context.get_extra("foo") == "bar"
+    with pytest.raises(DagsterExternalError, match="Extra `bar` is undefined"):
+        context.get_extra("bar")

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
@@ -506,16 +506,25 @@ def _get_output_asset_materializations(
         assert isinstance(output, Output)
         code_version = _get_code_version(asset_key, step_context)
         input_provenance_data = _get_input_provenance_data(asset_key, step_context)
+        cached_data_version = (
+            step_context.get_data_version(asset_key)
+            if step_context.has_data_version(asset_key)
+            else None
+        )
+        user_provided_data_version = output.data_version or cached_data_version
         data_version = (
             compute_logical_data_version(
                 code_version,
                 {k: meta["data_version"] for k, meta in input_provenance_data.items()},
             )
-            if output.data_version is None
-            else output.data_version
+            if user_provided_data_version is None
+            else user_provided_data_version
         )
         tags = _build_data_version_tags(
-            data_version, code_version, input_provenance_data, output.data_version is not None
+            data_version,
+            code_version,
+            input_provenance_data,
+            user_provided_data_version is not None,
         )
         if not step_context.has_data_version(asset_key):
             data_version = DataVersion(tags[DATA_VERSION_TAG])

--- a/python_modules/dagster/dagster/_core/external_execution/resource.py
+++ b/python_modules/dagster/dagster/_core/external_execution/resource.py
@@ -1,6 +1,6 @@
 from typing import Dict, Optional, Sequence, Union
 
-from dagster_external.protocol import ExternalExecutionUserdata
+from dagster_external.protocol import ExternalExecutionExtras
 from pydantic import Field
 
 from dagster._config.pythonic_config import ConfigurableResource
@@ -34,12 +34,12 @@ class ExternalExecutionResource(ConfigurableResource):
         self,
         command: Union[str, Sequence[str]],
         context: OpExecutionContext,
-        userdata: ExternalExecutionUserdata,
+        extras: ExternalExecutionExtras,
     ) -> None:
         return_code = ExternalExecutionTask(
             command=command,
             context=context,
-            userdata=userdata,
+            extras=extras,
             env=self.env,
             input_mode=self.input_mode,
             output_mode=self.output_mode,


### PR DESCRIPTION
## Summary & Motivation

Relevant Slack: https://elementl-workspace.slack.com/archives/C05M31J51J6/p1691782289350449

- Add `DagsterExternalError` class used to represent all errors (currently just data validation) issued by `DagsterExternal`
- Add runtime type checks to `ExternalExecutionContext` reporting methods (e.g. `report_asset_metadata`)
- Add plural forms of asset-related properties to `ExternalExecutionContext`:
    - `asset_key` -> `asset_keys`
    - `code_version` -> `code_versions_by_asset_key`
    - `provenance` -> `provenance_by_asset_key`
- Add predicates to classify `ExternalExecutionContext`
    - `is_asset_step`: is at least one asset key defined
    - `is_partition_step`: is at least one partition key defined
- Add guarded access to relevant `ExternalExecutionContext` properties:
    - Single-asset property (e.g. `asset_key`) access throws an error for context with no or multiple asset keys.
    - Multi-asset property (e.g. `asset_keys`) access throws an error for context with no asset keys.
    - Single-partition property (e.g. `partition_key`) access throws an error for context with no or multiple partition keys.
    - Single-partition property (e.g. `partition_key`) access throws an error for context with no partition keys.
- Change `ExternalExecutionContext.userdata` -> `extras`
    - `extras` is not exposed directly
    - `get_extra(key)` is used to access defined extras. Access to a missing key raises an error.
- Adjust `ExternalExecutionContext` reporting methods (e.g. `report_asset_metadata`) to work with a parameterized asset key
- Fix bug in data version reporting
- Add additional tests

## How I Tested These Changes

New unit tests