### PR TITLE
asset check sql

### DIFF
--- a/python_modules/dagster/dagster/_core/events/__init__.py
+++ b/python_modules/dagster/dagster/_core/events/__init__.py
@@ -80,6 +80,7 @@ EventSpecificData = Union[
     "AssetObservationData",
     "AssetMaterializationPlannedData",
     "AssetCheckEvaluation",
+    "AssetCheckEvaluationPlanned",
 ]
 
 

--- a/python_modules/dagster/dagster/_core/events/__init__.py
+++ b/python_modules/dagster/dagster/_core/events/__init__.py
@@ -242,6 +242,11 @@ ASSET_EVENTS = {
     DagsterEventType.ASSET_MATERIALIZATION_PLANNED,
 }
 
+ASSET_CHECK_EVENTS = {
+    DagsterEventType.ASSET_CHECK_EVALUATION,
+    DagsterEventType.ASSET_CHECK_EVALUATION_PLANNED,
+}
+
 
 def _assert_type(
     method: str,

--- a/python_modules/dagster/dagster/_core/storage/asset_check_execution_record.py
+++ b/python_modules/dagster/dagster/_core/storage/asset_check_execution_record.py
@@ -1,0 +1,18 @@
+import enum
+from typing import NamedTuple, Optional
+
+from dagster import EventLogEntry
+
+
+class AssetCheckExecutionStatus(enum.Enum):
+    PLANNED = "PLANNED"
+    SUCCESS = "SUCCESS"
+    FAILURE = "FAILURE"
+
+
+class AssetCheckExecutionRecord(NamedTuple):
+    id: int
+    run_id: str
+    status: AssetCheckExecutionStatus
+    evaluation_event: Optional[EventLogEntry]
+    create_timestamp: float

--- a/python_modules/dagster/dagster/_core/storage/asset_check_record.py
+++ b/python_modules/dagster/dagster/_core/storage/asset_check_record.py
@@ -1,7 +1,0 @@
-import enum
-
-
-class AssetCheckStatus(enum.Enum):
-    PLANNED = "PLANNED"
-    SUCCESS = "SUCCESS"
-    FAILURE = "FAILURE"

--- a/python_modules/dagster/dagster/_core/storage/asset_check_record.py
+++ b/python_modules/dagster/dagster/_core/storage/asset_check_record.py
@@ -1,0 +1,7 @@
+import enum
+
+
+class AssetCheckStatus(enum.Enum):
+    PLANNED = "PLANNED"
+    SUCCESS = "SUCCESS"
+    FAILURE = "FAILURE"

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -24,6 +24,7 @@ from dagster._core.execution.stats import (
     build_run_step_stats_from_events,
 )
 from dagster._core.instance import MayHaveInstanceWeakref, T_DagsterInstance
+from dagster._core.storage.asset_check_execution_record import AssetCheckExecutionRecord
 from dagster._core.storage.dagster_run import DagsterRunStatsSnapshot
 from dagster._core.storage.sql import AlembicVersion
 from dagster._seven import json
@@ -483,4 +484,19 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
     @abstractmethod
     def free_concurrency_slot_for_step(self, run_id: str, step_key: str) -> None:
         """Frees concurrency slots for a given run/step."""
+        raise NotImplementedError()
+
+    def get_asset_check_executions(
+        self,
+        asset_key: AssetKey,
+        check_name: str,
+        limit: int,
+        cursor: Optional[int] = None,
+        materialization_event_storage_id: Optional[int] = None,
+        include_planned: bool = True,
+    ) -> Sequence[AssetCheckExecutionRecord]:
+        """Get the executions for an asset check, sorted by recency. If materialization_event_storage_id
+        is set and include_planned is True, the returned Sequence will include executions that are planned
+        but do not have a target materialization yet (since we don't set the target until the check is executed).
+        """
         raise NotImplementedError()

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -18,6 +18,11 @@ from typing import (
     Union,
     cast,
 )
+from dagster._core.definitions.asset_check_evaluation import (
+    AssetCheckEvaluation,
+    AssetCheckEvaluationPlanned,
+)
+from dagster._core.storage.asset_check_record import AssetCheckStatus
 
 import pendulum
 import sqlalchemy as db
@@ -35,7 +40,7 @@ from dagster._core.errors import (
     DagsterInvariantViolationError,
 )
 from dagster._core.event_api import RunShardedEventsCursor
-from dagster._core.events import ASSET_EVENTS, MARKER_EVENTS, DagsterEventType
+from dagster._core.events import ASSET_CHECK_EVENTS, ASSET_EVENTS, MARKER_EVENTS, DagsterEventType
 from dagster._core.events.log import EventLogEntry
 from dagster._core.execution.stats import RunStepKeyStatsSnapshot, build_run_step_stats_from_events
 from dagster._core.storage.sql import SqlAlchemyQuery, SqlAlchemyRow
@@ -74,6 +79,7 @@ from .base import (
 )
 from .migration import ASSET_DATA_MIGRATIONS, ASSET_KEY_INDEX_COLS, EVENT_LOG_DATA_MIGRATIONS
 from .schema import (
+    AssetCheckExecutionsTable,
     AssetEventTagsTable,
     AssetKeyTable,
     ConcurrencySlotsTable,
@@ -400,6 +406,9 @@ class SqlEventLogStorage(EventLogStorage):
                 )
 
             self.store_asset_event_tags(event, event_id)
+
+        if event.is_dagster_event and event.dagster_event_type in ASSET_CHECK_EVENTS:
+            self.store_asset_check_event(event, event_id)
 
     def get_records_for_run(
         self,
@@ -2459,6 +2468,58 @@ class SqlEventLogStorage(EventLogStorage):
 
             # return the concurrency keys for the freed slots
             return [cast(str, row[1]) for row in rows]
+
+    def store_asset_check_event(self, event: EventLogEntry, event_id: int) -> None:
+        check.inst_param(event, "event", EventLogEntry)
+        check.int_param(event_id, "event_id")
+
+        if event.dagster_event_type == DagsterEventType.ASSET_CHECK_EVALUATION_PLANNED:
+            self._store_asset_check_evaluation_planned(event, event_id)
+        if event.dagster_event_type == DagsterEventType.ASSET_CHECK_EVALUATION:
+            self._update_asset_check_evaluation(event, event_id)
+
+    def _store_asset_check_evaluation_planned(self, event: EventLogEntry, event_id: int) -> None:
+        planned = cast(
+            AssetCheckEvaluationPlanned, check.not_none(event.dagster_event).event_specific_data
+        )
+        with self.index_connection() as conn:
+            conn.execute(
+                AssetCheckExecutionsTable.insert().values(
+                    asset_key=planned.asset_key.to_string(),
+                    check_name=planned.check_name,
+                    run_id=event.run_id,
+                    status=AssetCheckStatus.PLANNED,
+                )
+            )
+
+    def _update_asset_check_evaluation(self, event: EventLogEntry, event_id: int) -> None:
+        evaluation = cast(
+            AssetCheckEvaluation, check.not_none(event.dagster_event).event_specific_data
+        )
+        with self.index_connection() as conn:
+            conn.execute(
+                AssetCheckExecutionsTable.update()
+                .where(
+                    db.and_(
+                        AssetCheckExecutionsTable.c.asset_key == evaluation.asset_key.to_string(),
+                        AssetCheckExecutionsTable.c.check_name == evaluation.check_name,
+                        AssetCheckExecutionsTable.c.run_id == event.run_id,
+                    )
+                )
+                .values(
+                    execution_status=(
+                        AssetCheckStatus.SUCCESS if evaluation.success else AssetCheckStatus.FAILURE
+                    ),
+                    asset_check_evaluation_event_record=serialize_value(event),
+                    asset_check_evaluation_event_timestamp=event.timestamp,
+                    asset_check_evaluation_event_storage_id=event_id,
+                    materialization_event_storage_id=(
+                        evaluation.target_materialization_data.storage_id
+                        if evaluation.target_materialization_data
+                        else None
+                    ),
+                )
+            )
 
 
 def _get_from_row(row: SqlAlchemyRow, column: str) -> object:

--- a/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
@@ -25,7 +25,7 @@ from dagster._config.config_schema import UserConfigSchema
 from dagster._core.definitions.events import AssetKey
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.event_api import EventHandlerFn
-from dagster._core.events import ASSET_EVENTS
+from dagster._core.events import ASSET_CHECK_EVENTS, ASSET_EVENTS
 from dagster._core.events.log import EventLogEntry
 from dagster._core.storage.dagster_run import DagsterRunStatus, RunsFilter
 from dagster._core.storage.event_log.base import EventLogCursor, EventLogRecord, EventRecordsFilter
@@ -259,6 +259,9 @@ class SqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
                 )
 
             self.store_asset_event_tags(event, event_id)
+
+        if event.is_dagster_event and event.dagster_event_type in ASSET_CHECK_EVENTS:
+            self.store_asset_check_event(event, None)
 
     def get_event_records(
         self,

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -14,7 +14,11 @@ from dagster import (
 )
 from dagster._config.config_schema import UserConfigSchema
 from dagster._core.definitions.auto_materialize_rule import AutoMaterializeAssetEvaluation
+from dagster._core.definitions.events import AssetKey
 from dagster._core.event_api import EventHandlerFn
+from dagster._core.storage.asset_check_execution_record import (
+    AssetCheckExecutionRecord,
+)
 from dagster._serdes import ConfigurableClass, ConfigurableClassData
 from dagster._utils import PrintFn
 from dagster._utils.concurrency import ConcurrencyClaimStatus, ConcurrencyKeyInfo
@@ -31,7 +35,6 @@ from .runs.base import RunStorage
 from .schedules.base import ScheduleStorage
 
 if TYPE_CHECKING:
-    from dagster._core.definitions.events import AssetKey
     from dagster._core.definitions.run_request import InstigatorType
     from dagster._core.events import DagsterEvent, DagsterEventType
     from dagster._core.events.log import EventLogEntry
@@ -593,6 +596,24 @@ class LegacyEventLogStorage(EventLogStorage, ConfigurableClass):
 
     def free_concurrency_slot_for_step(self, run_id: str, step_key: str) -> None:
         return self._storage.event_log_storage.free_concurrency_slot_for_step(run_id, step_key)
+
+    def get_asset_check_executions(
+        self,
+        asset_key: AssetKey,
+        check_name: str,
+        limit: int,
+        cursor: Optional[int] = None,
+        materialization_event_storage_id: Optional[int] = None,
+        include_planned: bool = True,
+    ) -> Sequence[AssetCheckExecutionRecord]:
+        return self._storage.event_log_storage.get_asset_check_executions(
+            asset_key=asset_key,
+            check_name=check_name,
+            limit=limit,
+            cursor=cursor,
+            materialization_event_storage_id=materialization_event_storage_id,
+            include_planned=include_planned,
+        )
 
 
 class LegacyScheduleStorage(ScheduleStorage, ConfigurableClass):

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -35,6 +35,11 @@ from dagster import (
 )
 from dagster._core.assets import AssetDetails
 from dagster._core.definitions import ExpectationResult
+from dagster._core.definitions.asset_check_evaluation import (
+    AssetCheckEvaluation,
+    AssetCheckEvaluationPlanned,
+    AssetCheckEvaluationTargetMaterializationData,
+)
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.dependency import NodeHandle
 from dagster._core.definitions.job_base import InMemoryJob
@@ -60,6 +65,9 @@ from dagster._core.host_representation.origin import (
     ExternalJobOrigin,
     ExternalRepositoryOrigin,
     InProcessCodeLocationOrigin,
+)
+from dagster._core.storage.asset_check_execution_record import (
+    AssetCheckExecutionStatus,
 )
 from dagster._core.storage.event_log import InMemoryEventLogStorage, SqlEventLogStorage
 from dagster._core.storage.event_log.base import EventLogStorage
@@ -3898,3 +3906,88 @@ class TestEventLogStorage:
             assert foo_info.assigned_step_count == 0
 
             assert all(f.done() for f in futures)
+
+    def test_asset_checks(self, storage):
+        if self.can_wipe():
+            storage.wipe()
+
+        storage.store_event(
+            EventLogEntry(
+                error_info=None,
+                user_message="",
+                level="debug",
+                run_id="foo",
+                timestamp=time.time(),
+                dagster_event=DagsterEvent(
+                    DagsterEventType.ASSET_CHECK_EVALUATION_PLANNED.value,
+                    "nonce",
+                    event_specific_data=AssetCheckEvaluationPlanned(
+                        asset_key=AssetKey(["my_asset"]), check_name="my_check"
+                    ),
+                ),
+            )
+        )
+
+        checks = storage.get_asset_check_executions(AssetKey(["my_asset"]), "my_check", limit=10)
+        assert len(checks) == 1
+        assert checks[0].status == AssetCheckExecutionStatus.PLANNED
+        assert checks[0].run_id == "foo"
+
+        checks = storage.get_asset_check_executions(
+            AssetKey(["my_asset"]), "my_check", limit=10, include_planned=False
+        )
+        assert len(checks) == 0
+
+        checks = storage.get_asset_check_executions(
+            AssetKey(["my_asset"]), "my_check", limit=10, materialization_event_storage_id=123
+        )
+        assert len(checks) == 1
+
+        # update the planned check
+        storage.store_event(
+            EventLogEntry(
+                error_info=None,
+                user_message="",
+                level="debug",
+                run_id="foo",
+                timestamp=time.time(),
+                dagster_event=DagsterEvent(
+                    DagsterEventType.ASSET_CHECK_EVALUATION.value,
+                    "nonce",
+                    event_specific_data=AssetCheckEvaluation(
+                        asset_key=AssetKey(["my_asset"]),
+                        check_name="my_check",
+                        success=True,
+                        metadata={},
+                        target_materialization_data=AssetCheckEvaluationTargetMaterializationData(
+                            storage_id=42, run_id="bizbuz", timestamp=3.3
+                        ),
+                    ),
+                ),
+            )
+        )
+
+        checks = storage.get_asset_check_executions(AssetKey(["my_asset"]), "my_check", limit=10)
+        assert len(checks) == 1
+        assert checks[0].status == AssetCheckExecutionStatus.SUCCESS
+        assert (
+            checks[
+                0
+            ].evaluation_event.dagster_event.event_specific_data.target_materialization_data.storage_id
+            == 42
+        )
+
+        checks = storage.get_asset_check_executions(
+            AssetKey(["my_asset"]), "my_check", limit=10, include_planned=False
+        )
+        assert len(checks) == 1
+
+        checks = storage.get_asset_check_executions(
+            AssetKey(["my_asset"]), "my_check", limit=10, materialization_event_storage_id=123
+        )
+        assert len(checks) == 0
+
+        checks = storage.get_asset_check_executions(
+            AssetKey(["my_asset"]), "my_check", limit=10, materialization_event_storage_id=42
+        )
+        assert len(checks) == 1

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
@@ -7,7 +7,7 @@ import sqlalchemy.pool as db_pool
 from dagster._config.config_schema import UserConfigSchema
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.event_api import EventHandlerFn
-from dagster._core.events import ASSET_EVENTS
+from dagster._core.events import ASSET_CHECK_EVENTS, ASSET_EVENTS
 from dagster._core.events.log import EventLogEntry
 from dagster._core.storage.config import pg_config
 from dagster._core.storage.event_log import (
@@ -202,6 +202,9 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
                 )
 
             self.store_asset_event_tags(event, event_id)
+
+        if event.is_dagster_event and event.dagster_event_type in ASSET_CHECK_EVENTS:
+            self.store_asset_check_event(event, event_id)
 
     def store_asset_event(self, event: EventLogEntry, event_id: int) -> None:
         check.inst_param(event, "event", EventLogEntry)


### PR DESCRIPTION
Now we write to the `asset_check_executions` from store_event calls, and read from the table with `get_asset_check_executions(...)`.

### The write flow:

- check run is launched
- we write an ASSET_CHECK_EVALUATION_PLANNED event
- when we store that event, we create a row in the `asset_check_executions` table with PLANNED status
- ...
- the check executes and emits a result
- we write an ASSET_CHECK_EVALUATION event. This includes the id of the latest materialization event for the asset, which is the materialization that the check targeted.
- when we store that event, we update the row we created earlier (identified using [asset key, check name, run id]) and store:
  - the new SUCCESS/FAIL status
  - the serialized ASSET_CHECK_EVALUATION event, plus its id and timestamp
  - the target materialization info

### The read queries for our UI plans:

#### History for a check: 

```python
get_asset_check_executions(
  asset_key,
  check_name,
  limit=20,
  include_planned=True,
  materialization_event_storage_id=None
)
```

#### Current check status:

For each defined check,

```python
get_asset_check_executions(
  asset_key,
  check_name,
  limit=1,
  include_planned=True,
  materialization_event_storage_id=<latest materialization>
)
```

### Future queries:

- checks for a past materialization. This is where we need `include_planned=False`, because otherwise we'd surface recent in progress checks for every materialization
- batch query for multiple checks. Plan to wait until this is needed for perf
- if we need to optimize the asset graph view, we can add a query to collect the status counts from checks without deserializing the event