### PR TITLE
[docs] Expand+navigate when clicking an expandable nav item

### DIFF
--- a/docs/next/components/Sidebar.tsx
+++ b/docs/next/components/Sidebar.tsx
@@ -96,6 +96,7 @@ const MenuItem = React.forwardRef<HTMLAnchorElement, React.PropsWithChildren<Men
           ref={ref}
           target={item.isExternalLink ? '_blank' : '_self'}
           rel="noopener noreferrer"
+          onClick={onClick}
         >
           {itemContents}
         </a>


### PR DESCRIPTION
## Summary & Motivation

I incorrectly made it so that clicking an expandable nav item in Docs would not expand the subsection, and that only clicking the chevron would do that.

Instead, expand and navigate when clicking one of these items, while still making it so that clicking the chevron *only* expands it.

## How I Tested These Changes

Tested clicks on various parts of the nav.
