### PR TITLE
add prefix to labels in gh template

### DIFF
--- a/.github/ISSUE_TEMPLATE/report_bug.yml
+++ b/.github/ISSUE_TEMPLATE/report_bug.yml
@@ -1,6 +1,6 @@
 name: 🪲 Report a bug
 description: Report problems and issues with the Dagster framework.
-labels: ["kind: bug"]
+labels: ["type: bug"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/report_bug.yml
+++ b/.github/ISSUE_TEMPLATE/report_bug.yml
@@ -1,6 +1,6 @@
 name: 🪲 Report a bug
 description: Report problems and issues with the Dagster framework.
-labels: ["bug"]
+labels: ["kind: bug"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/report_documentation_issue.yml
+++ b/.github/ISSUE_TEMPLATE/report_documentation_issue.yml
@@ -1,6 +1,6 @@
 name: ❓ Report documentation issue
 description: Report problems and issues with Dagster documentation.
-labels: ["documentation"]
+labels: ["area: docs"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/request_a_feature.yml
+++ b/.github/ISSUE_TEMPLATE/request_a_feature.yml
@@ -1,6 +1,6 @@
 name: 💡 Request a feature
 description: Suggest an idea for Dagster.
-labels: ["kind: feature-request"]
+labels: ["type: feature-request"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/request_a_feature.yml
+++ b/.github/ISSUE_TEMPLATE/request_a_feature.yml
@@ -1,6 +1,6 @@
 name: 💡 Request a feature
 description: Suggest an idea for Dagster.
-labels: ["feature-request"]
+labels: ["kind: feature-request"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
## Summary & Motivation
reflect the recent label overhaul:
- https://github.com/dagster-io/dagster/labels/area%3A%20docs
- https://github.com/dagster-io/dagster/labels?q=type
## How I Tested These Changes
