### PR TITLE
Remove 'edit workspace' permission from docs

### DIFF
--- a/docs/content/dagster-cloud/account/managing-users/managing-user-roles-permissions.mdx
+++ b/docs/content/dagster-cloud/account/managing-users/managing-user-roles-permissions.mdx
@@ -692,14 +692,6 @@ Team management is accessed in the UI by navigating to **user menu (your icon) >
       <td className="bg-green-50">✅</td>
     </tr>
     <tr>
-      <td>Edit workspace</td>
-      <td className="bg-red-50">❌</td>
-      <td className="bg-red-50">❌</td>
-      <td className="bg-green-50">✅</td>
-      <td className="bg-green-50">✅</td>
-      <td className="bg-green-50">✅</td>
-    </tr>
-    <tr>
       <td>
         <a href="/dagster-cloud/account/authentication">Administer SAML</a>
       </td>


### PR DESCRIPTION
I believe this is redundant with the Code locations section above