### PR TITLE
[daggy-u-infra] markdoc nextjs starter

### DIFF
--- a/.github/workflows/build-dagster-university.yml
+++ b/.github/workflows/build-dagster-university.yml
@@ -1,0 +1,73 @@
+name: Deploy Dagster University
+on:
+  push:
+    branches:
+      - master
+      - docs-prod
+    paths:
+      - docs/dagster-university/**
+  pull_request:
+    paths:
+      - docs/dagster-university/**
+concurrency:
+  # Cancel in-progress runs on same branch
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      # Deploy to Vercel Previews on pull request or push to master branch
+      - name: Get branch preview subdomain
+        if: |
+          github.event_name == 'pull_request' ||
+          github.event_name == 'push' && github.ref == 'refs/heads/master'
+        run: |
+          BRANCH_PREVIEW_SUBDOMAIN=$(echo "${{ github.head_ref || github.ref_name }}" | sed 's/[^a-zA-Z0-9-]/-/g' | sed 's/^-*//' | sed 's/-*$//')
+          echo "$BRANCH_PREVIEW_SUBDOMAIN"
+          echo "BRANCH_PREVIEW_SUBDOMAIN=$BRANCH_PREVIEW_SUBDOMAIN" >> "${GITHUB_ENV}"
+
+      - name: Get PR fetch depth
+        if: github.event.pull_request
+        run: echo "PR_FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "${GITHUB_ENV}"
+
+      - name: Checkout master branch
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: actions/checkout@v3
+
+      - name: Checkout PR branch
+        if: github.event.pull_request
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: ${{ env.PR_FETCH_DEPTH }}
+
+      - name: Publish Preview to Vercel
+        uses: amondnet/vercel-action@v25
+        if: |
+          github.event_name == 'pull_request' || 
+          (github.event_name == 'push' && github.ref == 'refs/heads/master')
+        with:
+          github-comment: ${{ github.event.pull_request && env.CHANGES_ENTRY || true }}
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.DAGSTER_U_VERCEL_PROJECT_ID }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          scope: ${{ secrets.VERCEL_ORG_ID }}
+          alias-domains: ${{ env.BRANCH_PREVIEW_SUBDOMAIN }}.dagster-university.dagster-docs.io
+
+      # Deploy to Vercel Production on push to docs-prod branch
+      - name: Checkout docs-prod branch
+        if: github.event_name == 'push' && github.ref == 'refs/heads/docs-prod'
+        uses: actions/checkout@v3
+
+      - name: Publish to Vercel Production
+        uses: amondnet/vercel-action@v25
+        if: github.event_name == 'push' && github.ref == 'refs/heads/docs-prod'
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.DAGSTER_U_VERCEL_PROJECT_ID }}
+          vercel-args: "--prod"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          scope: ${{ secrets.VERCEL_ORG_ID }}

--- a/docs/dagster-university/.gitignore
+++ b/docs/dagster-university/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+.DS_Store
+.next/
+.vercel
+package-lock.json
+yarn.lock

--- a/docs/dagster-university/README.md
+++ b/docs/dagster-university/README.md
@@ -1,0 +1,39 @@
+# Full Next.js example
+
+This is a full-featured boilerplate for a creating a documentation website using Markdoc and Next.js.
+
+<img width="2032" alt="image" src="https://user-images.githubusercontent.com/62121649/174916143-16f18270-0463-402c-8b48-33c627ea7a7e.png">
+
+## Setup
+
+First, clone this repo and install the dependencies required:
+
+```bash
+npm install
+# or
+yarn install
+```
+
+Then, run the development server:
+
+```bash
+npm run dev
+# or
+yarn dev
+```
+
+Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+
+You can start editing the page by modifying `index.md`. The page auto-updates as you edit the file.
+
+## Deploy
+
+The quickest way to deploy your own version of this boilerplate is by deploying it with [Vercel](https://vercel.com) or [Netlify](https://www.netlify.com/) by clicking one of the buttons below.
+
+### Deploy with Vercel
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/markdoc/next.js-starter)
+
+### Deploy to Netlify
+
+[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/markdoc/next.js-starter)

