### PR TITLE
Remove test project Buildkite step dependency

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -5,7 +5,6 @@ from typing import List, Optional
 from dagster_buildkite.defines import GCP_CREDS_LOCAL_FILE, GIT_REPO_ROOT
 from dagster_buildkite.package_spec import PackageSpec
 from dagster_buildkite.python_version import AvailablePythonVersion
-from dagster_buildkite.steps.test_project import test_project_depends_fn
 from dagster_buildkite.utils import (
     BuildkiteStep,
     connect_sibling_docker_container,

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -467,7 +467,6 @@ LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
             "GOOGLE_APPLICATION_CREDENTIALS",
         ],
         pytest_extra_cmds=airflow_extra_cmds,
-        pytest_step_dependencies=test_project_depends_fn,
         pytest_tox_factors=[
             "default-airflow1",
             "localdb-airflow1",
@@ -489,7 +488,6 @@ LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
         "python_modules/libraries/dagster-celery",
         env_vars=["AWS_ACCOUNT_ID", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"],
         pytest_extra_cmds=celery_extra_cmds,
-        pytest_step_dependencies=test_project_depends_fn,
         unsupported_python_versions=[
             AvailablePythonVersion.V3_11,  # no celery support for 3.11
         ],
@@ -498,7 +496,6 @@ LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
         "python_modules/libraries/dagster-celery-docker",
         env_vars=["AWS_ACCOUNT_ID", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"],
         pytest_extra_cmds=celery_docker_extra_cmds,
-        pytest_step_dependencies=test_project_depends_fn,
         unsupported_python_versions=[
             AvailablePythonVersion.V3_11,  # no celery support for 3.11
         ],
@@ -518,7 +515,6 @@ LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
         "python_modules/libraries/dagster-docker",
         env_vars=["AWS_ACCOUNT_ID", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"],
         pytest_extra_cmds=docker_extra_cmds,
-        pytest_step_dependencies=test_project_depends_fn,
     ),
     PackageSpec(
         "python_modules/libraries/dagster-duckdb-pyspark",
@@ -584,7 +580,6 @@ LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
             "old_kubernetes",
         ],
         pytest_extra_cmds=k8s_extra_cmds,
-        pytest_step_dependencies=test_project_depends_fn,
     ),
     PackageSpec(
         "python_modules/libraries/dagster-mlflow",

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -5,6 +5,7 @@ from typing import List, Optional
 from dagster_buildkite.defines import GCP_CREDS_LOCAL_FILE, GIT_REPO_ROOT
 from dagster_buildkite.package_spec import PackageSpec
 from dagster_buildkite.python_version import AvailablePythonVersion
+from dagster_buildkite.steps.test_project import test_project_depends_fn
 from dagster_buildkite.utils import (
     BuildkiteStep,
     connect_sibling_docker_container,
@@ -495,6 +496,7 @@ LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
         "python_modules/libraries/dagster-celery-docker",
         env_vars=["AWS_ACCOUNT_ID", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"],
         pytest_extra_cmds=celery_docker_extra_cmds,
+        pytest_step_dependencies=test_project_depends_fn,
         unsupported_python_versions=[
             AvailablePythonVersion.V3_11,  # no celery support for 3.11
         ],
@@ -514,6 +516,7 @@ LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
         "python_modules/libraries/dagster-docker",
         env_vars=["AWS_ACCOUNT_ID", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"],
         pytest_extra_cmds=docker_extra_cmds,
+        pytest_step_dependencies=test_project_depends_fn,
     ),
     PackageSpec(
         "python_modules/libraries/dagster-duckdb-pyspark",


### PR DESCRIPTION
While setting up a public buildkite, I'm discovered that these tests don't actually depend on this test image being built and pushed.

Build where these tests never kicked off because I had already disabled building the image:

https://buildkite.com/dagster/unit-tests/builds/54

Build where these tests succeed (with one exception due to AWS creds not being available) without having the test-project image available:

https://buildkite.com/dagster/unit-tests/builds/55
