### PR TITLE
add MaterializeResult

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -37,7 +37,11 @@ from dagster._core.definitions.resource_requirement import (
 )
 from dagster._core.definitions.time_window_partition_mapping import TimeWindowPartitionMapping
 from dagster._core.definitions.time_window_partitions import TimeWindowPartitionsDefinition
-from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvalidInvocationError
+from dagster._core.errors import (
+    DagsterInvalidDefinitionError,
+    DagsterInvalidInvocationError,
+    DagsterInvariantViolationError,
+)
 from dagster._utils import IHasInternalInit
 from dagster._utils.merger import merge_dicts
 from dagster._utils.warnings import (
@@ -848,7 +852,9 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
             if key == asset_key:
                 return output_name
 
-        check.failed(f"Asset key {key.to_user_string()} not found in AssetsDefinition")
+        raise DagsterInvariantViolationError(
+            f"Asset key {key.to_user_string()} not found in AssetsDefinition"
+        )
 
     def get_op_def_for_asset_key(self, key: AssetKey) -> OpDefinition:
         """If this is an op-backed asset, returns the op def. If it's a graph-backed asset,

--- a/python_modules/dagster/dagster/_core/definitions/result.py
+++ b/python_modules/dagster/dagster/_core/definitions/result.py
@@ -1,0 +1,43 @@
+from typing import NamedTuple, Optional
+
+from dagster._annotations import PublicAttr, experimental
+
+from .events import (
+    AssetKey,
+    CoercibleToAssetKey,
+)
+from .metadata import MetadataUserInput
+
+
+@experimental
+class MaterializeResult(
+    NamedTuple(
+        "_MaterializeResult",
+        [
+            ("asset_key", PublicAttr[Optional[AssetKey]]),
+            ("metadata", PublicAttr[Optional[MetadataUserInput]]),
+        ],
+    )
+):
+    """An object representing a successful materialization of an asset. These can be returned from
+    @asset and @multi_asset decorated functions to pass metadata or specify specific assets were
+    materialized.
+
+    Attributes:
+        asset_key (Optional[AssetKey]): Optional in @asset, required in @multi_asset to discern which asset this refers to.
+        metadata (Optional[MetadataUserInput]): Metadata to record with the corresponding AssetMaterialization event.
+    """
+
+    def __new__(
+        cls,
+        *,  # enforce kwargs
+        asset_key: Optional[CoercibleToAssetKey] = None,
+        metadata: Optional[MetadataUserInput] = None,
+    ):
+        asset_key = AssetKey.from_coercible(asset_key) if asset_key else None
+
+        return super().__new__(
+            cls,
+            asset_key=asset_key,
+            metadata=metadata,  # check?
+        )

--- a/python_modules/dagster/dagster/_core/execution/plan/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/compute.py
@@ -29,6 +29,7 @@ from dagster._core.definitions import (
 )
 from dagster._core.definitions.asset_layer import AssetLayer
 from dagster._core.definitions.op_definition import OpComputeFunction
+from dagster._core.definitions.result import MaterializeResult
 from dagster._core.errors import DagsterExecutionStepExecutionError, DagsterInvariantViolationError
 from dagster._core.events import DagsterEvent
 from dagster._core.execution.context.compute import OpExecutionContext
@@ -50,6 +51,7 @@ OpOutputUnion: TypeAlias = Union[
     DagsterEvent,
     AssetCheckEvaluation,
     AssetCheckResult,
+    MaterializeResult,
 ]
 
 
@@ -100,6 +102,7 @@ def _validate_event(event: Any, step_context: StepExecutionContext) -> OpOutputU
             DagsterEvent,
             AssetCheckResult,
             AssetCheckEvaluation,
+            MaterializeResult,
         ),
     ):
         raise DagsterInvariantViolationError(

--- a/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
@@ -28,6 +28,7 @@ from dagster._core.definitions import (
 )
 from dagster._core.definitions.decorators.op_decorator import DecoratedOpFunction
 from dagster._core.definitions.op_definition import OpDefinition
+from dagster._core.definitions.result import MaterializeResult
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.types.dagster_type import DagsterTypeKind, is_generic_output_annotation
 from dagster._utils.warnings import disable_dagster_warnings
@@ -256,6 +257,8 @@ def validate_and_coerce_op_result_to_iterator(
                             mapping_key=dynamic_output.mapping_key,
                             metadata=dynamic_output.metadata,
                         )
+            elif isinstance(element, MaterializeResult):
+                yield element  # coerced in to Output in outer iterator
             elif isinstance(element, Output):
                 if annotation != inspect.Parameter.empty and not is_generic_output_annotation(
                     annotation


### PR DESCRIPTION
The latest evolution of https://github.com/dagster-io/dagster/pull/14931 & https://github.com/dagster-io/dagster/discussions/15392 intentionally aligned with https://github.com/dagster-io/dagster/pull/15928/ this PR adds support for a new "Result" return type from assets that do not deal with "Outputs" to be able to communicate materialization metadata.

## How I Tested These Changes

added tests.
