### PR TITLE
[Time Range filter] Fix RunsFilterInput test

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/RunFilterInput.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/RunFilterInput.test.tsx
@@ -163,10 +163,12 @@ describe('<RunFilterInput  />', () => {
     await userEvent.click(getByText('Created date'));
     await userEvent.click(getByText('Today'));
 
+    const todayRange = calculateTimeRanges('UTC').timeRanges.TODAY.range;
+
     expect(onChange).toHaveBeenCalledWith([
       {
         token: 'created_date_after',
-        value: '' + calculateTimeRanges('UTC').timeRanges.TODAY.range[0]! / 1000,
+        value: '' + todayRange[0]! / 1000,
       },
     ]);
   });

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/useTimeRangeFilter.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/useTimeRangeFilter.tsx
@@ -24,12 +24,11 @@ export type TimeRangeState = [number | null, number | null];
 export function calculateTimeRanges(timezone: string) {
   const targetTimezone = timezone === 'Automatic' ? browserTimezone() : timezone;
   const nowTimestamp = Date.now();
-  const now = Math.floor(nowTimestamp);
   const startOfDay = dayjs(nowTimestamp).tz(targetTimezone).startOf('day');
   const obj = {
     TODAY: {
       label: 'Today',
-      range: [startOfDay.valueOf(), now] as TimeRangeState,
+      range: [startOfDay.valueOf(), null] as TimeRangeState,
     },
     YESTERDAY: {
       label: 'Yesterday',
@@ -42,14 +41,14 @@ export function calculateTimeRanges(timezone: string) {
       label: 'Within last 7 days',
       range: [
         dayjs(nowTimestamp).tz(targetTimezone).subtract(1, 'week').valueOf(),
-        now,
+        null,
       ] as TimeRangeState,
     },
     LAST_30_DAYS: {
       label: 'Within last 30 days',
       range: [
         dayjs(nowTimestamp).tz(targetTimezone).subtract(30, 'days').valueOf(),
-        now,
+        null,
       ] as TimeRangeState,
     },
     CUSTOM: {label: 'Custom...', range: [null, null] as TimeRangeState},


### PR DESCRIPTION
## Summary & Motivation

I added "Now" as the "Before" in the date filter but updating the test to take it into account results in rounding errors failing the test so just going to set it back to `null` for now.

## How I Tested These Changes
<img width="581" alt="Screenshot 2023-08-21 at 1 08 35 PM" src="https://github.com/dagster-io/dagster/assets/2286579/6c22e80d-7585-4198-a785-09d97e3ff108">

<img width="431" alt="Screenshot 2023-08-21 at 1 08 15 PM" src="https://github.com/dagster-io/dagster/assets/2286579/f6d7061e-1107-4c54-a58c-94ed84520c73">
