### PR TITLE
[ui] Asset feature context

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/ContentRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/ContentRoot.tsx
@@ -2,6 +2,8 @@ import {MainContent, ErrorBoundary} from '@dagster-io/ui-components';
 import * as React from 'react';
 import {Route, Switch, useLocation} from 'react-router-dom';
 
+import {AssetFeatureProvider} from '../assets/AssetFeatureContext';
+
 const WorkspaceRoot = React.lazy(() => import('../workspace/WorkspaceRoot'));
 const OverviewRoot = React.lazy(() => import('../overview/OverviewRoot'));
 const FallthroughRoot = React.lazy(() => import('./FallthroughRoot'));
@@ -38,7 +40,9 @@ export const ContentRoot = React.memo(() => {
           </Route>
           <Route path="/assets(/?.*)">
             <React.Suspense fallback={<div />}>
-              <AssetsCatalogRoot />
+              <AssetFeatureProvider>
+                <AssetsCatalogRoot />
+              </AssetFeatureProvider>
             </React.Suspense>
           </Route>
           <Route path="/runs" exact>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEvents.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEvents.tsx
@@ -21,11 +21,10 @@ import {useStateWithStorage} from '../hooks/useStateWithStorage';
 import {AssetEventDetail, AssetEventDetailEmpty} from './AssetEventDetail';
 import {AssetEventList} from './AssetEventList';
 import {AssetPartitionDetail, AssetPartitionDetailEmpty} from './AssetPartitionDetail';
-import {AssetViewParams} from './AssetView';
 import {CurrentRunsBanner} from './CurrentRunsBanner';
 import {FailedRunSinceMaterializationBanner} from './FailedRunSinceMaterializationBanner';
 import {AssetEventGroup, useGroupedEvents} from './groupByPartition';
-import {AssetKey} from './types';
+import {AssetKey, AssetViewParams} from './types';
 import {AssetViewDefinitionNodeFragment} from './types/AssetView.types';
 import {useRecentAssetEvents} from './useRecentAssetEvents';
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetFeatureContext.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetFeatureContext.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react';
+
+import {AssetTabConfig, AssetTabConfigInput, buildAssetTabs} from './AssetTabs';
+import {AssetKey} from './types';
+import {AssetNodeDefinitionFragment} from './types/AssetNodeDefinition.types';
+
+export type AssetViewFeatureInput = {
+  selectedTab: string;
+  assetKey: AssetKey;
+  definition: AssetNodeDefinitionFragment | null;
+};
+
+type AssetFeatureContextType = {
+  tabBuilder: (input: AssetTabConfigInput) => AssetTabConfig[];
+  renderFeatureView: (input: AssetViewFeatureInput) => React.ReactNode;
+};
+
+export const AssetFeatureContext = React.createContext<AssetFeatureContextType>({
+  tabBuilder: () => [],
+  renderFeatureView: () => <span />,
+});
+
+const renderFeatureView = () => <span />;
+
+export const AssetFeatureProvider = ({children}: {children: React.ReactNode}) => {
+  const value = React.useMemo(() => {
+    return {
+      tabBuilder: buildAssetTabs,
+      renderFeatureView,
+    };
+  }, []);
+
+  return <AssetFeatureContext.Provider value={value}>{children}</AssetFeatureContext.Provider>;
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeLineage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeLineage.tsx
@@ -14,9 +14,9 @@ import {GraphData, LiveData} from '../asset-graph/Utils';
 import {AssetGraphQueryItem, calculateGraphDistances} from '../asset-graph/useAssetGraphData';
 import {AssetKeyInput} from '../graphql/types';
 
-import {AssetLineageScope, AssetNodeLineageGraph} from './AssetNodeLineageGraph';
-import {AssetViewParams} from './AssetView';
+import {AssetNodeLineageGraph} from './AssetNodeLineageGraph';
 import {LaunchAssetExecutionButton} from './LaunchAssetExecutionButton';
+import {AssetLineageScope, AssetViewParams} from './types';
 
 export const AssetNodeLineage: React.FC<{
   params: AssetViewParams;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeLineageGraph.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeLineageGraph.tsx
@@ -14,13 +14,10 @@ import {useAssetLayout} from '../graph/asyncGraphLayout';
 import {AssetKeyInput} from '../graphql/types';
 import {getJSONForKey} from '../hooks/useStateWithStorage';
 
-import {AssetViewParams} from './AssetView';
 import {assetDetailsPathForKey} from './assetDetailsPathForKey';
-import {AssetKey} from './types';
+import {AssetKey, AssetViewParams} from './types';
 
 const LINEAGE_GRAPH_ZOOM_LEVEL = 'lineageGraphZoomLevel';
-
-export type AssetLineageScope = 'neighbors' | 'upstream' | 'downstream';
 
 export const AssetNodeLineageGraph: React.FC<{
   assetKey: AssetKeyInput;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitions.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitions.tsx
@@ -24,9 +24,8 @@ import {AssetPartitionDetailEmpty, AssetPartitionDetailLoader} from './AssetPart
 import {AssetPartitionList} from './AssetPartitionList';
 import {AssetPartitionStatus} from './AssetPartitionStatus';
 import {AssetPartitionStatusCheckboxes} from './AssetPartitionStatusCheckboxes';
-import {AssetViewParams} from './AssetView';
 import {isTimeseriesDimension} from './MultipartitioningSupport';
-import {AssetKey} from './types';
+import {AssetViewParams, AssetKey} from './types';
 import {usePartitionDimensionSelections} from './usePartitionDimensionSelections';
 import {
   usePartitionHealthData,

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPlots.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPlots.tsx
@@ -2,9 +2,8 @@ import {Box, ButtonGroup, Colors, Spinner, Subheading} from '@dagster-io/ui-comp
 import * as React from 'react';
 
 import {AssetMaterializationGraphs} from './AssetMaterializationGraphs';
-import {AssetViewParams} from './AssetView';
 import {useGroupedEvents} from './groupByPartition';
-import {AssetKey} from './types';
+import {AssetViewParams, AssetKey} from './types';
 import {useRecentAssetEvents} from './useRecentAssetEvents';
 
 interface Props {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetTabs.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetTabs.tsx
@@ -1,0 +1,102 @@
+import {Tab, Tabs} from '@dagster-io/ui-components';
+import qs from 'qs';
+import * as React from 'react';
+
+import {TabLink} from '../ui/TabLink';
+
+import {AssetViewParams} from './types';
+import {AssetViewDefinitionNodeFragment} from './types/AssetView.types';
+
+interface Props {
+  selectedTab: string;
+  tabs: AssetTabConfig[];
+}
+
+export const AssetTabs = (props: Props) => {
+  const {selectedTab, tabs} = props;
+
+  return (
+    <Tabs size="large" selectedTabId={selectedTab}>
+      {tabs
+        .filter((tab) => !tab.hidden)
+        .map(({id, title, to, disabled}) => {
+          if (disabled) {
+            return <Tab disabled key={id} id={id} title={title} />;
+          }
+          return <TabLink key={id} id={id} title={title} to={to} disabled={disabled} />;
+        })}
+    </Tabs>
+  );
+};
+
+export const DEFAULT_ASSET_TAB_ORDER = [
+  'partitions',
+  'events',
+  'plots',
+  'definition',
+  'lineage',
+  'auto-materialize-history',
+];
+
+export type AssetTabConfigInput = {
+  definition: AssetViewDefinitionNodeFragment | null;
+  params: AssetViewParams;
+};
+
+export type AssetTabConfig = {
+  id: string;
+  title: string;
+  to: string;
+  disabled?: boolean;
+  hidden?: boolean;
+};
+
+export const buildAssetViewParams = (params: AssetViewParams) => `?${qs.stringify(params)}`;
+
+export const buildAssetTabMap = (input: AssetTabConfigInput): Record<string, AssetTabConfig> => {
+  const {definition, params} = input;
+  return {
+    partitions: {
+      id: 'partitions',
+      title: 'Partitions',
+      to: buildAssetViewParams({...params, view: 'partitions'}),
+      hidden: !definition?.partitionDefinition,
+    },
+    events: {
+      id: 'events',
+      title: 'Events',
+      to: buildAssetViewParams({...params, view: 'events', partition: undefined}),
+    },
+    plots: {
+      id: 'plots',
+      title: 'Plots',
+      to: buildAssetViewParams({...params, view: 'plots'}),
+    },
+    definition: {
+      id: 'definition',
+      title: 'Definition',
+      to: buildAssetViewParams({...params, view: 'definition'}),
+      disabled: !definition,
+    },
+    lineage: {
+      id: 'lineage',
+      title: 'Lineage',
+      to: buildAssetViewParams({...params, view: 'lineage'}),
+      disabled: !definition,
+    },
+    autoMaterialize: {
+      id: 'auto-materialize-history',
+      title: 'Auto-materialize history',
+      to: buildAssetViewParams({...params, view: 'auto-materialize-history'}),
+      disabled: !definition,
+      hidden: !definition?.autoMaterializePolicy,
+    },
+  };
+};
+
+export const buildAssetTabs = (input: AssetTabConfigInput): AssetTabConfig[] => {
+  const tabConfigs = buildAssetTabMap(input);
+  return DEFAULT_ASSET_TAB_ORDER.map((tabId) => tabConfigs[tabId]).filter(
+    (tab): tab is AssetTabConfig => !!tab,
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__stories__/AssetPartitions.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__stories__/AssetPartitions.stories.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 
 import {StorybookProvider} from '../../testing/StorybookProvider';
 import {AssetPartitions} from '../AssetPartitions';
-import {AssetViewParams} from '../AssetView';
 import {
   MultiDimensionStaticPartitionHealthQuery,
   MultiDimensionTimeFirstPartitionHealthQuery,
@@ -11,6 +10,7 @@ import {
   SingleDimensionStaticPartitionHealthQuery,
   SingleDimensionTimePartitionHealthQuery,
 } from '../__fixtures__/PartitionHealthSummary.fixtures';
+import {AssetViewParams} from '../types';
 
 // eslint-disable-next-line import/no-default-export
 export default {component: AssetPartitions};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/AssetPartitions.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/AssetPartitions.test.tsx
@@ -8,12 +8,12 @@ import {AssetKeyInput} from '../../graphql/types';
 import {AssetPartitionListProps} from '../AssetPartitionList';
 import {AssetPartitionStatus} from '../AssetPartitionStatus';
 import {AssetPartitions} from '../AssetPartitions';
-import {AssetViewParams} from '../AssetView';
 import {
   SingleDimensionStaticPartitionHealthQuery,
   SingleDimensionTimePartitionHealthQuery,
   MultiDimensionTimeFirstPartitionHealthQuery,
 } from '../__fixtures__/PartitionHealthSummary.fixtures';
+import {AssetViewParams} from '../types';
 
 // This file must be mocked because useVirtualizer tries to create a ResizeObserver,
 // and the component tree fails to mount. We still want to test whether certain partitions

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/assetDetailsPathForKey.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/assetDetailsPathForKey.tsx
@@ -1,7 +1,6 @@
 import qs from 'qs';
 
-import {AssetViewParams} from './AssetView';
-import {AssetKey} from './types';
+import {AssetKey, AssetViewParams} from './types';
 
 export const assetDetailsPathForKey = (key: AssetKey, query?: AssetViewParams) => {
   return `/assets/${key.path.map(encodeURIComponent).join('/')}?${qs.stringify(query)}`;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types.tsx
@@ -1,3 +1,15 @@
 export interface AssetKey {
   path: string[];
 }
+
+export type AssetLineageScope = 'neighbors' | 'upstream' | 'downstream';
+
+export interface AssetViewParams {
+  view?: string;
+  lineageScope?: AssetLineageScope;
+  lineageDepth?: number;
+  partition?: string;
+  time?: string;
+  asOf?: string;
+  evaluation?: string;
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/usePartitionKeyInParams.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/usePartitionKeyInParams.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import {AssetViewParams} from './AssetView';
+import {AssetViewParams} from './types';
 
 export function usePartitionKeyInParams({
   params,

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useRecentAssetEvents.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useRecentAssetEvents.tsx
@@ -5,8 +5,7 @@ import * as React from 'react';
 import {METADATA_ENTRY_FRAGMENT} from '../metadata/MetadataEntry';
 
 import {ASSET_LINEAGE_FRAGMENT} from './AssetLineageElements';
-import {AssetViewParams} from './AssetView';
-import {AssetKey} from './types';
+import {AssetViewParams, AssetKey} from './types';
 import {AssetEventsQuery, AssetEventsQueryVariables} from './types/useRecentAssetEvents.types';
 
 /**


### PR DESCRIPTION
## Summary & Motivation

Introduce `AssetFeatureContext`, which allows injecting tabs and views into the OSS assets view, so that we can add Cloud-specific features to this part of the Dagster app.

- Refactor the Assets tabs code so that it is build separately from `AssetView`. Configuration is provided via a tab builder function that can be overridden.
- Similarly, refactor how we render the selected tab view to allow defining a fallthrough view.

In Cloud, we can then define a provider that uses Cloud-specific tab and view configuration.

## How I Tested These Changes

View an asset in OSS app, verify that current rendering and behavior appears unchanged. Tabs and views all work correctly.

View an asset in Cloud app, verify that context overrides are consumed correctly, with new tabs and view rendering as expected -- as long as the relevant feature gate is enabled. See corresponding Cloud PR for details.
