### PR TITLE
feat(dbt): disable usage statistics by default

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -614,6 +614,8 @@ class DbtCliResource(ConfigurableResource):
             **os.environ.copy(),
             # Run dbt with unbuffered output.
             "PYTHONUNBUFFERED": "1",
+            # Disable anonymous usage statistics for performance.
+            "DBT_SEND_ANONYMOUS_USAGE_STATS": "false",
             # The DBT_LOG_FORMAT environment variable must be set to `json`. We use this
             # environment variable to ensure that the dbt CLI outputs structured logs.
             "DBT_LOG_FORMAT": "json",


### PR DESCRIPTION
## Summary & Motivation
In certain environments, egress to domains not unspecified in an allowlist will be prevented. Thus, usage tracking will not function in these scenarios. Although this tracking happens in a separate thread, to prevent warnings, just disable this feature. 

See https://docs.getdbt.com/reference/global-configs/usage-stats.

## How I Tested These Changes
N/A
