### PR TITLE
 change call sites for the get_event_records calls

### DIFF
--- a/examples/project_fully_featured/project_fully_featured/sensors/hn_tables_updated_sensor.py
+++ b/examples/project_fully_featured/project_fully_featured/sensors/hn_tables_updated_sensor.py
@@ -2,8 +2,7 @@ import json
 
 from dagster import (
     AssetKey,
-    DagsterEventType,
-    EventRecordsFilter,
+    AssetRecordsFilter,
     RunRequest,
     SensorDefinition,
     sensor,
@@ -21,22 +20,18 @@ def make_hn_tables_updated_sensor(job) -> SensorDefinition:
         comments_cursor = cursor_dict.get("comments")
         stories_cursor = cursor_dict.get("stories")
 
-        comments_event_records = context.instance.get_event_records(
-            EventRecordsFilter(
-                event_type=DagsterEventType.ASSET_MATERIALIZATION,
+        comments_event_records = context.instance.get_materialization_records(
+            AssetRecordsFilter(
                 asset_key=AssetKey(["snowflake", "core", "comments"]),
                 after_cursor=comments_cursor,
             ),
-            ascending=False,
             limit=1,
         )
-        stories_event_records = context.instance.get_event_records(
-            EventRecordsFilter(
-                event_type=DagsterEventType.ASSET_MATERIALIZATION,
+        stories_event_records = context.instance.get_materialization_records(
+            AssetRecordsFilter(
                 asset_key=AssetKey(["snowflake", "core", "stories"]),
                 after_cursor=stories_cursor,
             ),
-            ascending=False,
             limit=1,
         )
 

--- a/examples/project_fully_featured/project_fully_featured_tests/test_sensors/test_hn_tables_updated_sensor.py
+++ b/examples/project_fully_featured/project_fully_featured_tests/test_sensors/test_hn_tables_updated_sensor.py
@@ -10,7 +10,7 @@ from project_fully_featured.sensors.hn_tables_updated_sensor import (
 )
 
 
-def get_mock_event_records(asset_events: List[Tuple[str, int]]):
+def get_mock_materialization_records(asset_events: List[Tuple[str, int]]):
     def event_records(event_records_filter, **_kwargs):
         asset_key = event_records_filter.asset_key
         after_cursor = event_records_filter.after_cursor
@@ -26,9 +26,11 @@ def get_mock_event_records(asset_events: List[Tuple[str, int]]):
     return event_records
 
 
-@mock.patch("dagster._core.instance.DagsterInstance.get_event_records")
+@mock.patch("dagster._core.instance.DagsterInstance.get_materialization_records")
 def test_first_events(mock_event_records):
-    mock_event_records.side_effect = get_mock_event_records([("comments", 1), ("stories", 2)])
+    mock_event_records.side_effect = get_mock_materialization_records(
+        [("comments", 1), ("stories", 2)]
+    )
 
     with instance_for_test() as instance:
         context = build_sensor_context(instance=instance)
@@ -37,9 +39,11 @@ def test_first_events(mock_event_records):
         assert result.cursor == json.dumps({"comments": 1, "stories": 2})
 
 
-@mock.patch("dagster._core.instance.DagsterInstance.get_event_records")
+@mock.patch("dagster._core.instance.DagsterInstance.get_materialization_records")
 def test_nothing_new(mock_event_records):
-    mock_event_records.side_effect = get_mock_event_records([("comments", 1), ("stories", 2)])
+    mock_event_records.side_effect = get_mock_materialization_records(
+        [("comments", 1), ("stories", 2)]
+    )
 
     with instance_for_test() as instance:
         context = build_sensor_context(
@@ -50,9 +54,9 @@ def test_nothing_new(mock_event_records):
         assert result.cursor == json.dumps({"comments": 1, "stories": 2})
 
 
-@mock.patch("dagster._core.instance.DagsterInstance.get_event_records")
+@mock.patch("dagster._core.instance.DagsterInstance.get_materialization_records")
 def test_new_comments_old_stories(mock_event_records):
-    mock_event_records.side_effect = get_mock_event_records(
+    mock_event_records.side_effect = get_mock_materialization_records(
         [("comments", 1), ("comments", 2), ("stories", 2)]
     )
 
@@ -64,9 +68,9 @@ def test_new_comments_old_stories(mock_event_records):
         assert len(result.run_requests) == 0
 
 
-@mock.patch("dagster._core.instance.DagsterInstance.get_event_records")
+@mock.patch("dagster._core.instance.DagsterInstance.get_materialization_records")
 def test_old_comments_new_stories(mock_event_records):
-    mock_event_records.side_effect = get_mock_event_records(
+    mock_event_records.side_effect = get_mock_materialization_records(
         [("comments", 1), ("stories", 2), ("stories", 3)]
     )
 
@@ -78,9 +82,9 @@ def test_old_comments_new_stories(mock_event_records):
         assert len(result.run_requests) == 0
 
 
-@mock.patch("dagster._core.instance.DagsterInstance.get_event_records")
+@mock.patch("dagster._core.instance.DagsterInstance.get_materialization_records")
 def test_both_new(mock_event_records):
-    mock_event_records.side_effect = get_mock_event_records(
+    mock_event_records.side_effect = get_mock_materialization_records(
         [("comments", 1), ("comments", 2), ("stories", 2), ("stories", 3)]
     )
 

--- a/integration_tests/test_suites/daemon-test-suite/dagster_dev_command_tests/test_dagster_dev_command.py
+++ b/integration_tests/test_suites/daemon-test-suite/dagster_dev_command_tests/test_dagster_dev_command.py
@@ -6,7 +6,7 @@ import time
 
 import requests
 import yaml
-from dagster import DagsterEventType, DagsterInstance, EventRecordsFilter
+from dagster import DagsterEventType, DagsterInstance
 from dagster._core.test_utils import environ, new_cwd
 from dagster._grpc.client import DagsterGrpcClient
 from dagster._grpc.server import wait_for_grpc_server
@@ -124,10 +124,8 @@ def test_dagster_dev_command_no_dagster_home():
                             if (
                                 len(instance.get_runs()) > 0
                                 and len(
-                                    instance.get_event_records(
-                                        event_records_filter=EventRecordsFilter(
-                                            event_type=DagsterEventType.PIPELINE_ENQUEUED
-                                        )
+                                    instance.get_run_status_event_records(
+                                        DagsterEventType.PIPELINE_ENQUEUED
                                     )
                                 )
                                 > 0

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -17,9 +17,8 @@ from typing import (
 import dagster._seven as seven
 from dagster import (
     AssetKey,
-    DagsterEventType,
+    AssetRecordsFilter,
     DagsterInstance,
-    EventRecordsFilter,
     MultiPartitionKey,
     MultiPartitionsDefinition,
     _check as check,
@@ -253,9 +252,8 @@ def get_asset_materializations(
     check.opt_mapping_param(tags, "tags", key_type=str, value_type=str)
 
     instance = graphene_info.context.instance
-    event_records = instance.get_event_records(
-        EventRecordsFilter(
-            event_type=DagsterEventType.ASSET_MATERIALIZATION,
+    event_records = instance.get_materialization_records(
+        AssetRecordsFilter(
             asset_key=asset_key,
             asset_partitions=partitions,
             before_timestamp=before_timestamp,
@@ -280,9 +278,8 @@ def get_asset_observations(
     check.opt_float_param(before_timestamp, "before_timestamp")
     check.opt_float_param(after_timestamp, "after_timestamp")
     instance = graphene_info.context.instance
-    event_records = instance.get_event_records(
-        EventRecordsFilter(
-            event_type=DagsterEventType.ASSET_OBSERVATION,
+    event_records = instance.get_observation_records(
+        AssetRecordsFilter(
             asset_key=asset_key,
             asset_partitions=partitions,
             before_timestamp=before_timestamp,

--- a/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
@@ -279,8 +279,7 @@ class MultiAssetSensorEvaluationContext(SensorEvaluationContext):
         )
 
     def _cache_initial_unconsumed_events(self) -> None:
-        from dagster._core.events import DagsterEventType
-        from dagster._core.storage.event_log.base import EventRecordsFilter
+        from dagster._core.storage.event_log.base import AssetRecordsFilter
 
         # This method caches the initial unconsumed events for each asset key. To generate the
         # current unconsumed events, call get_trailing_unconsumed_events instead.
@@ -292,14 +291,14 @@ class MultiAssetSensorEvaluationContext(SensorEvaluationContext):
                 self._get_cursor(asset_key).trailing_unconsumed_partitioned_event_ids.values()
             )
             if unconsumed_event_ids:
-                event_records = self.instance.get_event_records(
-                    EventRecordsFilter(
-                        event_type=DagsterEventType.ASSET_MATERIALIZATION,
-                        storage_ids=unconsumed_event_ids,
-                    )
+                materialization_records = self.instance.get_materialization_records(
+                    AssetRecordsFilter(asset_key=asset_key, storage_ids=unconsumed_event_ids)
                 )
                 self._initial_unconsumed_events_by_id.update(
-                    {event_record.storage_id: event_record for event_record in event_records}
+                    {
+                        materialization_record.storage_id: materialization_record
+                        for materialization_record in materialization_records
+                    }
                 )
 
         self._fetched_initial_unconsumed_events = True
@@ -423,17 +422,15 @@ class MultiAssetSensorEvaluationContext(SensorEvaluationContext):
             asset_key (AssetKey): The asset to fetch materialization events for
             limit (Optional[int]): The number of events to fetch
         """
-        from dagster._core.events import DagsterEventType
-        from dagster._core.storage.event_log.base import EventRecordsFilter
+        from dagster._core.storage.event_log.base import AssetRecordsFilter
 
         asset_key = check.inst_param(asset_key, "asset_key", AssetKey)
         if asset_key not in self._assets_by_key:
             raise DagsterInvalidInvocationError(f"Asset key {asset_key} not monitored by sensor.")
 
         events = list(
-            self.instance.get_event_records(
-                EventRecordsFilter(
-                    event_type=DagsterEventType.ASSET_MATERIALIZATION,
+            self.instance.get_materialization_records(
+                AssetRecordsFilter(
                     asset_key=asset_key,
                     after_cursor=self._get_cursor(asset_key).latest_consumed_event_id,
                 ),
@@ -489,8 +486,7 @@ class MultiAssetSensorEvaluationContext(SensorEvaluationContext):
                 # returns {"2022-07-05": EventLogRecord(...)}
 
         """
-        from dagster._core.events import DagsterEventType
-        from dagster._core.storage.event_log.base import EventLogRecord, EventRecordsFilter
+        from dagster._core.storage.event_log.base import AssetRecordsFilter, EventLogRecord
 
         asset_key = check.inst_param(asset_key, "asset_key", AssetKey)
 
@@ -530,9 +526,8 @@ class MultiAssetSensorEvaluationContext(SensorEvaluationContext):
                 # Add partition and materialization to the end of the OrderedDict
                 materialization_by_partition[partition] = unconsumed_event
 
-        partition_materializations = self.instance.get_event_records(
-            EventRecordsFilter(
-                event_type=DagsterEventType.ASSET_MATERIALIZATION,
+        partition_materializations = self.instance.get_materialization_records(
+            AssetRecordsFilter(
                 asset_key=asset_key,
                 asset_partitions=partitions_to_fetch,
                 after_cursor=self._get_cursor(asset_key).latest_consumed_event_id,
@@ -828,8 +823,7 @@ class MultiAssetSensorCursorAdvances:
         context: MultiAssetSensorEvaluationContext,
         initial_cursor: MultiAssetSensorContextCursor,
     ) -> MultiAssetSensorAssetCursorComponent:
-        from dagster._core.events import DagsterEventType
-        from dagster._core.storage.event_log.base import EventRecordsFilter
+        from dagster._core.storage.event_log.base import AssetRecordsFilter
 
         advanced_records: Set[int] = self._advanced_record_ids_by_key.get(asset_key, set())
         if len(advanced_records) == 0:
@@ -851,9 +845,8 @@ class MultiAssetSensorCursorAdvances:
                 initial_asset_cursor.trailing_unconsumed_partitioned_event_ids
             )
             unconsumed_events = list(context.get_trailing_unconsumed_events(asset_key)) + list(
-                context.instance.get_event_records(
-                    EventRecordsFilter(
-                        event_type=DagsterEventType.ASSET_MATERIALIZATION,
+                context.instance.get_materialization_records(
+                    AssetRecordsFilter(
                         asset_key=asset_key,
                         after_cursor=latest_consumed_event_id_at_tick_start,
                         before_cursor=greatest_consumed_event_id_in_tick,
@@ -914,17 +907,11 @@ class MultiAssetSensorCursorAdvances:
 def get_cursor_from_latest_materializations(
     asset_keys: Sequence[AssetKey], instance: DagsterInstance
 ) -> str:
-    from dagster._core.events import DagsterEventType
-    from dagster._core.storage.event_log.base import EventRecordsFilter
-
     cursor_dict: Dict[str, MultiAssetSensorAssetCursorComponent] = {}
 
     for asset_key in asset_keys:
-        materializations = instance.get_event_records(
-            EventRecordsFilter(
-                DagsterEventType.ASSET_MATERIALIZATION,
-                asset_key=asset_key,
-            ),
+        materializations = instance.get_materialization_records(
+            asset_key,
             limit=1,
         )
         if materializations:

--- a/python_modules/dagster/dagster/_core/storage/branching/branching_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/branching/branching_io_manager.py
@@ -3,8 +3,7 @@ from typing import Any, Optional
 from dagster import InputContext, OutputContext
 from dagster._core.definitions.events import AssetKey, AssetMaterialization
 from dagster._core.definitions.metadata import TextMetadataValue
-from dagster._core.event_api import EventRecordsFilter
-from dagster._core.events import DagsterEventType
+from dagster._core.event_api import AssetRecordsFilter
 from dagster._core.events.log import EventLogEntry
 from dagster._core.instance import DagsterInstance
 from dagster._core.storage.io_manager import IOManager
@@ -19,9 +18,8 @@ def latest_materialization_log_entry(
     instance: DagsterInstance, asset_key: AssetKey, partition_key: Optional[str] = None
 ) -> Optional[EventLogEntry]:
     event_records = [
-        *instance.get_event_records(
-            event_records_filter=EventRecordsFilter(
-                event_type=DagsterEventType.ASSET_MATERIALIZATION,
+        *instance.get_materialization_records(
+            AssetRecordsFilter(
                 asset_key=asset_key,
                 asset_partitions=[partition_key] if partition_key else None,
             ),

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
@@ -49,7 +49,6 @@ from dagster._core.snap.dep_snapshot import (
     OutputHandleSnap,
     build_dep_structure_snapshot_from_graph_def,
 )
-from dagster._core.storage.event_log.base import EventRecordsFilter
 from dagster._core.test_utils import ignore_warning, instance_for_test
 from dagster._utils import safe_tempfile_path
 from dagster._utils.warnings import (
@@ -1397,9 +1396,10 @@ def test_asset_selection_reconstructable():
             assert len([event for event in events if event.is_job_success]) == 1
 
             materialization_planned = list(
-                instance.get_event_records(
-                    EventRecordsFilter(DagsterEventType.ASSET_MATERIALIZATION_PLANNED)
-                )
+                instance.get_records_for_run(
+                    run.run_id,
+                    of_type=DagsterEventType.ASSET_MATERIALIZATION_PLANNED,
+                ).records
             )
             assert len(materialization_planned) == 1
 
@@ -2366,9 +2366,10 @@ def test_subset_does_not_respect_context():
         result = job.execute_in_process(instance=instance)
         planned_asset_keys = {
             record.event_log_entry.dagster_event.event_specific_data.asset_key
-            for record in instance.get_event_records(
-                EventRecordsFilter(DagsterEventType.ASSET_MATERIALIZATION_PLANNED)
-            )
+            for record in instance.get_records_for_run(
+                result.run_id,
+                of_type=DagsterEventType.ASSET_MATERIALIZATION_PLANNED,
+            ).records
         }
 
     # should only plan on creating keys start, c, final
@@ -2494,9 +2495,10 @@ def test_asset_group_build_subset_job(job_selection, expected_assets, use_multi,
         result = job.execute_in_process(instance=instance)
         planned_asset_keys = {
             record.event_log_entry.dagster_event.event_specific_data.asset_key
-            for record in instance.get_event_records(
-                EventRecordsFilter(DagsterEventType.ASSET_MATERIALIZATION_PLANNED)
-            )
+            for record in instance.get_records_for_run(
+                result.run_id,
+                of_type=DagsterEventType.ASSET_MATERIALIZATION_PLANNED,
+            ).records
         }
 
     expected_asset_keys = set(

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_unresolved_asset_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_unresolved_asset_job.py
@@ -6,9 +6,7 @@ from dagster import (
     AssetOut,
     AssetsDefinition,
     AssetSelection,
-    DagsterEventType,
     DailyPartitionsDefinition,
-    EventRecordsFilter,
     HourlyPartitionsDefinition,
     IOManager,
     Out,
@@ -376,9 +374,7 @@ def test_define_selection_job(job_selection, expected_assets, use_multi, prefixe
         result = job.execute_in_process(instance=instance)
         planned_asset_keys = {
             record.event_log_entry.dagster_event.event_specific_data.asset_key
-            for record in instance.get_event_records(
-                EventRecordsFilter(DagsterEventType.ASSET_MATERIALIZATION_PLANNED)
-            )
+            for record in instance.get_planned_materialization_records()
         }
 
     expected_asset_keys = set(

--- a/python_modules/dagster/dagster_tests/core_tests/test_data_time.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_data_time.py
@@ -26,7 +26,6 @@ from dagster._core.definitions.events import AssetKeyPartitionKey
 from dagster._core.definitions.materialize import materialize_to_memory
 from dagster._core.definitions.observe import observe
 from dagster._core.definitions.time_window_partitions import DailyPartitionsDefinition
-from dagster._core.event_api import EventRecordsFilter
 from dagster._seven.compat.pendulum import create_pendulum_time
 from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
 
@@ -197,16 +196,11 @@ def _get_record(instance):
         instance=instance,
     )
     assert result.success
-    return next(
-        iter(
-            instance.get_event_records(
-                EventRecordsFilter(
-                    event_type=DagsterEventType.ASSET_MATERIALIZATION,
-                    asset_key=AssetKey("unpartitioned_asset"),
-                ),
-                ascending=False,
-                limit=1,
-            )
+    return list(
+        instance.get_materialization_records(
+            AssetKey("unpartitioned_asset"),
+            ascending=False,
+            limit=1,
         )
     )
 

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_run_status_sensors.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_run_status_sensors.py
@@ -18,7 +18,6 @@ from dagster._core.host_representation import CodeLocation, ExternalRepository
 from dagster._core.instance import DagsterInstance
 from dagster._core.log_manager import DAGSTER_META_KEY
 from dagster._core.scheduler.instigation import TickStatus
-from dagster._core.storage.event_log.base import EventRecordsFilter
 from dagster._core.test_utils import create_test_daemon_workspace_context, instance_for_test
 from dagster._core.workspace.context import WorkspaceProcessContext
 from dagster._core.workspace.load_target import WorkspaceFileTarget, WorkspaceLoadTarget
@@ -634,8 +633,8 @@ def test_run_failure_sensor_empty_run_records(
                 )
                 runs = instance.get_runs()
                 assert len(runs) == 0
-                failure_events = instance.get_event_records(
-                    EventRecordsFilter(event_type=DagsterEventType.PIPELINE_FAILURE)
+                failure_events = instance.get_run_status_event_records(
+                    DagsterEventType.PIPELINE_FAILURE
                 )
                 assert len(failure_events) == 1
                 freeze_datetime = freeze_datetime.add(seconds=60)

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -58,7 +58,6 @@ from dagster._core.scheduler.instigation import (
     InstigatorStatus,
     TickStatus,
 )
-from dagster._core.storage.event_log.base import EventRecordsFilter
 from dagster._core.test_utils import (
     BlockingThreadPoolExecutor,
     create_test_daemon_workspace_context,
@@ -1724,9 +1723,9 @@ def test_run_request_asset_selection_sensor(executor, instance, workspace_contex
         )
         planned_asset_keys = {
             record.event_log_entry.dagster_event.event_specific_data.asset_key
-            for record in instance.get_event_records(
-                EventRecordsFilter(DagsterEventType.ASSET_MATERIALIZATION_PLANNED)
-            )
+            for record in instance.get_records_for_run(
+                run.run_id, of_type=DagsterEventType.ASSET_MATERIALIZATION_PLANNED
+            ).records
         }
         assert planned_asset_keys == {AssetKey("a"), AssetKey("b")}
 
@@ -1825,9 +1824,7 @@ def test_targets_asset_selection_sensor(executor, instance, workspace_context, e
         )
         planned_asset_keys = [
             record.event_log_entry.dagster_event.event_specific_data.asset_key
-            for record in instance.get_event_records(
-                EventRecordsFilter(DagsterEventType.ASSET_MATERIALIZATION_PLANNED)
-            )
+            for record in instance.get_planned_materialization_records()
         ]
         assert len(planned_asset_keys) == 3
         assert set(planned_asset_keys) == {AssetKey("asset_a"), AssetKey("asset_b")}
@@ -1865,9 +1862,7 @@ def test_partitioned_asset_selection_sensor(executor, instance, workspace_contex
 
         planned_asset_keys = {
             record.event_log_entry.dagster_event.event_specific_data.asset_key
-            for record in instance.get_event_records(
-                EventRecordsFilter(DagsterEventType.ASSET_MATERIALIZATION_PLANNED)
-            )
+            for record in instance.get_planned_materialization_records()
         }
         assert planned_asset_keys == {AssetKey("hourly_asset_3")}
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_multi_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_multi_partitions.py
@@ -5,11 +5,10 @@ import pytest
 from dagster import (
     AssetIn,
     AssetKey,
-    DagsterEventType,
+    AssetRecordsFilter,
     DailyPartitionsDefinition,
     DimensionPartitionMapping,
     DynamicPartitionsDefinition,
-    EventRecordsFilter,
     IdentityPartitionMapping,
     IOManager,
     MultiPartitionKey,
@@ -122,7 +121,7 @@ def test_tags_multi_dimensional_partitions():
         assert result.dagster_run.tags[get_multidimensional_partition_tag("date")] == "2021-06-01"
 
         materializations = sorted(
-            instance.get_event_records(EventRecordsFilter(DagsterEventType.ASSET_MATERIALIZATION)),
+            instance.get_materialization_records(),
             key=lambda x: x.event_log_entry.dagster_event.asset_key,
         )
         assert len(materializations) == 2
@@ -133,44 +132,40 @@ def test_tags_multi_dimensional_partitions():
             )
 
         materializations = list(
-            instance.get_event_records(
-                EventRecordsFilter(
-                    DagsterEventType.ASSET_MATERIALIZATION,
+            instance.get_materialization_records(
+                AssetRecordsFilter(
                     asset_key=AssetKey("asset1"),
                     tags={get_multidimensional_partition_tag("abc"): "a"},
-                )
+                ),
             )
         )
         assert len(materializations) == 1
 
         materializations = list(
-            instance.get_event_records(
-                EventRecordsFilter(
-                    DagsterEventType.ASSET_MATERIALIZATION,
+            instance.get_materialization_records(
+                AssetRecordsFilter(
                     asset_key=AssetKey("asset1"),
                     tags={get_multidimensional_partition_tag("abc"): "nonexistent"},
-                )
+                ),
             )
         )
         assert len(materializations) == 0
 
         materializations = list(
-            instance.get_event_records(
-                EventRecordsFilter(
-                    DagsterEventType.ASSET_MATERIALIZATION,
+            instance.get_materialization_records(
+                AssetRecordsFilter(
                     asset_key=AssetKey("asset1"),
                     tags={get_multidimensional_partition_tag("date"): "2021-06-01"},
-                )
+                ),
             )
         )
         assert len(materializations) == 1
         materializations = list(
-            instance.get_event_records(
-                EventRecordsFilter(
-                    DagsterEventType.ASSET_MATERIALIZATION,
+            instance.get_materialization_records(
+                AssetRecordsFilter(
                     asset_key=AssetKey("asset2"),
                     tags={get_multidimensional_partition_tag("date"): "2021-06-01"},
-                )
+                ),
             )
         )
         assert len(materializations) == 1

--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_op_concurrency.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_op_concurrency.py
@@ -10,8 +10,6 @@ from dagster import (
 from dagster._core.definitions.events import AssetKey, AssetMaterialization
 from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.reconstruct import reconstructable
-from dagster._core.event_api import EventRecordsFilter
-from dagster._core.events import DagsterEventType
 from dagster._core.execution.api import execute_job
 from dagster._core.instance import DagsterInstance
 from dagster._core.storage.dagster_run import DagsterRunStatus
@@ -287,10 +285,8 @@ def test_multi_run_concurrency(instance, workspace, two_tier_job_def):
     assert run_one.status == DagsterRunStatus.SUCCESS
     assert run_two.status == DagsterRunStatus.SUCCESS
 
-    records = instance.get_event_records(
-        EventRecordsFilter(
-            event_type=DagsterEventType.ASSET_MATERIALIZATION, asset_key=AssetKey(["foo_slot"])
-        ),
+    records = instance.get_materialization_records(
+        AssetKey(["foo_slot"]),
         ascending=True,
     )
     max_active = 0

--- a/python_modules/dagster/dagster_tests/storage_tests/branching_io_manager_tests/utils.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/branching_io_manager_tests/utils.py
@@ -11,8 +11,7 @@ from dagster import (
     OutputContext,
 )
 from dagster._core.definitions.events import CoercibleToAssetKey
-from dagster._core.event_api import EventLogRecord, EventRecordsFilter
-from dagster._core.events import DagsterEventType
+from dagster._core.event_api import EventLogRecord
 
 
 class DefinitionsRunner:
@@ -64,11 +63,8 @@ class DefinitionsRunner:
         self, asset_key: CoercibleToAssetKey
     ) -> List[EventLogRecord]:
         return [
-            *self.instance.get_event_records(
-                EventRecordsFilter(
-                    event_type=DagsterEventType.ASSET_MATERIALIZATION,
-                    asset_key=AssetKey.from_coercible(asset_key),
-                )
+            *self.instance.get_materialization_records(
+                AssetKey.from_coercible(asset_key),
             )
         ]
 

--- a/python_modules/dagster/dagster_tests/storage_tests/test_partition_status_cache.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_partition_status_cache.py
@@ -7,7 +7,6 @@ from dagster import (
     DailyPartitionsDefinition,
     DynamicPartitionsDefinition,
     EventLogEntry,
-    EventRecordsFilter,
     MultiPartitionKey,
     MultiPartitionsDefinition,
     StaticPartitionsDefinition,
@@ -54,15 +53,7 @@ def test_get_cached_status_unpartitioned():
         assert (
             cached_status.latest_storage_id
             == next(
-                iter(
-                    instance.get_event_records(
-                        EventRecordsFilter(
-                            asset_key=AssetKey("asset1"),
-                            event_type=DagsterEventType.ASSET_MATERIALIZATION,
-                        ),
-                        limit=1,
-                    )
-                )
+                iter(instance.get_materialization_records(AssetKey("asset1"), limit=1))
             ).storage_id
         )
         assert cached_status.partitions_def_id is None

--- a/python_modules/libraries/dagster-mysql/dagster_mysql_tests/compat_tests/test_back_compat.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql_tests/compat_tests/test_back_compat.py
@@ -11,8 +11,7 @@ from dagster import (
     AssetKey,
     AssetMaterialization,
     AssetObservation,
-    DagsterEventType,
-    EventRecordsFilter,
+    AssetRecordsFilter,
     Output,
     job,
     op,
@@ -289,12 +288,8 @@ def test_add_asset_event_tags_table(backcompat_conn_string):
 
             assert (
                 len(
-                    instance.get_event_records(
-                        EventRecordsFilter(
-                            event_type=DagsterEventType.ASSET_MATERIALIZATION,
-                            asset_key=AssetKey("a"),
-                            tags={"dagster/foo": "bar"},
-                        )
+                    instance.get_materialization_records(
+                        AssetRecordsFilter(asset_key=AssetKey("a"), tags={"dagster/foo": "bar"}),
                     )
                 )
                 == 1
@@ -305,12 +300,10 @@ def test_add_asset_event_tags_table(backcompat_conn_string):
                 instance._event_storage._mysql_version = "8.0.30"
                 assert (
                     len(
-                        instance.get_event_records(
-                            EventRecordsFilter(
-                                event_type=DagsterEventType.ASSET_MATERIALIZATION,
-                                asset_key=AssetKey("a"),
-                                tags={"dagster/foo": "bar"},
-                            )
+                        instance.get_materialization_records(
+                            AssetRecordsFilter(
+                                asset_key=AssetKey("a"), tags={"dagster/foo": "bar"}
+                            ),
                         )
                     )
                     == 1

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
@@ -12,8 +12,7 @@ from dagster import (
     AssetKey,
     AssetMaterialization,
     AssetObservation,
-    DagsterEventType,
-    EventRecordsFilter,
+    AssetRecordsFilter,
     Output,
     job,
     op,
@@ -692,36 +691,30 @@ def test_add_asset_event_tags_table(hostname, conn_string):
 
             assert (
                 len(
-                    instance.get_event_records(
-                        EventRecordsFilter(
-                            event_type=DagsterEventType.ASSET_MATERIALIZATION,
+                    instance.get_materialization_records(
+                        AssetRecordsFilter(
                             asset_key=AssetKey("a"),
                             tags={"dagster/foo": "bar"},
-                        )
+                        ),
                     )
                 )
                 == 1
             )
             assert (
                 len(
-                    instance.get_event_records(
-                        EventRecordsFilter(
-                            event_type=DagsterEventType.ASSET_MATERIALIZATION,
-                            asset_key=AssetKey("a"),
-                            tags={"dagster/foo": "baz"},
-                        )
+                    instance.get_materialization_records(
+                        AssetRecordsFilter(asset_key=AssetKey("a"), tags={"dagster/foo": "baz"}),
                     )
                 )
                 == 0
             )
             assert (
                 len(
-                    instance.get_event_records(
-                        EventRecordsFilter(
-                            event_type=DagsterEventType.ASSET_MATERIALIZATION,
+                    instance.get_materialization_records(
+                        AssetRecordsFilter(
                             asset_key=AssetKey("a"),
                             tags={"dagster/foo": "bar", "other": "otherr"},
-                        )
+                        ),
                     )
                 )
                 == 0
@@ -730,9 +723,8 @@ def test_add_asset_event_tags_table(hostname, conn_string):
             with pytest.raises(
                 DagsterInvalidInvocationError, match="Cannot filter events on tags with a limit"
             ):
-                instance.get_event_records(
-                    EventRecordsFilter(
-                        event_type=DagsterEventType.ASSET_MATERIALIZATION,
+                instance.get_materialization_records(
+                    AssetRecordsFilter(
                         asset_key=AssetKey("a"),
                         tags={"dagster/foo": "bar", "other": "otherr"},
                     ),


### PR DESCRIPTION
## Summary & Motivation
Change internal calls from `get_event_records` => the new set of storage methods.

This should allow us to deprecate the generic get_event_records call, and restrict the set of data that can be queried across runs.

## How I Tested These Changes
BK