### PR TITLE
Pin pandas<2.1 for dagster-duckdb[pandas] and dagster-duckdb-pandas

### DIFF
--- a/python_modules/libraries/dagster-duckdb-pandas/setup.py
+++ b/python_modules/libraries/dagster-duckdb-pandas/setup.py
@@ -36,7 +36,9 @@ setup(
     install_requires=[
         f"dagster{pin}",
         f"dagster-duckdb{pin}",
-        "pandas",
+        # Pinned pending duckdb removal of broken pandas import. Pin can be
+        # removed as soon as it produces a working build.
+        "pandas<2.1",
     ],
     zip_safe=False,
 )

--- a/python_modules/libraries/dagster-duckdb-pyspark/setup.py
+++ b/python_modules/libraries/dagster-duckdb-pyspark/setup.py
@@ -38,7 +38,9 @@ setup(
         # Pyspark 2.x is incompatible with Python 3.8+
         'pyspark>=3.0.0; python_version >= "3.8"',
         'pyspark>=2.0.2; python_version < "3.8"',
-        "pandas",
+        # Pinned pending duckdb removal of broken pandas import. Pin can be
+        # removed as soon as it produces a working build.
+        "pandas<2.1",
         "pyarrow",
     ],
     zip_safe=False,

--- a/python_modules/libraries/dagster-duckdb/setup.py
+++ b/python_modules/libraries/dagster-duckdb/setup.py
@@ -37,7 +37,11 @@ setup(
         f"dagster{pin}",
     ],
     extras_require={
-        "pandas": ["pandas"],
+        "pandas": [
+            # Pinned pending duckdb removal of broken pandas import. Pin can be
+            # removed as soon as it produces a working build.
+            "pandas<2.1",
+        ],
         # Pyspark 2.x is incompatible with Python 3.8+
         "pyspark": [
             'pyspark>=3.0.0; python_version >= "3.8"',


### PR DESCRIPTION
## Summary & Motivation

Duckdb currently incompatible with new pandas==2.1. Temp pin pandas<2.1 until duckdb adds its own pin or fixes.

## How I Tested These Changes

BK