### PR TITLE
Feature/databricks oauth

### DIFF
--- a/python_modules/libraries/dagster-databricks/dagster_databricks/configs.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/configs.py
@@ -18,11 +18,11 @@ from dagster import (
     EnumValue,
     Field,
     Int,
+    Noneable,
     Permissive,
     Selector,
     Shape,
     String,
-    Noneable,
 )
 
 

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/configs.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/configs.py
@@ -11,7 +11,19 @@ See:
 """
 from typing import Dict, Union
 
-from dagster import Array, Bool, Enum, EnumValue, Field, Int, Permissive, Selector, Shape, String
+from dagster import (
+    Array,
+    Bool,
+    Enum,
+    EnumValue,
+    Field,
+    Int,
+    Permissive,
+    Selector,
+    Shape,
+    String,
+    Noneable,
+)
 
 
 def _define_autoscale() -> Field:
@@ -914,4 +926,24 @@ def define_databricks_permissions() -> Field:
             "job_permissions": _define_databricks_job_permission(),
             "cluster_permissions": _define_databricks_cluster_permission(),
         }
+    )
+
+
+def define_oauth_credentials():
+    return Field(
+        Noneable(
+            Shape(
+                fields={
+                    "client_id": Field(str, is_required=True, description="Oauth client ID"),
+                    "client_secret": Field(
+                        str, is_required=True, description="Oauth client secret"
+                    ),
+                }
+            ),
+        ),
+        description=(
+            "Oauth credentials for interacting with the Databricks REST API via a service"
+            " principal. See https://docs.databricks.com/en/dev-tools/auth.html#oauth-2-0"
+        ),
+        default_value=None,
     )

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks.py
@@ -1,7 +1,6 @@
 import base64
 import logging
 import time
-from dataclasses import dataclass
 from typing import IO, Any, Mapping, Optional, Tuple, Union, cast
 
 import dagster
@@ -83,7 +82,8 @@ class DatabricksClient:
     def client(self) -> databricks_api.DatabricksAPI:
         """Retrieve the legacy Databricks API client. Note: accessing this property will throw an exception if oauth
         credentials are used to initialize the DatabricksClient, because oauth credentials are not supported by the
-        legacy Databricks API client."""
+        legacy Databricks API client.
+        """
         if self._client is None:
             raise ValueError(
                 "Legacy Databricks API client from `databricks-api` was not initialized because"
@@ -107,7 +107,7 @@ class DatabricksClient:
         see the `Databricks Python API <https://docs.databricks.com/dev-tools/python-api.html>`_.
         Noe: accessing this property will throw an exception if oauth credentials are used to initialize the
         DatabricksClient, because oauth credentials are not supported by the legacy Databricks API client.
-        **Examples:**
+        **Examples:**.
 
         .. code-block:: python
 
@@ -314,10 +314,6 @@ class DatabricksJobRunner:
         max_wait_time_sec: int = DEFAULT_RUN_MAX_WAIT_TIME_SEC,
     ):
         self.host = check.str_param(host, "host")
