### PR TITLE
[ui] Dynamically populate AMP description using rules

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/SidebarAssetInfo.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/SidebarAssetInfo.tsx
@@ -239,6 +239,7 @@ const SIDEBAR_ASSET_FRAGMENT = gql`
     autoMaterializePolicy {
       policyType
       rules {
+        decisionType
         description
       }
     }

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__stories__/SidebarAssetInfo.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__stories__/SidebarAssetInfo.stories.tsx
@@ -8,10 +8,12 @@ import {AssetEventsQuery} from '../../assets/types/useRecentAssetEvents.types';
 import {ASSET_EVENTS_QUERY} from '../../assets/useRecentAssetEvents';
 import {
   AssetNode,
+  AutoMaterializeDecisionType,
   AutoMaterializePolicyType,
   RunStatus,
   buildAssetNode,
   buildAutoMaterializePolicy,
+  buildAutoMaterializeRule,
   buildFreshnessPolicy,
 } from '../../graphql/types';
 import {WorkspaceProvider} from '../../workspace/WorkspaceContext';
@@ -242,6 +244,16 @@ export const AssetWithPolicies = () => {
         buildSidebarQueryMock({
           autoMaterializePolicy: buildAutoMaterializePolicy({
             policyType: AutoMaterializePolicyType.EAGER,
+            rules: [
+              buildAutoMaterializeRule({
+                decisionType: AutoMaterializeDecisionType.MATERIALIZE,
+                description: 'Rule 1',
+              }),
+              buildAutoMaterializeRule({
+                decisionType: AutoMaterializeDecisionType.SKIP,
+                description: 'Skip Rule 1',
+              }),
+            ],
           }),
           freshnessPolicy: buildFreshnessPolicy({
             maximumLagMinutes: 60,

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/types/SidebarAssetInfo.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/types/SidebarAssetInfo.types.ts
@@ -119,7 +119,11 @@ export type SidebarAssetFragment = {
   autoMaterializePolicy: {
     __typename: 'AutoMaterializePolicy';
     policyType: Types.AutoMaterializePolicyType;
-    rules: Array<{__typename: 'AutoMaterializeRule'; description: string}>;
+    rules: Array<{
+      __typename: 'AutoMaterializeRule';
+      decisionType: Types.AutoMaterializeDecisionType;
+      description: string;
+    }>;
   } | null;
   partitionDefinition: {__typename: 'PartitionDefinition'; description: string} | null;
   assetKey: {__typename: 'AssetKey'; path: Array<string>};
@@ -15678,7 +15682,11 @@ export type SidebarAssetQuery = {
         autoMaterializePolicy: {
           __typename: 'AutoMaterializePolicy';
           policyType: Types.AutoMaterializePolicyType;
-          rules: Array<{__typename: 'AutoMaterializeRule'; description: string}>;
+          rules: Array<{
+            __typename: 'AutoMaterializeRule';
+            decisionType: Types.AutoMaterializeDecisionType;
+            description: string;
+          }>;
         } | null;
         partitionDefinition: {__typename: 'PartitionDefinition'; description: string} | null;
         assetKey: {__typename: 'AssetKey'; path: Array<string>};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeDefinition.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeDefinition.tsx
@@ -346,6 +346,10 @@ export const ASSET_NODE_DEFINITION_FRAGMENT = gql`
     jobNames
     autoMaterializePolicy {
       policyType
+      rules {
+        description
+        decisionType
+      }
     }
     freshnessPolicy {
       maximumLagMinutes

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetSidebarActivitySummary.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetSidebarActivitySummary.tsx
@@ -100,7 +100,7 @@ export const AssetSidebarActivitySummary: React.FC<Props> = ({
             <Icon name="open_in_new" color={Colors.Link} />
           </Box>
           <Box margin={{horizontal: 24}} flex={{gap: 12, alignItems: 'flex-start'}}>
-            <Body style={{flex: 1}}>
+            <Body style={{flex: 1, marginBottom: 12}}>
               {automaterializePolicyDescription(asset.autoMaterializePolicy)}
             </Body>
             <AutomaterializePolicyTag policy={asset.autoMaterializePolicy} />

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeRightPanel.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeRightPanel.tsx
@@ -76,7 +76,8 @@ export const AutomaterializeRightPanel = ({assetKey}: Props) => {
                 }
               >
                 <Body style={{flex: 1}}>
-                  {automaterializePolicyDescription(data.assetNodeOrError.autoMaterializePolicy)}
+                  This asset is automatically re-materialized when at least one of the conditions to
+                  the left is met and no skip conditions are met.
                 </Body>
               </RightPanelSection>
             ) : (
@@ -205,6 +206,10 @@ export const GET_POLICY_INFO_QUERY = gql`
         autoMaterializePolicy {
           policyType
           maxMaterializationsPerMinute
+          rules {
+            description
+            decisionType
+          }
         }
       }
     }

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeRightPanel.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeRightPanel.tsx
@@ -73,8 +73,8 @@ export const AutomaterializeRightPanel = ({assetKey}: Props) => {
                 }
               >
                 <Body style={{flex: 1}}>
-                  This asset is automatically re-materialized when at least one of the conditions to
-                  the left is met and no skip conditions are met.
+                  This asset will be automatically materialized when at least one of the conditions
+                  to the left is met and no skip conditions are met.
                 </Body>
               </RightPanelSection>
             ) : (

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeRightPanel.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeRightPanel.tsx
@@ -15,10 +15,7 @@ import {Link, Redirect} from 'react-router-dom';
 
 import {ErrorWrapper} from '../../app/PythonErrorInfo';
 import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../../app/QueryRefresh';
-import {
-  AutomaterializePolicyTag,
-  automaterializePolicyDescription,
-} from '../AutomaterializePolicyTag';
+import {AutomaterializePolicyTag} from '../AutomaterializePolicyTag';
 import {assetDetailsPathForKey} from '../assetDetailsPathForKey';
 import {AssetKey} from '../types';
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/types/AutomaterializeRightPanel.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/types/AutomaterializeRightPanel.types.ts
@@ -22,6 +22,11 @@ export type GetPolicyInfoQuery = {
           __typename: 'AutoMaterializePolicy';
           policyType: Types.AutoMaterializePolicyType;
           maxMaterializationsPerMinute: number | null;
+          rules: Array<{
+            __typename: 'AutoMaterializeRule';
+            description: string;
+            decisionType: Types.AutoMaterializeDecisionType;
+          }>;
         } | null;
       }
     | {__typename: 'AssetNotFoundError'};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutomaterializePolicyTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutomaterializePolicyTag.tsx
@@ -1,7 +1,8 @@
-import {Tag} from '@dagster-io/ui-components';
+import {Box, Tag} from '@dagster-io/ui-components';
+import groupBy from 'lodash/groupBy';
 import React from 'react';
 
-import {AutoMaterializePolicyType} from '../graphql/types';
+import {AutoMaterializePolicyType, AutoMaterializeRule} from '../graphql/types';
 
 export const AutomaterializePolicyTag: React.FC<{
   policy: {
@@ -13,21 +14,34 @@ export const AutomaterializePolicyTag: React.FC<{
 
 export const automaterializePolicyDescription = (policy: {
   policyType: AutoMaterializePolicyType;
-}) => (
-  <>
-    This asset is automatically re-materialized when at least one of the following are true:
-    <ul style={{paddingLeft: 20}}>
-      <li>it is missing</li>
-      <li>it has a freshness policy that requires more up-to-date data</li>
-      <li>any of its descendants have a freshness policy that require more up-to-date data</li>
-      {policy.policyType === AutoMaterializePolicyType.EAGER && (
-        <li>any of its parent assets / partitions have newer data</li>
+  rules: AutoMaterializeRule[];
+}) => {
+  const {MATERIALIZE, SKIP, DISCARD} = groupBy(policy.rules, (rule) => rule.decisionType);
+  return (
+    <Box flex={{direction: 'column', gap: 12}}>
+      This asset is automatically re-materialized when at least one of the following are true:
+      <ul style={{paddingLeft: 20, margin: 0}}>
+        {MATERIALIZE?.map((rule) => (
+          <li key={rule.description}>{rule.description}</li>
+        ))}
+      </ul>
+      and none of the following are true:
+      <ul style={{paddingLeft: 20, margin: 0}}>
+        {SKIP?.map((rule) => (
+          <li key={rule.description}>{rule.description}</li>
+        ))}
+      </ul>
+      {DISCARD && DISCARD.length > 0 && (
+        <>
+          Partitions may be skipped and require a backfill to materialize if any of the following
+          are true:
+          <ul style={{paddingLeft: 20, margin: 0}}>
+            {DISCARD.map((rule) => (
+              <li key={rule.description}>{rule.description}</li>
+            ))}
+          </ul>
+        </>
       )}
-    </ul>
-    and none of the following are true:
-    <ul style={{paddingLeft: 20, marginBottom: 0}}>
-      <li>any of its parent assets / partitions are missing</li>
-      <li>any of its ancestor assets / partitions have ancestors of their own with newer data</li>
-    </ul>
-  </>
-);
+    </Box>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutomaterializePolicyTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutomaterializePolicyTag.tsx
@@ -33,7 +33,7 @@ export const automaterializePolicyDescription = (policy: {
       </ul>
       {DISCARD && DISCARD.length > 0 && (
         <>
-          Partitions may be skipped and require a backfill to materialize if any of the following
+          Partitions may be discarded and require a backfill to materialize if any of the following
           are true:
           <ul style={{paddingLeft: 20, margin: 0}}>
             {DISCARD.map((rule) => (

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutomaterializePolicyTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutomaterializePolicyTag.tsx
@@ -19,13 +19,13 @@ export const automaterializePolicyDescription = (policy: {
   const {MATERIALIZE, SKIP, DISCARD} = groupBy(policy.rules, (rule) => rule.decisionType);
   return (
     <Box flex={{direction: 'column', gap: 12}}>
-      This asset is automatically re-materialized when at least one of the following are true:
+      This asset will be automatically materialized if it is:
       <ul style={{paddingLeft: 20, margin: 0}}>
         {MATERIALIZE?.map((rule) => (
           <li key={rule.description}>{rule.description}</li>
         ))}
       </ul>
-      and none of the following are true:
+      and it is not:
       <ul style={{paddingLeft: 20, margin: 0}}>
         {SKIP?.map((rule) => (
           <li key={rule.description}>{rule.description}</li>
@@ -33,8 +33,7 @@ export const automaterializePolicyDescription = (policy: {
       </ul>
       {DISCARD && DISCARD.length > 0 && (
         <>
-          Partitions may be discarded and require a backfill to materialize if any of the following
-          are true:
+          Partitions may be discarded and require a backfill to materialize if it:
           <ul style={{paddingLeft: 20, margin: 0}}>
             {DISCARD.map((rule) => (
               <li key={rule.description}>{rule.description}</li>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/buildAssetTabs.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/buildAssetTabs.test.tsx
@@ -1,6 +1,25 @@
-import {AutoMaterializePolicyType} from '../../graphql/types';
+import {
+  AutoMaterializeDecisionType,
+  AutoMaterializePolicyType,
+  buildAutoMaterializePolicy,
+  buildAutoMaterializeRule,
+} from '../../graphql/types';
 import {buildAssetTabs} from '../AssetTabs';
 import {AssetViewDefinitionNodeFragment} from '../types/AssetView.types';
+
+const autoMaterializePolicy = buildAutoMaterializePolicy({
+  policyType: AutoMaterializePolicyType.EAGER,
+  rules: [
+    buildAutoMaterializeRule({
+      decisionType: AutoMaterializeDecisionType.MATERIALIZE,
+      description: 'Rule 1',
+    }),
+    buildAutoMaterializeRule({
+      decisionType: AutoMaterializeDecisionType.SKIP,
+      description: 'Skip Rule 1',
+    }),
+  ],
+});
 
 describe('buildAssetTabs', () => {
   const definitionWithPartition: AssetViewDefinitionNodeFragment = {
@@ -42,10 +61,7 @@ describe('buildAssetTabs', () => {
     opNames: ['eager_downstream_3_partitioned'],
     opVersion: null,
     jobNames: ['__ASSET_JOB_0'],
-    autoMaterializePolicy: {
-      policyType: AutoMaterializePolicyType.EAGER,
-      __typename: 'AutoMaterializePolicy',
-    },
+    autoMaterializePolicy,
     freshnessPolicy: null,
     requiredResources: [],
     configField: {
@@ -188,10 +204,7 @@ describe('buildAssetTabs', () => {
     opNames: ['lazy_downstream_1'],
     opVersion: null,
     jobNames: ['__ASSET_JOB_0'],
-    autoMaterializePolicy: {
-      policyType: AutoMaterializePolicyType.LAZY,
-      __typename: 'AutoMaterializePolicy',
-    },
+    autoMaterializePolicy,
     freshnessPolicy: null,
     requiredResources: [],
     configField: {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetNodeDefinition.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetNodeDefinition.types.ts
@@ -18,6 +18,11 @@ export type AssetNodeDefinitionFragment = {
   autoMaterializePolicy: {
     __typename: 'AutoMaterializePolicy';
     policyType: Types.AutoMaterializePolicyType;
+    rules: Array<{
+      __typename: 'AutoMaterializeRule';
+      description: string;
+      decisionType: Types.AutoMaterializeDecisionType;
+    }>;
   } | null;
   freshnessPolicy: {
     __typename: 'FreshnessPolicy';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetView.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetView.types.ts
@@ -74,6 +74,11 @@ export type AssetViewDefinitionQuery = {
           autoMaterializePolicy: {
             __typename: 'AutoMaterializePolicy';
             policyType: Types.AutoMaterializePolicyType;
+            rules: Array<{
+              __typename: 'AutoMaterializeRule';
+              description: string;
+              decisionType: Types.AutoMaterializeDecisionType;
+            }>;
           } | null;
           freshnessPolicy: {
             __typename: 'FreshnessPolicy';
@@ -15786,6 +15791,11 @@ export type AssetViewDefinitionNodeFragment = {
   autoMaterializePolicy: {
     __typename: 'AutoMaterializePolicy';
     policyType: Types.AutoMaterializePolicyType;
+    rules: Array<{
+      __typename: 'AutoMaterializeRule';
+      description: string;
+      decisionType: Types.AutoMaterializeDecisionType;
+    }>;
   } | null;
   freshnessPolicy: {
     __typename: 'FreshnessPolicy';


### PR DESCRIPTION
## Summary & Motivation

This is a small follow-up to last week's rework of the Auto-materialize Policy page. Now that we have `rules` exposed in the GraphQL layer, it would make sense to use these rules to populate the policy description as well as the center portion of the AMP page.

This does mean that the right sidebar of the AMP page duplicates the center content, so I abbreviated it ("rules shown on the left") instead of repeating all the rules.

I also updated the description rendering so that it can mention the third "discard" category if any discard rules are present.

![image](https://github.com/dagster-io/dagster/assets/1037212/a545dbbd-aeb4-4e7c-8bc4-ddf72f64176d)
![image](https://github.com/dagster-io/dagster/assets/1037212/c6eb9450-c9cc-492f-bb2f-7a1f022d2014)

![image](https://github.com/dagster-io/dagster/assets/1037212/c6de7ad0-a4f9-497a-b19b-46224819864c)

## How I Tested These Changes

Just viewing assets with policies and updating storybooks