--- a/docs/dagster-university/components/Callout.tsx
+++ b/docs/dagster-university/components/Callout.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+
+export function Callout({ title, children }) {
+  return (
+    <div className="callout">
+      <strong>{title}</strong>
+      <span>{children}</span>
+      <style jsx>
+        {`
+          .callout {
+            display: flex;
+            flex-direction: column;
+            padding: 12px 16px;
+            background: #f6f9fc;
+            border: 1px solid #dce6e9;
+            border-radius: 4px;
+          }
+          .callout :global(p) {
+            margin: 0;
+          }
+        `}
+      </style>
+    </div>
+  );
+}

--- a/docs/dagster-university/components/CodeBlock.tsx
+++ b/docs/dagster-university/components/CodeBlock.tsx
@@ -1,0 +1,35 @@
+import Prism from 'prismjs';
+
+import * as React from 'react';
+
+export function CodeBlock({children, 'data-language': language}) {
+  const ref = React.useRef(null);
+
+  React.useEffect(() => {
+    if (ref.current) Prism.highlightElement(ref.current, false);
+  }, [children]);
+
+  return (
+    <div className="code" aria-live="polite">
+      <pre
+        ref={ref}
+        className={`language-${language}`}
+      >
+        {children}
+      </pre>
+      <style jsx>
+        {`
+          .code {
+            position: relative;
+          }
+
+          /* Override Prism styles */
+          .code :global(pre[class*='language-']) {
+            text-shadow: none;
+            border-radius: 4px;
+          }
+        `}
+      </style>
+    </div>
+  );
+}

--- a/docs/dagster-university/components/Heading.tsx
+++ b/docs/dagster-university/components/Heading.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+
+export function Heading({id = '', level = 1, children, className}) {
+  return React.createElement(
+    `h${level}`,
+    {
+      id,
+      className: ['heading', className].filter(Boolean).join(' '),
+    },
+    children
+  );
+}

