### PR TITLE
[externals] k8s pod resource MVP

### DIFF
--- a/integration_tests/test_suites/k8s-test-suite/tests/test_external_asset.py
+++ b/integration_tests/test_suites/k8s-test-suite/tests/test_external_asset.py
@@ -1,0 +1,170 @@
+import json
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
+
+import kubernetes
+import pytest
+from dagster import AssetExecutionContext, asset, materialize
+from dagster._core.ext.resource import (
+    ExtContextInjector,
+)
+from dagster_ext import ExtDefaultContextLoader
+from dagster_k8s.client import DagsterKubernetesClient
+from dagster_k8s.external_resource import ExtK8sPod
+from dagster_test.test_project import (
+    get_test_project_docker_image,
+)
+
+if TYPE_CHECKING:
+    from dagster._core.ext.context import (
+        ExtOrchestrationContext,
+    )
+
+
+@pytest.mark.skip("passes locally, BK debug in progress")
+@pytest.mark.default
+def test_ext_k8s_pod(namespace, cluster_provider):
+    kubernetes.config.load_kube_config(cluster_provider.kubeconfig_file)
+    docker_image = get_test_project_docker_image()
+
+    @asset
+    def number_y(
+        context: AssetExecutionContext,
+        ext_k8s_pod: ExtK8sPod,
+    ):
+        ext_k8s_pod.run(
+            context=context,
+            namespace=namespace,
+            image=docker_image,
+            command=[
+                "python",
+                "-m",
+                "numbers_example.number_y",
+            ],
+            extras={
+                "storage_root": "/tmp/",
+            },
+            env={
+                "PYTHONPATH": "/dagster_test/toys/external_execution/",
+                "NUMBER_Y": "2",
+            },
+        )
+
+    result = materialize(
+        [number_y],
+        resources={"ext_k8s_pod": ExtK8sPod()},
+        raise_on_error=False,
+    )
+    assert result.success
+    mats = result.asset_materializations_for_node(number_y.op.name)
+    assert "is_even" in mats[0].metadata
+    assert mats[0].metadata["is_even"].value is True
+
+
+class ExtConfigMapContextInjector(ExtContextInjector):
+    def __init__(
+        self,
+        k8s_client: DagsterKubernetesClient,
+        namespace: str,
+    ):
+        self._client = k8s_client
+        self._namespace = namespace
+        self._cm_name = "dagster-ext-cm"
+
+    @contextmanager
+    def inject_context(
+        self,
+        context: "ExtOrchestrationContext",
+    ):
+        context_config_map_body = kubernetes.client.V1ConfigMap(
+            metadata=kubernetes.client.V1ObjectMeta(
+                name=self._cm_name,
+            ),
+            data={
+                "context.json": json.dumps(context.get_data()),
+            },
+        )
+        self._client.core_api.create_namespaced_config_map(self._namespace, context_config_map_body)
+        try:
+            yield {ExtDefaultContextLoader.FILE_PATH_KEY: "/mnt/dagster/context.json"}
+        finally:
+            self._client.core_api.delete_namespaced_config_map(self._cm_name, self._namespace)
+
+    def build_pod_spec(self, image, command):
+        return {
+            "containers": [
+                {
+                    "image": image,
+                    "command": [
+                        "python",
+                        "-m",
+                        "numbers_example.number_y",
+                    ],
+                    "volume_mounts": [
+                        {
+                            "mountPath": "/mnt/dagster/",
+                            "name": "dagster-ext-context",
+                        }
+                    ],
+                }
+            ],
+            "volumes": [
+                {
+                    "name": "dagster-ext-context",
+                    "configMap": {
+                        "name": self._cm_name,
+                    },
+                }
+            ],
+        }
+
+
+@pytest.mark.skip("passes locally, BK debug in progress")
+@pytest.mark.default
+def test_ext_k8s_pod_file_inject(namespace, cluster_provider):
+    # a convoluted test to
+    # - vet base_pod_spec works for setting volumes & mounts
+    # - preserve file injection via config map code
+
+    docker_image = get_test_project_docker_image()
+    kubernetes.config.load_kube_config(cluster_provider.kubeconfig_file)
+
+    @asset
+    def number_y(
+        context: AssetExecutionContext,
+        ext_k8s_pod: ExtK8sPod,
+    ):
+        client = DagsterKubernetesClient.production_client()
+        injector = ExtConfigMapContextInjector(client, namespace)
+        pod_spec = injector.build_pod_spec(
+            image=docker_image,
+            command=[
+                "python",
+                "-m",
+                "numbers_example.number_y",
+            ],
+        )
+
+        ext_k8s_pod.run(
+            context=context,
+            namespace=namespace,
+            extras={
+                "storage_root": "/tmp/",
+            },
+            env={
+                "PYTHONPATH": "/dagster_test/toys/external_execution/",
+                "NUMBER_Y": "2",
+            },
+            base_pod_spec=pod_spec,
+            context_injector=injector,
+        )
+
+    result = materialize(
+        [number_y],
+        resources={"ext_k8s_pod": ExtK8sPod()},
+        raise_on_error=False,
+    )
+    assert result.success
+    mats = result.asset_materializations_for_node(number_y.op.name)
+    assert "is_even" in mats[0].metadata
+    assert mats[0].metadata["is_even"].value is True

