### PR TITLE
[rfc] add assets param to RunConfig

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/run_config.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_config.py
@@ -631,11 +631,15 @@ class RunConfig:
     def __init__(
         self,
         ops: Optional[Dict[str, Any]] = None,
+        assets: Optional[Dict[str, Any]] = None,
         resources: Optional[Dict[str, Any]] = None,
         loggers: Optional[Dict[str, Any]] = None,
         execution: Optional[Dict[str, Any]] = None,
     ):
         self.ops = check.opt_dict_param(ops, "ops")
+        # merge ops and assets config together, since they use the same "ops" key in the config_dict
+        self.ops.update(check.opt_dict_param(assets, "assets"))
+
         self.resources = check.opt_dict_param(resources, "resources")
         self.loggers = check.opt_dict_param(loggers, "loggers")
         self.execution = check.opt_dict_param(execution, "execution")


### PR DESCRIPTION
## Summary & Motivation
Tiny QOL idea i had, please feel free to reject if it might just add more confusion (see open question 2)

To me, it's still a bit funny to see `RunConfig(ops={...})` when only working with assets. So this adds an `assets` param that gets merged in with `ops` so that you can do `RunConfig(assets={...})`.  Maybe we should merge in a more complex/smart way, but I just implemented this basic version to start.

Couple open questions/concerns:
1. what to do if `assets` and `ops` are provided the same key? Probably error imo
2. would this give the impression that you can set `assets` in the launchpad and just add to confusion?

if adding this param seems ok, i will:
- [ ] implement the resolution to 1 (above)
- [ ] add testing

## How I Tested These Changes
