### PR TITLE
feat(dbt): recommend using `dbt.log` when viewing errors

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -363,7 +363,8 @@ class DbtCliInvocation:
             raise DagsterDbtCliRuntimeError(
                 description=(
                     f"The dbt CLI process failed with exit code {self.process.returncode}. Check"
-                    " the compute logs for the full information about the error."
+                    " the Dagster compute logs for the full information about the error, or view"
+                    f" the dbt debug log file: {self.target_path.joinpath('dbt.log')}."
                 )
             )
 
@@ -621,6 +622,9 @@ class DbtCliResource(ConfigurableResource):
             # See https://discourse.getdbt.com/t/multiple-run-results-json-and-manifest-json-files/7555
             # for more information.
             "DBT_TARGET_PATH": target_path,
+            # The DBT_LOG_PATH environment variable is set to the same value as DBT_TARGET_PATH
+            # so that logs for each dbt invocation has separate log files.
+            "DBT_LOG_PATH": target_path,
             # The DBT_PROFILES_DIR environment variable is set to the path containing the dbt
             # profiles.yml file.
             # See https://docs.getdbt.com/docs/core/connect-data-platform/connection-profiles#advanced-customizing-a-profile-directory


### PR DESCRIPTION
## Summary & Motivation
When encountering errors when running dbt with Dagster, it takes time to be intuitive to search through terminal stdout to parse the dbt logs or see the logs in Dagster's compute logs in the Dagster UI.

In dbt, a `dbt.log` file is written out for each dbt command invocation. Here, when an exception occurs, we now also recommend the user view the contents of that file to debug. Like dbt artifacts, to ensure that the logs are retained for each command invocation, ensure that `DBT_LOG_PATH` is set so that each log file has a unique path.

See https://docs.getdbt.com/reference/global-configs/logs#log-and-target-paths for more details.

## How I Tested These Changes
pytest
