### PR TITLE
fill in AssetCheckEvaluation.target_materialization_data

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_check_result.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_result.py
@@ -2,7 +2,10 @@ from typing import TYPE_CHECKING, Mapping, NamedTuple, Optional
 
 import dagster._check as check
 from dagster._annotations import PublicAttr, experimental
-from dagster._core.definitions.asset_check_evaluation import AssetCheckEvaluation
+from dagster._core.definitions.asset_check_evaluation import (
+    AssetCheckEvaluation,
+    AssetCheckEvaluationTargetMaterializationData,
+)
 from dagster._core.definitions.events import (
     AssetKey,
     CoercibleToAssetKey,
@@ -117,9 +120,20 @@ class AssetCheckResult(
 
             resolved_check_name = next(iter(check_names_with_specs))
 
+        input_asset_info = step_context.get_input_asset_version_info(resolved_asset_key)
+        if input_asset_info is not None:
+            target_materialization_data = AssetCheckEvaluationTargetMaterializationData(
+                run_id=input_asset_info.run_id,
+                storage_id=input_asset_info.storage_id,
+                timestamp=input_asset_info.timestamp,
+            )
+        else:
+            target_materialization_data = None
+
         return AssetCheckEvaluation(
             check_name=resolved_check_name,
             asset_key=resolved_asset_key,
             success=self.success,
             metadata=self.metadata,
+            target_materialization_data=target_materialization_data,
         )

--- a/python_modules/dagster/dagster/_core/execution/context/system.py
+++ b/python_modules/dagster/dagster/_core/execution/context/system.py
@@ -483,6 +483,12 @@ class InputAssetVersionInfo:
     # can be none if we are sourcing a materialization from before data versions.
     data_version: Optional["DataVersion"]
 
+    # This is the run_id on the event that the storage_id references
+    run_id: str
+
+    # This is the timestamp on the event that the storage_id references
+    timestamp: float
+
 
 class StepExecutionContext(PlanExecutionContext, IStepContext):
     """Context for the execution of a step. Users should not instantiate this class directly.
@@ -947,7 +953,9 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
                     data_version = extract_data_version_from_entry(event.event_log_entry)
             else:
                 data_version = extract_data_version_from_entry(event.event_log_entry)
-            self._input_asset_version_info[key] = InputAssetVersionInfo(storage_id, data_version)
+            self._input_asset_version_info[key] = InputAssetVersionInfo(
+                storage_id, data_version, event.run_id, event.timestamp
+            )
 
     def partition_mapping_for_input(self, input_name: str) -> Optional[PartitionMapping]:
         asset_layer = self.job_def.asset_layer


### PR DESCRIPTION
## Summary & Motivation

For AssetCheckEvaluation events, adds info about the materialization being checked. 

This was surprisingly easy, thanks to the internal APIs @smackesey has built for data versioning-related plumbing.

## How I Tested These Changes
