### PR TITLE
add storage, instance APIs for asset, run status event records

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -415,9 +415,12 @@ from dagster._core.errors import (
     raise_execution_interrupts as raise_execution_interrupts,
 )
 from dagster._core.event_api import (
+    AssetRecordsFilter as AssetRecordsFilter,
     EventLogRecord as EventLogRecord,
     EventRecordsFilter as EventRecordsFilter,
+    EventRecordsResult as EventRecordsResult,
     RunShardedEventsCursor as RunShardedEventsCursor,
+    RunStatusChangeRecordsFilter as RunStatusChangeRecordsFilter,
 )
 from dagster._core.events import (
     DagsterEvent as DagsterEvent,

--- a/python_modules/dagster/dagster/_core/event_api.py
+++ b/python_modules/dagster/dagster/_core/event_api.py
@@ -1,5 +1,7 @@
+import base64
 from datetime import datetime
-from typing import Callable, Mapping, NamedTuple, Optional, Sequence, Union
+from enum import Enum
+from typing import Callable, Literal, Mapping, NamedTuple, Optional, Sequence, Tuple, Union
 
 from typing_extensions import TypeAlias
 
@@ -7,11 +9,58 @@ import dagster._check as check
 from dagster._annotations import PublicAttr
 from dagster._core.definitions.events import AssetKey, AssetMaterialization, AssetObservation
 from dagster._core.errors import DagsterInvalidInvocationError
-from dagster._core.events import DagsterEventType
+from dagster._core.events import EVENT_TYPE_TO_PIPELINE_RUN_STATUS, DagsterEventType
 from dagster._core.events.log import EventLogEntry
 from dagster._serdes import whitelist_for_serdes
+from dagster._seven import json
 
 EventHandlerFn: TypeAlias = Callable[[EventLogEntry, str], None]
+
+
+class EventLogCursorType(Enum):
+    OFFSET = "OFFSET"
+    STORAGE_ID = "STORAGE_ID"
+
+
+class EventLogCursor(NamedTuple):
+    """Representation of an event record cursor, keeping track of the log query state."""
+
+    cursor_type: EventLogCursorType
+    value: int
+
+    def is_offset_cursor(self) -> bool:
+        return self.cursor_type == EventLogCursorType.OFFSET
+
+    def is_id_cursor(self) -> bool:
+        return self.cursor_type == EventLogCursorType.STORAGE_ID
+
+    def offset(self) -> int:
+        check.invariant(self.cursor_type == EventLogCursorType.OFFSET)
+        return max(0, int(self.value))
+
+    def storage_id(self) -> int:
+        check.invariant(self.cursor_type == EventLogCursorType.STORAGE_ID)
+        return int(self.value)
+
+    def __str__(self) -> str:
+        return self.to_string()
+
+    def to_string(self) -> str:
+        raw = json.dumps({"type": self.cursor_type.value, "value": self.value})
+        return base64.b64encode(bytes(raw, encoding="utf-8")).decode("utf-8")
+
+    @staticmethod
+    def parse(cursor_str: str) -> "EventLogCursor":
+        raw = json.loads(base64.b64decode(cursor_str).decode("utf-8"))
+        return EventLogCursor(EventLogCursorType(raw["type"]), raw["value"])
+
+    @staticmethod
+    def from_offset(offset: int) -> "EventLogCursor":
+        return EventLogCursor(EventLogCursorType.OFFSET, offset)
+
+    @staticmethod
+    def from_storage_id(storage_id: int) -> "EventLogCursor":
+        return EventLogCursor(EventLogCursorType.STORAGE_ID, storage_id)
 
 
 class RunShardedEventsCursor(NamedTuple):
@@ -22,6 +71,24 @@ class RunShardedEventsCursor(NamedTuple):
 
     id: int
     run_updated_after: datetime
+
+
+RunStatusChangeEventType: TypeAlias = Literal[
+    DagsterEventType.RUN_START,
+    DagsterEventType.RUN_SUCCESS,
+    DagsterEventType.RUN_FAILURE,
+    DagsterEventType.RUN_ENQUEUED,
+    DagsterEventType.RUN_STARTING,
+    DagsterEventType.RUN_CANCELING,
+    DagsterEventType.RUN_CANCELED,
+]
+AssetEventType: TypeAlias = Literal[
+    DagsterEventType.ASSET_MATERIALIZATION,
+    DagsterEventType.ASSET_OBSERVATION,
+    DagsterEventType.ASSET_MATERIALIZATION_PLANNED,
+]
+
+EventCursor: TypeAlias = Union[int, RunShardedEventsCursor]
 
 
 @whitelist_for_serdes
@@ -68,6 +135,16 @@ class EventLogRecord(NamedTuple):
         return self.event_log_entry.asset_observation
 
 
+class EventRecordsResult(NamedTuple):
+    """Return value for a query fetching event records from the instance.  Contains a list of event
+    records, a cursor string, and a boolean indicating whether there are more records to fetch.
+    """
+
+    records: Sequence[EventLogRecord]
+    cursor: str
+    has_more: bool
+
+
 @whitelist_for_serdes
 class EventRecordsFilter(
     NamedTuple(
@@ -76,8 +153,8 @@ class EventRecordsFilter(
             ("event_type", DagsterEventType),
             ("asset_key", Optional[AssetKey]),
             ("asset_partitions", Optional[Sequence[str]]),
-            ("after_cursor", Optional[Union[int, RunShardedEventsCursor]]),
-            ("before_cursor", Optional[Union[int, RunShardedEventsCursor]]),
+            ("after_cursor", Optional[EventCursor]),
+            ("before_cursor", Optional[EventCursor]),
             ("after_timestamp", Optional[float]),
             ("before_timestamp", Optional[float]),
             ("storage_ids", Optional[Sequence[int]]),
@@ -94,11 +171,11 @@ class EventRecordsFilter(
         asset_partitions (Optional[List[str]]): Filter parameter such that only asset
             events with a partition value matching one of the provided values.  Only
             valid when the `asset_key` parameter is provided.
-        after_cursor (Optional[Union[int, RunShardedEventsCursor]]): Filter parameter such that only
+        after_cursor (Optional[EventCursor]): Filter parameter such that only
             records with storage_id greater than the provided value are returned. Using a
             run-sharded events cursor will result in a significant performance gain when run against
             a SqliteEventLogStorage implementation (which is run-sharded)
-        before_cursor (Optional[Union[int, RunShardedEventsCursor]]): Filter parameter such that
+        before_cursor (Optional[EventCursor]): Filter parameter such that
             records with storage_id less than the provided value are returned. Using a run-sharded
             events cursor will result in a significant performance gain when run against
             a SqliteEventLogStorage implementation (which is run-sharded)
@@ -113,8 +190,8 @@ class EventRecordsFilter(
         event_type: DagsterEventType,
         asset_key: Optional[AssetKey] = None,
         asset_partitions: Optional[Sequence[str]] = None,
-        after_cursor: Optional[Union[int, RunShardedEventsCursor]] = None,
-        before_cursor: Optional[Union[int, RunShardedEventsCursor]] = None,
+        after_cursor: Optional[EventCursor] = None,
+        before_cursor: Optional[EventCursor] = None,
         after_timestamp: Optional[float] = None,
         before_timestamp: Optional[float] = None,
         storage_ids: Optional[Sequence[int]] = None,
@@ -145,4 +222,193 @@ class EventRecordsFilter(
             before_timestamp=check.opt_float_param(before_timestamp, "before_timestamp"),
             storage_ids=check.opt_nullable_sequence_param(storage_ids, "storage_ids", of_type=int),
             tags=check.opt_mapping_param(tags, "tags", key_type=str),
+        )
+
+    @staticmethod
+    def get_cursor_params(
+        cursor: Optional[str] = None, ascending: bool = False
+    ) -> Tuple[Optional[int], Optional[int]]:
+        if not cursor:
+            return None, None
+
+        cursor_obj = EventLogCursor.parse(cursor)
+        if not cursor_obj.is_id_cursor():
+            check.failed(f"Invalid cursor for fetching event records: {cursor}")
+        after_cursor = cursor_obj.storage_id() if ascending else None
+        before_cursor = cursor_obj.storage_id() if not ascending else None
+        return before_cursor, after_cursor
+
+
+@whitelist_for_serdes
+class AssetRecordsFilter(
+    NamedTuple(
+        "_AssetRecordsFilter",
+        [
+            ("asset_key", PublicAttr[Optional[AssetKey]]),
+            ("asset_partitions", PublicAttr[Optional[Sequence[str]]]),
+            ("after_timestamp", PublicAttr[Optional[float]]),
+            ("before_timestamp", PublicAttr[Optional[float]]),
+            ("after_storage_id", PublicAttr[Optional[int]]),
+            ("before_storage_id", PublicAttr[Optional[int]]),
+            ("storage_ids", PublicAttr[Optional[Sequence[int]]]),
+            ("tags", PublicAttr[Optional[Mapping[str, Union[str, Sequence[str]]]]]),
+        ],
+    )
+):
+    """Defines a set of filter fields for fetching a set of asset event records.
+
+    Args:
+        asset_key (Optional[AssetKey]): Asset key for which to get asset event entries / records.
+        asset_partitions (Optional[List[str]]): Filter parameter such that only asset
+            events with a partition value matching one of the provided values are returned.  Only
+            valid when the `asset_key` parameter is provided.
+        after_timestamp (Optional[float]): Filter parameter such that only event records for
+            events with timestamp greater than the provided value are returned.
+        before_timestamp (Optional[float]): Filter parameter such that only event records for
+            events with timestamp less than the provided value are returned.
+        after_storage_id (Optional[float]): Filter parameter such that only event records for
+            events with storage_id greater than the provided value are returned.
+        before_storage_id (Optional[float]): Filter parameter such that only event records for
+            events with storage_id less than the provided value are returned.
+        storage_ids (Optional[Sequence[int]]): Filter parameter such that only event records for
+            the given storage ids are returned.
+        tags (Optional[Mapping[str, Union[str, Sequence[str]]]]): Filter parameter such that only
+            events with the given event tags are returned
+    """
+
+    def __new__(
+        cls,
+        asset_key: Optional[AssetKey] = None,
+        asset_partitions: Optional[Sequence[str]] = None,
+        after_timestamp: Optional[float] = None,
+        before_timestamp: Optional[float] = None,
+        after_storage_id: Optional[int] = None,
+        before_storage_id: Optional[int] = None,
+        storage_ids: Optional[Sequence[int]] = None,
+        tags: Optional[Mapping[str, Union[str, Sequence[str]]]] = None,
+    ):
+        return super(AssetRecordsFilter, cls).__new__(
+            cls,
+            asset_key=check.opt_inst_param(asset_key, "asset_key", AssetKey),
+            asset_partitions=check.opt_nullable_sequence_param(
+                asset_partitions, "asset_partitions", of_type=str
+            ),
+            after_timestamp=check.opt_float_param(after_timestamp, "after_timestamp"),
+            before_timestamp=check.opt_float_param(before_timestamp, "before_timestamp"),
+            after_storage_id=check.opt_int_param(after_storage_id, "after_storage_id"),
+            before_storage_id=check.opt_int_param(before_storage_id, "before_storage_id"),
+            storage_ids=check.opt_nullable_sequence_param(storage_ids, "storage_ids", of_type=int),
+            tags=check.opt_nullable_mapping_param(tags, "tags", key_type=str),
+        )
+
+    def to_event_records_filter(
+        self, event_type: AssetEventType, cursor: Optional[str] = None, ascending: bool = False
+    ) -> EventRecordsFilter:
+        before_cursor_storage_id, after_cursor_storage_id = EventRecordsFilter.get_cursor_params(
+            cursor, ascending
+        )
+        if self.before_storage_id and before_cursor_storage_id:
+            before_cursor = min(self.before_storage_id, before_cursor_storage_id)
+        else:
+            before_cursor = (
+                before_cursor_storage_id if before_cursor_storage_id else self.before_storage_id
+            )
+        if self.after_storage_id and after_cursor_storage_id:
+            after_cursor = max(self.after_storage_id, after_cursor_storage_id)
+        else:
+            after_cursor = (
+                after_cursor_storage_id if after_cursor_storage_id else self.after_storage_id
+            )
+
+        return EventRecordsFilter(
+            event_type=event_type,
+            asset_key=self.asset_key,
+            asset_partitions=self.asset_partitions,
+            after_cursor=after_cursor,
+            before_cursor=before_cursor,
+            after_timestamp=self.after_timestamp,
+            before_timestamp=self.before_timestamp,
+            storage_ids=self.storage_ids,
+            tags=self.tags,
+        )
+
+
+@whitelist_for_serdes
+class RunStatusChangeRecordsFilter(
+    NamedTuple(
+        "_RunStatusChangeRecordsFilter",
+        [
+            ("event_type", PublicAttr[RunStatusChangeEventType]),
+            ("after_timestamp", PublicAttr[Optional[float]]),
+            ("before_timestamp", PublicAttr[Optional[float]]),
+            ("after_storage_id", PublicAttr[Optional[int]]),
+            ("before_storage_id", PublicAttr[Optional[int]]),
+            ("storage_ids", PublicAttr[Optional[Sequence[int]]]),
+        ],
+    )
+):
+    """Defines a set of filter fields for fetching a set of asset event records.
+
+    Args:
+        event_type (DagsterEventType): Filter argument for dagster event type
+        after_timestamp (Optional[float]): Filter parameter such that only event records for
+            events with timestamp greater than the provided value are returned.
+        before_timestamp (Optional[float]): Filter parameter such that only event records for
+            events with timestamp less than the provided value are returned.
+        after_storage_id (Optional[float]): Filter parameter such that only event records for
+            events with storage_id greater than the provided value are returned.
+        before_storage_id (Optional[float]): Filter parameter such that only event records for
+            events with storage_id less than the provided value are returned.
+        storage_ids (Optional[Sequence[int]]): Filter parameter such that only event records for
+            the given storage ids are returned.
+    """
+
+    def __new__(
+        cls,
+        event_type: RunStatusChangeEventType,
+        after_timestamp: Optional[float] = None,
+        before_timestamp: Optional[float] = None,
+        after_storage_id: Optional[int] = None,
+        before_storage_id: Optional[int] = None,
+        storage_ids: Optional[Sequence[int]] = None,
+    ):
+        if event_type not in EVENT_TYPE_TO_PIPELINE_RUN_STATUS:
+            check.failed("Invalid event type for run status change event filter")
+
+        return super(RunStatusChangeRecordsFilter, cls).__new__(
+            cls,
+            event_type=check.inst_param(event_type, "event_type", DagsterEventType),
+            after_timestamp=check.opt_float_param(after_timestamp, "after_timestamp"),
+            before_timestamp=check.opt_float_param(before_timestamp, "before_timestamp"),
+            after_storage_id=check.opt_int_param(after_storage_id, "after_storage_id"),
+            before_storage_id=check.opt_int_param(before_storage_id, "before_storage_id"),
+            storage_ids=check.opt_nullable_sequence_param(storage_ids, "storage_ids", of_type=int),
+        )
+
+    def to_event_records_filter(
+        self, cursor: Optional[str] = None, ascending: bool = False
+    ) -> EventRecordsFilter:
+        before_cursor_storage_id, after_cursor_storage_id = EventRecordsFilter.get_cursor_params(
+            cursor, ascending
+        )
+        if self.before_storage_id and before_cursor_storage_id:
+            before_cursor = min(self.before_storage_id, before_cursor_storage_id)
+        else:
+            before_cursor = (
+                before_cursor_storage_id if before_cursor_storage_id else self.before_storage_id
+            )
+        if self.after_storage_id and after_cursor_storage_id:
+            after_cursor = max(self.after_storage_id, after_cursor_storage_id)
+        else:
+            after_cursor = (
+                after_cursor_storage_id if after_cursor_storage_id else self.after_storage_id
+            )
+
+        return EventRecordsFilter(
+            event_type=self.event_type,
+            after_cursor=after_cursor,
+            before_cursor=before_cursor,
+            after_timestamp=self.after_timestamp,
+            before_timestamp=self.before_timestamp,
+            storage_ids=self.storage_ids,
         )

--- a/python_modules/dagster/dagster/_core/event_api.py
+++ b/python_modules/dagster/dagster/_core/event_api.py
@@ -244,7 +244,7 @@ class AssetRecordsFilter(
     NamedTuple(
         "_AssetRecordsFilter",
         [
-            ("asset_key", PublicAttr[Optional[AssetKey]]),
+            ("asset_key", PublicAttr[AssetKey]),
             ("asset_partitions", PublicAttr[Optional[Sequence[str]]]),
             ("after_timestamp", PublicAttr[Optional[float]]),
             ("before_timestamp", PublicAttr[Optional[float]]),
@@ -278,7 +278,7 @@ class AssetRecordsFilter(
 
     def __new__(
         cls,
-        asset_key: Optional[AssetKey] = None,
+        asset_key: AssetKey,
         asset_partitions: Optional[Sequence[str]] = None,
         after_timestamp: Optional[float] = None,
         before_timestamp: Optional[float] = None,
@@ -289,7 +289,7 @@ class AssetRecordsFilter(
     ):
         return super(AssetRecordsFilter, cls).__new__(
             cls,
-            asset_key=check.opt_inst_param(asset_key, "asset_key", AssetKey),
+            asset_key=check.inst_param(asset_key, "asset_key", AssetKey),
             asset_partitions=check.opt_nullable_sequence_param(
                 asset_partitions, "asset_partitions", of_type=str
             ),

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -1913,9 +1913,9 @@ class DagsterInstance(DynamicPartitionsStore):
 
     @public
     @traced
-    def get_materialization_records(
+    def fetch_materializations(
         self,
-        records_filter: Optional[Union[AssetKey, "AssetRecordsFilter"]],
+        records_filter: Union[AssetKey, "AssetRecordsFilter"],
         limit: int,
         cursor: Optional[str] = None,
         ascending: bool = False,
@@ -1933,15 +1933,13 @@ class DagsterInstance(DynamicPartitionsStore):
         Returns:
             EventRecordsResult: Object containing a list of event log records and a cursor string
         """
-        return self._event_storage.get_materialization_records(
-            records_filter, limit, cursor, ascending
-        )
+        return self._event_storage.fetch_materializations(records_filter, limit, cursor, ascending)
 
     @public
     @traced
-    def get_planned_materialization_records(
+    def fetch_planned_materializations(
         self,
-        records_filter: Optional[Union[AssetKey, "AssetRecordsFilter"]],
+        records_filter: Union[AssetKey, "AssetRecordsFilter"],
         limit: int,
         cursor: Optional[str] = None,
         ascending: bool = False,
@@ -1959,15 +1957,15 @@ class DagsterInstance(DynamicPartitionsStore):
         Returns:
             EventRecordsResult: Object containing a list of event log records and a cursor string
         """
-        return self._event_storage.get_planned_materialization_records(
+        return self._event_storage.fetch_planned_materializations(
             records_filter, limit, cursor, ascending
         )
 
     @public
     @traced
-    def get_observation_records(
+    def fetch_observations(
         self,
-        records_filter: Optional[Union[AssetKey, "AssetRecordsFilter"]],
+        records_filter: Union[AssetKey, "AssetRecordsFilter"],
         limit: int,
         cursor: Optional[str] = None,
         ascending: bool = False,
@@ -1985,11 +1983,11 @@ class DagsterInstance(DynamicPartitionsStore):
         Returns:
             EventRecordsResult: Object containing a list of event log records and a cursor string
         """
-        return self._event_storage.get_observation_records(records_filter, limit, cursor, ascending)
+        return self._event_storage.fetch_observations(records_filter, limit, cursor, ascending)
 
     @public
     @traced
-    def get_run_status_change_records(
+    def fetch_run_status_changes(
         self,
         records_filter: Union["DagsterEventType", "RunStatusChangeRecordsFilter"],
         limit: int,
@@ -2009,7 +2007,7 @@ class DagsterInstance(DynamicPartitionsStore):
         Returns:
             EventRecordsResult: Object containing a list of event log records and a cursor string
         """
-        return self._event_storage.get_run_status_change_records(
+        return self._event_storage.fetch_run_status_changes(
             records_filter, limit, cursor, ascending
         )
 

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -1915,8 +1915,8 @@ class DagsterInstance(DynamicPartitionsStore):
     @traced
     def get_materialization_records(
         self,
-        records_filter: Optional[Union[AssetKey, "AssetRecordsFilter"]] = None,
-        limit: int = 10000,
+        records_filter: Optional[Union[AssetKey, "AssetRecordsFilter"]],
+        limit: int,
         cursor: Optional[str] = None,
         ascending: bool = False,
     ) -> "EventRecordsResult":
@@ -1925,7 +1925,7 @@ class DagsterInstance(DynamicPartitionsStore):
         Args:
             records_filter (Optional[Union[AssetKey, AssetRecordsFilter]]): the filter by which to
                 filter event records.
-            limit (int): Number of results to get. Defaults to 10000.
+            limit (int): Number of results to get.
             cursor (Optional[str]): Cursor to use for pagination. Defaults to None.
             ascending (Optional[bool]): Sort the result in ascending order if True, descending
                 otherwise. Defaults to descending.
@@ -1941,8 +1941,8 @@ class DagsterInstance(DynamicPartitionsStore):
     @traced
     def get_planned_materialization_records(
         self,
-        records_filter: Optional[Union[AssetKey, "AssetRecordsFilter"]] = None,
-        limit: int = 10000,
+        records_filter: Optional[Union[AssetKey, "AssetRecordsFilter"]],
+        limit: int,
         cursor: Optional[str] = None,
         ascending: bool = False,
     ) -> "EventRecordsResult":
@@ -1951,7 +1951,7 @@ class DagsterInstance(DynamicPartitionsStore):
         Args:
             records_filter (Optional[Union[AssetKey, AssetRecordsFilter]]): the filter by which to
                 filter event records.
-            limit (int): Number of results to get. Defaults to 10000.
+            limit (int): Number of results to get.
             cursor (Optional[str]): Cursor to use for pagination. Defaults to None.
             ascending (Optional[bool]): Sort the result in ascending order if True, descending
                 otherwise. Defaults to descending.
@@ -1967,8 +1967,8 @@ class DagsterInstance(DynamicPartitionsStore):
     @traced
     def get_observation_records(
         self,
-        records_filter: Optional[Union[AssetKey, "AssetRecordsFilter"]] = None,
-        limit: int = 10000,
+        records_filter: Optional[Union[AssetKey, "AssetRecordsFilter"]],
+        limit: int,
         cursor: Optional[str] = None,
         ascending: bool = False,
     ) -> "EventRecordsResult":
@@ -1977,7 +1977,7 @@ class DagsterInstance(DynamicPartitionsStore):
         Args:
             records_filter (Optional[Union[AssetKey, AssetRecordsFilter]]): the filter by which to
                 filter event records.
-            limit (int): Number of results to get. Defaults to 10000.
+            limit (int): Number of results to get.
             cursor (Optional[str]): Cursor to use for pagination. Defaults to None.
             ascending (Optional[bool]): Sort the result in ascending order if True, descending
                 otherwise. Defaults to descending.
@@ -1992,7 +1992,7 @@ class DagsterInstance(DynamicPartitionsStore):
     def get_run_status_change_records(
         self,
         records_filter: Union["DagsterEventType", "RunStatusChangeRecordsFilter"],
-        limit: int = 10000,
+        limit: int,
         cursor: Optional[str] = None,
         ascending: bool = False,
     ) -> "EventRecordsResult":
@@ -2001,7 +2001,7 @@ class DagsterInstance(DynamicPartitionsStore):
         Args:
             records_filter (Optional[Union[DagsterEventType, RunStatusChangeRecordsFilter]]): the
                 filter by which to filter event records.
-            limit (int): Number of results to get. Defaults to 10000.
+            limit (int): Number of results to get.
             cursor (Optional[str]): Cursor to use for pagination. Defaults to None.
             ascending (Optional[bool]): Sort the result in ascending order if True, descending
                 otherwise. Defaults to descending.

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -475,8 +475,8 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
     @abstractmethod
     def get_materialization_records(
         self,
-        records_filter: Optional[Union[AssetKey, AssetRecordsFilter]] = None,
-        limit: int = 10000,
+        records_filter: Optional[Union[AssetKey, AssetRecordsFilter]],
+        limit: int,
         cursor: Optional[str] = None,
         ascending: bool = False,
     ) -> EventRecordsResult:
@@ -485,8 +485,8 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
     @abstractmethod
     def get_observation_records(
         self,
-        records_filter: Optional[Union[AssetKey, AssetRecordsFilter]] = None,
-        limit: Optional[int] = None,
+        records_filter: Optional[Union[AssetKey, AssetRecordsFilter]],
+        limit: int,
         cursor: Optional[str] = None,
         ascending: bool = False,
     ) -> EventRecordsResult:
@@ -495,8 +495,8 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
     @abstractmethod
     def get_planned_materialization_records(
         self,
-        records_filter: Optional[Union[AssetKey, AssetRecordsFilter]] = None,
-        limit: Optional[int] = None,
+        records_filter: Optional[Union[AssetKey, AssetRecordsFilter]],
+        limit: int,
         cursor: Optional[str] = None,
         ascending: bool = False,
     ) -> EventRecordsResult:
@@ -506,7 +506,7 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
     def get_run_status_change_records(
         self,
         records_filter: Union[DagsterEventType, RunStatusChangeRecordsFilter],
-        limit: Optional[int] = None,
+        limit: int,
         cursor: Optional[str] = None,
         ascending: bool = False,
     ) -> EventRecordsResult:

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -473,9 +473,9 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         pass
 
     @abstractmethod
-    def get_materialization_records(
+    def fetch_materializations(
         self,
-        records_filter: Optional[Union[AssetKey, AssetRecordsFilter]],
+        records_filter: Union[AssetKey, AssetRecordsFilter],
         limit: int,
         cursor: Optional[str] = None,
         ascending: bool = False,
@@ -483,9 +483,9 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         raise NotImplementedError()
 
     @abstractmethod
-    def get_observation_records(
+    def fetch_observations(
         self,
-        records_filter: Optional[Union[AssetKey, AssetRecordsFilter]],
+        records_filter: Union[AssetKey, AssetRecordsFilter],
         limit: int,
         cursor: Optional[str] = None,
         ascending: bool = False,
@@ -493,9 +493,9 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         raise NotImplementedError()
 
     @abstractmethod
-    def get_planned_materialization_records(
+    def fetch_planned_materializations(
         self,
-        records_filter: Optional[Union[AssetKey, AssetRecordsFilter]],
+        records_filter: Union[AssetKey, AssetRecordsFilter],
         limit: int,
         cursor: Optional[str] = None,
         ascending: bool = False,
@@ -503,7 +503,7 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         raise NotImplementedError()
 
     @abstractmethod
-    def get_run_status_change_records(
+    def fetch_run_status_changes(
         self,
         records_filter: Union[DagsterEventType, RunStatusChangeRecordsFilter],
         limit: int,

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -1042,9 +1042,9 @@ class SqlEventLogStorage(EventLogStorage):
         has_more = len(records) == limit
         return EventRecordsResult(records, cursor=new_cursor, has_more=has_more)
 
-    def get_materialization_records(
+    def fetch_materializations(
         self,
-        records_filter: Optional[Union[AssetKey, AssetRecordsFilter]],
+        records_filter: Union[AssetKey, AssetRecordsFilter],
         limit: int,
         cursor: Optional[str] = None,
         ascending: bool = False,
@@ -1058,7 +1058,7 @@ class SqlEventLogStorage(EventLogStorage):
             )
         else:
             before_cursor, after_cursor = EventRecordsFilter.get_cursor_params(cursor, ascending)
-            asset_key = records_filter if isinstance(records_filter, AssetKey) else None
+            asset_key = records_filter
             event_records_filter = EventRecordsFilter(
                 event_type=DagsterEventType.ASSET_MATERIALIZATION,
                 asset_key=asset_key,
@@ -1068,9 +1068,9 @@ class SqlEventLogStorage(EventLogStorage):
 
         return self._get_event_records_result(event_records_filter, limit, cursor, ascending)
 
-    def get_observation_records(
+    def fetch_observations(
         self,
-        records_filter: Optional[Union[AssetKey, AssetRecordsFilter]],
+        records_filter: Union[AssetKey, AssetRecordsFilter],
         limit: int,
         cursor: Optional[str] = None,
         ascending: bool = False,
@@ -1084,7 +1084,7 @@ class SqlEventLogStorage(EventLogStorage):
             )
         else:
             before_cursor, after_cursor = EventRecordsFilter.get_cursor_params(cursor, ascending)
-            asset_key = records_filter if isinstance(records_filter, AssetKey) else None
+            asset_key = records_filter
             event_records_filter = EventRecordsFilter(
                 event_type=DagsterEventType.ASSET_OBSERVATION,
                 asset_key=asset_key,
@@ -1094,7 +1094,7 @@ class SqlEventLogStorage(EventLogStorage):
 
         return self._get_event_records_result(event_records_filter, limit, cursor, ascending)
 
-    def get_planned_materialization_records(
+    def fetch_planned_materializations(
         self,
         records_filter: Optional[Union[AssetKey, AssetRecordsFilter]],
         limit: int,
@@ -1110,7 +1110,7 @@ class SqlEventLogStorage(EventLogStorage):
             )
         else:
             before_cursor, after_cursor = EventRecordsFilter.get_cursor_params(cursor, ascending)
-            asset_key = records_filter if isinstance(records_filter, AssetKey) else None
+            asset_key = records_filter
             event_records_filter = EventRecordsFilter(
                 event_type=DagsterEventType.ASSET_MATERIALIZATION_PLANNED,
                 asset_key=asset_key,
@@ -1119,7 +1119,7 @@ class SqlEventLogStorage(EventLogStorage):
             )
         return self._get_event_records_result(event_records_filter, limit, cursor, ascending)
 
-    def get_run_status_change_records(
+    def fetch_run_status_changes(
         self,
         records_filter: Union[DagsterEventType, RunStatusChangeRecordsFilter],
         limit: int,

--- a/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
@@ -374,7 +374,7 @@ class SqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
 
         return event_records[:limit]
 
-    def get_run_status_change_records(
+    def fetch_run_status_changes(
         self,
         records_filter: Union[DagsterEventType, RunStatusChangeRecordsFilter],
         limit: int,

--- a/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
@@ -8,7 +8,7 @@ import threading
 import time
 from collections import defaultdict
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, ContextManager, Iterable, Iterator, Optional, Sequence
+from typing import TYPE_CHECKING, Any, ContextManager, Iterator, Optional, Sequence, Union
 
 import sqlalchemy as db
 import sqlalchemy.exc as db_exc
@@ -24,8 +24,13 @@ from dagster._config import StringSource
 from dagster._config.config_schema import UserConfigSchema
 from dagster._core.definitions.events import AssetKey
 from dagster._core.errors import DagsterInvariantViolationError
-from dagster._core.event_api import EventHandlerFn
-from dagster._core.events import ASSET_CHECK_EVENTS, ASSET_EVENTS, EVENT_TYPE_TO_PIPELINE_RUN_STATUS
+from dagster._core.event_api import EventHandlerFn, EventRecordsResult, RunStatusChangeRecordsFilter
+from dagster._core.events import (
+    ASSET_CHECK_EVENTS,
+    ASSET_EVENTS,
+    EVENT_TYPE_TO_PIPELINE_RUN_STATUS,
+    DagsterEventType,
+)
 from dagster._core.events.log import EventLogEntry
 from dagster._core.storage.dagster_run import DagsterRunStatus, RunsFilter
 from dagster._core.storage.event_log.base import EventLogCursor, EventLogRecord, EventRecordsFilter
@@ -266,14 +271,14 @@ class SqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
         if event.is_dagster_event and event.dagster_event_type in EVENT_TYPE_TO_PIPELINE_RUN_STATUS:
             # should mirror run status change events in the index shard
             with self.index_connection() as conn:
-                result = conn.execute(insert_event_statement)
+                conn.execute(insert_event_statement)
 
     def get_event_records(
         self,
         event_records_filter: EventRecordsFilter,
         limit: Optional[int] = None,
         ascending: bool = False,
-    ) -> Iterable[EventLogRecord]:
+    ) -> Sequence[EventLogRecord]:
         """Overridden method to enable cross-run event queries in sqlite.
 
         The record id in sqlite does not auto increment cross runs, so instead of fetching events
@@ -285,12 +290,22 @@ class SqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
 
         is_asset_query = event_records_filter and event_records_filter.event_type in ASSET_EVENTS
         if is_asset_query:
-            # asset materializations, observations and materialization planned events get mirrored
-            # into the index shard, so no custom run shard-aware cursor logic needed
+            # asset materializations, observations and materialization planned events
+            # get mirrored into the index shard, so no custom run shard-aware cursor logic needed
             return super(SqliteEventLogStorage, self).get_event_records(
                 event_records_filter=event_records_filter, limit=limit, ascending=ascending
             )
 
+        return self._get_run_sharded_event_records(
+            event_records_filter=event_records_filter, limit=limit, ascending=ascending
+        )
+
+    def _get_run_sharded_event_records(
+        self,
+        event_records_filter: EventRecordsFilter,
+        limit: Optional[int] = None,
+        ascending: bool = False,
+    ) -> Sequence[EventLogRecord]:
         query = db_select([SqlEventLogStorageTable.c.id, SqlEventLogStorageTable.c.event])
         if event_records_filter.asset_key:
             asset_details = next(iter(self._get_assets_details([event_records_filter.asset_key])))
@@ -358,6 +373,50 @@ class SqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
                 break
 
         return event_records[:limit]
+
+    def get_run_status_change_records(
+        self,
+        records_filter: Union[DagsterEventType, RunStatusChangeRecordsFilter],
+        limit: int = 10000,
+        cursor: Optional[str] = None,
+        ascending: bool = False,
+    ) -> EventRecordsResult:
+        # custom implementation of the run status change event query to only read from the index
+        # shard instead of from the run shards.  This bypasses the default Sqlite implementation of
+        # the deprecated _get_event_records method, which reads from the run shards, opting for the
+        # super implementation instead, which reads from the index shard
+        event_type = (
+            records_filter
+            if isinstance(records_filter, DagsterEventType)
+            else records_filter.event_type
+        )
+        if event_type not in EVENT_TYPE_TO_PIPELINE_RUN_STATUS:
+            expected = ", ".join(EVENT_TYPE_TO_PIPELINE_RUN_STATUS.keys())
+            check.failed(f"Expected one of {expected}, received {event_type.value}")
+
+        before_cursor, after_cursor = EventRecordsFilter.get_cursor_params(cursor, ascending)
+        event_records_filter = (
+            records_filter.to_event_records_filter(cursor, ascending)
+            if isinstance(records_filter, RunStatusChangeRecordsFilter)
+            else EventRecordsFilter(
+                event_type, before_cursor=before_cursor, after_cursor=after_cursor
+            )
+        )
+
+        # bypass the run-sharded cursor logic... any caller of this run status change specific
+        # method should be reading from the index shard, which as of 1.5.0 contains mirrored run
+        # status change events
+        records = super(SqliteEventLogStorage, self).get_event_records(
+            event_records_filter=event_records_filter, limit=limit, ascending=ascending
+        )
+        if records:
+            new_cursor = EventLogCursor.from_storage_id(records[-1].storage_id).to_string()
+        elif cursor:
+            new_cursor = cursor
+        else:
+            new_cursor = EventLogCursor.from_storage_id(-1).to_string()
+        has_more = len(records) == limit
+        return EventRecordsResult(records, cursor=new_cursor, has_more=has_more)
 
     def supports_event_consumer_queries(self) -> bool:
         return False

--- a/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
@@ -377,7 +377,7 @@ class SqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
     def get_run_status_change_records(
         self,
         records_filter: Union[DagsterEventType, RunStatusChangeRecordsFilter],
-        limit: int = 10000,
+        limit: int,
         cursor: Optional[str] = None,
         ascending: bool = False,
     ) -> EventRecordsResult:

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -454,47 +454,45 @@ class LegacyEventLogStorage(EventLogStorage, ConfigurableClass):
             event_records_filter, limit, ascending  # type: ignore
         )
 
-    def get_materialization_records(
+    def fetch_materializations(
         self,
-        filters: Optional[Union[AssetKey, "AssetRecordsFilter"]],
+        filters: Union[AssetKey, "AssetRecordsFilter"],
         limit: int,
         cursor: Optional[str] = None,
         ascending: bool = False,
     ) -> EventRecordsResult:
-        return self._storage.event_log_storage.get_materialization_records(
+        return self._storage.event_log_storage.fetch_materializations(
             filters, limit, cursor, ascending
         )
 
-    def get_observation_records(
+    def fetch_observations(
         self,
-        filters: Optional[Union[AssetKey, "AssetRecordsFilter"]],
+        filters: Union[AssetKey, "AssetRecordsFilter"],
         limit: int,
         cursor: Optional[str] = None,
         ascending: bool = False,
     ) -> EventRecordsResult:
-        return self._storage.event_log_storage.get_observation_records(
-            filters, limit, cursor, ascending
-        )
+        return self._storage.event_log_storage.fetch_observations(filters, limit, cursor, ascending)
 
-    def get_planned_materialization_records(
+    def fetch_planned_materializations(
         self,
-        filters: Optional[Union[AssetKey, "AssetRecordsFilter"]],
+        filters: Union[AssetKey, "AssetRecordsFilter"],
         limit: int,
         cursor: Optional[str] = None,
         ascending: bool = False,
     ) -> EventRecordsResult:
-        return self._storage.event_log_storage.get_planned_materialization_records(
+        return self._storage.event_log_storage.fetch_planned_materializations(
             filters, limit, cursor, ascending
         )
 
-    def get_run_status_change_records(
+    def fetch_run_status_changes(
         self,
         filters: Union["DagsterEventType", "RunStatusChangeRecordsFilter"],
         limit: int,
         cursor: Optional[str] = None,
         ascending: bool = False,
     ) -> EventRecordsResult:
-        return self._storage.event_log_storage.get_run_status_change_records(
+        return self._storage.event_log_storage.fetch_run_status_changes(
             filters, limit, cursor, ascending
         )
 

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -30,6 +30,7 @@ from .event_log.base import (
     EventLogRecord,
     EventLogStorage,
     EventRecordsFilter,
+    EventRecordsResult,
 )
 from .runs.base import RunStorage
 from .schedules.base import ScheduleStorage
@@ -37,6 +38,7 @@ from .schedules.base import ScheduleStorage
 if TYPE_CHECKING:
     from dagster._core.definitions.asset_check_spec import AssetCheckKey
     from dagster._core.definitions.run_request import InstigatorType
+    from dagster._core.event_api import AssetRecordsFilter, RunStatusChangeRecordsFilter
     from dagster._core.events import DagsterEvent, DagsterEventType
     from dagster._core.events.log import EventLogEntry
     from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
@@ -450,6 +452,50 @@ class LegacyEventLogStorage(EventLogStorage, ConfigurableClass):
         # annotation is wrong.
         return self._storage.event_log_storage.get_event_records(
             event_records_filter, limit, ascending  # type: ignore
+        )
+
+    def get_materialization_records(
+        self,
+        filters: Optional[Union[AssetKey, "AssetRecordsFilter"]] = None,
+        limit: int = 10000,
+        cursor: Optional[str] = None,
+        ascending: bool = False,
+    ) -> EventRecordsResult:
+        return self._storage.event_log_storage.get_materialization_records(
+            filters, limit, cursor, ascending
+        )
+
+    def get_observation_records(
+        self,
+        filters: Optional[Union[AssetKey, "AssetRecordsFilter"]] = None,
+        limit: int = 10000,
+        cursor: Optional[str] = None,
+        ascending: bool = False,
+    ) -> EventRecordsResult:
+        return self._storage.event_log_storage.get_observation_records(
+            filters, limit, cursor, ascending
+        )
+
+    def get_planned_materialization_records(
+        self,
+        filters: Optional[Union[AssetKey, "AssetRecordsFilter"]] = None,
+        limit: int = 10000,
+        cursor: Optional[str] = None,
+        ascending: bool = False,
+    ) -> EventRecordsResult:
+        return self._storage.event_log_storage.get_planned_materialization_records(
+            filters, limit, cursor, ascending
+        )
+
+    def get_run_status_change_records(
+        self,
+        filters: Union["DagsterEventType", "RunStatusChangeRecordsFilter"],
+        limit: int = 10000,
+        cursor: Optional[str] = None,
+        ascending: bool = False,
+    ) -> EventRecordsResult:
+        return self._storage.event_log_storage.get_run_status_change_records(
+            filters, limit, cursor, ascending
         )
 
     def get_asset_records(

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -456,8 +456,8 @@ class LegacyEventLogStorage(EventLogStorage, ConfigurableClass):
 
     def get_materialization_records(
         self,
-        filters: Optional[Union[AssetKey, "AssetRecordsFilter"]] = None,
-        limit: int = 10000,
+        filters: Optional[Union[AssetKey, "AssetRecordsFilter"]],
+        limit: int,
         cursor: Optional[str] = None,
         ascending: bool = False,
     ) -> EventRecordsResult:
@@ -467,8 +467,8 @@ class LegacyEventLogStorage(EventLogStorage, ConfigurableClass):
 
     def get_observation_records(
         self,
-        filters: Optional[Union[AssetKey, "AssetRecordsFilter"]] = None,
-        limit: int = 10000,
+        filters: Optional[Union[AssetKey, "AssetRecordsFilter"]],
+        limit: int,
         cursor: Optional[str] = None,
         ascending: bool = False,
     ) -> EventRecordsResult:
@@ -478,8 +478,8 @@ class LegacyEventLogStorage(EventLogStorage, ConfigurableClass):
 
     def get_planned_materialization_records(
         self,
-        filters: Optional[Union[AssetKey, "AssetRecordsFilter"]] = None,
-        limit: int = 10000,
+        filters: Optional[Union[AssetKey, "AssetRecordsFilter"]],
+        limit: int,
         cursor: Optional[str] = None,
         ascending: bool = False,
     ) -> EventRecordsResult:
@@ -490,7 +490,7 @@ class LegacyEventLogStorage(EventLogStorage, ConfigurableClass):
     def get_run_status_change_records(
         self,
         filters: Union["DagsterEventType", "RunStatusChangeRecordsFilter"],
-        limit: int = 10000,
+        limit: int,
         cursor: Optional[str] = None,
         ascending: bool = False,
     ) -> EventRecordsResult:

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -1028,7 +1028,7 @@ class TestEventLogStorage:
             assert record.event_log_entry.dagster_event.asset_key == asset_key
 
             # new API
-            result = storage.get_materialization_records(asset_key)
+            result = storage.get_materialization_records(asset_key, limit=100)
             assert isinstance(result, EventRecordsResult)
             assert len(result.records) == 1
             record = result.records[0]
@@ -1413,7 +1413,7 @@ class TestEventLogStorage:
             _store_run_events(run_id_3)
 
             all_success_events = storage.get_run_status_change_records(
-                DagsterEventType.RUN_SUCCESS
+                DagsterEventType.RUN_SUCCESS, limit=100
             ).records
             assert len(all_success_events) == 3
             assert all_success_events[0].storage_id > all_success_events[2].storage_id
@@ -1424,6 +1424,7 @@ class TestEventLogStorage:
                         cursor=str(
                             EventLogCursor.from_storage_id(all_success_events[1].storage_id)
                         ),
+                        limit=100,
                     ).records
                 )
                 == 1
@@ -2774,7 +2775,7 @@ class TestEventLogStorage:
             assert len(records) == 1
 
             # new API
-            result = storage.get_observation_records(a)
+            result = storage.get_observation_records(a, limit=100)
             assert isinstance(result, EventRecordsResult)
             assert len(result.records) == 1
             record = result.records[0]
@@ -2809,7 +2810,7 @@ class TestEventLogStorage:
         assert len(records) == 1
 
         # new API
-        result = storage.get_planned_materialization_records(a)
+        result = storage.get_planned_materialization_records(a, limit=100)
         assert isinstance(result, EventRecordsResult)
         assert len(result.records) == 1
         record = result.records[0]

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -1028,7 +1028,7 @@ class TestEventLogStorage:
             assert record.event_log_entry.dagster_event.asset_key == asset_key
 
             # new API
-            result = storage.get_materialization_records(asset_key, limit=100)
+            result = storage.fetch_materializations(asset_key, limit=100)
             assert isinstance(result, EventRecordsResult)
             assert len(result.records) == 1
             record = result.records[0]
@@ -1412,14 +1412,14 @@ class TestEventLogStorage:
             _store_run_events(run_id_2)
             _store_run_events(run_id_3)
 
-            all_success_events = storage.get_run_status_change_records(
+            all_success_events = storage.fetch_run_status_changes(
                 DagsterEventType.RUN_SUCCESS, limit=100
             ).records
             assert len(all_success_events) == 3
             assert all_success_events[0].storage_id > all_success_events[2].storage_id
             assert (
                 len(
-                    storage.get_run_status_change_records(
+                    storage.fetch_run_status_changes(
                         DagsterEventType.RUN_SUCCESS,
                         cursor=str(
                             EventLogCursor.from_storage_id(all_success_events[1].storage_id)
@@ -1431,7 +1431,7 @@ class TestEventLogStorage:
             )
             assert [
                 i.storage_id
-                for i in storage.get_run_status_change_records(
+                for i in storage.fetch_run_status_changes(
                     DagsterEventType.RUN_SUCCESS,
                     ascending=True,
                     limit=2,
@@ -2775,7 +2775,7 @@ class TestEventLogStorage:
             assert len(records) == 1
 
             # new API
-            result = storage.get_observation_records(a, limit=100)
+            result = storage.fetch_observations(a, limit=100)
             assert isinstance(result, EventRecordsResult)
             assert len(result.records) == 1
             record = result.records[0]
@@ -2810,7 +2810,7 @@ class TestEventLogStorage:
         assert len(records) == 1
 
         # new API
-        result = storage.get_planned_materialization_records(a, limit=100)
+        result = storage.fetch_planned_materializations(a, limit=100)
         assert isinstance(result, EventRecordsResult)
         assert len(result.records) == 1
         record = result.records[0]


### PR DESCRIPTION
## Summary & Motivation
We want to start deprecating calls to `get_event_records`.  This creates 4 new storage methods, one for fetching each of the asset-based events (materialization, observation, materialization planned), and one for all the collective run status events (to power the run status sensor).

## How I Tested These Changes
BK, follow up diff.