--- a/integration_tests/test_suites/k8s-test-suite/tox.ini
+++ b/integration_tests/test_suites/k8s-test-suite/tox.ini
@@ -19,6 +19,7 @@ deps =
   -e ../../../python_modules/libraries/dagster-aws
   -e ../../../python_modules/libraries/dagster-gcp
   -e ../../python_modules/dagster-k8s-test-infra
+  -e ../../../python_modules/dagster-ext
   pyparsing<3.0.0
 allowlist_externals =
   /bin/bash

--- a/python_modules/libraries/dagster-docker/dagster_docker/external_resource.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/external_resource.py
@@ -1,7 +1,5 @@
-import os
-import tempfile
-from contextlib import ExitStack, contextmanager
-from typing import Iterator, Mapping, Optional, Sequence, Tuple, Union
+from contextlib import contextmanager
+from typing import Any, Iterator, Mapping, Optional, Sequence, Tuple, Union
 
 import docker
 from dagster import OpExecutionContext
@@ -14,54 +12,91 @@ from dagster._core.ext.resource import (
     ExtResource,
 )
 from dagster._core.ext.utils import (
-    ExtFileContextInjector,
-    ExtFileMessageReader,
+    ExtEnvContextInjector,
+    extract_message_or_forward_to_stdout,
     io_params_as_env_vars,
 )
 from dagster_ext import (
     DagsterExtError,
+    ExtDefaultMessageWriter,
     ExtExtras,
+    ExtParams,
 )
 from pydantic import Field
-from typing_extensions import TypeAlias
-
-VolumeMapping: TypeAlias = Mapping[str, Mapping[str, str]]
 
 
-_CONTEXT_SOURCE_FILENAME = "context"
-_MESSAGE_SINK_FILENAME = "messages"
+class DockerLogsMessageReader(ExtMessageReader):
+    @contextmanager
+    def read_messages(
+        self,
+        _context: ExtOrchestrationContext,
+    ) -> Iterator[ExtParams]:
+        yield {ExtDefaultMessageWriter.STDIO_KEY: ExtDefaultMessageWriter.STDERR}
+
+    def consume_docker_logs(self, container, ext_context):
+        for log_line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
+            extract_message_or_forward_to_stdout(ext_context, log_line)
 
 
 class ExtDocker(ExtResource):
+    """An ext protocol compliant resource for launching docker containers.
+
+    By default context is injected via environment variables and messages are parsed out of the
+    log stream and other logs are forwarded to stdout of the orchestration process.
+    """
+
     env: Optional[Mapping[str, str]] = Field(
         default=None,
-        description="An optional dict of environment variables to pass to the subprocess.",
+        description="An optional dict of environment variables to set on the container.",
     )
-    volumes: Optional[VolumeMapping] = Field(
-        default=None,
-        description="An optional dict of volumes to mount in the container.",
-    )
+
     registry: Optional[Mapping[str, str]] = Field(
         default=None,
-        description="An optional dict of registry credentials to use to pull the image.",
+        description="An optional dict of registry credentials to use to login the docker client.",
     )
 
     def run(
         self,
-        image: str,
-        command: Union[str, Sequence[str]],
         *,
         context: OpExecutionContext,
-        extras: Optional[ExtExtras] = None,
-        context_source: Optional[ExtContextInjector] = None,
-        message_sink: Optional[ExtMessageReader] = None,
+        image: str,
+        command: Union[str, Sequence[str]],
         env: Optional[Mapping[str, str]] = None,
-        volumes: Optional[Mapping[str, Mapping[str, str]]] = None,
         registry: Optional[Mapping[str, str]] = None,
+        container_kwargs: Optional[Mapping[str, Any]] = None,
+        extras: Optional[ExtExtras] = None,
+        context_injector: Optional[ExtContextInjector] = None,
+        message_reader: Optional[ExtMessageReader] = None,
     ) -> None:
