### PR TITLE
[docs] Show breadcrumbs on every doc page

### DIFF
--- a/docs/content/concepts.mdx
+++ b/docs/content/concepts.mdx
@@ -2,7 +2,7 @@
 title: Concepts | Dagster Docs
 ---
 
-# Concepts
+# Core concepts
 
 Learn about Dagster's core concepts and how to use them in your data platform.
 

--- a/docs/content/deployment.mdx
+++ b/docs/content/deployment.mdx
@@ -2,7 +2,7 @@
 title: Deployment | Dagster
 ---
 
-# Deployment
+# Deployment options
 
 Explore your options for deploying Dagster to your infrastructure or using Dagster Cloud.
 

--- a/docs/content/guides.mdx
+++ b/docs/content/guides.mdx
@@ -2,7 +2,7 @@
 title: Guides | Dagster Docs
 ---
 
-# Guides
+# Guides and examples
 
 Learn to apply [Dagster concepts](/concepts) to your work, explore experimental features, and check out some examples.
 

--- a/docs/content/integrations.mdx
+++ b/docs/content/integrations.mdx
@@ -3,7 +3,7 @@ title: Integrations | Dagster
 description: Dagster is flexible and allows incremental adoption. It provides add-on libraries to integrate with your existing tools and infrastructure.
 ---
 
-# Integrations
+# Integration guides and libraries
 
 Using our integration guides and libraries, you can extend Dagster to interoperate with your external services.
 

--- a/docs/next/components/mdx/MDXRenderer.tsx
+++ b/docs/next/components/mdx/MDXRenderer.tsx
@@ -105,7 +105,7 @@ const BreadcrumbNav = ({asPath}) => {
   }
 
   return (
-    breadcrumbItems.length > 1 && (
+    breadcrumbItems.length >= 1 && (
       <nav className="flex py-2" aria-label="Breadcrumb">
         <ol className="inline-flex">
           {breadcrumbItems.map((item, index) => {


### PR DESCRIPTION
## Summary & Motivation

The Algolia crawler is looking for `DocSearch-lvl0` elements to assign the top level of hierarchy, but on root pages of sections (e.g. `/tutorial`) we don't show the breadcrumbs at all, which means for these pages we fall back to "Dagster Docs" as the level-0 hierarchy value.

To improve this, always show breadcrumbs, even if it's just one item. This looks a bit redundant on the root pages, so I tried to make the `h1` elements a little more descriptive of what's actually on those pages. Feel free to push back on this or tell me better strings to use!

## How I Tested These Changes

View docs site, verify that breadcrumbs always appear, and that modified strings appear as expected.
