### PR TITLE
Surface asset check run failures

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetCheckStatusTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetCheckStatusTag.tsx
@@ -26,7 +26,7 @@ export const AssetCheckStatusTag = ({
           </Box>
         </Tag>
       );
-    case AssetCheckExecutionResolvedStatus.FAILURE:
+    case AssetCheckExecutionResolvedStatus.FAILED:
       return (
         <Tag icon={isWarn ? 'warning_outline' : 'cancel'} intent={isWarn ? 'warning' : 'danger'}>
           Failed

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetCheckStatusTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetCheckStatusTag.tsx
@@ -1,22 +1,23 @@
 import {Box, Spinner, Tag} from '@dagster-io/ui-components';
 import * as React from 'react';
 
-import {AssetCheckExecutionStatus, AssetCheckSeverity} from '../../graphql/types';
+import {AssetCheckExecutionResolvedStatus, AssetCheckSeverity} from '../../graphql/types';
 
 export const AssetCheckStatusTag = ({
   status,
   severity,
   notChecked,
 }: {
-  status?: AssetCheckExecutionStatus;
+  status?: AssetCheckExecutionResolvedStatus;
   severity?: AssetCheckSeverity;
   notChecked?: boolean;
 }) => {
   if (notChecked) {
     return <Tag>Not checked</Tag>;
   }
+  const isWarn = severity === AssetCheckSeverity.WARN;
   switch (status) {
-    case AssetCheckExecutionStatus.PLANNED:
+    case AssetCheckExecutionResolvedStatus.IN_PROGRESS:
       return (
         <Tag intent="primary">
           <Box flex={{direction: 'row', alignItems: 'center', gap: 4}}>
@@ -25,20 +26,15 @@ export const AssetCheckStatusTag = ({
           </Box>
         </Tag>
       );
-    case AssetCheckExecutionStatus.FAILURE:
-      const isWarn = severity === AssetCheckSeverity.WARN;
+    case AssetCheckExecutionResolvedStatus.FAILURE:
       return (
         <Tag icon={isWarn ? 'warning_outline' : 'cancel'} intent={isWarn ? 'warning' : 'danger'}>
           Failed
         </Tag>
       );
-    // case 'error':
-    //   return (
-    //     <Tag icon="warning_outline" intent="danger">
-    //       Execution failed
-    //     </Tag>
-    //   );
-    case AssetCheckExecutionStatus.SUCCESS:
+    case AssetCheckExecutionResolvedStatus.EXECUTION_FAILURE:
+      return <Tag intent={isWarn ? 'warning' : 'danger'}>Execution failed</Tag>;
+    case AssetCheckExecutionResolvedStatus.SUCCESS:
       return (
         <Tag icon="check_circle" intent="success">
           Passed

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetCheckStatusTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetCheckStatusTag.tsx
@@ -32,9 +32,9 @@ export const AssetCheckStatusTag = ({
           Failed
         </Tag>
       );
-    case AssetCheckExecutionResolvedStatus.EXECUTION_FAILURE:
+    case AssetCheckExecutionResolvedStatus.EXECUTION_FAILED:
       return <Tag intent={isWarn ? 'warning' : 'danger'}>Execution failed</Tag>;
-    case AssetCheckExecutionResolvedStatus.SUCCESS:
+    case AssetCheckExecutionResolvedStatus.SUCCEEDED:
       return (
         <Tag icon="check_circle" intent="success">
           Passed

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/VirtualizedAssetCheckTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/VirtualizedAssetCheckTable.tsx
@@ -4,7 +4,11 @@ import * as React from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components';
 
-import {AssetCheckExecutionStatus, AssetCheckSeverity, AssetKeyInput} from '../../graphql/types';
+import {
+  AssetCheckExecutionResolvedStatus,
+  AssetCheckSeverity,
+  AssetKeyInput,
+} from '../../graphql/types';
 import {TimestampDisplay} from '../../schedules/TimestampDisplay';
 import {testId} from '../../testing/testId';
 import {HeaderCell, Row, RowCell, Container, Inner} from '../../ui/VirtualizedTable';
@@ -93,7 +97,7 @@ export const VirtualizedAssetCheckRow = ({
       // for the asset, then that means this check was not checked on that materialization.
       (!lastExecution ||
         lastExecution.evaluation?.targetMaterialization?.runId !== lastMaterializationRunId) &&
-      lastExecution?.status !== AssetCheckExecutionStatus.PLANNED
+      lastExecution?.status !== AssetCheckExecutionResolvedStatus.IN_PROGRESS
     ) {
       return <AssetCheckStatusTag notChecked={true} />;
     }

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/__fixtures__/AssetChecks.fixtures.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/__fixtures__/AssetChecks.fixtures.tsx
@@ -32,7 +32,7 @@ export const TestAssetCheck = buildAssetCheck({
         metadataEntries: [buildIntMetadataEntry({})],
       }),
       runId: testLatestMaterializationRunId,
-      status: AssetCheckExecutionResolvedStatus.FAILURE,
+      status: AssetCheckExecutionResolvedStatus.FAILED,
     }),
     buildAssetCheckExecution({
       evaluation: buildAssetCheckEvaluation({
@@ -75,7 +75,7 @@ export const TestAssetCheckWarning = buildAssetCheck({
         metadataEntries: [buildIntMetadataEntry({})],
       }),
       runId: testLatestMaterializationRunId,
-      status: AssetCheckExecutionResolvedStatus.FAILURE,
+      status: AssetCheckExecutionResolvedStatus.FAILED,
     }),
     buildAssetCheckExecution({
       evaluation: buildAssetCheckEvaluation({

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/__fixtures__/AssetChecks.fixtures.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/__fixtures__/AssetChecks.fixtures.tsx
@@ -1,5 +1,5 @@
 import {
-  AssetCheckExecutionStatus,
+  AssetCheckExecutionResolvedStatus,
   AssetCheckSeverity,
   buildAssetCheck,
   buildAssetCheckEvaluation,
@@ -32,7 +32,7 @@ export const TestAssetCheck = buildAssetCheck({
         metadataEntries: [buildIntMetadataEntry({})],
       }),
       runId: testLatestMaterializationRunId,
-      status: AssetCheckExecutionStatus.FAILURE,
+      status: AssetCheckExecutionResolvedStatus.FAILURE,
     }),
     buildAssetCheckExecution({
       evaluation: buildAssetCheckEvaluation({
@@ -75,7 +75,7 @@ export const TestAssetCheckWarning = buildAssetCheck({
         metadataEntries: [buildIntMetadataEntry({})],
       }),
       runId: testLatestMaterializationRunId,
-      status: AssetCheckExecutionStatus.FAILURE,
+      status: AssetCheckExecutionResolvedStatus.FAILURE,
     }),
     buildAssetCheckExecution({
       evaluation: buildAssetCheckEvaluation({

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/types/AssetCheckDetailModal.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/types/AssetCheckDetailModal.types.ts
@@ -6,7 +6,7 @@ export type AssetCheckExecutionFragment = {
   __typename: 'AssetCheckExecution';
   id: string;
   runId: string;
-  status: Types.AssetCheckExecutionStatus;
+  status: Types.AssetCheckExecutionResolvedStatus;
   evaluation: {
     __typename: 'AssetCheckEvaluation';
     timestamp: number;
@@ -147,7 +147,7 @@ export type AssetCheckDetailsQuery = {
             __typename: 'AssetCheckExecution';
             id: string;
             runId: string;
-            status: Types.AssetCheckExecutionStatus;
+            status: Types.AssetCheckExecutionResolvedStatus;
             evaluation: {
               __typename: 'AssetCheckEvaluation';
               timestamp: number;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/types/AssetChecks.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/types/AssetChecks.types.ts
@@ -21,7 +21,7 @@ export type AssetChecksQuery = {
             __typename: 'AssetCheckExecution';
             id: string;
             runId: string;
-            status: Types.AssetCheckExecutionStatus;
+            status: Types.AssetCheckExecutionResolvedStatus;
             evaluation: {
               __typename: 'AssetCheckEvaluation';
               timestamp: number;

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -3202,9 +3202,9 @@ type AssetCheckExecution {
 
 enum AssetCheckExecutionResolvedStatus {
   IN_PROGRESS
-  SUCCESS
+  SUCCEEDED
   FAILED
-  EXECUTION_FAILURE
+  EXECUTION_FAILED
   SKIPPED
 }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -3203,7 +3203,7 @@ type AssetCheckExecution {
 enum AssetCheckExecutionResolvedStatus {
   IN_PROGRESS
   SUCCESS
-  FAILURE
+  FAILED
   EXECUTION_FAILURE
   SKIPPED
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -3196,14 +3196,16 @@ enum AssetCheckSeverity {
 type AssetCheckExecution {
   id: String!
   runId: String!
-  status: AssetCheckExecutionStatus!
+  status: AssetCheckExecutionResolvedStatus!
   evaluation: AssetCheckEvaluation
 }
 
-enum AssetCheckExecutionStatus {
-  PLANNED
+enum AssetCheckExecutionResolvedStatus {
+  IN_PROGRESS
   SUCCESS
   FAILURE
+  EXECUTION_FAILURE
+  SKIPPED
 }
 
 type AssetCheckNeedsMigrationError implements Error {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -174,12 +174,14 @@ export type AssetCheckExecution = {
   evaluation: Maybe<AssetCheckEvaluation>;
   id: Scalars['String'];
   runId: Scalars['String'];
-  status: AssetCheckExecutionStatus;
+  status: AssetCheckExecutionResolvedStatus;
 };
 
-export enum AssetCheckExecutionStatus {
+export enum AssetCheckExecutionResolvedStatus {
+  EXECUTION_FAILURE = 'EXECUTION_FAILURE',
   FAILURE = 'FAILURE',
-  PLANNED = 'PLANNED',
+  IN_PROGRESS = 'IN_PROGRESS',
+  SKIPPED = 'SKIPPED',
   SUCCESS = 'SUCCESS',
 }
 
@@ -4533,7 +4535,7 @@ export const buildAssetCheckExecution = (
     status:
       overrides && overrides.hasOwnProperty('status')
         ? overrides.status!
-        : AssetCheckExecutionStatus.FAILURE,
+        : AssetCheckExecutionResolvedStatus.EXECUTION_FAILURE,
   };
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -179,7 +179,7 @@ export type AssetCheckExecution = {
 
 export enum AssetCheckExecutionResolvedStatus {
   EXECUTION_FAILURE = 'EXECUTION_FAILURE',
-  FAILURE = 'FAILURE',
+  FAILED = 'FAILED',
   IN_PROGRESS = 'IN_PROGRESS',
   SKIPPED = 'SKIPPED',
   SUCCESS = 'SUCCESS',

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -178,11 +178,11 @@ export type AssetCheckExecution = {
 };
 
 export enum AssetCheckExecutionResolvedStatus {
-  EXECUTION_FAILURE = 'EXECUTION_FAILURE',
+  EXECUTION_FAILED = 'EXECUTION_FAILED',
   FAILED = 'FAILED',
   IN_PROGRESS = 'IN_PROGRESS',
   SKIPPED = 'SKIPPED',
-  SUCCESS = 'SUCCESS',
+  SUCCEEDED = 'SUCCEEDED',
 }
 
 export type AssetCheckNeedsMigrationError = Error & {
@@ -4535,7 +4535,7 @@ export const buildAssetCheckExecution = (
     status:
       overrides && overrides.hasOwnProperty('status')
         ? overrides.status!
-        : AssetCheckExecutionResolvedStatus.EXECUTION_FAILURE,
+        : AssetCheckExecutionResolvedStatus.EXECUTION_FAILED,
   };
 };
 

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_checks.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_checks.py
@@ -47,8 +47,8 @@ def _get_asset_check_execution_status(
     """
     record_status = execution.status
 
-    if record_status == AssetCheckExecutionRecordStatus.SUCCESS:
-        return AssetCheckExecutionResolvedStatus.SUCCESS
+    if record_status == AssetCheckExecutionRecordStatus.SUCCEEDED:
+        return AssetCheckExecutionResolvedStatus.SUCCEEDED
     elif record_status == AssetCheckExecutionRecordStatus.FAILED:
         return AssetCheckExecutionResolvedStatus.FAILED
     elif record_status == AssetCheckExecutionRecordStatus.PLANNED:
@@ -56,7 +56,7 @@ def _get_asset_check_execution_status(
 
         if run.is_finished:
             if run.status == DagsterRunStatus.FAILURE:
-                return AssetCheckExecutionResolvedStatus.EXECUTION_FAILURE
+                return AssetCheckExecutionResolvedStatus.EXECUTION_FAILED
             else:
                 return AssetCheckExecutionResolvedStatus.SKIPPED
         else:

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_checks.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_checks.py
@@ -1,6 +1,14 @@
 from typing import TYPE_CHECKING, Optional
 
+import dagster._check as check
 from dagster import AssetKey
+from dagster._core.instance import DagsterInstance
+from dagster._core.storage.asset_check_execution_record import (
+    AssetCheckExecutionRecord,
+    AssetCheckExecutionResolvedStatus,
+    AssetCheckExecutionStoredStatus,
+)
+from dagster._core.storage.dagster_run import DagsterRunStatus
 
 from ..schema.asset_checks import (
     GrapheneAssetCheck,
@@ -27,3 +35,30 @@ def fetch_asset_checks(
     return GrapheneAssetChecks(
         checks=[GrapheneAssetCheck(check) for check in external_asset_checks]
     )
+
+
+def get_asset_check_execution_status(
+    instance: DagsterInstance, execution: AssetCheckExecutionRecord
+) -> AssetCheckExecutionResolvedStatus:
+    """Asset checks stay in PLANNED status until the evaluation event arives. Check if the run is
+    still active, and if not, return the actual status.
+    """
+    stored_status = execution.stored_status
+
+    if stored_status == AssetCheckExecutionStoredStatus.SUCCESS:
+        return AssetCheckExecutionResolvedStatus.SUCCESS
+    elif stored_status == AssetCheckExecutionStoredStatus.FAILURE:
+        return AssetCheckExecutionResolvedStatus.FAILURE
+    elif stored_status == AssetCheckExecutionStoredStatus.PLANNED:
+        run = check.not_none(instance.get_run_by_id(execution.run_id))
+
+        if run.is_finished:
+            if run.status == DagsterRunStatus.FAILURE:
+                return AssetCheckExecutionResolvedStatus.EXECUTION_FAILURE
+            else:
+                return AssetCheckExecutionResolvedStatus.SKIPPED
+        else:
+            return AssetCheckExecutionResolvedStatus.IN_PROGRESS
+
+    else:
+        check.failed(f"Unexpected status {stored_status}")

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_checks.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_checks.py
@@ -168,6 +168,8 @@ class TestAssetChecks(ExecutingGraphQLContextTestMatrix):
     def test_asset_check_executions(self, graphql_context: WorkspaceRequestContext):
         graphql_context.instance.wipe()
 
+        create_run_for_test(graphql_context.instance, run_id="foo")
+
         graphql_context.instance.event_log_storage.store_event(
             _planned_event(
                 "foo",
@@ -188,7 +190,7 @@ class TestAssetChecks(ExecutingGraphQLContextTestMatrix):
                         "executions": [
                             {
                                 "runId": "foo",
-                                "status": "PLANNED",
+                                "status": "IN_PROGRESS",
                                 "evaluation": None,
                             }
                         ],
@@ -284,6 +286,60 @@ class TestAssetChecks(ExecutingGraphQLContextTestMatrix):
                     {
                         "__typename": "AssetCheckEvaluationEvent",
                     },
+                ],
+            }
+        }
+
+    def test_asset_check_failure(self, graphql_context: WorkspaceRequestContext, snapshot):
+        graphql_context.instance.wipe()
+
+        run = create_run_for_test(graphql_context.instance)
+
+        graphql_context.instance.event_log_storage.store_event(
+            _planned_event(
+                run.run_id,
+                AssetCheckEvaluationPlanned(asset_key=AssetKey(["asset_1"]), check_name="my_check"),
+            )
+        )
+
+        res = execute_dagster_graphql(
+            graphql_context,
+            GET_ASSET_CHECK_HISTORY,
+            variables={"assetKey": {"path": ["asset_1"]}, "checkName": "my_check"},
+        )
+        assert res.data == {
+            "assetChecksOrError": {
+                "checks": [
+                    {
+                        "name": "my_check",
+                        "executions": [
+                            {
+                                "runId": run.run_id,
+                                "status": "IN_PROGRESS",
+                                "evaluation": None,
+                            }
+                        ],
+                    }
+                ]
+            }
+        }
+
+        graphql_context.instance.report_run_failed(run)
+
+        res = execute_dagster_graphql(
+            graphql_context,
+            GET_ASSET_CHECK_HISTORY,
+            variables={"assetKey": {"path": ["asset_1"]}, "checkName": "my_check"},
+        )
+        assert res.data == {
+            "assetChecksOrError": {
+                "checks": [
+                    {
+                        "name": "my_check",
+                        "executions": [
+                            {"runId": run.run_id, "status": "EXECUTION_FAILURE", "evaluation": None}
+                        ],
+                    }
                 ],
             }
         }

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_checks.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_checks.py
@@ -232,7 +232,7 @@ class TestAssetChecks(ExecutingGraphQLContextTestMatrix):
                         "executions": [
                             {
                                 "runId": "foo",
-                                "status": "SUCCESS",
+                                "status": "SUCCEEDED",
                                 "evaluation": {
                                     "timestamp": evaluation_timestamp,
                                     "targetMaterialization": {
@@ -339,7 +339,7 @@ class TestAssetChecks(ExecutingGraphQLContextTestMatrix):
                     {
                         "name": "my_check",
                         "executions": [
-                            {"runId": run.run_id, "status": "EXECUTION_FAILURE", "evaluation": None}
+                            {"runId": run.run_id, "status": "EXECUTION_FAILED", "evaluation": None}
                         ],
                     }
                 ],

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_checks.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_checks.py
@@ -163,7 +163,9 @@ class TestAssetChecks(ExecutingGraphQLContextTestMatrix):
         )
         assert res.data
         assert res.data["assetChecksOrError"]["checks"][0]["executions"][0]["id"]
-        assert res.data["assetChecksOrError"]["checks"][0]["executions"][0]["status"] == "PLANNED"
+        assert (
+            res.data["assetChecksOrError"]["checks"][0]["executions"][0]["status"] == "IN_PROGRESS"
+        )
 
     def test_asset_check_executions(self, graphql_context: WorkspaceRequestContext):
         graphql_context.instance.wipe()

--- a/python_modules/dagster/dagster/_core/storage/asset_check_execution_record.py
+++ b/python_modules/dagster/dagster/_core/storage/asset_check_execution_record.py
@@ -8,16 +8,16 @@ from dagster import EventLogEntry
 # at read time. This is because the write path is to store a planned event (which creates a row
 # with PLANNED status) then update the row when we get the check result. But if the check never
 # runs, the row stays in PLANNED status.
-class AssetCheckExecutionStoredStatus(enum.Enum):
+class AssetCheckExecutionRecordStatus(enum.Enum):
     PLANNED = "PLANNED"
     SUCCESS = "SUCCESS"
-    FAILURE = "FAILURE"  # explicit fail result
+    FAILED = "FAILED"  # explicit fail result
 
 
 class AssetCheckExecutionResolvedStatus(enum.Enum):
     IN_PROGRESS = "IN_PROGRESS"
     SUCCESS = "SUCCESS"
-    FAILURE = "FAILURE"  # explicit fail result
+    FAILED = "FAILED"  # explicit fail result
     EXECUTION_FAILURE = "EXECUTION_FAILURE"  # hit some exception
     SKIPPED = "SKIPPED"  # the run finished, didn't fail, but the check didn't execute
 
@@ -25,6 +25,6 @@ class AssetCheckExecutionResolvedStatus(enum.Enum):
 class AssetCheckExecutionRecord(NamedTuple):
     id: int
     run_id: str
-    stored_status: AssetCheckExecutionStoredStatus
+    status: AssetCheckExecutionRecordStatus
     evaluation_event: Optional[EventLogEntry]
     create_timestamp: float

--- a/python_modules/dagster/dagster/_core/storage/asset_check_execution_record.py
+++ b/python_modules/dagster/dagster/_core/storage/asset_check_execution_record.py
@@ -10,15 +10,15 @@ from dagster import EventLogEntry
 # runs, the row stays in PLANNED status.
 class AssetCheckExecutionRecordStatus(enum.Enum):
     PLANNED = "PLANNED"
-    SUCCESS = "SUCCESS"
+    SUCCEEDED = "SUCCEEDED"
     FAILED = "FAILED"  # explicit fail result
 
 
 class AssetCheckExecutionResolvedStatus(enum.Enum):
     IN_PROGRESS = "IN_PROGRESS"
-    SUCCESS = "SUCCESS"
+    SUCCEEDED = "SUCCEEDED"
     FAILED = "FAILED"  # explicit fail result
-    EXECUTION_FAILURE = "EXECUTION_FAILURE"  # hit some exception
+    EXECUTION_FAILED = "EXECUTION_FAILED"  # hit some exception
     SKIPPED = "SKIPPED"  # the run finished, didn't fail, but the check didn't execute
 
 

--- a/python_modules/dagster/dagster/_core/storage/asset_check_execution_record.py
+++ b/python_modules/dagster/dagster/_core/storage/asset_check_execution_record.py
@@ -4,15 +4,27 @@ from typing import NamedTuple, Optional
 from dagster import EventLogEntry
 
 
-class AssetCheckExecutionStatus(enum.Enum):
+# We store a limit set of statuses in the database, and then resolve them to the actual status
+# at read time. This is because the write path is to store a planned event (which creates a row
+# with PLANNED status) then update the row when we get the check result. But if the check never
+# runs, the row stays in PLANNED status.
+class AssetCheckExecutionStoredStatus(enum.Enum):
     PLANNED = "PLANNED"
     SUCCESS = "SUCCESS"
-    FAILURE = "FAILURE"
+    FAILURE = "FAILURE"  # explicit fail result
+
+
+class AssetCheckExecutionResolvedStatus(enum.Enum):
+    IN_PROGRESS = "IN_PROGRESS"
+    SUCCESS = "SUCCESS"
+    FAILURE = "FAILURE"  # explicit fail result
+    EXECUTION_FAILURE = "EXECUTION_FAILURE"  # hit some exception
+    SKIPPED = "SKIPPED"  # the run finished, didn't fail, but the check didn't execute
 
 
 class AssetCheckExecutionRecord(NamedTuple):
     id: int
     run_id: str
-    status: AssetCheckExecutionStatus
+    stored_status: AssetCheckExecutionStoredStatus
     evaluation_event: Optional[EventLogEntry]
     create_timestamp: float

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -2520,7 +2520,7 @@ class SqlEventLogStorage(EventLogStorage):
                 )
                 .values(
                     execution_status=(
-                        AssetCheckExecutionRecordStatus.SUCCESS.value
+                        AssetCheckExecutionRecordStatus.SUCCEEDED.value
                         if evaluation.success
                         else AssetCheckExecutionRecordStatus.FAILED.value
                     ),

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -44,7 +44,7 @@ from dagster._core.events.log import EventLogEntry
 from dagster._core.execution.stats import RunStepKeyStatsSnapshot, build_run_step_stats_from_events
 from dagster._core.storage.asset_check_execution_record import (
     AssetCheckExecutionRecord,
-    AssetCheckExecutionStoredStatus,
+    AssetCheckExecutionRecordStatus,
 )
 from dagster._core.storage.sql import SqlAlchemyQuery, SqlAlchemyRow
 from dagster._core.storage.sqlalchemy_compat import (
@@ -2499,7 +2499,7 @@ class SqlEventLogStorage(EventLogStorage):
                     asset_key=planned.asset_key.to_string(),
                     check_name=planned.check_name,
                     run_id=event.run_id,
-                    execution_status=AssetCheckExecutionStoredStatus.PLANNED.value,
+                    execution_status=AssetCheckExecutionRecordStatus.PLANNED.value,
                 )
             )
 
@@ -2520,9 +2520,9 @@ class SqlEventLogStorage(EventLogStorage):
                 )
                 .values(
                     execution_status=(
-                        AssetCheckExecutionStoredStatus.SUCCESS.value
+                        AssetCheckExecutionRecordStatus.SUCCESS.value
                         if evaluation.success
-                        else AssetCheckExecutionStoredStatus.FAILURE.value
+                        else AssetCheckExecutionRecordStatus.FAILED.value
                     ),
                     evaluation_event=serialize_value(event),
                     evaluation_event_timestamp=datetime.utcfromtimestamp(event.timestamp),
@@ -2573,7 +2573,7 @@ class SqlEventLogStorage(EventLogStorage):
         if not include_planned:
             query = query.where(
                 AssetCheckExecutionsTable.c.execution_status
-                != AssetCheckExecutionStoredStatus.PLANNED.value
+                != AssetCheckExecutionRecordStatus.PLANNED.value
             )
         if materialization_event_storage_id:
             if include_planned:
@@ -2583,7 +2583,7 @@ class SqlEventLogStorage(EventLogStorage):
                         AssetCheckExecutionsTable.c.materialization_event_storage_id
                         == materialization_event_storage_id,
                         AssetCheckExecutionsTable.c.execution_status
-                        == AssetCheckExecutionStoredStatus.PLANNED.value,
+                        == AssetCheckExecutionRecordStatus.PLANNED.value,
                     )
                 )
             else:
@@ -2599,7 +2599,7 @@ class SqlEventLogStorage(EventLogStorage):
             AssetCheckExecutionRecord(
                 id=cast(int, row[0]),
                 run_id=cast(str, row[1]),
-                stored_status=AssetCheckExecutionStoredStatus(row[2]),
+                status=AssetCheckExecutionRecordStatus(row[2]),
                 evaluation_event=(
                     deserialize_value(cast(str, row[3]), EventLogEntry) if row[3] else None
                 ),

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -44,7 +44,7 @@ from dagster._core.events.log import EventLogEntry
 from dagster._core.execution.stats import RunStepKeyStatsSnapshot, build_run_step_stats_from_events
 from dagster._core.storage.asset_check_execution_record import (
     AssetCheckExecutionRecord,
-    AssetCheckExecutionStatus,
+    AssetCheckExecutionStoredStatus,
 )
 from dagster._core.storage.sql import SqlAlchemyQuery, SqlAlchemyRow
 from dagster._core.storage.sqlalchemy_compat import (
@@ -2499,7 +2499,7 @@ class SqlEventLogStorage(EventLogStorage):
                     asset_key=planned.asset_key.to_string(),
                     check_name=planned.check_name,
                     run_id=event.run_id,
-                    execution_status=AssetCheckExecutionStatus.PLANNED.value,
+                    execution_status=AssetCheckExecutionStoredStatus.PLANNED.value,
                 )
             )
 
@@ -2520,9 +2520,9 @@ class SqlEventLogStorage(EventLogStorage):
                 )
                 .values(
                     execution_status=(
-                        AssetCheckExecutionStatus.SUCCESS.value
+                        AssetCheckExecutionStoredStatus.SUCCESS.value
                         if evaluation.success
-                        else AssetCheckExecutionStatus.FAILURE.value
+                        else AssetCheckExecutionStoredStatus.FAILURE.value
                     ),
                     evaluation_event=serialize_value(event),
                     evaluation_event_timestamp=datetime.utcfromtimestamp(event.timestamp),
@@ -2573,7 +2573,7 @@ class SqlEventLogStorage(EventLogStorage):
         if not include_planned:
             query = query.where(
                 AssetCheckExecutionsTable.c.execution_status
-                != AssetCheckExecutionStatus.PLANNED.value
+                != AssetCheckExecutionStoredStatus.PLANNED.value
             )
         if materialization_event_storage_id:
             if include_planned:
@@ -2583,7 +2583,7 @@ class SqlEventLogStorage(EventLogStorage):
                         AssetCheckExecutionsTable.c.materialization_event_storage_id
                         == materialization_event_storage_id,
                         AssetCheckExecutionsTable.c.execution_status
-                        == AssetCheckExecutionStatus.PLANNED.value,
+                        == AssetCheckExecutionStoredStatus.PLANNED.value,
                     )
                 )
             else:
@@ -2599,7 +2599,7 @@ class SqlEventLogStorage(EventLogStorage):
             AssetCheckExecutionRecord(
                 id=cast(int, row[0]),
                 run_id=cast(str, row[1]),
-                status=AssetCheckExecutionStatus(row[2]),
+                stored_status=AssetCheckExecutionStoredStatus(row[2]),
                 evaluation_event=(
                     deserialize_value(cast(str, row[3]), EventLogEntry) if row[3] else None
                 ),

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -3969,7 +3969,7 @@ class TestEventLogStorage:
 
         checks = storage.get_asset_check_executions(AssetKey(["my_asset"]), "my_check", limit=10)
         assert len(checks) == 1
-        assert checks[0].status == AssetCheckExecutionRecordStatus.SUCCESS
+        assert checks[0].status == AssetCheckExecutionRecordStatus.SUCCEEDED
         assert (
             checks[
                 0

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -67,7 +67,7 @@ from dagster._core.host_representation.origin import (
     InProcessCodeLocationOrigin,
 )
 from dagster._core.storage.asset_check_execution_record import (
-    AssetCheckExecutionStoredStatus,
+    AssetCheckExecutionRecordStatus,
 )
 from dagster._core.storage.event_log import InMemoryEventLogStorage, SqlEventLogStorage
 from dagster._core.storage.event_log.base import EventLogStorage
@@ -3930,7 +3930,7 @@ class TestEventLogStorage:
 
         checks = storage.get_asset_check_executions(AssetKey(["my_asset"]), "my_check", limit=10)
         assert len(checks) == 1
-        assert checks[0].stored_status == AssetCheckExecutionStoredStatus.PLANNED
+        assert checks[0].status == AssetCheckExecutionRecordStatus.PLANNED
         assert checks[0].run_id == "foo"
 
         checks = storage.get_asset_check_executions(
@@ -3969,7 +3969,7 @@ class TestEventLogStorage:
 
         checks = storage.get_asset_check_executions(AssetKey(["my_asset"]), "my_check", limit=10)
         assert len(checks) == 1
-        assert checks[0].stored_status == AssetCheckExecutionStoredStatus.SUCCESS
+        assert checks[0].status == AssetCheckExecutionRecordStatus.SUCCESS
         assert (
             checks[
                 0

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -67,7 +67,7 @@ from dagster._core.host_representation.origin import (
     InProcessCodeLocationOrigin,
 )
 from dagster._core.storage.asset_check_execution_record import (
-    AssetCheckExecutionStatus,
+    AssetCheckExecutionStoredStatus,
 )
 from dagster._core.storage.event_log import InMemoryEventLogStorage, SqlEventLogStorage
 from dagster._core.storage.event_log.base import EventLogStorage
@@ -3930,7 +3930,7 @@ class TestEventLogStorage:
 
         checks = storage.get_asset_check_executions(AssetKey(["my_asset"]), "my_check", limit=10)
         assert len(checks) == 1
-        assert checks[0].status == AssetCheckExecutionStatus.PLANNED
+        assert checks[0].stored_status == AssetCheckExecutionStoredStatus.PLANNED
         assert checks[0].run_id == "foo"
 
         checks = storage.get_asset_check_executions(
@@ -3969,7 +3969,7 @@ class TestEventLogStorage:
 
         checks = storage.get_asset_check_executions(AssetKey(["my_asset"]), "my_check", limit=10)
         assert len(checks) == 1
-        assert checks[0].status == AssetCheckExecutionStatus.SUCCESS
+        assert checks[0].stored_status == AssetCheckExecutionStoredStatus.SUCCESS
         assert (
             checks[
                 0


### PR DESCRIPTION
Per the write path described in https://github.com/dagster-io/dagster/pull/16006, the status goes

- planned event
- row created with status PLANNED
- evaluation event
- row updated with status SUCCESS/FAILURE

but there's also a case where

- planned event
- row created with status PLANNED
- run failure

and the check stays in PLANNED status. Similarly to how we reconcile asset status at read time, use the status of the associated run to adjust the status when we surface it over gql.

---

In the future with both assets and asset checks, I'd like to move to emitting explicit MATERIALIZATION_FAILURE/ASSET_CHECK_RUN_FAILURE events when the step fails (or when the run monitoring daemon fails the run). Plus analogous skip or cancel events. This would mean
- we can keep actual status in the db. helpful for filtering on status etc.
- we can use the event log consumer to alert on materialization and check run failures

but that's a bit larger of a project, and I think it's safe to mimic asset behavior in the meantime