### PR TITLE
[docs] - Essentials v1 sidenav updates

### DIFF
--- a/docs/content/_navigation.json
+++ b/docs/content/_navigation.json
@@ -73,7 +73,6 @@
     "children": [
       {
         "title": "Assets",
-        "path": "/concepts/assets/software-defined-assets",
         "children": [
           {
             "title": "Software-defined Assets",
@@ -104,7 +103,6 @@
       
       {
         "title": "Schedules & Sensors",
-        "path": "/concepts/partitions-schedules-sensors/schedules",
         "children": [
           {
             "title": "Schedules",
@@ -121,8 +119,7 @@
         ]
       },
       {
-        "title": "Partitions & Backfills",
-        "path": "/concepts/partitions-schedules-sensors/partitions",
+        "title": "Partitions & backfills",
         "children": [
           {
             "title": "Partitions",
@@ -153,7 +150,6 @@
       },
       {
         "title": "Code locations",
-        "path": "/concepts/code-locations",
         "children": [
           {
             "title": "Code locations (Definitions)",
@@ -178,7 +174,6 @@
         "children": [
           {
             "title": "Ops",
-            "path": "/concepts/ops-jobs-graphs/ops",
             "children": [
               {
                 "title": "Ops",
@@ -212,7 +207,6 @@
           },
           {
             "title": "Jobs",
-            "path": "/concepts/ops-jobs-graphs/jobs",
             "children": [
               {
                 "title": "Jobs",
@@ -230,7 +224,6 @@
           },
           {
             "title": "I/O management",
-            "path": "/concepts/io-management/io-managers",
             "children": [
               {
                 "title": "I/O managers",

--- a/docs/content/_navigation.json
+++ b/docs/content/_navigation.json
@@ -101,58 +101,7 @@
           }
         ]
       },
-      {
-        "title": "Ops",
-        "path": "/concepts/ops-jobs-graphs/ops",
-        "children": [
-          {
-            "title": "Ops",
-            "path": "/concepts/ops-jobs-graphs/ops"
-          },
-          {
-            "title": "Op events",
-            "path": "/concepts/ops-jobs-graphs/op-events"
-          },
-          {
-            "title": "Op hooks",
-            "path": "/concepts/ops-jobs-graphs/op-hooks"
-          },
-          {
-            "title": "Op retries",
-            "path": "/concepts/ops-jobs-graphs/op-retries"
-          },
-          {
-            "title": "Op graphs",
-            "path": "/concepts/ops-jobs-graphs/graphs"
-          },
-          {
-            "title": "Nesting op graphs",
-            "path": "/concepts/ops-jobs-graphs/nesting-graphs"
-          },
-          {
-            "title": "Dynamic op graphs",
-            "path": "/concepts/ops-jobs-graphs/dynamic-graphs"
-          }
-        ]
-      },
-      {
-        "title": "Jobs",
-        "path": "/concepts/ops-jobs-graphs/jobs",
-        "children": [
-          {
-            "title": "Jobs",
-            "path": "/concepts/ops-jobs-graphs/jobs"
-          },
-          {
-            "title": "Job execution",
-            "path": "/concepts/ops-jobs-graphs/job-execution"
-          },
-          {
-            "title": "Metadata & tags",
-            "path": "/concepts/ops-jobs-graphs/metadata-tags"
-          }
-        ]
-      },
+      
       {
         "title": "Schedules & Sensors",
         "path": "/concepts/partitions-schedules-sensors/schedules",
@@ -186,23 +135,12 @@
         ]
       },
       {
-        "title": "I/O management",
-        "path": "/concepts/io-management/io-managers",
+        "title": "Resources & configuration",
         "children": [
           {
-            "title": "I/O managers",
-            "path": "/concepts/io-management/io-managers"
+            "title": "Resources",
+            "path": "/concepts/resources"
           },
-          {
-            "title": "Unconnected inputs",
-            "path": "/concepts/io-management/unconnected-inputs"
-          }
-        ]
-      },
-      {
-        "title": "Configuration",
-        "path": "/concepts/configuration/config-schema",
-        "children": [
           {
             "title": "Run configuration",
             "path": "/concepts/configuration/config-schema"
@@ -212,10 +150,6 @@
             "path": "/concepts/configuration/advanced-config-types"
           }
         ]
-      },
-      {
-        "title": "Resources",
-        "path": "/concepts/resources"
       },
       {
         "title": "Code locations",
@@ -232,42 +166,113 @@
         ]
       },
       {
-        "title": "Dagster webserver & UI",
-        "children": [
-          {
-            "title": "Dagster UI",
-            "path": "/concepts/webserver/ui"
-          },
-          {
-            "title": "GraphQL API",
-            "path": "/concepts/webserver/graphql"
-          },
-          {
-            "title": "GraphQL Python client",
-            "path": "/concepts/webserver/graphql-client"
-          }
-        ]
-      },
-      {
-        "title": "Dagster Types",
-        "path": "/concepts/types"
-      },
-      {
-        "title": "Logging",
-        "children": [
-          {
-            "title": "Loggers",
-            "path": "/concepts/logging/loggers"
-          },
-          {
-            "title": "Python logging",
-            "path": "/concepts/logging/python-logging"
-          }
-        ]
+        "title": "Dagster UI",
+        "path": "/concepts/webserver/ui"
       },
       {
         "title": "Testing",
         "path": "/concepts/testing"
+      },
+      {
+        "title": "Advanced",
+        "children": [
+          {
+            "title": "Ops",
+            "path": "/concepts/ops-jobs-graphs/ops",
+            "children": [
+              {
+                "title": "Ops",
+                "path": "/concepts/ops-jobs-graphs/ops"
+              },
+              {
+                "title": "Op events",
+                "path": "/concepts/ops-jobs-graphs/op-events"
+              },
+              {
+                "title": "Op hooks",
+                "path": "/concepts/ops-jobs-graphs/op-hooks"
+              },
+              {
+                "title": "Op retries",
+                "path": "/concepts/ops-jobs-graphs/op-retries"
+              },
+              {
+                "title": "Op graphs",
+                "path": "/concepts/ops-jobs-graphs/graphs"
+              },
+              {
+                "title": "Nesting op graphs",
+                "path": "/concepts/ops-jobs-graphs/nesting-graphs"
+              },
+              {
+                "title": "Dynamic op graphs",
+                "path": "/concepts/ops-jobs-graphs/dynamic-graphs"
+              }
+            ]
+          },
+          {
+            "title": "Jobs",
+            "path": "/concepts/ops-jobs-graphs/jobs",
+            "children": [
+              {
+                "title": "Jobs",
+                "path": "/concepts/ops-jobs-graphs/jobs"
+              },
+              {
+                "title": "Job execution",
+                "path": "/concepts/ops-jobs-graphs/job-execution"
+              },
+              {
+                "title": "Metadata & tags",
+                "path": "/concepts/ops-jobs-graphs/metadata-tags"
+              }
+            ]
+          },
+          {
+            "title": "I/O management",
+            "path": "/concepts/io-management/io-managers",
+            "children": [
+              {
+                "title": "I/O managers",
+                "path": "/concepts/io-management/io-managers"
+              },
+              {
+                "title": "Unconnected inputs",
+                "path": "/concepts/io-management/unconnected-inputs"
+              }
+            ]
+          },
+          {
+            "title": "Dagster Types",
+            "path": "/concepts/types"
+          },
+          {
+            "title": "Logging",
+            "children": [
+              {
+                "title": "Loggers",
+                "path": "/concepts/logging/loggers"
+              },
+              {
+                "title": "Python logging",
+                "path": "/concepts/logging/python-logging"
+              }
+            ]
+          },
+          {
+            "title": "GraphQL",
+            "children": [
+              {
+                "title": "GraphQL API",
+                "path": "/concepts/webserver/graphql"
+              },
+              {
+                "title": "GraphQL Python client",
+                "path": "/concepts/webserver/graphql-client"
+              }
+            ]
+          }
+        ]
       }
     ]
   },


### PR DESCRIPTION
## Summary & Motivation

This PR updates the sidenav in the docs to reflect the changes in the Essentials v1 project:

- Adds a **Concepts > Advanced** section
- Moves some concepts to **Advanced**: Ops, Graphs, Jobs, I/O, Dagster Types, Logging, and GraphQL
- Removes URLs from sidenav items that have children, but don't have a category page. Ex: Partitions & backfills. It feels like a weird experience to click on an item like this and be taken to a page that only describes one of the items. This is simpler than adding adding category pages, at least for now.

## How I Tested These Changes

👀 , local