### PR TITLE
[ui] Choose correct anchor position for the “graph is large” notice

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -281,7 +281,7 @@ const AssetGraphExplorerWithData: React.FC<WithDataProps> = ({
           {graphQueryItems.length === 0 ? (
             <EmptyDAGNotice nodeType="asset" isGraph />
           ) : applyingEmptyDefault ? (
-            <LargeDAGNotice nodeType="asset" />
+            <LargeDAGNotice nodeType="asset" anchorLeft={fetchOptionFilters ? '300px' : '40px'} />
           ) : Object.keys(assetGraphData.nodes).length === 0 ? (
             <EntirelyFilteredDAGNotice nodeType="asset" />
           ) : undefined}

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/GraphNotices.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/GraphNotices.tsx
@@ -3,8 +3,14 @@ import capitalize from 'lodash/capitalize';
 import * as React from 'react';
 import styled from 'styled-components';
 
-export const LargeDAGNotice = ({nodeType}: {nodeType: 'op' | 'asset'}) => (
-  <LargeDAGContainer>
+export const LargeDAGNotice = ({
+  nodeType,
+  anchorLeft = '40px',
+}: {
+  nodeType: 'op' | 'asset';
+  anchorLeft?: string;
+}) => (
+  <LargeDAGContainer style={{left: anchorLeft}}>
     <Icon name="arrow_upward" size={24} />
     <LargeDAGInstructionBox>
       <p>
@@ -100,7 +106,6 @@ const CenteredContainer = styled.div`
 const LargeDAGContainer = styled.div`
   width: 45vw;
   position: absolute;
-  left: 40px;
   top: 60px;
   z-index: 2;
   max-width: 500px;


### PR DESCRIPTION
## Summary & Motivation

This is a small fix for the positioning of this informational bubble. When the new / conditional asset group picker is included in the top nav, the message needs to be pushed over to the right.

I think there could be a broader rework of this to couple this empty state's DOM with the input DOM so that they move together, but I think this is sufficient for now.

Before:
<img width="747" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/49db78a2-498d-42c0-b23c-cba507124b27">


After:
<img width="836" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/cad73dc0-799f-4735-8328-2c7d613d3c5e">


## How I Tested These Changes

I tested this in both asset DAGs larger than the cutoff and DAGs smaller than the cutoff, and with scenarios where the asset groups picker is present and not present.