### PR TITLE
docs(dbt): make `dagster.asset_key` metadata explicit for dbt source

### DIFF
--- a/docs/content/integrations/dbt/using-dbt-with-dagster/upstream-assets.mdx
+++ b/docs/content/integrations/dbt/using-dbt-with-dagster/upstream-assets.mdx
@@ -128,7 +128,7 @@ defs = Definitions(
          - name: raw_customers
            meta:
              dagster:
-               asset_key: ["raw_customers"]
+               asset_key: ["raw_customers"] # This metadata specifies the corresponding Dagster asset for this dbt source.
    ```
 
 This is a standard dbt source definition, with one addition: it includes metadata, under the `meta` property, that specifies the Dagster asset that it corresponds to. When Dagster reads the contents of the dbt project, it reads this metadata and infers the correspondence. For any dbt model that depends on this dbt source, Dagster then knows that the Dagster asset corresponding to the dbt model should depend on the Dagster asset corresponding to the source.


### PR DESCRIPTION
## Summary & Motivation
As the title. Resolves this feedback:

> I have been working on the same thing and I didn't realize based on the documentation that the Database table name and the Dagster Asset Key name had to be Identical. Might be something you say explicitly in the documentation. I might be the only one that didn't realize that though...

## How I Tested These Changes
read
