### PR TITLE
AssetCheckExecution and ASSET_CHECK_EXECUTION event

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_check_execution.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_execution.py
@@ -1,0 +1,116 @@
+import enum
+from typing import TYPE_CHECKING, NamedTuple, Optional
+
+import dagster._check as check
+from dagster._serdes.serdes import whitelist_for_serdes
+
+from .asset_check_result import AssetCheckResult
+from .events import AssetKey
+
+if TYPE_CHECKING:
+    from dagster._core.event_api import EventLogRecord
+
+
+@whitelist_for_serdes
+class AssetCheckExecutionStatus(enum.Enum):
+    PLANNED = "PLANNED"  # No result yet
+    RESULT_SUCCESS = "RESULT_SUCCESS"
+    RESULT_FAILURE = "RESULT_FAILURE"
+
+
+@whitelist_for_serdes
+class AssetCheckExecution(
+    NamedTuple(
+        "_AssetCheckExecution",
+        [
+            ("asset_key", AssetKey),
+            ("check_name", str),
+            ("check_status", AssetCheckExecutionStatus),
+            ("run_id", str),
+            ("check_result", Optional[AssetCheckResult]),
+            ("target_materialization_record", Optional["EventLogRecord"]),
+            ("start_timestamp", Optional[float]),
+            ("end_timestamp", Optional[float]),
+        ],
+    )
+):
+    """Wrapper around AssetCheckResult that includes metadata about the execution of the check.
+
+    Normal use is to instantiate this class with AssetCheckExecution.planned(), then call
+    with_result() when the check is complete.
+    """
+
+    def __new__(
+        cls,
+        asset_key: AssetKey,
+        check_name: str,
+        check_status: AssetCheckExecutionStatus,
+        run_id: str,
+        check_result: Optional[AssetCheckResult] = None,
+        target_materialization_record: Optional["EventLogRecord"] = None,
+        start_timestamp: Optional[float] = None,
+        end_timestamp: Optional[float] = None,
+    ):
+        if check_status == AssetCheckExecutionStatus.PLANNED:
+            check.invariant(
+                check_result is None, "check_result must be None when check_status is PLANNED"
+            )
+        else:
+            check_result = check.not_none(
+                check_result,
+                "check_result must be provided when check_status is not PLANNED",
+            )
+            check.invariant(
+                asset_key == check_result.asset_key,
+                "asset_key and check_result.asset_key must match",
+            )
+            check.invariant(
+                check_name == check_result.check_name,
+                "check_name and check_result.check_name must match",
+            )
+            check.invariant(
+                (
+                    check_status == AssetCheckExecutionStatus.RESULT_SUCCESS
+                    if check_result.success
+                    else AssetCheckExecutionStatus.RESULT_FAILURE
+                ),
+                "check_status and check_result.success must match",
+            )
+
+        return super().__new__(
+            cls,
+            asset_key=asset_key,
+            check_name=check_name,
+            check_status=check_status,
+            check_result=check_result,
+            target_materialization_record=target_materialization_record,
+            run_id=run_id,
+            start_timestamp=start_timestamp,
+            end_timestamp=end_timestamp,
+        )
+
+    @classmethod
+    def planned(cls, asset_key: AssetKey, check_name: str, run_id: str):
+        return cls(asset_key, check_name, AssetCheckExecutionStatus.PLANNED, run_id)
+
+    def with_result(
+        self,
+        check_result: AssetCheckResult,
+        target_materialization_record: "EventLogRecord",
+        start_timestamp: float,
+        end_timestamp: float,
+    ):
+        return AssetCheckExecution(
+            asset_key=self.asset_key,
+            check_name=self.check_name,
+            check_status=(
+                AssetCheckExecutionStatus.RESULT_SUCCESS
+                if check_result.success
+                else AssetCheckExecutionStatus.RESULT_FAILURE
+            ),
+            run_id=self.run_id,
+            check_result=check_result,
+            target_materialization_record=target_materialization_record,
+            start_timestamp=start_timestamp,
+            end_timestamp=end_timestamp,
+        )

--- a/python_modules/dagster/dagster/_core/events/__init__.py
+++ b/python_modules/dagster/dagster/_core/events/__init__.py
@@ -27,6 +27,7 @@ from dagster._core.definitions import (
     HookDefinition,
     NodeHandle,
 )
