### PR TITLE
docs redirects: deprecate old versioning scheme

### DIFF
--- a/docs/next/util/redirectUrls.json
+++ b/docs/next/util/redirectUrls.json
@@ -69,7 +69,7 @@
     "destination": "/tutorial/advanced-tutorial/scheduling",
     "statusCode": 302
   },
-  { "source": "/overview", "destination": "/concepts", "statusCode": 302 },
+  {"source": "/overview", "destination": "/concepts", "statusCode": 302},
   {
     "source": "/overview/solids-pipelines/solids",
     "destination": "/concepts/solids-pipelines/solids",
@@ -239,7 +239,7 @@
     "destination": "/guides/dagster/testing-assets",
     "statusCode": 302
   },
-    {
+  {
     "source": "/tutorial/assets/testing-assets",
     "destination": "/guides/dagster/testing-assets",
     "statusCode": 302
@@ -718,6 +718,16 @@
   {
     "source": "/tutorial/managing-your-own-io",
     "destination": "/tutorial/saving-your-data",
+    "statusCode": 302
+  },
+  {
+    "source": "/concepts/assets/asset-materializations",
+    "destination": "/concepts/ops-jobs-graphs/op-events#asset-materializations",
+    "statusCode": 302
+  },
+  {
+    "source": "/:version(\\d+.\\d+.\\d+)/:slug*",
+    "destination": "/:slug*",
     "statusCode": 302
   }
 ]


### PR DESCRIPTION
## Summary & Motivation
fix two things causing the 404s:
1. as https://github.com/dagster-io/dagster/pull/15776 removes old versioning scheme (e.g. `/0.12.0/...` is no longer valid), we direct the urls that follow the old versioning scheme `/<major_number.minor_number.patch_number>/<path>` to `/<path>`.
    * cause: we used to set canonical link for versioned pages to the latest, and we removed it since last friday as part of versioning elimination. my hunch is because we didn't set the redirect and the versioned urls are still out there somewhere, google started to pick up those links. now after this fix, we removed all versioning logic and set up the redirect, users shouldn't be able to access the old versioned pages under docs.dagster.io anymore, and google should be starting to pick up the redirects. 
    
2. fix a missing redirect introduced in https://github.com/dagster-io/dagster/commit/11ac2d6881bbcbe422967bd72b33c5a1edcf5cbb

## How I Tested These Changes
links redirected successfully:
- https://08-25-docs-redirects-deprecate-old-versioning-scheme.dagster.dagster-docs.io/0.12.0/concepts/assets/asset-materializations
- https://08-25-docs-redirects-deprecate-old-versioning-scheme.dagster.dagster-docs.io/0.14.4/tutorial/advanced-tutorial/materializations
- https://08-25-docs-redirects-deprecate-old-versioning-scheme.dagster.dagster-docs.io/0.15.6/concepts/assets/asset-materializations
- https://08-25-docs-redirects-deprecate-old-versioning-scheme.dagster.dagster-docs.io/0.12.0/concepts/assets/asset-materializations
