### PR TITLE
[ui] Styling adjustment to tag link in Runs table

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunTable.tsx
@@ -15,6 +15,7 @@ import {
   ButtonLink,
   ProductTour,
   ProductTourPosition,
+  Caption,
 } from '@dagster-io/ui-components';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
@@ -425,20 +426,27 @@ const RunRow: React.FC<{
               </Link>
             </Box>
           )}
-          <Box flex={{direction: 'row', gap: 8, wrap: 'wrap'}}>
+          <Box
+            flex={{direction: 'row', alignItems: 'center', wrap: 'wrap'}}
+            style={{gap: '4px 8px'}}
+          >
             <RunTagsWrapper>
               {tagsToShow.length ? (
                 <RunTags tags={tagsToShow} onAddTag={onAddTag} onToggleTagPin={onToggleTagPin} />
               ) : null}
             </RunTagsWrapper>
             {allTagsWithPinned.length > tagsToShow.length ? (
-              <ButtonLink
-                onClick={() => {
-                  setShowRunTags(true);
-                }}
-              >
-                View all {allTagsWithPinned.length} tag{allTagsWithPinned.length === 1 ? '' : 's'}
-              </ButtonLink>
+              <Caption>
+                <ButtonLink
+                  onClick={() => {
+                    setShowRunTags(true);
+                  }}
+                  color={Colors.Gray700}
+                  style={{margin: '-4px', padding: '4px'}}
+                >
+                  View all tags ({allTagsWithPinned.length})
+                </ButtonLink>
+              </Caption>
             ) : null}
           </Box>
         </Box>


### PR DESCRIPTION
## Summary & Motivation

Make a style adjustment to the "View tags" link in the Runs table, to make it a little more subtle.

<img width="907" alt="Screenshot 2023-08-15 at 4 44 50 PM" src="https://github.com/dagster-io/dagster/assets/2823852/ebdd12bc-0268-4cbb-b679-549adaadfd2c">


## How I Tested These Changes

View Runs table, verify rendering and behavior.
