### PR TITLE
[docs] Mention AssetSelection in job docs

### DIFF
--- a/docs/content/concepts/ops-jobs-graphs/jobs.mdx
+++ b/docs/content/concepts/ops-jobs-graphs/jobs.mdx
@@ -68,6 +68,8 @@ defs = Definitions(
 
 Unlike jobs created using the <PyObject object="job"/> decorator where you explicitly define the dependencies when you create the job, the topology of an asset-based job is based on the [assets](/concepts/assets/software-defined-assets) and their dependencies.
 
+You can use the <PyObject object="AssetSelection" /> syntax to create more complex selections for `define_asset_job`.
+
 ### Directly from ops
 
 - [Using the @job decorator](#using-the-job-decorator)


### PR DESCRIPTION
## Summary & Motivation
We got some feedback that we could show more complex asset selections in the example for creating a job from assets. I don't know how much we want to bloat that section with examples, but a mention and link to the API docs for `AssetSelection` seemed like a good first step

## How I Tested These Changes
👀 