### PR TITLE
change gql asset check id to str

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/types/AssetCheckDetailModal.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/types/AssetCheckDetailModal.types.ts
@@ -4,7 +4,7 @@ import * as Types from '../../../graphql/types';
 
 export type AssetCheckExecutionFragment = {
   __typename: 'AssetCheckExecution';
-  id: number;
+  id: string;
   runId: string;
   status: Types.AssetCheckExecutionStatus;
   evaluation: {
@@ -145,7 +145,7 @@ export type AssetCheckDetailsQuery = {
           description: string | null;
           executions: Array<{
             __typename: 'AssetCheckExecution';
-            id: number;
+            id: string;
             runId: string;
             status: Types.AssetCheckExecutionStatus;
             evaluation: {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/types/AssetChecks.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/types/AssetChecks.types.ts
@@ -19,7 +19,7 @@ export type AssetChecksQuery = {
           severity: Types.AssetCheckSeverity;
           executions: Array<{
             __typename: 'AssetCheckExecution';
-            id: number;
+            id: string;
             runId: string;
             status: Types.AssetCheckExecutionStatus;
             evaluation: {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -3194,7 +3194,7 @@ enum AssetCheckSeverity {
 }
 
 type AssetCheckExecution {
-  id: Int!
+  id: String!
   runId: String!
   status: AssetCheckExecutionStatus!
   evaluation: AssetCheckEvaluation

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -172,7 +172,7 @@ export type AssetCheckEvaluationTargetMaterializationData = {
 export type AssetCheckExecution = {
   __typename: 'AssetCheckExecution';
   evaluation: Maybe<AssetCheckEvaluation>;
-  id: Scalars['Int'];
+  id: Scalars['String'];
   runId: Scalars['String'];
   status: AssetCheckExecutionStatus;
 };
@@ -4528,7 +4528,7 @@ export const buildAssetCheckExecution = (
         : relationshipsToOmit.has('AssetCheckEvaluation')
         ? ({} as AssetCheckEvaluation)
         : buildAssetCheckEvaluation({}, relationshipsToOmit),
-    id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 2672,
+    id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'ut',
     runId: overrides && overrides.hasOwnProperty('runId') ? overrides.runId! : 'veritatis',
     status:
       overrides && overrides.hasOwnProperty('status')

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_checks.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_checks.py
@@ -66,7 +66,7 @@ class GrapheneAssetCheckEvaluation(graphene.ObjectType):
 
 
 class GrapheneAssetCheckExecution(graphene.ObjectType):
-    id = graphene.NonNull(graphene.Int)
+    id = graphene.NonNull(graphene.String)
     runId = graphene.NonNull(graphene.String)
     status = graphene.NonNull(GrapheneAssetCheckExecutionStatus)
     evaluation = graphene.Field(GrapheneAssetCheckEvaluation)
@@ -75,7 +75,8 @@ class GrapheneAssetCheckExecution(graphene.ObjectType):
         name = "AssetCheckExecution"
 
     def __init__(self, execution: AssetCheckExecutionRecord):
-        self.id = execution.id
+        super().__init__()
+        self.id = str(execution.id)
         self.runId = execution.run_id
         self.status = execution.status
         self.evaluation = (


### PR DESCRIPTION
To avoid `graphql.error.graphql_error.GraphQLError: Int cannot represent non 32-bit signed integer value: <UUID instance>` in cloud, where we're using ulids rather than auto incrementing ids for perf.

Added a test which fetches execution id