### PR TITLE
Fix on construction of base asset jobs

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets_job.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets_job.py
@@ -213,7 +213,7 @@ def build_assets_job(
             *(asset_check.node_def for asset_check in asset_checks),
         ]
     else:
-        node_defs = list(filter(None, [asset.node_def for asset in [*source_assets]]))
+        node_defs = list(filter(None, [asset.node_def for asset in [*resolved_source_assets]]))
 
     graph = GraphDefinition(
         name=name,

--- a/python_modules/dagster/dagster/_core/definitions/assets_job.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets_job.py
@@ -213,7 +213,11 @@ def build_assets_job(
             *(asset_check.node_def for asset_check in asset_checks),
         ]
     else:
-        node_defs = list(filter(None, [asset.node_def for asset in [*resolved_source_assets]]))
+        node_defs = [
+            asset.node_def
+            for asset in source_assets
+            if isinstance(asset, SourceAsset) and asset.is_observable
+        ]
 
     graph = GraphDefinition(
         name=name,

--- a/python_modules/dagster/dagster/_core/definitions/assets_job.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets_job.py
@@ -216,7 +216,7 @@ def build_assets_job(
         node_defs = [
             asset.node_def
             for asset in source_assets
-            if isinstance(asset, SourceAsset) and asset.is_observable
+            if isinstance(asset, SourceAsset) and asset.is_observable and asset.node_def is not None
         ]
 
     graph = GraphDefinition(

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
@@ -1993,6 +1993,7 @@ def test_get_base_asset_jobs_multiple_partitions_defs():
         frozenset(["daily_asset_different_start_date", "unpartitioned_asset"]),
     }
 
+
 @ignore_warning("Function `observable_source_asset` is experimental")
 def test_get_base_asset_jobs_multiple_partitions_defs_and_observable_assets():
     class B:
@@ -2003,6 +2004,7 @@ def test_get_base_asset_jobs_multiple_partitions_defs_and_observable_assets():
     @observable_source_asset(partitions_def=partitions_a)
     def asset_a():
         ...
+
     partitions_b = StaticPartitionsDefinition(["b1"])
 
     @observable_source_asset(partitions_def=partitions_b)
@@ -2030,6 +2032,7 @@ def test_get_base_asset_jobs_multiple_partitions_defs_and_observable_assets():
         "__ASSET_JOB_0",
         "__ASSET_JOB_1",
     }
+
 
 def test_coerce_resource_build_asset_job() -> None:
     executed = {}

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
@@ -1998,9 +1998,6 @@ def test_get_base_asset_jobs_multiple_partitions_defs_and_observable_assets():
     class B:
         ...
 
-    class X:
-        ...
-
     partitions_a = StaticPartitionsDefinition(["a1"])
 
     @observable_source_asset(partitions_def=partitions_a)


### PR DESCRIPTION
## Summary & Motivation
Fixes #16088.

This adds a test case, and a one-line fix. At that point, source_assets may contain non-source assets. Make sure we resolve them to `SourceAsset` before building a graph. Otherwise downstream may try to do dependency resolution.

## How I Tested These Changes
Tested on the code that triggered it, plus ran the unit tests.