### PR TITLE
[docs] - Fix example in Spark/Pandas SDA guide

### DIFF
--- a/docs/content/guides/dagster/software-defined-assets.mdx
+++ b/docs/content/guides/dagster/software-defined-assets.mdx
@@ -206,9 +206,9 @@ class LocalFileSystemIOManager(ConfigurableIOManager):
         if isinstance(obj, PandasDF):
             directory = self._get_fs_path(context.asset_key)
             os.makedirs(directory, exist_ok=True)
-            open(os.path.join(directory, "_SUCCESS"), "wb").close()
             csv_path = os.path.join(directory, "part-00000.csv")
             obj.to_csv(csv_path)
+            open(os.path.join(directory, "_SUCCESS"), "wb").close()
         elif isinstance(obj, SparkDF):
             obj.write.format("csv").options(header="true").save(
                 self._get_fs_path(context.asset_key), mode="overwrite"

--- a/examples/assets_pandas_pyspark/assets_pandas_pyspark/local_spark_filesystem_io_manager.py
+++ b/examples/assets_pandas_pyspark/assets_pandas_pyspark/local_spark_filesystem_io_manager.py
@@ -40,9 +40,9 @@ class LocalFileSystemIOManager(ConfigurableIOManager):
         if isinstance(obj, PandasDF):
             directory = self._get_fs_path(context.asset_key)
             os.makedirs(directory, exist_ok=True)
-            open(os.path.join(directory, "_SUCCESS"), "wb").close()
             csv_path = os.path.join(directory, "part-00000.csv")
             obj.to_csv(csv_path)
+            open(os.path.join(directory, "_SUCCESS"), "wb").close()
         elif isinstance(obj, SparkDF):
             obj.write.format("csv").options(header="true").save(
                 self._get_fs_path(context.asset_key), mode="overwrite"


### PR DESCRIPTION
## Summary & Motivation

This PR fixes a small ordering issue in the Spark/Pandas SDA guide. TL;DR is that the file in this example should be written only after data is written. Related to #14108.

## How I Tested These Changes

eyeballs
