### PR TITLE
fix(dbt): allow dbt commands to work with `--debug`

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -88,6 +88,9 @@ class DbtCliEventMessage:
                 - AssetMaterializations for refables (e.g. models, seeds, snapshots.)
                 - AssetObservations for test results.
         """
+        if self.raw_event["info"]["level"] == "debug":
+            return
+
         event_node_info: Dict[str, Any] = self.raw_event["data"].get("node_info")
         if not event_node_info:
             return

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resources_v2.py
@@ -153,6 +153,20 @@ def test_dbt_with_partial_parse() -> None:
     )
 
 
+def test_dbt_cli_debug_execution() -> None:
+    @dbt_assets(manifest=manifest)
+    def my_dbt_assets(context: OpExecutionContext, dbt: DbtCliResource):
+        yield from dbt.cli(["--debug", "run"], context=context).stream()
+
+    result = materialize(
+        [my_dbt_assets],
+        resources={
+            "dbt": DbtCliResource(project_dir=TEST_PROJECT_DIR),
+        },
+    )
+    assert result.success
+
+
 def test_dbt_cli_subsetted_execution() -> None:
     dbt_select = " ".join(
         [
@@ -161,11 +175,8 @@ def test_dbt_cli_subsetted_execution() -> None:
         ]
     )
 
-    @dbt_assets(
-        manifest=manifest,
-        select=dbt_select,
-    )
-    def my_dbt_assets(context, dbt: DbtCliResource):
+    @dbt_assets(manifest=manifest, select=dbt_select)
+    def my_dbt_assets(context: OpExecutionContext, dbt: DbtCliResource):
         dbt_cli_invocation = dbt.cli(["run"], context=context).wait()
 
         assert dbt_cli_invocation.process.args == ["dbt", "run", "--select", dbt_select]
@@ -188,7 +199,7 @@ def test_dbt_cli_asset_selection() -> None:
     ]
 
     @dbt_assets(manifest=manifest)
-    def my_dbt_assets(context, dbt: DbtCliResource):
+    def my_dbt_assets(context: OpExecutionContext, dbt: DbtCliResource):
         dbt_cli_invocation = dbt.cli(["run"], context=context).wait()
 
         dbt_cli_args: List[str] = list(dbt_cli_invocation.process.args)  # type: ignore
@@ -218,7 +229,7 @@ def test_dbt_cli_asset_selection() -> None:
 @pytest.mark.parametrize("exclude", [None, "fqn:dagster_dbt_test_project.subdir.least_caloric"])
 def test_dbt_cli_default_selection(exclude: Optional[str]) -> None:
     @dbt_assets(manifest=manifest, exclude=exclude)
-    def my_dbt_assets(context):
+    def my_dbt_assets(context: OpExecutionContext):
         dbt = DbtCliResource(project_dir=TEST_PROJECT_DIR)
         dbt_cli_invocation = dbt.cli(["run"], context=context)
 
@@ -298,13 +309,19 @@ def test_dbt_cli_op_execution() -> None:
     ],
 )
 def test_no_default_asset_events_emitted(data: dict) -> None:
-    asset_events = DbtCliEventMessage(raw_event={"data": data}).to_default_asset_events(manifest={})
+    asset_events = DbtCliEventMessage(
+        raw_event={
+            "info": {"level": "info"},
+            "data": data,
+        }
+    ).to_default_asset_events(manifest={})
 
     assert list(asset_events) == []
 
 
 def test_to_default_asset_output_events() -> None:
     raw_event = {
+        "info": {"level": "info"},
         "data": {
             "node_info": {
                 "unique_id": "a.b.c",
@@ -313,7 +330,7 @@ def test_to_default_asset_output_events() -> None:
                 "node_started_at": "2024-01-01T00:00:00Z",
                 "node_finished_at": "2024-01-01T00:01:00Z",
             }
-        }
+        },
     }
     asset_events = list(
         DbtCliEventMessage(raw_event=raw_event).to_default_asset_events(manifest={})
@@ -351,6 +368,7 @@ def test_to_default_asset_observation_events() -> None:
         },
     }
     raw_event = {
+        "info": {"level": "info"},
         "data": {
             "node_info": {
                 "unique_id": "a.b.c",
@@ -358,7 +376,7 @@ def test_to_default_asset_observation_events() -> None:
                 "node_status": "success",
                 "node_finished_at": "2024-01-01T00:00:00Z",
             }
-        }
+        },
     }
     asset_events = list(
         DbtCliEventMessage(raw_event=raw_event).to_default_asset_events(manifest=manifest)


### PR DESCRIPTION
## Summary & Motivation
Resolves https://github.com/dagster-io/dagster/issues/13586. Skip emitting events from dbt event logs are are at the `debug` level.

## How I Tested These Changes
pytest