-        check.invariant(
-            token is not None or (oauth_client_id is not None and oauth_client_secret is not None),
-            "Must provide either databricks_token or oauth_credentials",
-        )
         check.invariant(
             token is None or (oauth_client_id is None and oauth_client_secret is None),
             "Must provide either databricks_token or oauth_credentials, but cannot provide both",

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks.py
@@ -1,6 +1,7 @@
 import base64
 import logging
 import time
+from dataclasses import dataclass
 from typing import IO, Any, Mapping, Optional, Tuple, Union, cast
 
 import dagster
@@ -32,13 +33,22 @@ class DatabricksError(Exception):
 class DatabricksClient:
     """A thin wrapper over the Databricks REST API."""
 
-    def __init__(self, host: str, token: str, workspace_id: Optional[str] = None):
+    def __init__(
+        self,
+        host: str,
+        token: Optional[str] = None,
+        oauth_client_id: Optional[str] = None,
+        oauth_client_secret: Optional[str] = None,
+        workspace_id: Optional[str] = None,
+    ):
         self.host = host
         self.workspace_id = workspace_id
 
         self._workspace_client = WorkspaceClient(
             host=host,
             token=token,
+            client_id=oauth_client_id,
+            client_secret=oauth_client_secret,
             product="dagster-databricks",
             product_version=__version__,
         )
@@ -46,14 +56,17 @@ class DatabricksClient:
         # TODO: This is the old shim client that we were previously using. Arguably this is
         # confusing for users to use since this is an unofficial wrapper around the documented
         # Databricks REST API. We should consider removing this in the next minor release.
-        self._client = databricks_api.DatabricksAPI(host=host, token=token)
-        self.__setup_user_agent(self._client.client)
-
-        # TODO: This is the old `databricks_cli` client that was previous recommended by Databricks.
-        # It is no longer supported and should be removed in favour of `databricks-sdk` in the next
-        # minor release.
-        self._api_client = databricks_cli.sdk.ApiClient(host=host, token=token)
-        self.__setup_user_agent(self._api_client)
+        if token:
+            self._client = databricks_api.DatabricksAPI(host=host, token=token)
+            self.__setup_user_agent(self._client.client)
+            # TODO: This is the old `databricks_cli` client that was previously recommended by Databricks.
+            # It is no longer supported and should be removed in favour of `databricks-sdk` in the next
+            # minor release.
+            self._api_client = databricks_cli.sdk.ApiClient(host=host, token=token)
+            self.__setup_user_agent(self._api_client)
+        else:
+            self._client = None
+            self._api_client = None
 
     def __setup_user_agent(
         self,
@@ -68,11 +81,20 @@ class DatabricksClient:
     @public
     @property
     def client(self) -> databricks_api.DatabricksAPI:
-        """Retrieve the legacy Databricks API client."""
+        """Retrieve the legacy Databricks API client. Note: accessing this property will throw an exception if oauth
+        credentials are used to initialize the DatabricksClient, because oauth credentials are not supported by the
+        legacy Databricks API client."""
+        if self._client is None:
+            raise ValueError(
+                "Legacy Databricks API client from `databricks-api` was not initialized because"
+                " oauth credentials were used instead of an access token. This legacy Databricks"
+                " API client is not supported when using oauth credentials. Use the"
+                " `workspace_client` property instead."
+            )
         return self._client
 
     @client.setter
-    def client(self, value: databricks_api.DatabricksAPI) -> None:
+    def client(self, value: Optional[databricks_api.DatabricksAPI]) -> None:
         self._client = value
 
     @deprecated(
@@ -83,7 +105,8 @@ class DatabricksClient:
     def api_client(self) -> databricks_cli.sdk.ApiClient:
         """Retrieve a reference to the underlying Databricks API client. For more information,
         see the `Databricks Python API <https://docs.databricks.com/dev-tools/python-api.html>`_.
-
+        Noe: accessing this property will throw an exception if oauth credentials are used to initialize the
+        DatabricksClient, because oauth credentials are not supported by the legacy Databricks API client.
         **Examples:**
 
         .. code-block:: python
@@ -119,6 +142,13 @@ class DatabricksClient:
         Returns:
             ApiClient: The authenticated Databricks API client.
         """
+        if self._api_client is None:
+            raise ValueError(
+                "Legacy Databricks API client from `databricks-cli` was not initialized because"
+                " oauth credentials were used instead of an access token. This legacy Databricks"
+                " API client is not supported when using oauth credentials. Use the"
+                " `workspace_client` property instead."
+            )
         return self._api_client
 
     @public
@@ -277,16 +307,33 @@ class DatabricksJobRunner:
     def __init__(
         self,
         host: str,
-        token: str,
+        token: Optional[str] = None,
+        oauth_client_id: Optional[str] = None,
+        oauth_client_secret: Optional[str] = None,
         poll_interval_sec: float = 5,
         max_wait_time_sec: int = DEFAULT_RUN_MAX_WAIT_TIME_SEC,
     ):
         self.host = check.str_param(host, "host")
-        self.token = check.str_param(token, "token")
+        check.invariant(
+            token is not None or (oauth_client_id is not None and oauth_client_secret is not None),
+            "Must provide either databricks_token or oauth_credentials",
+        )
+        check.invariant(
+            token is None or (oauth_client_id is None and oauth_client_secret is None),
+            "Must provide either databricks_token or oauth_credentials, but cannot provide both",
+        )
+        self.token = check.opt_str_param(token, "token")
+        self.oauth_client_id = check.opt_str_param(oauth_client_id, "oauth_client_id")
+        self.oauth_client_secret = check.opt_str_param(oauth_client_secret, "oauth_client_secret")
         self.poll_interval_sec = check.numeric_param(poll_interval_sec, "poll_interval_sec")
         self.max_wait_time_sec = check.int_param(max_wait_time_sec, "max_wait_time_sec")
 
-        self._client: DatabricksClient = DatabricksClient(host=self.host, token=self.token)
+        self._client: DatabricksClient = DatabricksClient(
+            host=self.host,
+            token=self.token,
+            oauth_client_id=oauth_client_id,
+            oauth_client_secret=oauth_client_secret,
+        )
 
     @property
     def client(self) -> DatabricksClient:

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
@@ -12,10 +12,10 @@ from dagster import (
     Bool,
     Field,
     IntSource,
+    Noneable,
     StringSource,
     _check as check,
     resource,
-    Noneable,
 )
 from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._core.definitions.step_launcher import StepLauncher, StepRunRef
@@ -222,7 +222,7 @@ class DatabricksPySparkStepLauncher(StepLauncher):
             "Must provide either databricks_token or oauth_credentials, but cannot provide both",
         )
         self.databricks_token = check.opt_str_param(databricks_token, "databricks_token")
-        oauth_credentials = check.opt_dict_param(
+        oauth_credentials = check.opt_mapping_param(
             oauth_credentials,
             "oauth_credentials",
             key_type=str,

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
@@ -15,6 +15,7 @@ from dagster import (
     StringSource,
     _check as check,
     resource,
+    Noneable,
 )
 from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._core.definitions.step_launcher import StepLauncher, StepRunRef
@@ -47,6 +48,7 @@ from .configs import (
     define_databricks_secrets_config,
     define_databricks_storage_config,
     define_databricks_submit_run_config,
+    define_oauth_credentials,
 )
 
 CODE_ZIP_NAME = "code.zip"
@@ -77,10 +79,11 @@ DAGSTER_SYSTEM_ENV_VARS = {
             description="Databricks host, e.g. uksouth.azuredatabricks.com",
         ),
         "databricks_token": Field(
-            StringSource,
-            is_required=True,
+            Noneable(StringSource),
+            default_value=None,
             description="Databricks access token",
         ),
+        "oauth_credentials": define_oauth_credentials(),
         "env_variables": define_databricks_env_variables(),
         "secrets_to_env_variables": define_databricks_secrets_config(),
         "storage": define_databricks_storage_config(),
@@ -192,11 +195,12 @@ class DatabricksPySparkStepLauncher(StepLauncher):
         run_config: Mapping[str, Any],
         permissions: Mapping[str, Any],
         databricks_host: str,
-        databricks_token: str,
         secrets_to_env_variables: Sequence[Mapping[str, Any]],
         staging_prefix: str,
         wait_for_logs: bool,
         max_completion_wait_time_seconds: int,
+        databricks_token: Optional[str] = None,
+        oauth_credentials: Optional[Mapping[str, str]] = None,
         env_variables: Optional[Mapping[str, str]] = None,
         storage: Optional[Mapping[str, Any]] = None,
         poll_interval_sec: int = 5,
@@ -208,7 +212,23 @@ class DatabricksPySparkStepLauncher(StepLauncher):
         self.run_config = check.mapping_param(run_config, "run_config")
         self.permissions = check.mapping_param(permissions, "permissions")
         self.databricks_host = check.str_param(databricks_host, "databricks_host")
-        self.databricks_token = check.str_param(databricks_token, "databricks_token")
+
+        check.invariant(
+            databricks_token is not None or oauth_credentials is not None,
+            "Must provide either databricks_token or oauth_credentials",
+        )
+        check.invariant(
+            databricks_token is None or oauth_credentials is None,
+            "Must provide either databricks_token or oauth_credentials, but cannot provide both",
+        )
+        self.databricks_token = check.opt_str_param(databricks_token, "databricks_token")
+        oauth_credentials = check.opt_dict_param(
+            oauth_credentials,
+            "oauth_credentials",
+            key_type=str,
+            value_type=str,
+        )
+
         self.secrets = check.sequence_param(
             secrets_to_env_variables, "secrets_to_env_variables", dict
         )
@@ -235,6 +255,8 @@ class DatabricksPySparkStepLauncher(StepLauncher):
         self.databricks_runner = DatabricksJobRunner(
             host=databricks_host,
             token=databricks_token,
+            oauth_client_id=oauth_credentials.get("client_id"),
+            oauth_client_secret=oauth_credentials.get("client_secret"),
             poll_interval_sec=poll_interval_sec,
             max_wait_time_sec=max_completion_wait_time_seconds,
         )

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/resources.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/resources.py
@@ -1,14 +1,25 @@
 from typing import Any, Optional
 
 from dagster import (
+    Config,
     ConfigurableResource,
     IAttachDifferentObjectToOpContext,
     resource,
 )
 from dagster._core.definitions.resource_definition import dagster_maintained_resource
-from pydantic import Field
+from pydantic import Field, root_validator
 
 from .databricks import DatabricksClient
+
+
+class OauthCredentials(Config):
+    """OAuth credentials for Databricks.
+
+    See https://docs.databricks.com/dev-tools/api/latest/authentication.html#oauth-2-0.
+    """
+
+    client_id: str = Field(description="OAuth client ID")
+    client_secret: str = Field(description="OAuth client secret")
 
 
 class DatabricksClientResource(ConfigurableResource, IAttachDifferentObjectToOpContext):
@@ -16,8 +27,15 @@ class DatabricksClientResource(ConfigurableResource, IAttachDifferentObjectToOpC
     op or asset.
     """
 
-    host: str = Field(description="Databricks host, e.g. uksouth.azuredatabricks.com")
-    token: str = Field(description="Databricks access token")
+    host: str = Field(description="Databricks host, e.g. https://uksouth.azuredatabricks.com")
+    token: Optional[str] = Field(default=None, description="Databricks access token")
+    oauth_credentials: Optional[OauthCredentials] = Field(
+        default=None,
+        description=(
+            "Databricks OAuth credentials for using a service principal. See"
+            " https://docs.databricks.com/en/dev-tools/auth.html#oauth-2-0"
+        ),
+    )
     workspace_id: Optional[str] = Field(
         default=None,
         description=(
@@ -27,14 +45,33 @@ class DatabricksClientResource(ConfigurableResource, IAttachDifferentObjectToOpC
         ),
     )
 
+    @root_validator()
+    def has_token_or_oauth_credentials(cls, values):
+        token = values.get("token")
+        oauth_credentials = values.get("oauth_credentials")
+        if not token and not oauth_credentials:
+            raise ValueError("Must provide either token or oauth_credentials")
+        if token and oauth_credentials:
+            raise ValueError("Must provide either token or oauth_credentials, not both")
+        return values
+
     @classmethod
     def _is_dagster_maintained(cls) -> bool:
         return True
 
     def get_client(self) -> DatabricksClient:
+        if self.oauth_credentials:
+            client_id = self.oauth_credentials.client_id
+            client_secret = self.oauth_credentials.client_secret
+        else:
+            client_id = None
+            client_secret = None
+
         return DatabricksClient(
             host=self.host,
             token=self.token,
+            oauth_client_id=client_id,
+            oauth_client_secret=client_secret,
             workspace_id=self.workspace_id,
         )
 

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_databricks_pyspark_step_launcher.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_databricks_pyspark_step_launcher.py
@@ -1,20 +1,23 @@
 import os
+from typing import Dict, Optional
+from unittest import mock
 
 import pytest
 from dagster_databricks.databricks_pyspark_step_launcher import (
     DAGSTER_SYSTEM_ENV_VARS,
     DatabricksPySparkStepLauncher,
 )
+from dagster._check import CheckError
 
 
 @pytest.fixture
 def mock_step_launcher_factory():
-    def _mocked(add_dagster_env_variables: bool, env_variables: dict):
+    def _mocked(add_dagster_env_variables: bool = True, env_variables: Optional[dict] = None, databricks_token: Optional[str] = "abc123", oauth_creds: Dict[str, str] = None):
         return DatabricksPySparkStepLauncher(
             run_config={"some": "config"},
             permissions={"some": "permissions"},
             databricks_host="databricks.host.com",
-            databricks_token="abc123",
+            databricks_token=databricks_token,
             secrets_to_env_variables=[{"some": "secret"}],
             staging_prefix="/a/prefix",
             wait_for_logs=False,
@@ -22,6 +25,7 @@ def mock_step_launcher_factory():
             env_variables=env_variables,
             add_dagster_env_variables=add_dagster_env_variables,
             local_dagster_job_package_path="some/local/path",
+            oauth_credentials=oauth_creds,
         )
 
     return _mocked
@@ -67,3 +71,19 @@ class TestCreateRemoteConfig:
 
         env_vars = test_launcher.create_remote_config()
         assert env_vars.env_variables == vars_to_add
+
+    @mock.patch("dagster_databricks.databricks.WorkspaceClient")
+    def test_given_oauth_creds_when_accessing_legacy_clients_raises_ValueError(self, mock_workspace_client, mock_step_launcher_factory):
+        test_launcher = mock_step_launcher_factory(databricks_token=None, oauth_creds={"client_id": "abc123", "client_secret": "super-secret"})
+        assert test_launcher.databricks_runner.oauth_client_id == "abc123"
+        assert test_launcher.databricks_runner.oauth_client_secret == "super-secret"
+
+        with pytest.raises(ValueError):
+            client = test_launcher.databricks_runner.client.api_client
+        with pytest.raises(ValueError):
+            client = test_launcher.databricks_runner.client.client
+
+    @mock.patch("dagster_databricks.databricks.WorkspaceClient")
+    def test_given_oauth_creds_and_token_raises_ValueError(self, mock_workspace_client, mock_step_launcher_factory):
+        with pytest.raises(CheckError):
+            test_launcher = mock_step_launcher_factory(databricks_token="abc123", oauth_creds={"client_id": "abc123", "client_secret": "super-secret"})

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_databricks_pyspark_step_launcher.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_databricks_pyspark_step_launcher.py
@@ -3,16 +3,21 @@ from typing import Dict, Optional
 from unittest import mock
 
 import pytest
+from dagster._check import CheckError
 from dagster_databricks.databricks_pyspark_step_launcher import (
     DAGSTER_SYSTEM_ENV_VARS,
     DatabricksPySparkStepLauncher,
 )
-from dagster._check import CheckError
 
 
 @pytest.fixture
 def mock_step_launcher_factory():
-    def _mocked(add_dagster_env_variables: bool = True, env_variables: Optional[dict] = None, databricks_token: Optional[str] = "abc123", oauth_creds: Dict[str, str] = None):
+    def _mocked(
+        add_dagster_env_variables: bool = True,
+        env_variables: Optional[dict] = None,
+        databricks_token: Optional[str] = "abc123",
+        oauth_creds: Optional[Dict[str, str]] = None,
+    ):
         return DatabricksPySparkStepLauncher(
             run_config={"some": "config"},
             permissions={"some": "permissions"},
@@ -73,17 +78,25 @@ class TestCreateRemoteConfig:
         assert env_vars.env_variables == vars_to_add
 
     @mock.patch("dagster_databricks.databricks.WorkspaceClient")
-    def test_given_oauth_creds_when_accessing_legacy_clients_raises_ValueError(self, mock_workspace_client, mock_step_launcher_factory):
-        test_launcher = mock_step_launcher_factory(databricks_token=None, oauth_creds={"client_id": "abc123", "client_secret": "super-secret"})
+    def test_given_oauth_creds_when_accessing_legacy_clients_raises_ValueError(
+        self, mock_workspace_client, mock_step_launcher_factory
+    ):
+        test_launcher = mock_step_launcher_factory(
+            databricks_token=None,
+            oauth_creds={"client_id": "abc123", "client_secret": "super-secret"},
+        )
         assert test_launcher.databricks_runner.oauth_client_id == "abc123"
         assert test_launcher.databricks_runner.oauth_client_secret == "super-secret"
 
         with pytest.raises(ValueError):
-            client = test_launcher.databricks_runner.client.api_client
-        with pytest.raises(ValueError):
-            client = test_launcher.databricks_runner.client.client
+            assert test_launcher.databricks_runner.client.client
 
     @mock.patch("dagster_databricks.databricks.WorkspaceClient")
-    def test_given_oauth_creds_and_token_raises_ValueError(self, mock_workspace_client, mock_step_launcher_factory):
+    def test_given_oauth_creds_and_token_raises_ValueError(
+        self, mock_workspace_client, mock_step_launcher_factory
+    ):
         with pytest.raises(CheckError):
-            test_launcher = mock_step_launcher_factory(databricks_token="abc123", oauth_creds={"client_id": "abc123", "client_secret": "super-secret"})
+            mock_step_launcher_factory(
+                databricks_token="abc123",
+                oauth_creds={"client_id": "abc123", "client_secret": "super-secret"},
+            )


### PR DESCRIPTION
## Summary & Motivation
Fixes #16126 about enabling oauth authentication for Databricks service principals
## How I Tested These Changes
Unit tests + manually tested that Databricks steps can be launched via the step launcher using either a personal access token or oauth client ID + client secret. 

During this manual testing I also uncovered a few bugs around the `submit()` call to the `databricks-sdk` which were preventing jobs from being launched (databricks-sdk requires a [task_key parameter](https://github.com/dagster-io/dagster/commit/7d2466c4490acaa017e3c1002f258cd0a5edb708), and reading a file that doesn't exist now raises a [DatabricksError](https://github.com/dagster-io/dagster/commit/fd91538bddea0821b1b8a94e94b709e2e8f8790b)). Currently the step launcher is broken as-is and will not work without these changes, so if this whole PR doesn't get merged before the next release then those two commits should probably at least get cherry-picked into a different PR and merged in. I should also note that it appears that the most recent release 0.20.10 works, and that the breaking changes must have been made since the last release.