### PR TITLE
rename arg to AssetCheckSpec to asset and accept defs

### DIFF
--- a/python_modules/dagster-test/dagster_test/toys/asset_checks.py
+++ b/python_modules/dagster-test/dagster_test/toys/asset_checks.py
@@ -50,7 +50,7 @@ def slow_check():
     check_specs=[
         AssetCheckSpec(
             name="random_fail_check",
-            asset_key="asset_with_check_in_same_op",
+            asset="asset_with_check_in_same_op",
             description=(
                 "An ERROR check calculated in the same op with the asset. It fails half the time."
             ),

--- a/python_modules/dagster/dagster/_core/definitions/asset_check_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_spec.py
@@ -1,10 +1,14 @@
 from enum import Enum
-from typing import NamedTuple, Optional
+from typing import TYPE_CHECKING, NamedTuple, Optional, Union
 
 import dagster._check as check
 from dagster._annotations import PublicAttr, experimental
 from dagster._core.definitions.events import AssetKey, CoercibleToAssetKey
 from dagster._serdes.serdes import whitelist_for_serdes
+
+if TYPE_CHECKING:
+    from dagster._core.definitions.assets import AssetsDefinition
+    from dagster._core.definitions.source_asset import SourceAsset
 
 
 @experimental
@@ -53,7 +57,8 @@ class AssetCheckSpec(
 
     Attributes:
         name (str): Name of the check.
-        asset_key (AssetKey): The key of the asset that the check applies to.
+        asset (Union[AssetKey, Sequence[str], str, AssetsDefinition, SourceAsset]): The asset that
+            the check applies to.
         description (Optional[str]): Description for the check.
         severity (AssetCheckSeverity): Severity of the check.
     """
@@ -62,14 +67,14 @@ class AssetCheckSpec(
         cls,
         name: str,
         *,
-        asset_key: CoercibleToAssetKey,
+        asset: Union[CoercibleToAssetKey, "AssetsDefinition", "SourceAsset"],
         description: Optional[str] = None,
         severity: AssetCheckSeverity = AssetCheckSeverity.WARN,
     ):
         return super().__new__(
             cls,
             name=check.str_param(name, "name"),
-            asset_key=AssetKey.from_coercible(asset_key),
+            asset_key=AssetKey.from_coercible_or_definition(asset),
             description=check.opt_str_param(description, "description"),
             severity=check.inst_param(severity, "severity", AssetCheckSeverity),
         )

--- a/python_modules/dagster/dagster/_core/definitions/asset_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_spec.py
@@ -76,17 +76,13 @@ class AssetSpec(
         freshness_policy: Optional[FreshnessPolicy] = None,
         auto_materialize_policy: Optional[AutoMaterializePolicy] = None,
     ):
-        from .decorators.asset_decorator import (
-            asset_key_from_coercible_or_definition,
-        )
-
         dep_set = set()
         if deps:
             for dep in deps:
                 if isinstance(dep, AssetSpec):
                     dep_set.add(dep.asset_key)
                 else:
-                    dep_set.add(asset_key_from_coercible_or_definition(dep))
+                    dep_set.add(AssetKey.from_coercible_or_definition(dep))
 
         return super().__new__(
             cls,

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_check_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_check_decorator.py
@@ -10,11 +10,8 @@ from dagster._core.definitions.asset_checks import (
     AssetChecksDefinitionInputOutputProps,
 )
 from dagster._core.definitions.assets import AssetsDefinition
-from dagster._core.definitions.decorators.asset_decorator import (
-    asset_key_from_coercible_or_definition,
-    build_asset_ins,
-)
-from dagster._core.definitions.events import CoercibleToAssetKey
+from dagster._core.definitions.decorators.asset_decorator import build_asset_ins
+from dagster._core.definitions.events import AssetKey, CoercibleToAssetKey
 from dagster._core.definitions.output import Out
 from dagster._core.definitions.policy import RetryPolicy
 from dagster._core.definitions.source_asset import SourceAsset
@@ -96,7 +93,7 @@ def asset_check(
     def inner(fn: AssetCheckFunction) -> AssetChecksDefinition:
         check.callable_param(fn, "fn")
         resolved_name = name or fn.__name__
-        asset_key = asset_key_from_coercible_or_definition(asset) if asset is not None else None
+        asset_key = AssetKey.from_coercible_or_definition(asset) if asset is not None else None
 
         out = Out(dagster_type=None)
         input_tuples_by_asset_key = build_asset_ins(
@@ -118,7 +115,7 @@ def asset_check(
         spec = AssetCheckSpec(
             name=resolved_name,
             description=description,
-            asset_key=resolved_asset_key,
+            asset=resolved_asset_key,
             severity=severity,
         )
 

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -1189,22 +1189,9 @@ def _make_asset_keys(
 
     deps_asset_keys: Set[AssetKey] = set()
     for dep in deps:
-        deps_asset_keys.add(asset_key_from_coercible_or_definition(dep))
+        deps_asset_keys.add(AssetKey.from_coercible_or_definition(dep))
 
     return deps_asset_keys
-
-
-def asset_key_from_coercible_or_definition(
-    arg: Union[CoercibleToAssetKey, AssetsDefinition, SourceAsset]
-) -> AssetKey:
-    if isinstance(arg, AssetsDefinition):
-        # this will error if the AssetsDefinition is a multi_asset, but we should have caught that
-        # earlier in execution
-        return arg.key
-    elif isinstance(arg, SourceAsset):
-        return arg.key
-    else:
-        return AssetKey.from_coercible(arg)
 
 
 def _validate_and_assign_output_names_to_check_specs(

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_repository_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_repository_snap.py
@@ -631,8 +631,8 @@ def test_asset_check():
 def test_asset_check_in_asset_op():
     @asset(
         check_specs=[
-            AssetCheckSpec(name="my_other_asset_check", asset_key="my_asset"),
-            AssetCheckSpec(name="my_other_asset_check_2", asset_key="my_asset"),
+            AssetCheckSpec(name="my_other_asset_check", asset="my_asset"),
+            AssetCheckSpec(name="my_other_asset_check_2", asset="my_asset"),
         ]
     )
     def my_asset():
@@ -659,7 +659,7 @@ def test_asset_check_in_asset_op():
 def test_asset_check_multiple_jobs():
     @asset(
         check_specs=[
-            AssetCheckSpec(name="my_other_asset_check", asset_key="my_asset"),
+            AssetCheckSpec(name="my_other_asset_check", asset="my_asset"),
         ]
     )
     def my_asset():

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_asset_decorator_with_check_specs.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_asset_decorator_with_check_specs.py
@@ -25,7 +25,7 @@ from dagster._core.storage.io_manager import IOManager
 
 
 def test_asset_check_same_op():
-    @asset(check_specs=[AssetCheckSpec("check1", asset_key="asset1", description="desc")])
+    @asset(check_specs=[AssetCheckSpec("check1", asset="asset1", description="desc")])
     def asset1():
         yield Output(None)
         yield AssetCheckResult(check_name="check1", success=True, metadata={"foo": "bar"})
@@ -53,8 +53,8 @@ def test_asset_check_same_op():
 def test_multiple_asset_checks_same_op():
     @asset(
         check_specs=[
-            AssetCheckSpec("check1", asset_key="asset1", description="desc"),
-            AssetCheckSpec("check2", asset_key="asset1", description="desc"),
+            AssetCheckSpec("check1", asset="asset1", description="desc"),
+            AssetCheckSpec("check2", asset="asset1", description="desc"),
         ]
     )
     def asset1():
@@ -77,7 +77,7 @@ def test_multiple_asset_checks_same_op():
 
 
 def test_check_targets_other_asset():
-    @asset(check_specs=[AssetCheckSpec("check1", asset_key="asset2", description="desc")])
+    @asset(check_specs=[AssetCheckSpec("check1", asset="asset2", description="desc")])
     def asset1():
         yield Output(None)
         yield AssetCheckResult(
@@ -96,7 +96,7 @@ def test_check_targets_other_asset():
 
 
 def test_check_targets_other_asset_and_result_omits_key():
-    @asset(check_specs=[AssetCheckSpec("check1", asset_key="asset2", description="desc")])
+    @asset(check_specs=[AssetCheckSpec("check1", asset="asset2", description="desc")])
     def asset1():
         yield Output(None)
         yield AssetCheckResult(check_name="check1", success=True, metadata={"foo": "bar"})
@@ -113,7 +113,7 @@ def test_check_targets_other_asset_and_result_omits_key():
 
 
 def test_no_result_for_check():
-    @asset(check_specs=[AssetCheckSpec("check1", asset_key="asset1")])
+    @asset(check_specs=[AssetCheckSpec("check1", asset="asset1")])
     def asset1():
         yield Output(None)
 
@@ -128,7 +128,7 @@ def test_no_result_for_check():
 
 
 def test_check_result_but_no_output():
-    @asset(check_specs=[AssetCheckSpec("check1", asset_key="asset1")])
+    @asset(check_specs=[AssetCheckSpec("check1", asset="asset1")])
     def asset1():
         yield AssetCheckResult(success=True)
 
@@ -142,7 +142,7 @@ def test_check_result_but_no_output():
 
 
 def test_unexpected_check_name():
-    @asset(check_specs=[AssetCheckSpec("check1", asset_key=AssetKey("asset1"), description="desc")])
+    @asset(check_specs=[AssetCheckSpec("check1", asset="asset1", description="desc")])
     def asset1():
         return AssetCheckResult(check_name="check2", success=True, metadata={"foo": "bar"})
 
@@ -157,7 +157,7 @@ def test_unexpected_check_name():
 
 
 def test_asset_decorator_unexpected_asset_key():
-    @asset(check_specs=[AssetCheckSpec("check1", asset_key=AssetKey("asset1"), description="desc")])
+    @asset(check_specs=[AssetCheckSpec("check1", asset="asset1", description="desc")])
     def asset1():
         return AssetCheckResult(asset_key=AssetKey("asset2"), check_name="check1", success=True)
 
@@ -174,8 +174,8 @@ def test_asset_decorator_unexpected_asset_key():
 def test_result_missing_check_name():
     @asset(
         check_specs=[
-            AssetCheckSpec("check1", asset_key="asset1"),
-            AssetCheckSpec("check2", asset_key="asset1"),
+            AssetCheckSpec("check1", asset="asset1"),
+            AssetCheckSpec("check2", asset="asset1"),
         ]
     )
     def asset1():
@@ -193,7 +193,7 @@ def test_result_missing_check_name():
 
 
 def test_asset_check_fails_downstream_still_executes():
-    @asset(check_specs=[AssetCheckSpec("check1", asset_key=AssetKey("asset1"))])
+    @asset(check_specs=[AssetCheckSpec("check1", asset="asset1")])
     def asset1():
         yield Output(None)
         yield AssetCheckResult(success=False)
@@ -218,11 +218,7 @@ def test_asset_check_fails_downstream_still_executes():
 
 def test_error_severity_skip_downstream():
     @asset(
-        check_specs=[
-            AssetCheckSpec(
-                "check1", asset_key=AssetKey("asset1"), severity=AssetCheckSeverity.ERROR
-            )
-        ]
+        check_specs=[AssetCheckSpec("check1", asset="asset1", severity=AssetCheckSeverity.ERROR)]
     )
     def asset1():
         yield Output(5)
@@ -260,8 +256,8 @@ def test_duplicate_checks_same_asset():
 
         @asset(
             check_specs=[
-                AssetCheckSpec("check1", asset_key="asset1", description="desc1"),
-                AssetCheckSpec("check1", asset_key="asset1", description="desc2"),
+                AssetCheckSpec("check1", asset="asset1", description="desc1"),
+                AssetCheckSpec("check1", asset="asset1", description="desc2"),
             ]
         )
         def asset1():
@@ -271,7 +267,7 @@ def test_duplicate_checks_same_asset():
 def test_multi_asset_with_check():
     @multi_asset(
         outs={"one": AssetOut("asset1"), "two": AssetOut("asset2")},
-        check_specs=[AssetCheckSpec("check1", asset_key="asset1", description="desc")],
+        check_specs=[AssetCheckSpec("check1", asset="asset1", description="desc")],
     )
     def asset_1_and_2():
         yield Output(None, output_name="one")
@@ -294,7 +290,7 @@ def test_multi_asset_with_check():
 def test_multi_asset_no_result_for_check():
     @multi_asset(
         outs={"one": AssetOut("asset1"), "two": AssetOut("asset2")},
-        check_specs=[AssetCheckSpec("check1", asset_key="asset1", description="desc")],
+        check_specs=[AssetCheckSpec("check1", asset="asset1", description="desc")],
     )
     def asset_1_and_2():
         yield Output(None, output_name="one")
@@ -314,8 +310,8 @@ def test_result_missing_asset_key():
     @multi_asset(
         outs={"one": AssetOut("asset1"), "two": AssetOut("asset2")},
         check_specs=[
-            AssetCheckSpec("check1", asset_key="asset1"),
-            AssetCheckSpec("check2", asset_key="asset2"),
+            AssetCheckSpec("check1", asset="asset1"),
+            AssetCheckSpec("check2", asset="asset2"),
         ],
     )
     def asset_1_and_2():
@@ -348,7 +344,7 @@ def test_asset_check_doesnt_store_output():
             assert context
             return {}
 
-    @asset(check_specs=[AssetCheckSpec("check1", asset_key="asset1", description="desc")])
+    @asset(check_specs=[AssetCheckSpec("check1", asset="asset1", description="desc")])
     def asset1():
         yield Output("the-only-allowed-output")
         yield AssetCheckResult(check_name="check1", success=True, metadata={"foo": "bar"})

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_asset_check_spec.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_asset_check_spec.py
@@ -1,5 +1,19 @@
-from dagster import AssetCheckSpec, AssetKey
+from dagster import AssetCheckSpec, AssetKey, SourceAsset, asset
 
 
 def test_coerce_asset_key():
-    assert AssetCheckSpec(asset_key="foo", name="check1").asset_key == AssetKey("foo")
+    assert AssetCheckSpec(asset="foo", name="check1").asset_key == AssetKey("foo")
+
+
+def test_asset_def():
+    @asset
+    def foo():
+        ...
+
+    assert AssetCheckSpec(asset=foo, name="check1").asset_key == AssetKey("foo")
+
+
+def test_source_asset():
+    foo = SourceAsset("foo")
+
+    assert AssetCheckSpec(asset=foo, name="check1").asset_key == AssetKey("foo")


### PR DESCRIPTION
## Summary & Motivation

Now you can do:

```python
@asset
def my_asset():
    ...

AssetCheckSpec("check1", asset=my_asset)
```

This is a breaking change, because `asset_key` is no longer accepted.

## How I Tested These Changes
