### PR TITLE
Reduce lru_cache size on get_partition_keys_in_time_window from 100 to 5

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -523,7 +523,7 @@ class TimeWindowPartitionsDefinition(
     def end_time_for_partition_key(self, partition_key: str) -> datetime:
         return self.time_window_for_partition_key(partition_key).end
 
-    @functools.lru_cache(maxsize=100)
+    @functools.lru_cache(maxsize=5)
     def get_partition_keys_in_time_window(self, time_window: TimeWindow) -> Sequence[str]:
         result: List[str] = []
         for partition_time_window in self._iterate_time_windows(time_window.start):


### PR DESCRIPTION
Summary:
As we have been digging into memory on auto-materialization policies a bit more I realized that I hadn't really been considering the memory size of the cached result here, particularly since the time window is updated on each iteration right? So if there are 70k partitions, we'll be keeping, say, up to 100 2MB chunks. Seems like a lot - since reducing the cache to 5 helps with the specific test case we have been optimizing around, let's be conservative and drop it down to 5 (and maybe it's still worth investigating that instance-scoped partitions cacher class to pass around).

Test Plan: BK, run a dry run reconciliation on a large set of assets with many hourly partitions

## Summary & Motivation

## How I Tested These Changes
