### PR TITLE
include hidden --grpc-port, --grpc-host, --grpc-socket args to dagster dev

### DIFF
--- a/integration_tests/test_suites/daemon-test-suite/dagster_dev_command_tests/test_dagster_dev_command.py
+++ b/integration_tests/test_suites/daemon-test-suite/dagster_dev_command_tests/test_dagster_dev_command.py
@@ -8,7 +8,10 @@ import requests
 import yaml
 from dagster import DagsterEventType, DagsterInstance, EventRecordsFilter
 from dagster._core.test_utils import environ, new_cwd
+from dagster._grpc.client import DagsterGrpcClient
+from dagster._grpc.server import wait_for_grpc_server
 from dagster._utils import find_free_port
+from dagster_graphql import DagsterGraphQLClient
 
 
 def _wait_for_dagit_running(dagit_port):
@@ -138,3 +141,59 @@ def test_dagster_dev_command_no_dagster_home():
                 finally:
                     dev_process.send_signal(signal.SIGINT)
                     dev_process.communicate()
+
+
+def test_dagster_dev_command_grpc_port():
+    with tempfile.TemporaryDirectory() as tempdir:
+        dagit_port = find_free_port()
+        grpc_port = find_free_port()
+
+        grpc_process = None
+        dev_process = None
+
+        try:
+            subprocess_args = [
+                "dagster",
+                "api",
+                "grpc",
+                "-f",
+                os.path.join(
+                    os.path.dirname(__file__),
+                    "repo.py",
+                ),
+                "--working-directory",
+                os.path.dirname(__file__),
+                "-p",
+                str(grpc_port),
+            ]
+            grpc_process = subprocess.Popen(subprocess_args)
+
+            client = DagsterGrpcClient(port=grpc_port, host="localhost")
+            wait_for_grpc_server(grpc_process, client, subprocess_args)
+
+            dev_process = subprocess.Popen(
+                [
+                    "dagster",
+                    "dev",
+                    "--dagit-port",
+                    str(dagit_port),
+                    "--dagit-host",
+                    "127.0.0.1",
+                    "--grpc-port",
+                    str(grpc_port),
+                    "--grpc-host",
+                    "localhost",
+                ],
+                cwd=tempdir,
+            )
+            _wait_for_dagit_running(dagit_port)
+            client = DagsterGraphQLClient(hostname="localhost", port_number=dagit_port)
+            client.submit_job_execution("foo_job")
+        finally:
+            if grpc_process:
+                grpc_process.send_signal(signal.SIGINT)
+                grpc_process.communicate()
+
+            if dev_process:
+                dev_process.send_signal(signal.SIGINT)
+                dev_process.communicate()

--- a/python_modules/dagster/dagster/_cli/dev.py
+++ b/python_modules/dagster/dagster/_cli/dev.py
@@ -19,6 +19,7 @@ from .utils import get_possibly_temporary_instance_for_cli
 from .workspace.cli_target import (
     ClickArgValue,
     get_workspace_load_target,
+    grpc_server_target_click_options,
     python_file_option,
     python_module_option,
     working_directory_option,
@@ -36,6 +37,7 @@ def dev_command_options(f):
         python_file_option(allow_multiple=True),
         python_module_option(allow_multiple=True),
         working_directory_option(),
+        *grpc_server_target_click_options(hidden=True),
     )
 
 
@@ -135,6 +137,18 @@ def dev_command(
 
         if kwargs.get("working_directory"):
             args.extend(["--working-directory", check.str_elem(kwargs, "working_directory")])
+
+        if kwargs.get("grpc_port"):
+            args.extend(["--grpc-port", str(kwargs["grpc_port"])])
+
+        if kwargs.get("grpc_host"):
+            args.extend(["--grpc-host", str(kwargs["grpc_host"])])
+
+        if kwargs.get("grpc_socket"):
+            args.extend(["--grpc-socket", str(kwargs["grpc_socket"])])
+
+        if kwargs.get("use_ssl"):
+            args.extend(["--use-ssl"])
 
         webserver_process = open_ipc_subprocess(
             [sys.executable, "-m", "dagster_webserver"]

--- a/python_modules/dagster/dagster/_cli/workspace/cli_target.py
+++ b/python_modules/dagster/dagster/_cli/workspace/cli_target.py
@@ -370,31 +370,35 @@ def python_target_click_options(allow_multiple_python_targets: bool) -> Sequence
     ]
 
 
-def grpc_server_target_click_options() -> Sequence[ClickOption]:
+def grpc_server_target_click_options(hidden=False) -> Sequence[ClickOption]:
     return [
         click.option(
             "--grpc-port",
             type=click.INT,
             required=False,
             help="Port to use to connect to gRPC server",
+            hidden=hidden,
         ),
         click.option(
             "--grpc-socket",
             type=click.Path(),
             required=False,
             help="Named socket to use to connect to gRPC server",
+            hidden=hidden,
         ),
         click.option(
             "--grpc-host",
             type=click.STRING,
             required=False,
             help="Host to use to connect to gRPC server, defaults to localhost",
+            hidden=hidden,
         ),
         click.option(
             "--use-ssl",
             is_flag=True,
             required=False,
             help="Use a secure channel when connecting to the gRPC server",
+            hidden=hidden,
         ),
     ]
 


### PR DESCRIPTION
Summary:
This is useful for debugging and development, but I made the new args hidden because I don't think we need to pollute the '--help' output with them.

## Summary & Motivation

## How I Tested These Changes
