### PR TITLE
[docs] Add branch depl permission to perms breakdown page

### DIFF
--- a/docs/content/dagster-cloud/account/managing-users/managing-user-roles-permissions.mdx
+++ b/docs/content/dagster-cloud/account/managing-users/managing-user-roles-permissions.mdx
@@ -354,9 +354,9 @@ Deployment settings are accessed in the UI by navigating to **user menu (your ic
       <td className="bg-red-50">❌</td>
       <td className="bg-green-50">✅</td>
     </tr>
-     <tr>
+    <tr>
       <td>
-        Create {" "}
+        Create{" "}
         <a href="/dagster-cloud/managing-deployments/branch-deployments">
           Branch Deployments
         </a>

--- a/docs/content/dagster-cloud/account/managing-users/managing-user-roles-permissions.mdx
+++ b/docs/content/dagster-cloud/account/managing-users/managing-user-roles-permissions.mdx
@@ -354,6 +354,19 @@ Deployment settings are accessed in the UI by navigating to **user menu (your ic
       <td className="bg-red-50">❌</td>
       <td className="bg-green-50">✅</td>
     </tr>
+     <tr>
+      <td>
+        Create {" "}
+        <a href="/dagster-cloud/managing-deployments/branch-deployments">
+          Branch Deployments
+        </a>
+      </td>
+      <td className="bg-red-50">❌</td>
+      <td className="bg-red-50">❌</td>
+      <td className="bg-red-50">✅</td>
+      <td className="bg-red-50">✅</td>
+      <td className="bg-green-50">✅</td>
+    </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
## Summary

Adds the branch deployment creation permission to the breakdown page, since it's currently undocumented


