### PR TITLE
Fix asset prefix replacement logic in OSS

### DIFF
--- a/python_modules/dagster-webserver/dagster_webserver/webserver.py
+++ b/python_modules/dagster-webserver/dagster_webserver/webserver.py
@@ -42,9 +42,11 @@ T_IWorkspaceProcessContext = TypeVar("T_IWorkspaceProcessContext", bound=IWorksp
 
 class DagsterWebserver(GraphQLServer, Generic[T_IWorkspaceProcessContext]):
     _process_context: T_IWorkspaceProcessContext
+    _uses_app_path_prefix: bool
 
-    def __init__(self, process_context: T_IWorkspaceProcessContext, app_path_prefix: str = ""):
+    def __init__(self, process_context: T_IWorkspaceProcessContext, app_path_prefix: str = "", uses_app_path_prefix: bool = True):
         self._process_context = process_context
+        self._uses_app_path_prefix= uses_app_path_prefix
         super().__init__(app_path_prefix)
 
     def build_graphql_schema(self) -> Schema:
@@ -248,7 +250,7 @@ class DagsterWebserver(GraphQLServer, Generic[T_IWorkspaceProcessContext]):
                 full_path = path.join(subdir, file)
                 relative_path = "/" + full_path[len(base_dir) :].lstrip(path.sep)
                 # We only need to replace BUILDTIME_ASSETPREFIX_REPLACE_ME in javascript files
-                if self._app_path_prefix and (file.endswith(".js") or file.endswith(".js.map")):
+                if self._uses_app_path_prefix and (file.endswith(".js") or file.endswith(".js.map")):
                     routes.append(_next_static_file(relative_path, full_path))
                 else:
                     routes.append(_static_file(relative_path, full_path))

--- a/python_modules/dagster-webserver/dagster_webserver/webserver.py
+++ b/python_modules/dagster-webserver/dagster_webserver/webserver.py
@@ -44,9 +44,14 @@ class DagsterWebserver(GraphQLServer, Generic[T_IWorkspaceProcessContext]):
     _process_context: T_IWorkspaceProcessContext
     _uses_app_path_prefix: bool
 
-    def __init__(self, process_context: T_IWorkspaceProcessContext, app_path_prefix: str = "", uses_app_path_prefix: bool = True):
+    def __init__(
+        self,
+        process_context: T_IWorkspaceProcessContext,
+        app_path_prefix: str = "",
+        uses_app_path_prefix: bool = True,
+    ):
         self._process_context = process_context
-        self._uses_app_path_prefix= uses_app_path_prefix
+        self._uses_app_path_prefix = uses_app_path_prefix
         super().__init__(app_path_prefix)
 
     def build_graphql_schema(self) -> Schema:
@@ -250,7 +255,9 @@ class DagsterWebserver(GraphQLServer, Generic[T_IWorkspaceProcessContext]):
                 full_path = path.join(subdir, file)
                 relative_path = "/" + full_path[len(base_dir) :].lstrip(path.sep)
                 # We only need to replace BUILDTIME_ASSETPREFIX_REPLACE_ME in javascript files
-                if self._uses_app_path_prefix and (file.endswith(".js") or file.endswith(".js.map")):
+                if self._uses_app_path_prefix and (
+                    file.endswith(".js") or file.endswith(".js.map")
+                ):
                     routes.append(_next_static_file(relative_path, full_path))
                 else:
                     routes.append(_static_file(relative_path, full_path))


### PR DESCRIPTION
## Summary & Motivation

To support path_prefix in OSS we need to modify strings in the javascript output to jam the prefix in. This causes extra work for every request and makes our JS uncacheable so I added a check to avoid taking that perf hit from cloud in https://github.com/dagster-io/dagster/pull/16020 . The problem is this also makes OSS skip the path prefix replacement logic (it needs to replace the special string with an empty string) so static files referenced from JS were not being loaded correctly.

This PR fixes that and also adds a way for cloud to opt of that behavior via the `_uses_app_path_prefix` flag.

Long term we should cache the string replaced version in a file locally to avoid doing the work on every request, and also set the proper headers for caching.

## How I Tested These Changes

Loaded dagster dev after building