### PR TITLE
asset checks instance migrate error

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetCheckDetailModal.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetCheckDetailModal.tsx
@@ -287,7 +287,7 @@ export function MigrationRequired() {
         description={
           <Box flex={{direction: 'column'}}>
             <Body2 color={Colors.Gray700} style={{padding: '6px 0'}}>
-              A data migration is required to use asset checks. Run{' '}
+              A database schema migration is required to use asset checks. Run{' '}
               <Mono>dagster instance migrate</Mono>.
             </Body2>
             {/* <Box

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -31,7 +31,7 @@ from dagster._core.workspace.permissions import Permissions
 from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
 
 from dagster_graphql.implementation.events import iterate_metadata_entries
-from dagster_graphql.implementation.fetch_asset_checks import fetch_asset_checks
+from dagster_graphql.implementation.fetch_asset_checks import has_asset_checks
 from dagster_graphql.implementation.fetch_assets import (
     get_asset_materializations,
     get_asset_observations,
@@ -1089,7 +1089,7 @@ class GrapheneAssetNode(graphene.ObjectType):
             check.failed("Asset node has no partitions definition")
 
     def resolve_hasAssetChecks(self, graphene_info: ResolveInfo) -> bool:
-        return bool(fetch_asset_checks(graphene_info, self._external_asset_node.asset_key).checks)
+        return has_asset_checks(graphene_info, self._external_asset_node.asset_key)
 
 
 class GrapheneAssetGroup(graphene.ObjectType):

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -486,6 +486,10 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         """Frees concurrency slots for a given run/step."""
         raise NotImplementedError()
 
+    @property
+    def supports_asset_checks(self):
+        return True
+
     def get_asset_check_executions(
         self,
         asset_key: AssetKey,

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -2608,6 +2608,10 @@ class SqlEventLogStorage(EventLogStorage):
             for row in rows
         ]
 
+    @property
+    def supports_asset_checks(self):
+        return self.has_table(AssetCheckExecutionsTable.name)
+
 
 def _get_from_row(row: SqlAlchemyRow, column: str) -> object:
     """Utility function for extracting a column from a sqlalchemy row proxy, since '_asdict' is not

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -2482,6 +2482,11 @@ class SqlEventLogStorage(EventLogStorage):
         check.inst_param(event, "event", EventLogEntry)
         check.opt_int_param(event_id, "event_id")
 
+        check.invariant(
+            self.supports_asset_checks,
+            "Asset checks require a database schema migration. Run `dagster instance migrate`.",
+        )
+
         if event.dagster_event_type == DagsterEventType.ASSET_CHECK_EVALUATION_PLANNED:
             self._store_asset_check_evaluation_planned(event, event_id)
         if event.dagster_event_type == DagsterEventType.ASSET_CHECK_EVALUATION:


### PR DESCRIPTION
Return an error message when you view the checks tab and haven't run the latest migration. @salazarm already handled it in the UI 🙌 

![Screenshot 2023-08-28 at 11 21 13 PM](https://github.com/dagster-io/dagster/assets/22018973/b9f20878-b3fd-4759-9c52-bda0dde831de)

And when you try to launch a check:

![Screenshot 2023-08-28 at 11 27 38 PM](https://github.com/dagster-io/dagster/assets/22018973/63a33985-95a8-46ce-9d92-82eaeb79c8b2)

This one is a little harsh... we could let you do the run and just not store results of the checks. But I think silently failing is scary