### PR TITLE
Add get_run_tags to DagsterGraphQLClient

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/client/client.py
+++ b/python_modules/dagster-graphql/dagster_graphql/client/client.py
@@ -15,6 +15,7 @@ from .client_queries import (
     CLIENT_GET_REPO_LOCATIONS_NAMES_AND_PIPELINES_QUERY,
     CLIENT_SUBMIT_PIPELINE_RUN_MUTATION,
     GET_PIPELINE_RUN_STATUS_QUERY,
+    GET_PIPELINE_RUN_TAGS_QUERY,
     RELOAD_REPOSITORY_LOCATION_MUTATION,
     SHUTDOWN_REPOSITORY_LOCATION_MUTATION,
     TERMINATE_RUN_JOB_MUTATION,
@@ -283,6 +284,32 @@ class DagsterGraphQLClient:
         query_result_type: str = query_result["__typename"]
         if query_result_type == "PipelineRun" or query_result_type == "Run":
             return DagsterRunStatus(query_result["status"])
+        else:
+            raise DagsterGraphQLClientError(query_result_type, query_result["message"])
+    
+    @public
+    def get_run_tags(self, run_id: str) -> Dict[str, str]:
+        """Get the tags of a given Pipeline Run.
+        
+        Args:
+            run_id (str): run id of the requested pipeline run.
+        
+        Raises:
+            DagsterGraphQLClientError("PipelineNotFoundError", message): if the requested run id is not found
+            DagsterGraphQLClientError("PythonError", message): on internal framework errors
+        
+        Returns:
+            Dict[str, str]: returns a dictionary of tags for the requested pipeline run
+        """
+        check.str_param(run_id, "run_id")
+        
+        res_data: Dict[str, Dict[str, Any]] = self._execute(
+            GET_PIPELINE_RUN_TAGS_QUERY, {"runId": run_id}
+        )
+        query_result: Dict[str, Any] = res_data["pipelineRunOrError"]
+        query_result_type: str = query_result["__typename"]
+        if query_result_type == "PipelineRun" or query_result_type == "Run":
+            return query_result["tags"]
         else:
             raise DagsterGraphQLClientError(query_result_type, query_result["message"])
 

--- a/python_modules/dagster-graphql/dagster_graphql/client/client_queries.py
+++ b/python_modules/dagster-graphql/dagster_graphql/client/client_queries.py
@@ -110,6 +110,26 @@ query($runId: ID!) {
 }
 """
 
+GET_PIPELINE_RUN_TAGS_QUERY = """
+query($runId: ID!) {
+  pipelineRunOrError(runId: $runId) {
+    __typename
+    ... on PipelineRun {
+        tags {
+          key
+          value
+        }
+    }
+    ... on PipelineRunNotFoundError {
+      message
+    }
+    ... on PythonError {
+      message
+    }
+  }
+}
+"""
+
 SHUTDOWN_REPOSITORY_LOCATION_MUTATION = """
 mutation ($repositoryLocationName: String!) {
    shutdownRepositoryLocation(repositoryLocationName: $repositoryLocationName) {

--- a/python_modules/dagster-graphql/dagster_graphql_tests/client_tests/test_get_run_tags.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/client_tests/test_get_run_tags.py
@@ -1,0 +1,78 @@
+import pytest
+from dagster_graphql import DagsterGraphQLClientError
+from dagster_graphql.client.query import LAUNCH_PIPELINE_EXECUTION_MUTATION
+from dagster_graphql.test.utils import execute_dagster_graphql, infer_pipeline_selector
+
+from ..graphql.graphql_context_test_suite import ExecutingGraphQLContextTestMatrix
+from ..graphql.repo import csv_hello_world_ops_config
+from .conftest import MockClient, python_client_test_suite
+
+
+@python_client_test_suite
+def test_get_run_tags_success(mock_client: MockClient):
+    expected_result = [{"tag1": "value1", "tag2": "value2"}]
+    response = {"pipelineRunOrError": {"__typename": "PipelineRun", "tags": expected_result}}
+    mock_client.mock_gql_client.execute.return_value = response
+
+    actual_result = mock_client.python_client.get_run_tags("foo")
+    assert actual_result == expected_result
+
+
+@python_client_test_suite
+def test_get_run_tags_fails_with_python_error(mock_client: MockClient):
+    error_type, error_msg = "PythonError", "something exploded"
+    response = {"pipelineRunOrError": {"__typename": error_type, "message": error_msg}}
+    mock_client.mock_gql_client.execute.return_value = response
+
+    with pytest.raises(DagsterGraphQLClientError) as exc_info:
+        mock_client.python_client.get_run_tags("foo")
+
+    assert exc_info.value.args == (error_type, error_msg)
+
+
+@python_client_test_suite
+def test_get_run_tags_fails_with_pipeline_run_not_found_error(mock_client: MockClient):
+    error_type, error_msg = "RunNotFoundError", "The specified pipeline run does not exist"
+    response = {"pipelineRunOrError": {"__typename": error_type, "message": error_msg}}
+    mock_client.mock_gql_client.execute.return_value = response
+
+    with pytest.raises(DagsterGraphQLClientError) as exc_info:
+        mock_client.python_client.get_run_tags("foo")
+
+    assert exc_info.value.args == (error_type, error_msg)
+
+
+@python_client_test_suite
+def test_get_run_tags_fails_with_query_error(mock_client: MockClient):
+    mock_client.mock_gql_client.execute.side_effect = Exception("foo")
+
+    with pytest.raises(DagsterGraphQLClientError) as _:
+        mock_client.python_client.get_run_tags("foo")
+    
+
+class TestGetRunTagsWithClient(ExecutingGraphQLContextTestMatrix):
+    def test_get_run_tags(self, graphql_context, graphql_client):
+        selector = infer_pipeline_selector(graphql_context, "csv_hello_world")
+        result = execute_dagster_graphql(
+            graphql_context,
+            LAUNCH_PIPELINE_EXECUTION_MUTATION,
+            variables={
+                "executionParams": {
+                    "selector": selector,
+                    "runConfigData": csv_hello_world_ops_config(),
+                    "mode": "default",
+                    "executionMetadata": {"tags": [{"key": "dagster/test_key", "value": "test_value"}]},
+                }
+            },
+        )
+
+        assert not result.errors
+        assert result.data
+
+        run_id = result.data["launchPipelineExecution"]["run"]["runId"]
+
+        tags = graphql_client.get_run_tags(run_id)
+        
+        tag = [tag for tag in tags if tag["key"] == "dagster/test_key"]
+        assert len(tag) == 1, f"Expected to a tag with key 'dagster/test_key' in {tags}"
+        assert tag["dagster/test_key"] == "test_value"


### PR DESCRIPTION
## Summary & Motivation
We want to be able to easily retrieve metadata related to a pipeline run that we put in the tags from python, for example the git commit hash of the repository used for a pipeline run.

## How I Tested These Changes
I adapted the tests for `DagsterGraphQLClient.get_run_status` to work for this new function.