### PR TITLE
[dagster-databricks] Add type annotations and standardize public API

### DIFF
--- a/python_modules/libraries/dagster-databricks/dagster_databricks/__init__.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/__init__.py
@@ -10,33 +10,24 @@ This package provides:
 
 from dagster._core.libraries import DagsterLibraryRegistry
 
-from .databricks import DatabricksClient, DatabricksError, DatabricksJobRunner
+from .databricks import (
+    DatabricksClient as DatabricksClient,
+    DatabricksError as DatabricksError,
+    DatabricksJobRunner as DatabricksJobRunner,
+)
 from .databricks_pyspark_step_launcher import (
-    DatabricksConfig,
-    DatabricksPySparkStepLauncher,
-    databricks_pyspark_step_launcher,
+    DatabricksConfig as DatabricksConfig,
+    DatabricksPySparkStepLauncher as DatabricksPySparkStepLauncher,
+    databricks_pyspark_step_launcher as databricks_pyspark_step_launcher,
 )
 from .ops import (
-    create_databricks_run_now_op,
-    create_databricks_submit_run_op,
+    create_databricks_run_now_op as create_databricks_run_now_op,
+    create_databricks_submit_run_op as create_databricks_submit_run_op,
 )
 from .resources import (
     DatabricksClientResource as DatabricksClientResource,
-    databricks_client,
+    databricks_client as databricks_client,
 )
 from .version import __version__
 
 DagsterLibraryRegistry.register("dagster-databricks", __version__)
