### PR TITLE
Make every daemon heartbeat once immediately on startup

### DIFF
--- a/integration_tests/test_suites/daemon-test-suite/test_dagster_daemon_health.py
+++ b/integration_tests/test_suites/daemon-test-suite/test_dagster_daemon_health.py
@@ -231,10 +231,8 @@ def test_error_daemon(monkeypatch):
                         heartbeat_interval_seconds=heartbeat_interval_seconds,
                     )[SensorDaemon.daemon_type()]
 
-                    assert status.healthy is False
-
                     # Errors build up until there are > 5, then pull off the last
-                    if len(status.last_heartbeat.errors) >= 5:
+                    if status.healthy is False and len(status.last_heartbeat.errors) >= 5:
                         first_error_number = _get_error_number(status.last_heartbeat.errors[0])
 
                         if first_error_number > 5:


### PR DESCRIPTION
Summary:
Fixes an issue I ran into while testing sensor timeouts - if the first tick the sensor daemon runs is slow, the daemon might not heartbeat in time, and the daemon process gets shut down due to not heartbeating.

IntervalDaemons solve this by yielding once right away, but the sensor daemon is not an interval daemon.

To fix this, move the initial heartbeat check to the start of the daemon loop instead of after the first iteration (no need to heartbeat one last time on shutdown, so should be the same in practice other than heartbeating once right away on startup)

Test Plan:
Existing daemon heartbeat tests
Manually run a sensor that hangs via 'dagster dev' - sensor daemon no longer crashes after 60 seconds since it has not heartbeated in time

## Summary & Motivation

## How I Tested These Changes
