### PR TITLE
[auto-materialize] Skip on not all parents updated rule

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -255,7 +255,7 @@ class AutoMaterializeRule(ABC):
 
     @staticmethod
     def skip_on_not_all_parents_updated(
-        require_update_on_all_parent_partitions: Optional[bool] = False,
+        require_update_on_all_parent_partitions: bool = False,
     ) -> "SkipOnNotAllParentsUpdatedRule":
         return SkipOnNotAllParentsUpdatedRule(require_update_on_all_parent_partitions)
 

--- a/python_modules/dagster/dagster/_core/definitions/materialize.py
+++ b/python_modules/dagster/dagster/_core/definitions/materialize.py
@@ -17,6 +17,8 @@ if TYPE_CHECKING:
 
     from ..execution.execute_in_process_result import ExecuteInProcessResult
 
+EPHEMERAL_JOB_NAME = "__ephemeral_asset_job__"
+
 
 def materialize(
     assets: Sequence[Union[AssetsDefinition, SourceAsset]],
@@ -93,15 +95,13 @@ def materialize(
         if isinstance(asset, AssetsDefinition):
             all_executable_keys = all_executable_keys.union(set(asset.keys))
 
-    JOB_NAME = "__ephemeral_asset_job__"
-
     defs = Definitions(
-        jobs=[define_asset_job(name=JOB_NAME, selection=selection)],
+        jobs=[define_asset_job(name=EPHEMERAL_JOB_NAME, selection=selection)],
         assets=assets,
         resources=resources,
     )
     return check.not_none(
-        defs.get_job_def(JOB_NAME),
+        defs.get_job_def(EPHEMERAL_JOB_NAME),
         "This should always return a job",
     ).execute_in_process(
         run_config=run_config,

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/auto_materialize_policy_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/auto_materialize_policy_scenarios.py
@@ -58,6 +58,11 @@ single_lazy_asset_with_freshness_policy = [
         freshness_policy=FreshnessPolicy(maximum_lag_minutes=60),
     )
 ]
+vee = [
+    asset_def("A"),
+    asset_def("B"),
+    asset_def("C", ["A", "B"]),
+]
 lopsided_vee = [
     asset_def("root1"),
     asset_def("root2"),
@@ -649,5 +654,25 @@ auto_materialize_policy_scenarios = {
             run(["unpartitioned1"]),
         ],
         expected_run_requests=[run_request(["unpartitioned2"])],
+    ),
+    "test_wait_for_all_parents_updated": AssetReconciliationScenario(
+        assets=with_auto_materialize_policy(
+            vee,
+            AutoMaterializePolicy.eager().with_rules(
+                AutoMaterializeRule.skip_on_not_all_parents_updated(),
+            ),
+        ),
+        cursor_from=AssetReconciliationScenario(
+            assets=with_auto_materialize_policy(
+                vee,
+                AutoMaterializePolicy.eager().with_rules(
+                    AutoMaterializeRule.skip_on_not_all_parents_updated(),
+                ),
+            ),
+            unevaluated_runs=[run(["A", "B", "C"]), run(["A"])],
+            expected_run_requests=[],
+        ),
+        unevaluated_runs=[run(["B"])],
+        expected_run_requests=[run_request(["C"])],
     ),
 }

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/auto_materialize_policy_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/auto_materialize_policy_scenarios.py
@@ -724,7 +724,12 @@ auto_materialize_policy_scenarios = {
             assets=unpartitioned_with_one_parent_partitioned_skip_on_not_all_parents_updated,
             cursor_from=AssetReconciliationScenario(
                 assets=unpartitioned_with_one_parent_partitioned_skip_on_not_all_parents_updated,
-                unevaluated_runs=[run(["asset2"]), run(["asset1"], partition_key="2020-01-01")],
+                unevaluated_runs=[
+                    run(["asset1"], "2020-01-01"),
+                    run(["asset1"], "2020-01-02"),
+                    run(["asset2", "asset3"]),
+                    run(["asset2"]),
+                ],
                 current_time=create_pendulum_time(year=2020, month=1, day=3, hour=1),
                 expected_run_requests=[],
             ),
@@ -733,7 +738,6 @@ auto_materialize_policy_scenarios = {
             expected_run_requests=[run_request(["asset3"])],
         ),
         unevaluated_runs=[
-            run(["asset1"], "2020-01-01"),
             run(["asset1"], "2020-01-02"),
             run(["asset2"]),
         ],

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/auto_materialize_policy_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/auto_materialize_policy_scenarios.py
@@ -139,11 +139,11 @@ partitioned_to_unpartitioned_allow_missing_parent = [
 ]
 
 get_unpartitioned_with_one_parent_partitioned_skip_on_parents_updated = (
-    lambda require_update_on_all_parent_partitions: with_auto_materialize_policy(
+    lambda require_update_for_all_parent_partitions: with_auto_materialize_policy(
         unpartitioned_with_one_parent_partitioned,
         AutoMaterializePolicy.eager().with_rules(
             AutoMaterializeRule.skip_on_not_all_parents_updated(
-                require_update_on_all_parent_partitions
+                require_update_for_all_parent_partitions
             ),
         ),
     )

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/auto_materialize_policy_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/auto_materialize_policy_scenarios.py
@@ -718,7 +718,7 @@ auto_materialize_policy_scenarios = {
         unevaluated_runs=[run(["A"]), run(["B"]), run(["A"])],
         expected_run_requests=[run_request(["C"])],
     ),
-    "test_wait_for_all_parents_updated_unpartitioned_with_one_parent_partitioned": AssetReconciliationScenario(
+    "test_wait_for_all_parents_updated_any_upstream_partition": AssetReconciliationScenario(
         assets=unpartitioned_with_one_parent_partitioned_skip_on_not_all_parents_updated,
         cursor_from=AssetReconciliationScenario(
             assets=unpartitioned_with_one_parent_partitioned_skip_on_not_all_parents_updated,
@@ -733,13 +733,38 @@ auto_materialize_policy_scenarios = {
                 current_time=create_pendulum_time(year=2020, month=1, day=3, hour=1),
                 expected_run_requests=[],
             ),
-            unevaluated_runs=[run(["asset1"], "2020-01-02")],
+            unevaluated_runs=[run(["asset1"], "2020-01-01")],
             current_time=create_pendulum_time(year=2020, month=1, day=3, hour=1),
             expected_run_requests=[run_request(["asset3"])],
         ),
         unevaluated_runs=[
             run(["asset1"], "2020-01-02"),
             run(["asset2"]),
+        ],
+        current_time=create_pendulum_time(year=2020, month=1, day=3, hour=1),
+        expected_run_requests=[run_request(["asset3"])],
+    ),
+    "test_wait_for_all_parents_updated_all_upstream_partitions": AssetReconciliationScenario(
+        assets=unpartitioned_with_one_parent_partitioned_skip_on_not_all_parents_updated,
+        cursor_from=AssetReconciliationScenario(
+            assets=unpartitioned_with_one_parent_partitioned_skip_on_not_all_parents_updated,
+            cursor_from=AssetReconciliationScenario(
+                assets=unpartitioned_with_one_parent_partitioned_skip_on_not_all_parents_updated,
+                unevaluated_runs=[
+                    run(["asset1"], "2020-01-01"),
+                    run(["asset1"], "2020-01-02"),
+                    run(["asset2", "asset3"]),
+                    run(["asset2"]),
+                ],
+                current_time=create_pendulum_time(year=2020, month=1, day=3, hour=1),
+                expected_run_requests=[],
+            ),
+            unevaluated_runs=[run(["asset1"], "2020-01-01")],
+            current_time=create_pendulum_time(year=2020, month=1, day=3, hour=1),
+            expected_run_requests=[],
+        ),
+        unevaluated_runs=[
+            run(["asset1"], "2020-01-02"),
         ],
         current_time=create_pendulum_time(year=2020, month=1, day=3, hour=1),
         expected_run_requests=[run_request(["asset3"])],

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/partition_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/partition_scenarios.py
@@ -116,6 +116,14 @@ two_hourly_to_one_daily = [
     ),
 ]
 
+unpartitioned_with_one_parent_partitioned = [
+    asset_def("asset1", partitions_def=DailyPartitionsDefinition(start_date="2020-01-01")),
+    asset_def("asset2"),
+    asset_def(
+        "asset3",
+        ["asset1", "asset2"],
+    ),
+]
 
 partition_scenarios = {
     "one_asset_one_partition_never_materialized": AssetReconciliationScenario(

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon.py
@@ -1,10 +1,9 @@
 import pytest
 from dagster import AssetKey
-from dagster._core.definitions.materialize import EPHEMERAL_JOB_NAME
 from dagster._core.instance_for_test import instance_for_test
 from dagster._core.storage.dagster_run import DagsterRunStatus
 from dagster._core.storage.tags import PARTITION_NAME_TAG
-from dagster._daemon.asset_daemon import set_auto_materialize_paused
+from dagster._daemon.asset_daemon import get_current_evaluation_id, set_auto_materialize_paused
 
 from .scenarios.auto_materialize_policy_scenarios import auto_materialize_policy_scenarios
 from .scenarios.auto_observe_scenarios import auto_observe_scenarios
@@ -100,13 +99,17 @@ def test_daemon(scenario_item, daemon_not_paused_instance):
     def sort_run_key_fn(run):
         return (min(run.asset_selection), run.tags.get(PARTITION_NAME_TAG))
 
-    # The submitted runs are the N most recent runs that were not the "unevaluated_runs"
-    # executed via materialize_in_memory
-    submitted_runs_in_scenario = []
-    for run in runs:
-        if run.job_name == EPHEMERAL_JOB_NAME:
-            break
-        submitted_runs_in_scenario.append(run)
+    # Get all of the runs that were submitted in the most recent asset evaluation
+    asset_evaluation_id = get_current_evaluation_id(daemon_not_paused_instance)
+    submitted_runs_in_scenario = (
+        [
+            run
+            for run in runs
+            if run.tags.get("dagster/asset_evaluation_id") == str(asset_evaluation_id)
+        ]
+        if asset_evaluation_id
+        else []
+    )
 
     assert len(submitted_runs_in_scenario) == len(scenario.expected_run_requests), (
         "Expected the following run requests to be submitted:"


### PR DESCRIPTION
Adds a new rule that allows us to skip when only a subset of the parents of this asset have been updated, i.e.:

A -> C
B -> C

and everything is materialized, then materializing A will generate the following evaluation:
- materialize on parent updated: True (A updated)
- skip on not all parents updated: True (B not updated)

Then, if A is materialized, the following evaluation will be generated:
- materialize on parent updated: True (B updated)
- skip on not all parents updated: False

This rule accepts an additional `require_update_on_all_parents_updated` argument:
- when True, enforces that all parent partitions are updated in order for an asset to be updated
- when False, enforces that at least one partition in each parent asset has been updated in order for an asset to be updated. This will be the default argument.