### PR TITLE
[auto-materialize] Forwards-compat for AutoMaterializeRuleEvaluation

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/auto_materialize_asset_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/auto_materialize_asset_evaluations.py
@@ -13,6 +13,7 @@ from dagster._core.definitions.auto_materialize_condition import (
     ParentMaterializedAutoMaterializeCondition,
     ParentOutdatedAutoMaterializeCondition,
 )
+from dagster._core.definitions.auto_materialize_rule import AutoMaterializeRuleEvaluation
 from dagster._core.definitions.partition import SerializedPartitionsSubset
 from dagster._core.scheduler.instigation import AutoMaterializeAssetEvaluationRecord
 
@@ -190,6 +191,7 @@ class GrapheneAutoMaterializeAssetEvaluationRecord(graphene.ObjectType):
             conditions=[
                 create_graphene_auto_materialize_condition(c, partitions_def)
                 for c in record.evaluation.partition_subsets_by_condition
+                if not isinstance(c[0], AutoMaterializeRuleEvaluation)
             ],
             timestamp=record.timestamp,
             runIds=record.evaluation.run_ids,

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -290,3 +290,15 @@ class SkipOnParentOutdatedRule(AutoMaterializeRule, NamedTuple("_SkipOnParentOut
                     )
                 ].update({candidate})
         return conditions
+
+
+# FORWARD COMAT GRAVEYARD
+
+
+@whitelist_for_serdes
+class AutoMaterializeRuleEvaluation(NamedTuple):
+    """This serves to allow this version of Dagster to deserialize NamedTuples written by the
+    new version of Dagster.
+    """
+
+    ...


### PR DESCRIPTION
## Summary & Motivation

This commit is useful in the unlikely case that we need to roll back after pushing out the change to start storing `AutoMaterializeRuleEvaluation` objects instead of `AutoMaterializeCondition`s. This PR can be cherry-picked onto the 1.4.9 branch, to make it compatible with later versions of dagster.

In case of a rollback, the steps would be:

1. roll back
2. cherry-pick this change onto the version that was rolled back to
3. push out a release of (previous version + this PR)

## How I Tested These Changes

First, generate some evaluations with the new version of the daemon. Then, roll back to 1.4.9, and rebuild the UI. Finally, observe the Auto-materialize history page.

Before:
![Screenshot 2023-08-25 at 10 37 11 AM](https://github.com/dagster-io/dagster/assets/22457492/ee3f235f-35e7-45ca-8a57-762eba8f6826)

After:
![Screenshot 2023-08-25 at 10 37 48 AM](https://github.com/dagster-io/dagster/assets/22457492/dfc74546-b1d9-45fc-bd4d-02f625445efe)

Note: in this image, the rows are empty, as we are not able to glean any information out of these empty AutoMaterializeRuleEvaluation objects.
