### PR TITLE
feat(airbyte): Allow for special chars in streams

### DIFF
--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
@@ -226,6 +226,7 @@ def build_airbyte_assets(
     upstream_assets: Optional[Set[AssetKey]] = None,
     schema_by_table_name: Optional[Mapping[str, TableSchema]] = None,
     freshness_policy: Optional[FreshnessPolicy] = None,
+    stream_to_asset_map: Optional[Mapping[str, str]] = None,
 ) -> Sequence[AssetsDefinition]:
     """Builds a set of assets representing the tables created by an Airbyte sync operation.
 
@@ -244,6 +245,8 @@ def build_airbyte_assets(
             A list of assets to add as sources.
         upstream_assets (Optional[Set[AssetKey]]): Deprecated, use deps instead. A list of assets to add as sources.
         freshness_policy (Optional[FreshnessPolicy]): A freshness policy to apply to the assets
+        stream_to_asset_map (Optional[Mapping[str, str]]): A mapping of an Airbyte stream name to a Dagster asset.
+            This allows the use of the "prefix" setting in Airbyte with special characters that aren't valid asset names.
     """
     if upstream_assets is not None and deps is not None:
         raise DagsterInvalidDefinitionError(
@@ -314,7 +317,9 @@ def build_airbyte_assets(
                             output_name=_table_to_output_name_fn(dependent_table),
                         )
         else:
-            for materialization in generate_materializations(ab_output, asset_key_prefix):
+            for materialization in generate_materializations(
+                ab_output, asset_key_prefix, stream_to_asset_map
+            ):
                 table_name = materialization.asset_key.path[-1]
                 if table_name in destination_tables:
                     yield Output(

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/utils.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/utils.py
@@ -1,4 +1,4 @@
-from typing import Any, Iterator, Mapping, Sequence
+from typing import Any, Iterator, Mapping, Optional, Sequence
 
 from dagster import AssetMaterialization, MetadataValue
 from dagster._core.definitions.metadata.table import TableColumn, TableSchema
@@ -46,7 +46,9 @@ def _get_attempt(attempt: dict):
 
 
 def generate_materializations(
-    output: AirbyteOutput, asset_key_prefix: Sequence[str]
+    output: AirbyteOutput,
+    asset_key_prefix: Sequence[str],
+    stream_to_asset_map: Optional[Mapping[str, str]] = None,
 ) -> Iterator[AssetMaterialization]:
     prefix = output.connection_details.get("prefix") or ""
     # all the streams that are set to be sync'd by this connection
@@ -64,11 +66,12 @@ def generate_materializations(
         s["streamName"]: s.get("stats", {})
         for s in _get_attempt(output.job_details.get("attempts", [{}])[-1]).get("streamStats", [])
     }
+    stream_to_asset_map = stream_to_asset_map if stream_to_asset_map else {}
     for stream_name, stream_props in all_stream_props.items():
         yield _materialization_for_stream(
-            stream_name,
+            stream_to_asset_map.get(stream_name, stream_name),
             stream_props,
-            # if no records are sync'd, no stats will be avaiable for this stream
+            # if no records are sync'd, no stats will be available for this stream
             all_stream_stats.get(stream_name, {}),
             asset_key_prefix=asset_key_prefix,
         )

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_resources.py
@@ -345,7 +345,62 @@ def test_assets(
 
     materializations = list(generate_materializations(airbyte_output, []))
     assert len(materializations) == 3
+    assert materializations[0].metadata["bytesEmitted"] == MetadataValue.int(1234)
+    assert materializations[0].metadata["recordsCommitted"] == MetadataValue.int(4321)
 
+
+@responses.activate
+@pytest.mark.parametrize(
+    "forward_logs",
+    [True, False],
+)
+def test_assets_with_mapping(
+    forward_logs, airbyte_instance_constructor: Callable[[Dict[str, Any]], AirbyteResource]
+) -> None:
+    ab_resource = airbyte_instance_constructor(
+        {
+            "host": "some_host",
+            "port": "8000",
+            "forward_logs": forward_logs,
+        }
+    )
+    responses.add(
+        method=responses.POST,
+        url=ab_resource.api_base_url + "/connections/get",
+        json=get_sample_connection_json(stream_prefix="test/"),
+        status=200,
+    )
+    responses.add(
+        method=responses.POST,
+        url=ab_resource.api_base_url + "/connections/sync",
+        json={"job": {"id": 1}},
+        status=200,
+    )
+
+    if forward_logs:
+        responses.add(
+            method=responses.POST,
+            url=ab_resource.api_base_url + "/jobs/get",
+            json=get_sample_job_json("test/"),
+            status=200,
+        )
+    else:
+        responses.add(
+            method=responses.POST,
+            url=ab_resource.api_base_url + "/jobs/list",
+            json=get_sample_job_list_json("test/"),
+            status=200,
+        )
+    responses.add(responses.POST, f"{ab_resource.api_base_url}/jobs/cancel", status=204)
+
+    airbyte_output = ab_resource.sync_and_poll("some_connection", 0, None)
+
+    materializations = list(
+        generate_materializations(
+            airbyte_output, [], {"test/foo": "foo", "test/bar": "bar", "test/baz": "baz"}
+        )
+    )
+    assert len(materializations) == 3
     assert materializations[0].metadata["bytesEmitted"] == MetadataValue.int(1234)
     assert materializations[0].metadata["recordsCommitted"] == MetadataValue.int(4321)
 

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/utils.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/utils.py
@@ -2,7 +2,7 @@ from dagster._utils.merger import deep_merge_dicts
 from dagster_airbyte import AirbyteState
 
 
-def get_sample_connection_json(**kwargs):
+def get_sample_connection_json(stream_prefix="", **kwargs):
     return deep_merge_dicts(
         {
             "name": "xyz",
@@ -10,7 +10,7 @@ def get_sample_connection_json(**kwargs):
                 "streams": [
                     {
                         "stream": {
-                            "name": "foo",
+                            "name": stream_prefix + "foo",
                             "jsonSchema": {
                                 "properties": {"a": {"type": "str"}, "b": {"type": "int"}}
                             },
@@ -19,7 +19,7 @@ def get_sample_connection_json(**kwargs):
                     },
                     {
                         "stream": {
-                            "name": "bar",
+                            "name": stream_prefix + "bar",
                             "jsonSchema": {
                                 "properties": {
                                     "c": {"type": "str"},
@@ -30,7 +30,7 @@ def get_sample_connection_json(**kwargs):
                     },
                     {
                         "stream": {
-                            "name": "baz",
+                            "name": stream_prefix + "baz",
                             "jsonSchema": {
                                 "properties": {
                                     "d": {"type": "str"},
@@ -41,7 +41,7 @@ def get_sample_connection_json(**kwargs):
                     },
                     {
                         "stream": {
-                            "name": "qux",
+                            "name": stream_prefix + "qux",
                             "jsonSchema": {
                                 "properties": {
                                     "e": {"type": "str"},


### PR DESCRIPTION
Closes #11861

## tl;dr

Adds an optional `stream_to_asset_map` argument to `build_airbyte_assets` to support the Airbyte prefix setting with special characters, e.g. a `/` for an `s3` or `gcs` target (or, really, any targets that aren't w/in the `^[A-Za-z0-9_]+$` spec).

## Details / Test Case

Set up an Airbyte connection like this:

![image](https://github.com/dagster-io/dagster/assets/6397962/2986ba94-9d17-4d1c-9905-80eb74f9e630)

When you define your asset as 

```python
with_resources(
    construct_airbyte_assets(
        connection_id="uud",
        destination_tables="e2e/data"
    ),
    {"airbyte": self._airbyte_resource()},
)
```

You will be greeted with `e2e/data" is not a valid name in Dagster. Names must be in regex ^[A-Za-z0-9_]+$`.

If you run

```python
with_resources(
    construct_airbyte_assets(
        connection_id="uud",
        destination_tables="data"
    ),
    {"airbyte": self._airbyte_resource()},
)
```

You will get `DagsterStepOutputNotFoundError`.

The reason for this is, the result of the API communication to Airbyte via Dagster looks a little something like this:

```json
{
    "job": {
        "id": 22,
        "configType": "sync",
        "configId": "$uuid",
        "enabledStreams": [
            {
                "name": "data"
            }
        ],
        "createdAt": 1692286065,
        "updatedAt": 1692286068,
        "status": "succeeded"
    },
    "attempts": [
        {
            "attempt": {
                "id": 0,
                "status": "succeeded",
                "createdAt": 1692286065,
                "updatedAt": 1692286068,
                "endedAt": 1692286068,
                "bytesSynced": 1392,
                "recordsSynced": 100,
                "totalStats": {
                    "recordsEmitted": 100,
                    "bytesEmitted": 1392,
                    "stateMessagesEmitted": 0,
                    "recordsCommitted": 100
                },
                "streamStats": [
                    {
                        "streamName": "e2e/data",
                        "stats": {
                            "recordsEmitted": 100,
                            "bytesEmitted": 1392,
                            "recordsCommitted": 100
                        }
                    }
                ]
            },
```

`attempts.attempt[n].streamStats.streamname` is used for the output at the end in `utils.generate_materializations`, whereas the `destination_tables` property is used for asset names.

Now, if you run this code version with the new mapping argument:

```python
with_resources(
    construct_airbyte_assets(
        connection_id="uud",
        destination_tables="data",
        stream_to_asset_map={"e2e/data": "data"},
    ),
    {"airbyte": self._airbyte_resource()},
)
```

Everything works, since it'll correctly map the `streamName` to the Dagster `asset`, solving this without any need for `string.replace()` shenanigans. 

<img width="1370" alt="image" src="https://github.com/dagster-io/dagster/assets/6397962/fbf615c4-7345-4f99-b411-6f1b89e5a7a2">


```bash
python -m pytest python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/*.py 
285 passed, 131 warnings in 1279.47s (0:21:19)
```