### PR TITLE
Asset check severity

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -111,7 +111,10 @@ from dagster._config.source import (
     StringSource as StringSource,
 )
 from dagster._core.definitions import AssetCheckResult as AssetCheckResult
-from dagster._core.definitions.asset_check_spec import AssetCheckSpec as AssetCheckSpec
+from dagster._core.definitions.asset_check_spec import (
+    AssetCheckSeverity as AssetCheckSeverity,
+    AssetCheckSpec as AssetCheckSpec,
+)
 from dagster._core.definitions.asset_in import AssetIn as AssetIn
 from dagster._core.definitions.asset_out import AssetOut as AssetOut
 from dagster._core.definitions.asset_selection import AssetSelection as AssetSelection

--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -710,11 +710,15 @@ class AssetLayer:
 
     def get_spec_for_asset_check(
         self, node_handle: NodeHandle, asset_check_handle: AssetCheckHandle
-    ) -> AssetCheckSpec:
+    ) -> Optional[AssetCheckSpec]:
         asset_checks_def_or_assets_def = self._asset_checks_defs_by_node_handle.get(
             node_handle
         ) or self._assets_defs_by_node_handle.get(node_handle)
-        return asset_checks_def_or_assets_def.get_spec_for_check_handle(asset_check_handle)
+        return (
+            asset_checks_def_or_assets_def.get_spec_for_check_handle(asset_check_handle)
+            if asset_checks_def_or_assets_def
+            else None
+        )
 
     def get_check_names_by_asset_key_for_node_handle(
         self, node_handle: NodeHandle

--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -708,6 +708,14 @@ class AssetLayer:
         else:
             return []
 
+    def get_spec_for_asset_check(
+        self, node_handle: NodeHandle, asset_check_handle: AssetCheckHandle
+    ) -> AssetCheckSpec:
+        asset_checks_def_or_assets_def = self._asset_checks_defs_by_node_handle.get(
+            node_handle
+        ) or self._assets_defs_by_node_handle.get(node_handle)
+        return asset_checks_def_or_assets_def.get_spec_for_check_handle(asset_check_handle)
+
     def get_check_names_by_asset_key_for_node_handle(
         self, node_handle: NodeHandle
     ) -> Mapping[AssetKey, AbstractSet[str]]:

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -19,7 +19,7 @@ from typing import (
 
 import dagster._check as check
 from dagster._annotations import experimental_param, public
-from dagster._core.definitions.asset_check_spec import AssetCheckSpec
+from dagster._core.definitions.asset_check_spec import AssetCheckHandle, AssetCheckSpec
 from dagster._core.definitions.asset_layer import get_dep_node_handles_of_graph_backed_asset
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.definitions.backfill_policy import BackfillPolicy, BackfillPolicyType
@@ -240,6 +240,10 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
             key_type=str,
             value_type=AssetCheckSpec,
         )
+
+        self._check_specs_by_handle = {
+            spec.handle: spec for spec in self._check_specs_by_output_name.values()
+        }
 
         if self._partitions_def is None:
             # check if backfill policy is BackfillPolicyType.SINGLE_RUN if asset is not partitioned
@@ -753,6 +757,9 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
     @property
     def check_specs_by_output_name(self) -> Mapping[str, AssetCheckSpec]:
         return self._check_specs_by_output_name
+
+    def get_spec_for_check_handle(self, asset_check_handle: AssetCheckHandle) -> AssetCheckSpec:
+        return self._check_specs_by_handle[asset_check_handle]
 
     @property
     def keys_by_output_name(self) -> Mapping[str, AssetKey]:

--- a/python_modules/dagster/dagster/_core/definitions/assets_job.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets_job.py
@@ -22,6 +22,7 @@ from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.selector.subset_selector import AssetSelectionData
 from dagster._utils.merger import merge_dicts
 
+from .asset_check_spec import AssetCheckSeverity, AssetCheckSpec
 from .asset_checks import AssetChecksDefinition
 from .asset_layer import AssetLayer
 from .assets import AssetsDefinition
@@ -30,8 +31,10 @@ from .dependency import (
     DependencyDefinition,
     DependencyMapping,
     IDependencyDefinition,
+    MultiDependencyDefinition,
     NodeHandle,
     NodeInvocation,
+    NodeOutputHandle,
 )
 from .events import AssetKey
 from .executor_definition import ExecutorDefinition
@@ -432,6 +435,18 @@ def build_node_deps(
         for output_name, key in assets_def.keys_by_output_name.items():
             node_alias_and_output_by_asset_key[key] = (node_alias, output_name)
 
+    asset_checks_defs_by_node_handle: Dict[NodeHandle, AssetChecksDefinition] = {}
+    for asset_checks_def in asset_checks_defs:
+        node_def_name = asset_checks_def.node_def.name
+        node_key = NodeInvocation(node_def_name)
+        asset_checks_defs_by_node_handle[NodeHandle(node_def_name, parent=None)] = asset_checks_def
+
+    blocking_asset_check_output_handles_by_asset_key = (
+        _get_blocking_asset_check_output_handles_by_asset_key(
+            assets_defs_by_node_handle, asset_checks_defs_by_node_handle
+        )
+    )
+
     deps: Dict[NodeInvocation, Dict[str, IDependencyDefinition]] = {}
     for node_handle, assets_def in assets_defs_by_node_handle.items():
         # the key that we'll use to reference the node inside this AssetsDefinition
@@ -450,12 +465,32 @@ def build_node_deps(
             if upstream_asset_key in assets_def.keys:
                 continue
 
+            blocking_asset_check_output_handles = (
+                blocking_asset_check_output_handles_by_asset_key.get(upstream_asset_key)
+            )
+            asset_check_deps = [
+                DependencyDefinition(
+                    node_output_handle.node_handle.name, node_output_handle.output_name
+                )
+                for node_output_handle in blocking_asset_check_output_handles or []
+            ]
+
             if upstream_asset_key in node_alias_and_output_by_asset_key:
                 upstream_node_alias, upstream_output_name = node_alias_and_output_by_asset_key[
                     upstream_asset_key
                 ]
-                deps[node_key][input_name] = DependencyDefinition(
-                    upstream_node_alias, upstream_output_name
+                asset_dep_def = DependencyDefinition(upstream_node_alias, upstream_output_name)
+                if blocking_asset_check_output_handles:
+                    deps[node_key][input_name] = MultiDependencyDefinition(
+                        dependencies=asset_check_deps + [asset_dep_def],
+                        dependencies_not_to_load_from=asset_check_deps,
+                    )
+                else:
+                    deps[node_key][input_name] = asset_dep_def
+            elif asset_check_deps:
+                deps[node_key][input_name] = MultiDependencyDefinition(
+                    dependencies=asset_check_deps,
+                    dependencies_not_to_load_from=asset_check_deps,
                 )
 
     # put asset checks downstream of the assets they're checking
@@ -478,6 +513,38 @@ def build_node_deps(
     return deps, assets_defs_by_node_handle, asset_checks_defs_by_node_handle
 
 
+def _get_blocking_asset_check_output_handles_by_asset_key(
+    assets_defs_by_node_handle, asset_checks_defs_by_node_handle
+) -> Mapping[AssetKey, AbstractSet[NodeOutputHandle]]:
+    """For each asset key, returns the set of node output handles that correspond to asset check
+    specs that should block the execution of downstream assets if they fail.
+    """
+    check_specs_by_node_output_handle: Mapping[NodeOutputHandle, AssetCheckSpec] = {}
+
+    for node_handle, assets_def in assets_defs_by_node_handle.items():
+        for output_name, check_spec in assets_def.check_specs_by_output_name.items():
+            check_specs_by_node_output_handle[
+                NodeOutputHandle(node_handle, output_name=output_name)
+            ] = check_spec
+
+    for node_handle, asset_checks_def in asset_checks_defs_by_node_handle.items():
+        for output_name, check_spec in asset_checks_def.specs_by_output_name.items():
+            check_specs_by_node_output_handle[
+                NodeOutputHandle(node_handle, output_name=output_name)
+            ] = check_spec
+
+    blocking_asset_check_output_handles_by_asset_key: Dict[AssetKey, Set[NodeOutputHandle]] = (
+        defaultdict(set)
+    )
+    for node_output_handle, check_spec in check_specs_by_node_output_handle.items():
+        if check_spec.severity == AssetCheckSeverity.ERROR:
+            blocking_asset_check_output_handles_by_asset_key[check_spec.asset_key].add(
+                node_output_handle
+            )
+
+    return blocking_asset_check_output_handles_by_asset_key
+
+
 def _has_cycles(
     deps: DependencyMapping[NodeInvocation],
 ) -> bool:
@@ -491,6 +558,12 @@ def _has_cycles(
             for dep in downstream_deps.values():
                 if isinstance(dep, DependencyDefinition):
                     node_deps[node_name].add(dep.node)
+                elif isinstance(dep, MultiDependencyDefinition):
+                    for subdep in dep.dependencies:
+                        if isinstance(subdep, DependencyDefinition):
+                            node_deps[node_name].add(subdep.node)
+                        else:
+                            check.failed(f"Unexpected sub-dependency type {type(dep)}.")
                 else:
                     check.failed(f"Unexpected dependency type {type(dep)}.")
         # make sure that there is a valid topological sorting of these node dependencies

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_check_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_check_decorator.py
@@ -4,7 +4,7 @@ from dagster import _check as check
 from dagster._annotations import experimental
 from dagster._config import UserConfigSchema
 from dagster._core.definitions.asset_check_result import AssetCheckResult
-from dagster._core.definitions.asset_check_spec import AssetCheckSpec
+from dagster._core.definitions.asset_check_spec import AssetCheckSeverity, AssetCheckSpec
 from dagster._core.definitions.asset_checks import (
     AssetChecksDefinition,
     AssetChecksDefinitionInputOutputProps,
@@ -38,6 +38,7 @@ def asset_check(
     compute_kind: Optional[str] = None,
     op_tags: Optional[Mapping[str, Any]] = None,
     retry_policy: Optional[RetryPolicy] = None,
+    severity: AssetCheckSeverity = AssetCheckSeverity.WARN,
 ) -> Callable[[AssetCheckFunction], AssetChecksDefinition]:
     """Create a definition for how to execute an asset check.
 
@@ -60,6 +61,7 @@ def asset_check(
         compute_kind (Optional[str]): A string to represent the kind of computation that executes
             the check, e.g. "dbt" or "spark".
         retry_policy (Optional[RetryPolicy]): The retry policy for the op that executes the check.
+        severity (AssetCheckSeverity): Severity of the check.
 
     Produces an :py:class:`AssetChecksDefinition` object.
 
@@ -117,6 +119,7 @@ def asset_check(
             name=resolved_name,
             description=description,
             asset_key=resolved_asset_key,
+            severity=severity,
         )
 
         op_def = _Op(

--- a/python_modules/dagster/dagster/_core/definitions/dependency.py
+++ b/python_modules/dagster/dagster/_core/definitions/dependency.py
@@ -771,7 +771,7 @@ class MultiDependencyDefinition(
 class BlockingAssetChecksDependencyDefinition(
     IDependencyDefinition,
     NamedTuple(
-        "_MultiDependencyDefinition",
+        "_BlockingAssetChecksDependencyDefinition",
         [
             (
                 "asset_check_dependencies",

--- a/python_modules/dagster/dagster/_core/errors.py
+++ b/python_modules/dagster/dagster/_core/errors.py
@@ -580,6 +580,10 @@ class DagsterTypeCheckDidNotPass(DagsterError):
         self.dagster_type = check.opt_inst_param(dagster_type, "dagster_type", DagsterType)
 
 
+class DagsterAssetCheckFailedError(DagsterError):
+    """Indicates than an asset check failed."""
+
+
 class DagsterEventLogInvalidForRun(DagsterError):
     """Raised when the event logs for a historical run are malformed or invalid."""
 

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
@@ -89,8 +89,12 @@ def _asset_check_results_to_outputs_and_evaluations(
     for user_event in user_event_sequence:
         if isinstance(user_event, AssetCheckResult):
             asset_check_evaluation = user_event.to_asset_check_evaluation(step_context)
-            spec = step_context.job_def.asset_layer.get_spec_for_asset_check(
-                step_context.node_handle, asset_check_evaluation.asset_check_handle
+            spec = check.not_none(
+                step_context.job_def.asset_layer.get_spec_for_asset_check(
+                    step_context.node_handle, asset_check_evaluation.asset_check_handle
+                ),
+                "If we were able to create an AssetCheckEvaluation from the AssetCheckResult, then"
+                " there should be a spec for the check",
             )
 
             output_name = step_context.job_def.asset_layer.get_output_name_for_asset_check(

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
@@ -25,6 +25,7 @@ from dagster._core.definitions import (
     OutputDefinition,
     TypeCheck,
 )
+from dagster._core.definitions.asset_check_spec import AssetCheckSeverity
 from dagster._core.definitions.data_version import (
     CODE_VERSION_TAG,
     DATA_VERSION_IS_USER_PROVIDED_TAG,
@@ -47,6 +48,7 @@ from dagster._core.definitions.multi_dimensional_partitions import (
     get_tags_from_multi_partition_key,
 )
 from dagster._core.errors import (
+    DagsterAssetCheckFailedError,
     DagsterExecutionHandleOutputError,
     DagsterInvariantViolationError,
     DagsterStepOutputNotFoundError,
@@ -87,6 +89,9 @@ def _asset_check_results_to_outputs_and_evaluations(
     for user_event in user_event_sequence:
         if isinstance(user_event, AssetCheckResult):
             asset_check_evaluation = user_event.to_asset_check_evaluation(step_context)
+            spec = step_context.job_def.asset_layer.get_spec_for_asset_check(
+                step_context.node_handle, asset_check_evaluation.asset_check_handle
+            )
 
             output_name = step_context.job_def.asset_layer.get_output_name_for_asset_check(
                 asset_check_evaluation.asset_check_handle
@@ -94,6 +99,12 @@ def _asset_check_results_to_outputs_and_evaluations(
             output = Output(value=None, output_name=output_name)
 
             yield asset_check_evaluation
+
+            if not asset_check_evaluation.success and spec.severity == AssetCheckSeverity.ERROR:
+                raise DagsterAssetCheckFailedError(
+                    f"Check '{spec.name}' for asset '{spec.asset_key.to_user_string()}' failed with"
+                    " ERROR severity."
+                )
             yield output
         else:
             yield user_event

--- a/python_modules/dagster/dagster/_core/execution/plan/plan.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/plan.py
@@ -63,6 +63,7 @@ from .inputs import (
     FromDynamicCollect,
     FromInputManager,
     FromMultipleSources,
+    FromMultipleSourcesLoadSingleSource,
     FromPendingDynamicStepOutput,
     FromSourceAsset,
     FromStepOutput,
@@ -593,7 +594,7 @@ def _step_input_source_from_multi_dep_def(
                 check.failed(f"Unexpected parent mapped input source type {source}")
             sources.append(source)
 
-    return FromMultipleSources(sources=sources, source_to_load_from=None)
+    return FromMultipleSources(sources=sources)
 
 
 def _step_input_source_from_blocking_asset_checks_dep_def(
@@ -605,7 +606,7 @@ def _step_input_source_from_blocking_asset_checks_dep_def(
     node_handle: NodeHandle,
     input_name: str,
     asset_layer: AssetLayer,
-) -> FromMultipleSources:
+) -> FromMultipleSourcesLoadSingleSource:
     sources: List[StepInputSource] = []
     source_to_load_from: Optional[StepInputSource] = None
     deps = dependency_structure.get_fan_in_deps(input_handle)
@@ -641,7 +642,9 @@ def _step_input_source_from_blocking_asset_checks_dep_def(
         else:
             check.failed("Unexpected: no sources to load from and no asset key to load from")
 
-    return FromMultipleSources(sources=sources, source_to_load_from=source_to_load_from)
+    return FromMultipleSourcesLoadSingleSource(
+        sources=sources, source_to_load_from=source_to_load_from
+    )
 
 
 class ExecutionPlan(


### PR DESCRIPTION
## Summary & Motivation

Introduces `AssetCheckSeverity` for asset checks, which can be set on either an `AssetCheckSpec` or directly when defining an asset check via the `@asset_check` decorator.

By setting its severity level to ERROR, you can specify that a check impacts control flow, i.e. only materialize downstream assets if the check on the upstream asset succeeds.

## How I Tested These Changes
