### PR TITLE
[ui] Add "expand" icon

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/components/Dialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/Dialog.tsx
@@ -91,7 +91,7 @@ export const DialogFooter: React.FC<DialogFooterProps> = ({
   );
 };
 
-const DialogHeaderText = styled.div`
+export const DialogHeaderText = styled.div`
   font-size: 16px;
   font-weight: 500;
   overflow: hidden;

--- a/js_modules/dagster-ui/packages/ui-components/src/components/Icon.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/Icon.tsx
@@ -51,6 +51,7 @@ import editor_role from '../icon-svgs/editor-role.svg';
 import email from '../icon-svgs/email.svg';
 import error from '../icon-svgs/error.svg';
 import error_outline from '../icon-svgs/error_outline.svg';
+import expand from '../icon-svgs/expand.svg';
 import expand_less from '../icon-svgs/expand_less.svg';
 import expand_more from '../icon-svgs/expand_more.svg';
 import filter_alt from '../icon-svgs/filter_alt.svg';
@@ -248,6 +249,7 @@ export const Icons = {
   email,
   error,
   error_outline,
+  expand,
   expand_less,
   expand_more,
   filter_alt,

--- a/js_modules/dagster-ui/packages/ui-components/src/icon-svgs/expand.svg
+++ b/js_modules/dagster-ui/packages/ui-components/src/icon-svgs/expand.svg
@@ -1,0 +1,10 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_639_298)">
+<path d="M14 7.33333V2H8.66667L10.86 4.19333L4.19333 10.86L2 8.66667V14H7.33333L5.14 11.8067L11.8067 5.14L14 7.33333Z" fill="#171615"/>
+</g>
+<defs>
+<clipPath id="clip0_639_298">
+<rect width="16" height="16" fill="white"/>
+</clipPath>
+</defs>
+</svg>


### PR DESCRIPTION
## Summary & Motivation

Adding an "expand" icon for Cloud. Also exporting dialog header text so that it can be used in situations that need a little more flexibility.

## How I Tested These Changes

Storybook
