### PR TITLE
Update customizing k8s docs

### DIFF
--- a/docs/content/dagster-cloud/deployment/agents/kubernetes/configuration-reference.mdx
+++ b/docs/content/dagster-cloud/deployment/agents/kubernetes/configuration-reference.mdx
@@ -155,7 +155,7 @@ def k8s_job():
 
 ## Per-job and per-op configuration
 
-To add configuration to specific Dagster jobs or ops, use the `dagster-k8s/config` tag. For example, to specify that a job should have certain resource limits when it runs. Refer to [Customizing your Kubernetes deployment for Dagster Open Source](/deployment/guides/kubernetes/customizing-your-deployment#per-job-or-per-op-kubernetes-configuration) for more info.
+To add configuration to specific Dagster jobs, ops, or assets, use the `dagster-k8s/config` tag. For example, to specify that a job should have certain resource limits when it runs. Refer to [Customizing your Kubernetes deployment for Dagster Open Source](/deployment/guides/kubernetes/customizing-your-deployment#per-job-kubernetes-configuration) for more info.
 
 ---
 

--- a/docs/content/deployment/guides/kubernetes/customizing-your-deployment.mdx
+++ b/docs/content/deployment/guides/kubernetes/customizing-your-deployment.mdx
@@ -1,6 +1,6 @@
 ---
-title: Customizing Helm | Dagster
-description: This section covers common ways to customize your Dagster Helm deployment.
+title: Customizing your Kubernetes Deployment | Dagster
+description: This section covers common ways to customize your Dagster Kubernetes deployment.
 ---
 
 # Customizing your Kubernetes Deployment
@@ -53,9 +53,11 @@ runLauncher:
             mykey: myvalue
 ```
 
-### Per-job or per-op Kubernetes configuration
+If your Dagster job is configured with the <PyObject module="dagster_k8s" object="k8s_job_executor" /> that runs each step in its own pod, configuration that you set in `runK8sConfig` will also be propagated to the pods that are created for each step, unless that step's configuration is overridden using one of the methods below.
 
-The `dagster-k8s/config` tag allows you to pass custom configuration to the Kubernetes Jobs and Pods created by Dagster for specific jobs or ops.
+### Per-job Kubernetes configuration
+
+If your instance is using the <PyObject module="dagster_k8s" object="K8sRunLauncher" /> or <PyObject module="dagster_celery_k8s" object="CeleryK8sRunLauncher" />, you can use the `dagster-k8s/config` tag on a Dagster job to pass custom configuration to the Kubernetes Jobs and Pods created by Dagster for that job.
 
 `dagster-k8s/config` is a dictionary with the following keys:
 
@@ -67,9 +69,7 @@ The `dagster-k8s/config` tag allows you to pass custom configuration to the Kube
 
 Refer to the [Kubernetes documentation](https://kubernetes.io/docs/home/) for more information about containers, Pod Specs, etc.
 
-The value for each of these keys is a dictionary with the YAML configuration for the underlying Kubernetes object. The Kubernetes object fields can be configured using either snake case (for example, `volume_mounts`) or camel case (`volumeMounts`).
-
-If your instance is using the <PyObject module="dagster_k8s" object="K8sRunLauncher" /> or <PyObject module="dagster_celery_k8s" object="CeleryK8sRunLauncher" />, you can use the `dagster-k8s/config` tag on a Dagster job. For example:
+The value for each of these keys is a dictionary with the YAML configuration for the underlying Kubernetes object. The Kubernetes object fields can be configured using either snake case (for example, `volume_mounts`) or camel case (`volumeMounts`). For example:
 
 ```python file=/deploying/kubernetes/k8s_config_tag_job.py startafter=start_k8s_config endbefore=end_k8s_config
 @job(
@@ -114,7 +114,81 @@ def my_job():
     my_op()
 ```
 
-If your Dagster job is configured with an executor that runs each op in its own pod, like the <PyObject module="dagster_k8s" object="k8s_job_executor" /> or <PyObject module="dagster_celery_k8s" object="celery_k8s_job_executor" />, you can also use the `dagster-k8s/config` tag on a Dagster op to control the Kubernetes configuration for that specific op. For example:
+Other run launchers will ignore the `dagster-k8s/config` tag.
+
+If your Dagster job is configured with the <PyObject module="dagster_k8s" object="k8s_job_executor" /> that runs each step in its own pod, configuration that you set on a job using the `dagster-k8s/config` tag will _not_ be propagated to any of those step pods.
+
+### Kubernetes configuration on every step in a run
+
+If your Dagster job is configured with the <PyObject module="dagster_k8s" object="k8s_job_executor" /> that runs each step in its own pod, you can use the `step_k8s_config` field on the executor to control the Kubernetes configuration for every step pod.
+
+`step_k8s_config` is a dictionary with the following keys:
+
+- `container_config`: The Pod's Container
+- `pod_spec_config`: The Pod's PodSpec
+- `pod_template_spec_metadata`: The Pod's Metadata
+- `job_spec_config`: The Job's JobSpec
+- `job_metadata`: The Job's Metadata
+
+Refer to the [Kubernetes documentation](https://kubernetes.io/docs/home/) for more information about containers, Pod Specs, etc.
+
+The value for each of these keys is a dictionary with the YAML configuration for the underlying Kubernetes object. The Kubernetes object fields can be configured using either snake case (for example, `volume_mounts`) or camel case (`volumeMounts`). For example:
+
+```python file=/deploying/kubernetes/step_k8s_config.py startafter=start_step_k8s_config endbefore=end_step_k8s_config
+my_k8s_executor = k8s_job_executor.configured(
+    {
+        "step_k8s_config": {
+            "container_config": {
+                "resources": {
+                    "requests": {"cpu": "200m", "memory": "32Mi"},
+                }
+            }
+        }
+    }
+)
+
+@job(executor_def=my_k8s_executor)
+def my_job():
+    ...
+```
+
+### Kubernetes configuration on individual steps in a run
+
+If your Dagster job is configured with the <PyObject module="dagster_k8s" object="k8s_job_executor" /> or <PyObject module="dagster_celery_k8s" object="celery_k8s_job_executor" /> that run each step in its own Kubernetes pod, you can use the `dagster-k8s/config` tag on a Dagster op to control the Kubernetes configuration for that specific op.
+
+As above when used on jobs, `dagster-k8s/config` is a dictionary with the following keys:
+
+- `container_config`: The Pod's Container
+- `pod_spec_config`: The Pod's PodSpec
+- `pod_template_spec_metadata`: The Pod's Metadata
+- `job_spec_config`: The Job's JobSpec
+- `job_metadata`: The Job's Metadata
+
+Refer to the [Kubernetes documentation](https://kubernetes.io/docs/home/) for more information about containers, Pod Specs, etc.
+
+The value for each of these keys is a dictionary with the YAML configuration for the underlying Kubernetes object. The Kubernetes object fields can be configured using either snake case (for example, `volume_mounts`) or camel case (`volumeMounts`). For example:
+
+For example, for an asset:
+
+```python file=/deploying/kubernetes/k8s_config_tag_asset.py startafter=start_k8s_config endbefore=end_k8s_config
+@asset(
+    op_tags={
+        "dagster-k8s/config": {
+            "container_config": {
+                "resources": {
+                    "requests": {"cpu": "200m", "memory": "32Mi"},
+                }
+            },
+        }
+    }
+)
+def my_asset(context):
+    context.log.info("running")
+
+my_job = define_asset_job(name="my_job", selection="my_asset", executor_def=k8s_job_executor)
+```
+
+or an op:
 
 ```python file=/deploying/kubernetes/k8s_config_tag_op.py startafter=start_k8s_config endbefore=end_k8s_config
 @op(
@@ -136,11 +210,27 @@ def my_job():
     my_op()
 ```
 
-Non-k8s run launchers and executors will ignore the `dagster-k8s/config` tag.
+Other executors will ignore the `dagster-k8s/config` tag when it is set on an op or asset.
 
-If a Kubernetes configuration dictionary (like `container_config`) is specified at both the instance level in the Helm chart and in a specific Dagster job or op, the two dictionaries will be shallowly merged. The more specific configuration takes precedence if the same key is set in both dictionaries.
+### Precedence rules
 
-For example, if `k8sRunLauncher.runK8sConfig.podSpecConfig` is set to `{"nodeSelector": {"disktype": "ssd"}, "dns_policy": "ClusterFirst"}` in the Helm chart, but a specific job has the `pod_spec_config` key in the `dagster-k8s/config` tag set to `{"nodeSelector": {"region": "east"}}`, the node selector from the job and the DNS policy from the Helm chart will be applied, since only the node selector is overridden in the job.
+If a Kubernetes configuration dictionary (like `container_config`) is specified at both the instance level in the Helm chart and in a specific Dagster job or op, the dictionaries will be shallowly merged. The more specific configuration takes precedence if the same key is set in both dictionaries.
+
+Consider the following example:
+
+- **In the Helm chart**, `k8sRunLauncher.runK8sConfig.podSpecConfig` is set to:
+
+  ```json
+  { "nodeSelector": { "disktype": "ssd" }, "dns_policy": "ClusterFirst" }
+  ```
+
+- **But a specific job** has the `pod_spec_config` key in the `dagster-k8s/config` tag set to:
+
+  ```json
+  { "nodeSelector": { "region": "east" } }
+  ```
+
+Then the node selector from the job and the DNS policy from the Helm chart will be applied, since only the node selector is overridden in the job.
 
 ---
 

--- a/examples/docs_snippets/docs_snippets/deploying/kubernetes/k8s_config_tag_asset.py
+++ b/examples/docs_snippets/docs_snippets/deploying/kubernetes/k8s_config_tag_asset.py
@@ -1,0 +1,25 @@
+from dagster_k8s import k8s_job_executor
+
+from dagster import asset, define_asset_job
+
+
+# fmt: off
+# start_k8s_config
+@asset(
+    op_tags={
+        "dagster-k8s/config": {
+            "container_config": {
+                "resources": {
+                    "requests": {"cpu": "200m", "memory": "32Mi"},
+                }
+            },
+        }
+    }
+)
+def my_asset(context):
+    context.log.info("running")
+
+my_job = define_asset_job(name="my_job", selection="my_asset", executor_def=k8s_job_executor)
+
+# end_k8s_config
+# fmt: on

--- a/examples/docs_snippets/docs_snippets/deploying/kubernetes/step_k8s_config.py
+++ b/examples/docs_snippets/docs_snippets/deploying/kubernetes/step_k8s_config.py
@@ -1,0 +1,23 @@
+from dagster_k8s import k8s_job_executor
+
+from dagster import job
+
+# fmt: off
+# start_step_k8s_config
+my_k8s_executor = k8s_job_executor.configured(
+    {
+        "step_k8s_config": {
+            "container_config": {
+                "resources": {
+                    "requests": {"cpu": "200m", "memory": "32Mi"},
+                }
+            }
+        }
+    }
+)
+
+@job(executor_def=my_k8s_executor)
+def my_job():
+    ...
+# end_step_k8s_config
+# fmt: on


### PR DESCRIPTION
Summary:
- include assets, not just ops
- include new `step_k8s_config` field in https://github.com/dagster-io/dagster/pull/15836/files
- clarify when config is propagated from the job to the steps and when it is not (somewhat inconsistently)

Test Plan: Read docs page

## Summary & Motivation

## How I Tested These Changes
