### PR TITLE
[ui] Hide partition UI elements for partitioned observable assets

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode.tsx
@@ -81,7 +81,7 @@ export const AssetNode: React.FC<{
             ) : (
               <Description $color={Colors.Gray400}>No description</Description>
             )}
-            {definition.isPartitioned && !definition.isObservable && (
+            {definition.isPartitioned && !definition.isSource && (
               <PartitionCountTags definition={definition} liveData={liveData} />
             )}
             <StaleReasonsTags liveData={liveData} assetKey={definition.assetKey} include="self" />

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode.tsx
@@ -81,7 +81,7 @@ export const AssetNode: React.FC<{
             ) : (
               <Description $color={Colors.Gray400}>No description</Description>
             )}
-            {definition.isPartitioned && (
+            {definition.isPartitioned && !definition.isObservable && (
               <PartitionCountTags definition={definition} liveData={liveData} />
             )}
             <StaleReasonsTags liveData={liveData} assetKey={definition.assetKey} include="self" />

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetTabs.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetTabs.tsx
@@ -61,7 +61,7 @@ export const buildAssetTabMap = (input: AssetTabConfigInput): Record<string, Ass
       id: 'partitions',
       title: 'Partitions',
       to: buildAssetViewParams({...params, view: 'partitions'}),
-      hidden: !definition?.partitionDefinition,
+      hidden: !definition?.partitionDefinition || definition?.isObservable,
     },
     checks: {
       id: 'checks',

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetTabs.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetTabs.tsx
@@ -61,7 +61,7 @@ export const buildAssetTabMap = (input: AssetTabConfigInput): Record<string, Ass
       id: 'partitions',
       title: 'Partitions',
       to: buildAssetViewParams({...params, view: 'partitions'}),
-      hidden: !definition?.partitionDefinition || definition?.isObservable,
+      hidden: !definition?.partitionDefinition || definition?.isSource,
     },
     checks: {
       id: 'checks',

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
@@ -70,8 +70,13 @@ export const AssetView = ({assetKey}: Props) => {
   const {definition, definitionQueryResult, lastMaterialization} = useAssetViewAssetDefinition(
     assetKey,
   );
+  const tabList = React.useMemo(() => tabBuilder({definition, params}), [
+    definition,
+    params,
+    tabBuilder,
+  ]);
 
-  const defaultTab = definition?.partitionDefinition ? 'partitions' : 'events';
+  const defaultTab = tabList.some((t) => t.id === 'partitions') ? 'partitions' : 'events';
   const selectedTab = params.view || defaultTab;
 
   // Load the asset graph - a large graph for the Lineage tab, a small graph for the Definition tab
@@ -109,12 +114,6 @@ export const AssetView = ({assetKey}: Props) => {
     useQueryRefreshAtInterval(definitionQueryResult, FIFTEEN_SECONDS),
     liveDataRefreshState,
   );
-
-  const tabList = React.useMemo(() => tabBuilder({definition, params}), [
-    definition,
-    params,
-    tabBuilder,
-  ]);
 
   const renderDefinitionTab = () => {
     if (definitionQueryResult.loading && !definitionQueryResult.previousData) {


### PR DESCRIPTION
## Summary & Motivation

Short-term fix Sandy proposed in https://github.com/dagster-io/dagster/issues/15888

- Hides the `Partitions` tab in Asset Details
- HIdes the partition stats inside the asset node on the graph
- Partition info in the sidebar was already hidden by #15629

## How I Tested These Changes

- Viewed asset UI for partitioned source asset, non partitioned assets 