### PR TITLE
unpin pytest

### DIFF
--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -119,7 +119,7 @@ setup(
             "pytest-rerunfailures==10.0",
             "pytest-runner==5.2",
             "pytest-xdist==2.1.0",
-            "pytest==7.0.1",  # last version supporting python 3.6
+            "pytest",
             "responses<=0.23.1",  # https://github.com/getsentry/responses/issues/654
             "syrupy<4",  # 3.7 compatible,
             "tox==3.25.0",


### PR DESCRIPTION
no longer support 3.6

## How I Tested These Changes

bk