### PR TITLE
[dagster-azure] rename io manager to ADLS2PickleIOManager

### DIFF
--- a/python_modules/libraries/dagster-azure/dagster_azure/adls2/__init__.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/adls2/__init__.py
@@ -8,6 +8,7 @@ from .file_manager import (
     ADLS2FileManager as ADLS2FileManager,
 )
 from .io_manager import (
+    ADLS2PickleIOManager as ADLS2PickleIOManager,
     ConfigurablePickledObjectADLS2IOManager as ConfigurablePickledObjectADLS2IOManager,
     PickledObjectADLS2IOManager as PickledObjectADLS2IOManager,
     adls2_pickle_io_manager as adls2_pickle_io_manager,

--- a/python_modules/libraries/dagster-azure/dagster_azure/adls2/io_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/adls2/io_manager.py
@@ -9,6 +9,7 @@ from dagster import (
     _check as check,
     io_manager,
 )
+from dagster._annotations import deprecated
 from dagster._config.pythonic_config import ConfigurableIOManager
 from dagster._core.storage.io_manager import dagster_maintained_io_manager
 from dagster._core.storage.upath_io_manager import UPathIOManager
@@ -200,8 +201,14 @@ class ADLS2PickleIOManager(ConfigurableIOManager):
         self._internal_io_manager.handle_output(context, obj)
 
 
-# ADLS2PickleIOManager used to be named ConfigurablePickledObjectADLS2IOManager, keep this symbol around for backcompat
-ConfigurablePickledObjectADLS2IOManager = ADLS2PickleIOManager
+@deprecated(
+    breaking_version="2.0",
+    additional_warn_text="Please use GCSPickleIOManager instead.",
+)
+class ConfigurablePickledObjectADLS2IOManager(ADLS2PickleIOManager):
+    """Renamed to ADLS2PickleIOManager. See ADLS2PickleIOManager for documentation."""
+
+    pass
 
 
 @dagster_maintained_io_manager

--- a/python_modules/libraries/dagster-azure/dagster_azure/adls2/io_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/adls2/io_manager.py
@@ -105,7 +105,7 @@ class PickledObjectADLS2IOManager(UPathIOManager):
             file.upload_data(pickled_obj, lease=lease, overwrite=True)
 
 
-class ConfigurablePickledObjectADLS2IOManager(ConfigurableIOManager):
+class ADLS2PickleIOManager(ConfigurableIOManager):
     """Persistent IO manager using Azure Data Lake Storage Gen2 for storage.
 
     Serializes objects via pickling. Suitable for objects storage for distributed executors, so long
@@ -129,7 +129,7 @@ class ConfigurablePickledObjectADLS2IOManager(ConfigurableIOManager):
     .. code-block:: python
 
         from dagster import Definitions, asset
-        from dagster_azure.adls2 import ConfigurablePickledObjectADLS2IOManager, adls2_resource
+        from dagster_azure.adls2 import ADLS2PickleIOManager, adls2_resource
 
         @asset
         def asset1():
@@ -143,7 +143,7 @@ class ConfigurablePickledObjectADLS2IOManager(ConfigurableIOManager):
         defs = Definitions(
             assets=[asset1, asset2],
             resources={
-                "io_manager": ConfigurablePickledObjectADLS2IOManager(
+                "io_manager": ADLS2PickleIOManager(
                     adls2_file_system="my-cool-fs",
                     adls2_prefix="my-cool-prefix"
                 ),
@@ -157,11 +157,11 @@ class ConfigurablePickledObjectADLS2IOManager(ConfigurableIOManager):
     .. code-block:: python
 
         from dagster import job
-        from dagster_azure.adls2 import ConfigurablePickledObjectADLS2IOManager, adls2_resource
+        from dagster_azure.adls2 import ADLS2PickleIOManager, adls2_resource
 
         @job(
             resource_defs={
-                "io_manager": ConfigurablePickledObjectADLS2IOManager(
+                "io_manager": ADLS2PickleIOManager(
                     adls2_file_system="my-cool-fs",
                     adls2_prefix="my-cool-prefix"
                 ),
@@ -200,9 +200,13 @@ class ConfigurablePickledObjectADLS2IOManager(ConfigurableIOManager):
         self._internal_io_manager.handle_output(context, obj)
 
 
+# ADLS2PickleIOManager used to be named ConfigurablePickledObjectADLS2IOManager, keep this symbol around for backcompat
+ConfigurablePickledObjectADLS2IOManager = ADLS2PickleIOManager
+
+
 @dagster_maintained_io_manager
 @io_manager(
-    config_schema=ConfigurablePickledObjectADLS2IOManager.to_config_schema(),
+    config_schema=ADLS2PickleIOManager.to_config_schema(),
     required_resource_keys={"adls2"},
 )
 def adls2_pickle_io_manager(init_context):

--- a/python_modules/libraries/dagster-azure/dagster_azure_tests/adls2_tests/test_io_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure_tests/adls2_tests/test_io_manager.py
@@ -36,7 +36,7 @@ from dagster._core.utils import make_new_run_id
 from dagster_azure.adls2 import create_adls2_client
 from dagster_azure.adls2.fake_adls2_resource import FakeADLS2Resource, fake_adls2_resource
 from dagster_azure.adls2.io_manager import (
-    ConfigurablePickledObjectADLS2IOManager,
+    ADLS2PickleIOManager,
     PickledObjectADLS2IOManager,
     adls2_pickle_io_manager,
 )
@@ -376,7 +376,7 @@ def test_nothing_pythonic() -> None:
         with_resources(
             [asset1, asset2],
             resource_defs={
-                "io_manager": ConfigurablePickledObjectADLS2IOManager(
+                "io_manager": ADLS2PickleIOManager(
                     adls2=FakeADLS2Resource(account_name="my_account"),
                     adls2_file_system="fake_file_system",
                 )


### PR DESCRIPTION
## Summary & Motivation
Rename `ConfigurablePickledObjectADLS2IOManager` to `ADLS2PickleIOManager` as per discussion in https://github.com/dagster-io/dagster-website/pull/667 

docs changes in the stacked PR that adds pydantic resources

## How I Tested These Changes
