### PR TITLE
[brownfield-essentials] socket support for ExternalExecutionTask

### DIFF
--- a/python_modules/dagster-external/dagster_external/protocol.py
+++ b/python_modules/dagster-external/dagster_external/protocol.py
@@ -30,9 +30,12 @@ class ExternalExecutionIOMode(str, Enum):
     stdio = "stdio"
     file = "file"
     fifo = "fifo"
+    socket = "socket"
 
 
 # ##### NOTIFICATION
+
+GET_CONTEXT_MESSAGE: Final = "__get_context__"
 
 
 class Notification(TypedDict):

--- a/python_modules/dagster-external/dagster_external_tests/test_context.py
+++ b/python_modules/dagster-external/dagster_external_tests/test_context.py
@@ -28,7 +28,7 @@ def _make_external_execution_context(**kwargs):
     kwargs = {**TEST_EXTERNAL_EXECUTION_CONTEXT_DEFAULTS, **kwargs}
     return ExternalExecutionContext(
         data=ExternalExecutionContextData(**kwargs),
-        output_stream=MagicMock(),
+        output_target=MagicMock(),
     )
 
 

--- a/python_modules/dagster-external/dagster_external_tests/test_external_execution.py
+++ b/python_modules/dagster-external/dagster_external_tests/test_external_execution.py
@@ -39,31 +39,42 @@ def temp_script(script_fn: Callable[[], Any]) -> Iterator[str]:
         ("stdio", "file/user"),
         ("stdio", "fifo/auto"),
         ("stdio", "fifo/user"),
+        ("stdio", "socket"),
         ("file/auto", "stdio"),
         ("file/auto", "file/auto"),
         ("file/auto", "file/user"),
         ("file/auto", "fifo/auto"),
         ("file/auto", "fifo/user"),
+        ("file/auto", "socket"),
         ("file/user", "stdio"),
         ("file/user", "file/auto"),
         ("file/user", "file/user"),
         ("file/user", "fifo/auto"),
         ("file/user", "fifo/user"),
+        ("file/user", "socket"),
         ("fifo/auto", "stdio"),
         ("fifo/auto", "file/auto"),
         ("fifo/auto", "file/user"),
         ("fifo/auto", "fifo/auto"),
         ("fifo/auto", "fifo/user"),
+        ("fifo/auto", "socket"),
         ("fifo/user", "stdio"),
         ("fifo/user", "file/auto"),
         ("fifo/user", "file/user"),
         ("fifo/user", "fifo/auto"),
         ("fifo/user", "fifo/user"),
+        ("fifo/user", "socket"),
+        ("socket", "stdio"),
+        ("socket", "file/auto"),
+        ("socket", "file/user"),
+        ("socket", "fifo/auto"),
+        ("socket", "fifo/user"),
+        ("socket", "socket"),
     ],
 )
 def test_external_execution_asset(input_spec: str, output_spec: str, tmpdir, capsys):
-    if input_spec == "stdio":
-        input_mode = ExternalExecutionIOMode.stdio
+    if input_spec in ["stdio", "socket"]:
+        input_mode = ExternalExecutionIOMode(input_spec)
         input_path = None
     else:
         input_mode_spec, input_path_spec = input_spec.split("/")
