### PR TITLE
[ui] Default compute logs to stderr instead of stdout

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/LogsRowStructuredContent.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/LogsRowStructuredContent.tsx
@@ -53,7 +53,7 @@ export const LogsRowStructuredContent: React.FC<IStructuredContentProps> = ({nod
         const currentQuery = qs.parse(location.search);
         const updatedQuery = {
           ...currentQuery,
-          logType: 'stdout',
+          logType: 'stderr',
           logs: `query:${node.stepKey}`,
           selection: node.stepKey,
         };
@@ -215,7 +215,7 @@ export const LogsRowStructuredContent: React.FC<IStructuredContentProps> = ({nod
       return <DefaultContent message={node.message} />;
     case 'LogsCapturedEvent':
       const currentQuery = qs.parse(location.search, {ignoreQueryPrefix: true});
-      const updatedQuery = {...currentQuery, logType: 'stdout', logFileKey: node.stepKey};
+      const updatedQuery = {...currentQuery, logType: 'stderr', logFileKey: node.stepKey};
       const rawLogsUrl = `${location.pathname}?${qs.stringify(updatedQuery)}`;
       const rawLogsLink = (
         <Link to={rawLogsUrl} style={{color: 'inherit'}}>

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/LogsToolbar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/LogsToolbar.tsx
@@ -79,7 +79,7 @@ export const LogsToolbar: React.FC<ILogsToolbarProps> = (props) => {
     initialComputeLogType,
     setInitialComputeLogType,
   ] = useStateWithStorage(INITIAL_COMPUTE_LOG_TYPE, (value: any) =>
-    typeof value === 'string' ? (value as LogType) : LogType.stdout,
+    typeof value === 'string' ? (value as LogType) : LogType.stderr,
   );
 
   const setComputeLogType = React.useCallback(


### PR DESCRIPTION
This reflects the fact that python logs to stderr by default.

To fully test the change to the default, you need to clear your local storage because the view returns to your last stderr/stdout selection.

## Summary & Motivation
Related thread: 
https://elementl-workspace.slack.com/archives/C03CCE471E0/p1692281822567499

## How I Tested These Changes

- Clicked links to logs and verified they now go to stderr
- Reset local storage and clicked "Compute Logs", verified it chooses stderr by default