### PR TITLE
AssetSpec.asset_key -> AssetSpec.key

### DIFF
--- a/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/domain_specific_dsl/stocks_dsl.py
+++ b/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/domain_specific_dsl/stocks_dsl.py
@@ -77,7 +77,7 @@ def assets_defs_from_stock_assets(stock_assets: StockAssets) -> List[AssetsDefin
     def spec_for_stock_info(stock_info: StockInfo) -> AssetSpec:
         ticker = stock_info.ticker
         return AssetSpec(
-            asset_key=AssetKey(ticker),
+            AssetKey(ticker),
             group_name=group_name,
             description=f"Fetch {ticker} from internal service",
         )
@@ -93,7 +93,9 @@ def assets_defs_from_stock_assets(stock_assets: StockAssets) -> List[AssetsDefin
         assert python_executable is not None
         script_path = file_relative_path(__file__, "user_scripts/fetch_the_tickers.py")
         subprocess_resource.run(
-            command=[python_executable, script_path], context=context, extras={"tickers": tickers}
+            command=[python_executable, script_path],
+            context=context,
+            extras={"tickers": tickers},
         )
 
     @asset(deps=fetch_the_tickers.keys, group_name=group_name)

--- a/python_modules/dagster/dagster/_core/definitions/asset_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_spec.py
@@ -19,7 +19,7 @@ class AssetSpec(
     NamedTuple(
         "_AssetSpec",
         [
-            ("asset_key", PublicAttr[AssetKey]),
+            ("key", PublicAttr[AssetKey]),
             ("deps", PublicAttr[AbstractSet[AssetKey]]),
             ("description", PublicAttr[Optional[str]]),
             ("metadata", PublicAttr[Optional[Mapping[str, Any]]]),
@@ -35,7 +35,7 @@ class AssetSpec(
     function that defines how it materialized.
 
     Attributes:
-        asset_key (AssetKey): The unique identifier for this asset.
+        key (AssetKey): The unique identifier for this asset.
         deps (Optional[AbstractSet[AssetKey]]): The asset keys for the upstream assets that
             materializing this asset depends on.
         description (Optional[str]): Human-readable description of this asset.
@@ -57,7 +57,8 @@ class AssetSpec(
 
     def __new__(
         cls,
-        asset_key: CoercibleToAssetKey,
+        key: CoercibleToAssetKey,
+        *,
         deps: Optional[
             Iterable[
                 Union[
@@ -90,7 +91,7 @@ class AssetSpec(
 
         return super().__new__(
             cls,
-            asset_key=AssetKey.from_coercible(asset_key),
+            key=AssetKey.from_coercible(key),
             deps=dep_set,
             description=check.opt_str_param(description, "description"),
             metadata=check.opt_mapping_param(metadata, "metadata", key_type=str),
@@ -108,3 +109,7 @@ class AssetSpec(
                 AutoMaterializePolicy,
             ),
         )
+
+    @property
+    def asset_key(self) -> AssetKey:
+        return self.key


### PR DESCRIPTION
* rename the tuple member and input arg for consistency with `AssetsDefinition` and `SourceAsset` 
* explicitly disallow positional args after the `key` arg 
* add an `asset_key` property alias for read access  

## How I Tested These Changes

bk