### PR TITLE
[graph_asset] derive GraphIns from AssetIns

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -1249,7 +1249,6 @@ def _infer_keys_by_input_names(
     node_def: Union["GraphDefinition", OpDefinition], keys_by_input_name: Mapping[str, AssetKey]
 ) -> Mapping[str, AssetKey]:
     all_input_names = [input_def.name for input_def in node_def.input_defs]
-
     if keys_by_input_name:
         check.invariant(
             set(keys_by_input_name.keys()) == set(all_input_names),

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -42,7 +42,7 @@ from ..backfill_policy import BackfillPolicy, BackfillPolicyType
 from ..decorators.graph_decorator import graph
 from ..decorators.op_decorator import _Op
 from ..events import AssetKey, CoercibleToAssetKey, CoercibleToAssetKeyPrefix
-from ..input import In
+from ..input import GraphIn, In
 from ..output import GraphOut, Out
 from ..partition import PartitionsDefinition
 from ..policy import RetryPolicy
@@ -910,8 +910,12 @@ def graph_asset(
             for input_name, asset_in in ins.items()
             if asset_in.partition_mapping
         }
+
         op_graph = graph(
-            name=out_asset_key.to_python_identifier(), description=description, config=config
+            name=out_asset_key.to_python_identifier(),
+            description=description,
+            config=config,
+            ins={input_name: GraphIn() for _, (input_name, _) in asset_ins.items()},
         )(compose_fn)
         return AssetsDefinition.from_graph(
             op_graph,


### PR DESCRIPTION

motivated by https://discuss.dagster.io/t/14140882/to-reopen-an-ol-discussion-https-dagster-slack-com-archives-#995322e4-83cd-457f-a970-72bcd6b46a66

currently we derive the GraphIns solely from the fn signature, this instead uses the defined `AssetIn` to explicitly declare the `GraphIn`s 

## How I Tested These Changes

added a test
