### PR TITLE
Create migration for converting to bigint ids

### DIFF
--- a/python_modules/dagster/dagster/_cli/instance.py
+++ b/python_modules/dagster/dagster/_cli/instance.py
@@ -4,6 +4,7 @@ import click
 
 import dagster._check as check
 from dagster._core.instance import DagsterInstance
+from dagster._core.storage.migration.bigint_migration import run_bigint_migration
 
 from .utils import get_instance_for_cli
 
@@ -40,7 +41,12 @@ def info_command():
 
 
 @instance_cli.command(name="migrate", help="Automatically migrate an out of date instance.")
-def migrate_command():
+@click.option("--bigint-migration", is_flag=True, help="Run an optional bigint migration")
+def migrate_command(**kwargs):
+    if kwargs.get("bigint_migration"):
+        _run_bigint_migration()
+        return
+
     with get_instance_for_cli() as instance:
         home = os.environ.get("DAGSTER_HOME")
         if not home:
@@ -154,3 +160,22 @@ def check_concurrency_support(instance: DagsterInstance):
         "to run `dagster instance migrate` to add the necessary tables in your dagster storage to "
         "support this feature."
     )
+
+
+def _run_bigint_migration():
+    with get_instance_for_cli() as instance:
+        home = os.environ.get("DAGSTER_HOME")
+        if not home:
+            click.echo("$DAGSTER_HOME is not set; ephemeral instances do not need to be migrated.")
+            return
+
+        confirmation = click.prompt(
+            "Are you sure you want to migrate all your id cols from int to bigint? This may lock "
+            "tables for an extended period of time while the migration is under way. Type MIGRATE "
+            "to confirm"
+        )
+
+        if confirmation == "MIGRATE":
+            run_bigint_migration(instance, click.echo)
+        else:
+            click.echo("Exiting without running bigint migration")

