### PR TITLE
Use FileResponse if no _app_prefix

### DIFF
--- a/python_modules/dagster-webserver/dagster_webserver/webserver.py
+++ b/python_modules/dagster-webserver/dagster_webserver/webserver.py
@@ -248,7 +248,7 @@ class DagsterWebserver(GraphQLServer, Generic[T_IWorkspaceProcessContext]):
                 full_path = path.join(subdir, file)
                 relative_path = "/" + full_path[len(base_dir) :].lstrip(path.sep)
                 # We only need to replace BUILDTIME_ASSETPREFIX_REPLACE_ME in javascript files
-                if file.endswith(".js") or file.endswith(".js.map"):
+                if self.app_path_prefix and (file.endswith(".js") or file.endswith(".js.map")):
                     routes.append(_next_static_file(relative_path, full_path))
                 else:
                     routes.append(_static_file(relative_path, full_path))

--- a/python_modules/dagster-webserver/dagster_webserver/webserver.py
+++ b/python_modules/dagster-webserver/dagster_webserver/webserver.py
@@ -248,7 +248,7 @@ class DagsterWebserver(GraphQLServer, Generic[T_IWorkspaceProcessContext]):
                 full_path = path.join(subdir, file)
                 relative_path = "/" + full_path[len(base_dir) :].lstrip(path.sep)
                 # We only need to replace BUILDTIME_ASSETPREFIX_REPLACE_ME in javascript files
-                if self.app_path_prefix and (file.endswith(".js") or file.endswith(".js.map")):
+                if self._app_path_prefix and (file.endswith(".js") or file.endswith(".js.map")):
                     routes.append(_next_static_file(relative_path, full_path))
                 else:
                     routes.append(_static_file(relative_path, full_path))


### PR DESCRIPTION
## Summary & Motivation

Use FileResponse so the browser caches javascript responses. I need to set the proper headers even when there is an app_path_prefix so that they're cached for OSS users but I'll tackle that next time, for now I want to fix this for cloud.

## How I Tested These Changes

Locally made sure files are cached

<img width="844" alt="Screenshot 2023-08-22 at 4 25 36 PM" src="https://github.com/dagster-io/dagster/assets/2286579/faa024f6-10a4-4f7b-809b-9fb5a4507cc6">
