### PR TITLE
[examples] update quickstart_aws and project_fully_featured to use S3PickleIOManager

### DIFF
--- a/examples/project_fully_featured/project_fully_featured/resources/__init__.py
+++ b/examples/project_fully_featured/project_fully_featured/resources/__init__.py
@@ -2,7 +2,7 @@ import os
 
 from dagster._utils import file_relative_path
 from dagster_aws.s3 import S3Resource
-from dagster_aws.s3.io_manager import ConfigurablePickledObjectS3IOManager
+from dagster_aws.s3.io_manager import S3PickleIOManager
 from dagster_dbt import DbtCliClientResource
 from dagster_pyspark import pyspark_resource
 
@@ -59,7 +59,7 @@ SHARED_SNOWFLAKE_CONF = {
 }
 
 RESOURCES_PROD = {
-    "io_manager": ConfigurablePickledObjectS3IOManager(
+    "io_manager": S3PickleIOManager(
         s3_resource=S3Resource.configure_at_launch(),
         s3_bucket="hackernews-elementl-prod",
     ),
@@ -73,7 +73,7 @@ RESOURCES_PROD = {
 
 
 RESOURCES_STAGING = {
-    "io_manager": ConfigurablePickledObjectS3IOManager(
+    "io_manager": S3PickleIOManager(
         s3_resource=S3Resource.configure_at_launch(),
         s3_bucket="hackernews-elementl-dev",
     ),

--- a/examples/quickstart_aws/README.md
+++ b/examples/quickstart_aws/README.md
@@ -58,7 +58,7 @@ To connect to AWS, you'll need to set up your credentials in Dagster.
 
 Dagster allows using environment variables to handle sensitive information. You can define various configuration options and access environment variables through them. This also allows you to parameterize your pipeline without modifying code.
 
-In this example, we use [`ConfigurablePickledObjectS3IOManager`](https://docs.dagster.io/_apidocs/libraries/dagster-aws#dagster_aws.s3.ConfigurablePickledObjectS3IOManager) to write outputs to S3 and read inputs from it and [`S3Resource`](https://docs.dagster.io/_apidocs/libraries/dagster-aws#dagster_aws.s3.S3Resource) to interact with S3 instance inside an asset.
+In this example, we use [`S3PickleIOManager`](https://docs.dagster.io/_apidocs/libraries/dagster-aws#dagster_aws.s3.S3PickleIOManager) to write outputs to S3 and read inputs from it and [`S3Resource`](https://docs.dagster.io/_apidocs/libraries/dagster-aws#dagster_aws.s3.S3Resource) to interact with S3 instance inside an asset.
 
 The configurations of the S3 connection are defined in [`quickstart_aws/repository.py`](./quickstart_aws/repository.py), which requires the following environment variables:
 - `AWS_ACCESS_KEY_ID`

--- a/examples/quickstart_aws/quickstart_aws/__init__.py
+++ b/examples/quickstart_aws/quickstart_aws/__init__.py
@@ -5,7 +5,7 @@ from dagster import (
     define_asset_job,
     load_assets_from_package_module,
 )
-from dagster_aws.s3 import ConfigurablePickledObjectS3IOManager, S3Resource
+from dagster_aws.s3 import S3PickleIOManager, S3Resource
 
 from . import assets
 
@@ -25,7 +25,7 @@ defs = Definitions(
     resources={
         # With this I/O manager in place, your job runs will store data passed between assets
         # on S3 in the location s3://<bucket>/dagster/storage/<asset key>.
-        "io_manager": ConfigurablePickledObjectS3IOManager(
+        "io_manager": S3PickleIOManager(
             s3_resource=my_s3_resource,
             s3_bucket=EnvVar("S3_BUCKET"),
         ),


### PR DESCRIPTION
## Summary & Motivation

updates `quickstart_aws` and `project_fully_featured` to use the `S3PickleIOManager` from https://github.com/dagster-io/dagster/pull/15894
## How I Tested These Changes
