### PR TITLE
AssetCheckSpec on @asset

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -111,6 +111,7 @@ from dagster._config.source import (
     StringSource as StringSource,
 )
 from dagster._core.definitions import AssetCheckResult as AssetCheckResult
+from dagster._core.definitions.asset_check_spec import AssetCheckSpec as AssetCheckSpec
 from dagster._core.definitions.asset_in import AssetIn as AssetIn
 from dagster._core.definitions.asset_out import AssetOut as AssetOut
 from dagster._core.definitions.asset_selection import AssetSelection as AssetSelection

--- a/python_modules/dagster/dagster/_core/definitions/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/__init__.py
@@ -1,4 +1,7 @@
-from .asset_check_result import AssetCheckResult as AssetCheckResult
+from .asset_check_result import (
+    AssetCheckEvaluation as AssetCheckEvaluation,
+    AssetCheckResult as AssetCheckResult,
+)
 from .composition import PendingNodeInvocation as PendingNodeInvocation
 from .config import ConfigMapping as ConfigMapping
 from .dependency import (

--- a/python_modules/dagster/dagster/_core/definitions/asset_check_result.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_result.py
@@ -1,11 +1,21 @@
-from typing import Mapping, NamedTuple, Optional
+from collections import defaultdict
+from typing import TYPE_CHECKING, Dict, Mapping, NamedTuple, Optional, Set
 
 import dagster._check as check
 from dagster._annotations import PublicAttr, experimental
-from dagster._core.definitions.events import AssetKey, MetadataValue, RawMetadataValue
+from dagster._core.definitions.asset_check_evaluation import AssetCheckEvaluation
+from dagster._core.definitions.events import (
+    AssetKey,
+    CoercibleToAssetKey,
+    MetadataValue,
+    RawMetadataValue,
+    normalize_metadata,
+)
+from dagster._core.errors import DagsterInvariantViolationError
 from dagster._serdes import whitelist_for_serdes
 
-from .metadata import normalize_metadata
+if TYPE_CHECKING:
+    from dagster._core.execution.context.compute import StepExecutionContext
 
 
 @experimental
@@ -40,7 +50,7 @@ class AssetCheckResult(
         cls,
         *,
         success: bool,
-        asset_key: Optional[AssetKey] = None,
+        asset_key: Optional[CoercibleToAssetKey] = None,
         check_name: Optional[str] = None,
         metadata: Optional[Mapping[str, RawMetadataValue]] = None,
     ):
@@ -49,8 +59,64 @@ class AssetCheckResult(
         )
         return super().__new__(
             cls,
-            asset_key=check.opt_inst_param(asset_key, "asset_key", AssetKey),
+            asset_key=AssetKey.from_coercible(asset_key) if asset_key is not None else None,
             check_name=check.opt_str_param(check_name, "check_name"),
             success=check.bool_param(success, "success"),
             metadata=normalized_metadata,
+        )
+
+    def to_asset_check_evaluation(
+        self, step_context: "StepExecutionContext"
+    ) -> AssetCheckEvaluation:
+        specs = step_context.job_def.asset_layer.check_specs_for_node(step_context.node_handle)
+
+        spec_check_names_by_asset_key: Dict[AssetKey, Set[str]] = defaultdict(set)
+        for spec in specs:
+            spec_check_names_by_asset_key[spec.asset_key].add(spec.name)
+
+        if self.asset_key is not None:
+            if self.asset_key not in spec_check_names_by_asset_key.keys():
+                raise DagsterInvariantViolationError(
+                    "Received unexpected AssetCheckResult. It targets asset"
+                    f" '{self.asset_key.to_user_string()}' which is not targeted by any of the"
+                    " checks currently being evaluated. Targeted assets:"
+                    f" {[asset_key.to_user_string() for asset_key in spec_check_names_by_asset_key.keys()]}."
+                )
+
+            resolved_asset_key = self.asset_key
+
+        else:
+            if len(spec_check_names_by_asset_key) > 1:
+                raise DagsterInvariantViolationError(
+                    "TODO Check result didn't specify an asset key, but there are multiple assets"
+                    " to choose from: {name the assets}"
+                )
+
+            resolved_asset_key = next(iter(spec_check_names_by_asset_key.keys()))
+
+        spec_check_names_for_asset_key = spec_check_names_by_asset_key[resolved_asset_key]
+        if self.check_name is not None:
+            if self.check_name not in spec_check_names_for_asset_key:
+                raise DagsterInvariantViolationError(
+                    "Received unexpected AssetCheckResult. No checks currently being evaluated"
+                    f" target asset '{resolved_asset_key.to_user_string()}' and have name"
+                    f" '{self.check_name}'. Checks being evaluated for this asset:"
+                    f" {spec_check_names_for_asset_key}"
+                )
+
+            resolved_check_name = self.check_name
+        else:
+            if len(spec_check_names_for_asset_key) > 1:
+                raise DagsterInvariantViolationError(
+                    "TODO Check result didn't specify a check name, but there are multiple"
+                    " checks to choose from for the this asset key: {name the checks}"
+                )
+
+            resolved_check_name = next(iter(spec_check_names_for_asset_key))
+
+        return AssetCheckEvaluation(
+            check_name=resolved_check_name,
+            asset_key=resolved_asset_key,
+            success=self.success,
+            metadata=self.metadata,
         )

--- a/python_modules/dagster/dagster/_core/definitions/asset_check_result.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_result.py
@@ -14,9 +14,9 @@ class AssetCheckResult(
     NamedTuple(
         "_AssetCheckResult",
         [
-            ("asset_key", PublicAttr[AssetKey]),
-            ("check_name", PublicAttr[str]),
             ("success", PublicAttr[bool]),
+            ("asset_key", PublicAttr[Optional[AssetKey]]),
+            ("check_name", PublicAttr[Optional[str]]),
             ("metadata", PublicAttr[Mapping[str, MetadataValue]]),
         ],
     )
@@ -24,9 +24,9 @@ class AssetCheckResult(
     """The result of an asset check.
 
     Attributes:
-        asset_key (AssetKey):
+        asset_key (Optional[AssetKey]):
             The asset key that was checked.
-        check_name (str):
+        check_name (Optional[str]):
             The name of the check.
         success (bool):
             The pass/fail result of the check.
@@ -38,9 +38,10 @@ class AssetCheckResult(
 
     def __new__(
         cls,
-        asset_key: AssetKey,
-        check_name: str,
+        *,
         success: bool,
+        asset_key: Optional[AssetKey] = None,
+        check_name: Optional[str] = None,
         metadata: Optional[Mapping[str, RawMetadataValue]] = None,
     ):
         normalized_metadata = normalize_metadata(
@@ -48,8 +49,8 @@ class AssetCheckResult(
         )
         return super().__new__(
             cls,
-            asset_key=check.inst_param(asset_key, "asset_key", AssetKey),
-            check_name=check.str_param(check_name, "check_name"),
+            asset_key=check.opt_inst_param(asset_key, "asset_key", AssetKey),
+            check_name=check.opt_str_param(check_name, "check_name"),
             success=check.bool_param(success, "success"),
             metadata=normalized_metadata,
         )

--- a/python_modules/dagster/dagster/_core/definitions/asset_check_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_spec.py
@@ -1,0 +1,43 @@
+from typing import NamedTuple, Optional
+
+import dagster._check as check
+from dagster._annotations import PublicAttr, experimental
+from dagster._core.definitions.events import AssetKey, CoercibleToAssetKey
+
+
+@experimental
+class AssetCheckSpec(
+    NamedTuple(
+        "_AssetCheckSpec",
+        [
+            ("name", PublicAttr[str]),
+            ("asset_key", PublicAttr[AssetKey]),
+            ("description", PublicAttr[Optional[str]]),
+        ],
+    )
+):
+    """Defines information about an check, except how to execute it.
+
+    AssetCheckSpec is often used as an argument to decorators that decorator a function that can
+    execute multiple checks - e.g. `@asset`, and `@multi_asset`. It defines one of the checks that
+    will be executed inside that function.
+
+    Attributes:
+        name (str): Name of the check.
+        asset_key (AssetKey): The key of the asset that the check applies to.
+        description (Optional[str]): Description for the check.
+    """
+
+    def __new__(
+        cls,
+        name: str,
+        *,
+        asset_key: CoercibleToAssetKey,
+        description: Optional[str] = None,
+    ):
+        return super().__new__(
+            cls,
+            name=check.str_param(name, "name"),
+            asset_key=AssetKey.from_coercible(asset_key),
+            description=check.opt_str_param(description, "description"),
+        )

--- a/python_modules/dagster/dagster/_core/events/__init__.py
+++ b/python_modules/dagster/dagster/_core/events/__init__.py
@@ -79,6 +79,7 @@ EventSpecificData = Union[
     "ComputeLogsCaptureData",
     "AssetObservationData",
     "AssetMaterializationPlannedData",
+    "AssetCheckEvaluation",
 ]
 
 
@@ -954,6 +955,16 @@ class DagsterEvent(
             event_type=DagsterEventType.ASSET_OBSERVATION,
             step_context=step_context,
             event_specific_data=AssetObservationData(observation),
+        )
+
+    @staticmethod
+    def asset_check_evaluation(
+        step_context: IStepContext, asset_check_evaluation: AssetCheckEvaluation
+    ) -> "DagsterEvent":
+        return DagsterEvent.from_step(
+            event_type=DagsterEventType.ASSET_CHECK_EVALUATION,
+            step_context=step_context,
+            event_specific_data=asset_check_evaluation,
         )
 
     @staticmethod

--- a/python_modules/dagster/dagster/_core/execution/execution_result.py
+++ b/python_modules/dagster/dagster/_core/execution/execution_result.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from typing import AbstractSet, Callable, List, Optional, Sequence, Set, cast
 
 import dagster._check as check
-from dagster._core.definitions import JobDefinition, NodeHandle
+from dagster._core.definitions import AssetCheckEvaluation, JobDefinition, NodeHandle
 from dagster._core.definitions.events import AssetMaterialization, AssetObservation
 from dagster._core.definitions.utils import DEFAULT_OUTPUT
 from dagster._core.errors import DagsterError, DagsterInvariantViolationError
@@ -175,6 +175,13 @@ class ExecutionResult(ABC):
 
     def get_asset_materialization_events(self) -> Sequence[DagsterEvent]:
         return [event for event in self.all_events if event.is_step_materialization]
+
+    def get_asset_check_evaluations(self) -> Sequence[AssetCheckEvaluation]:
+        return [
+            cast(AssetCheckEvaluation, event.event_specific_data)
+            for event in self.all_events
+            if event.event_type_value == DagsterEventType.ASSET_CHECK_EVALUATION.value
+        ]
 
     def get_step_success_events(self) -> Sequence[DagsterEvent]:
         return [event for event in self.all_events if event.is_step_success]

--- a/python_modules/dagster/dagster/_core/execution/plan/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/compute.py
@@ -17,6 +17,8 @@ from typing_extensions import TypeAlias
 
 import dagster._check as check
 from dagster._core.definitions import (
+    AssetCheckEvaluation,
+    AssetCheckResult,
     AssetMaterialization,
     AssetObservation,
     DynamicOutput,
@@ -46,6 +48,8 @@ OpOutputUnion: TypeAlias = Union[
     ExpectationResult,
     AssetObservation,
     DagsterEvent,
+    AssetCheckEvaluation,
+    AssetCheckResult,
 ]
 
 
@@ -94,6 +98,8 @@ def _validate_event(event: Any, step_context: StepExecutionContext) -> OpOutputU
             ExpectationResult,
             AssetObservation,
             DagsterEvent,
+            AssetCheckResult,
+            AssetCheckEvaluation,
         ),
     ):
         raise DagsterInvariantViolationError(

--- a/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
@@ -19,6 +19,7 @@ from typing_extensions import get_args
 
 from dagster._config.pythonic_config import Config
 from dagster._core.definitions import (
+    AssetCheckResult,
     AssetMaterialization,
     DynamicOutput,
     ExpectationResult,
@@ -216,6 +217,8 @@ def validate_and_coerce_op_result_to_iterator(
             "value. Check out the docs on logging events here: "
             "https://docs.dagster.io/concepts/ops-jobs-graphs/op-events#op-events-and-exceptions"
         )
+    elif isinstance(result, AssetCheckResult):
+        yield result
     elif result is not None and not output_defs:
         raise DagsterInvariantViolationError(
             f"Error in {context.describe_op()}: Unexpectedly returned output of type"

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
@@ -15,6 +15,8 @@ from typing_extensions import TypedDict
 
 import dagster._check as check
 from dagster._core.definitions import (
+    AssetCheckEvaluation,
+    AssetCheckResult,
     AssetKey,
     AssetMaterialization,
     AssetObservation,
@@ -72,6 +74,29 @@ from dagster._utils.warnings import (
 from .compute import OpOutputUnion
 from .compute_generator import create_op_compute_wrapper
 from .utils import op_execution_error_boundary
+
+
+def _asset_check_results_to_outputs_and_evaluations(
+    step_context: StepExecutionContext, user_event_sequence: Iterator[OpOutputUnion]
+) -> Iterator[OpOutputUnion]:
+    """We convert each AssetCheckResult to two events:
+    - An Output, which allows downstream steps to depend on it
+    - An AssetCheckEvaluation, which combines the check result with information from the context
+        to create a full picture of the asset check's evaluation.
+    """
+    for user_event in user_event_sequence:
+        if isinstance(user_event, AssetCheckResult):
+            asset_check_evaluation = user_event.to_asset_check_evaluation(step_context)
+
+            output_name = step_context.job_def.asset_layer.get_output_name_for_asset_check(
+                asset_check_evaluation.asset_key, asset_check_evaluation.check_name
+            )
+            output = Output(value=None, output_name=output_name)
+
+            yield asset_check_evaluation
+            yield output
+        else:
+            yield user_event
 
 
 def _step_output_error_checked_user_event_sequence(
@@ -404,7 +429,10 @@ def core_dagster_event_sequence_for_step(
         # It is important for this loop to be indented within the
         # timer block above in order for time to be recorded accurately.
         for user_event in check.generator(
-            _step_output_error_checked_user_event_sequence(step_context, user_event_sequence)
+            _step_output_error_checked_user_event_sequence(
+                step_context,
+                _asset_check_results_to_outputs_and_evaluations(step_context, user_event_sequence),
+            )
         ):
             if isinstance(user_event, DagsterEvent):
                 yield user_event
@@ -417,6 +445,8 @@ def core_dagster_event_sequence_for_step(
                 yield DagsterEvent.asset_materialization(step_context, user_event)
             elif isinstance(user_event, AssetObservation):
                 yield DagsterEvent.asset_observation(step_context, user_event)
+            elif isinstance(user_event, AssetCheckEvaluation):
+                yield DagsterEvent.asset_check_evaluation(step_context, user_event)
             elif isinstance(user_event, ExpectationResult):
                 yield DagsterEvent.step_expectation_result(step_context, user_event)
             else:

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_asset_decorator_with_check_specs.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_asset_decorator_with_check_specs.py
@@ -1,0 +1,195 @@
+import re
+
+import pytest
+from dagster import (
+    AssetCheckResult,
+    AssetCheckSpec,
+    AssetKey,
+    MetadataValue,
+    Output,
+    asset,
+    materialize,
+)
+from dagster._core.errors import (
+    DagsterInvalidDefinitionError,
+    DagsterInvariantViolationError,
+    DagsterStepOutputNotFoundError,
+)
+
+
+def test_asset_check_same_op():
+    @asset(check_specs=[AssetCheckSpec("check1", asset_key="asset1", description="desc")])
+    def asset1():
+        yield Output(None)
+        yield AssetCheckResult(check_name="check1", success=True, metadata={"foo": "bar"})
+
+    result = materialize(assets=[asset1])
+    assert result.success
+
+    check_evals = result.get_asset_check_evaluations()
+    assert len(check_evals) == 1
+    check_eval = check_evals[0]
+    assert check_eval.asset_key == asset1.key
+    assert check_eval.check_name == "check1"
+    assert check_eval.metadata == {"foo": MetadataValue.text("bar")}
+
+
+def test_multiple_asset_checks_same_op():
+    @asset(
+        check_specs=[
+            AssetCheckSpec("check1", asset_key="asset1", description="desc"),
+            AssetCheckSpec("check2", asset_key="asset1", description="desc"),
+        ]
+    )
+    def asset1():
+        yield Output(None)
+        yield AssetCheckResult(check_name="check1", success=True, metadata={"foo": "bar"})
+        yield AssetCheckResult(check_name="check2", success=False, metadata={"baz": "bla"})
+
+    result = materialize(assets=[asset1])
+    assert result.success
+
+    check_evals = result.get_asset_check_evaluations()
+    assert len(check_evals) == 2
+    assert check_evals[0].asset_key == asset1.key
+    assert check_evals[0].check_name == "check1"
+    assert check_evals[0].metadata == {"foo": MetadataValue.text("bar")}
+
+    assert check_evals[1].asset_key == asset1.key
+    assert check_evals[1].check_name == "check2"
+    assert check_evals[1].metadata == {"baz": MetadataValue.text("bla")}
+
+
+def test_check_targets_other_asset():
+    @asset(check_specs=[AssetCheckSpec("check1", asset_key="asset2", description="desc")])
+    def asset1():
+        yield Output(None)
+        yield AssetCheckResult(
+            asset_key="asset2", check_name="check1", success=True, metadata={"foo": "bar"}
+        )
+
+    result = materialize(assets=[asset1])
+    assert result.success
+
+    check_evals = result.get_asset_check_evaluations()
+    assert len(check_evals) == 1
+    check_eval = check_evals[0]
+    assert check_eval.asset_key == AssetKey("asset2")
+    assert check_eval.check_name == "check1"
+    assert check_eval.metadata == {"foo": MetadataValue.text("bar")}
+
+
+def test_check_targets_other_asset_and_result_omits_key():
+    @asset(check_specs=[AssetCheckSpec("check1", asset_key="asset2", description="desc")])
+    def asset1():
+        yield Output(None)
+        yield AssetCheckResult(check_name="check1", success=True, metadata={"foo": "bar"})
+
+    result = materialize(assets=[asset1])
+    assert result.success
+
+    check_evals = result.get_asset_check_evaluations()
+    assert len(check_evals) == 1
+    check_eval = check_evals[0]
+    assert check_eval.asset_key == AssetKey("asset2")
+    assert check_eval.check_name == "check1"
+    assert check_eval.metadata == {"foo": MetadataValue.text("bar")}
+
+
+def test_no_result_for_check():
+    @asset(check_specs=[AssetCheckSpec("check1", asset_key="asset1")])
+    def asset1():
+        yield Output(None)
+
+    with pytest.raises(
+        DagsterStepOutputNotFoundError,
+        match=(
+            'Core compute for op "asset1" did not return an output for non-optional output'
+            ' "asset1_check1"'
+        ),
+    ):
+        materialize(assets=[asset1])
+
+
+def test_check_result_but_no_output():
+    @asset(check_specs=[AssetCheckSpec("check1", asset_key="asset1")])
+    def asset1():
+        yield AssetCheckResult(success=True)
+
+    with pytest.raises(
+        DagsterStepOutputNotFoundError,
+        match=(
+            'Core compute for op "asset1" did not return an output for non-optional output "result"'
+        ),
+    ):
+        materialize(assets=[asset1])
+
+
+def test_unexpected_check_name():
+    @asset(check_specs=[AssetCheckSpec("check1", asset_key=AssetKey("asset1"), description="desc")])
+    def asset1():
+        return AssetCheckResult(check_name="check2", success=True, metadata={"foo": "bar"})
+
+    with pytest.raises(
+        DagsterInvariantViolationError,
+        match=(
+            "No checks currently being evaluated target asset 'asset1' and have name"
+            " 'check2'. Checks being evaluated for this asset: {'check1'}"
+        ),
+    ):
+        materialize(assets=[asset1])
+
+
+def test_asset_decorator_unexpected_asset_key():
+    @asset(check_specs=[AssetCheckSpec("check1", asset_key=AssetKey("asset1"), description="desc")])
+    def asset1():
+        return AssetCheckResult(asset_key=AssetKey("asset2"), check_name="check1", success=True)
+
+    with pytest.raises(
+        DagsterInvariantViolationError,
+        match=re.escape(
+            "Received unexpected AssetCheckResult. It targets asset 'asset2' which is not targeted"
+            " by any of the checks currently being evaluated. Targeted assets: ['asset1']."
+        ),
+    ):
+        materialize(assets=[asset1])
+
+
+def test_asset_check_fails_downstream_still_executes():
+    @asset(check_specs=[AssetCheckSpec("check1", asset_key=AssetKey("asset1"))])
+    def asset1():
+        yield Output(None)
+        yield AssetCheckResult(success=False)
+
+    @asset(deps=[asset1])
+    def asset2():
+        ...
+
+    result = materialize(assets=[asset1, asset2])
+    assert result.success
+
+    materialization_events = result.get_asset_materialization_events()
+    assert len(materialization_events) == 2
+
+    check_evals = result.get_asset_check_evaluations()
+    assert len(check_evals) == 1
+    check_eval = check_evals[0]
+    assert check_eval.asset_key == AssetKey("asset1")
+    assert check_eval.check_name == "check1"
+    assert not check_eval.success
+
+
+def test_duplicate_checks_same_asset():
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match=re.escape("Duplicate check specs: {(AssetKey(['asset1']), 'check1'): 2}"),
+    ):
+
+        @asset(
+            check_specs=[
+                AssetCheckSpec("check1", asset_key="asset1", description="desc1"),
+                AssetCheckSpec("check1", asset_key="asset1", description="desc2"),
+            ]
+        )
+        def asset1():
+            ...

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_asset_check_spec.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_asset_check_spec.py
@@ -1,0 +1,5 @@
+from dagster import AssetCheckSpec, AssetKey
+
+
+def test_coerce_asset_key():
+    assert AssetCheckSpec(asset_key="foo", name="check1").asset_key == AssetKey("foo")


### PR DESCRIPTION
## Summary & Motivation

Enables writing `@asset`s with `AssetCheckSpec`s on them.

This PR:
- Adds the `AssetCheckSpec` type
- Modifies the `@asset` decorator to accept it
- Enables `@asset`-decorated functions to yield `AssetCheckResult`s and records the appropriate events when they do.

## How I Tested These Changes
