### PR TITLE
@asset_check decorator and AssetChecksDefinition

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -130,6 +130,9 @@ from dagster._core.definitions.data_version import (
     DataVersion as DataVersion,
     DataVersionsByPartition as DataVersionsByPartition,
 )
+from dagster._core.definitions.decorators.asset_check_decorator import (
+    asset_check as asset_check,
+)
 from dagster._core.definitions.decorators.asset_decorator import (
     asset as asset,
     graph_asset as graph_asset,

--- a/python_modules/dagster/dagster/_core/definitions/asset_check_evaluation.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_evaluation.py
@@ -1,6 +1,7 @@
 from typing import Mapping, NamedTuple, Optional
 
 import dagster._check as check
+from dagster._core.definitions.asset_check_spec import AssetCheckHandle
 from dagster._core.definitions.events import AssetKey, MetadataValue
 from dagster._serdes import whitelist_for_serdes
 
@@ -100,3 +101,7 @@ class AssetCheckEvaluation(
                 AssetCheckEvaluationTargetMaterializationData,
             ),
         )
+
+    @property
+    def asset_check_handle(self) -> AssetCheckHandle:
+        return AssetCheckHandle(self.asset_key, self.check_name)

--- a/python_modules/dagster/dagster/_core/definitions/asset_check_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_spec.py
@@ -6,6 +6,16 @@ from dagster._core.definitions.events import AssetKey, CoercibleToAssetKey
 
 
 @experimental
