### PR TITLE
[externals] `ExternalExecutionBlobStoreMessage{Reader,Writer}` classes and S3 impl

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -352,15 +352,6 @@ EXAMPLE_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
 
 LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
     PackageSpec("python_modules/automation"),
-    PackageSpec(
-        "python_modules/dagster-externals",
-        env_vars=[
-            "AWS_ACCOUNT_ID",
-            "AWS_ACCESS_KEY_ID",
-            "AWS_SECRET_ACCESS_KEY",
-            "BUILDKITE_SECRETS_BUCKET",
-        ],
-    ),
     PackageSpec("python_modules/dagster-webserver", pytest_extra_cmds=ui_extra_cmds),
     PackageSpec(
         "python_modules/dagster",

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -352,6 +352,15 @@ EXAMPLE_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
 
 LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
     PackageSpec("python_modules/automation"),
+    PackageSpec(
+        "python_modules/dagster-externals",
+        env_vars=[
+            "AWS_ACCOUNT_ID",
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+            "BUILDKITE_SECRETS_BUCKET",
+        ],
+    ),
     PackageSpec("python_modules/dagster-webserver", pytest_extra_cmds=ui_extra_cmds),
     PackageSpec(
         "python_modules/dagster",

--- a/python_modules/dagster-externals/dagster_externals/__init__.py
+++ b/python_modules/dagster-externals/dagster_externals/__init__.py
@@ -13,6 +13,9 @@ from dagster_externals._io.default import (
 from dagster_externals._io.env import (
     ExternalExecutionEnvContextLoader as ExternalExecutionEnvContextLoader,
 )
+from dagster_externals._io.s3 import (
+    ExternalExecutionS3MessageWriter as ExternalExecutionS3MessageWriter,
+)
 from dagster_externals._protocol import (
     DAGSTER_EXTERNALS_ENV_KEYS as DAGSTER_EXTERNALS_ENV_KEYS,
     ExternalExecutionContextData as ExternalExecutionContextData,

--- a/python_modules/dagster-externals/dagster_externals/_io/base.py
+++ b/python_modules/dagster-externals/dagster_externals/_io/base.py
@@ -1,6 +1,11 @@
+import datetime
+import json
+import time
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
-from typing import Generic, Iterator, TypeVar
+from io import StringIO
+from threading import Event, Thread
+from typing import Iterator, List, TypeVar
 
 from .._protocol import (
     ExternalExecutionContextData,
@@ -42,3 +47,58 @@ class ExternalExecutionParamLoader(ABC):
     @abstractmethod
     def load_messages_params(self) -> ExternalExecutionParams:
         ...
+
+
+class ExternalExecutionBlobStoreMessageWriter(ABC):
+    interval: int
+    max_chunk_size: int
+    buffer: List[ExternalExecutionMessage]
+    counter: int
+
+    def __init__(self, *, interval: int = 10):
+        self.interval = interval
+        self.buffer = []
+        self.counter = 1
+
+    @contextmanager
+    def setup(self, params: ExternalExecutionParams) -> Iterator[None]:
+        self.set_params(params)
+        thread = None
+        is_task_complete = Event()
+        try:
+            thread = Thread(target=self.writer_thread, args=(is_task_complete,), daemon=True)
+            thread.start()
+            yield
+        finally:
+            is_task_complete.set()
+            if thread:
+                thread.join()
+
+    def write_message(self, message: ExternalExecutionMessage) -> None:
+        self.buffer.append(message)
+
+    def write_messages_chunk(self, index: int) -> None:
+        payload = "\n".join([json.dumps(message) for message in self.buffer])
+        self.upload_messages_chunk(StringIO(payload), index)
+
+    @abstractmethod
+    def set_params(self, params: ExternalExecutionParams) -> None:
+        ...
+
+    @abstractmethod
+    def upload_messages_chunk(self, payload: StringIO, index: int) -> None:
+        ...
+
+    def writer_thread(self, is_task_complete: Event) -> None:
+        start_or_last_upload = datetime.datetime.now()
+        while True:
+            num_pending = len(self.buffer)
+            now = datetime.datetime.now()
+            if num_pending == 0 and is_task_complete.is_set():
+                break
+            elif is_task_complete.is_set() or (now - start_or_last_upload).seconds > self.interval:
+                self.write_messages_chunk(self.counter)
+                start_or_last_upload = now
+                self.buffer.clear()
+                self.counter += 1
+            time.sleep(1)

--- a/python_modules/dagster-externals/dagster_externals/_io/s3.py
+++ b/python_modules/dagster-externals/dagster_externals/_io/s3.py
@@ -1,0 +1,47 @@
+from typing import IO, Any, Optional
+
+from .._protocol import DAGSTER_EXTERNALS_ENV_KEYS, ExternalExecutionParams
+from .._util import DagsterExternalsError
+from .base import ExternalExecutionBlobStoreMessageWriter
+
+
+class ExternalExecutionS3MessageWriter(ExternalExecutionBlobStoreMessageWriter):
+    bucket: Optional[str] = None
+    key_prefix: Optional[str] = None
+    client: Any
+
+    def set_params(
+        self,
+        params: ExternalExecutionParams,
+    ) -> None:
+        self._validate_params(params)
+        self.bucket = params.get("bucket")
+        self.key_prefix = params.get("key_prefix")
+
+        try:
+            import boto3
+
+            self.client = boto3.client("s3")
+        except ImportError:
+            raise ImportError(
+                "Missing boto3 library, required for S3 message writer. Install"
+                " dagster-externals[s3]."
+            )
+
+    def _validate_params(self, params: ExternalExecutionParams) -> None:
+        try:
+            assert isinstance(params.get("bucket"), str)
+            assert isinstance(params.get("key_prefix"), str)
+        except AssertionError:
+            raise DagsterExternalsError(
+                f"`{self.__class__.__name__}` requires `bucket` and `key_prefix` keys in the"
+                f" {DAGSTER_EXTERNALS_ENV_KEYS['messages']} environment variable."
+            )
+
+    def upload_messages_chunk(self, payload: IO, index: int) -> None:
+        key = f"{self.key_prefix}/{index}.json" if self.key_prefix else f"{index}.json"
+        self.client.put_object(
+            Body=payload.read(),
+            Bucket=self.bucket,
+            Key=key,
+        )

--- a/python_modules/dagster-externals/dagster_externals/_io/s3.py
+++ b/python_modules/dagster-externals/dagster_externals/_io/s3.py
@@ -1,47 +1,50 @@
 from typing import IO, Any, Optional
 
-from .._protocol import DAGSTER_EXTERNALS_ENV_KEYS, ExternalExecutionParams
-from .._util import DagsterExternalsError
-from .base import ExternalExecutionBlobStoreMessageWriter
+from .._protocol import ExternalExecutionParams
+from .._util import assert_env_param_type, assert_opt_env_param_type, assert_param_type
+from .base import (
+    ExternalExecutionBlobStoreMessageWriter,
+    ExternalExecutionBlobStoreMessageWriterChannel,
+)
 
 
 class ExternalExecutionS3MessageWriter(ExternalExecutionBlobStoreMessageWriter):
-    bucket: Optional[str] = None
-    key_prefix: Optional[str] = None
-    client: Any
+    # client is a boto3.client("s3") object
+    def __init__(self, client: Any, *, interval: float = 10):
+        super().__init__(interval=interval)
+        self._interval = assert_param_type(interval, float, self.__class__.__name__, "interval")
+        # Not checking client type for now because it's a boto3.client object and we don't want to
+        # depend on boto3.
+        self._client = client
 
-    def set_params(
+    def make_channel(
         self,
         params: ExternalExecutionParams,
-    ) -> None:
-        self._validate_params(params)
-        self.bucket = params.get("bucket")
-        self.key_prefix = params.get("key_prefix")
+    ) -> "ExternalExecutionS3MessageChannel":
+        bucket = assert_env_param_type(params, "bucket", str, self.__class__)
+        key_prefix = assert_opt_env_param_type(params, "key_prefix", str, self.__class__)
+        return ExternalExecutionS3MessageChannel(
+            client=self._client,
+            bucket=bucket,
+            key_prefix=key_prefix,
+            interval=self._interval,
+        )
 
-        try:
-            import boto3
 
-            self.client = boto3.client("s3")
-        except ImportError:
-            raise ImportError(
-                "Missing boto3 library, required for S3 message writer. Install"
-                " dagster-externals[s3]."
-            )
-
-    def _validate_params(self, params: ExternalExecutionParams) -> None:
-        try:
-            assert isinstance(params.get("bucket"), str)
-            assert isinstance(params.get("key_prefix"), str)
-        except AssertionError:
-            raise DagsterExternalsError(
-                f"`{self.__class__.__name__}` requires `bucket` and `key_prefix` keys in the"
-                f" {DAGSTER_EXTERNALS_ENV_KEYS['messages']} environment variable."
-            )
+class ExternalExecutionS3MessageChannel(ExternalExecutionBlobStoreMessageWriterChannel):
+    # client is a boto3.client("s3") object
+    def __init__(
+        self, client: Any, bucket: str, key_prefix: Optional[str], *, interval: float = 10
+    ):
+        super().__init__(interval=interval)
+        self._client = client
+        self._bucket = bucket
+        self._key_prefix = key_prefix
 
     def upload_messages_chunk(self, payload: IO, index: int) -> None:
-        key = f"{self.key_prefix}/{index}.json" if self.key_prefix else f"{index}.json"
-        self.client.put_object(
+        key = f"{self._key_prefix}/{index}.json" if self._key_prefix else f"{index}.json"
+        self._client.put_object(
             Body=payload.read(),
-            Bucket=self.bucket,
+            Bucket=self._bucket,
             Key=key,
         )

--- a/python_modules/dagster-externals/dagster_externals/_util.py
+++ b/python_modules/dagster-externals/dagster_externals/_util.py
@@ -87,6 +87,18 @@ def assert_env_param_type(
     return value
 
 
+def assert_opt_env_param_type(
+    env_params: ExternalExecutionParams, key: str, expected_type: Type[T], cls: Type
+) -> Optional[T]:
+    value = env_params.get(key)
+    if value is not None and not isinstance(value, expected_type):
+        raise DagsterExternalsError(
+            f"Invalid type for parameter `{key}` passed from orchestration side to"
+            f" `{cls.__name__}`. Expected `Optional[{expected_type}]`, got `{type(value)}`."
+        )
+    return value
+
+
 def assert_param_value(value: T, expected_values: Sequence[T], method: str, param: str) -> T:
     if value not in expected_values:
         raise DagsterExternalsError(

--- a/python_modules/dagster-externals/dagster_externals_tests/test_external_execution.py
+++ b/python_modules/dagster-externals/dagster_externals_tests/test_external_execution.py
@@ -8,6 +8,7 @@ from contextlib import contextmanager
 from tempfile import NamedTemporaryFile
 from typing import Any, Callable, Iterator
 
+import boto3
 import pytest
 from dagster._core.definitions.data_version import (
     DATA_VERSION_IS_USER_PROVIDED_TAG,
@@ -28,6 +29,7 @@ from dagster._core.external_execution.utils import (
 )
 from dagster._core.instance_for_test import instance_for_test
 from dagster_aws.externals import ExternalExecutionS3MessageReader
+from moto.server import ThreadedMotoServer
 
 _PYTHON_EXECUTABLE = shutil.which("python")
 
@@ -42,39 +44,17 @@ def temp_script(script_fn: Callable[[], Any]) -> Iterator[str]:
         yield file.name
 
 
-@pytest.mark.parametrize(
-    ("context_injector_spec", "message_reader_spec"),
-    [
-        ("default", "default"),
-        ("default", "user/file"),
-        ("default", "user/s3"),
-        ("user/file", "default"),
-        ("user/file", "user/file"),
-        ("user/env", "default"),
-        ("user/env", "user/file"),
-    ],
-)
-def test_external_subprocess_asset(capsys, tmpdir, context_injector_spec, message_reader_spec):
-    if context_injector_spec == "default":
-        context_injector = None
-    elif context_injector_spec == "user/file":
-        context_injector = ExternalExecutionFileContextInjector(os.path.join(tmpdir, "input"))
-    elif context_injector_spec == "user/env":
-        context_injector = ExternalExecutionEnvContextInjector()
-    else:
-        assert False, "Unreachable"
+_S3_TEST_BUCKET = "externals-testing"
+_S3_SERVER_PORT = 5193
+_S3_SERVER_URL = f"http://localhost:{_S3_SERVER_PORT}"
 
-    if message_reader_spec == "default":
-        message_reader = None
-    elif message_reader_spec == "user/file":
-        message_reader = ExternalExecutionFileMessageReader(os.path.join(tmpdir, "output"))
-    elif message_reader_spec == "user/s3":
-        message_reader = ExternalExecutionS3MessageReader(bucket="externals-testing")
-    else:
-        assert False, "Unreachable"
 
+@pytest.fixture
+def external_script() -> Iterator[str]:
+    # This is called in an external process and so cannot access outer scope
     def script_fn():
         import os
+        import time
 
         from dagster_externals import (
             ExternalExecutionContext,
@@ -89,34 +69,87 @@ def test_external_subprocess_asset(capsys, tmpdir, context_injector_spec, messag
             context_loader = None  # use default
 
         if os.getenv("MESSAGE_READER_SPEC") == "user/s3":
-            message_writer = ExternalExecutionS3MessageWriter()
+            import boto3
+
+            client = boto3.client(
+                "s3", region_name="us-east-1", endpoint_url="http://localhost:5193"
+            )
+            message_writer = ExternalExecutionS3MessageWriter(client, interval=0.001)
         else:
             message_writer = None  # use default
 
         init_dagster_externals(context_loader=context_loader, message_writer=message_writer)
         context = ExternalExecutionContext.get()
         context.log("hello world")
+        time.sleep(0.1)  # sleep to make sure that we encompass multiple intervals for blob store IO
         context.report_asset_metadata("foo", "bar", context.get_extra("bar"))
         context.report_asset_data_version("foo", "alpha")
+
+    with temp_script(script_fn) as script_path:
+        yield script_path
+
+
+@pytest.fixture
+def s3_client() -> Iterator[boto3.client]:
+    # We need to use the moto server for cross-process communication
+    server = ThreadedMotoServer(port=5193)  # on localhost:5000 by default
+    server.start()
+    client = boto3.client("s3", region_name="us-east-1", endpoint_url=_S3_SERVER_URL)
+    client.create_bucket(Bucket=_S3_TEST_BUCKET)
+    yield client
+    server.stop()
+
+
+@pytest.mark.parametrize(
+    ("context_injector_spec", "message_reader_spec"),
+    [
+        ("default", "default"),
+        ("default", "user/file"),
+        ("default", "user/s3"),
+        ("user/file", "default"),
+        ("user/file", "user/file"),
+        ("user/env", "default"),
+        ("user/env", "user/file"),
+    ],
+)
+def test_external_subprocess_asset(
+    capsys, tmpdir, external_script, s3_client, context_injector_spec, message_reader_spec
+):
+    if context_injector_spec == "default":
+        context_injector = None
+    elif context_injector_spec == "user/file":
+        context_injector = ExternalExecutionFileContextInjector(os.path.join(tmpdir, "input"))
+    elif context_injector_spec == "user/env":
+        context_injector = ExternalExecutionEnvContextInjector()
+    else:
+        assert False, "Unreachable"
+
+    if message_reader_spec == "default":
+        message_reader = None
+    elif message_reader_spec == "user/file":
+        message_reader = ExternalExecutionFileMessageReader(os.path.join(tmpdir, "output"))
+    elif message_reader_spec == "user/s3":
+        message_reader = ExternalExecutionS3MessageReader(
+            bucket=_S3_TEST_BUCKET, client=s3_client, interval=0.001
+        )
+    else:
+        assert False, "Unreachable"
 
     @asset
     def foo(context: AssetExecutionContext, ext: SubprocessExecutionResource):
         extras = {"bar": "baz"}
-        aws_env_vars = {k: v for k, v in os.environ.items() if k.startswith("AWS_")}
-        with temp_script(script_fn) as script_path:
-            cmd = [_PYTHON_EXECUTABLE, script_path]
-            ext.run(
-                cmd,
-                context=context,
-                extras=extras,
-                context_injector=context_injector,
-                message_reader=message_reader,
-                env={
-                    "CONTEXT_INJECTOR_SPEC": context_injector_spec,
-                    "MESSAGE_READER_SPEC": message_reader_spec,
-                    **aws_env_vars,
-                },
-            )
+        cmd = [_PYTHON_EXECUTABLE, external_script]
+        ext.run(
+            cmd,
+            context=context,
+            extras=extras,
+            context_injector=context_injector,
+            message_reader=message_reader,
+            env={
+                "CONTEXT_INJECTOR_SPEC": context_injector_spec,
+                "MESSAGE_READER_SPEC": message_reader_spec,
+            },
+        )
 
     resource = SubprocessExecutionResource()
     with instance_for_test() as instance:

--- a/python_modules/dagster-externals/setup.py
+++ b/python_modules/dagster-externals/setup.py
@@ -36,9 +36,10 @@ setup(
         "typing_extensions>=4.4.0",
     ],
     extras_require={
+        "s3": ["boto3", "botocore"],
         "test": [
             f"dagster{pin}",
-        ]
+        ],
     },
     zip_safe=False,
     entry_points={"console_scripts": ["dagster-graphql = dagster_graphql.cli:main"]},

--- a/python_modules/dagster-externals/setup.py
+++ b/python_modules/dagster-externals/setup.py
@@ -36,9 +36,11 @@ setup(
         "typing_extensions>=4.4.0",
     ],
     extras_require={
-        "s3": ["boto3", "botocore"],
         "test": [
             f"dagster{pin}",
+            "boto3",
+            "botocore",
+            "moto[s3,server]",
         ],
     },
     zip_safe=False,

--- a/python_modules/dagster-externals/tox.ini
+++ b/python_modules/dagster-externals/tox.ini
@@ -6,10 +6,11 @@ download = True
 setenv =
   !windows: COVERAGE_ARGS = --cov=dagster --cov-append --cov-report term:skip-covered --cov-report html --cov-report xml
   windows: COVERAGE_ARGS =
-passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
+passenv = CI_* COVERALLS_REPO_TOKEN AWS_* BUILDKITE*
 deps =
   -e ../dagster[test]
-  -e .[test]
+  -e ../libraries/dagster-aws
+  -e .[s3,test]
 
 allowlist_externals =
   /bin/bash

--- a/python_modules/dagster-externals/tox.ini
+++ b/python_modules/dagster-externals/tox.ini
@@ -6,11 +6,11 @@ download = True
 setenv =
   !windows: COVERAGE_ARGS = --cov=dagster --cov-append --cov-report term:skip-covered --cov-report html --cov-report xml
   windows: COVERAGE_ARGS =
-passenv = CI_* COVERALLS_REPO_TOKEN AWS_* BUILDKITE*
+passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
 deps =
   -e ../dagster[test]
   -e ../libraries/dagster-aws
-  -e .[s3,test]
+  -e .[test]
 
 allowlist_externals =
   /bin/bash

--- a/python_modules/dagster/dagster/_core/external_execution/utils.py
+++ b/python_modules/dagster/dagster/_core/external_execution/utils.py
@@ -79,10 +79,10 @@ class ExternalExecutionFileMessageReader(ExternalExecutionMessageReader):
 
 
 class ExternalExecutionBlobStoreMessageReader(ExternalExecutionMessageReader):
-    interval: int
+    interval: float
     counter: int
 
-    def __init__(self, interval: int = 10):
+    def __init__(self, interval: float = 10):
         self.interval = interval
         self.counter = 1
 

--- a/python_modules/dagster/dagster/_core/external_execution/utils.py
+++ b/python_modules/dagster/dagster/_core/external_execution/utils.py
@@ -1,8 +1,11 @@
+import datetime
 import json
 import os
+import time
+from abc import abstractmethod
 from contextlib import contextmanager
 from threading import Event, Thread
-from typing import TYPE_CHECKING, Iterator, Mapping
+from typing import TYPE_CHECKING, Iterator, Mapping, Optional
 
 from dagster_externals import DAGSTER_EXTERNALS_ENV_KEYS, ExternalExecutionParams, encode_env_var
 
@@ -56,7 +59,7 @@ class ExternalExecutionFileMessageReader(ExternalExecutionMessageReader):
         try:
             open(self._path, "w").close()  # create file
             thread = Thread(
-                target=_read_messages, args=(context, self._path, is_task_complete), daemon=True
+                target=self._reader_thread, args=(context, is_task_complete), daemon=True
             )
             thread.start()
             yield {"path": self._path}
@@ -67,13 +70,75 @@ class ExternalExecutionFileMessageReader(ExternalExecutionMessageReader):
             if thread:
                 thread.join()
 
+    def _reader_thread(
+        self, context: "ExternalExecutionOrchestrationContext", is_resource_complete: Event
+    ) -> None:
+        for line in tail_file(self._path, lambda: is_resource_complete.is_set()):
+            message = json.loads(line)
+            context.handle_message(message)
 
-def _read_messages(
-    context: "ExternalExecutionOrchestrationContext", path: str, is_resource_complete: Event
-) -> None:
-    for line in tail_file(path, lambda: is_resource_complete.is_set()):
-        message = json.loads(line)
-        context.handle_message(message)
+
+class ExternalExecutionBlobStoreMessageReader(ExternalExecutionMessageReader):
+    interval: int
+    counter: int
+
+    def __init__(self, interval: int = 10):
+        self.interval = interval
+        self.counter = 1
+
+    @contextmanager
+    def read_messages(
+        self,
+        context: "ExternalExecutionOrchestrationContext",
+    ) -> Iterator[ExternalExecutionParams]:
+        with self.setup():
+            is_task_complete = Event()
+            thread = None
+            try:
+                thread = Thread(
+                    target=self._reader_thread,
+                    args=(
+                        context,
+                        is_task_complete,
+                    ),
+                    daemon=True,
+                )
+                thread.start()
+                yield self.get_params()
+            finally:
+                is_task_complete.set()
+                if thread:
+                    thread.join()
+
+    @contextmanager
+    def setup(self) -> Iterator[None]:
+        yield
+
+    @abstractmethod
+    def get_params(self) -> ExternalExecutionParams:
+        ...
+
+    @abstractmethod
+    def download_messages_chunk(self, index: int) -> Optional[str]:
+        ...
+
+    def _reader_thread(
+        self, context: "ExternalExecutionOrchestrationContext", is_task_complete: Event
+    ) -> None:
+        start_or_last_download = datetime.datetime.now()
+        while True:
+            now = datetime.datetime.now()
+            if (now - start_or_last_download).seconds > self.interval or is_task_complete.is_set():
+                chunk = self.download_messages_chunk(self.counter)
+                start_or_last_download = now
+                if chunk:
+                    for line in chunk.split("\n"):
+                        message = json.loads(line)
+                        context.handle_message(message)
+                    self.counter += 1
+                elif is_task_complete.is_set():
+                    break
+            time.sleep(1)
 
 
 def io_params_as_env_vars(

--- a/python_modules/libraries/dagster-aws/dagster_aws/externals.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/externals.py
@@ -1,0 +1,29 @@
+import random
+import string
+from typing import Optional
+
+import boto3
+from botocore.exceptions import ClientError
+from dagster._core.external_execution.resource import (
+    ExternalExecutionParams,
+)
+from dagster._core.external_execution.utils import ExternalExecutionBlobStoreMessageReader
+
+
+class ExternalExecutionS3MessageReader(ExternalExecutionBlobStoreMessageReader):
+    def __init__(self, *, interval: int = 10, bucket: str):
+        super().__init__(interval=interval)
+        self.bucket = bucket
+        self.key_prefix = "".join(random.choices(string.ascii_letters, k=30))
+        self.client = boto3.client("s3")
+
+    def get_params(self) -> ExternalExecutionParams:
+        return {"bucket": self.bucket, "key_prefix": self.key_prefix}
+
+    def download_messages_chunk(self, index: int) -> Optional[str]:
+        key = f"{self.key_prefix}/{index}.json"
+        try:
+            obj = self.client.get_object(Bucket=self.bucket, Key=key)
+            return obj["Body"].read().decode("utf-8")
+        except ClientError:
+            return None

--- a/python_modules/libraries/dagster-aws/dagster_aws/externals.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/externals.py
@@ -3,6 +3,7 @@ import string
 from typing import Optional
 
 import boto3
+import dagster._check as check
 from botocore.exceptions import ClientError
 from dagster._core.external_execution.resource import (
     ExternalExecutionParams,
@@ -11,11 +12,11 @@ from dagster._core.external_execution.utils import ExternalExecutionBlobStoreMes
 
 
 class ExternalExecutionS3MessageReader(ExternalExecutionBlobStoreMessageReader):
-    def __init__(self, *, interval: int = 10, bucket: str):
+    def __init__(self, *, interval: int = 10, bucket: str, client: boto3.client):
         super().__init__(interval=interval)
-        self.bucket = bucket
+        self.bucket = check.str_param(bucket, "bucket")
         self.key_prefix = "".join(random.choices(string.ascii_letters, k=30))
-        self.client = boto3.client("s3")
+        self.client = client
 
     def get_params(self) -> ExternalExecutionParams:
         return {"bucket": self.bucket, "key_prefix": self.key_prefix}


### PR DESCRIPTION
## Summary & Motivation

Add three new abstract classes:

`ExternalExecutionBlobStoreMessageWriter`/`ExternalExecutionBlobStoreMessageWriterChannel` (ext side): Writes sets of messages to some blob store on a configurable interval. User implements:

```python

class ExternalExecutionBlobStoreMessageWriter(Generic[T_Channel]):
    @abstractmethod
    def get_channel(self, params: ExternalExecutionParams) -> T_Channel:
       ... # validate params and return T_Channel

class ExternalExecutionBlobStoreMessageWriterChannel(...):
    @abstractmethod
    def upload_messages_chunk(self, payload: StringIO, index: int) -> None:
        ...
```

`ExternalExecutionBlobStoreMessageReader` (orch side): Reads sets of messages from some blob store on a configurable interval. User implements:

```python

    # `ExternalExecutionBlobStoreMessageReader` implements standard logic for `read_messages`, `get_params` is the adapter-specific hook that it calls.
    @abstractmethod
    def get_params(self) -> ExternalExecutionParams:
        ...  # returns e.g. a bucket for S3

    @abstractmethod
    def download_messages_chunk(self, index: int) -> Optional[str]:
        ...
```

Also includes an implementation for S3. I was not sure where exactly to put the two parts of the S3 implementation. Currently (I know this will be subject to debate):

- `ExternalExecutionS3MessageReader`: in new `dagster-aws` submodule `dagster_aws.externals`
- `ExternalExecutionS3MessageWriter`: in `dagster_externals._io.s3`. Added an `s3` extra that adds `boto3` and `botocore` as deps in `setup.py`.

## How I Tested These Changes

New unit test for S3 message reader/writer