### PR TITLE
fix bug with self-dependency and multi-assets

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
@@ -170,7 +170,10 @@ def _step_output_error_checked_user_event_sequence(
                     for dependent_key in step_local_dependent_keys:
                         output_name = assets_def.get_output_name_for_asset_key(dependent_key)
                         # Need to skip self-dependent assets (possible with partitions)
-                        if step_context.has_seen_output(output_name):
+                        self_dep = dependent_key in asset_layer.upstream_assets_for_asset(
+                            asset_info.key
+                        )
+                        if not self_dep and step_context.has_seen_output(output_name):
                             raise DagsterInvariantViolationError(
                                 f'Asset "{dependent_key.to_user_string()}" was yielded before its'
                                 f' dependency "{asset_info.key.to_user_string()}".Multiassets'


### PR DESCRIPTION
## Summary & Motivation

This fixes a bug recently reported by a user. Here's the setup:

- Multi-asset with two assets (A and B) that have self-dependencies on earlier time partitions
- This means that partition N of A depends on partition N-1 of both A and B
- Ditto with partition N of B

We have a check that makes sure that, when there are internal asset deps inside a multi-asset, the outputs need to be yielded in topological order.

This check was being overactive: despite what the check was doing, it's actually OK that asset B gets yielded after asset A even though A has a dependency on B, because A's dependency is actually on an earlier partition of B, not the partition of B that was just yielded.

It looks like we actually already had a comment in the codebase about this situation, but weren't handling it yet.

## How I Tested These Changes

Added a test