@@ -73,8 +84,8 @@ def test_external_execution_asset(input_spec: str, output_spec: str, tmpdir, cap
         else:
             input_path = str(tmpdir.join("input"))
 
-    if output_spec == "stdio":
-        output_mode = ExternalExecutionIOMode.stdio
+    if output_spec in ["stdio", "socket"]:
+        output_mode = ExternalExecutionIOMode(output_spec)
         output_path = None
     else:
         output_mode_spec, output_path_spec = output_spec.split("/")

--- a/python_modules/dagster/dagster/_core/external_execution/task.py
+++ b/python_modules/dagster/dagster/_core/external_execution/task.py
@@ -1,16 +1,21 @@
 import json
 import os
 import shutil
+import socket
+import socketserver
 import tempfile
 from copy import copy
+from dataclasses import dataclass
 from subprocess import Popen
-from threading import Thread
+from threading import Event, Thread
 from typing import Any, Mapping, Optional, Sequence, Tuple, Union
 
 from dagster_external.protocol import (
     DAGSTER_EXTERNAL_DEFAULT_INPUT_FILENAME,
     DAGSTER_EXTERNAL_DEFAULT_OUTPUT_FILENAME,
+    DAGSTER_EXTERNAL_DEFAULT_PORT,
     DAGSTER_EXTERNAL_ENV_KEYS,
+    GET_CONTEXT_MESSAGE,
     ExternalExecutionExtras,
     ExternalExecutionIOMode,
 )
@@ -21,6 +26,15 @@ from dagster import OpExecutionContext
 from dagster._core.definitions.data_version import DataVersion
 from dagster._core.definitions.events import AssetKey
 from dagster._core.external_execution.context import build_external_execution_context
+
+
+@dataclass
+class SocketAddress:
+    host: str
+    port: int
+
+
+CLOSE_SOCKET_MESSAGE = "__CLOSE_SOCKET__"
 
 
 class ExternalExecutionTask:
@@ -49,18 +63,43 @@ class ExternalExecutionTask:
         write_target, stdin_fd, input_env_vars = self._prepare_input()
         read_target, stdout_fd, output_env_vars = self._prepare_output()
 
-        input_thread = Thread(target=self._write_input, args=(write_target,), daemon=True)
-        output_thread = Thread(target=self._read_output, args=(read_target,), daemon=True)
-
-        # Synchronously write the file in advance if using file mode
-        if self._input_mode == ExternalExecutionIOMode.file:
-            input_thread.run()
-        else:
+        if self._input_mode == ExternalExecutionIOMode.stdio:
+            assert isinstance(write_target, int)
+            input_thread = self._default_input_thread(write_target)
             input_thread.start()
+        elif self._input_mode == ExternalExecutionIOMode.file:
+            assert isinstance(write_target, str)
+            input_thread = None
+            self._write_input(write_target)
+        elif self._input_mode == ExternalExecutionIOMode.fifo:
+            assert isinstance(write_target, str)
+            input_thread = self._default_input_thread(write_target)
+            input_thread.start()
+        elif self._input_mode == ExternalExecutionIOMode.socket:
+            assert isinstance(write_target, SocketAddress)
+            input_thread = self._start_socket_server(write_target)
+        else:
+            check.failed(f"Unsupported input mode: {self._input_mode}")
 
-        # If we're using an output file, we won't read it until the process is done
-        if self._output_mode != ExternalExecutionIOMode.file:
+        if self._output_mode == ExternalExecutionIOMode.stdio:
+            assert isinstance(read_target, int)
+            output_thread = self._default_output_thread(read_target)
             output_thread.start()
+        elif self._output_mode == ExternalExecutionIOMode.file:
+            output_thread = None
+        elif self._output_mode == ExternalExecutionIOMode.fifo:
+            assert isinstance(read_target, str)
+            output_thread = self._default_output_thread(read_target)
+            output_thread.start()
+        elif self._output_mode == ExternalExecutionIOMode.socket:
+            assert isinstance(read_target, SocketAddress)
+            # thread already exists
+            if self._input_mode == ExternalExecutionIOMode.socket:
+                output_thread = input_thread
+            else:
+                output_thread = self._start_socket_server(read_target)
+        else:
+            check.failed(f"Unsupported output mode: {self._output_mode}")
 
         process = Popen(
             self._command,
@@ -68,23 +107,47 @@ class ExternalExecutionTask:
             stdout=stdout_fd,
             env={**os.environ, **self.env, **input_env_vars, **output_env_vars},
         )
-
-        if stdin_fd is not None:
-            os.close(stdin_fd)
-        if stdout_fd is not None:
-            os.close(stdout_fd)
-
         process.wait()
 
-        # Tempfile input will have been synchronously written without a living thread
-        if self._input_mode != ExternalExecutionIOMode.file:
+        if self._input_mode == ExternalExecutionIOMode.stdio:
+            assert stdin_fd is not None
+            os.close(stdin_fd)
+            assert input_thread is not None
             input_thread.join()
-
-        # Read tempfile output synchronously ofter everything the process has finished
-        if self._output_mode == ExternalExecutionIOMode.file:
-            output_thread.run()
+        elif self._input_mode == ExternalExecutionIOMode.file:
+            pass
+        elif self._input_mode == ExternalExecutionIOMode.fifo:
+            assert input_thread is not None
+            input_thread.join()
+        elif self._input_mode == ExternalExecutionIOMode.socket:
+            assert isinstance(write_target, SocketAddress)
+            self._shutdown_socket_server(write_target)
+            assert input_thread is not None
+            input_thread.join()
         else:
+            check.failed(f"Unsupported input mode: {self._input_mode}")
+
+        if self._output_mode == ExternalExecutionIOMode.stdio:
+            assert stdout_fd is not None
+            os.close(stdout_fd)
+            assert output_thread is not None
             output_thread.join()
+        elif self._output_mode == ExternalExecutionIOMode.file:
+            assert isinstance(read_target, str)
+            self._read_output(read_target)
+        elif self._output_mode == ExternalExecutionIOMode.fifo:
+            assert output_thread is not None
+            output_thread.join()
+        elif self._output_mode == ExternalExecutionIOMode.socket:
+            # If input_mode is socket, we will have already shut down the socket server and joined
+            # the socket thread
+            if self._input_mode != ExternalExecutionIOMode.socket:
+                assert isinstance(read_target, SocketAddress)
+                self._shutdown_socket_server(read_target)
+                assert output_thread is not None
+                output_thread.join()
+        else:
+            check.failed(f"Unsupported output mode: {self._output_mode}")
 
         if self._input_path:
             os.remove(self._input_path)
@@ -95,23 +158,17 @@ class ExternalExecutionTask:
 
         return process.returncode
 
-    def _write_input(self, input_target: Union[str, int]) -> None:
-        external_context = build_external_execution_context(self._context, self._extras)
-        with open(input_target, "w") as input_stream:
-            json.dump(external_context, input_stream)
+    def process_notification(self, message: Mapping[str, Any]) -> None:
+        if message["method"] == "report_asset_metadata":
+            self._handle_report_asset_metadata(**message["params"])
+        elif message["method"] == "report_asset_data_version":
+            self._handle_report_asset_data_version(**message["params"])
+        elif message["method"] == "log":
+            self._handle_log(**message["params"])
 
-    def _read_output(self, output_target: Union[str, int]) -> Any:
-        with open(output_target, "r") as output_stream:
-            for line in output_stream:
-                message = json.loads(line)
-                if message["method"] == "report_asset_metadata":
-                    self._handle_report_asset_metadata(**message["params"])
-                elif message["method"] == "report_asset_data_version":
-                    self._handle_report_asset_data_version(**message["params"])
-                elif message["method"] == "log":
-                    self._handle_log(**message["params"])
-
-    def _prepare_input(self) -> Tuple[Union[str, int], Optional[int], Mapping[str, str]]:
+    def _prepare_input(
+        self,
+    ) -> Tuple[Union[str, int, SocketAddress], Optional[int], Mapping[str, str]]:
         env = {DAGSTER_EXTERNAL_ENV_KEYS["input_mode"]: self._input_mode.value}
         if self._input_mode == ExternalExecutionIOMode.stdio:
             stdin_fd, write_target = os.pipe()
@@ -128,11 +185,19 @@ class ExternalExecutionTask:
             ):
                 os.mkfifo(write_target)
             env[DAGSTER_EXTERNAL_ENV_KEYS["input"]] = write_target
