### PR TITLE
Change schedule context to use DualStateContextResourcesContainer

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
@@ -234,8 +234,8 @@ class ScheduleEvaluationContext:
         """Mapping of resource key to resource definition to be made available
         during schedule execution.
         """
-        if self._resources_container.has_resources:
-            return self._resources_container.get_resources()
+        if self._resources_container.has_been_accessed:
+            return self._resources_container.get_already_accessed_resources()
 
         instance = self.instance if self._instance or self._instance_ref else None
         return self._resources_container.make_resources("build_schedule_context", instance=instance)

--- a/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
@@ -234,7 +234,8 @@ class ScheduleEvaluationContext:
         """Mapping of resource key to resource definition to be made available
         during schedule execution.
         """
-        return self._resources_container.get_resources("build_schedule_context")
+        instance = self.instance if self._instance or self._instance_ref else None
+        return self._resources_container.get_resources("build_schedule_context", instance=instance)
 
     def merge_resources(self, resources_dict: Mapping[str, Any]) -> "ScheduleEvaluationContext":
         """Merge the specified resources into this context.

--- a/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
@@ -248,7 +248,7 @@ class ScheduleEvaluationContext:
             resources_dict (Mapping[str, Any]): The resources to replace in the context.
         """
         check.invariant(
-            not self._resources_container.has_been_accessed,
+            not self._resources_container.cm_scope_entered,
             "Cannot merge resources in context that has been initialized.",
         )
         from dagster._core.execution.build_resources import wrap_resources_for_execution

--- a/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
@@ -27,7 +27,8 @@ import dagster._check as check
 from dagster._annotations import deprecated, deprecated_param, public
 from dagster._core.definitions.instigation_logger import InstigationLogger
 from dagster._core.definitions.resource_annotation import get_resource_args
-from dagster._core.definitions.scoped_resources_builder import Resources, ScopedResourcesBuilder
+from dagster._core.definitions.scoped_resources_builder import Resources
+from dagster._core.execution.context.dual_state_context import DualStateContextResourcesContainer
 from dagster._serdes import whitelist_for_serdes
 from dagster._utils import IHasInternalInit, ensure_gen
 from dagster._utils.merger import merge_dicts
