### PR TITLE
Add step key to asset materialization planned events

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -1319,6 +1319,7 @@ class DagsterInstance(DynamicPartitionsStore):
                             event_specific_data=AssetMaterializationPlannedData(
                                 asset_key, partition=partition
                             ),
+                            step_key=step.key,
                         )
                         self.report_dagster_event(event, dagster_run.run_id, logging.DEBUG)
 


### PR DESCRIPTION
Adds step key to asset materialization planned events. Having this information available means we don't need to introspect from the execution plan snapshot in other places.
