### PR TITLE
[auto-materialize] Store and fetch historic rules

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeMiddlePanel.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeMiddlePanel.tsx
@@ -115,7 +115,7 @@ export const AutomaterializeMiddlePanel = (props: Props) => {
     );
   }
 
-  const rules =
+  const currentRules =
     (data?.assetNodeOrError.__typename === 'AssetNode' &&
       data.assetNodeOrError.autoMaterializePolicy?.rules) ||
     [];
@@ -126,7 +126,7 @@ export const AutomaterializeMiddlePanel = (props: Props) => {
 
   return (
     <AutomaterializeMiddlePanelWithData
-      rules={rules}
+      currentRules={currentRules}
       assetHasDefinedPartitions={assetHasDefinedPartitions}
       selectedEvaluation={selectedEvaluation}
     />
@@ -134,11 +134,11 @@ export const AutomaterializeMiddlePanel = (props: Props) => {
 };
 
 export const AutomaterializeMiddlePanelWithData = ({
-  rules,
+  currentRules,
   selectedEvaluation,
   assetHasDefinedPartitions,
 }: {
-  rules: AutoMaterializeRule[];
+  currentRules: AutoMaterializeRule[];
   selectedEvaluation: NoConditionsMetEvaluation | AutoMaterializeAssetEvaluationRecord;
   assetHasDefinedPartitions: boolean;
 }) => {
@@ -150,6 +150,11 @@ export const AutomaterializeMiddlePanelWithData = ({
     selectedEvaluation?.__typename === 'AutoMaterializeAssetEvaluationRecord'
       ? selectedEvaluation.rulesWithRuleEvaluations
       : [];
+  const rules =
+    selectedEvaluation?.__typename === 'AutoMaterializeAssetEvaluationRecord' &&
+    selectedEvaluation.rules
+      ? selectedEvaluation.rules
+      : currentRules;
 
   const headerRight = () => {
     if (runIds.length === 0) {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/GetEvaluationsQuery.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/GetEvaluationsQuery.tsx
@@ -40,7 +40,7 @@ export const GET_EVALUATIONS_QUERY = gql`
     rulesWithRuleEvaluations {
       ...RuleWithEvaluationsFragment
     }
-    ruleSnapshots {
+    rules {
       description
       decisionType
     }

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/GetEvaluationsQuery.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/GetEvaluationsQuery.tsx
@@ -40,6 +40,10 @@ export const GET_EVALUATIONS_QUERY = gql`
     rulesWithRuleEvaluations {
       ...RuleWithEvaluationsFragment
     }
+    ruleSnapshots {
+      description
+      decisionType
+    }
   }
 
   fragment RuleWithEvaluationsFragment on AutoMaterializeRuleWithRuleEvaluations {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/RuleEvaluationOutcomes.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/RuleEvaluationOutcomes.tsx
@@ -95,13 +95,13 @@ export const RuleEvaluationOutcomes = ({
           details={section.details}
         >
           <Box flex={{direction: 'column', gap: 8}}>
-            {(groupedRules[section.decisionType] || []).map(({description}) => {
+            {(groupedRules[section.decisionType] || []).map(({description}, idx) => {
               const evaluations =
                 ruleEvaluations.find((e) => e.rule?.description === description)?.ruleEvaluations ||
                 [];
               return (
                 <RuleEvaluationOutcome
-                  key={description}
+                  key={idx}
                   text={description}
                   met={evaluations.length > 0}
                   rightElement={

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/types/GetEvaluationsQuery.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/types/GetEvaluationsQuery.types.ts
@@ -68,6 +68,11 @@ export type GetEvaluationsQuery = {
                 | null;
             }>;
           }>;
+          ruleSnapshots: Array<{
+            __typename: 'AutoMaterializeRule';
+            description: string;
+            decisionType: Types.AutoMaterializeDecisionType;
+          }>;
         }>;
       }
     | null;
@@ -108,6 +113,11 @@ export type AutoMaterializeEvaluationRecordItemFragment = {
         | {__typename: 'PartitionSubsetDeserializationError'; message: string}
         | null;
     }>;
+  }>;
+  ruleSnapshots: Array<{
+    __typename: 'AutoMaterializeRule';
+    description: string;
+    decisionType: Types.AutoMaterializeDecisionType;
   }>;
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/types/GetEvaluationsQuery.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/types/GetEvaluationsQuery.types.ts
@@ -68,7 +68,7 @@ export type GetEvaluationsQuery = {
                 | null;
             }>;
           }>;
-          ruleSnapshots: Array<{
+          rules: Array<{
             __typename: 'AutoMaterializeRule';
             description: string;
             decisionType: Types.AutoMaterializeDecisionType;
@@ -114,7 +114,7 @@ export type AutoMaterializeEvaluationRecordItemFragment = {
         | null;
     }>;
   }>;
-  ruleSnapshots: Array<{
+  rules: Array<{
     __typename: 'AutoMaterializeRule';
     description: string;
     decisionType: Types.AutoMaterializeDecisionType;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/types/GetEvaluationsQuery.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/types/GetEvaluationsQuery.types.ts
@@ -72,7 +72,7 @@ export type GetEvaluationsQuery = {
             __typename: 'AutoMaterializeRule';
             description: string;
             decisionType: Types.AutoMaterializeDecisionType;
-          }>;
+          }> | null;
         }>;
       }
     | null;
@@ -118,7 +118,7 @@ export type AutoMaterializeEvaluationRecordItemFragment = {
     __typename: 'AutoMaterializeRule';
     description: string;
     decisionType: Types.AutoMaterializeDecisionType;
-  }>;
+  }> | null;
 };
 
 export type RuleWithEvaluationsFragment = {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -3130,7 +3130,7 @@ type AutoMaterializeAssetEvaluationRecord {
   rulesWithRuleEvaluations: [AutoMaterializeRuleWithRuleEvaluations!]!
   timestamp: Float!
   runIds: [String!]!
-  rules: [AutoMaterializeRule!]!
+  rules: [AutoMaterializeRule!]
 }
 
 type AutoMaterializeRuleWithRuleEvaluations {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -3130,7 +3130,7 @@ type AutoMaterializeAssetEvaluationRecord {
   rulesWithRuleEvaluations: [AutoMaterializeRuleWithRuleEvaluations!]!
   timestamp: Float!
   runIds: [String!]!
-  ruleSnapshots: [AutoMaterializeRule!]!
+  rules: [AutoMaterializeRule!]!
 }
 
 type AutoMaterializeRuleWithRuleEvaluations {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -3130,6 +3130,7 @@ type AutoMaterializeAssetEvaluationRecord {
   rulesWithRuleEvaluations: [AutoMaterializeRuleWithRuleEvaluations!]!
   timestamp: Float!
   runIds: [String!]!
+  ruleSnapshots: [AutoMaterializeRule!]!
 }
 
 type AutoMaterializeRuleWithRuleEvaluations {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -727,6 +727,7 @@ enum AutoMaterializePolicyType {
 type AutoMaterializeRule {
   description: String!
   decisionType: AutoMaterializeDecisionType!
+  className: String!
 }
 
 enum AutoMaterializeDecisionType {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -434,7 +434,7 @@ export type AutoMaterializeAssetEvaluationRecord = {
   numDiscarded: Scalars['Int'];
   numRequested: Scalars['Int'];
   numSkipped: Scalars['Int'];
-  ruleSnapshots: Array<AutoMaterializeRule>;
+  rules: Array<AutoMaterializeRule>;
   rulesWithRuleEvaluations: Array<AutoMaterializeRuleWithRuleEvaluations>;
   runIds: Array<Scalars['String']>;
   timestamp: Scalars['Float'];
@@ -5053,8 +5053,7 @@ export const buildAutoMaterializeAssetEvaluationRecord = (
     numRequested:
       overrides && overrides.hasOwnProperty('numRequested') ? overrides.numRequested! : 2522,
     numSkipped: overrides && overrides.hasOwnProperty('numSkipped') ? overrides.numSkipped! : 6444,
-    ruleSnapshots:
-      overrides && overrides.hasOwnProperty('ruleSnapshots') ? overrides.ruleSnapshots! : [],
+    rules: overrides && overrides.hasOwnProperty('rules') ? overrides.rules! : [],
     rulesWithRuleEvaluations:
       overrides && overrides.hasOwnProperty('rulesWithRuleEvaluations')
         ? overrides.rulesWithRuleEvaluations!

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -470,6 +470,7 @@ export enum AutoMaterializePolicyType {
 
 export type AutoMaterializeRule = {
   __typename: 'AutoMaterializeRule';
+  className: Scalars['String'];
   decisionType: AutoMaterializeDecisionType;
   description: Scalars['String'];
 };
@@ -5109,6 +5110,8 @@ export const buildAutoMaterializeRule = (
   relationshipsToOmit.add('AutoMaterializeRule');
   return {
     __typename: 'AutoMaterializeRule',
+    className:
+      overrides && overrides.hasOwnProperty('className') ? overrides.className! : 'voluptatibus',
     decisionType:
       overrides && overrides.hasOwnProperty('decisionType')
         ? overrides.decisionType!

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -434,7 +434,7 @@ export type AutoMaterializeAssetEvaluationRecord = {
   numDiscarded: Scalars['Int'];
   numRequested: Scalars['Int'];
   numSkipped: Scalars['Int'];
-  rules: Array<AutoMaterializeRule>;
+  rules: Maybe<Array<AutoMaterializeRule>>;
   rulesWithRuleEvaluations: Array<AutoMaterializeRuleWithRuleEvaluations>;
   runIds: Array<Scalars['String']>;
   timestamp: Scalars['Float'];

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -434,6 +434,7 @@ export type AutoMaterializeAssetEvaluationRecord = {
   numDiscarded: Scalars['Int'];
   numRequested: Scalars['Int'];
   numSkipped: Scalars['Int'];
+  ruleSnapshots: Array<AutoMaterializeRule>;
   rulesWithRuleEvaluations: Array<AutoMaterializeRuleWithRuleEvaluations>;
   runIds: Array<Scalars['String']>;
   timestamp: Scalars['Float'];
@@ -5052,6 +5053,8 @@ export const buildAutoMaterializeAssetEvaluationRecord = (
     numRequested:
       overrides && overrides.hasOwnProperty('numRequested') ? overrides.numRequested! : 2522,
     numSkipped: overrides && overrides.hasOwnProperty('numSkipped') ? overrides.numSkipped! : 6444,
+    ruleSnapshots:
+      overrides && overrides.hasOwnProperty('ruleSnapshots') ? overrides.ruleSnapshots! : [],
     rulesWithRuleEvaluations:
       overrides && overrides.hasOwnProperty('rulesWithRuleEvaluations')
         ? overrides.rulesWithRuleEvaluations!

--- a/python_modules/dagster-graphql/dagster_graphql/schema/auto_materialize_asset_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/auto_materialize_asset_evaluations.py
@@ -181,7 +181,7 @@ class GrapheneAutoMaterializeAssetEvaluationRecord(graphene.ObjectType):
     rulesWithRuleEvaluations = non_null_list(GrapheneAutoMaterializeRuleWithRuleEvaluations)
     timestamp = graphene.NonNull(graphene.Float)
     runIds = non_null_list(graphene.String)
-    ruleSnapshots = non_null_list(GrapheneAutoMaterializeRule)
+    rules = non_null_list(GrapheneAutoMaterializeRule)
 
     class Meta:
         name = "AutoMaterializeAssetEvaluationRecord"
@@ -202,7 +202,7 @@ class GrapheneAutoMaterializeAssetEvaluationRecord(graphene.ObjectType):
             ),
             timestamp=record.timestamp,
             runIds=record.evaluation.run_ids,
-            ruleSnapshots=[
+            rules=[
                 GrapheneAutoMaterializeRule(snapshot)
                 for snapshot in record.evaluation.rule_snapshots
             ],

--- a/python_modules/dagster-graphql/dagster_graphql/schema/auto_materialize_asset_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/auto_materialize_asset_evaluations.py
@@ -181,6 +181,7 @@ class GrapheneAutoMaterializeAssetEvaluationRecord(graphene.ObjectType):
     rulesWithRuleEvaluations = non_null_list(GrapheneAutoMaterializeRuleWithRuleEvaluations)
     timestamp = graphene.NonNull(graphene.Float)
     runIds = non_null_list(graphene.String)
+    ruleSnapshots = non_null_list(GrapheneAutoMaterializeRule)
 
     class Meta:
         name = "AutoMaterializeAssetEvaluationRecord"
@@ -201,6 +202,10 @@ class GrapheneAutoMaterializeAssetEvaluationRecord(graphene.ObjectType):
             ),
             timestamp=record.timestamp,
             runIds=record.evaluation.run_ids,
+            ruleSnapshots=[
+                GrapheneAutoMaterializeRule(snapshot)
+                for snapshot in record.evaluation.rule_snapshots
+            ],
         )
 
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/auto_materialize_asset_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/auto_materialize_asset_evaluations.py
@@ -181,7 +181,7 @@ class GrapheneAutoMaterializeAssetEvaluationRecord(graphene.ObjectType):
     rulesWithRuleEvaluations = non_null_list(GrapheneAutoMaterializeRuleWithRuleEvaluations)
     timestamp = graphene.NonNull(graphene.Float)
     runIds = non_null_list(graphene.String)
-    rules = non_null_list(GrapheneAutoMaterializeRule)
+    rules = graphene.Field(graphene.List(graphene.NonNull(GrapheneAutoMaterializeRule)))
 
     class Meta:
         name = "AutoMaterializeAssetEvaluationRecord"
@@ -202,10 +202,14 @@ class GrapheneAutoMaterializeAssetEvaluationRecord(graphene.ObjectType):
             ),
             timestamp=record.timestamp,
             runIds=record.evaluation.run_ids,
-            rules=[
-                GrapheneAutoMaterializeRule(snapshot)
-                for snapshot in record.evaluation.rule_snapshots
-            ],
+            rules=(
+                [
+                    GrapheneAutoMaterializeRule(snapshot)
+                    for snapshot in record.evaluation.rule_snapshots
+                ]
+                if record.evaluation.rule_snapshots is not None
+                else None  # Return None if no rules serialized in evaluation
+            ),
         )
 
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/auto_materialize_policy.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/auto_materialize_policy.py
@@ -18,6 +18,7 @@ GrapheneAutoMaterializeDecisionType = graphene.Enum.from_enum(AutoMaterializeDec
 class GrapheneAutoMaterializeRule(graphene.ObjectType):
     description = graphene.NonNull(graphene.String)
     decisionType = graphene.NonNull(GrapheneAutoMaterializeDecisionType)
+    className = graphene.NonNull(graphene.String)
 
     class Meta:
         name = "AutoMaterializeRule"
@@ -26,6 +27,7 @@ class GrapheneAutoMaterializeRule(graphene.ObjectType):
         super().__init__(
             decisionType=auto_materialize_rule_snapshot.decision_type,
             description=auto_materialize_rule_snapshot.description,
+            className=auto_materialize_rule_snapshot.class_name,
         )
 
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_auto_materialize_asset_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_auto_materialize_asset_evaluations.py
@@ -64,6 +64,10 @@ query GetEvaluationsQuery($assetKey: AssetKeyInput!, $limit: Int!, $cursor: Stri
                         }
                     }
                 }
+                rules {
+                    decisionType
+                    description
+                }
             }
             currentEvaluationId
         }
@@ -94,6 +98,7 @@ class TestAutoMaterializeAssetEvaluations(ExecutingGraphQLContextTestMatrix):
                     num_requested=0,
                     num_skipped=0,
                     num_discarded=0,
+                    rule_snapshots=[AutoMaterializeRule.materialize_on_missing().to_snapshot()],
                 ),
                 AutoMaterializeAssetEvaluation(
                     asset_key=AssetKey("asset_two"),
@@ -154,16 +159,22 @@ class TestAutoMaterializeAssetEvaluations(ExecutingGraphQLContextTestMatrix):
             variables={"assetKey": {"path": ["asset_one"]}, "limit": 10, "cursor": None},
         )
         assert results.data == {
-            "autoMaterializeAssetEvaluationsOrError": {
-                "records": [
+            'autoMaterializeAssetEvaluationsOrError': {
+                'records': [
                     {
-                        "numRequested": 0,
-                        "numSkipped": 0,
-                        "numDiscarded": 0,
-                        "rulesWithRuleEvaluations": [],
+                        'numRequested': 0,
+                        'numSkipped': 0,
+                        'numDiscarded': 0,
+                        'rulesWithRuleEvaluations': [],
+                        'rules': [
+                            {
+                                'decisionType': 'MATERIALIZE',
+                                'description': 'materialization is missing',
+                            }
+                        ],
                     }
                 ],
-                "currentEvaluationId": None,
+                'currentEvaluationId': None,
             }
         }
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_auto_materialize_asset_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_auto_materialize_asset_evaluations.py
@@ -67,6 +67,7 @@ query GetEvaluationsQuery($assetKey: AssetKeyInput!, $limit: Int!, $cursor: Stri
                 rules {
                     decisionType
                     description
+                    className
                 }
             }
             currentEvaluationId
@@ -123,6 +124,7 @@ class TestAutoMaterializeAssetEvaluations(ExecutingGraphQLContextTestMatrix):
 
         assert rule["decisionType"] == "MATERIALIZE"
         assert rule["description"] == "materialization is missing"
+        assert rule["className"] == "MaterializeOnMissingRule"
 
     def _test_get_evaluations(self, graphql_context: WorkspaceRequestContext):
         results = execute_dagster_graphql(

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -409,6 +409,8 @@ class AssetDaemonContext:
         to_materialize.difference_update(to_discard)
         to_skip.difference_update(to_discard)
 
+        print("wtf", self.asset_graph.auto_materialize_policies_by_key)
+
         return (
             AutoMaterializeAssetEvaluation.from_rule_evaluation_results(
                 asset_key=asset_key,

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -409,8 +409,6 @@ class AssetDaemonContext:
         to_materialize.difference_update(to_discard)
         to_skip.difference_update(to_discard)
 
-        print("wtf", self.asset_graph.auto_materialize_policies_by_key)
-
         return (
             AutoMaterializeAssetEvaluation.from_rule_evaluation_results(
                 asset_key=asset_key,
@@ -486,7 +484,18 @@ class AssetDaemonContext:
             # over evaluation to any required neighbor key
             if to_materialize_for_asset:
                 for neighbor_key in self.asset_graph.get_required_multi_asset_keys(asset_key):
-                    evaluations_by_key[neighbor_key] = evaluation._replace(asset_key=neighbor_key)
+                    auto_materialize_policy = self.asset_graph.auto_materialize_policies_by_key.get(
+                        neighbor_key
+                    )
+
+                    if auto_materialize_policy is None:
+                        check.failed(f"Expected auto materialize policy on asset {asset_key}")
+
+                    evaluations_by_key[neighbor_key] = evaluation._replace(
+                        asset_key=neighbor_key
+                    )._replace(
+                        rule_snapshots=auto_materialize_policy.rule_snapshots
+                    )  # Neighbors can have different rule snapshots
                     will_materialize_mapping[neighbor_key] = {
                         ap._replace(asset_key=neighbor_key) for ap in to_materialize_for_asset
                     }

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_policy.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_policy.py
@@ -1,12 +1,5 @@
 from enum import Enum
-from typing import (
-    TYPE_CHECKING,
-    AbstractSet,
-    Dict,
-    FrozenSet,
-    NamedTuple,
-    Optional,
-)
+from typing import TYPE_CHECKING, AbstractSet, Dict, FrozenSet, NamedTuple, Optional, Sequence
 
 import dagster._check as check
 from dagster._annotations import experimental, public
@@ -18,7 +11,10 @@ from dagster._serdes.serdes import (
 )
 
 if TYPE_CHECKING:
-    from dagster._core.definitions.auto_materialize_rule import AutoMaterializeRule
+    from dagster._core.definitions.auto_materialize_rule import (
+        AutoMaterializeRule,
+        AutoMaterializeRuleSnapshot,
+    )
 
 
 class AutoMaterializePolicySerializer(NamedTupleSerializer):
@@ -237,3 +233,7 @@ class AutoMaterializePolicy(
         if AutoMaterializeRule.materialize_on_parent_updated() in self.rules:
             return AutoMaterializePolicyType.EAGER
         return AutoMaterializePolicyType.LAZY
+
+    @property
+    def rule_snapshots(self) -> Sequence["AutoMaterializeRuleSnapshot"]:
+        return [rule.to_snapshot() for rule in self.rules]

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -632,7 +632,7 @@ class AutoMaterializeAssetEvaluation(NamedTuple):
     num_skipped: int
     num_discarded: int
     run_ids: Set[str] = set()
-    rule_snapshots: Optional[Sequence[AutoMaterializeRuleSnapshot]] = list()
+    rule_snapshots: Optional[Sequence[AutoMaterializeRuleSnapshot]] = None
 
     @staticmethod
     def from_rule_evaluation_results(

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -646,10 +646,10 @@ class AutoMaterializeAssetEvaluation(NamedTuple):
         num_discarded: int,
         dynamic_partitions_store: "DynamicPartitionsStore",
     ) -> "AutoMaterializeAssetEvaluation":
-        rule_snapshots = []
-        auto_materialize_policies = asset_graph.auto_materialize_policies_by_key.get(asset_key)
-        if auto_materialize_policies:
-            rule_snapshots = [rule.to_snapshot() for rule in auto_materialize_policies.rules]
+        auto_materialize_policy = asset_graph.auto_materialize_policies_by_key.get(asset_key)
+        if not auto_materialize_policy:
+            check.failed(f"Expected auto-materialize policy on asset {asset_key}")
+        rule_snapshots = [rule.to_snapshot() for rule in auto_materialize_policy.rules]
 
         partitions_def = asset_graph.get_partitions_def(asset_key)
         if partitions_def is None:

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -632,6 +632,7 @@ class AutoMaterializeAssetEvaluation(NamedTuple):
     num_skipped: int
     num_discarded: int
     run_ids: Set[str] = set()
+    rule_snapshots: Optional[Sequence[AutoMaterializeRuleSnapshot]] = list()
 
     @staticmethod
     def from_rule_evaluation_results(
@@ -645,6 +646,11 @@ class AutoMaterializeAssetEvaluation(NamedTuple):
         num_discarded: int,
         dynamic_partitions_store: "DynamicPartitionsStore",
     ) -> "AutoMaterializeAssetEvaluation":
+        rule_snapshots = []
+        auto_materialize_policies = asset_graph.auto_materialize_policies_by_key.get(asset_key)
+        if auto_materialize_policies:
+            rule_snapshots = [rule.to_snapshot() for rule in auto_materialize_policies.rules]
+
         partitions_def = asset_graph.get_partitions_def(asset_key)
         if partitions_def is None:
             return AutoMaterializeAssetEvaluation(
@@ -656,6 +662,7 @@ class AutoMaterializeAssetEvaluation(NamedTuple):
                 num_requested=num_requested,
                 num_skipped=num_skipped,
                 num_discarded=num_discarded,
+                rule_snapshots=rule_snapshots,
             )
         else:
             return AutoMaterializeAssetEvaluation(
@@ -676,6 +683,7 @@ class AutoMaterializeAssetEvaluation(NamedTuple):
                 num_requested=num_requested,
                 num_skipped=num_skipped,
                 num_discarded=num_discarded,
+                rule_snapshots=rule_snapshots,
             )
 
 

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -647,9 +647,14 @@ class AutoMaterializeAssetEvaluation(NamedTuple):
         dynamic_partitions_store: "DynamicPartitionsStore",
     ) -> "AutoMaterializeAssetEvaluation":
         auto_materialize_policy = asset_graph.auto_materialize_policies_by_key.get(asset_key)
-        if not auto_materialize_policy:
-            check.failed(f"Expected auto-materialize policy on asset {asset_key}")
-        rule_snapshots = [rule.to_snapshot() for rule in auto_materialize_policy.rules]
+
+        # TODO once all tests contain auto-materialize policies on the assets, can assume
+        # that rule_snapshots is always a list
+        rule_snapshots = (
+            [rule.to_snapshot() for rule in auto_materialize_policy.rules]
+            if auto_materialize_policy
+            else None
+        )
 
         partitions_def = asset_graph.get_partitions_def(asset_key)
         if partitions_def is None:

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -651,8 +651,6 @@ class AutoMaterializeAssetEvaluation(NamedTuple):
         if not auto_materialize_policy:
             check.failed(f"Expected auto materialize policy on asset {asset_key}")
 
-        rule_snapshots = [rule.to_snapshot() for rule in auto_materialize_policy.rules]
-
         partitions_def = asset_graph.get_partitions_def(asset_key)
         if partitions_def is None:
             return AutoMaterializeAssetEvaluation(
@@ -664,7 +662,7 @@ class AutoMaterializeAssetEvaluation(NamedTuple):
                 num_requested=num_requested,
                 num_skipped=num_skipped,
                 num_discarded=num_discarded,
-                rule_snapshots=rule_snapshots,
+                rule_snapshots=auto_materialize_policy.rule_snapshots,
             )
         else:
             return AutoMaterializeAssetEvaluation(
@@ -685,7 +683,7 @@ class AutoMaterializeAssetEvaluation(NamedTuple):
                 num_requested=num_requested,
                 num_skipped=num_skipped,
                 num_discarded=num_discarded,
-                rule_snapshots=rule_snapshots,
+                rule_snapshots=auto_materialize_policy.rule_snapshots,
             )
 
 

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -648,13 +648,10 @@ class AutoMaterializeAssetEvaluation(NamedTuple):
     ) -> "AutoMaterializeAssetEvaluation":
         auto_materialize_policy = asset_graph.auto_materialize_policies_by_key.get(asset_key)
 
-        # TODO once all tests contain auto-materialize policies on the assets, can assume
-        # that rule_snapshots is always a list
-        rule_snapshots = (
-            [rule.to_snapshot() for rule in auto_materialize_policy.rules]
-            if auto_materialize_policy
-            else None
-        )
+        if not auto_materialize_policy:
+            check.failed(f"Expected auto materialize policy on asset {asset_key}")
+
+        rule_snapshots = [rule.to_snapshot() for rule in auto_materialize_policy.rules]
 
         partitions_def = asset_graph.get_partitions_def(asset_key)
         if partitions_def is None:

--- a/python_modules/dagster/dagster/_core/scheduler/instigation.py
+++ b/python_modules/dagster/dagster/_core/scheduler/instigation.py
@@ -4,7 +4,10 @@ from typing import Any, List, NamedTuple, Optional, Sequence, Union
 from typing_extensions import TypeAlias
 
 import dagster._check as check
-from dagster._core.definitions.auto_materialize_rule import AutoMaterializeAssetEvaluation
+from dagster._core.definitions.auto_materialize_rule import (
+    AutoMaterializeAssetEvaluation,
+    AutoMaterializeRuleSnapshot,
+)
 
 # re-export
 from dagster._core.definitions.run_request import (

--- a/python_modules/dagster/dagster/_core/scheduler/instigation.py
+++ b/python_modules/dagster/dagster/_core/scheduler/instigation.py
@@ -6,7 +6,6 @@ from typing_extensions import TypeAlias
 import dagster._check as check
 from dagster._core.definitions.auto_materialize_rule import (
     AutoMaterializeAssetEvaluation,
-    AutoMaterializeRuleSnapshot,
 )
 
 # re-export

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/auto_materialize_policy_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/auto_materialize_policy_scenarios.py
@@ -297,7 +297,9 @@ auto_materialize_policy_scenarios = {
             assets=lazy_assets_nothing_dep,
             unevaluated_runs=[run(["asset1"])],
             expected_run_requests=[run_request(asset_keys=["asset2", "asset3"])],
+            asset_selection=AssetSelection.keys("asset2", "asset3"),
         ),
+        asset_selection=AssetSelection.keys("asset2", "asset3"),
         unevaluated_runs=[run(["asset2", "asset3"], failed_asset_keys=["asset2", "asset3"])],
         # should not run again
         expected_run_requests=[],

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon.py
@@ -19,7 +19,10 @@ def instance():
 
 @pytest.mark.parametrize(
     "scenario_item",
-    list(ASSET_RECONCILIATION_SCENARIOS.items()),
+    [
+        (name, scenario.with_implicit_auto_materialize_policies())
+        for name, scenario in list(ASSET_RECONCILIATION_SCENARIOS.items())
+    ],
     ids=list(ASSET_RECONCILIATION_SCENARIOS.keys()),
 )
 def test_reconcile_with_external_asset_graph(scenario_item, instance):

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon.py
@@ -19,10 +19,7 @@ def instance():
 
 @pytest.mark.parametrize(
     "scenario_item",
-    [
-        (name, scenario.with_implicit_auto_materialize_policies())
-        for name, scenario in list(ASSET_RECONCILIATION_SCENARIOS.items())
-    ],
+    list(ASSET_RECONCILIATION_SCENARIOS.items()),
     ids=list(ASSET_RECONCILIATION_SCENARIOS.keys()),
 )
 def test_reconcile_with_external_asset_graph(scenario_item, instance):

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_fast.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_fast.py
@@ -35,10 +35,7 @@ from .scenarios.scenarios import ASSET_RECONCILIATION_SCENARIOS
 )
 @pytest.mark.parametrize(
     "scenario",
-    [
-        scenario.with_implicit_auto_materialize_policies()
-        for scenario in list(ASSET_RECONCILIATION_SCENARIOS.values())
-    ],
+    list(ASSET_RECONCILIATION_SCENARIOS.values()),
     ids=list(ASSET_RECONCILIATION_SCENARIOS.keys()),
 )
 def test_reconciliation(scenario, respect_materialization_data_versions):
@@ -56,6 +53,12 @@ def test_reconciliation(scenario, respect_materialization_data_versions):
                 evaluation._replace(
                     partition_subsets_by_condition=sorted(
                         evaluation.partition_subsets_by_condition, key=repr
+                    )
+                )._replace(
+                    rule_snapshots=(
+                        sorted(evaluation.rule_snapshots, key=repr)
+                        if evaluation.rule_snapshots
+                        else None
                     )
                 )
                 for evaluation in evaluations
@@ -89,11 +92,7 @@ def test_reconciliation(scenario, respect_materialization_data_versions):
 
 @pytest.mark.parametrize(
     "scenario",
-    [
-        ASSET_RECONCILIATION_SCENARIOS[
-            "freshness_complex_subsettable"
-        ].with_implicit_auto_materialize_policies()
-    ],
+    [ASSET_RECONCILIATION_SCENARIOS["freshness_complex_subsettable"]],
 )
 def test_reconciliation_no_tags(scenario):
     # simulates an environment where asset_event_tags cannot be added
@@ -138,7 +137,5 @@ def test_bad_partition_key():
     scenario = AssetReconciliationScenario(
         assets=assets, unevaluated_runs=[], asset_selection=AssetSelection.keys("hourly2")
     )
-    run_requests, _, _ = scenario.with_implicit_auto_materialize_policies().do_sensor_scenario(
-        instance
-    )
+    run_requests, _, _ = scenario.do_sensor_scenario(instance)
     assert len(run_requests) == 0

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_fast.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_fast.py
@@ -35,7 +35,10 @@ from .scenarios.scenarios import ASSET_RECONCILIATION_SCENARIOS
 )
 @pytest.mark.parametrize(
     "scenario",
-    list(ASSET_RECONCILIATION_SCENARIOS.values()),
+    [
+        scenario.with_implicit_auto_materialize_policies()
+        for scenario in list(ASSET_RECONCILIATION_SCENARIOS.values())
+    ],
     ids=list(ASSET_RECONCILIATION_SCENARIOS.keys()),
 )
 def test_reconciliation(scenario, respect_materialization_data_versions):
@@ -87,7 +90,9 @@ def test_reconciliation(scenario, respect_materialization_data_versions):
 @pytest.mark.parametrize(
     "scenario",
     [
-        ASSET_RECONCILIATION_SCENARIOS["freshness_complex_subsettable"],
+        ASSET_RECONCILIATION_SCENARIOS[
+            "freshness_complex_subsettable"
+        ].with_implicit_auto_materialize_policies()
     ],
 )
 def test_reconciliation_no_tags(scenario):
@@ -133,5 +138,7 @@ def test_bad_partition_key():
     scenario = AssetReconciliationScenario(
         assets=assets, unevaluated_runs=[], asset_selection=AssetSelection.keys("hourly2")
     )
-    run_requests, _, _ = scenario.do_sensor_scenario(instance)
+    run_requests, _, _ = scenario.with_implicit_auto_materialize_policies().do_sensor_scenario(
+        instance
+    )
     assert len(run_requests) == 0

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_perf.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_perf.py
@@ -34,7 +34,7 @@ from dagster._core.storage.partition_status_cache import get_and_update_asset_st
 from dagster._core.types.dagster_type import Nothing
 from dagster._utils import file_relative_path
 
-from .base_scenario import with_implicit_auto_materialize_policy
+from .base_scenario import with_implicit_auto_materialize_policies
 
 
 class RandomAssets(NamedTuple):
@@ -217,7 +217,7 @@ class PerfScenario(NamedTuple):
             )
             assets = [*sources, *roots, multi_asset]
 
-            return with_implicit_auto_materialize_policy(assets, AssetGraph.from_assets(assets))
+            return with_implicit_auto_materialize_policies(assets, AssetGraph.from_assets(assets))
 
         return repo
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_perf.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_perf.py
@@ -34,6 +34,8 @@ from dagster._core.storage.partition_status_cache import get_and_update_asset_st
 from dagster._core.types.dagster_type import Nothing
 from dagster._utils import file_relative_path
 
+from .base_scenario import with_implicit_auto_materialize_policy
+
 
 class RandomAssets(NamedTuple):
     name: str
@@ -208,15 +210,14 @@ class PerfScenario(NamedTuple):
 
         @repository
         def repo():
-            return list(
-                self.snapshot.assets.get_definitions(
-                    freshness_ids=set(
-                        random.sample(
-                            range(self.snapshot.assets.n_assets), self.n_freshness_policies
-                        )
-                    )
+            sources, roots, multi_asset = self.snapshot.assets.get_definitions(
+                freshness_ids=set(
+                    random.sample(range(self.snapshot.assets.n_assets), self.n_freshness_policies)
                 )
             )
+            assets = [*sources, *roots, multi_asset]
+
+            return with_implicit_auto_materialize_policy(assets, AssetGraph.from_assets(assets))
 
         return repo
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_auto_materialize_asset_evaluation.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_auto_materialize_asset_evaluation.py
@@ -100,6 +100,11 @@ def test_backcompat():
         num_discarded=0,
         dynamic_partitions_store=None,
     )
+
+    # This field is populated via the auto materialize policies on the asset graph,
+    # replace to be None
+    expected_asset_evaluation.rule_snapshots._replace(rule_snapshots=None)
+
     # json doesn't handle tuples, so they get turned into lists
     assert (
         deserialize_value(serialized_asset_evaluation)._replace(

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_auto_materialize_asset_evaluation.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_auto_materialize_asset_evaluation.py
@@ -1,4 +1,4 @@
-from dagster import AssetKey, StaticPartitionsDefinition, asset
+from dagster import AssetKey, AutoMaterializePolicy, StaticPartitionsDefinition, asset
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.auto_materialize_rule import (
     AutoMaterializeAssetEvaluation,
@@ -13,7 +13,7 @@ from dagster._serdes.serdes import deserialize_value, serialize_value
 partitions = StaticPartitionsDefinition(partition_keys=["a", "b", "c"])
 
 
-@asset(partitions_def=partitions)
+@asset(partitions_def=partitions, auto_materialize_policy=AutoMaterializePolicy.eager())
 def my_asset(_):
     pass
 
@@ -101,9 +101,9 @@ def test_backcompat():
         dynamic_partitions_store=None,
     )
 
-    # This field is populated via the auto materialize policies on the asset graph,
-    # replace to be None
-    expected_asset_evaluation.rule_snapshots._replace(rule_snapshots=None)
+    # Previously serialized asset evaluations do not contain rule snapshots, so
+    # we override to be None
+    expected_asset_evaluation = expected_asset_evaluation._replace(rule_snapshots=None)
 
     # json doesn't handle tuples, so they get turned into lists
     assert (


### PR DESCRIPTION
Currently, the UI uses the current set of automaterialize rules for every past evaluation. This PR modifies the existing behavior by:
- serializing the existent rules as part of the asset evaluation
- loading the serialized rules in the UI, using the current set of rules when rules were not serialized in the evaluation for backcompat