-        external_context = ExtOrchestrationContext(context=context, extras=extras)
-        with self._setup_io(external_context, context_source, message_sink) as (io_env, io_volumes):
+        """Create a docker container and run it to completion, enriched with the ext protocol.
+
+        Args:
+            image (str):
+                The image for the container to use.
+            command (Optional[Union[str, Sequence[str]]]):
+                The command for the container use.
+            env (Optional[Mapping[str,str]]):
+                A mapping of environment variable names to values to set on the first
+                container in the pod spec, on top of those configured on resource.
+            registry (Optional[Mapping[str, str]]:
+                A mapping containing url, username, and password to be used
+                with docker client login.
+            container_kwargs (Optional[Mapping[str, Any]]:
+                Arguments to be forwarded to docker client containers.create.
+            extras (Optional[ExtExtras]):
+                Extra values to pass along as part of the ext protocol.
+            context_injector (Optional[ExtContextInjector]):
+                Override the default ext protocol context injection.
+            message_Reader (Optional[ExtMessageReader]):
+                Override the default ext protocol message reader.
+        """
+        ext_context = ExtOrchestrationContext(context=context, extras=extras)
+        with self._setup_ext_protocol(ext_context, context_injector, message_reader) as (
+            ext_env,
+            message_reader,
+        ):
             client = docker.client.from_env()
+            registry = registry or self.registry
             if registry:
                 client.login(
                     registry=registry["url"],
@@ -69,24 +104,30 @@ class ExtDocker(ExtResource):
                     password=registry["password"],
                 )
 
-            # will need to deal with when its necessary to pull the image before starting the container
-            # client.images.pull(image)
-
-            container = client.containers.create(
-                image=image,
-                command=command,
-                detach=True,
-                environment={**self.get_base_env(), **(self.env or {}), **(env or {}), **io_env},
-                volumes={
-                    **(volumes or {}),
-                    **io_volumes,
-                },
-            )
+            try:
+                container = self._create_container(
+                    client=client,
+                    image=image,
+                    command=command,
+                    env=env,
+                    ext_env=ext_env,
+                    container_kwargs=container_kwargs,
+                )
+            except docker.errors.ImageNotFound:
+                client.images.pull(image)
+                container = self._create_container(
+                    client=client,
+                    image=image,
+                    command=command,
+                    env=env,
+                    ext_env=ext_env,
+                    container_kwargs=container_kwargs,
+                )
 
             result = container.start()
             try:
-                for line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
-                    print(line)  # noqa: T201
+                if isinstance(message_reader, DockerLogsMessageReader):
+                    message_reader.consume_docker_logs(container, ext_context)
 
                 result = container.wait()
                 if result["StatusCode"] != 0:
@@ -94,30 +135,45 @@ class ExtDocker(ExtResource):
             finally:
                 container.stop()
 
+    def _create_container(
+        self,
+        client,
+        image: str,
+        command: Union[str, Sequence[str]],
+        env: Optional[Mapping[str, str]],
+        container_kwargs: Optional[Mapping[str, Any]],
+        ext_env: Mapping[str, str],
+    ):
+        kwargs = dict(container_kwargs or {})
+        kwargs_env = kwargs.pop("environment", {})
+        return client.containers.create(
+            image=image,
+            command=command,
+            detach=True,
+            environment={
+                **self.get_base_env(),
+                **ext_env,
+                **(self.env or {}),
+                **(env or {}),
+                **kwargs_env,
+            },
+            **kwargs,
+        )
+
     @contextmanager
-    def _setup_io(
+    def _setup_ext_protocol(
         self,
         external_context: ExtOrchestrationContext,
         context_injector: Optional[ExtContextInjector],
         message_reader: Optional[ExtMessageReader],
-    ) -> Iterator[Tuple[Mapping[str, str], VolumeMapping]]:
-        with ExitStack() as stack:
-            if context_injector is None or message_reader is None:
-                tempdir = stack.enter_context(tempfile.TemporaryDirectory())
-                context_injector = context_injector or ExtFileContextInjector(
-                    os.path.join(tempdir, _CONTEXT_SOURCE_FILENAME)
-                )
-                message_reader = message_reader or ExtFileMessageReader(
-                    os.path.join(tempdir, _MESSAGE_SINK_FILENAME)
-                )
-                volumes = {tempdir: {"bind": tempdir, "mode": "rw"}}
-            else:
-                volumes = {}
-            context_injector_params = stack.enter_context(
-                context_injector.inject_context(external_context)
-            )
-            message_reader_params = stack.enter_context(
-                message_reader.read_messages(external_context)
-            )
-            io_env = io_params_as_env_vars(context_injector_params, message_reader_params)
-            yield io_env, volumes
+    ) -> Iterator[Tuple[Mapping[str, str], ExtMessageReader]]:
+        context_injector = context_injector or ExtEnvContextInjector()
+        message_reader = message_reader or DockerLogsMessageReader()
+
+        with context_injector.inject_context(
+            external_context,
+        ) as ci_params, message_reader.read_messages(
+            external_context,
+        ) as mr_params:
+            protocol_envs = io_params_as_env_vars(ci_params, mr_params)
+            yield protocol_envs, message_reader

