### PR TITLE
Move one of the steps into an external script

### DIFF
--- a/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/domain_specific_dsl/user_scripts/fetch_the_tickers.py
+++ b/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/domain_specific_dsl/user_scripts/fetch_the_tickers.py
@@ -1,0 +1,5 @@
+from dagster_externals import init_dagster_externals
+
+context = init_dagster_externals()
+
+context.log(f"Got tickers: {context.extras['tickers']}")

--- a/examples/experimental/assets_yaml_dsl/assets_yaml_dsl_tests/test_stocks_dsl.py
+++ b/examples/experimental/assets_yaml_dsl/assets_yaml_dsl_tests/test_stocks_dsl.py
@@ -18,6 +18,7 @@ import yaml
 from assets_yaml_dsl.domain_specific_dsl.stocks_dsl import assets_defs_from_stock_assets
 from dagster import AssetKey
 from dagster._core.definitions import materialize
+from dagster._core.external_execution.subprocess import SubprocessExecutionResource
 from examples.experimental.assets_yaml_dsl.assets_yaml_dsl.domain_specific_dsl.stocks_dsl import (
     build_stock_assets_object,
 )
@@ -53,4 +54,6 @@ def test_materialize_stocks_dsl():
     stocks_dsl_document = yaml.safe_load(EXAMPLE_TEXT)
     stock_assets = build_stock_assets_object(stocks_dsl_document)
     assets_defs = assets_defs_from_stock_assets(stock_assets)
-    assert materialize(assets=assets_defs).success
+    assert materialize(
+        assets=assets_defs, resources={"subprocess_resource": SubprocessExecutionResource()}
+    ).success

--- a/python_modules/dagster-externals/dagster_externals/_context.py
+++ b/python_modules/dagster-externals/dagster_externals/_context.py
@@ -166,6 +166,10 @@ class ExternalExecutionContext:
     def get_extra(self, key: str) -> Any:
         return assert_defined_extra(self._data["extras"], key)
 
+    @property
+    def extras(self) -> Mapping[str, Any]:
+        return self._data["extras"]
+
     # ##### WRITE
 
     def report_asset_metadata(self, asset_key: str, label: str, value: Any) -> None:


### PR DESCRIPTION
## Summary & Motivation

Moves one of the multi-assets to invoke an external script

Also:

* Added `extras` property to `ExternalExecutionContext`

## How I Tested These Changes

BK.

Ran manually in `dagster dev` to verify log message shipped back to dagster instance.