### PR TITLE
asset checks status index

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/alembic/versions/042_add_asset_check_executions_status_index.py
+++ b/python_modules/dagster/dagster/_core/storage/alembic/versions/042_add_asset_check_executions_status_index.py
@@ -1,0 +1,37 @@
+"""Add asset check executions status index
+
+Revision ID: 7dbe52b865b6
+Revises: ec80dd91891a
+Create Date: 2023-08-28 23:33:23.532049
+
+"""
+from alembic import op
+from dagster._core.storage.migration.utils import has_index
+
+# revision identifiers, used by Alembic.
+revision = "7dbe52b865b6"
+down_revision = "ec80dd91891a"
+branch_labels = None
+depends_on = None
+
+TABLE_NAME = "asset_check_executions"
+INDEX_NAME = "idx_asset_check_executions_status"
+
+
+def upgrade():
+    if not has_index(TABLE_NAME, INDEX_NAME):
+        op.create_index(
+            INDEX_NAME,
+            TABLE_NAME,
+            [
+                "asset_key",
+                "check_name",
+                "execution_status",
+            ],
+            mysql_length={"asset_key": 64, "check_name": 64},
+        )
+
+
+def downgrade():
+    if has_index(TABLE_NAME, INDEX_NAME):
+        op.drop_index(INDEX_NAME, table_name=TABLE_NAME)

--- a/python_modules/dagster/dagster/_core/storage/event_log/schema.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/schema.py
@@ -188,6 +188,14 @@ db.Index(
 )
 
 db.Index(
+    "idx_asset_check_executions_status",
+    AssetCheckExecutionsTable.c.asset_key,
+    AssetCheckExecutionsTable.c.check_name,
+    AssetCheckExecutionsTable.c.execution_status,
+    mysql_length={"asset_key": 64, "check_name": 64},
+)
+
+db.Index(
     "idx_step_key",
     SqlEventLogStorageTable.c.step_key,
     mysql_length=32,


### PR DESCRIPTION
It seems likely that we'd offer filtering on status in the future. Adding this now guarantees that we have the index along with the asset checks table

Same in cloud: https://github.com/dagster-io/internal/pull/6602