### PR TITLE
[ui] Fix typeahead filtering of compute logs selector, show attempt numbers

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/LogsRowStructuredContent.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/LogsRowStructuredContent.tsx
@@ -215,7 +215,7 @@ export const LogsRowStructuredContent: React.FC<IStructuredContentProps> = ({nod
       return <DefaultContent message={node.message} />;
     case 'LogsCapturedEvent':
       const currentQuery = qs.parse(location.search, {ignoreQueryPrefix: true});
-      const updatedQuery = {...currentQuery, logType: 'stderr', logFileKey: node.stepKey};
+      const updatedQuery = {...currentQuery, logType: 'stderr', logFileKey: node.fileKey};
       const rawLogsUrl = `${location.pathname}?${qs.stringify(updatedQuery)}`;
       const rawLogsLink = (
         <Link to={rawLogsUrl} style={{color: 'inherit'}}>


### PR DESCRIPTION
This PR is a response to the issue reported in Slack here: https://elementl-workspace.slack.com/archives/C03C0GR1YN9/p1692865065317209

## Summary & Motivation

- The typeahead filtering of the compute logs picker was broken because we recently switched this to select a fileKey and display the corresponding step / pid. You had to type a file key (which was not displayed) to get accurate filtering.

- The "View stderr / stdout" link in the logs was broken for the same reason.

- The user report also mentioned it being annoying to use this with step retries, because the same step name appeared repeatedly. I updated the state machine that builds `metadata.logCaptureSteps` so it includes the number of step attempts that had been run when the log capture event was seen. This allows us to display the attempts in the dropdown.

I switched this from using a custom Select to a Suggest component, which also virtualizes the dropdown menu to better support a massive number of items. (I think this just predated that component in our ui kit)
![image](https://github.com/dagster-io/dagster/assets/1037212/ee28a8f7-5a15-4981-af4c-3fc1f07b7b06)

## How I tested these changes

I tested this manually on both op and asset runs and used a job that repeatedly retries the same op to verify the behavior of the "attempts" addition.