### PR TITLE
Set a default timeout when using the Dagster GraphQL client, allow setting headers without requiring a custom Transport

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/client/client.py
+++ b/python_modules/dagster-graphql/dagster_graphql/client/client.py
@@ -48,12 +48,16 @@ class DagsterGraphQLClient:
     Args:
         hostname (str): Hostname for the Dagster GraphQL API, like `localhost` or
             `dagster.YOUR_ORG_HERE`.
-        port_number (Optional[int], optional): Optional port number to connect to on the host.
+        port_number (Optional[int]): Port number to connect to on the host.
             Defaults to None.
         transport (Optional[Transport], optional): A custom transport to use to connect to the
             GraphQL API with (e.g. for custom auth). Defaults to None.
         use_https (bool, optional): Whether to use https in the URL connection string for the
             GraphQL API. Defaults to False.
+        timeout (int): Number of seconds before requests should time out. Defaults to 60.
+        headers (Optional[Dict[str, str]]): Additional headers to include in the request. To use
+            this client in Dagster Cloud, set the "Dagster-Cloud-Api-Token" header to a user token
+            generated in the Dagster Cloud UI.
 
     Raises:
         :py:class:`~requests.exceptions.ConnectionError`: if the client cannot connect to the host.
@@ -65,6 +69,8 @@ class DagsterGraphQLClient:
         port_number: Optional[int] = None,
         transport: Optional[Transport] = None,
         use_https: bool = False,
+        timeout: int = 300,
+        headers: Optional[Dict[str, str]] = None,
     ):
         self._hostname = check.str_param(hostname, "hostname")
         self._port_number = check.opt_int_param(port_number, "port_number")
@@ -80,7 +86,9 @@ class DagsterGraphQLClient:
             transport,
             "transport",
             Transport,
-            default=RequestsHTTPTransport(url=self._url, use_json=True),
+            default=RequestsHTTPTransport(
+                url=self._url, use_json=True, timeout=timeout, headers=headers
+            ),
         )
         try:
             self._client = Client(transport=self._transport, fetch_schema_from_transport=True)


### PR DESCRIPTION
Summary:
The default behavior here sets no timeout, which can hang as per https://requests.readthedocs.io/en/latest/user/quickstart/#timeouts. Instead, set a default configurable timeout.

Also add a headers arg, which makes it much less awkward when using this class to connect to Dagster Cloud.

Test Plan:
Existing graphql python client test suite
Tricky to verify that the specific hang is gone, but can verify that the timeout is actually being applied by:
Spinning up a local dagit with dagster dev

from dagster_graphql import DagsterGraphQLClient

DagsterGraphQLClient("localhost", 3000, timeout=0.1).reload_repository_location("dagster_test.toys.repo") - times out
DagsterGraphQLClient("localhost", 3000).reload_repository_location("dagster_test.toys.repo") - does not time out

## Summary & Motivation

## How I Tested These Changes