+from dagster._core.definitions.asset_check_execution import AssetCheckExecution
 from dagster._core.definitions.events import AssetLineageInfo, ObjectStoreOperationType
 from dagster._core.definitions.metadata import (
     MetadataFieldSerializer,
@@ -104,6 +105,7 @@ class DagsterEventType(str, Enum):
     ASSET_MATERIALIZATION = "ASSET_MATERIALIZATION"
     ASSET_MATERIALIZATION_PLANNED = "ASSET_MATERIALIZATION_PLANNED"
     ASSET_OBSERVATION = "ASSET_OBSERVATION"
+    ASSET_CHECK_EXECUTION = "ASSET_CHECK_EXECUTION"
     STEP_EXPECTATION_RESULT = "STEP_EXPECTATION_RESULT"
 
     # We want to display RUN_* events in the Dagster UI and in our LogManager output, but in order to
@@ -168,6 +170,7 @@ STEP_EVENTS = {
     DagsterEventType.STEP_SKIPPED,
     DagsterEventType.ASSET_MATERIALIZATION,
     DagsterEventType.ASSET_OBSERVATION,
+    DagsterEventType.ASSET_CHECK_EXECUTION,
     DagsterEventType.STEP_EXPECTATION_RESULT,
     DagsterEventType.OBJECT_STORE_OPERATION,
     DagsterEventType.HANDLED_OUTPUT,
@@ -279,6 +282,8 @@ def _validate_event_specific_data(
         check.inst_param(
             event_specific_data, "event_specific_data", AssetMaterializationPlannedData
         )
+    elif event_type == DagsterEventType.ASSET_CHECK_EXECUTION:
+        check.inst_param(event_specific_data, "event_specific_data", AssetCheckExecutionData)
 
     return event_specific_data
 
@@ -1485,6 +1490,22 @@ class StepExpectationResultData(
             expectation_result=check.inst_param(
                 expectation_result, "expectation_result", ExpectationResult
             ),
+        )
+
+
+@whitelist_for_serdes
+class AssetCheckExecutionData(
+    NamedTuple(
+        "_AssetCheckExecutionData",
+        [
+            ("execution", AssetCheckExecution),
+        ],
+    )
+):
+    def __new__(cls, execution: AssetCheckExecution):
+        return super(AssetCheckExecutionData, cls).__new__(
+            cls,
+            execution=check.inst_param(execution, "execution", AssetCheckExecution),
         )
 
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_asset_check_execution.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_asset_check_execution.py
@@ -1,0 +1,62 @@
+import pytest
+from dagster import AssetCheckResult, AssetKey
+from dagster._check import CheckError
+from dagster._core.definitions.asset_check_execution import (
+    AssetCheckExecution,
+    AssetCheckExecutionStatus,
+)
+from dagster._core.event_api import EventLogRecord
+from dagster._core.events.log import EventLogEntry
+
+
+def test_status():
+    key = AssetKey("foo")
+
+    execution = AssetCheckExecution.planned(asset_key=key, check_name="bar", run_id="baz")
+    assert execution.check_status == AssetCheckExecutionStatus.PLANNED
+
+    success_execution = execution.with_result(
+        check_result=AssetCheckResult(asset_key=key, check_name="bar", success=True),
+        target_materialization_record=EventLogRecord(
+            storage_id=1,
+            event_log_entry=EventLogEntry(
+                user_message="",
+                level="WARN",
+                timestamp=0.0,
+                step_key="",
+                dagster_event=None,
+                error_info=None,
+                run_id="",
+            ),
+        ),
+        start_timestamp=0,
+        end_timestamp=0,
+    )
+    assert success_execution.check_status == AssetCheckExecutionStatus.RESULT_SUCCESS
+
+    fail_execution = execution.with_result(
+        check_result=AssetCheckResult(asset_key=key, check_name="bar", success=False),
+        target_materialization_record=EventLogRecord(
+            storage_id=1,
+            event_log_entry=EventLogEntry(
+                user_message="",
+                level="WARNING",
+                timestamp=0.0,
+                step_key="",
+                dagster_event=None,
+                error_info=None,
+                run_id="",
+            ),
+        ),
+        start_timestamp=0,
+        end_timestamp=0,
+    )
+    assert fail_execution.check_status == AssetCheckExecutionStatus.RESULT_FAILURE
+
+    with pytest.raises(CheckError):
+        AssetCheckExecution(
+            asset_key=key,
+            check_name="bar",
+            check_status=AssetCheckExecutionStatus.RESULT_SUCCESS,
+            run_id="baz",
+        )


### PR DESCRIPTION
Users return AssetCheckResults. We want to store more data about the result. Hence a wrapper class, AssetCheckExecution.

https://github.com/dagster-io/dagster/pull/15851 shows the class in use