### PR TITLE
Reload code locations hotkey

### DIFF
--- a/js_modules/dagster-ui/packages/app-oss/src/App.tsx
+++ b/js_modules/dagster-ui/packages/app-oss/src/App.tsx
@@ -38,7 +38,7 @@ const appCache = createAppCache();
 export default function AppPage() {
   return (
     <AppProvider appCache={appCache} config={config}>
-      <AppTopNav searchPlaceholder="Search…">
+      <AppTopNav searchPlaceholder="Search…" allowGlobalReload>
         <UserSettingsButton />
       </AppTopNav>
       <App>

--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav.tsx
@@ -25,6 +25,7 @@ interface Props {
   rightOfSearchBar?: React.ReactNode;
   showStatusWarningIcon?: boolean;
   getNavLinks?: (navItems: AppNavLinkType[]) => React.ReactNode;
+  allowGlobalReload?: boolean;
 }
 
 export const AppTopNav: React.FC<Props> = ({
@@ -32,6 +33,7 @@ export const AppTopNav: React.FC<Props> = ({
   rightOfSearchBar,
   searchPlaceholder,
   getNavLinks,
+  allowGlobalReload = false,
 }) => {
   const history = useHistory();
 
@@ -137,18 +139,20 @@ export const AppTopNav: React.FC<Props> = ({
         {rightOfSearchBar}
       </Box>
       <Box flex={{direction: 'row', alignItems: 'center'}}>
-        <ShortcutHandler
-          onShortcut={() => {
-            if (!reloading) {
-              tryReload();
-            }
-          }}
-          shortcutLabel={`⌥R - ${reloading ? 'Reloading' : 'Reload all code locations'}`}
-          // On OSX Alt + R creates ®, not sure about windows, so checking 'r' for windows
-          shortcutFilter={(e) => e.altKey && (e.key === '®' || e.key === 'r')}
-        >
-          <div style={{width: '0px', height: '30px'}} />
-        </ShortcutHandler>
+        {allowGlobalReload ? (
+          <ShortcutHandler
+            onShortcut={() => {
+              if (!reloading) {
+                tryReload();
+              }
+            }}
+            shortcutLabel={`⌥R - ${reloading ? 'Reloading' : 'Reload all code locations'}`}
+            // On OSX Alt + R creates ®, not sure about windows, so checking 'r' for windows
+            shortcutFilter={(e) => e.altKey && (e.key === '®' || e.key === 'r')}
+          >
+            <div style={{width: '0px', height: '30px'}} />
+          </ShortcutHandler>
+        ) : null}
         <SearchDialog searchPlaceholder={searchPlaceholder} />
         {children}
       </Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav.tsx
@@ -5,6 +5,10 @@ import styled from 'styled-components';
 
 import {DeploymentStatusIcon} from '../nav/DeploymentStatusIcon';
 import {VersionNumber} from '../nav/VersionNumber';
+import {
+  reloadFnForWorkspace,
+  useRepositoryLocationReload,
+} from '../nav/useRepositoryLocationReload';
 import {SearchDialog} from '../search/SearchDialog';
 
 import {LayoutContext} from './LayoutProvider';
@@ -118,6 +122,11 @@ export const AppTopNav: React.FC<Props> = ({
     ];
   };
 
+  const {reloading, tryReload} = useRepositoryLocationReload({
+    scope: 'workspace',
+    reloadFn: reloadFnForWorkspace,
+  });
+
   return (
     <AppTopNavContainer>
       <Box flex={{direction: 'row', alignItems: 'center', gap: 16}}>
@@ -128,6 +137,18 @@ export const AppTopNav: React.FC<Props> = ({
         {rightOfSearchBar}
       </Box>
       <Box flex={{direction: 'row', alignItems: 'center'}}>
+        <ShortcutHandler
+          onShortcut={() => {
+            if (!reloading) {
+              tryReload();
+            }
+          }}
+          shortcutLabel={`⌥R - ${reloading ? 'Reloading' : 'Reload all code locations'}`}
+          // On OSX Alt + R creates ®, not sure about windows, so checking 'r' for windows
+          shortcutFilter={(e) => e.altKey && (e.key === '®' || e.key === 'r')}
+        >
+          <div style={{width: '0px', height: '30px'}} />
+        </ShortcutHandler>
         <SearchDialog searchPlaceholder={searchPlaceholder} />
         {children}
       </Box>


### PR DESCRIPTION
## Summary & Motivation

Allow reloading code locations from any page using Alt + R as a hotkey

https://elementl-workspace.slack.com/archives/C03CCE471E0/p1686935865299879

## How I Tested These Changes

https://github.com/dagster-io/dagster/assets/2286579/2ccd3664-b63f-4f75-a8c5-0820c5c7a942


