### PR TITLE
Remove old pyspark pins for python<3.8

### DIFF
--- a/python_modules/libraries/dagster-duckdb-pyspark/setup.py
+++ b/python_modules/libraries/dagster-duckdb-pyspark/setup.py
@@ -35,9 +35,7 @@ setup(
     install_requires=[
         f"dagster{pin}",
         f"dagster-duckdb{pin}",
-        # Pyspark 2.x is incompatible with Python 3.8+
-        'pyspark>=3.0.0; python_version >= "3.8"',
-        'pyspark>=2.0.2; python_version < "3.8"',
+        "pyspark>=3",
         # Pinned pending duckdb removal of broken pandas import. Pin can be
         # removed as soon as it produces a working build.
         "pandas<2.1",

--- a/python_modules/libraries/dagster-duckdb/setup.py
+++ b/python_modules/libraries/dagster-duckdb/setup.py
@@ -42,11 +42,7 @@ setup(
             # removed as soon as it produces a working build.
             "pandas<2.1",
         ],
-        # Pyspark 2.x is incompatible with Python 3.8+
-        "pyspark": [
-            'pyspark>=3.0.0; python_version >= "3.8"',
-            'pyspark>=2.0.2; python_version < "3.8"',
-        ],
+        "pyspark": ["pyspark>=3"],
     },
     zip_safe=False,
 )

--- a/python_modules/libraries/dagster-pyspark/setup.py
+++ b/python_modules/libraries/dagster-pyspark/setup.py
@@ -36,9 +36,7 @@ setup(
     install_requires=[
         f"dagster{pin}",
         f"dagster_spark{pin}",
-        # Pyspark 2.x is incompatible with Python 3.8+
-        'pyspark>=3.0.0; python_version >= "3.8"',
-        'pyspark>=2.0.2; python_version < "3.8"',
+        "pyspark>=3",
     ],
     zip_safe=False,
 )


### PR DESCRIPTION
## Summary & Motivation

We no longer support Python<3.8