### PR TITLE
Add securityContext to daemon initContainer (#16092)

### DIFF
--- a/helm/dagster/templates/deployment-daemon.yaml
+++ b/helm/dagster/templates/deployment-daemon.yaml
@@ -59,6 +59,8 @@ spec:
         - name: "init-user-deployment-{{- $deployment.name -}}"
           image: {{ include "dagster.externalImage.name" $.Values.busybox.image | quote }}
           command: ['sh', '-c', "until nslookup {{ $deployment.name -}}; do echo waiting for user service; sleep 2; done"]
+          securityContext:
+            {{- toYaml $.Values.dagsterDaemon.securityContext | nindent 12 }}
         {{- end }}
         {{- end }}
       containers:


### PR DESCRIPTION
## Summary & Motivation

In the deployment-daemon.yaml a initContainer is created for every element of userDeployment.deployments

This is not inheriting the (container-)security context Values.dagsterDaemon.securityContext like the check-db-ready initContainer or the actual daemon.

With Pod Security restrictions in place there is no way to get past the admission hook

## How I tested

I tested building the helm chart und submitting it and it renders and starts. This is my first Contribution, and I followed all Guidelines I could find (wonderful template btw). If there is a formal issue, please don't hesitate to point to hit. :)