### PR TITLE
add whitelist_for_serdes to backfill related classes

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/backfill_policy.py
+++ b/python_modules/dagster/dagster/_core/definitions/backfill_policy.py
@@ -3,6 +3,7 @@ from typing import NamedTuple, Optional
 
 import dagster._check as check
 from dagster._annotations import experimental, public
+from dagster._serdes import whitelist_for_serdes
 
 
 class BackfillPolicyType(Enum):
@@ -11,6 +12,7 @@ class BackfillPolicyType(Enum):
 
 
 @experimental
+@whitelist_for_serdes
 class BackfillPolicy(
     NamedTuple(
         "_BackfillPolicy",

--- a/python_modules/dagster/dagster/_core/definitions/selector.py
+++ b/python_modules/dagster/dagster/_core/definitions/selector.py
@@ -311,7 +311,6 @@ class PartitionSetSelector(
         }
 
 
-@whitelist_for_serdes
 class PartitionRangeSelector(
     NamedTuple(
         "_PartitionRangeSelector",
@@ -341,7 +340,6 @@ class PartitionRangeSelector(
         )
 
 
-@whitelist_for_serdes
 class PartitionsSelector(
     NamedTuple(
         "_PartitionsSelector",
@@ -370,7 +368,6 @@ class PartitionsSelector(
         )
 
 
-@whitelist_for_serdes
 class PartitionsByAssetSelector(
     NamedTuple(
         "PartitionsByAssetSelector",

--- a/python_modules/dagster/dagster/_core/definitions/selector.py
+++ b/python_modules/dagster/dagster/_core/definitions/selector.py
@@ -311,6 +311,7 @@ class PartitionSetSelector(
         }
 
 
+@whitelist_for_serdes
 class PartitionRangeSelector(
     NamedTuple(
         "_PartitionRangeSelector",
@@ -340,6 +341,7 @@ class PartitionRangeSelector(
         )
 
 
+@whitelist_for_serdes
 class PartitionsSelector(
     NamedTuple(
         "_PartitionsSelector",
@@ -368,6 +370,7 @@ class PartitionsSelector(
         )
 
 
+@whitelist_for_serdes
 class PartitionsByAssetSelector(
     NamedTuple(
         "PartitionsByAssetSelector",

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
@@ -38,7 +38,7 @@ from dagster._core.host_representation.external_data import (
     external_multi_partitions_definition_from_def,
     external_time_window_partitions_definition_from_def,
 )
-from dagster._serdes.serdes import deserialize_value
+from dagster._serdes import deserialize_value, serialize_value
 from dagster._utils.partitions import DEFAULT_HOURLY_FORMAT_WITHOUT_TIMEZONE
 
 
@@ -117,6 +117,8 @@ def test_asset_with_single_run_backfill_policy():
             backfill_policy=BackfillPolicy.single_run(),
         )
     ]
+
+    deserialize_value(serialize_value(external_asset_nodes[0]), ExternalAssetNode)
 
 
 def test_asset_with_multi_run_backfill_policy():

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
@@ -118,7 +118,10 @@ def test_asset_with_single_run_backfill_policy():
         )
     ]
 
-    deserialize_value(serialize_value(external_asset_nodes[0]), ExternalAssetNode)
+    assert (
+        deserialize_value(serialize_value(external_asset_nodes[0]), ExternalAssetNode)
+        == external_asset_nodes[0]
+    )
 
 
 def test_asset_with_multi_run_backfill_policy():


### PR DESCRIPTION
## Summary & Motivation
Need to whitelist `BackfillPolicy` and classes needed for ranged partition backfill, otherwise, we will get errors like
`dagster._serdes.errors.SerializationError: Can only serialize whitelisted namedtuples, received BackfillPolicy(max_partitions_per_run=None).`
when trying to deploy the user code.

## How I Tested These Changes
No unit test covering this whitelisting feature. 