--- a/python_modules/dagster/dagster/_core/storage/migration/bigint_migration.py
+++ b/python_modules/dagster/dagster/_core/storage/migration/bigint_migration.py
@@ -1,0 +1,111 @@
+from typing import Callable
+
+import sqlalchemy as db
+
+from dagster._core.instance import DagsterInstance
+from dagster._core.storage.event_log import (
+    SqlEventLogStorage,
+    SqlEventLogStorageMetadata,
+    SqliteEventLogStorage,
+)
+from dagster._core.storage.runs import RunStorageSqlMetadata, SqliteRunStorage, SqlRunStorage
+from dagster._core.storage.schedules import (
+    ScheduleStorageSqlMetadata,
+    SqliteScheduleStorage,
+    SqlScheduleStorage,
+)
+
+
+def _has_integer_id_column(inspector, table):
+    type_by_col_name = {col["name"]: col["type"] for col in inspector.get_columns(table)}
+    id_col_type = type_by_col_name.get("id")
+    return id_col_type and str(id_col_type) == str(db.Integer())
+
+
+def _convert_int_to_bigint(conn, table, colname):
+    # Since we are not using alembic (which might mess up the versioning system), we need to
+    # manually handle the dialect differences for running the migration
+    dialect = db.inspect(conn).dialect.name
+    if dialect == "postgresql":
+        statement = db.text(f"ALTER TABLE {table} ALTER COLUMN {colname} TYPE BIGINT")
+    elif dialect == "mysql":
+        statement = db.text(f"ALTER TABLE {table} MODIFY COLUMN {colname} BIGINT")
+    else:
+        raise Exception(f"Unsupported dialect {dialect}")
+    conn.execute(statement)
+
+
+def _drop_foreign_key_constraint(conn, table, fk):
+    conn.execute(db.text(f"ALTER TABLE {table} DROP CONSTRAINT {fk['name']}"))
+
+
+def _add_foreign_key_constraint(conn, table, fk):
+    constrained_columns = ", ".join(fk["constrained_columns"])
+    referred_columns = ", ".join(fk["referred_columns"])
+    conn.execute(
+        db.text(
+            f"ALTER TABLE {table} ADD CONSTRAINT {fk['name']} FOREIGN KEY ({constrained_columns})"
+            f" REFERENCES {fk['referred_table']}({referred_columns}) ON DELETE CASCADE"
+        )
+    )
+
+
+def _migrate_storage(conn, metadata, print_fn):
+    inspector = db.inspect(conn)
+    storage_tables = [table for table in inspector.get_table_names() if table in metadata.tables]
+    to_migrate = set()
+    for table in storage_tables:
+        if _has_integer_id_column(inspector, table):
+            to_migrate.add(table)
+
+    dropped_fks = []
+    for table in storage_tables:
+        for fk in inspector.get_foreign_keys(table):
+            if fk["referred_table"] not in to_migrate:
+                continue
+
+            if "id" not in fk["referred_columns"]:
+                continue
+
+            print_fn(f"Dropping foreign key {fk['name']} on table {table}")
+            _drop_foreign_key_constraint(conn, table, fk)
+            dropped_fks.append(tuple([table, fk]))
+            print_fn(f"Completed dropping foreign key {fk['name']} on table {table}")
+
+    for table in to_migrate:
+        print_fn(f"Altering {table} to use bigint for id column")
+        _convert_int_to_bigint(conn, table, "id")
+        print_fn(f"Completed {table} migration")
+
+    for table, fk in dropped_fks:
+        # first convert the constrained column to bigint, to match the referred column
+        assert len(fk["constrained_columns"]) == 1
+        constrained_col = fk["constrained_columns"][0]
+        print_fn(f"Altering {table} to use bigint for {constrained_col} column")
+        _convert_int_to_bigint(conn, table, constrained_col)
+        print_fn(f"Completed {table} migration")
+
+        # add the foreign key constraint back, if it does not exist
+        print_fn(f"Adding foreign key {fk['name']} on table {table}")
+        _add_foreign_key_constraint(conn, table, fk)
+        print_fn(f"Completed adding foreign key {fk['name']} on table {table}")
+
+
+def run_bigint_migration(instance: DagsterInstance, print_fn: Callable = print):
+    if isinstance(instance.event_log_storage, SqliteEventLogStorage):
+        print_fn("Sqlite does not support bigint types, no need to migrate event log storage.")
+    elif isinstance(instance.event_log_storage, SqlEventLogStorage):
+        with instance.event_log_storage.index_connection() as conn:
+            _migrate_storage(conn, SqlEventLogStorageMetadata, print_fn)
+
+    if isinstance(instance.run_storage, SqliteRunStorage):
+        print_fn("Sqlite does not support bigint types, no need to migrate run storage.")
+    elif isinstance(instance.run_storage, SqlRunStorage):
+        with instance.run_storage.connect() as conn:
+            _migrate_storage(conn, RunStorageSqlMetadata, print_fn)
+
+    if isinstance(instance.schedule_storage, SqliteScheduleStorage):
+        print_fn("Sqlite does not support bigint types, no need to migrate schedule storage.")
+    elif isinstance(instance.schedule_storage, SqlScheduleStorage):
+        with instance.schedule_storage.connect() as conn:
+            _migrate_storage(conn, ScheduleStorageSqlMetadata, print_fn)

--- a/python_modules/dagster/dagster/_core/storage/migration/bigint_migration.py
+++ b/python_modules/dagster/dagster/_core/storage/migration/bigint_migration.py
@@ -9,6 +9,7 @@ from dagster._core.storage.event_log import (
 )
 from dagster._core.storage.event_log.schema import (
     AssetKeyTable,
+    DynamicPartitionsTable,
     SecondaryIndexMigrationTable as EventLogSecondaryIndexTable,
     SqlEventLogStorageTable,
 )
