### PR TITLE
Add DualStateContextResourcesContainer and apply it to UnboundOpExecutionContext

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/context/dual_state_context.py
+++ b/python_modules/dagster/dagster/_core/execution/context/dual_state_context.py
@@ -1,0 +1,46 @@
+from contextlib import ExitStack
+from typing import Any, Mapping
+
+from dagster._core.definitions.scoped_resources_builder import IContainsGenerator, Resources
+from dagster._core.errors import DagsterInvariantViolationError
+from dagster._core.execution.build_resources import build_resources, wrap_resources_for_execution
+
+
+class DualStateContextResourcesContainer:
+    """We have generalized pattern where we allow users to either directly construct
+    bare contexts or to use them in the context managers. We require that they
+    use context managers when they themselves contain resources that are context
+    managers. Thie results in a complicated, stateful, difficult-to-reason-about
+    message in all of our context objects subject to this pattern where `__enter__`
+    is optionally called, and we must track whether it has been called, and error
+    appropriately when resources are accessed.
+
+    This class exists to comparmentalize this grosteque, stateful pattern to a single
+    point of pain, rather than blithely spreading it throughout the codebase.
+    """
+
+    def __init__(self, resources_dict: Mapping[str, Any]):
+        self._cm_scope_entered = False
+        self._exit_stack = ExitStack()
+        self.resource_defs = wrap_resources_for_execution(resources_dict)
+        self._resources = self._exit_stack.enter_context(build_resources(self.resource_defs))
+        self._resources_contain_cm = isinstance(self._resources, IContainsGenerator)
+
+    def call_on_enter(self) -> None:
+        self._cm_scope_entered = True
+        pass
+
+    def call_on_exit(self) -> None:
+        self._exit_stack.close()
+
+    def call_on_del(self) -> None:
+        self._exit_stack.close()
+
+    def get_resources(self, fn_name_for_err_msg: str) -> Resources:
+        if self._resources_contain_cm and not self._cm_scope_entered:
+            raise DagsterInvariantViolationError(
+                "At least one provided resource is a generator, but attempting to access "
+                "resources outside of context manager scope. You can use the following syntax to "
+                f"open a context manager: `with {fn_name_for_err_msg}(...) as context:`"
+            )
+        return self._resources

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -95,7 +95,9 @@ class UnboundOpExecutionContext(OpExecutionContext):
         self._instance = self._exit_stack.enter_context(ephemeral_instance_if_missing(instance))
 
         self._resources_config = resources_config
-        self._resources_container = DualStateContextResourcesContainer(resources_dict)
+        self._resources_container = DualStateContextResourcesContainer(
+            resources_dict, resources_config
+        )
 
         self._log = initialize_console_manager(None)
         self._pdb: Optional[ForkedPdb] = None

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -280,7 +280,7 @@ class UnboundOpExecutionContext(OpExecutionContext):
                 op_def,
                 pending_invocation,
                 assets_def,
-                self._resources,
+                self.resources,
                 op_config,
                 self._resource_defs,
             )

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -57,6 +57,7 @@ from dagster._utils.forked_pdb import ForkedPdb
 from dagster._utils.merger import merge_dicts
 
 from .compute import OpExecutionContext
+from .dual_state_context import DualStateContextResourcesContainer
 from .system import StepExecutionContext, TypeCheckContext
 
 
@@ -64,9 +65,6 @@ def _property_msg(prop_name: str, method_name: str) -> str:
     return (
         f"The {prop_name} {method_name} is not set on the context when a solid is directly invoked."
     )
-
-
-from .dual_state_context import DualStateContextResourcesContainer
 
 
 class UnboundOpExecutionContext(OpExecutionContext):

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -99,7 +99,6 @@ class UnboundOpExecutionContext(OpExecutionContext):
 
         self._log = initialize_console_manager(None)
         self._pdb: Optional[ForkedPdb] = None
-        self._cm_scope_entered = False
         check.invariant(
             not (partition_key and partition_key_range),
             "Must supply at most one of partition_key or partition_key_range",


### PR DESCRIPTION
## Summary & Motivation

From docblock of DualStateContextResourcesContainer:


We have generalized pattern where we allow users to either directly construct
bare contexts or to use them in the context managers. We require that they
use context managers when they themselves contain resources that are context
managers. Thie results in a complicated, stateful, difficult-to-reason-about
message in all of our context objects subject to this pattern where `__enter__`
is optionally called, and we must track whether it has been called, and error
appropriately when resources are accessed.

This class exists to comparmentalize this grosteque, stateful pattern to a single
point of pain, rather than blithely spreading it throughout the codebase.

## How I Tested These Changes

BK
