### PR TITLE
[ui] Use smooth lines in horizontal asset graph, increase node spacing

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/Utils.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/Utils.tsx
@@ -1,4 +1,4 @@
-import {pathVerticalDiagonal, pathHorizontalStep} from '@vx/shape';
+import {pathVerticalDiagonal, pathHorizontalDiagonal} from '@vx/shape';
 
 import {featureEnabled, FeatureFlag} from '../app/Flags';
 import {Maybe, RunStatus, StaleCauseCategory, StaleStatus} from '../graphql/types';
@@ -118,8 +118,7 @@ export const graphHasCycles = (graphData: GraphData) => {
 };
 
 export const buildSVGPath = featureEnabled(FeatureFlag.flagHorizontalDAGs)
-  ? pathHorizontalStep({
-      percent: 0.5,
+  ? pathHorizontalDiagonal({
       source: (s: any) => s.source,
       target: (s: any) => s.target,
       x: (s: any) => s.x,

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/layout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/layout.ts
@@ -55,7 +55,7 @@ export const layoutAssetGraph = (
           marginy: MARGIN,
           nodesep: -10,
           edgesep: 10,
-          ranksep: 30,
+          ranksep: 60,
         }
       : {
           rankdir: 'TB',


### PR DESCRIPTION
## Summary & Motivation

This PR tweaks a few constants in asset graph layout that increase spacing between layers of nodes in the horizontal asset graph from 55px to 85px, and restore the "flowing" lines which, though less cool looking, are easier to follow in a larger range of graphs. 

![Screen Shot 2023-08-21 at 11 36 55 AM](https://github.com/dagster-io/dagster/assets/1037212/f5d3303a-97cf-41f5-ab55-6051ca6c9a89)
![Screen Shot 2023-08-21 at 11 36 26 AM](https://github.com/dagster-io/dagster/assets/1037212/dc73aa18-e2a1-4937-b480-5909b73f0775)
