### PR TITLE
Show loading state if an error happens in Tick history.

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/PythonErrorInfo.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/PythonErrorInfo.tsx
@@ -49,7 +49,7 @@ export const PythonErrorInfo: React.FC<IPythonErrorInfoProps> = (props) => {
         <CopyErrorButton
           copy={() => {
             const text = wrapperRef.current?.innerText || '';
-            copy(text);
+            copy(text.slice(5)); // Strip the word "Copy"
           }}
         />
         <ErrorHeader>{message}</ErrorHeader>

--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/TickHistory.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/TickHistory.tsx
@@ -307,7 +307,11 @@ export const TickHistoryTimeline = ({
   );
 
   useQueryRefreshAtInterval(queryResult, pollingPaused ? ONE_MONTH : 1000);
-  const {data} = queryResult;
+  const {data, error} = queryResult;
+
+  if (error) {
+    debugger;
+  }
 
   if (!data) {
     return (
@@ -332,7 +336,9 @@ export const TickHistoryTimeline = ({
     return null;
   }
 
-  const {ticks, nextTick} = data.instigationStateOrError;
+  // Set it equal to an empty array in case of a weird error
+  // https://elementl-workspace.slack.com/archives/C03CCE471E0/p1693237968395179?thread_ts=1693233109.602669&cid=C03CCE471E0
+  const {ticks = [], nextTick} = data.instigationStateOrError;
 
   const onTickClick = (tick?: InstigationTick) => {
     setSelectedTime(tick ? tick.timestamp : undefined);

--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/TickHistory.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/TickHistory.tsx
@@ -309,11 +309,7 @@ export const TickHistoryTimeline = ({
   useQueryRefreshAtInterval(queryResult, pollingPaused ? ONE_MONTH : 1000);
   const {data, error} = queryResult;
 
-  if (error) {
-    debugger;
-  }
-
-  if (!data) {
+  if (!data || error) {
     return (
       <>
         <Box


### PR DESCRIPTION
## Summary & Motivation

1. Set ticks=[] as a default because after an error occurs apollo decides to return data (without an error) and without the "ticks" field after an error:
<img width="1031" alt="Screenshot 2023-08-28 at 11 52 32 AM" src="https://github.com/dagster-io/dagster/assets/2286579/06ff95de-2321-4411-abc8-62f419803a7d">

2. Remove "Copy " text from Copy error button.

## How I Tested These Changes

Locally