### PR TITLE
[docs infra] always open the current section in left nav

### DIFF
--- a/docs/next/components/Sidebar.tsx
+++ b/docs/next/components/Sidebar.tsx
@@ -163,7 +163,7 @@ const ChevronButton = ({
         stroke="currentColor"
         aria-hidden="true"
       >
-        {expanded ? Icons.ChevronDown : Icons.ChevronRight}
+        {expanded || match ? Icons.ChevronDown : Icons.ChevronRight}
       </svg>
     </button>
   );
@@ -226,7 +226,7 @@ const RecursiveNavigation = ({
         onClick={() => onClick(navKey)}
         expanded={expanded}
       />
-      {expanded &&
+      {(expanded || match) &&
         itemOrSection.children.map((item, idx) => {
           return (
             <div className="border-l ml-6" key={idx}>


### PR DESCRIPTION
## Summary & Motivation
there was an old pr that i never landed. so picked this fix up in a new pr (esp now that we've landed a couple left nav improvements lately)

status quo: https://docs.dagster.io/concepts/partitions-schedules-sensors/sensors
<img width="500" alt="image" src="https://github.com/dagster-io/dagster/assets/4531914/3cce7d01-7256-4c1a-a4b8-b2bc7aa192ab">


new: https://08-18--docs-infra-always-open-the-current-section-in-left-nac.dagster.dagster-docs.io/concepts/partitions-schedules-sensors/sensors
<img width="596" alt="image" src="https://github.com/dagster-io/dagster/assets/4531914/0247ccb9-6cc0-49b8-8a7d-34f26604b5b5">

## How I Tested These Changes
