### PR TITLE
Memoize results of get_partition_keys_in_time_window and time_windows_for_partition_keys

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -591,7 +591,7 @@ def get_2d_run_length_encoded_partitions(
                 if isinstance(primary_partitions_def, TimeWindowPartitionsDefinition):
                     time_windows = cast(
                         TimeWindowPartitionsDefinition, primary_partitions_def
-                    ).time_windows_for_partition_keys(list(set([start_key, end_key])))
+                    ).time_windows_for_partition_keys(frozenset([start_key, end_key]))
                     start_time = time_windows[0].start.timestamp()
                     end_time = time_windows[-1].end.timestamp()
                 else:


### PR DESCRIPTION
Summary:
Profiling on the asset daemon indicates that we spend a lot of time repeatedly computing the set of partition keys for a given time window in certain situations.

Test Plan:
Run a large test dataset with one hourly partitions definition powering many assets - py-spy record should show a notable difference in where we spend our time before and after this change.

## Summary & Motivation

## How I Tested These Changes
