### PR TITLE
Add OutboundNotificationStream to abstract away TextIO

### DIFF
--- a/python_modules/dagster-externals/dagster_externals_tests/test_context.py
+++ b/python_modules/dagster-externals/dagster_externals_tests/test_context.py
@@ -28,7 +28,7 @@ def _make_external_execution_context(**kwargs):
     kwargs = {**TEST_EXTERNAL_EXECUTION_CONTEXT_DEFAULTS, **kwargs}
     return ExternalExecutionContext(
         data=ExternalExecutionContextData(**kwargs),
-        output_stream=MagicMock(),
+        outbound_notif_stream=MagicMock(),
     )
 
 


### PR DESCRIPTION
## Summary & Motivation

TextIO is too specific for all the various interconnects we want to support (s3, dbfs, etc).

Instead add an interface which operates on typed notification objects and have a synchronoustextio variant be the default.

## How I Tested These Changes

BK
