### PR TITLE
[brownfield-essentials] make sure output stream is closed when dagster external process shuts down

### DIFF
--- a/python_modules/dagster/dagster/_core/external_execution/task.py
+++ b/python_modules/dagster/dagster/_core/external_execution/task.py
@@ -294,7 +294,7 @@ class ExternalExecutionTask:
     # Only used in socket mode
     def _shutdown_socket_server(self, sockaddr: SocketAddress) -> None:
         with socket.create_connection(sockaddr) as sock:
-            sock.makefile("w").write(f"{SocketServerControlMessage.shutdown}\n")
+            sock.makefile("w").write(f"{SocketServerControlMessage.shutdown.value}\n")
 
     # ########################
     # ##### HANDLE NOTIFICATIONS


### PR DESCRIPTION
## Summary & Motivation

This was hanging on 3.11. Turns out the problem was a [breaking change](https://blog.pecar.me/python-enum) to how enums are string-formatted in Python 3.11, which was breaking the socket protocol (which uses an enum to define control messages). Also added an `atexit` call to guarantee client socket gets closed cleanly, though this turned out not to matter.

## How I Tested These Changes

Existing test suite with `test-all` (tests all python versions).