--- a/docs/dagster-university/components/SideNav.tsx
+++ b/docs/dagster-university/components/SideNav.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import {useRouter} from 'next/router';
+import Link from 'next/link';
+
+const items = [
+  {
+    title: 'Get started',
+    links: [{href: '/docs', children: 'Overview'}],
+  },
+];
+
+export function SideNav() {
+  const router = useRouter();
+
+  return (
+    <nav className="sidenav">
+      {items.map((item) => (
+        <div key={item.title}>
+          <span>{item.title}</span>
+          <ul className="flex column">
+            {item.links.map((link) => {
+              const active = router.pathname === link.href;
+              return (
+                <li key={link.href} className={active ? 'active' : ''}>
+                  <Link {...link} />
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      ))}
+      <style jsx>
+        {`
+          nav {
+            position: sticky;
+            top: var(--top-nav-height);
+            height: calc(100vh - var(--top-nav-height));
+            flex: 0 0 auto;
+            overflow-y: auto;
+            padding: 2.5rem 2rem 2rem;
+            border-right: 1px solid var(--border-color);
+          }
+          span {
+            font-size: larger;
+            font-weight: 500;
+            padding: 0.5rem 0 0.5rem;
+          }
+          ul {
+            padding: 0;
+          }
+          li {
+            list-style: none;
+            margin: 0;
+          }
+          li :global(a) {
+            text-decoration: none;
+          }
+          li :global(a:hover),
+          li.active :global(a) {
+            text-decoration: underline;
+          }
+        `}
+      </style>
+    </nav>
+  );
+}

--- a/docs/dagster-university/components/TableOfContents.tsx
+++ b/docs/dagster-university/components/TableOfContents.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import Link from 'next/link';
+
+export function TableOfContents({toc}) {
+  const items = toc.filter(
+    (item) => item.id && (item.level === 2 || item.level === 3)
+  );
+
+  if (items.length <= 1) {
+    return null;
+  }
+
+  return (
+    <nav className="toc">
+      <ul className="flex column">
+        {items.map((item) => {
+          const href = `#${item.id}`;
+          const active =
+            typeof window !== 'undefined' && window.location.hash === href;
+          return (
+            <li
+              key={item.title}
+              className={[
+                active ? 'active' : undefined,
+                item.level === 3 ? 'padded' : undefined,
+              ]
+                .filter(Boolean)
+                .join(' ')}
+            >
+              <Link href={href}>
+                {item.title}
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+      <style jsx>
+        {`
+          nav {
+            position: sticky;
+            top: calc(2.5rem + var(--top-nav-height));
+            max-height: calc(100vh - var(--top-nav-height));
+            flex: 0 0 auto;
+            align-self: flex-start;
+            margin-bottom: 1rem;
+            padding: 0.5rem 0 0;
+            border-left: 1px solid var(--border-color);
+          }
+          ul {
+            margin: 0;
+            padding: 0 1.5rem;
+          }
+          li {
+            list-style-type: none;
+            margin: 0 0 1rem;
+          }
+          li :global(a) {
+            text-decoration: none;
+          }
+          li :global(a:hover),
+          li.active :global(a) {
+            text-decoration: underline;
+          }
+          li.padded {
+            padding-left: 1rem;
+          }
+        `}
+      </style>
+    </nav>
+  );
+}

--- a/docs/dagster-university/components/TopNav.tsx
+++ b/docs/dagster-university/components/TopNav.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import Link from 'next/link';
+
+export function TopNav({children}) {
+  return (
+    <nav>
+      <Link href="/" className="flex">
+        Home
+      </Link>
+      <section>{children}</section>
+      <style jsx>
+        {`
+          nav {
+            top: 0;
+            position: fixed;
+            width: 100%;
+            z-index: 100;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 1rem;
+            padding: 1rem 2rem;
+            background: white;
+            border-bottom: 1px solid var(--border-color);
+          }
+          nav :global(a) {
+            text-decoration: none;
+          }
+          section {
+            display: flex;
+            gap: 1rem;
+            padding: 0;
+          }
+        `}
+      </style>
+    </nav>
+  );
+}

--- a/docs/dagster-university/components/index.js
+++ b/docs/dagster-university/components/index.js
@@ -1,0 +1,6 @@
+export * from './Callout';
+export * from './CodeBlock';
+export * from './Heading';
+export * from './SideNav';
+export * from './TableOfContents';
+export * from './TopNav';

--- a/docs/dagster-university/markdoc/functions.ts
+++ b/docs/dagster-university/markdoc/functions.ts
@@ -1,0 +1,16 @@
+/* Use this file to export your Markdoc functions */
+
+export const includes = {
+  transform(parameters) {
+    const [array, value] = Object.values(parameters);
+
+    return Array.isArray(array) ? array.includes(value) : false;
+  },
+};
+
+export const upper = {
+  transform(parameters) {
+    const string = parameters[0];
+    return typeof string === 'string' ? string.toUpperCase() : string;
+  },
+};

--- a/docs/dagster-university/markdoc/nodes/fence.markdoc.ts
+++ b/docs/dagster-university/markdoc/nodes/fence.markdoc.ts
@@ -1,0 +1,7 @@
+import {nodes} from '@markdoc/markdoc';
+import {CodeBlock} from '../../components';
+
+export const fence = {
+  render: CodeBlock,
+  attributes: nodes.fence.attributes,
+};

--- a/docs/dagster-university/markdoc/nodes/heading.markdoc.ts
+++ b/docs/dagster-university/markdoc/nodes/heading.markdoc.ts
@@ -1,0 +1,32 @@
+import {Tag} from '@markdoc/markdoc';
+
+import {Heading} from '../../components';
+
+function generateID(children, attributes) {
+  if (attributes.id && typeof attributes.id === 'string') {
+    return attributes.id;
+  }
+  return children
+    .filter((child) => typeof child === 'string')
+    .join(' ')
+    .replace(/[?]/g, '')
+    .replace(/\s+/g, '-')
+    .toLowerCase();
+}
+
+export const heading = {
+  render: Heading,
+  children: ['inline'],
+  attributes: {
+    id: {type: String},
+    level: {type: Number, required: true, default: 1},
+    className: {type: String},
+  },
+  transform(node, config) {
+    const attributes = node.transformAttributes(config);
+    const children = node.transformChildren(config);
+    const id = generateID(children, attributes);
+
+    return new Tag(this.render, {...attributes, id}, children);
+  },
+};

--- a/docs/dagster-university/markdoc/nodes/index.ts
+++ b/docs/dagster-university/markdoc/nodes/index.ts
@@ -1,0 +1,3 @@
+/* Use this file to export your markdoc nodes */
+export * from './fence.markdoc';
+export * from './heading.markdoc';

--- a/docs/dagster-university/next-env.d.ts
+++ b/docs/dagster-university/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/docs/dagster-university/next.config.js
+++ b/docs/dagster-university/next.config.js
@@ -1,0 +1,6 @@
+const withMarkdoc = require('@markdoc/next.js');
+
+module.exports =
+  withMarkdoc(/* config: https://markdoc.io/docs/nextjs#options */)({
+    pageExtensions: ['js', 'jsx', 'ts', 'tsx', 'md', 'mdoc'],
+  });

--- a/docs/dagster-university/package.json
+++ b/docs/dagster-university/package.json
@@ -1,0 +1,22 @@
+{
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "@markdoc/markdoc": "latest",
+    "@markdoc/next.js": "latest",
+    "next": "latest",
+    "prismjs": "latest",
+    "react": "latest",
+    "react-dom": "latest"
+  },
+  "devDependencies": {
+    "@types/node": "latest",
+    "@types/react": "latest",
+    "@types/react-dom": "latest",
+    "typescript": "latest"
+  }
+}

--- a/docs/dagster-university/pages/_app.tsx
+++ b/docs/dagster-university/pages/_app.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import Head from 'next/head';
+import Link from 'next/link';
+
+import { SideNav, TableOfContents, TopNav } from '../components';
+
+import 'prismjs';
+// Import other Prism themes here
+import 'prismjs/components/prism-bash.min';
+import 'prismjs/themes/prism.css';
+
+import '../public/globals.css'
+
+import type { AppProps } from 'next/app'
+import type { MarkdocNextJsPageProps } from '@markdoc/next.js'
+
+const TITLE = 'Markdoc';
+const DESCRIPTION = 'A powerful, flexible, Markdown-based authoring framework';
+
+function collectHeadings(node, sections = []) {
+  if (node) {
+    if (node.name === 'Heading') {
+      const title = node.children[0];
+
+      if (typeof title === 'string') {
+        sections.push({
+          ...node.attributes,
+          title
+        });
+      }
+    }
+
+    if (node.children) {
+      for (const child of node.children) {
+        collectHeadings(child, sections);
+      }
+    }
+  }
+
+  return sections;
+}
+
+export type MyAppProps = MarkdocNextJsPageProps
+
+export default function MyApp({ Component, pageProps }: AppProps<MyAppProps>) {
+  const { markdoc } = pageProps;
+
+  let title = TITLE;
+  let description = DESCRIPTION;
+  if (markdoc) {
+    if (markdoc.frontmatter.title) {
+      title = markdoc.frontmatter.title;
+    }
+    if (markdoc.frontmatter.description) {
+      description = markdoc.frontmatter.description;
+    }
+  }
+
+  const toc = pageProps.markdoc?.content
+    ? collectHeadings(pageProps.markdoc.content)
+    : [];
+
+  return (
+    <>
+      <Head>
+        <title>{title}</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta name="referrer" content="strict-origin" />
+        <meta name="title" content={title} />
+        <meta name="description" content={description} />
+        <link rel="shortcut icon" href="/favicon.ico" />
+        <link rel="icon" href="/favicon.ico" />
+      </Head>
+      <TopNav>
+        <Link href="/docs">Docs</Link>
+      </TopNav>
+      <div className="page">
+        <SideNav />
+        <main className="flex column">
+          <Component {...pageProps} />
+        </main>
+        <TableOfContents toc={toc} />
+      </div>
+      <style jsx>
+        {`
+          .page {
+            position: fixed; 
+            top: var(--top-nav-height);
+            display: flex;
+            width: 100vw;
+            flex-grow: 1;
+          }
+          main {
+            overflow: auto;
+            height: calc(100vh - var(--top-nav-height));
+            flex-grow: 1;
+            font-size: 16px;
+            padding: 0 2rem 2rem;
+          }
+        `}
+      </style>
+    </>
+  );
+}

--- a/docs/dagster-university/pages/docs/index.md
+++ b/docs/dagster-university/pages/docs/index.md
@@ -1,0 +1,5 @@
+---
+title: Overview
+---
+
+# {% $markdoc.frontmatter.title %}

--- a/docs/dagster-university/pages/index.md
+++ b/docs/dagster-university/pages/index.md
@@ -1,0 +1,44 @@
+---
+title: Get started with Markdoc
+description: How to get started with Markdoc
+---
+
+# Full Next.js example
+
+{% callout %}
+This is a full-featured boilerplate for a creating a documentation website using Markdoc and Next.js.
+{% /callout %}
+
+## Setup
+
+First, clone this repo and install the dependencies required:
+
+```bash
+npm install
+# or
+yarn install
+```
+
+Then, run the development server:
+
+```bash
+npm run dev
+# or
+yarn dev
+```
+
+Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+
+You can start editing the page by modifying `index.md`. The page auto-updates as you edit the file.
+
+## Deploy
+
+The quickest way to deploy your own version of this boilerplate is by deploying it with [Vercel](https://vercel.com) or [Netlify](https://www.netlify.com/) by clicking one of the buttons below.
+
+### Deploy with Vercel
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/markdoc/next.js-starter)
+
+### Deploy to Netlify
+
+[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/markdoc/next.js-starter)

--- a/docs/dagster-university/public/globals.css
+++ b/docs/dagster-university/public/globals.css
@@ -1,0 +1,35 @@
+:root {
+  --top-nav-height: 51px;
+  --border-color: #dce6e9;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif,
+    'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+  color: rgba(60, 66, 87, 1);
+  margin: 0;
+}
+
+p {
+  line-height: 1.5em;
+}
+
+
+h1 {
+  font-size: 40px;
+}
+
+h2 {
+  margin: 1.5em 0;
+}
+
+a {
+  color: rgba(75, 85, 99, 1);
+}

--- a/docs/dagster-university/tsconfig.json
+++ b/docs/dagster-university/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "incremental": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary & Motivation
addresses https://www.notion.so/dagster/Set-up-Vercel-site-to-serve-static-pages-1e9d778fe9b04aaf92a381d9bd545081

this pr sets up the skeleton for a standalone docs project for dagster university.
- it checks in a clone of https://github.com/markdoc/markdoc-starter. here's the markdoc + nextjs docs: https://markdoc.dev/docs/nextjs#setup

i've also set up a standalone vercel project [here](https://vercel.com/elementl/dagster-university), so this pr also sets up the gh action for deploying previews and prod (same as the main docs site, prod uses docs-prod branch which will be updated in weekly release)

next up:
- add code snippet components

## How I Tested These Changes
https://08-18--daggy-u-infra-markdoc-nextjs-starter.dagster-university.dagster-docs.io/