### PR TITLE
[docs] Breadcrumbs for unversioned docs

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,4 +1,4 @@
-# Introduction
+# Version migration
 
 When new releases include breaking changes or deprecations, this document describes how to migrate.
 

--- a/docs/content/_navigation.json
+++ b/docs/content/_navigation.json
@@ -794,6 +794,11 @@
         ]
       },
       {
+        "title": "Version migration",
+        "path": "/migration",
+        "isUnversioned": true
+      },
+      {
         "title": "Migrating to Dagster",
         "children": [
           {
@@ -1185,11 +1190,6 @@
       {
         "title": "Changelog",
         "path": "/changelog",
-        "isUnversioned": true
-      },
-      {
-        "title": "Migration guides",
-        "path": "/migration",
         "isUnversioned": true
       }
     ]

--- a/docs/next/components/VersionDropdown.tsx
+++ b/docs/next/components/VersionDropdown.tsx
@@ -29,7 +29,7 @@ export default function VersionDropdown() {
             <>
               <div>
                 <Menu.Button className="group rounded-full px-2 lg:px-4 lg:py-2 text-gray-400 border border-gray-300 hover:bg-white transition-colors duration-200">
-                  <span className="flex w-full justify-between items-center">
+                  <span className="flex w-full justify-between items-center gap-x-2">
                     <span className="flex min-w-0 items-center justify-between space-x-3">
                       <span className="flex-1 min-w-0 text-gable-green dark:text-gray-300 text-xs lg:text-sm truncate space-x-1">
                         <span>

--- a/docs/next/components/mdx/MDXRenderer.tsx
+++ b/docs/next/components/mdx/MDXRenderer.tsx
@@ -106,15 +106,15 @@ const BreadcrumbNav = ({asPath}) => {
 
   return (
     breadcrumbItems.length > 1 && (
-      <nav className="flex flex-nowrap lg:px-4 py-2" aria-label="Breadcrumb">
-        <ol className="md:inline-flex space-x-1 lg:space-x-3">
+      <nav className="flex py-2" aria-label="Breadcrumb">
+        <ol className="inline-flex">
           {breadcrumbItems.map((item, index) => {
             return (
               <li key={item.path || item.title}>
-                <div className="flex flex-nowrap items-center">
+                <div className="flex items-center">
                   {index > 0 && (
                     <svg
-                      className="w-3 h-3 text-gray-400 flex-shrink-0"
+                      className="w-3 h-3 text-gray-400 flex-shrink-0 mr-2"
                       fill="none"
                       stroke="currentColor"
                       viewBox="0 0 20 20"
@@ -124,15 +124,12 @@ const BreadcrumbNav = ({asPath}) => {
                   )}
                   <a
                     href={item.path}
-                    className={cx(
-                      'ml-1 lg:ml-2 text-xs lg:text-sm lg:font-normal text-gable-green truncate',
-                      {
-                        // Map nav hierarchy to levels for docs search
-                        'DocSearch-lvl0': index === 0,
-                        'DocSearch-lvl1': index === 1,
-                        'DocSearch-lvl2': index === 2,
-                      },
-                    )}
+                    className={cx('mr-1 lg:mr-2 text-sm lg:font-normal text-gable-green truncate', {
+                      // Map nav hierarchy to levels for docs search
+                      'DocSearch-lvl0': index === 0,
+                      'DocSearch-lvl1': index === 1,
+                      'DocSearch-lvl2': index === 2,
+                    })}
                   >
                     {item.title}
                   </a>
@@ -226,13 +223,11 @@ export const VersionedContentLayout = ({children, asPath = null}) => {
         style={{marginLeft: 'auto', marginRight: 'auto'}}
       >
         <div className="flex justify-between px-4 mb-4">
-          <div className="flex justify-start flex-col lg:flex-row lg:px-4 w-full">
-            <div className="flex">
+          <div className="flex justify-start flex-col lg:flex-row lg:px-4 w-full lg:items-center">
+            <div className="flex pr-4">
               <VersionDropdown />
             </div>
-            <div className="flex">
-              <BreadcrumbNav asPath={asPath} />
-            </div>
+            <BreadcrumbNav asPath={asPath} />
           </div>
         </div>
         <div className="flex flex-col">
@@ -284,6 +279,9 @@ export function UnversionedMDXRenderer({
         }}
       />
       <div className="flex-1 min-w-0 relative z-0 focus:outline-none pt-4" tabIndex={0}>
+        <div className="pl-4 sm:pl-6 lg:pl-8 ">
+          <BreadcrumbNav asPath={null} />
+        </div>
         <div
           className="flex flex-row pb-8 max-w-7xl"
           style={{marginLeft: 'auto', marginRight: 'auto'}}


### PR DESCRIPTION
## Summary & Motivation

Our docs crawler currently leverages breadcrumbs for determining page hierarchy, which means that unversiond docs (which have no breadcrumbs) are being stranded with no `lvl0` hierarchy value. This severely impacts search results.

To resolve this, always render breadcrumbs, even on unversioned docs.

Also, move the version migration guide to "Guides".

<img width="1438" alt="Screenshot 2023-08-17 at 10 49 53 AM" src="https://github.com/dagster-io/dagster/assets/2823852/46892224-5011-4bea-82bd-0147fe2bbcee">
<img width="496" alt="Screenshot 2023-08-17 at 10 49 45 AM" src="https://github.com/dagster-io/dagster/assets/2823852/4af75411-8633-4fc3-8d5f-412669239fa9">


## How I Tested These Changes

View Docs site in desktop viewport and mobile viewport, verify correct rendering and behavior of breadcrumbs in versioned and unversioned docs.
