### PR TITLE
feat(dbt): convert `Path` to `str` for `DbtCliResource`

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -33,7 +33,7 @@ from dagster._annotations import public
 from dagster._core.errors import DagsterInvalidPropertyError
 from dbt.contracts.results import NodeStatus
 from dbt.node_types import NodeType
-from pydantic import Field
+from pydantic import Field, validator
 from typing_extensions import Literal
 
 from ..asset_utils import get_manifest_and_translator_from_dbt_assets, output_name_fn
@@ -440,6 +440,13 @@ class DbtCliResource(ConfigurableResource):
             " information."
         ),
     )
+
+    @validator("project_dir", "profiles_dir", pre=True)
+    def convert_path_to_str(cls, v: Any) -> Any:
+        if v and isinstance(v, Path):
+            return os.fspath(v)
+
+        return v
 
     def _get_unique_target_path(self, *, context: Optional[OpExecutionContext]) -> str:
         """Get a unique target path for the dbt CLI invocation.


### PR DESCRIPTION
## Summary & Motivation
This was also noted in https://github.com/dagster-io/dagster/issues/15689, but a long term fix would require some sort of mapping from `Path` to `str` in our config library.

As an example, a workaround that some users have done is: https://github.com/dagster-io/dagster/issues/14564#issuecomment-1576830733, which does just that.

Although this change is still bothersome for users who have Python type checkers in place, at least this won't error if they choose to use `Path` in place of `str`.

## How I Tested These Changes
pytest
