### PR TITLE
Wait for grpc calls to finish before shutting down the server on termination

### DIFF
--- a/python_modules/dagster/dagster/_cli/api.py
+++ b/python_modules/dagster/dagster/_cli/api.py
@@ -692,6 +692,7 @@ def grpc_command(
         socket=socket,
         host=host,
         max_workers=max_workers,
+        logger=logger,
     )
 
     code_desc = " "

--- a/python_modules/dagster/dagster/_cli/code_server.py
+++ b/python_modules/dagster/dagster/_cli/code_server.py
@@ -210,6 +210,7 @@ def start_command(
         socket=socket,
         host=host,
         max_workers=max_workers,
+        logger=logger,
     )
 
     code_desc = " "

--- a/python_modules/dagster/dagster/_grpc/utils.py
+++ b/python_modules/dagster/dagster/_grpc/utils.py
@@ -85,3 +85,15 @@ def default_grpc_timeout() -> int:
 
     # default 60 seconds
     return 60
+
+
+def default_grpc_server_shutdown_grace_period():
+    # Time to wait for calls to finish before shutting down the server
+    # Defaults to the same as default_grpc_timeout() unless
+    # DAGSTER_GRPC_SHUTDOWN_GRACE_PERIOD is set
+
+    env_set = os.getenv("DAGSTER_GRPC_SHUTDOWN_GRACE_PERIOD")
+    if env_set:
+        return int(env_set)
+
+    return default_grpc_timeout()

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_ping.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_ping.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import re
 import threading
@@ -22,6 +23,7 @@ def test_server_socket_on_windows():
             DagsterGrpcServer(
                 server_termination_event=threading.Event(),
                 dagster_api_servicer=mock.MagicMock(),
+                logger=logging.getLogger("dagster.code_server"),
                 socket=skt,
             )
 
@@ -35,6 +37,7 @@ def test_server_port_and_socket():
             DagsterGrpcServer(
                 server_termination_event=threading.Event(),
                 dagster_api_servicer=mock.MagicMock(),
+                logger=logging.getLogger("dagster.code_server"),
                 socket=skt,
                 port=find_free_port(),
             )


### PR DESCRIPTION
Summary:
This is a prereq for supporting sensor ticks that are longer than 60 seconds b/c of the issue in https://github.com/dagster-io/dagster/issues/14523 - the daemon reloads servers locally every 60 seconds, and stops heartbeating on the old ones - so the grpc server shuts down, forcibly terminating any in-progress RPCs.

Luckily the grpc server APIs give you a way to shut down more gracefully and wait for rpc handlers to finish, we just weren't using it properly and were shutting everything down after 5 seconds: https://grpc.github.io/grpc/python/grpc.html#grpc.Server.stop

Increase that call to whatever the client timeout is to ensure that any calls that we have given up on on the server, the client has too.

Test Plan:
Write a sensor that takes 3 minutes to tick, set DAGSTER_GRPC_TIMEOUT_SECONDS to 300, run dagster dev with the sensor on
Before: After ~90 seconds the server would shut down and the tick would be interrupted with an UNAVAILABLE error
Now: The tick completes
Do the same but with DAGSTER_GRPC_SHUTDOWN_GRACE_PERIOD set to 5, see the same behavior as the "Before:" case above

## Summary & Motivation

## How I Tested These Changes
