### PR TITLE
[Run Tags] Pass original key to action

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunTag.tsx
@@ -38,6 +38,7 @@ export type TagType = {
   value: string;
   link?: string;
   pinned?: boolean;
+  originalKey?: string;
 };
 
 export type TagAction = {

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunTags.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunTags.tsx
@@ -45,7 +45,7 @@ export const RunTags: React.FC<{
         ? {
             label: 'Add tag to filter',
             onClick: (tag: TagType) => {
-              onAddTag({token: 'tag', value: `${tag.key}=${tag.value}`});
+              onAddTag({token: 'tag', value: `${tag.originalKey || tag.key}=${tag.value}`});
             },
           }
         : null,
@@ -61,7 +61,7 @@ export const RunTags: React.FC<{
       list.push({
         label: tag.pinned ? 'Hide tag' : 'Show tag in table',
         onClick: () => {
-          onToggleTagPin(tag.key);
+          onToggleTagPin(tag.originalKey || tag.key);
         },
       });
     }
@@ -71,11 +71,17 @@ export const RunTags: React.FC<{
   const displayedTags = React.useMemo(() => {
     const priority = [];
     const others = [];
-    const copiedTags = tags.map(({key, value, pinned, link}) => ({key, value, pinned, link}));
+    const copiedTags: TagType[] = tags.map(({key, value, pinned, link}) => ({
+      key,
+      value,
+      pinned,
+      link,
+    }));
     for (const tag of copiedTags) {
       const {key} = tag;
       if (renamedTags.hasOwnProperty(key)) {
         tag.key = renamedTags[key as keyof typeof renamedTags];
+        tag.originalKey = key;
       }
 
       if (


### PR DESCRIPTION
## Summary & Motivation
Noticed that the op_selection tag wasn't able to be hidden/shown, this is because it is renamed from solid_selection and the action was receiving the renamed key instead of the original key. This updates the logic to pass the original key instead.

## How I Tested These Changes
Locally toggled the op_selection tag.