### PR TITLE
Fix mounting static files on windows

### DIFF
--- a/python_modules/dagster-webserver/dagster_webserver/webserver.py
+++ b/python_modules/dagster-webserver/dagster_webserver/webserver.py
@@ -253,14 +253,16 @@ class DagsterWebserver(GraphQLServer, Generic[T_IWorkspaceProcessContext]):
         for subdir, _, files in walk(base_dir):
             for file in files:
                 full_path = path.join(subdir, file)
-                relative_path = "/" + full_path[len(base_dir) :].replace(path.sep, "/")
+
+                # Replace path.sep to make sure our routes use forward slashes on windows
+                mount_path = "/" + full_path[len(base_dir) :].replace(path.sep, "/")
                 # We only need to replace BUILDTIME_ASSETPREFIX_REPLACE_ME in javascript files
                 if self._uses_app_path_prefix and (
                     file.endswith(".js") or file.endswith(".js.map")
                 ):
-                    routes.append(_next_static_file(relative_path, full_path))
+                    routes.append(_next_static_file(mount_path, full_path))
                 else:
-                    routes.append(_static_file(relative_path, full_path))
+                    routes.append(_static_file(mount_path, full_path))
 
         # No build directory, this happens in a test environment. Don't fail loudly since we already have other tests that will fail loudly if
         # there is in fact no build

--- a/python_modules/dagster-webserver/dagster_webserver/webserver.py
+++ b/python_modules/dagster-webserver/dagster_webserver/webserver.py
@@ -253,7 +253,7 @@ class DagsterWebserver(GraphQLServer, Generic[T_IWorkspaceProcessContext]):
         for subdir, _, files in walk(base_dir):
             for file in files:
                 full_path = path.join(subdir, file)
-                relative_path = "/" + full_path[len(base_dir) :].lstrip(path.sep)
+                relative_path = "/" + full_path[len(base_dir) :].lstrip(path.sep).replace(os.path.sep, "/")
                 # We only need to replace BUILDTIME_ASSETPREFIX_REPLACE_ME in javascript files
                 if self._uses_app_path_prefix and (
                     file.endswith(".js") or file.endswith(".js.map")

--- a/python_modules/dagster-webserver/dagster_webserver/webserver.py
+++ b/python_modules/dagster-webserver/dagster_webserver/webserver.py
@@ -253,7 +253,7 @@ class DagsterWebserver(GraphQLServer, Generic[T_IWorkspaceProcessContext]):
         for subdir, _, files in walk(base_dir):
             for file in files:
                 full_path = path.join(subdir, file)
-                relative_path = full_path[len(base_dir) :].replace(os.path.sep, "/")
+                relative_path = "/" + full_path[len(base_dir) :].replace(path.sep, "/")
                 # We only need to replace BUILDTIME_ASSETPREFIX_REPLACE_ME in javascript files
                 if self._uses_app_path_prefix and (
                     file.endswith(".js") or file.endswith(".js.map")

--- a/python_modules/dagster-webserver/dagster_webserver/webserver.py
+++ b/python_modules/dagster-webserver/dagster_webserver/webserver.py
@@ -253,7 +253,7 @@ class DagsterWebserver(GraphQLServer, Generic[T_IWorkspaceProcessContext]):
         for subdir, _, files in walk(base_dir):
             for file in files:
                 full_path = path.join(subdir, file)
-                relative_path = "/" + full_path[len(base_dir) :].lstrip(path.sep).replace(os.path.sep, "/")
+                relative_path = full_path[len(base_dir) :].replace(os.path.sep, "/")
                 # We only need to replace BUILDTIME_ASSETPREFIX_REPLACE_ME in javascript files
                 if self._uses_app_path_prefix and (
                     file.endswith(".js") or file.endswith(".js.map")

--- a/python_modules/dagster-webserver/dagster_webserver_tests/test_app.py
+++ b/python_modules/dagster-webserver/dagster_webserver_tests/test_app.py
@@ -90,7 +90,7 @@ def test_index_view(instance):
         res = client.get("/")
 
         assert res.status_code == 200, res.content
-        assert b"<title>Dagster Cloud</title>" in res.content
+        assert b"<title>Dagster</title>" in res.content
 
 
 def test_index_view_at_path_prefix(instance):


### PR DESCRIPTION
## Summary & Motivation

The logic for mounting static files kept the system's path separators resulting in static files being mounted to `localhost:3000/path\to\file.js` on windows. This fixes that issue by replacing the separators of the OS with "/".

## How I Tested These Changes

Works locally on OSX.

Confirmed it fixes windows:
![image](https://github.com/dagster-io/dagster/assets/2286579/9c74ce40-abd4-46ca-8e59-5d1146e5dc77)
