### PR TITLE
[ui] Only show default config in tooltip if default value is present

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/resources/ResourceRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/resources/ResourceRoot.tsx
@@ -322,7 +322,10 @@ const ResourceConfig: React.FC<{
                     <td>{remapName(field.configTypeKey)}</td>
                     <td>
                       <Box flex={{direction: 'row', gap: 16}}>
-                        <Tooltip content={<>Default: {defaultValue}</>} canShow={!isDefault}>
+                        <Tooltip
+                          content={<>Default: {defaultValue}</>}
+                          canShow={!isDefault && !!defaultValue}
+                        >
                           {type === 'ENV_VAR' ? <Tag>{actualValue}</Tag> : actualValue}
                         </Tooltip>
                         {isDefault && <Tag>Default</Tag>}


### PR DESCRIPTION
## Summary & Motivation
This is a tiny fix for an issue reported in Slack here: https://elementl-workspace.slack.com/archives/C03CCE471E0/p1692292103007949.

isDefault is false if no default is defined, but that doesn't necessarily mean that the tooltip has content to display.
