### PR TITLE
build-docs: skip certain PR specific steps for master branch and handle release- branch

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -3,7 +3,8 @@ on:
   push:
     branches:
       - master
-      - docs-prod
+      - 'release-*' # older verions of the docs
+      - docs-prod # prod
     paths:
       - docs/**
   pull_request:
@@ -17,16 +18,18 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      # Deploy to Vercel Previews on pull request or push to master branch
+      # Deploy to Vercel Previews on pull request, push to master branch, or push to release-* branch
       - name: Get branch preview subdomain
-        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/master')
+        if: |
+          github.event_name == 'pull_request' || 
+          (github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-')))
         run: |
           BRANCH_PREVIEW_SUBDOMAIN=$(echo "${{ github.head_ref || github.ref_name }}" | sed 's/[^a-zA-Z0-9-]/-/g' | sed 's/^-*//' | sed 's/-*$//')
           echo "$BRANCH_PREVIEW_SUBDOMAIN"
           echo "BRANCH_PREVIEW_SUBDOMAIN=$BRANCH_PREVIEW_SUBDOMAIN" >> "${GITHUB_ENV}"
 
-      - name: Checkout master branch
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+      - name: Checkout master/release branch
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-'))
         uses: actions/checkout@v3
         
       - name: Get PR fetch depth
@@ -60,7 +63,9 @@ jobs:
 
       - name: Publish Preview to Vercel
         uses: amondnet/vercel-action@v25
-        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/master')
+        if: |
+          github.event_name == 'pull_request' || 
+          (github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-')))
         with:
           github-comment: ${{ github.event.pull_request && env.CHANGES_ENTRY || true }}
           vercel-token: ${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -25,19 +25,22 @@ jobs:
           echo "$BRANCH_PREVIEW_SUBDOMAIN"
           echo "BRANCH_PREVIEW_SUBDOMAIN=$BRANCH_PREVIEW_SUBDOMAIN" >> "${GITHUB_ENV}"
 
+      - name: Checkout master branch
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: actions/checkout@v3
+        
       - name: Get PR fetch depth
-        if: ${{ github.event.pull_request }} || (github.event_name == 'push' && github.ref == 'refs/heads/master')
+        if: ${{ github.event.pull_request }}
         run: echo "PR_FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "${GITHUB_ENV}"
 
       - name: Checkout PR branch
         uses: actions/checkout@v3
-        if: ${{ github.event.pull_request }} || (github.event_name == 'push' && github.ref == 'refs/heads/master')
-        with:
+        if: ${{ github.event.pull_request }} 
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: ${{ env.PR_FETCH_DEPTH }}
 
-      - name: Get changed docs files
-        if: ${{ github.event.pull_request }} || (github.event_name == 'push' && github.ref == 'refs/heads/master')
+      - name: Get changed docs files for PR comment
+        if: ${{ github.event.pull_request }}
         run: |
           echo "Base ref is $GITHUB_BASE_SHA"
           echo "Head ref is $GITHUB_HEAD_SHA"


### PR DESCRIPTION
## Summary & Motivation
fix an issue in https://github.com/dagster-io/dagster/pull/16007
master commit like [this](https://github.com/dagster-io/dagster/actions/runs/5955629524/job/16154679369) failed because some steps don't apply to master. this pr handles PR branches and master differently.

this pr also adds back the condition to build on push to release-* branch.
- @prha we removed it here: https://github.com/dagster-io/dagster/commit/aafe1b12e807c70c604607922efbb9fec6aa4972 - wonder if there's a reason removing it? i'd like to reference the preview generated from release-* as the older version

## How I Tested These Changes
