### PR TITLE
Use iteration instead of recursion in get_root_unreconciled_ancestors

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -458,6 +458,9 @@ class AssetDaemonContext:
             # an asset may have already been visited if it was part of a non-subsettable multi-asset
             if asset_key not in self.target_asset_keys or asset_key in visited_multi_asset_keys:
                 continue
+
+            self._logger.debug(f"Evaluating asset {asset_key.to_user_string()}")
+
             (evaluation, to_materialize_for_asset, to_discard_for_asset) = self.evaluate_asset(
                 asset_key, will_materialize_mapping, expected_data_time_mapping
             )

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -442,7 +442,6 @@ class SkipOnParentOutdatedRule(AutoMaterializeRule, NamedTuple("_SkipOnParentOut
                 unreconciled_ancestors.update(
                     context.instance_queryer.get_root_unreconciled_ancestors(
                         asset_partition=parent,
-                        respect_materialization_data_versions=context.daemon_context.respect_materialization_data_versions,
                     )
                 )
             if unreconciled_ancestors:

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/exotic_partition_mapping_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/exotic_partition_mapping_scenarios.py
@@ -57,6 +57,13 @@ one_asset_self_dependency_hourly = [
     )
 ]
 
+one_asset_self_dependency_hourly_many_partitions = [
+    asset_def(
+        "asset1",
+        partitions_def=HourlyPartitionsDefinition(start_date="2015-01-01-00:00"),
+        deps={"asset1": TimeWindowPartitionMapping(start_offset=-1, end_offset=-1)},
+    )
+]
 
 one_asset_self_dependency = [
     asset_def(
@@ -155,6 +162,14 @@ hourly_with_daily_downstream_nonexistent_upstream_partitions_not_allowed = [
 
 
 exotic_partition_mapping_scenarios = {
+    "self_dependency_never_materialized_many_partitions": AssetReconciliationScenario(
+        assets=one_asset_self_dependency_hourly_many_partitions,
+        unevaluated_runs=[],
+        expected_run_requests=[
+            run_request(asset_keys=["asset1"], partition_key="2015-01-01-00:00")
+        ],
+        current_time=create_pendulum_time(year=2015, month=4, day=1, hour=0),
+    ),
     "fan_in_partitions_none_materialized": AssetReconciliationScenario(
         assets=two_assets_in_sequence_fan_in_partitions,
         unevaluated_runs=[],

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_perf.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_perf.py
@@ -350,7 +350,7 @@ perf_scenarios = [
     PerfScenario(
         snapshot=unpartitioned_500_assets_2_random_runs,
         n_freshness_policies=0,
-        max_execution_time_seconds=5,
+        max_execution_time_seconds=10,
     ),
     PerfScenario(
         snapshot=unpartitioned_500_assets_2_random_runs,

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_perf.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_perf.py
@@ -323,6 +323,16 @@ all_hourly_partitioned_100_assets_100_partition_keys = InstanceSnapshot(
 # ==============================================
 perf_scenarios = [
     PerfScenario(
+        snapshot=unpartitioned_500_assets_2_random_runs,
+        n_freshness_policies=0,
+        max_execution_time_seconds=5,
+    ),
+    PerfScenario(
+        snapshot=unpartitioned_500_assets_2_random_runs,
+        n_freshness_policies=100,
+        max_execution_time_seconds=10,
+    ),
+    PerfScenario(
         snapshot=unpartitioned_2000_assets_1_run,
         n_freshness_policies=0,
         max_execution_time_seconds=10,
@@ -346,16 +356,6 @@ perf_scenarios = [
         snapshot=unpartitioned_2000_assets_2_random_runs,
         n_freshness_policies=10,
         max_execution_time_seconds=25,
-    ),
-    PerfScenario(
-        snapshot=unpartitioned_500_assets_2_random_runs,
-        n_freshness_policies=0,
-        max_execution_time_seconds=10,
-    ),
-    PerfScenario(
-        snapshot=unpartitioned_500_assets_2_random_runs,
-        n_freshness_policies=100,
-        max_execution_time_seconds=10,
     ),
     PerfScenario(
         snapshot=all_daily_partitioned_500_assets_2_partition_keys,

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_perf.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_perf.py
@@ -323,16 +323,6 @@ all_hourly_partitioned_100_assets_100_partition_keys = InstanceSnapshot(
 # ==============================================
 perf_scenarios = [
     PerfScenario(
-        snapshot=unpartitioned_500_assets_2_random_runs,
-        n_freshness_policies=0,
-        max_execution_time_seconds=5,
-    ),
-    PerfScenario(
-        snapshot=unpartitioned_500_assets_2_random_runs,
-        n_freshness_policies=100,
-        max_execution_time_seconds=10,
-    ),
-    PerfScenario(
         snapshot=unpartitioned_2000_assets_1_run,
         n_freshness_policies=0,
         max_execution_time_seconds=10,
@@ -356,6 +346,16 @@ perf_scenarios = [
         snapshot=unpartitioned_2000_assets_2_random_runs,
         n_freshness_policies=10,
         max_execution_time_seconds=25,
+    ),
+    PerfScenario(
+        snapshot=unpartitioned_500_assets_2_random_runs,
+        n_freshness_policies=0,
+        max_execution_time_seconds=5,
+    ),
+    PerfScenario(
+        snapshot=unpartitioned_500_assets_2_random_runs,
+        n_freshness_policies=100,
+        max_execution_time_seconds=10,
     ),
     PerfScenario(
         snapshot=all_daily_partitioned_500_assets_2_partition_keys,


### PR DESCRIPTION
Summary:s
With self-dependant assets it's possible to end up with a dependancy chain that is >1000 nodes deep and hit a RecursionError in this method. Using a BFS and queue instead keeps us from hitting that limit.

One thing I still need to determine:
- whether we were relying anywhere on the fact that this was a *recursive* cached_method - i.e. do we need to cache the intermediate results at each step? Doesn't seem to affect the test cases I ran

Test Plan:
BK, AMP test suites same before and after change

## Summary & Motivation

## How I Tested These Changes