+        elif self._input_mode == ExternalExecutionIOMode.socket:
+            stdin_fd = None
+            write_target = SocketAddress("localhost", DAGSTER_EXTERNAL_DEFAULT_PORT)
+
+            env[DAGSTER_EXTERNAL_ENV_KEYS["host"]] = write_target.host
+            env[DAGSTER_EXTERNAL_ENV_KEYS["port"]] = str(write_target.port)
         else:
             check.failed(f"Unsupported input mode: {self._input_mode}")
         return write_target, stdin_fd, env
 
-    def _prepare_output(self) -> Tuple[Union[str, int], Optional[int], Mapping[str, str]]:
+    def _prepare_output(
+        self,
+    ) -> Tuple[Union[str, int, SocketAddress], Optional[int], Mapping[str, str]]:
         env = {DAGSTER_EXTERNAL_ENV_KEYS["output_mode"]: self._output_mode.value}
         if self._output_mode == ExternalExecutionIOMode.stdio:
             read_target, stdout_fd = os.pipe()
@@ -149,6 +214,11 @@ class ExternalExecutionTask:
             ):
                 os.mkfifo(read_target)
             env[DAGSTER_EXTERNAL_ENV_KEYS["output"]] = read_target
+        elif self._output_mode == ExternalExecutionIOMode.socket:
+            stdout_fd = None
+            read_target = SocketAddress("localhost", DAGSTER_EXTERNAL_DEFAULT_PORT)
+            env[DAGSTER_EXTERNAL_ENV_KEYS["host"]] = read_target.host
+            env[DAGSTER_EXTERNAL_ENV_KEYS["port"]] = str(read_target.port)
         else:
             check.failed(f"Unsupported output mode: {self._output_mode}")
         return read_target, stdout_fd, env
