### PR TITLE
Update snippet with missing import

### DIFF
--- a/docs/content/concepts/ops-jobs-graphs/op-events.mdx
+++ b/docs/content/concepts/ops-jobs-graphs/op-events.mdx
@@ -282,7 +282,7 @@ A <PyObject object="Failure" /> is a kind of [Exception](https://docs.python.org
 A <PyObject object="Failure" /> can include a dictionary with structured <PyObject object="MetadataValue"/> values, which will be rendered in the UI according to their type. It also has an `allow_retries` argument that can be used to bypass the op's retry policy.
 
 ```python file=/concepts/ops_jobs_graphs/op_events.py startafter=start_failure_op endbefore=end_failure_op
-from dagster import Failure, op
+from dagster import Failure, op, MetadataValue
 
 
 @op

--- a/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/op_events.py
+++ b/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/op_events.py
@@ -115,7 +115,7 @@ def my_metadata_expectation_op(context, df):
 # end_metadata_expectation_op
 
 # start_failure_op
-from dagster import Failure, op
+from dagster import Failure, op, MetadataValue
 
 
 @op


### PR DESCRIPTION
The example missed the import utilized.

## Summary & Motivation
I was (once again) reading your lovely documentation, but saw what is probably a typo. I fixed it :) 

## How I Tested These Changes
N/A