### PR TITLE
Adds --op-selection for dagster job execute CLI command

### DIFF
--- a/python_modules/dagster/dagster/_cli/job.py
+++ b/python_modules/dagster/dagster/_cli/job.py
@@ -311,6 +311,21 @@ def add_step_to_table(memoized_plan):
 @python_job_target_argument
 @python_job_config_argument("execute")
 @click.option("--tags", type=click.STRING, help="JSON string of tags to use for this job run")
+@click.option(
+    "-o",
+    "--ops-selection",
+    type=click.STRING,
+    help=(
+        "Specify the op subselection to execute. It can be multiple clauses separated by commas."
+        "Examples:"
+        '\n- "some_op" will execute "some_op" itself'
+        '\n- "*some_op" will execute "some_op" and all its ancestors (upstream dependencies)'
+        '\n- "*some_op+++" will execute "some_op", all its ancestors, and its descendants'
+        "   (downstream dependencies) within 3 levels down"
+        '\n- "*some_op,other_op_a,other_op_b+" will execute "some_op" and all its'
+        '   ancestors, "other_op_a" itself, and "other_op_b" and its direct child ops'
+    ),
+)
 def job_execute_command(**kwargs: ClickArgValue):
     with capture_interrupts():
         with get_possibly_temporary_instance_for_cli("``dagster job execute``") as instance:

--- a/python_modules/dagster/dagster/_cli/job.py
+++ b/python_modules/dagster/dagster/_cli/job.py
@@ -313,7 +313,7 @@ def add_step_to_table(memoized_plan):
 @click.option("--tags", type=click.STRING, help="JSON string of tags to use for this job run")
 @click.option(
     "-o",
-    "--ops-selection",
+    "--op-selection",
     type=click.STRING,
     help=(
         "Specify the op subselection to execute. It can be multiple clauses separated by commas."
@@ -399,7 +399,7 @@ def get_config_from_args(kwargs: Mapping[str, str]) -> Mapping[str, object]:
 
 
 def get_op_selection_from_args(kwargs: ClickArgMapping) -> Optional[Sequence[str]]:
-    op_selection_str = kwargs.get("solid_selection")
+    op_selection_str = kwargs.get("op_selection")
     if not isinstance(op_selection_str, str):
         return None
 


### PR DESCRIPTION
In dagster pipeline execute we had --solid-selection flag which did the same selection as we do on UI eg - solid*, solid++ etc. Can't find any such flag in dagster job execute

## Summary & Motivation
In dagster pipeline execute we had --solid-selection flag which did the same selection as we do on UI eg - solid*, solid++ etc.
Can't find any such flag in dagster job execute

## How I Tested These Changes
The execute_job command already expects solid-selection to be there so just exposing the flag would work. 
