### PR TITLE
[brownfield-essentials] refactor io modes

### DIFF
--- a/python_modules/dagster-external/dagster_external/params.py
+++ b/python_modules/dagster-external/dagster_external/params.py
@@ -1,0 +1,39 @@
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+from dagster_external.protocol import (
+    DAGSTER_EXTERNAL_DEFAULT_HOST,
+    DAGSTER_EXTERNAL_DEFAULT_INPUT_MODE,
+    DAGSTER_EXTERNAL_DEFAULT_OUTPUT_MODE,
+    DAGSTER_EXTERNAL_DEFAULT_PORT,
+    DAGSTER_EXTERNAL_ENV_KEYS,
+    ExternalExecutionIOMode,
+)
+
+
+def get_external_execution_params() -> "ExternalExecutionParams":
+    raw_input_mode = os.getenv(
+        DAGSTER_EXTERNAL_ENV_KEYS["input_mode"], DAGSTER_EXTERNAL_DEFAULT_INPUT_MODE
+    )
+    raw_output_mode = os.getenv(
+        DAGSTER_EXTERNAL_ENV_KEYS["output_mode"], DAGSTER_EXTERNAL_DEFAULT_OUTPUT_MODE
+    )
+    return ExternalExecutionParams(
+        input_mode=ExternalExecutionIOMode[raw_input_mode],
+        output_mode=ExternalExecutionIOMode[raw_output_mode],
+        input_path=os.getenv(DAGSTER_EXTERNAL_ENV_KEYS["input"]),
+        output_path=os.getenv(DAGSTER_EXTERNAL_ENV_KEYS["output"]),
+        host=os.getenv(DAGSTER_EXTERNAL_ENV_KEYS["host"], DAGSTER_EXTERNAL_DEFAULT_HOST),
+        port=int(os.getenv(DAGSTER_EXTERNAL_ENV_KEYS["port"], DAGSTER_EXTERNAL_DEFAULT_PORT)),
+    )
+
+
+@dataclass
+class ExternalExecutionParams:
+    input_mode: str
+    output_mode: str
+    input_path: Optional[str]
+    output_path: Optional[str]
+    host: str
+    port: int

--- a/python_modules/dagster-external/dagster_external/protocol.py
+++ b/python_modules/dagster-external/dagster_external/protocol.py
@@ -1,10 +1,16 @@
+from enum import Enum
 from typing import Any, Mapping, Optional, Sequence
 
 from typing_extensions import Final, TypeAlias, TypedDict
 
 ExternalExecutionExtras: TypeAlias = Mapping[str, Any]
 
+# ##### PARAMETERS
+
+DAGSTER_EXTERNAL_DEFAULT_HOST: Final = "localhost"
 DAGSTER_EXTERNAL_DEFAULT_PORT: Final = 9716
+DAGSTER_EXTERNAL_DEFAULT_INPUT_MODE: Final = "stdio"
+DAGSTER_EXTERNAL_DEFAULT_OUTPUT_MODE: Final = "stdio"
 DAGSTER_EXTERNAL_DEFAULT_INPUT_FILENAME: Final = "dagster_external_input"
 DAGSTER_EXTERNAL_DEFAULT_OUTPUT_FILENAME: Final = "dagster_external_output"
 
@@ -17,15 +23,24 @@ DAGSTER_EXTERNAL_ENV_KEYS: Final = {
     "port": "DAGSTER_EXTERNAL_PORT",
 }
 
+# ##### IO MODES
+
+
+class ExternalExecutionIOMode(str, Enum):
+    stdio = "stdio"
+    file = "file"
+    fifo = "fifo"
+
+
+# ##### NOTIFICATION
+
 
 class Notification(TypedDict):
     method: str
     params: Optional[Mapping[str, Any]]
 
 
-# ########################
 # ##### EXTERNAL EXECUTION CONTEXT
-# ########################
 
 
 class ExternalExecutionContextData(TypedDict):


### PR DESCRIPTION
## Summary & Motivation

Refactor of `ExternalExecutionContext` for clarity.

- New `ExternalExecutionParams` abstraction contains all info passed by environment variables. You get it by calling `get_external_execution_params` (not user-facing). This replaces _ad hoc_ reading of environment variables to access params.
- New `ExternalExecutionIOMode` enum with values `stdio`, `fifo`, `file` replaces bare strings.
- `ExternalExecutionTask.{input_fifo,output_fifo}` -> `{input_path,output_path}`. These properties are now used for both `fifo` and `file` mode. 
- Eliminate `temp_fifo` IO mode. Now there is just `fifo`, and a FIFO in a tempdir is auto-generated if corresponding `input_path` or `output_path` is provided
- `temp_file` mode is renamed to `file` mode. If `input_path`/`output_path` are passed, existence of directory is validated.

Some subtleties:

- In `fifo` mode:
    - We auto-create a FIFO specified by `input_path` or `output_path` (but error if containing directory doesn't exist)
    - We always delete the FIFO at the end regardless of whether we created it (not sure if this makes sense)
- In `file` mode:
    - It is an error if a file specified by `input_path` or `output_path` already exists when task is started
    - We always delete the files at the end

## How I Tested These Changes

New unit tests