+class AssetCheckHandle(NamedTuple):
+    """Check names are expected to be unique per-asset. Thus, this combination of asset key and
+    check name uniquely identifies an asset check within a deployment.
+    """
+
+    asset_key: PublicAttr[AssetKey]
+    name: PublicAttr[str]
+
+
+@experimental
 class AssetCheckSpec(
     NamedTuple(
         "_AssetCheckSpec",
@@ -47,3 +57,7 @@ class AssetCheckSpec(
         allowed in a Python identifier.
         """
         return f"{self.asset_key.to_python_identifier()}_{self.name}"
+
+    @property
+    def handle(self) -> AssetCheckHandle:
+        return AssetCheckHandle(self.asset_key, self.name)

--- a/python_modules/dagster/dagster/_core/definitions/asset_checks.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_checks.py
@@ -1,0 +1,129 @@
+from typing import Any, Dict, Iterable, Iterator, Mapping, NamedTuple, Optional, Sequence, Set
+
+from dagster import _check as check
+from dagster._annotations import experimental, public
+from dagster._core.definitions.asset_check_spec import AssetCheckHandle, AssetCheckSpec
+from dagster._core.definitions.events import AssetKey
+from dagster._core.definitions.node_definition import NodeDefinition
+from dagster._core.definitions.resource_definition import ResourceDefinition
+from dagster._core.definitions.resource_requirement import (
+    RequiresResources,
+    ResourceAddable,
+    ResourceRequirement,
+    merge_resource_defs,
+)
+
+
+@experimental
+class AssetChecksDefinitionInputOutputProps(NamedTuple):
+    asset_check_handles_by_output_name: Mapping[str, AssetCheckHandle]
+    asset_keys_by_input_name: Mapping[str, AssetKey]
+
+
+@experimental
+class AssetChecksDefinition(ResourceAddable, RequiresResources):
+    """Defines a set of checks that are produced by the same op or op graph.
+
+    AssetChecksDefinition are typically not instantiated directly, but rather produced using a
+    decorator like :py:func:`@asset_check <asset>`.
+    """
+
+    def __init__(
+        self,
+        *,
+        node_def: NodeDefinition,
+        resource_defs: Mapping[str, ResourceDefinition],
+        specs: Sequence[AssetCheckSpec],
+        input_output_props: AssetChecksDefinitionInputOutputProps
+        # if adding new fields, make sure to handle them in the get_attributes_dict method
+    ):
+        self._node_def = node_def
+        self._resource_defs = resource_defs
+        self._specs = check.sequence_param(specs, "specs", of_type=AssetCheckSpec)
+        self._input_output_props = check.inst_param(
+            input_output_props, "input_output_props", AssetChecksDefinitionInputOutputProps
+        )
+        self._specs_by_handle = {spec.handle: spec for spec in specs}
+        self._specs_by_output_name = {
+            output_name: self._specs_by_handle[check_handle]
+            for output_name, check_handle in input_output_props.asset_check_handles_by_output_name.items()
+        }
+
+    @public
+    @property
+    def node_def(self) -> NodeDefinition:
+        """The op or op graph that can be executed to check the assets."""
+        return self._node_def
+
+    @public
+    @property
+    def name(self) -> str:
+        return self.spec.name
+
+    @public
+    @property
+    def description(self) -> Optional[str]:
+        return self.spec.description
+
+    @public
+    @property
+    def asset_key(self) -> AssetKey:
+        return self.spec.asset_key
+
+    @public
+    @property
+    def spec(self) -> AssetCheckSpec:
+        if len(self._specs_by_output_name) > 1:
+            check.failed(
+                "Tried to retrieve single-check property from a checks definition with multiple"
+                " checks: "
+                + ", ".join(spec.name for spec in self._specs_by_output_name.values()),
+            )
+
+        return next(iter(self.specs))
+
+    @public
+    @property
+    def specs(self) -> Iterable[AssetCheckSpec]:
+        return self._specs_by_output_name.values()
+
+    @property
+    def specs_by_output_name(self) -> Mapping[str, AssetCheckSpec]:
+        return self._specs_by_output_name
+
+    @property
+    def asset_keys_by_input_name(self) -> Mapping[str, AssetKey]:
+        return self._input_output_props.asset_keys_by_input_name
+
+    def get_resource_requirements(self) -> Iterator[ResourceRequirement]:
+        yield from self.node_def.get_resource_requirements()  # type: ignore[attr-defined]
+        for source_key, resource_def in self._resource_defs.items():
+            yield from resource_def.get_resource_requirements(outer_context=source_key)
+
+    def get_spec_for_check_handle(self, asset_check_handle: AssetCheckHandle) -> AssetCheckSpec:
+        return self._specs_by_handle[asset_check_handle]
+
+    @public
+    @property
+    def required_resource_keys(self) -> Set[str]:
+        """Set[str]: The set of keys for resources that must be provided to this AssetsDefinition."""
+        return {requirement.key for requirement in self.get_resource_requirements()}
+
+    def with_resources(
+        self, resource_defs: Mapping[str, ResourceDefinition]
+    ) -> "AssetChecksDefinition":
+        attributes_dict = self.get_attributes_dict()
+        attributes_dict["resource_defs"] = merge_resource_defs(
+            old_resource_defs=self._resource_defs,
+            resource_defs_to_merge_in=resource_defs,
+            requires_resources=self,
+        )
+        return self.__class__(**attributes_dict)
+
+    def get_attributes_dict(self) -> Dict[str, Any]:
+        return dict(
+            node_def=self._node_def,
+            resource_defs=self._resource_defs,
+            specs=self._specs,
+            input_output_props=self._input_output_props,
+        )

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -33,6 +33,7 @@ from dagster._core.selector.subset_selector import (
 )
 from dagster._utils.cached_method import cached_method
 
+from .asset_checks import AssetChecksDefinition
 from .assets import AssetsDefinition
 from .backfill_policy import BackfillPolicy
 from .events import AssetKey, AssetKeyPartitionKey
@@ -146,7 +147,8 @@ class AssetGraph:
 
     @staticmethod
     def from_assets(
-        all_assets: Iterable[Union[AssetsDefinition, SourceAsset]]
+        all_assets: Iterable[Union[AssetsDefinition, SourceAsset]],
+        asset_checks: Optional[Sequence[AssetChecksDefinition]] = None,
     ) -> "InternalAssetGraph":
         assets_defs: List[AssetsDefinition] = []
         source_assets: List[SourceAsset] = []
@@ -198,6 +200,7 @@ class AssetGraph:
             backfill_policies_by_key=backfill_policies_by_key,
             required_multi_asset_sets_by_key=required_multi_asset_sets_by_key,
             assets=assets_defs,
+            asset_checks=asset_checks or [],
             source_assets=source_assets,
             code_versions_by_key=code_versions_by_key,
             is_observable_by_key=is_observable_by_key,
@@ -680,6 +683,7 @@ class InternalAssetGraph(AssetGraph):
         required_multi_asset_sets_by_key: Optional[Mapping[AssetKey, AbstractSet[AssetKey]]],
         assets: Sequence[AssetsDefinition],
         source_assets: Sequence[SourceAsset],
+        asset_checks: Sequence[AssetChecksDefinition],
         code_versions_by_key: Mapping[AssetKey, Optional[str]],
         is_observable_by_key: Mapping[AssetKey, bool],
         auto_observe_interval_minutes_by_key: Mapping[AssetKey, Optional[float]],
@@ -700,6 +704,7 @@ class InternalAssetGraph(AssetGraph):
         )
         self._assets = assets
         self._source_assets = source_assets
+        self._asset_checks = asset_checks
 
     @property
     def assets(self) -> Sequence[AssetsDefinition]:
@@ -708,6 +713,10 @@ class InternalAssetGraph(AssetGraph):
     @property
     def source_assets(self) -> Sequence[SourceAsset]:
         return self._source_assets
+
+    @property
+    def asset_checks(self) -> Sequence[AssetChecksDefinition]:
+        return self._asset_checks
 
 
 def sort_key_for_asset_partition(

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_check_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_check_decorator.py
@@ -1,0 +1,151 @@
+from typing import Any, Callable, Mapping, Optional, Set, Union
+
+from dagster import _check as check
+from dagster._annotations import experimental
+from dagster._config import UserConfigSchema
+from dagster._core.definitions.asset_check_result import AssetCheckResult
+from dagster._core.definitions.asset_check_spec import AssetCheckSpec
+from dagster._core.definitions.asset_checks import (
+    AssetChecksDefinition,
+    AssetChecksDefinitionInputOutputProps,
+)
+from dagster._core.definitions.assets import AssetsDefinition
+from dagster._core.definitions.decorators.asset_decorator import (
+    asset_key_from_coercible_or_definition,
+    build_asset_ins,
+)
+from dagster._core.definitions.events import CoercibleToAssetKey
+from dagster._core.definitions.output import Out
+from dagster._core.definitions.policy import RetryPolicy
+from dagster._core.definitions.source_asset import SourceAsset
+from dagster._core.errors import DagsterInvalidDefinitionError
+
+from .op_decorator import _Op
+
+AssetCheckFunctionReturn = AssetCheckResult
+AssetCheckFunction = Callable[..., AssetCheckFunctionReturn]
+
+
+@experimental
+def asset_check(
+    *,
+    asset: Optional[Union[CoercibleToAssetKey, AssetsDefinition, SourceAsset]] = None,
+    name: Optional[str] = None,
+    description: Optional[str] = None,
+    required_resource_keys: Optional[Set[str]] = None,
+    resource_defs: Optional[Mapping[str, object]] = None,
+    config_schema: Optional[UserConfigSchema] = None,
+    compute_kind: Optional[str] = None,
+    op_tags: Optional[Mapping[str, Any]] = None,
+    retry_policy: Optional[RetryPolicy] = None,
+) -> Callable[[AssetCheckFunction], AssetChecksDefinition]:
+    """Create a definition for how to execute an asset check.
+
+    Args:
+        asset (Optional[Union[AssetKey, Sequence[str], str, AssetsDefinition, SourceAsset]]): The
+            asset that the check applies to.
+        name (Optional[str]): The name of the check. If not specified, the name of the decorated
+            function will be used. Checks for the same asset must have unique names.
+        description (Optional[str]): The description of the check.
+        required_resource_keys (Optional[Set[str]]): A set of keys for resources that are required
+            by the function that execute the check. These can alternatively be specified by
+            including resource-typed parameters in the function signature.
+        config_schema (Optional[ConfigSchema): The configuration schema for the check's underlying
+            op. If set, Dagster will check that config provided for the op matches this schema and fail
+            if it does not. If not set, Dagster will accept any config provided for the op.
+        op_tags (Optional[Dict[str, Any]]): A dictionary of tags for the op that executes the check.
+            Frameworks may expect and require certain metadata to be attached to a op. Values that
+            are not strings will be json encoded and must meet the criteria that
+            `json.loads(json.dumps(value)) == value`.
+        compute_kind (Optional[str]): A string to represent the kind of computation that executes
+            the check, e.g. "dbt" or "spark".
+        retry_policy (Optional[RetryPolicy]): The retry policy for the op that executes the check.
+
+    Produces an :py:class:`AssetChecksDefinition` object.
+
+    Examples:
+        .. code-block:: python
+            from dagster import asset, asset_check, AssetCheckResult
+
+            @asset
+            def my_asset() -> None:
+                ...
+
+            @asset_check(asset=my_asset, description="Check that my asset has enough rows")
+            def my_asset_has_enough_rows() -> AssetCheckResult:
+                num_rows = ...
+                return AssetCheckResult(success=num_rows > 5, metadata={"num_rows": num_rows})
+
+
+        .. code-block:: python
+            from dagster import asset, asset_check, AssetCheckResult
+            from pandas import DataFrame
+
+            @asset
+            def my_asset() -> DataFrame:
+                ...
+
+            @asset_check(description="Check that my asset has enough rows")
+            def my_asset_has_enough_rows(my_asset: DataFrame) -> AssetCheckResult:
+                num_rows = my_asset.shape[0]
+                return AssetCheckResult(success=num_rows > 5, metadata={"num_rows": num_rows})
+    """
+
+    def inner(fn: AssetCheckFunction) -> AssetChecksDefinition:
+        check.callable_param(fn, "fn")
+        resolved_name = name or fn.__name__
+        asset_key = asset_key_from_coercible_or_definition(asset) if asset is not None else None
+
+        out = Out(dagster_type=None)
+        input_tuples_by_asset_key = build_asset_ins(
+            fn, {}, {asset_key} if asset_key is not None else set()
+        )
+        if len(input_tuples_by_asset_key) == 0:
+            raise DagsterInvalidDefinitionError(
+                f"No target asset provided when defining check '{resolved_name}'"
+            )
+
+        if len(input_tuples_by_asset_key) > 1:
+            raise DagsterInvalidDefinitionError(
+                f"When defining check '{resolved_name}', Multiple target assets provided:"
+                f" {[key.to_user_string() for key in input_tuples_by_asset_key.keys()]}. Only one"
+                " is allowed."
+            )
+
+        resolved_asset_key = next(iter(input_tuples_by_asset_key.keys()))
+        spec = AssetCheckSpec(
+            name=resolved_name,
+            description=description,
+            asset_key=resolved_asset_key,
+        )
+
+        op_def = _Op(
+            name=spec.get_python_identifier(),
+            ins=dict(input_tuples_by_asset_key.values()),
+            out=out,
+            # Any resource requirements specified as arguments will be identified as
+            # part of the Op definition instantiation
+            required_resource_keys=required_resource_keys,
+            tags={
+                **({"kind": compute_kind} if compute_kind else {}),
+                **(op_tags or {}),
+            },
+            config_schema=config_schema,
+            retry_policy=retry_policy,
+        )(fn)
+
+        checks_def = AssetChecksDefinition(
+            node_def=op_def,
+            resource_defs={},
+            specs=[spec],
+            input_output_props=AssetChecksDefinitionInputOutputProps(
+                asset_keys_by_input_name={
+                    input_tuples_by_asset_key[resolved_asset_key][0]: resolved_asset_key
+                },
+                asset_check_handles_by_output_name={op_def.output_defs[0].name: spec.handle},
+            ),
+        )
+
+        return checks_def
+
+    return inner

--- a/python_modules/dagster/dagster/_core/definitions/decorators/repository_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/repository_decorator.py
@@ -24,6 +24,7 @@ from dagster._core.definitions.metadata import (
 from dagster._core.definitions.resource_definition import ResourceDefinition
 from dagster._core.errors import DagsterInvalidDefinitionError
 
+from ..asset_checks import AssetChecksDefinition
 from ..executor_definition import ExecutorDefinition
 from ..graph_definition import GraphDefinition
 from ..job_definition import JobDefinition
@@ -137,6 +138,7 @@ class _Repository:
                         AssetsDefinition,
                         SourceAsset,
                         UnresolvedAssetJobDefinition,
+                        AssetChecksDefinition,
                     ),
                 ):
                     bad_defns.append((i, type(definition)))
@@ -151,7 +153,7 @@ class _Repository:
                     "Bad return value from repository construction function: all elements of list "
                     "must be of type JobDefinition, GraphDefinition, "
                     "ScheduleDefinition, SensorDefinition, "
-                    "AssetsDefinition, or SourceAsset."
+                    "AssetsDefinition, SourceAsset, or AssetChecksDefinition."
                     f"Got {bad_definitions_str}."
                 )
 

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -790,6 +790,7 @@ class JobDefinition(IHasInternalInit):
             asset_selection=asset_selection,
             asset_selection_data=asset_selection_data,
             config=self.config_mapping or self.partitioned_config,
+            asset_checks=self.asset_layer.asset_checks_defs,
         )
         return new_job
 

--- a/python_modules/dagster/dagster/_core/definitions/resource_requirement.py
+++ b/python_modules/dagster/dagster/_core/definitions/resource_requirement.py
@@ -10,7 +10,9 @@ from typing import (
     Type,
 )
 
-from ..errors import DagsterInvalidDefinitionError
+from dagster._utils.merger import merge_dicts
+
+from ..errors import DagsterInvalidDefinitionError, DagsterInvalidInvocationError
 from .utils import DEFAULT_IO_MANAGER_KEY
 
 if TYPE_CHECKING:
@@ -238,3 +240,40 @@ def get_resource_key_conflicts(
     overlapping_keys = set(resource_defs.keys()).intersection(set(other_resource_defs.keys()))
     overlapping_keys = {key for key in overlapping_keys if key != DEFAULT_IO_MANAGER_KEY}
     return overlapping_keys
+
+
+def merge_resource_defs(
+    old_resource_defs: Mapping[str, "ResourceDefinition"],
+    resource_defs_to_merge_in: Mapping[str, "ResourceDefinition"],
+    requires_resources: RequiresResources,
+) -> Mapping[str, "ResourceDefinition"]:
+    from dagster._core.execution.resources_init import get_transitive_required_resource_keys
+
+    overlapping_keys = get_resource_key_conflicts(old_resource_defs, resource_defs_to_merge_in)
+    if overlapping_keys:
+        overlapping_keys_str = ", ".join(sorted(list(overlapping_keys)))
+        raise DagsterInvalidInvocationError(
+            f"{requires_resources} has conflicting resource "
+            "definitions with provided resources for the following keys: "
+            f"{overlapping_keys_str}. Either remove the existing "
+            "resources from the asset or change the resource keys so that "
+            "they don't overlap."
+        )
+
+    merged_resource_defs = merge_dicts(resource_defs_to_merge_in, old_resource_defs)
+
+    # Ensure top-level resource requirements are met - except for
+    # io_manager, since that is a default it can be resolved later.
+    ensure_requirements_satisfied(
+        merged_resource_defs, list(requires_resources.get_resource_requirements())
+    )
+
+    # Get all transitive resource dependencies from other resources.
+    relevant_keys = get_transitive_required_resource_keys(
+        requires_resources.required_resource_keys, merged_resource_defs
+    )
+    return {
+        key: resource_def
+        for key, resource_def in merged_resource_defs.items()
+        if key in relevant_keys
+    }

--- a/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
@@ -217,6 +217,7 @@ class UnresolvedAssetJobDefinition(
         return build_asset_selection_job(
             name=self.name,
             assets=assets,
+            asset_checks=asset_graph.asset_checks,
             config=self.config,
             source_assets=source_assets,
             description=self.description,

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -16,6 +16,7 @@ from typing_extensions import TypeAlias
 
 import dagster._check as check
 from dagster._annotations import deprecated, experimental, public
+from dagster._core.definitions.asset_check_spec import AssetCheckSpec
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.data_version import (
     DataProvenance,
@@ -649,6 +650,14 @@ class OpExecutionContext(AbstractComputeExecutionContext):
             data_version (DataVersion): The data version to set.
         """
         self._step_execution_context.set_data_version(asset_key, data_version)
+
+    @property
+    def asset_check_spec(self) -> AssetCheckSpec:
+        asset_checks_def = check.not_none(
+            self.job_def.asset_layer.asset_checks_def_for_node(self.node_handle),
+            "This context does not correspond to an AssetChecksDefinition",
+        )
+        return asset_checks_def.spec
 
 
 # actually forking the object type for assets is tricky for users in the cases of:

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
@@ -89,7 +89,7 @@ def _asset_check_results_to_outputs_and_evaluations(
             asset_check_evaluation = user_event.to_asset_check_evaluation(step_context)
 
             output_name = step_context.job_def.asset_layer.get_output_name_for_asset_check(
-                asset_check_evaluation.asset_key, asset_check_evaluation.check_name
+                asset_check_evaluation.asset_check_handle
             )
             output = Output(value=None, output_name=output_name)
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
@@ -1976,6 +1976,7 @@ def test_get_base_asset_jobs_multiple_partitions_defs():
         source_assets=[],
         executor_def=None,
         resource_defs={},
+        asset_checks=[],
     )
     assert len(jobs) == 3
     assert {job_def.name for job_def in jobs} == {

--- a/python_modules/dagster/dagster_tests/core_tests/test_data_time.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_data_time.py
@@ -123,6 +123,7 @@ def test_calculate_data_time_unpartitioned(ignore_asset_tags, runs_to_expected_d
                 asset_selection=AssetSelection.keys(*(AssetKey(c) for c in to_materialize)).resolve(
                     all_assets
                 ),
+                asset_checks=[],
             ).execute_in_process(instance=instance)
 
             assert result.success

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_asset_check_decorator.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_asset_check_decorator.py
@@ -1,0 +1,315 @@
+import re
+from typing import NamedTuple
+
+import pytest
+from dagster import (
+    AssetCheckResult,
+    AssetKey,
+    Definitions,
+    ExecuteInProcessResult,
+    IOManager,
+    MetadataValue,
+    ResourceParam,
+    asset,
+    asset_check,
+    define_asset_job,
+)
+from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvariantViolationError
+
+
+def execute_assets_and_checks(
+    assets=None, asset_checks=None, raise_on_error: bool = True, resources=None
+) -> ExecuteInProcessResult:
+    defs = Definitions(assets=assets, asset_checks=asset_checks, resources=resources)
+    job_def = defs.get_implicit_global_asset_job_def()
+    return job_def.execute_in_process(raise_on_error=raise_on_error)
+
+
+def test_asset_check_decorator():
+    @asset_check(asset="asset1", description="desc")
+    def check1():
+        ...
+
+    assert check1.name == "check1"
+    assert check1.description == "desc"
+    assert check1.asset_key == AssetKey("asset1")
+
+
+def test_asset_check_decorator_name():
+    @asset_check(asset="asset1", description="desc", name="check1")
+    def _check():
+        ...
+
+    assert _check.name == "check1"
+
+
+def test_execute_asset_and_check():
+    @asset
+    def asset1():
+        ...
+
+    @asset_check(asset=asset1, description="desc")
+    def check1(context):
+        assert context.asset_key_for_input("asset1") == asset1.key
+        asset_check_spec = context.asset_check_spec
+        return AssetCheckResult(
+            asset_key=asset_check_spec.asset_key,
+            check_name=asset_check_spec.name,
+            success=True,
+            metadata={"foo": "bar"},
+        )
+
+    result = execute_assets_and_checks(assets=[asset1], asset_checks=[check1])
+    assert result.success
+
+    check_evals = result.get_asset_check_evaluations()
+    assert len(check_evals) == 1
+    check_eval = check_evals[0]
+    assert check_eval.asset_key == asset1.key
+    assert check_eval.check_name == "check1"
+    assert check_eval.metadata == {"foo": MetadataValue.text("bar")}
+
+
+def test_execute_check_without_asset():
+    @asset_check(asset="asset1", description="desc")
+    def check1():
+        return AssetCheckResult(success=True, metadata={"foo": "bar"})
+
+    result = execute_assets_and_checks(asset_checks=[check1])
+    assert result.success
+
+    check_evals = result.get_asset_check_evaluations()
+    assert len(check_evals) == 1
+    check_eval = check_evals[0]
+    assert check_eval.asset_key == AssetKey("asset1")
+    assert check_eval.check_name == "check1"
+    assert check_eval.metadata == {"foo": MetadataValue.text("bar")}
+
+
+def test_execute_check_and_unrelated_asset():
+    @asset
+    def asset2():
+        ...
+
+    @asset_check(asset="asset1", description="desc")
+    def check1():
+        return AssetCheckResult(success=True)
+
+    result = execute_assets_and_checks(assets=[asset2], asset_checks=[check1])
+    assert result.success
+
+    materialization_events = result.get_asset_materialization_events()
+    assert len(materialization_events) == 1
+
+    check_evals = result.get_asset_check_evaluations()
+    assert len(check_evals) == 1
+    check_eval = check_evals[0]
+    assert check_eval.asset_key == AssetKey("asset1")
+    assert check_eval.check_name == "check1"
+
+
+def test_check_doesnt_execute_if_asset_fails():
+    check_executed = [False]
+
+    @asset
+    def asset1():
+        raise ValueError()
+
+    @asset_check(asset=asset1)
+    def asset1_check(context):
+        check_executed[0] = True
+
+    result = execute_assets_and_checks(
+        assets=[asset1], asset_checks=[asset1_check], raise_on_error=False
+    )
+    assert not result.success
+
+    assert not check_executed[0]
+
+
+def test_check_decorator_unexpected_asset_key():
+    @asset_check(asset="asset1", description="desc")
+    def asset1_check():
+        return AssetCheckResult(asset_key=AssetKey("asset2"), success=True)
+
+    with pytest.raises(
+        DagsterInvariantViolationError,
+        match=re.escape(
+            "Received unexpected AssetCheckResult. It targets asset 'asset2' which is not targeted"
+            " by any of the checks currently being evaluated. Targeted assets: ['asset1']."
+        ),
+    ):
+        execute_assets_and_checks(asset_checks=[asset1_check])
+
+
+def test_asset_check_separate_op_downstream_still_executes():
+    @asset
+    def asset1():
+        ...
+
+    @asset_check(asset=asset1)
+    def asset1_check(context):
+        return AssetCheckResult(success=False)
+
+    @asset(deps=[asset1])
+    def asset2():
+        ...
+
+    result = execute_assets_and_checks(assets=[asset1, asset2], asset_checks=[asset1_check])
+    assert result.success
+
+    materialization_events = result.get_asset_materialization_events()
+    assert len(materialization_events) == 2
+
+    check_evals = result.get_asset_check_evaluations()
+    assert len(check_evals) == 1
+    check_eval = check_evals[0]
+    assert check_eval.asset_key == AssetKey("asset1")
+    assert check_eval.check_name == "asset1_check"
+    assert not check_eval.success
+
+
+def test_definitions_conflicting_checks():
+    def make_check():
+        @asset_check(asset="asset1")
+        def check1(context):
+            ...
+
+        return check1
+
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match='Detected conflicting node definitions with the same name "asset1_check1"',
+    ):
+        Definitions(asset_checks=[make_check(), make_check()])
+
+
+def test_definitions_same_name_different_asset():
+    def make_check_for_asset(asset_key: str):
+        @asset_check(asset=asset_key)
+        def check1(context):
+            ...
+
+        return check1
+
+    Definitions(asset_checks=[make_check_for_asset("asset1"), make_check_for_asset("asset2")])
+
+
+def test_definitions_same_asset_different_name():
+    def make_check(check_name: str):
+        @asset_check(asset="asset1", name=check_name)
+        def _check(context):
+            ...
+
+        return _check
+
+    Definitions(asset_checks=[make_check("check1"), make_check("check2")])
+
+
+def test_resource_params():
+    class MyResource(NamedTuple):
+        value: int
+
+    @asset_check(asset=AssetKey("asset1"))
+    def check1(my_resource: ResourceParam[MyResource]):
+        assert my_resource.value == 5
+        return AssetCheckResult(success=True)
+
+    execute_assets_and_checks(asset_checks=[check1], resources={"my_resource": MyResource(5)})
+
+
+def test_job_only_execute_checks_downstream_of_selected_assets():
+    @asset
+    def asset1():
+        ...
+
+    @asset
+    def asset2():
+        ...
+
+    @asset_check(asset=asset1)
+    def check1():
+        return AssetCheckResult(success=False)
+
+    @asset_check(asset=asset2)
+    def check2():
+        return AssetCheckResult(success=False)
+
+    defs = Definitions(
+        assets=[asset1, asset2],
+        asset_checks=[check1, check2],
+        jobs=[define_asset_job("job1", selection=[asset1])],
+    )
+    job_def = defs.get_job_def("job1")
+    result = job_def.execute_in_process()
+    assert result.success
+
+    check_evals = result.get_asset_check_evaluations()
+    assert len(check_evals) == 1
+    check_eval = check_evals[0]
+    assert check_eval.asset_key == asset1.key
+    assert check_eval.check_name == "check1"
+
+
+def test_asset_not_provided():
+    with pytest.raises(
+        DagsterInvalidDefinitionError, match="No target asset provided when defining check 'check1'"
+    ):
+
+        @asset_check(description="desc")
+        def check1():
+            ...
+
+
+def test_managed_input():
+    @asset
+    def asset1() -> int:
+        return 4
+
+    @asset_check(description="desc")
+    def check1(asset1):
+        assert asset1 == 4
+        return AssetCheckResult(success=True)
+
+    class MyIOManager(IOManager):
+        def load_input(self, context):
+            assert context.asset_key == asset1.key
+            return 4
+
+        def handle_output(self, context, obj):
+            ...
+
+    assert check1.name == "check1"
+    assert check1.asset_key == asset1.key
+
+    assert execute_assets_and_checks(
+        assets=[asset1], asset_checks=[check1], resources={"io_manager": MyIOManager()}
+    ).success
+
+
+def test_multiple_managed_inputs():
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match=re.escape("When defining check 'check1', Multiple target assets provided:"),
+    ):
+
+        @asset_check(description="desc")
+        def check1(asset1, asset2):
+            ...
+
+
+def test_managed_input_with_context():
+    @asset
+    def asset1() -> int:
+        return 4
+
+    @asset_check(description="desc")
+    def check1(context, asset1):
+        assert context
+        assert asset1 == 4
+        return AssetCheckResult(success=True)
+
+    assert check1.name == "check1"
+    assert check1.asset_key == asset1.key
+
+    execute_assets_and_checks(assets=[asset1], asset_checks=[check1])


### PR DESCRIPTION
## Summary & Motivation

Adds `@asset_check` and `AssetChecksDefinition` and threads them through the underlying `AssetLayer` so they can be included in execution.

Checks are included on the implicit asset job.

This PR is sits on top of this other PR in the stack: https://github.com/dagster-io/dagster/pull/15928.

## How I Tested These Changes
