### PR TITLE
docs version fix: determine latest version properly

### DIFF
--- a/docs/next/util/version.ts
+++ b/docs/next/util/version.ts
@@ -1,7 +1,6 @@
-import ALL_VERSIONS from '../.versioned_content/_versions.json';
 import MAP_VERSION_TO_LINK from '../.versioned_content/_versions_with_static_links.json';
 
-export const LATEST_VERSION = ALL_VERSIONS[ALL_VERSIONS.length - 1];
+export const LATEST_VERSION = MAP_VERSION_TO_LINK[MAP_VERSION_TO_LINK.length - 1].version;
 
 export function getOlderVersions() {
   // exclude latest version which will be the current site. sort by version desc


### PR DESCRIPTION
## Summary & Motivation
as we no longer update _versions.json (plan to remove it after this week's release), LATEST_VERSION should not be derived from it.

## How I Tested These Changes
`yarn dev` and preview

https://08-24-docs-version-fix-determine-latest-version-properly.dagster.dagster-docs.io/getting-started shows 1.4.9 as the latest version, while the current site (https://docs.dagster.io/getting-started) shows 1.4.8 after 1.4.9 is released.