-
-__all__ = [
-    "create_databricks_run_now_op",
-    "create_databricks_submit_run_op",
-    "databricks_client",
-    "DatabricksClient",
-    "DatabricksConfig",
-    "DatabricksError",
-    "DatabricksJobRunner",
-    "DatabricksPySparkStepLauncher",
-    "databricks_pyspark_step_launcher",
-    "DatabricksClientResource",
-]

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/configs.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/configs.py
@@ -9,10 +9,12 @@ See:
 - https://docs.databricks.com/dev-tools/api/latest/clusters.html
 - https://docs.databricks.com/dev-tools/api/latest/libraries.html
 """
+from typing import Dict, Union
+
 from dagster import Array, Bool, Enum, EnumValue, Field, Int, Permissive, Selector, Shape, String
 
 
-def _define_autoscale():
+def _define_autoscale() -> Field:
     return Field(
         Shape(
             fields={
@@ -36,7 +38,7 @@ def _define_autoscale():
     )
 
 
-def _define_size():
+def _define_size() -> Selector:
     num_workers = Field(
         Int,
         description=(
@@ -49,7 +51,7 @@ def _define_size():
     return Selector({"autoscale": _define_autoscale(), "num_workers": num_workers})
 
 
-def _define_custom_tags():
+def _define_custom_tags() -> Field:
     key = Field(
         String,
         description=(
@@ -81,12 +83,12 @@ def _define_custom_tags():
     )
 
 
-def _define_dbfs_storage_info():
+def _define_dbfs_storage_info() -> Field:
     destination = Field(String, description="DBFS destination, e.g. dbfs:/my/path")
     return Field(Shape(fields={"destination": destination}), description="DBFS storage information")
 
 
-def _define_s3_storage_info():
+def _define_s3_storage_info() -> Field:
     destination = Field(
         String,
         description=(
@@ -160,7 +162,7 @@ def _define_s3_storage_info():
     )
 
 
-def _define_aws_attributes_conf():
+def _define_aws_attributes_conf() -> Field:
     return Field(
         Permissive(
             fields={
@@ -258,7 +260,7 @@ def _define_aws_attributes_conf():
     )
 
 
-def _define_cluster_log_conf():
+def _define_cluster_log_conf() -> Field:
     return Field(
         Selector({"dbfs": _define_dbfs_storage_info(), "s3": _define_s3_storage_info()}),
         description=(
@@ -276,7 +278,7 @@ def _define_init_script():
     return Selector({"dbfs": _define_dbfs_storage_info(), "s3": _define_s3_storage_info()})
 
 
-def _define_node_types():
+def _define_node_types() -> Field:
     node_type_id = Field(
         String,
         description=(
@@ -304,7 +306,7 @@ def _define_node_types():
     )
 
 
-def _define_nodes():
+def _define_nodes() -> Field:
     instance_pool_id = Field(
         String,
         description=(
@@ -324,7 +326,7 @@ def _define_nodes():
     )
 
 
-def _define_new_cluster():
+def _define_new_cluster() -> Field:
     spark_version = Field(
         String,
         description=(
@@ -416,7 +418,7 @@ def _define_new_cluster():
     )
 
 
-def _define_cluster():
+def _define_cluster() -> Selector:
     existing_cluster_id = Field(
         String,
         description=(
@@ -431,7 +433,7 @@ def _define_cluster():
     return Selector({"new": _define_new_cluster(), "existing": existing_cluster_id})
 
 
-def _define_pypi_library():
+def _define_pypi_library() -> Field:
     package = Field(
         String,
         description=(
@@ -457,7 +459,7 @@ def _define_pypi_library():
     )
 
 
-def _define_maven_library():
+def _define_maven_library() -> Field:
     coordinates = Field(
         String,
         description=(
@@ -490,7 +492,7 @@ def _define_maven_library():
     )
 
 
-def _define_cran_library():
+def _define_cran_library() -> Field:
     package = Field(
         String,
         description="The name of the CRAN package to install. This field is required.",
@@ -510,7 +512,7 @@ def _define_cran_library():
     )
 
 
-def _define_libraries():
+def _define_libraries() -> Field:
     jar = Field(
         String,
         description=(
@@ -564,7 +566,7 @@ def _define_libraries():
     )
 
 
-def _define_submit_run_fields():
+def _define_submit_run_fields() -> Dict[str, Union[Selector, Field]]:
     run_name = Field(
         String,
         description="An optional name for the run. The default value is Untitled",
@@ -610,7 +612,7 @@ def _define_submit_run_fields():
     }
 
 
-def _define_notebook_task():
+def _define_notebook_task() -> Field:
     notebook_path = Field(
         String,
         description=(
@@ -632,7 +634,7 @@ def _define_notebook_task():
     return Field(Shape(fields={"notebook_path": notebook_path, "base_parameters": base_parameters}))
 
 
-def _define_spark_jar_task():
+def _define_spark_jar_task() -> Field:
     main_class_name = Field(
         String,
         description=(
@@ -652,7 +654,7 @@ def _define_spark_jar_task():
     return Field(Shape(fields={"main_class_name": main_class_name, "parameters": parameters}))
 
 
-def _define_spark_python_task():
+def _define_spark_python_task() -> Field:
     python_file = Field(
         String,
         description=(
@@ -670,7 +672,7 @@ def _define_spark_python_task():
     return Field(Shape(fields={"python_file": python_file, "parameters": parameters}))
 
 
-def _define_spark_submit_task():
+def _define_spark_submit_task() -> Field:
     parameters = Field(
         [String],
         description="Command-line parameters passed to spark submit.",
@@ -692,7 +694,7 @@ def _define_spark_submit_task():
     )
 
 
-def _define_task():
+def _define_task() -> Field:
     return Field(
         Selector(
             {
@@ -707,20 +709,20 @@ def _define_task():
     )
 
 
-def define_databricks_submit_custom_run_config():
+def define_databricks_submit_custom_run_config() -> Field:
     fields = _define_submit_run_fields()
     fields["task"] = _define_task()
     return Field(Shape(fields=fields), description="Databricks job run configuration")
 
 
-def define_databricks_submit_run_config():
+def define_databricks_submit_run_config() -> Field:
     return Field(
         Shape(fields=_define_submit_run_fields()),
         description="Databricks job run configuration",
     )
 
 
-def _define_secret_scope():
+def _define_secret_scope() -> Field:
     return Field(
         String,
         description="The Databricks secret scope containing the storage secrets.",
@@ -728,7 +730,7 @@ def _define_secret_scope():
     )
 
 
-def _define_s3_storage_credentials():
+def _define_s3_storage_credentials() -> Field:
     access_key_key = Field(
         String,
         description="The key of a Databricks secret containing the S3 access key ID.",
@@ -751,7 +753,7 @@ def _define_s3_storage_credentials():
     )
 
 
-def _define_adls2_storage_credentials():
+def _define_adls2_storage_credentials() -> Field:
     storage_account_name = Field(
         String,
         description="The name of the storage account used to access data.",
@@ -774,7 +776,7 @@ def _define_adls2_storage_credentials():
     )
 
 
-def define_databricks_storage_config():
+def define_databricks_storage_config() -> Field:
     return Field(
         Selector(
             {
@@ -791,7 +793,7 @@ def define_databricks_storage_config():
     )
 
 
-def define_databricks_env_variables():
+def define_databricks_env_variables() -> Field:
     return Field(
         Permissive(),
         description=(
@@ -801,7 +803,7 @@ def define_databricks_env_variables():
     )
 
 
-def define_databricks_secrets_config():
+def define_databricks_secrets_config() -> Field:
     name = Field(
         String,
         description="The environment variable name, e.g. `DATABRICKS_TOKEN`.",
@@ -822,14 +824,14 @@ def define_databricks_secrets_config():
     )
 
 
-def _define_accessor():
+def _define_accessor() -> Selector:
     return Selector(
         {"group_name": str, "user_name": str},
         description="Group or User that shall access the target.",
     )
 
 
-def _define_databricks_job_permission():
+def _define_databricks_job_permission() -> Field:
     job_permission_levels = [
         "NO_PERMISSIONS",
         "CAN_VIEW",
@@ -850,7 +852,7 @@ def _define_databricks_job_permission():
     )
 
 
-def _define_databricks_cluster_permission():
+def _define_databricks_cluster_permission() -> Field:
     cluster_permission_levels = ["NO_PERMISSIONS", "CAN_ATTACH_TO", "CAN_RESTART", "CAN_MANAGE"]
     return Field(
         {
@@ -865,7 +867,7 @@ def _define_databricks_cluster_permission():
     )
 
 
-def define_databricks_permissions():
+def define_databricks_permissions() -> Field:
     return Field(
         {
             "job_permissions": _define_databricks_job_permission(),

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/ops.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/ops.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, cast
 
 from dagster import (
     In,
@@ -110,10 +110,13 @@ def create_databricks_run_now_op(
         databricks: DatabricksClient = getattr(context.resources, databricks_resource_key)
         jobs_service = JobsService(databricks.api_client)
 
-        run_id: int = jobs_service.run_now(
-            job_id=databricks_job_id,
-            **(databricks_job_configuration or {}),
-        )["run_id"]
+        run_id = cast(
+            int,
+            jobs_service.run_now(
+                job_id=databricks_job_id,
+                **(databricks_job_configuration or {}),
+            )["run_id"],
+        )
 
         get_run_response: dict = jobs_service.get_run(run_id=run_id)
 


### PR DESCRIPTION
## Summary & Motivation

Normalizes the public API of `dagster-databricks` to use redundant aliases instead of `__all__` and adds type annotations where missing.

## How I Tested These Changes

Existing test suite.