### PR TITLE
[externals] ExternalExecutionResource -> SubprocessExecutionResource

### DIFF
--- a/python_modules/dagster-external/dagster_external_tests/test_external_execution.py
+++ b/python_modules/dagster-external/dagster_external_tests/test_external_execution.py
@@ -16,7 +16,7 @@ from dagster._core.definitions.materialize import materialize
 from dagster._core.errors import DagsterExternalExecutionError
 from dagster._core.execution.context.compute import AssetExecutionContext
 from dagster._core.external_execution.resource import (
-    ExternalExecutionResource,
+    SubprocessExecutionResource,
 )
 from dagster._core.instance_for_test import instance_for_test
 from dagster_external.protocol import ExternalExecutionIOMode
@@ -106,13 +106,13 @@ def test_external_execution_asset(input_spec: str, output_spec: str, tmpdir, cap
         context.report_asset_data_version("foo", "alpha")
 
     @asset
-    def foo(context: AssetExecutionContext, ext: ExternalExecutionResource):
+    def foo(context: AssetExecutionContext, ext: SubprocessExecutionResource):
         extras = {"bar": "baz"}
         with temp_script(script_fn) as script_path:
             cmd = ["python", script_path]
             ext.run(cmd, context, extras)
 
-    resource = ExternalExecutionResource(
+    resource = SubprocessExecutionResource(
         input_mode=input_mode,
         output_mode=output_mode,
         input_path=input_path,
@@ -140,12 +140,12 @@ def test_external_execution_asset_failed():
         raise Exception("foo")
 
     @asset
-    def foo(context: AssetExecutionContext, ext: ExternalExecutionResource):
+    def foo(context: AssetExecutionContext, ext: SubprocessExecutionResource):
         with temp_script(script_fn) as script_path:
             cmd = ["python", script_path]
             ext.run(cmd, context)
 
-    resource = ExternalExecutionResource(
+    resource = SubprocessExecutionResource(
         input_mode=ExternalExecutionIOMode.stdio,
     )
     with pytest.raises(DagsterExternalExecutionError):
@@ -174,12 +174,12 @@ def test_external_execution_invalid_path(
         pass
 
     @asset
-    def foo(context: AssetExecutionContext, ext: ExternalExecutionResource):
+    def foo(context: AssetExecutionContext, ext: SubprocessExecutionResource):
         with temp_script(script_fn) as script_path:
             cmd = ["python", script_path]
             ext.run(cmd, context)
 
-    resource = ExternalExecutionResource(
+    resource = SubprocessExecutionResource(
         input_mode=ExternalExecutionIOMode(input_mode_name),
         input_path=input_path,
         output_mode=ExternalExecutionIOMode(output_mode_name),

--- a/python_modules/dagster-test/dagster_test/toys/external_execution/__init__.py
+++ b/python_modules/dagster-test/dagster_test/toys/external_execution/__init__.py
@@ -2,7 +2,7 @@ import os
 import sys
 
 from dagster import AssetExecutionContext, Config, Definitions, asset
-from dagster._core.external_execution.resource import ExternalExecutionResource
+from dagster._core.external_execution.resource import SubprocessExecutionResource
 from dagster_external.protocol import ExternalExecutionIOMode
 from pydantic import Field
 
@@ -32,25 +32,27 @@ class NumberConfig(Config):
 
 @asset
 def number_x(
-    context: AssetExecutionContext, ext: ExternalExecutionResource, config: NumberConfig
+    context: AssetExecutionContext, ext: SubprocessExecutionResource, config: NumberConfig
 ) -> None:
     extras = {**get_common_extras(context), "multiplier": config.multiplier}
     ext.run(command_for_asset("number_x"), context, extras)
 
 
 @asset
-def number_y(context: AssetExecutionContext, ext: ExternalExecutionResource, config: NumberConfig):
+def number_y(
+    context: AssetExecutionContext, ext: SubprocessExecutionResource, config: NumberConfig
+):
     extras = {**get_common_extras(context), "multiplier": config.multiplier}
     env = {"NUMBER_Y": "4"}
     ext.run(command_for_asset("number_y"), context, extras, env)
 
 
 @asset(deps=[number_x, number_y])
-def number_sum(context: AssetExecutionContext, ext: ExternalExecutionResource) -> None:
+def number_sum(context: AssetExecutionContext, ext: SubprocessExecutionResource) -> None:
     ext.run(command_for_asset("number_sum"), context, get_common_extras(context))
 
 
-ext = ExternalExecutionResource(
+ext = SubprocessExecutionResource(
     input_mode=ExternalExecutionIOMode.stdio,
     output_mode=ExternalExecutionIOMode.stdio,
     env=get_env(),

--- a/python_modules/dagster/dagster/_core/external_execution/resource.py
+++ b/python_modules/dagster/dagster/_core/external_execution/resource.py
@@ -10,7 +10,7 @@ from dagster._core.external_execution.task import (
 )
 
 
-class ExternalExecutionResource(ConfigurableResource):
+class SubprocessExecutionResource(ConfigurableResource):
     env: Optional[Dict[str, str]] = Field(
         default=None,
         description="An optional dict of environment variables to pass to the subprocess.",

--- a/python_modules/libraries/dagster-docker/dagster_docker/external_resource.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/external_resource.py
@@ -6,7 +6,7 @@ from typing import Mapping, Optional, Sequence, Union
 import docker
 from dagster import OpExecutionContext
 from dagster._core.external_execution.resource import (
-    ExternalExecutionResource,
+    SubprocessExecutionResource,
 )
 from dagster._core.external_execution.task import ExternalExecutionTask
 from dagster_external.protocol import (
@@ -110,7 +110,7 @@ class DockerExecutionTask(ExternalExecutionTask):
                 container.stop()
 
 
-class DockerExecutionResource(ExternalExecutionResource):
+class DockerExecutionResource(SubprocessExecutionResource):
     def run(
         self,
         image: str,


### PR DESCRIPTION
## Summary & Motivation

- Rename `ExternalExecutionResource` -> `SubprocessExecutionResource`

## How I Tested These Changes

Existing test suite.