@@ -170,6 +240,73 @@ class ExternalExecutionTask:
         if self._tempdir is None:
             self._tempdir = tempfile.mkdtemp()
         return self._tempdir
+
+    # ########################
+    # ##### THREADED IO ROUTINES
+    # ########################
+
+    def _default_input_thread(self, write_target) -> Thread:
+        return Thread(target=self._write_input, args=(write_target,), daemon=True)
+
+    def _default_output_thread(self, read_target) -> Thread:
+        return Thread(target=self._read_output, args=(read_target,), daemon=True)
+
+    # Not used in socket mode
+    def _write_input(self, input_target: Union[str, int]) -> None:
+        external_context = build_external_execution_context(self._context, self._extras)
+        with open(input_target, "w") as input_stream:
+            json.dump(external_context, input_stream)
+
+    # Not used in socket mode
+    def _read_output(self, output_target: Union[str, int]) -> Any:
+        with open(output_target, "r") as output_stream:
+            for line in output_stream:
+                notification = json.loads(line)
+                self.process_notification(notification)
+
+    # Only used in socket mode
+    def _socket_serve(self, socket_address: SocketAddress, ready_event: Event) -> None:
+        context = build_external_execution_context(self._context, self._extras)
+
+        handle_notification = self.process_notification
+
+        class Handler(socketserver.StreamRequestHandler):
+            def handle(self):
+                data = self.rfile.readline().strip().decode("utf-8")
+                if data == CLOSE_SOCKET_MESSAGE:
+                    self.server.shutdown()
+                elif data == GET_CONTEXT_MESSAGE:
+                    serialized_context = json.dumps(context) + "\n"
+                    self.wfile.write(serialized_context.encode("utf-8"))
+                else:
+                    notification = json.loads(data)
+                    handle_notification(notification)
+
+        # It is essential to set `allow_reuse_address` to True here, otherwise `socket.bind` seems
+        # to nondeterministically block when running multiple tests using the same address in
+        # succession.
+        class Server(socketserver.ThreadingTCPServer):
+            allow_reuse_address = True
+
+        with Server((socket_address.host, socket_address.port), Handler) as server:
+            ready_event.set()
+            server.serve_forever()
+
+    def _start_socket_server(self, write_target: SocketAddress) -> Thread:
+        ready_event = Event()
+        thread = Thread(target=self._socket_serve, args=(write_target, ready_event), daemon=True)
+        thread.start()
+
+        if not ready_event.is_set():
+            ready_event.wait()
+
+        return thread
+
+    def _shutdown_socket_server(self, address: SocketAddress) -> None:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.connect((address.host, address.port))
+            message = CLOSE_SOCKET_MESSAGE + "\n"
+            sock.sendall(message.encode("utf-8"))
 
     # ########################
     # ##### HANDLE NOTIFICATIONS


### PR DESCRIPTION
## Summary & Motivation

Add support for TCP socket IO mode to `dagster-external`. This can be set as either `input_mode`, `output_mode`, or both. In all cases, the orchestration process spins up a TCP server. The same server can be used for both input and output.

This also opens the door to allowing the external process to query the orchestration process during the run, if we want to support that.

With the many possible IO modes `ExternalExecutionTask.run` has gotten fairly complex. Currently it uses a "flat" conditional structure, but I think it should be refactored to use context managers later.

## How I Tested These Changes

New unit tests