### PR TITLE
[ui] Address significant (20s+) wait when opening Materialize modal

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/usePartitionHealthData.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/usePartitionHealthData.tsx
@@ -101,7 +101,7 @@ export function buildPartitionHealthData(data: PartitionHealthQuery, loadKey: As
   const ranges = addKeyIndexesToMaterializedRanges(dimensions, assetPartitionStatuses);
 
   const stateForKey = (dimensionKeys: string[]): AssetPartitionStatus => {
-    if (dimensionKeys.length !== dimensions.length) {
+    if (dimensionKeys.length !== __dims.length) {
       warnUnlessTest('[stateForKey] called with incorrect number of dimensions');
       return AssetPartitionStatus.MISSING;
     }
@@ -109,9 +109,7 @@ export function buildPartitionHealthData(data: PartitionHealthQuery, loadKey: As
       warnUnlessTest('[stateForKey] called with zero dimension keys');
       return AssetPartitionStatus.MISSING;
     }
-    return stateForKeyIdx(
-      dimensionKeys.map((key, idx) => dimensions[idx]!.partitionKeys.indexOf(key)),
-    );
+    return stateForKeyIdx(dimensionKeys.map((key, idx) => __dims[idx]!.partitionKeys.indexOf(key)));
   };
 
   const stateForKeyIdx = (dIndexes: number[]): AssetPartitionStatus => {

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/AssetJobPartitionsView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/AssetJobPartitionsView.tsx
@@ -55,7 +55,7 @@ export const AssetJobPartitionsView: React.FC<{
 
     return {
       merged,
-      total: keyCountInSelections.length,
+      total: keyCountInSelections(selection),
       missing: missing.length,
     };
   }, [assetHealth]);

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/AssetJobPartitionsView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/AssetJobPartitionsView.tsx
@@ -6,10 +6,10 @@ import {AssetPartitionStatus} from '../assets/AssetPartitionStatus';
 import {LaunchAssetExecutionButton} from '../assets/LaunchAssetExecutionButton';
 import {
   mergedAssetHealth,
-  explodePartitionKeysInSelection,
+  explodePartitionKeysInSelectionMatching,
   isTimeseriesDimension,
 } from '../assets/MultipartitioningSupport';
-import {usePartitionHealthData} from '../assets/usePartitionHealthData';
+import {keyCountInSelections, usePartitionHealthData} from '../assets/usePartitionHealthData';
 import {RepositorySelector} from '../graphql/types';
 import {DagsterTag} from '../runs/RunTag';
 import {repoAddressToSelector} from '../workspace/repoAddressToSelector';
@@ -49,12 +49,14 @@ export const AssetJobPartitionsView: React.FC<{
       selectedRanges: [allPartitionsRange(d)],
       dimension: d,
     }));
-    const allKeys = explodePartitionKeysInSelection(selection, merged.stateForKey);
+    const missing = explodePartitionKeysInSelectionMatching(selection, (dIdxs) =>
+      merged.stateForKeyIdx(dIdxs).includes(AssetPartitionStatus.MISSING),
+    );
 
     return {
       merged,
-      total: allKeys.length,
-      missing: allKeys.filter((p) => p.state.includes(AssetPartitionStatus.MISSING)).length,
+      total: keyCountInSelections.length,
+      missing: missing.length,
     };
   }, [assetHealth]);
 

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/SpanRepresentation.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/SpanRepresentation.tsx
@@ -64,7 +64,9 @@ export function spanTextToSelectionsOrError(
       if (allStartIdx === -1 || allEndIdx === -1) {
         return new Error(`Could not find partitions for provided range: ${start}...${end}`);
       }
-      result.selectedKeys.push(...allPartitionKeys.slice(allStartIdx, allEndIdx + 1));
+      result.selectedKeys = result.selectedKeys.concat(
+        allPartitionKeys.slice(allStartIdx, allEndIdx + 1),
+      );
       result.selectedRanges.push({
         start: {idx: allStartIdx, key: allPartitionKeys[allStartIdx]!},
         end: {idx: allEndIdx, key: allPartitionKeys[allEndIdx]!},
@@ -74,7 +76,7 @@ export function spanTextToSelectionsOrError(
 
       let start = -1;
       const close = (end: number) => {
-        result.selectedKeys.push(...allPartitionKeys.slice(start, end + 1));
+        result.selectedKeys = result.selectedKeys.concat(allPartitionKeys.slice(start, end + 1));
         result.selectedRanges.push({
           start: {idx: start, key: allPartitionKeys[start]!},
           end: {idx: end, key: allPartitionKeys[end]!},


### PR DESCRIPTION
## Summary & Motivation

Before vs After loom! https://www.loom.com/share/98e9ef0a95ff4f15b05a9a3feed08704

This PR speeds up the rendering of the "Choose Partitions" modal in a few ways:

1) When the `usePartitionHealthData` hook is told it can refresh in the background as partitions or partition data changes, it attempts to populate on mount using data from the Apollo cache. This means that on the Asset partitions page, which shows the health bar, clicking Materialize doesn't re-fetch the partition health all over again from scratch before you can do anything.

2) A new helper (`keyCountInSelections`) optimizes a few code paths that need the COUNT of selected partitions only, and were previously building a huge array to call .length.

3) The Choose Partition modal was using an extremely inefficient strategy to filter for "failed and missing only", which iterated over the selected partition keys and called through to code that ran an `indexOf(key)` each time (even though the keys were checked sequentially) and even worse, it was running the logic to do so even when the checkbox was unchecked. I exposed a new getter that takes the key indexes to remove the indexOf. This takes it from O(large^2) to O(large) and is way faster.

Some of this code is still `O(dimension1 * dimension2 * range count)` for 2D assets which is **_not great_**, but with these fixes applied it is sufficiently fast for a 200k partition key set and a similar ~50 x 5000 partition key set. There are two primary reasons this code is so messy. A) it supports multi-selection of assets (where partition health ranges are unioned and there can be >1 status per partition), and B) our system does not send down MISSING ranges. ("Missing" is the absence of a range).

I think the latter could be changed fairly easily and would help to clean up some of this a fair bit. "Failed ranges + anywhere there isn't a range in this 2d space" is hard to get right and requires merging the results. (See `AssetPartitions.tsx::dimensionKeysInSelection`)

## How I Tested These Changes

We thankfully have extensive test coverage of all this! I also took screenshots of the UI before and after these changes to verify I see the same things for all my test assets.
