### PR TITLE
[ui] Align “Lauched run / backfill” toasts — cmd-click to open in new tab

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunUtils.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunUtils.tsx
@@ -60,7 +60,7 @@ export function useDidLaunchEvent(cb: () => void, delay = 1500) {
   }, [cb, delay]);
 }
 
-export type LaunchBehavior = 'open' | 'open-in-new-tab' | 'toast';
+export type LaunchBehavior = 'open' | 'toast';
 
 export async function handleLaunchResult(
   pipelineName: string,
@@ -76,12 +76,9 @@ export async function handleLaunchResult(
   if (result.__typename === 'LaunchRunSuccess') {
     const pathname = `/runs/${result.run.id}`;
     const search = options.preserveQuerystring ? history.location.search : '';
-    const openInNewTab = () => window.open(history.createHref({pathname, search}), '_blank');
     const openInSameTab = () => history.push({pathname, search});
 
-    if (options.behavior === 'open-in-new-tab') {
-      openInNewTab();
-    } else if (options.behavior === 'open') {
+    if (options.behavior === 'open') {
       openInSameTab();
     } else {
       await showSharedToaster({
@@ -93,7 +90,7 @@ export async function handleLaunchResult(
         ),
         action: {
           text: 'View',
-          onClick: () => openInNewTab(),
+          href: history.createHref({pathname, search}),
         },
       });
     }


### PR DESCRIPTION
## Summary & Motivation

Fixes https://github.com/dagster-io/dagster/issues/15929

This PR slightly adjusts the behavior of the "Launched run" toasts in dagster UI to be consistent with the launched backfill toasts. The new behavior is:

- Click "View" =>  opens in same tab
- Cmd-click "View" => opens in new tab

Depending on the browser and your settings the new tab may open behind the current one. In Firefox, cmd-shift-click makes a separate tab and foregrounds it, which aligns with the previous behavior.

We believe this approach offers the most flexibility because users can use the standard keyboard shortcuts to get the behavior they want.

## How I Tested These Changes

I tested this by creating runs and backfills and clicking the toasts in both ways.

## Prior Art

There have been several discussions of this behavior over the last year or two:

- https://elementl-workspace.slack.com/archives/C03CCE471E0/p1664470710262119
- https://elementl-workspace.slack.com/archives/C03CCE471E0/p1692298385801809