--- a/python_modules/libraries/dagster-docker/dagster_docker_tests/test_external_asset.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker_tests/test_external_asset.py
@@ -1,7 +1,9 @@
 import os
+import tempfile
 
 import pytest
 from dagster import AssetExecutionContext, asset, materialize
+from dagster._core.ext.utils import ExtFileContextInjector, ExtFileMessageReader
 from dagster_docker.external_resource import ExtDocker
 from dagster_test.test_project import (
     IS_BUILDKITE,
@@ -12,35 +14,22 @@ from dagster_test.test_project import (
 
 
 @pytest.mark.integration
-def test_basic():
+def test_default():
     docker_image = get_test_project_docker_image()
 
-    launcher_config = {}
+    ext_config = {}
 
     if IS_BUILDKITE:
-        launcher_config["registry"] = get_buildkite_registry_config()
+        ext_config["registry"] = get_buildkite_registry_config()
     else:
         find_local_test_image(docker_image)
 
     @asset
     def number_x(
         context: AssetExecutionContext,
-        docker_resource: ExtDocker,
+        ext_docker: ExtDocker,
     ):
-        instance_storage = context.instance.storage_directory()
-        host_storage = os.path.join(instance_storage, "number_example")
-        os.makedirs(host_storage, exist_ok=True)
-
-        container_storage = "/mnt/asset_storage/"
-
-        volumes = {
-            host_storage: {
-                "bind": container_storage,
-                "mode": "rw",
-            }
-        }
-
-        docker_resource.run(
+        ext_docker.run(
             image=docker_image,
             command=[
                 "python",
@@ -48,16 +37,80 @@ def test_basic():
                 "numbers_example.number_x",
             ],
             context=context,
-            extras={"storage_root": container_storage, "multiplier": 2},
+            extras={"storage_root": "/tmp/", "multiplier": 2},
             env={"PYTHONPATH": "/dagster_test/toys/external_execution/"},
-            volumes=volumes,
         )
 
     result = materialize(
         [number_x],
-        resources={"docker_resource": ExtDocker()},
+        resources={"ext_docker": ExtDocker(**ext_config)},
         raise_on_error=False,
     )
     assert result.success
     mats = result.asset_materializations_for_node(number_x.op.name)
     assert mats[0].metadata["path"]
+
+
+@pytest.mark.integration
+def test_file_io():
+    docker_image = get_test_project_docker_image()
+
+    registry = None
+
+    if IS_BUILDKITE:
+        registry = get_buildkite_registry_config()
+    else:
+        find_local_test_image(docker_image)
+
+    with tempfile.TemporaryDirectory() as tempdir:
+        context_injector = ExtFileContextInjector(os.path.join(tempdir, "context"))
+        message_reader = ExtFileMessageReader(os.path.join(tempdir, "messages"))
+
+        @asset
+        def number_x(
+            context: AssetExecutionContext,
+            ext_docker: ExtDocker,
+        ):
+            instance_storage = context.instance.storage_directory()
+            host_storage = os.path.join(instance_storage, "number_example")
+            os.makedirs(host_storage, exist_ok=True)
+
+            container_storage = "/mnt/asset_storage/"
+
+            volumes = {
+                host_storage: {
+                    "bind": container_storage,
+                    "mode": "rw",
+                },
+                tempdir: {
+                    "bind": tempdir,
+                    "mode": "rw",
+                },
+            }
+
+            ext_docker.run(
+                image=docker_image,
+                command=[
+                    "python",
+                    "-m",
+                    "numbers_example.number_x",
+                ],
+                registry=registry,
+                context=context,
+                context_injector=context_injector,
+                message_reader=message_reader,
+                extras={"storage_root": container_storage, "multiplier": 2},
+                container_kwargs={
+                    "environment": {"PYTHONPATH": "/dagster_test/toys/external_execution/"},
+                    "volumes": volumes,
+                },
+            )
+
+        result = materialize(
+            [number_x],
+            resources={"ext_docker": ExtDocker()},
+            raise_on_error=False,
+        )
+        assert result.success
+        mats = result.asset_materializations_for_node(number_x.op.name)
+        assert mats[0].metadata["path"]

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/external_resource.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/external_resource.py
@@ -1,0 +1,238 @@
+import random
+import string
+from contextlib import contextmanager
+from typing import Any, Iterator, Mapping, Optional, Sequence, Union
+
+import kubernetes
+from dagster import OpExecutionContext
+from dagster._core.errors import DagsterInvariantViolationError
+from dagster._core.ext.context import (
+    ExtOrchestrationContext,
+)
+from dagster._core.ext.resource import (
+    ExtContextInjector,
+    ExtMessageReader,
+    ExtParams,
+    ExtResource,
+)
+from dagster._core.ext.utils import (
+    ExtEnvContextInjector,
+    extract_message_or_forward_to_stdout,
+    io_params_as_env_vars,
+)
+from dagster_ext import (
+    ExtDefaultMessageWriter,
+    ExtExtras,
+)
+from pydantic import Field
+
+from dagster_k8s.utils import get_common_labels
+
+from .client import DagsterKubernetesClient, WaitForPodState
+from .models import k8s_model_from_dict, k8s_snake_case_dict
+
+
+def get_pod_name(run_id: str, op_name: str):
+    clean_op_name = op_name.replace("_", "-")
+    suffix = "".join(random.choice(string.digits) for i in range(10))
+    return f"dagster-{run_id[:18]}-{clean_op_name[:20]}-{suffix}"
+
+
+DEFAULT_CONTAINER_NAME = "dagster-ext-execution"
+
+
+class K8sPodLogsMessageReader(ExtMessageReader):
+    @contextmanager
+    def read_messages(
+        self,
+        _context: ExtOrchestrationContext,
+    ) -> Iterator[ExtParams]:
+        yield {ExtDefaultMessageWriter.STDIO_KEY: ExtDefaultMessageWriter.STDERR}
+
+    def consume_pod_logs(
+        self,
+        ext_context: ExtOrchestrationContext,
+        client: DagsterKubernetesClient,
+        pod_name: str,
+        namespace: str,
+    ):
+        for line in client.core_api.read_namespaced_pod_log(
+            pod_name,
+            namespace,
+            follow=True,
+            _preload_content=False,  # avoid JSON processing
+        ).stream():
+            log_chunk = line.decode("utf-8")
+            for log_line in log_chunk.split("\n"):
+                extract_message_or_forward_to_stdout(ext_context, log_line)
+
+
+class ExtK8sPod(ExtResource):
+    """An ext protocol compliant resource for launching kubernetes pods.
+
+    By default context is injected via environment variables and messages are parsed out of
+    the pod logs, with other logs forwarded to stdout of the orchestration process.
+
+    The first container within the containers list of the pod spec is expected (or set) to be
+    the container prepared for ext protocol communication.
+    """
+
+    env: Optional[Mapping[str, str]] = Field(
+        default=None,
+        description="An optional dict of environment variables to set on the container.",
+    )
+
+    def run(
+        self,
+        *,
+        context: OpExecutionContext,
+        image: Optional[str] = None,
+        command: Optional[Union[str, Sequence[str]]] = None,
+        namespace: Optional[str] = None,
+        env: Optional[Mapping[str, str]] = None,
+        base_pod_meta: Optional[Mapping[str, Any]] = None,
+        base_pod_spec: Optional[Mapping[str, Any]] = None,
+        extras: Optional[ExtExtras] = None,
+        context_injector: Optional[ExtContextInjector] = None,
+        message_reader: Optional[ExtMessageReader] = None,
+    ) -> None:
+        """Publish a kubernetes pod and wait for it to complete, enriched with the ext protocol.
+
+        Args:
+            image (Optional[str]):
+                The image to set the first container in the pod spec to use.
+            command (Optional[Union[str, Sequence[str]]]):
+                The command to set the first container in the pod spec to use.
+            namespace (Optional[str]):
+                Which kubernetes namespace to use, defaults to "default"
+            env (Optional[Mapping[str,str]]):
+                A mapping of environment variable names to values to set on the first
+                container in the pod spec, on top of those configured on resource.
+            base_pod_meta (Optional[Mapping[str, Any]]:
+                Raw k8s config for the k8s pod's metadata
+                (https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/object-meta/#ObjectMeta)
+                Keys can either snake_case or camelCase. The name value will be overridden.
+            base_pod_spec (Optional[Mapping[str, Any]]:
+                Raw k8s config for the k8s pod's pod spec
+                (https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec).
+                Keys can either snake_case or camelCase.
+            extras (Optional[ExtExtras]):
+                Extra values to pass along as part of the ext protocol.
+            context_injector (Optional[ExtContextInjector]):
+                Override the default ext protocol context injection.
+            message_Reader (Optional[ExtMessageReader]):
+                Override the default ext protocol message reader.
+        """
+        client = DagsterKubernetesClient.production_client()
+
+        ext_context = ExtOrchestrationContext(context=context, extras=extras)
+        with _setup_ext_protocol(ext_context, context_injector, message_reader) as (
+            protocol_env_vars,
+            resolved_msg_reader,
+        ):
+            namespace = namespace or "default"
+            pod_name = get_pod_name(context.run_id, context.op.name)
+            pod_body = build_pod_body(
+                pod_name=pod_name,
+                image=image,
+                command=command,
+                env_vars={
+                    **self.get_base_env(),
+                    **protocol_env_vars,
+                    **(self.env or {}),
+                    **(env or {}),
+                },
+                base_pod_meta=base_pod_meta,
+                base_pod_spec=base_pod_spec,
+            )
+            client.core_api.create_namespaced_pod(namespace, pod_body)
+            try:
+                # if were doing direct pod reading, wait for pod to start and then stream logs out
+                if isinstance(resolved_msg_reader, K8sPodLogsMessageReader):
+                    client.wait_for_pod(
+                        pod_name,
+                        namespace,
+                        wait_for_state=WaitForPodState.Ready,
+                    )
+                    resolved_msg_reader.consume_pod_logs(
+                        ext_context=ext_context,
+                        client=client,
+                        pod_name=pod_name,
+                        namespace=namespace,
+                    )
+                else:
+                    # if were not doing direct log reading, just wait for pod to finish
+                    client.wait_for_pod(
+                        pod_name,
+                        namespace,
+                        wait_for_state=WaitForPodState.Terminated,
+                    )
+            finally:
+                client.core_api.delete_namespaced_pod(pod_name, namespace)
+
+
+def build_pod_body(
+    pod_name: str,
+    image: Optional[str],
+    command: Optional[Union[str, Sequence[str]]],
+    env_vars: Mapping[str, str],
+    base_pod_meta: Optional[Mapping[str, Any]],
+    base_pod_spec: Optional[Mapping[str, Any]],
+):
+    meta = {
+        **(k8s_snake_case_dict(kubernetes.client.V1ObjectMeta, base_pod_meta or {})),
+        "name": pod_name,
+    }
+    if "labels" in meta:
+        meta["labels"] = {**get_common_labels(), **meta["labels"]}
+    else:
+        meta["labels"] = get_common_labels()
+
+    spec = {**k8s_snake_case_dict(kubernetes.client.V1PodSpec, base_pod_spec or {})}
+    if "containers" not in spec:
+        spec["containers"] = [{}]
+
+    if "image" not in spec["containers"][0] and not image:
+        raise DagsterInvariantViolationError(
+            "Must specify image property or provide base_pod_spec with one set."
+        )
+
+    if "name" not in spec["containers"][0]:
+        spec["containers"][0]["name"] = DEFAULT_CONTAINER_NAME
+
+    if image:
+        spec["containers"][0]["image"] = image
+
+    if command:
+        spec["containers"][0]["command"] = command
+
+    if "env" not in spec["containers"][0]:
+        spec["containers"][0]["env"] = []
+
+    spec["containers"][0]["env"].extend({"name": k, "value": v} for k, v in env_vars.items())
+
+    return k8s_model_from_dict(
+        kubernetes.client.V1Pod,
+        {
+            "metadata": meta,
+            "spec": spec,
+        },
+    )
+
+
+@contextmanager
+def _setup_ext_protocol(
+    external_context: ExtOrchestrationContext,
+    context_injector: Optional[ExtContextInjector],
+    message_reader: Optional[ExtMessageReader],
+):
+    context_injector = context_injector or ExtEnvContextInjector()
+    message_reader = message_reader or K8sPodLogsMessageReader()
+
+    with context_injector.inject_context(
+        external_context,
+    ) as ci_params, message_reader.read_messages(
+        external_context,
+    ) as mr_params:
+        protocol_envs = io_params_as_env_vars(ci_params, mr_params)
+        yield protocol_envs, message_reader

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
@@ -13,7 +13,6 @@ from dagster import (
     Field,
     Noneable,
     StringSource,
-    __version__ as dagster_version,
 )
 from dagster._config import Permissive, Shape, validate_config
 from dagster._core.errors import DagsterInvalidConfigError
@@ -22,7 +21,7 @@ from dagster._serdes import whitelist_for_serdes
 from dagster._utils.merger import merge_dicts
 
 from .models import k8s_model_from_dict, k8s_snake_case_dict
-from .utils import sanitize_k8s_label
+from .utils import get_common_labels, sanitize_k8s_label
 
 # To retry step worker, users should raise RetryRequested() so that the dagster system is aware of the
 # retry. As an example, see retry_job in dagster_test.test_project.test_jobs.repo
@@ -696,13 +695,7 @@ def construct_dagster_k8s_job(
         % (len(pod_name), MAX_K8S_NAME_LEN),
     )
 
-    # See: https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/
-    k8s_common_labels = {
-        "app.kubernetes.io/name": "dagster",
-        "app.kubernetes.io/instance": "dagster",
-        "app.kubernetes.io/version": sanitize_k8s_label(dagster_version),
-        "app.kubernetes.io/part-of": "dagster",
-    }
+    k8s_common_labels = get_common_labels()
 
     if component:
         k8s_common_labels["app.kubernetes.io/component"] = component

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/models.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/models.py
@@ -124,7 +124,7 @@ def k8s_snake_case_dict(model_class, model_dict: Mapping[str, Any]):
 
 
 # Heavily inspired by kubernetes.client.ApiClient.__deserialize_model, with more validation
-# that the keys and values match the expected format. Requires k8s atribute names to be in
+# that the keys and values match the expected format. Requires k8s attribute names to be in
 # snake_case.
 def k8s_model_from_dict(model_class, model_dict: Mapping[str, Any]):
     check.mapping_param(model_dict, "model_dict")

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
@@ -69,7 +69,7 @@ K8S_JOB_OP_CONFIG = merge_dicts(
             is_required=False,
             description=(
                 "Raw k8s config for the k8s pod's metadata"
-                " (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta)."
+                " (https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/object-meta/#ObjectMeta)."
                 " Keys can either snake_case or camelCase."
             ),
         ),
@@ -78,7 +78,7 @@ K8S_JOB_OP_CONFIG = merge_dicts(
             is_required=False,
             description=(
                 "Raw k8s config for the k8s pod's pod spec"
-                " (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#podspec-v1-core)."
+                " (https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec)."
                 " Keys can either snake_case or camelCase."
             ),
         ),
@@ -87,7 +87,7 @@ K8S_JOB_OP_CONFIG = merge_dicts(
             is_required=False,
             description=(
                 "Raw k8s config for the k8s job's metadata"
-                " (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta)."
+                " (https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/object-meta/#ObjectMeta)."
                 " Keys can either snake_case or camelCase."
             ),
         ),
@@ -185,13 +185,13 @@ def execute_k8s_job(
             (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#container-v1-core).
             Keys can either snake_case or camelCase.Default: None.
         pod_template_spec_metadata (Optional[Dict[str, Any]]): Raw k8s config for the k8s pod's
-            metadata (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta).
+            metadata (https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/object-meta/#ObjectMeta).
             Keys can either snake_case or camelCase. Default: None.
         pod_spec_config (Optional[Dict[str, Any]]): Raw k8s config for the k8s pod's pod spec
-            (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#podspec-v1-core).
+            (https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec).
             Keys can either snake_case or camelCase. Default: None.
-        job_metadata (Optional[Dict[str, Any]]): aw k8s config for the k8s job's metadata
-            (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta).
+        job_metadata (Optional[Dict[str, Any]]): Raw k8s config for the k8s job's metadata
+            (https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/object-meta/#ObjectMeta).
             Keys can either snake_case or camelCase. Default: None.
         job_spec_config (Optional[Dict[str, Any]]): Raw k8s config for the k8s job's job spec
             (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#jobspec-v1-batch).

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/utils.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/utils.py
@@ -1,8 +1,20 @@
 import re
 
+from dagster import __version__ as dagster_version
+
 
 def sanitize_k8s_label(label_name: str):
     # Truncate too long label values to fit into 63-characters limit and avoid invalid characters.
     # https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
     label_name = label_name[:63]
     return re.sub(r"[^a-zA-Z0-9\-_\.]", "-", label_name).strip("-").strip("_").strip(".")
+
+
+def get_common_labels():
+    # See: https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/
+    return {
+        "app.kubernetes.io/name": "dagster",
+        "app.kubernetes.io/instance": "dagster",
+        "app.kubernetes.io/version": sanitize_k8s_label(dagster_version),
+        "app.kubernetes.io/part-of": "dagster",
+    }

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_ext_pod.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_ext_pod.py
@@ -1,0 +1,167 @@
+import pytest
+from dagster._core.errors import DagsterInvariantViolationError
+from dagster_k8s.external_resource import build_pod_body
+
+
+def test_pod_building():
+    test_image = "my_test_image"
+    # min info
+    pod = build_pod_body(
+        pod_name="test",
+        image=test_image,
+        command=None,  # image provides default entrypoint
+        env_vars={},
+        base_pod_spec=None,
+        base_pod_meta=None,
+    )
+    assert pod.spec.containers[0].image == test_image
+
+    # expected common case
+    pod = build_pod_body(
+        pod_name="test",
+        image=test_image,
+        command=["echo", "hello"],
+        env_vars={},
+        base_pod_spec=None,
+        base_pod_meta=None,
+    )
+    assert pod.spec.containers[0].image == test_image
+
+    # spec provided
+    pod = build_pod_body(
+        pod_name="test",
+        image=None,
+        command=None,
+        env_vars={},
+        base_pod_spec={
+            "containers": [
+                {
+                    "image": test_image,
+                }
+            ]
+        },
+        base_pod_meta=None,
+    )
+    assert pod.spec.containers[0].image == test_image
+
+    # no image
+    with pytest.raises(DagsterInvariantViolationError):
+        build_pod_body(
+            pod_name="test",
+            image=None,
+            command=None,
+            env_vars={},
+            base_pod_spec=None,
+            base_pod_meta=None,
+        )
+
+    # invalid other containers
+    with pytest.raises(ValueError):
+        build_pod_body(
+            pod_name="test",
+            image=test_image,
+            command=None,
+            env_vars={},
+            base_pod_spec={
+                "containers": [
+                    {},
+                    {},
+                    {},
+                ],
+            },
+            base_pod_meta=None,
+        )
+
+    # metadata provided
+    pod = build_pod_body(
+        pod_name="test",
+        image=test_image,
+        command=None,
+        env_vars={},
+        base_pod_spec=None,
+        base_pod_meta={
+            "labels": {
+                "foo": "bar",
+            },
+            "annotations": {
+                "fizz": "buzz",
+            },
+        },
+    )
+    assert pod.metadata.labels["foo"] == "bar"
+    assert pod.metadata.annotations["fizz"] == "buzz"
+
+    # env overrides
+    pod = build_pod_body(
+        pod_name="test",
+        image=test_image,
+        command=None,
+        env_vars={
+            "from_arg": "arg",
+            "collide": "arg",
+        },
+        base_pod_spec={
+            "containers": [
+                {
+                    "image": test_image,
+                    "env": [
+                        {"name": "from_spec", "value": "spec"},
+                        {"name": "collide", "value": "spec"},
+                    ],
+                }
+            ]
+        },
+        base_pod_meta=None,
+    )
+    assert len(pod.spec.containers[0].env) == 4
+    resolved_env_vars = {pair.name: pair.value for pair in pod.spec.containers[0].env}
+    assert len(resolved_env_vars) == 3
+    assert resolved_env_vars["collide"] == "arg"
+
+    # snake case camel case mix
+    pod = build_pod_body(
+        pod_name="test",
+        image=None,
+        command=None,
+        env_vars={},
+        base_pod_meta=None,
+        base_pod_spec={
+            "containers": [
+                {
+                    "image": test_image,
+                    "command": [
+                        "python",
+                        "-m",
+                        "numbers_example.number_y",
+                    ],
+                    "volume_mounts": [
+                        {
+                            "mountPath": "/mnt/dagster/",
+                            "name": "dagster-ext-context",
+                        }
+                    ],
+                }
+            ],
+            "volumes": [
+                {
+                    "name": "dagster-ext-context",
+                    "configMap": {
+                        "name": "cm",
+                    },
+                }
+            ],
+        },
+    )
+    assert pod  # cases coerced correctly and passed internal validation
+
+    # common labels dont override
+    pod = build_pod_body(
+        pod_name="test",
+        image=test_image,
+        command=["echo", "hello"],
+        env_vars={},
+        base_pod_spec=None,
+        base_pod_meta={"labels": {"app.kubernetes.io/name": "custom"}},
+    )
+    assert pod.metadata.labels["app.kubernetes.io/name"] == "custom"
+    assert pod.metadata.labels["app.kubernetes.io/instance"] == "dagster"

--- a/python_modules/libraries/dagster-k8s/tox.ini
+++ b/python_modules/libraries/dagster-k8s/tox.ini
@@ -17,6 +17,7 @@ deps =
   -e ../../libraries/dagster-postgres
   -e ../../libraries/dagster-celery-k8s
   -e ../../libraries/dagster-celery-docker
+  -e ../../dagster-ext
   -e .
 allowlist_externals =
   /bin/bash


### PR DESCRIPTION
Adds a k8s pod external ext protocol implementation which  injects context via env var and sinks messages using stdout/stderr sifting - a little greasy but I think a good option to support for an easy "out of the box" working experience. 

This PR also aligns docker to the same pattern. The file IO set-ups that have been made to work are preserved under test, sort of demonstrating what it would look like to do it "in user land". 

`container_kwargs` in docker and `base_pod_spec` / `base_pod_meta` in k8s have been added as catch-all escape hatch arguments that allow passing any random thing from the orch layer through to the target substrate. 


## How I Tested These Changes

added tests