### PR TITLE
fix(databricks): remove output type hint for op factory

### DIFF
--- a/python_modules/libraries/dagster-databricks/dagster_databricks/ops.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/ops.py
@@ -106,9 +106,7 @@ def create_databricks_run_now_op(
         tags={"kind": "databricks"},
         name=name,
     )
-    def _databricks_run_now_op(
-        context: OpExecutionContext, config: DatabricksRunNowOpConfig
-    ) -> None:
+    def _databricks_run_now_op(context: OpExecutionContext, config: DatabricksRunNowOpConfig):
         databricks: DatabricksClient = getattr(context.resources, databricks_resource_key)
         jobs_service = JobsService(databricks.api_client)
 


### PR DESCRIPTION
## Summary & Motivation
From a user:

> I am attempting to trigger a databricks job that creates several tables - I am using the create_databricks_run_now_op.
I would like this represented in the global asset lineage as an asset per table.
To do this I am using AssetsDefinition.from_op() and providing an updated list of outputs in the OpDefinition.
I am encountering the following issue:
The '-> None' type hint in the _databricks_run_now_op() function casues it to error
DagsterInvariantViolationError: Expected Tuple annotation for multiple outputs, but received non-tuple annotation.
I have tested copying the functions to my package and removing the '-> None' hint and it then works

Fix that.
## How I Tested These Changes
existing bk
