### PR TITLE
[externals] Modify context construction to support direct invocation for SubprocessExecutionResource

### DIFF
--- a/python_modules/dagster-external/dagster_external/context.py
+++ b/python_modules/dagster-external/dagster_external/context.py
@@ -215,7 +215,7 @@ class ExternalExecutionContext:
         return self._data["run_id"]
 
     @property
-    def job_name(self) -> str:
+    def job_name(self) -> Optional[str]:
         return self._data["job_name"]
 
     @property

--- a/python_modules/dagster-external/dagster_external/protocol.py
+++ b/python_modules/dagster-external/dagster_external/protocol.py
@@ -62,7 +62,7 @@ class ExternalExecutionContextData(TypedDict):
     partition_key_range: Optional["ExternalPartitionKeyRange"]
     partition_time_window: Optional["ExternalTimeWindow"]
     run_id: str
-    job_name: str
+    job_name: Optional[str]
     retry_number: int
     extras: Mapping[str, Any]
 

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -467,10 +467,9 @@ class OpExecutionContext(AbstractComputeExecutionContext):
     @property
     def selected_asset_keys(self) -> AbstractSet[AssetKey]:
         """Get the set of AssetKeys this execution is expected to materialize."""
-        assets_def = self.job_def.asset_layer.assets_def_for_node(self.node_handle)
-        if assets_def is None:
+        if not self.has_assets_def:
             return set()
-        return assets_def.keys
+        return self.assets_def.keys
 
     @public
     @property

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -535,6 +535,10 @@ class BoundOpExecutionContext(OpExecutionContext):
             )
         return self._assets_def
 
+    @property
+    def has_partition_key(self) -> bool:
+        return self._partition_key is not None
+
     def has_tag(self, key: str) -> bool:
         return key in self._tags
 

--- a/python_modules/dagster/dagster/_core/external_execution/context.py
+++ b/python_modules/dagster/dagster/_core/external_execution/context.py
@@ -12,6 +12,7 @@ from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
 from dagster._core.definitions.time_window_partitions import TimeWindow
 from dagster._core.execution.context.compute import OpExecutionContext
+from dagster._core.execution.context.invocation import BoundOpExecutionContext
 
 
 def build_external_execution_context(
@@ -25,7 +26,7 @@ def build_external_execution_context(
     )
     code_version_by_asset_key = (
         {
-            _convert_asset_key(key): context.job_def.asset_layer.code_version_for_asset(key)
+            _convert_asset_key(key): context.assets_def.code_versions_by_key[key]
             for key in context.selected_asset_keys
         }
         if context.has_assets_def
@@ -54,8 +55,8 @@ def build_external_execution_context(
             _convert_time_window(partition_time_window) if partition_time_window else None
         ),
         run_id=context.run_id,
-        job_name=context.job_def.name,
-        retry_number=context.retry_number,
+        job_name=None if isinstance(context, BoundOpExecutionContext) else context.job_name,
+        retry_number=0 if isinstance(context, BoundOpExecutionContext) else context.retry_number,
         extras=extras or {},
     )
 


### PR DESCRIPTION
## Summary & Motivation

This required a few minor supporting changes to `OpExecutionContext` and `BoundOpExecutionContext`.

## How I Tested These Changes

New unit test.
