### PR TITLE
Only run a single python version on merge

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/python_version.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/python_version.py
@@ -24,7 +24,7 @@ class AvailablePythonVersion(str, Enum):
     def get_pytest_defaults(cls) -> List["AvailablePythonVersion"]:
         branch_name = safe_getenv("BUILDKITE_BRANCH")
         commit_message = safe_getenv("BUILDKITE_MESSAGE")
-        if branch_name == "master" or is_release_branch(branch_name):
+        if is_release_branch(branch_name):
             return cls.get_all()
         else:
             # environment variable-specified defaults


### PR DESCRIPTION
We still will run them all on the release branch. This quarters our test volume in exchange for potentially finding out later in the release cycle that we've introduced a backward incompatible change.