### PR TITLE
Don't store asset check outputs

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
@@ -706,55 +706,58 @@ def _store_output(
     manager_metadata: Dict[str, MetadataValue] = {}
 
     # don't store asset check outputs
-    if not step_context.step.step_output_named(
+    if step_context.step.step_output_named(
         step_output_handle.output_name
     ).properties.asset_check_handle:
-        # output_manager.handle_output is either a generator function, or a normal function with or
-        # without a return value. In the case that handle_output is a normal function, we need to
-        # catch errors should they be raised before a return value. We can do this by wrapping
-        # handle_output in a generator so that errors will be caught within iterate_with_context.
-        if not inspect.isgeneratorfunction(output_manager.handle_output):
 
-            def _gen_fn():
-                gen_output = output_manager.handle_output(output_context, output.value)
-                for event in output_context.consume_events():
-                    yield event
-                if gen_output:
-                    yield gen_output
+        def _no_op() -> Iterator[DagsterEvent]:
+            yield from ()
 
-            handle_output_gen = _gen_fn()
-        else:
-            handle_output_gen = output_manager.handle_output(output_context, output.value)
+        handle_output_gen = _no_op()
+    # output_manager.handle_output is either a generator function, or a normal function with or
+    # without a return value. In the case that handle_output is a normal function, we need to
+    # catch errors should they be raised before a return value. We can do this by wrapping
+    # handle_output in a generator so that errors will be caught within iterate_with_context.
+    elif not inspect.isgeneratorfunction(output_manager.handle_output):
 
-        for elt in iterate_with_context(
-            lambda: op_execution_error_boundary(
-                DagsterExecutionHandleOutputError,
-                msg_fn=lambda: f'Error occurred while handling output "{output_context.name}" of step "{step_context.step.key}":',
-                step_context=step_context,
-                step_key=step_context.step.key,
-                output_name=output_context.name,
-            ),
-            handle_output_gen,
-        ):
+        def _gen_fn():
+            gen_output = output_manager.handle_output(output_context, output.value)
             for event in output_context.consume_events():
                 yield event
+            if gen_output:
+                yield gen_output
 
-            manager_metadata = {**manager_metadata, **output_context.consume_logged_metadata()}
-            if isinstance(elt, DagsterEvent):
-                yield elt
-            elif isinstance(elt, AssetMaterialization):
-                manager_materializations.append(elt)
-            elif isinstance(elt, dict):  # should remove this?
-                experimental_warning(
-                    "Yielding metadata from an IOManager's handle_output() function"
-                )
-                manager_metadata = {**manager_metadata, **normalize_metadata(elt)}
-            else:
-                raise DagsterInvariantViolationError(
-                    f"IO manager on output {output_def.name} has returned "
-                    f"value {elt} of type {type(elt).__name__}. The return type can only be "
-                    "one of AssetMaterialization, Dict[str, MetadataValue]."
-                )
+        handle_output_gen = _gen_fn()
+    else:
+        handle_output_gen = output_manager.handle_output(output_context, output.value)
+
+    for elt in iterate_with_context(
+        lambda: op_execution_error_boundary(
+            DagsterExecutionHandleOutputError,
+            msg_fn=lambda: f'Error occurred while handling output "{output_context.name}" of step "{step_context.step.key}":',
+            step_context=step_context,
+            step_key=step_context.step.key,
+            output_name=output_context.name,
+        ),
+        handle_output_gen,
+    ):
+        for event in output_context.consume_events():
+            yield event
+
+        manager_metadata = {**manager_metadata, **output_context.consume_logged_metadata()}
+        if isinstance(elt, DagsterEvent):
+            yield elt
+        elif isinstance(elt, AssetMaterialization):
+            manager_materializations.append(elt)
+        elif isinstance(elt, dict):  # should remove this?
+            experimental_warning("Yielding metadata from an IOManager's handle_output() function")
+            manager_metadata = {**manager_metadata, **normalize_metadata(elt)}
+        else:
+            raise DagsterInvariantViolationError(
+                f"IO manager on output {output_def.name} has returned "
+                f"value {elt} of type {type(elt).__name__}. The return type can only be "
+                "one of AssetMaterialization, Dict[str, MetadataValue]."
+            )
 
     for event in output_context.consume_events():
         yield event


### PR DESCRIPTION
We shouldn't call io manager's handle_output on asset check outputs