### PR TITLE
ExecutionResult.get_job_failure_event -> get_run_failure_event

### DIFF
--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/sensor_alert.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/sensor_alert.py
@@ -70,7 +70,7 @@ result = my_job_fails.execute_in_process(instance=instance, raise_on_error=False
 dagster_run = result.dagster_run
 
 # retrieve a failure event from the completed job execution
-dagster_event = result.get_job_failure_event()
+dagster_event = result.get_run_failure_event()
 
 # create the context
 run_failure_sensor_context = build_run_status_sensor_context(
@@ -162,7 +162,7 @@ result = my_job_succeeds.execute_in_process(instance=instance)
 dagster_run = result.dagster_run
 
 # retrieve a success event from the completed execution
-dagster_event = result.get_job_success_event()
+dagster_event = result.get_run_success_event()
 
 # create the context
 run_status_sensor_context = build_run_status_sensor_context(

--- a/python_modules/dagster/dagster/_core/execution/execution_result.py
+++ b/python_modules/dagster/dagster/_core/execution/execution_result.py
@@ -132,7 +132,7 @@ class ExecutionResult(ABC):
         return len(self.events_for_node(node_str)) == 0
 
     def get_run_failure_event(self) -> DagsterEvent:
-        """Returns a DagsterEvent with type DagsterEventType.PIPELINE_FAILURE if it ocurred during
+        """Returns a DagsterEvent with type DagsterEventType.RUN_FAILURE if it ocurred during
         execution.
         """
         events = self.filter_events(
@@ -145,7 +145,7 @@ class ExecutionResult(ABC):
         return events[0]
 
     def get_run_success_event(self) -> DagsterEvent:
-        """Returns a DagsterEvent with type DagsterEventType.PIPELINE_SUCCESS if it ocurred during
+        """Returns a DagsterEvent with type DagsterEventType.RUN_SUCCESS if it ocurred during
         execution.
         """
         events = self.filter_events(

--- a/python_modules/dagster/dagster/_core/execution/execution_result.py
+++ b/python_modules/dagster/dagster/_core/execution/execution_result.py
@@ -131,7 +131,7 @@ class ExecutionResult(ABC):
     def is_node_untouched(self, node_str: str) -> bool:
         return len(self.events_for_node(node_str)) == 0
 
-    def get_job_failure_event(self) -> DagsterEvent:
+    def get_run_failure_event(self) -> DagsterEvent:
         """Returns a DagsterEvent with type DagsterEventType.PIPELINE_FAILURE if it ocurred during
         execution.
         """
@@ -144,7 +144,7 @@ class ExecutionResult(ABC):
 
         return events[0]
 
-    def get_job_success_event(self) -> DagsterEvent:
+    def get_run_success_event(self) -> DagsterEvent:
         """Returns a DagsterEvent with type DagsterEventType.PIPELINE_SUCCESS if it ocurred during
         execution.
         """

--- a/python_modules/dagster/dagster_tests/core_tests/test_event_logging.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_event_logging.py
@@ -248,7 +248,7 @@ def test_earliest_step_failure_on_failed_job():
             job=reconstructable(failing_job_concurrent_events),
             instance=instance,
         )
-        failure_event = result.get_job_failure_event()
+        failure_event = result.get_run_failure_event()
         step_failure = failure_event.job_failure_data.first_step_failure_event
         assert step_failure
         assert step_failure.step_key == "mapped_op[0]"

--- a/python_modules/dagster/dagster_tests/core_tests/test_job_execution.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_job_execution.py
@@ -237,7 +237,9 @@ def test_create_job_with_empty_ops_list():
     def empty_pipe():
         pass
 
-    assert empty_pipe.execute_in_process().success
+    result = empty_pipe.execute_in_process()
+    assert result.success
+    assert result.get_run_success_event()
 
 
 def test_singleton_job():
@@ -633,7 +635,7 @@ def test_job_init_failure():
             instance=fs_instance,
         )
         assert result.success is False
-        event = result.all_events[-1]
+        event = result.get_run_failure_event()
         assert event.event_type_value == "PIPELINE_FAILURE"
         assert event.job_failure_data
         assert fs_instance.get_run_by_id(result.run_id).is_failure_or_canceled  # pyright: ignore[reportOptionalMemberAccess]

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
@@ -435,7 +435,7 @@ def test_run_status_sensor_invocation_resources() -> None:
     result = my_job_2.execute_in_process(instance=instance, raise_on_error=False)
 
     dagster_run = result.dagster_run
-    dagster_event = result.get_job_success_event()
+    dagster_event = result.get_run_success_event()
 
     context = build_run_status_sensor_context(
         sensor_name="status_sensor",
@@ -474,7 +474,7 @@ def test_run_status_sensor_invocation_resources_direct() -> None:
     result = my_job_2.execute_in_process(instance=instance, raise_on_error=False)
 
     dagster_run = result.dagster_run
-    dagster_event = result.get_job_success_event()
+    dagster_event = result.get_run_success_event()
 
     context = build_run_status_sensor_context(
         sensor_name="status_sensor",
@@ -512,7 +512,7 @@ def test_run_failure_sensor_invocation_resources() -> None:
     result = my_job_2.execute_in_process(instance=instance, raise_on_error=False)
 
     dagster_run = result.dagster_run
-    dagster_event = result.get_job_success_event()
+    dagster_event = result.get_run_success_event()
 
     context = build_run_status_sensor_context(
         sensor_name="failure_sensor",
@@ -715,7 +715,7 @@ def test_run_status_sensor():
     result = my_job_2.execute_in_process(instance=instance, raise_on_error=False)
 
     dagster_run = result.dagster_run
-    dagster_event = result.get_job_success_event()
+    dagster_event = result.get_run_success_event()
 
     context = build_run_status_sensor_context(
         sensor_name="status_sensor",
@@ -744,7 +744,7 @@ def test_run_failure_sensor():
     result = my_job.execute_in_process(instance=instance, raise_on_error=False)
 
     dagster_run = result.dagster_run
-    dagster_event = result.get_job_failure_event()
+    dagster_event = result.get_run_failure_event()
 
     context = build_run_status_sensor_context(
         sensor_name="failure_sensor",
@@ -769,7 +769,7 @@ def test_run_status_sensor_run_request():
     result = my_job_2.execute_in_process(instance=instance, raise_on_error=False)
 
     dagster_run = result.dagster_run
-    dagster_event = result.get_job_success_event()
+    dagster_event = result.get_run_success_event()
 
     context = build_run_status_sensor_context(
         sensor_name="status_sensor",
@@ -806,7 +806,7 @@ def test_run_failure_w_run_request():
     result = my_job.execute_in_process(instance=instance, raise_on_error=False)
 
     dagster_run = result.dagster_run
-    dagster_event = result.get_job_failure_event()
+    dagster_event = result.get_run_failure_event()
 
     context = build_run_status_sensor_context(
         sensor_name="failure_sensor",


### PR DESCRIPTION
## Summary & Motivation

Not a public API, so shouldn't be a problem

## How I Tested These Changes
