### PR TITLE
[externals] Make dagster-external no-op if launching process was not dagster

### DIFF
--- a/python_modules/dagster-external/dagster_external/__init__.py
+++ b/python_modules/dagster-external/dagster_external/__init__.py
@@ -1,6 +1,7 @@
 from dagster_external.context import (
     ExternalExecutionContext as ExternalExecutionContext,
     init_dagster_external as init_dagster_external,
+    is_dagster_orchestration_active as is_dagster_orchestration_active,
 )
 from dagster_external.protocol import (
     ExternalExecutionContextData as ExternalExecutionContextData,

--- a/python_modules/dagster-external/dagster_external/params.py
+++ b/python_modules/dagster-external/dagster_external/params.py
@@ -13,6 +13,7 @@ from dagster_external.protocol import (
 
 
 def get_external_execution_params() -> "ExternalExecutionParams":
+    is_orchestration_active = bool(os.getenv("DAGSTER_EXTERNAL_IS_ORCHESTRATION_ACTIVE"))
     raw_input_mode = os.getenv(
         DAGSTER_EXTERNAL_ENV_KEYS["input_mode"], DAGSTER_EXTERNAL_DEFAULT_INPUT_MODE
     )
@@ -20,6 +21,7 @@ def get_external_execution_params() -> "ExternalExecutionParams":
         DAGSTER_EXTERNAL_ENV_KEYS["output_mode"], DAGSTER_EXTERNAL_DEFAULT_OUTPUT_MODE
     )
     return ExternalExecutionParams(
+        is_orchestration_active=is_orchestration_active,
         input_mode=ExternalExecutionIOMode[raw_input_mode],
         output_mode=ExternalExecutionIOMode[raw_output_mode],
         input_path=os.getenv(DAGSTER_EXTERNAL_ENV_KEYS["input"]),
@@ -31,6 +33,7 @@ def get_external_execution_params() -> "ExternalExecutionParams":
 
 @dataclass
 class ExternalExecutionParams:
+    is_orchestration_active: bool
     input_mode: str
     output_mode: str
     input_path: Optional[str]

--- a/python_modules/dagster-external/dagster_external/protocol.py
+++ b/python_modules/dagster-external/dagster_external/protocol.py
@@ -15,6 +15,7 @@ DAGSTER_EXTERNAL_DEFAULT_INPUT_FILENAME: Final = "dagster_external_input"
 DAGSTER_EXTERNAL_DEFAULT_OUTPUT_FILENAME: Final = "dagster_external_output"
 
 DAGSTER_EXTERNAL_ENV_KEYS: Final = {
+    "is_orchestration_active": "DAGSTER_EXTERNAL_IS_ORCHESTRATION_ACTIVE",
     "input_mode": "DAGSTER_EXTERNAL_INPUT_MODE",
     "output_mode": "DAGSTER_EXTERNAL_OUTPUT_MODE",
     "input": "DAGSTER_EXTERNAL_INPUT",

--- a/python_modules/dagster/dagster/_core/external_execution/task.py
+++ b/python_modules/dagster/dagster/_core/external_execution/task.py
@@ -64,6 +64,7 @@ class ExternalExecutionTask:
         base_env = {
             **os.environ,
             **self.env,
+            DAGSTER_EXTERNAL_ENV_KEYS["is_orchestration_active"]: "1",
             DAGSTER_EXTERNAL_ENV_KEYS["input_mode"]: self._input_mode.value,
             DAGSTER_EXTERNAL_ENV_KEYS["output_mode"]: self._output_mode.value,
         }

--- a/python_modules/libraries/dagster-docker/dagster_docker/external_resource.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/external_resource.py
@@ -26,6 +26,7 @@ class DockerExecutionTask(ExternalExecutionTask):
         base_env = {
             **os.environ,
             **self.env,
+            DAGSTER_EXTERNAL_ENV_KEYS["is_orchestration_active"]: "1",
             DAGSTER_EXTERNAL_ENV_KEYS["input_mode"]: self._input_mode.value,
             DAGSTER_EXTERNAL_ENV_KEYS["output_mode"]: self._output_mode.value,
         }


### PR DESCRIPTION
## Summary & Motivation

This allows scripts using `dagster-external` to not crash if the script was not launched by a dagster `ExternalExecutionTask`.

- Add a new injected env var `DAGSTER_EXTERNAL_IS_ORCHESTRATION_ACTIVE`
- Add a top level function `is_dagster_orchestration_active` that checks this env var.
- If this env var is not set, and `init_dagster_external` is called, emit a warning and return a `unittest.mock.MagicMock` object in place of the context. This will cause any methods called on the context to just return another `unitest.mock.MagicMock` object.

Obviously the user will still need to add special logic to handle the "not-launched-by-dagster" case if using context info in any significant way, but this allows `init_dagster_context` to be called without crashing.

## How I Tested These Changes

New unit test.