@@ -44,7 +45,6 @@ from ..errors import (
 from ..instance import DagsterInstance
 from ..instance.ref import InstanceRef
 from ..storage.dagster_run import DagsterRun
-from dagster._core.execution.context.dual_state_context import DualStateContextResourcesContainer
 from .graph_definition import GraphDefinition
 from .job_definition import JobDefinition
 from .run_request import RunRequest, SkipReason

--- a/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
@@ -234,8 +234,11 @@ class ScheduleEvaluationContext:
         """Mapping of resource key to resource definition to be made available
         during schedule execution.
         """
+        if self._resources_container.has_resources:
+            return self._resources_container.get_resources()
+
         instance = self.instance if self._instance or self._instance_ref else None
-        return self._resources_container.get_resources("build_schedule_context", instance=instance)
+        return self._resources_container.make_resources("build_schedule_context", instance=instance)
 
     def merge_resources(self, resources_dict: Mapping[str, Any]) -> "ScheduleEvaluationContext":
         """Merge the specified resources into this context.

--- a/python_modules/dagster/dagster/_core/execution/context/dual_state_context.py
+++ b/python_modules/dagster/dagster/_core/execution/context/dual_state_context.py
@@ -1,13 +1,13 @@
 from contextlib import ExitStack
 from typing import TYPE_CHECKING, Any, Mapping, Optional, Union
 
+from dagster import _check as check
 from dagster._core.definitions.scoped_resources_builder import (
     IContainsGenerator,
     Resources,
     ScopedResourcesBuilder,
 )
 from dagster._core.errors import DagsterInvariantViolationError
-from dagster import _check as check
 
 if TYPE_CHECKING:
     from dagster._core.instance import DagsterInstance

--- a/python_modules/dagster/dagster/_core/execution/context/dual_state_context.py
+++ b/python_modules/dagster/dagster/_core/execution/context/dual_state_context.py
@@ -57,7 +57,9 @@ class DualStateContextResourcesContainer:
     def has_been_accessed(self) -> bool:
         return self._resources is not None
 
-    def get_resources(self, fn_name_for_err_msg: str) -> Resources:
+    def get_resources(
+        self, fn_name_for_err_msg: str, instance: Optional["DagsterInstance"]
+    ) -> Resources:
         if self._resources:
             return self._resources
 
@@ -76,7 +78,9 @@ class DualStateContextResourcesContainer:
         from dagster._core.execution.build_resources import build_resources
 
         self._resources = self._exit_stack.enter_context(
-            build_resources(self.resource_defs, resource_config=self._resources_config)
+            build_resources(
+                self.resource_defs, resource_config=self._resources_config, instance=instance
+            )
         )
         resources_contain_cm = isinstance(self._resources, IContainsGenerator)
 

--- a/python_modules/dagster/dagster/_core/execution/context/dual_state_context.py
+++ b/python_modules/dagster/dagster/_core/execution/context/dual_state_context.py
@@ -58,14 +58,12 @@ class DualStateContextResourcesContainer:
     def call_on_del(self) -> None:
         self._exit_stack.close()
 
+    @property
     def has_been_accessed(self) -> bool:
-        return self._resources is not None
-
-    def has_resources(self) -> bool:
         return bool(self._resources)
 
-    def get_resources(self) -> Resources:
-        assert self.has_resources
+    def get_already_accessed_resources(self) -> Resources:
+        check.invariant(self.has_been_accessed)
         return check.not_none(self._resources)
 
     def make_resources(

--- a/python_modules/dagster/dagster/_core/execution/context/dual_state_context.py
+++ b/python_modules/dagster/dagster/_core/execution/context/dual_state_context.py
@@ -31,7 +31,7 @@ class DualStateContextResourcesContainer:
         resources_dict_or_resources_obj: Optional[Union[Mapping[str, Any], Resources]],
         resources_config: Optional[Mapping[str, Any]] = None,
     ):
-        self._cm_scope_entered = False
+        self.cm_scope_entered = False
         self._exit_stack = ExitStack()
         self._resources_config = resources_config
 
@@ -49,7 +49,7 @@ class DualStateContextResourcesContainer:
                 self._resources = ScopedResourcesBuilder.build_empty()
 
     def call_on_enter(self) -> None:
-        self._cm_scope_entered = True
+        self.cm_scope_entered = True
 
     def call_on_exit(self) -> None:
         self._exit_stack.close()

--- a/python_modules/dagster/dagster/_core/execution/context/dual_state_context.py
+++ b/python_modules/dagster/dagster/_core/execution/context/dual_state_context.py
@@ -59,7 +59,7 @@ class DualStateContextResourcesContainer:
 
     @property
     def has_been_accessed(self) -> bool:
-        return bool(self._resources)
+        return isinstance(self._resources, Resources)
 
     def get_already_accessed_resources(self) -> Resources:
         check.invariant(self.has_been_accessed)

--- a/python_modules/dagster/dagster/_core/execution/context/dual_state_context.py
+++ b/python_modules/dagster/dagster/_core/execution/context/dual_state_context.py
@@ -58,7 +58,7 @@ class DualStateContextResourcesContainer:
         return self._resources is not None
 
     def get_resources(
-        self, fn_name_for_err_msg: str, instance: Optional["DagsterInstance"]
+        self, fn_name_for_err_msg: str, instance: Optional["DagsterInstance"] = None
     ) -> Resources:
         if self._resources:
             return self._resources

--- a/python_modules/dagster/dagster/_core/execution/context/dual_state_context.py
+++ b/python_modules/dagster/dagster/_core/execution/context/dual_state_context.py
@@ -1,9 +1,15 @@
 from contextlib import ExitStack
-from typing import Any, Mapping, Optional, Union
+from typing import TYPE_CHECKING, Any, Mapping, Optional, Union
 
-from dagster._core.definitions.scoped_resources_builder import IContainsGenerator, Resources
+from dagster._core.definitions.scoped_resources_builder import (
+    IContainsGenerator,
+    Resources,
+    ScopedResourcesBuilder,
+)
 from dagster._core.errors import DagsterInvariantViolationError
-from dagster._core.instance import DagsterInstance
+
+if TYPE_CHECKING:
+    from dagster._core.instance import DagsterInstance
 
 
 class DualStateContextResourcesContainer:
@@ -26,22 +32,18 @@ class DualStateContextResourcesContainer:
     ):
         self._cm_scope_entered = False
         self._exit_stack = ExitStack()
+        self._resources_config = resources_config
 
         if isinstance(resources_dict_or_resources_obj, Resources):
             self.resource_defs = {}
             self._resources = resources_dict_or_resources_obj
-            self._resources_contain_cm = False
         else:
             from dagster._core.execution.build_resources import (
-                build_resources,
                 wrap_resources_for_execution,
             )
 
+            self._resources = None
             self.resource_defs = wrap_resources_for_execution(resources_dict_or_resources_obj)
-            self._resources = self._exit_stack.enter_context(
-                build_resources(self.resource_defs, resource_config=resources_config)
-            )
-            self._resources_contain_cm = isinstance(self._resources, IContainsGenerator)
 
     def call_on_enter(self) -> None:
         self._cm_scope_entered = True
@@ -52,8 +54,33 @@ class DualStateContextResourcesContainer:
     def call_on_del(self) -> None:
         self._exit_stack.close()
 
+    def has_been_accessed(self) -> bool:
+        return self._resources is not None
+
     def get_resources(self, fn_name_for_err_msg: str) -> Resources:
-        if self._resources_contain_cm and not self._cm_scope_entered:
+        if self._resources:
+            return self._resources
+
+        # Early exit if no resources are defined. This skips unnecessary initialization
+        # entirely. This allows users to run user code servers in cases where they
+        # do not have access to the instance if they use a subset of features do
+        # that do not require instance access. In this case, if they do not use
+        # resources on schedules they do not require the instance, so we do not
+        # instantiate it
+        #
+        # Tracking at https://github.com/dagster-io/dagster/issues/14345
+        if not self.resource_defs:
+            self._resources = ScopedResourcesBuilder.build_empty()
+            return self._resources
+
+        from dagster._core.execution.build_resources import build_resources
+
+        self._resources = self._exit_stack.enter_context(
+            build_resources(self.resource_defs, resource_config=self._resources_config)
+        )
+        resources_contain_cm = isinstance(self._resources, IContainsGenerator)
+
+        if resources_contain_cm and not self._cm_scope_entered:
             raise DagsterInvariantViolationError(
                 "At least one provided resource is a generator, but attempting to access "
                 "resources outside of context manager scope. You can use the following syntax to "
@@ -63,7 +90,7 @@ class DualStateContextResourcesContainer:
 
 
 class DualStateInstanceContainer:
-    def __init__(self, instance: Optional[DagsterInstance]):
+    def __init__(self, instance: Optional["DagsterInstance"]):
         from dagster._core.execution.api import ephemeral_instance_if_missing
 
         self._exit_stack = ExitStack()

--- a/python_modules/dagster/dagster/_core/execution/context/dual_state_context.py
+++ b/python_modules/dagster/dagster/_core/execution/context/dual_state_context.py
@@ -45,9 +45,8 @@ class DualStateContextResourcesContainer:
 
             self._resources = None
             self.resource_defs = wrap_resources_for_execution(resources_dict_or_resources_obj)
-
-        if not self.resource_defs:
-            self._resources = ScopedResourcesBuilder.build_empty()
+            if not self.resource_defs:
+                self._resources = ScopedResourcesBuilder.build_empty()
 
     def call_on_enter(self) -> None:
         self._cm_scope_entered = True

--- a/python_modules/dagster/dagster/_core/execution/context/hook.py
+++ b/python_modules/dagster/dagster/_core/execution/context/hook.py
@@ -267,7 +267,7 @@ class UnboundHookContext(HookContext):
 
     @property
     def resources(self) -> "Resources":
-        return self._resources_container.get_resources("build_hook_context")
+        return self._resources_container.make_resources("build_hook_context")
 
     @property
     def solid_config(self) -> Any:

--- a/python_modules/dagster/dagster/_core/execution/context/init.py
+++ b/python_modules/dagster/dagster/_core/execution/context/init.py
@@ -172,7 +172,7 @@ class UnboundInitResourceContext(InitResourceContext):
     @property
     def resources(self) -> Resources:
         """The resources that are available to the resource that we are initalizing."""
-        return self._resources_container.get_resources("build_init_resource_context")
+        return self._resources_container.make_resources("build_init_resource_context")
 
     @property
     def instance(self) -> Optional[DagsterInstance]:

--- a/python_modules/dagster/dagster/_core/execution/context/input.py
+++ b/python_modules/dagster/dagster/_core/execution/context/input.py
@@ -232,7 +232,7 @@ class InputContext:
                 "but it was not provided when constructing the InputContext"
             )
 
-        return self._resources_container.get_resources("build_input_context")
+        return self._resources_container.make_resources("build_input_context")
 
     @public
     @property

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -134,7 +134,7 @@ class UnboundOpExecutionContext(OpExecutionContext):
 
     @property
     def resources(self) -> Resources:
-        return self._resources_container.get_resources("build_op_context")
+        return self._resources_container.make_resources("build_op_context")
 
     @property
     def dagster_run(self) -> DagsterRun:

--- a/python_modules/dagster/dagster/_core/execution/context/output.py
+++ b/python_modules/dagster/dagster/_core/execution/context/output.py
@@ -269,7 +269,7 @@ class OutputContext:
                 "but it was not provided when constructing the OutputContext"
             )
 
-        return self._resources_container.get_resources("build_output_context")
+        return self._resources_container.make_resources("build_output_context")
 
     @property
     def asset_info(self) -> Optional[AssetOutputInfo]:

--- a/python_modules/dagster/dagster_tests/core_tests/test_op_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_op_invocation.py
@@ -1037,9 +1037,12 @@ def test_build_context_with_resources_config(context_builder):
         DagsterInvalidConfigError,
         match='Received unexpected config entry "bad_resource" at the root.',
     ):
-        context_builder(
-            resources={"my_resource": my_resource},
-            resources_config={"bad_resource": {"config": "foo"}},
+        # behavior change to deferred config eval
+        my_op(
+            context_builder(
+                resources={"my_resource": my_resource},
+                resources_config={"bad_resource": {"config": "foo"}},
+            )
         )
 
 


### PR DESCRIPTION
## Summary & Motivation

Change Schedule context to use DualStateContextResourcesContainer

This also changes DualStateContextResourcesContainer to defer construction of
resources to the accessor to match the behavior in contexts used in the daemon

## How I Tested These Changes

BK
