### PR TITLE
When opening local code servers, unset click env vars that have the potential to mess things up

### DIFF
--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -1115,6 +1115,18 @@ def open_server_process(
     if loadable_target_origin:
         subprocess_args += loadable_target_origin.get_cli_args()
 
+    env = {
+        **(env or os.environ),
+    }
+
+    # Unset click environment variables in the current environment
+    # that might conflict with arguments that we're using
+    if port and "DAGSTER_GRPC_SOCKET" in env:
+        del env["DAGSTER_GRPC_SOCKET"]
+
+    if socket and "DAGSTER_GRPC_PORT" in env:
+        del env["DAGSTER_GRPC_PORT"]
+
     server_process = open_ipc_subprocess(subprocess_args, cwd=cwd, env=env)
 
     from dagster._grpc.client import DagsterGrpcClient

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_persistent.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_persistent.py
@@ -32,7 +32,11 @@ from dagster._grpc.server import (
 from dagster._grpc.types import ListRepositoriesResponse, SensorExecutionArgs, StartRunResult
 from dagster._serdes import serialize_value
 from dagster._serdes.serdes import deserialize_value
-from dagster._utils import file_relative_path, find_free_port
+from dagster._utils import (
+    file_relative_path,
+    find_free_port,
+    safe_tempfile_path_unmanaged,
+)
 from dagster._utils.error import SerializableErrorInfo
 from dagster.version import __version__ as dagster_version
 
@@ -104,6 +108,49 @@ def test_python_environment_args():
                 instance.get_ref(), port, socket=None, loadable_target_origin=loadable_target_origin
             )
             assert process.args[:5] == [sys.executable, "-m", "dagster", "api", "grpc"]
+        finally:
+            if process:
+                process.terminate()
+                process.wait()
+
+
+def test_env_var_port_collision():
+    port = find_free_port()
+    socket = safe_tempfile_path_unmanaged()
+    python_file = file_relative_path(__file__, "grpc_repo.py")
+    loadable_target_origin = LoadableTargetOrigin(
+        executable_path=sys.executable, python_file=python_file
+    )
+
+    with instance_for_test() as instance:
+        process = None
+        try:
+            # env var that would cause a collision with port if we are not careful
+            with environ({"DAGSTER_GRPC_SOCKET": str(socket)}):
+                process = open_server_process(
+                    instance.get_ref(),
+                    port,
+                    socket=None,
+                    loadable_target_origin=loadable_target_origin,
+                )
+                client = DagsterGrpcClient(port=port, host="localhost")
+                wait_for_grpc_server(process, client, [])
+        finally:
+            if process:
+                process.terminate()
+                process.wait()
+
+        try:
+            # env var that would cause a collision with socket if we are not careful
+            with environ({"DAGSTER_GRPC_PORT": str(port)}):
+                process = open_server_process(
+                    instance.get_ref(),
+                    port=None,
+                    socket=socket,
+                    loadable_target_origin=loadable_target_origin,
+                )
+                client = DagsterGrpcClient(socket=socket, host="localhost")
+                wait_for_grpc_server(process, client, [])
         finally:
             if process:
                 process.terminate()


### PR DESCRIPTION
Summary:
If you have DAGSTER_GRPC_PORT set and we try to open a socket, click gets confused (and vice versa). Disallow those env vars when spinning up local code servers.

Test Plan: BK new test case

Manually, run locally:
DAGSTER_GRPC_PORT=4000 dagster dev -f hi.py

## Summary & Motivation

## How I Tested These Changes