@@ -33,19 +34,19 @@ from dagster._core.storage.schedules.schema import (
 
 
 def _has_integer_id_column(inspector, table):
-    type_by_col_name = {col["name"]: col["type"] for col in inspector.get_columns(table)}
+    type_by_col_name = {col["name"]: col["type"] for col in inspector.get_columns(table.name)}
     id_col_type = type_by_col_name.get("id")
     return id_col_type and str(id_col_type) == str(db.Integer())
 
 
-def _convert_int_to_bigint(conn, table, colname):
+def _convert_id_from_int_to_bigint(conn, table):
     # Since we are not using alembic (which might mess up the versioning system), we need to
     # manually handle the dialect differences for running the migration
     dialect = db.inspect(conn).dialect.name
     if dialect == "postgresql":
-        statement = db.text(f"ALTER TABLE {table} ALTER COLUMN {colname} TYPE BIGINT")
+        statement = db.text(f"ALTER TABLE {table.name} ALTER COLUMN id TYPE BIGINT")
     elif dialect == "mysql":
-        statement = db.text(f"ALTER TABLE {table} MODIFY COLUMN {colname} BIGINT")
+        statement = db.text(f"ALTER TABLE {table.name} MODIFY COLUMN id BIGINT")
     else:
         raise Exception(f"Unsupported dialect {dialect}")
     conn.execute(statement)
@@ -61,10 +62,12 @@ def _remove_asset_event_tags_foreign_key(conn, inspector, print_fn):
         print_fn("Completed dropping foreign key constraint on asset event tags table")
 
 
-def _restore_asset_event_tags_foreign_key(conn, print_fn):
+def _restore_asset_event_tags_foreign_key(conn, inspector, print_fn):
+    if len(inspector.get_foreign_keys("asset_event_tags")) > 0:
+        # There are foreign keys present for the asset event tags table already, no need to restore
+        return
+
     print_fn("Restoring foreign key constraint on asset event tags table")
-    # For pseudo-idempotence, just come up with a foreign key name rather on relying for the
-    # foreign key name to be the same across invocations
     conn.execute(
         db.text(
             "ALTER TABLE asset_event_tags ADD CONSTRAINT asset_event_tags_event_id_fkey"
@@ -74,26 +77,24 @@ def _restore_asset_event_tags_foreign_key(conn, print_fn):
     print_fn("Completed restoring foreign key constraint on asset event tags table")
 
 
-def _migrate_storage(conn, id_tables, print_fn):
+def _migrate_storage(conn, tables_to_migrate, print_fn):
     inspector = db.inspect(conn)
-    table_names = [table.name for table in id_tables]
-    storage_tables = [table for table in inspector.get_table_names() if table in table_names]
-    to_migrate = set()
-    for table in storage_tables:
+    all_table_names = set(inspector.get_table_names())
+
+    for table in tables_to_migrate:
         if _has_integer_id_column(inspector, table):
-            to_migrate.add(table)
+            if table.name == "event_logs" and "asset_event_tags" in all_table_names:
+                # the asset event tags table has a foreign key on the event_logs id that has to be
+                # removed before the event logs col can be converted to bigint
+                _remove_asset_event_tags_foreign_key(conn, inspector, print_fn)
 
-    for table in to_migrate:
-        if table == "event_logs" and "asset_event_tags" in storage_tables:
-            # the asset event tags table has a foreign key on the event_logs id that has to be
-            # removed before the event logs col can be converted to bigint
-            _remove_asset_event_tags_foreign_key(conn, inspector, print_fn)
+            print_fn(f"Altering {table} to use bigint for id column")
+            _convert_id_from_int_to_bigint(conn, table)
+            print_fn(f"Completed {table} migration")
 
-        print_fn(f"Altering {table} to use bigint for id column")
-        _convert_int_to_bigint(conn, table, "id")
-        print_fn(f"Completed {table} migration")
-
-        if table == "event_logs" and "asset_event_tags" in storage_tables:
+        # restore the foreign key on the asset event tags table if needed, even if we did not just
+        # migrate the event logs table in case we hit some error and exited in a bad state
+        if table == "event_logs" and "asset_event_tags" in all_table_names:
             _restore_asset_event_tags_foreign_key(conn, print_fn)
 
 
@@ -102,7 +103,12 @@ def run_bigint_migration(instance: DagsterInstance, print_fn: Callable = print):
         print_fn("Sqlite does not support bigint types, no need to migrate event log storage.")
     elif isinstance(instance.event_log_storage, SqlEventLogStorage):
         with instance.event_log_storage.index_connection() as conn:
-            id_tables = [SqlEventLogStorageTable, EventLogSecondaryIndexTable, AssetKeyTable]
+            id_tables = [
+                SqlEventLogStorageTable,
+                EventLogSecondaryIndexTable,
+                AssetKeyTable,
+                DynamicPartitionsTable,
+            ]
             _migrate_storage(conn, id_tables, print_fn)
 
     if isinstance(instance.run_storage, SqliteRunStorage):

--- a/python_modules/dagster/dagster/_core/storage/migration/bigint_migration.py
+++ b/python_modules/dagster/dagster/_core/storage/migration/bigint_migration.py
@@ -5,14 +5,30 @@ import sqlalchemy as db
 from dagster._core.instance import DagsterInstance
 from dagster._core.storage.event_log import (
     SqlEventLogStorage,
-    SqlEventLogStorageMetadata,
     SqliteEventLogStorage,
 )
-from dagster._core.storage.runs import RunStorageSqlMetadata, SqliteRunStorage, SqlRunStorage
+from dagster._core.storage.event_log.schema import (
+    AssetKeyTable,
+    SecondaryIndexMigrationTable as EventLogSecondaryIndexTable,
+    SqlEventLogStorageTable,
+)
+from dagster._core.storage.runs import SqliteRunStorage, SqlRunStorage
+from dagster._core.storage.runs.schema import (
+    BulkActionsTable,
+    RunsTable,
+    RunTagsTable,
+    SecondaryIndexMigrationTable as RunSecondaryIndexTable,
+    SnapshotsTable,
+)
 from dagster._core.storage.schedules import (
-    ScheduleStorageSqlMetadata,
     SqliteScheduleStorage,
     SqlScheduleStorage,
+)
+from dagster._core.storage.schedules.schema import (
+    InstigatorsTable,
+    JobTable,
+    JobTickTable,
+    SecondaryIndexMigrationTable as ScheduleSecondaryIndexTable,
 )
 
 
@@ -35,60 +51,50 @@ def _convert_int_to_bigint(conn, table, colname):
     conn.execute(statement)
 
 
-def _drop_foreign_key_constraint(conn, table, fk):
-    conn.execute(db.text(f"ALTER TABLE {table} DROP CONSTRAINT {fk['name']}"))
+def _remove_asset_event_tags_foreign_key(conn, inspector, print_fn):
+    for fk in inspector.get_foreign_keys("asset_event_tags"):
+        # even though there should only be one foreign key, each dialect might have a
+        # different naming scheme.  Drop all foreign keys in case this migration exited in
+        # a bad state
+        print_fn("Dropping foreign key constraint on asset event tags table")
+        conn.execute(db.text(f"ALTER TABLE asset_event_tags DROP CONSTRAINT {fk['name']}"))
+        print_fn("Completed dropping foreign key constraint on asset event tags table")
 
 
-def _add_foreign_key_constraint(conn, table, fk):
-    constrained_columns = ", ".join(fk["constrained_columns"])
-    referred_columns = ", ".join(fk["referred_columns"])
+def _restore_asset_event_tags_foreign_key(conn, print_fn):
+    print_fn("Restoring foreign key constraint on asset event tags table")
+    # For pseudo-idempotence, just come up with a foreign key name rather on relying for the
+    # foreign key name to be the same across invocations
     conn.execute(
         db.text(
-            f"ALTER TABLE {table} ADD CONSTRAINT {fk['name']} FOREIGN KEY ({constrained_columns})"
-            f" REFERENCES {fk['referred_table']}({referred_columns}) ON DELETE CASCADE"
+            "ALTER TABLE asset_event_tags ADD CONSTRAINT asset_event_tags_event_id_fkey"
+            " FOREIGN KEY (event_id) REFERENCES event_logs(id) ON DELETE CASCADE"
         )
     )
+    print_fn("Completed restoring foreign key constraint on asset event tags table")
 
 
-def _migrate_storage(conn, metadata, print_fn):
+def _migrate_storage(conn, id_tables, print_fn):
     inspector = db.inspect(conn)
-    storage_tables = [table for table in inspector.get_table_names() if table in metadata.tables]
+    table_names = [table.name for table in id_tables]
+    storage_tables = [table for table in inspector.get_table_names() if table in table_names]
     to_migrate = set()
     for table in storage_tables:
         if _has_integer_id_column(inspector, table):
             to_migrate.add(table)
 
-    dropped_fks = []
-    for table in storage_tables:
-        for fk in inspector.get_foreign_keys(table):
-            if fk["referred_table"] not in to_migrate:
-                continue
-
-            if "id" not in fk["referred_columns"]:
-                continue
-
-            print_fn(f"Dropping foreign key {fk['name']} on table {table}")
-            _drop_foreign_key_constraint(conn, table, fk)
-            dropped_fks.append(tuple([table, fk]))
-            print_fn(f"Completed dropping foreign key {fk['name']} on table {table}")
-
     for table in to_migrate:
+        if table == "event_logs" and "asset_event_tags" in storage_tables:
+            # the asset event tags table has a foreign key on the event_logs id that has to be
+            # removed before the event logs col can be converted to bigint
+            _remove_asset_event_tags_foreign_key(conn, inspector, print_fn)
+
         print_fn(f"Altering {table} to use bigint for id column")
         _convert_int_to_bigint(conn, table, "id")
         print_fn(f"Completed {table} migration")
 
-    for table, fk in dropped_fks:
-        # first convert the constrained column to bigint, to match the referred column
-        assert len(fk["constrained_columns"]) == 1
-        constrained_col = fk["constrained_columns"][0]
-        print_fn(f"Altering {table} to use bigint for {constrained_col} column")
-        _convert_int_to_bigint(conn, table, constrained_col)
-        print_fn(f"Completed {table} migration")
-
-        # add the foreign key constraint back, if it does not exist
-        print_fn(f"Adding foreign key {fk['name']} on table {table}")
-        _add_foreign_key_constraint(conn, table, fk)
-        print_fn(f"Completed adding foreign key {fk['name']} on table {table}")
+        if table == "event_logs" and "asset_event_tags" in storage_tables:
+            _restore_asset_event_tags_foreign_key(conn, print_fn)
 
 
 def run_bigint_migration(instance: DagsterInstance, print_fn: Callable = print):
@@ -96,16 +102,25 @@ def run_bigint_migration(instance: DagsterInstance, print_fn: Callable = print):
         print_fn("Sqlite does not support bigint types, no need to migrate event log storage.")
     elif isinstance(instance.event_log_storage, SqlEventLogStorage):
         with instance.event_log_storage.index_connection() as conn:
-            _migrate_storage(conn, SqlEventLogStorageMetadata, print_fn)
+            id_tables = [SqlEventLogStorageTable, EventLogSecondaryIndexTable, AssetKeyTable]
+            _migrate_storage(conn, id_tables, print_fn)
 
     if isinstance(instance.run_storage, SqliteRunStorage):
         print_fn("Sqlite does not support bigint types, no need to migrate run storage.")
     elif isinstance(instance.run_storage, SqlRunStorage):
         with instance.run_storage.connect() as conn:
-            _migrate_storage(conn, RunStorageSqlMetadata, print_fn)
+            id_tables = [
+                RunsTable,
+                RunSecondaryIndexTable,
+                RunTagsTable,
+                SnapshotsTable,
+                BulkActionsTable,
+            ]
+            _migrate_storage(conn, id_tables, print_fn)
 
     if isinstance(instance.schedule_storage, SqliteScheduleStorage):
         print_fn("Sqlite does not support bigint types, no need to migrate schedule storage.")
     elif isinstance(instance.schedule_storage, SqlScheduleStorage):
         with instance.schedule_storage.connect() as conn:
-            _migrate_storage(conn, ScheduleStorageSqlMetadata, print_fn)
+            id_tables = [JobTable, InstigatorsTable, JobTickTable, ScheduleSecondaryIndexTable]
+            _migrate_storage(conn, id_tables, print_fn)

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
@@ -23,6 +23,7 @@ from dagster._core.errors import DagsterInvalidInvocationError
 from dagster._core.execution.api import execute_job
 from dagster._core.instance import DagsterInstance
 from dagster._core.storage.event_log.migration import ASSET_KEY_INDEX_COLS
+from dagster._core.storage.migration.bigint_migration import run_bigint_migration
 from dagster._core.storage.sqlalchemy_compat import db_select
 from dagster._core.storage.tags import PARTITION_NAME_TAG, PARTITION_SET_TAG
 from dagster._daemon.types import DaemonHeartbeat
@@ -895,3 +896,49 @@ def test_add_primary_keys(hostname, conn_string):
                 )
             assert daemon_heartbeats_id_count == daemon_heartbeats_row_count
             assert get_primary_key(instance, "daemon_heartbeats")
+
+
+def test_bigint_migration(hostname, conn_string):
+    _reconstruct_from_file(
+        hostname,
+        conn_string,
+        file_relative_path(
+            __file__,
+            "snapshot_1_1_22_pre_primary_key/postgres/pg_dump.txt",
+        ),
+    )
+
+    def _get_integer_id_tables(conn):
+        inspector = db.inspect(conn)
+        integer_tables = set()
+        for table in inspector.get_table_names():
+            type_by_col_name = {c["name"]: c["type"] for c in db.inspect(conn).get_columns(table)}
+            id_type = type_by_col_name.get("id")
+            if id_type and str(id_type) == "INTEGER":
+                integer_tables.add(table)
+        return integer_tables
+
+    with tempfile.TemporaryDirectory() as tempdir:
+        with open(
+            file_relative_path(__file__, "dagster.yaml"), "r", encoding="utf8"
+        ) as template_fd:
+            with open(os.path.join(tempdir, "dagster.yaml"), "w", encoding="utf8") as target_fd:
+                template = template_fd.read().format(hostname=hostname)
+                target_fd.write(template)
+
+        with DagsterInstance.from_config(tempdir) as instance:
+            with instance.run_storage.connect() as conn:
+                assert len(_get_integer_id_tables(conn)) > 0
+            with instance.event_log_storage.index_connection() as conn:
+                assert len(_get_integer_id_tables(conn)) > 0
+            with instance.schedule_storage.connect() as conn:
+                assert len(_get_integer_id_tables(conn)) > 0
+
+            run_bigint_migration(instance)
+
+            with instance.run_storage.connect() as conn:
+                assert len(_get_integer_id_tables(conn)) == 0
+            with instance.event_log_storage.index_connection() as conn:
+                assert len(_get_integer_id_tables(conn)) == 0
+            with instance.schedule_storage.connect() as conn:
+                assert len(_get_integer_id_tables(conn)) == 0


### PR DESCRIPTION
## Summary & Motivation
Creates an optional schema migration (may incur downtime) to convert all table ids from int => bigint.

This is run outside of the alembic machinery, since it is optional and can be applied at any time.  This uses the db inspector to convert the `id` column of any known tables.

## How I Tested These Changes
BK