### PR TITLE
switch to use docs-prod as the production branch for docs vercel deployment

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -17,26 +17,27 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
+      # Deploy to Vercel Previews on pull request or push to master branch
       - name: Get branch preview subdomain
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/master')
         run: |
           BRANCH_PREVIEW_SUBDOMAIN=$(echo "${{ github.head_ref || github.ref_name }}" | sed 's/[^a-zA-Z0-9-]/-/g' | sed 's/^-*//' | sed 's/-*$//')
           echo "$BRANCH_PREVIEW_SUBDOMAIN"
           echo "BRANCH_PREVIEW_SUBDOMAIN=$BRANCH_PREVIEW_SUBDOMAIN" >> "${GITHUB_ENV}"
 
       - name: Get PR fetch depth
-        if: ${{ github.event.pull_request }}
+        if: ${{ github.event.pull_request }} || (github.event_name == 'push' && github.ref == 'refs/heads/master')
         run: echo "PR_FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "${GITHUB_ENV}"
 
       - name: Checkout PR branch
         uses: actions/checkout@v3
-        if: ${{ github.event.pull_request }}
+        if: ${{ github.event.pull_request }} || (github.event_name == 'push' && github.ref == 'refs/heads/master')
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: ${{ env.PR_FETCH_DEPTH }}
 
       - name: Get changed docs files
-        if: ${{ github.event.pull_request }}
+        if: ${{ github.event.pull_request }} || (github.event_name == 'push' && github.ref == 'refs/heads/master')
         run: |
           echo "Base ref is $GITHUB_BASE_SHA"
           echo "Head ref is $GITHUB_HEAD_SHA"
@@ -56,7 +57,7 @@ jobs:
 
       - name: Publish Preview to Vercel
         uses: amondnet/vercel-action@v25
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/master')
         with:
           github-comment: ${{ github.event.pull_request && env.CHANGES_ENTRY || true }}
           vercel-token: ${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - docs-prod
     paths:
       - docs/**
   pull_request:
@@ -22,15 +23,12 @@ jobs:
           BRANCH_PREVIEW_SUBDOMAIN=$(echo "${{ github.head_ref || github.ref_name }}" | sed 's/[^a-zA-Z0-9-]/-/g' | sed 's/^-*//' | sed 's/-*$//')
           echo "$BRANCH_PREVIEW_SUBDOMAIN"
           echo "BRANCH_PREVIEW_SUBDOMAIN=$BRANCH_PREVIEW_SUBDOMAIN" >> "${GITHUB_ENV}"
-      - name: Checkout
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-        uses: actions/checkout@v3
 
-      - name: 'Get PR fetch depth'
+      - name: Get PR fetch depth
         if: ${{ github.event.pull_request }}
         run: echo "PR_FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "${GITHUB_ENV}"
 
-      - name: 'Checkout PR branch'
+      - name: Checkout PR branch
         uses: actions/checkout@v3
         if: ${{ github.event.pull_request }}
         with:
@@ -68,13 +66,18 @@ jobs:
           scope: ${{ secrets.VERCEL_ORG_ID }}
           alias-domains: ${{ env.BRANCH_PREVIEW_SUBDOMAIN }}.dagster.dagster-docs.io
 
-      - name: Publish to Vercel
+      # Deploy to Vercel Production on push to docs-prod branch
+      - name: Checkout docs-prod branch
+        if: github.event_name == 'push' && github.ref == 'refs/heads/docs-prod'
+        uses: actions/checkout@v3
+
+      - name: Publish to Vercel Production
         uses: amondnet/vercel-action@v25
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/docs-prod'
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
-          vercel-args: '--prod'
+          vercel-args: "--prod"
           github-token: ${{ secrets.GITHUB_TOKEN }}
           scope: ${{ secrets.VERCEL_ORG_ID }}


### PR DESCRIPTION
## Summary & Motivation
after landing the stack of https://github.com/dagster-io/dagster/pull/15776, we started to face dev friction because docs changes show up immediately when commits land on master - most of the times it's ok to continuously deploy master changes to prod docs, but when a doc change depends on code change and the code change hasn't been released, this set up will slow down dev workflow and cause manual coordination.

so, per [discussion in slack](https://elementl-workspace.slack.com/archives/C03AFEEDDNX/p1692653911282439?thread_ts=1692651585.117609&cid=C03AFEEDDNX), we're switching to use a production branch for docs that is not master: `docs-prod`. going forward every weekly release will update the docs-prod branch to move it to the tip of release-<...>. if there's any hot fix, it can be picked to the docs prod branch, instead of manual backfill.

## How I Tested These Changes
not sure what's the best way to test 😅 