### PR TITLE
Make poll_interval configurable on airbyte resources

### DIFF
--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
@@ -69,6 +69,10 @@ class BaseAirbyteResource(ConfigurableResource):
             " that do not impact your Airbyte deployment."
         ),
     )
+    poll_interval: float = Field(
+        default=DEFAULT_POLL_INTERVAL_SECONDS,
+        description="Time (in seconds) to wait between checking a sync's status.",
+    )
 
     @classmethod
     def _is_dagster_maintained(cls) -> bool:
@@ -161,7 +165,7 @@ class BaseAirbyteResource(ConfigurableResource):
     def sync_and_poll(
         self,
         connection_id: str,
-        poll_interval: float = DEFAULT_POLL_INTERVAL_SECONDS,
+        poll_interval: Optional[float] = None,
         poll_timeout: Optional[float] = None,
     ) -> AirbyteOutput:
         """Initializes a sync operation for the given connector, and polls until it completes.
@@ -195,7 +199,7 @@ class BaseAirbyteResource(ConfigurableResource):
                         f"Timeout: Airbyte job {job_id} is not ready after the timeout"
                         f" {poll_timeout} seconds"
                     )
-                time.sleep(poll_interval)
+                time.sleep(poll_interval or self.poll_interval)
                 job_details = self.get_job_status(connection_id, job_id)
                 attempts = cast(List, job_details.get("attempts", []))
                 cur_attempt = len(attempts)
@@ -589,7 +593,7 @@ class AirbyteResource(BaseAirbyteResource):
     def sync_and_poll(
         self,
         connection_id: str,
-        poll_interval: float = DEFAULT_POLL_INTERVAL_SECONDS,
+        poll_interval: Optional[float] = None,
         poll_timeout: Optional[float] = None,
     ) -> AirbyteOutput:
         """Initializes a sync operation for the given connector, and polls until it completes.
@@ -623,7 +627,7 @@ class AirbyteResource(BaseAirbyteResource):
                         f"Timeout: Airbyte job {job_id} is not ready after the timeout"
                         f" {poll_timeout} seconds"
                     )
-                time.sleep(poll_interval)
+                time.sleep(poll_interval or self.poll_interval)
                 job_details = self.get_job_status(connection_id, job_id)
                 attempts = cast(List, job_details.get("attempts", []))
                 cur_attempt = len(attempts)

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_asset_defs.py
@@ -20,12 +20,13 @@ from .utils import get_sample_connection_json, get_sample_job_json
 
 @responses.activate
 @pytest.mark.parametrize("schema_prefix", ["", "the_prefix_"])
-def test_assets(schema_prefix):
+def test_assets(schema_prefix, monkeypatch):
     ab_resource = airbyte_resource(
         build_init_resource_context(
             config={
                 "host": "some_host",
                 "port": "8000",
+                "poll_interval": 0,
             }
         )
     )
@@ -68,6 +69,7 @@ def test_assets(schema_prefix):
                 {
                     "host": "some_host",
                     "port": "8000",
+                    "poll_interval": 0,
                 }
             )
         },
@@ -108,6 +110,7 @@ def test_assets_with_normalization(schema_prefix, source_asset, freshness_policy
             config={
                 "host": "some_host",
                 "port": "8000",
+                "poll_interval": 0,
             }
         )
     )
@@ -161,6 +164,7 @@ def test_assets_with_normalization(schema_prefix, source_asset, freshness_policy
                 {
                     "host": "some_host",
                     "port": "8000",
+                    "poll_interval": 0,
                 }
             )
         },
@@ -196,7 +200,7 @@ def test_assets_with_normalization(schema_prefix, source_asset, freshness_policy
 
 
 def test_assets_cloud() -> None:
-    ab_resource = AirbyteCloudResource(api_key="some_key")
+    ab_resource = AirbyteCloudResource(api_key="some_key", poll_interval=0)
     ab_url = ab_resource.api_base_url
 
     ab_assets = build_airbyte_assets(

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_cloud_resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_cloud_resources.py
@@ -10,7 +10,7 @@ from dagster_airbyte import AirbyteCloudResource, AirbyteOutput, AirbyteState
 
 @responses.activate
 def test_trigger_connection() -> None:
-    ab_resource = AirbyteCloudResource(api_key="some_key")
+    ab_resource = AirbyteCloudResource(api_key="some_key", poll_interval=0)
     responses.add(
         method=responses.POST,
         url=ab_resource.api_base_url + "/jobs",
@@ -36,7 +36,7 @@ def test_trigger_connection_fail() -> None:
     [AirbyteState.SUCCEEDED, AirbyteState.CANCELLED, AirbyteState.ERROR, "unrecognized"],
 )
 def test_sync_and_poll(state) -> None:
-    ab_resource = AirbyteCloudResource(api_key="some_key")
+    ab_resource = AirbyteCloudResource(api_key="some_key", poll_interval=0)
     responses.add(
         method=responses.POST,
         url=ab_resource.api_base_url + "/jobs",
@@ -80,7 +80,7 @@ def test_sync_and_poll(state) -> None:
 
 @responses.activate
 def test_start_sync_bad_out_fail() -> None:
-    ab_resource = AirbyteCloudResource(api_key="some_key")
+    ab_resource = AirbyteCloudResource(api_key="some_key", poll_interval=0)
 
     responses.add(
         method=responses.POST,

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_load_from_instance.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_load_from_instance.py
@@ -38,10 +38,12 @@ TEST_FRESHNESS_POLICY = FreshnessPolicy(maximum_lag_minutes=60)
 def airbyte_instance_fixture(request):
     with environ({"AIRBYTE_HOST": "some_host"}):
         if request.param:
-            yield AirbyteResource(host=EnvVar("AIRBYTE_HOST"), port="8000")
+            yield AirbyteResource(host=EnvVar("AIRBYTE_HOST"), port="8000", poll_interval=0)
         else:
             yield airbyte_resource(
-                build_init_resource_context({"host": "some_host", "port": "8000"})
+                build_init_resource_context(
+                    {"host": "some_host", "port": "8000", "poll_interval": 0}
+                )
             )
 
 
@@ -267,7 +269,7 @@ def test_load_from_instance(
 
 
 def test_load_from_instance_cloud() -> None:
-    airbyte_cloud_instance = AirbyteCloudResource(api_key="foo")
+    airbyte_cloud_instance = AirbyteCloudResource(api_key="foo", poll_interval=0)
 
     with pytest.raises(
         DagsterInvalidInvocationError,
@@ -278,7 +280,7 @@ def test_load_from_instance_cloud() -> None:
 
 def test_load_from_instance_with_downstream_asset_errors():
     ab_cacheable_assets = load_assets_from_airbyte_instance(
-        AirbyteResource(host="some_host", port="8000")
+        AirbyteResource(host="some_host", port="8000", poll_interval=0)
     )
 
     with pytest.raises(

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_load_from_project.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_load_from_project.py
@@ -11,9 +11,11 @@ from .utils import get_project_connection_json, get_project_job_json
 @pytest.fixture(name="airbyte_instance", params=[True, False], scope="module")
 def airbyte_instance_fixture(request) -> AirbyteResource:
     if request.param:
-        return AirbyteResource(host="some_host", port="8000")
+        return AirbyteResource(host="some_host", port="8000", poll_interval=0)
     else:
-        return airbyte_resource(build_init_resource_context({"host": "some_host", "port": "8000"}))
+        return airbyte_resource(
+            build_init_resource_context({"host": "some_host", "port": "8000", "poll_interval": 0})
+        )
 
 
 @responses.activate
@@ -127,6 +129,7 @@ def test_load_from_project(
                     {
                         "host": "some_host",
                         "port": "8000",
+                        "poll_interval": 0,
                     }
                 )
             },

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_ops.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_ops.py
@@ -36,6 +36,7 @@ def test_airbyte_sync_op(forward_logs, additional_request_params, use_auth):
                 else {}
             ),
             **({"username": "foo", "password": "bar"} if use_auth else {}),
+            "poll_interval": 0,
         }
     )
 

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_resources.py
@@ -32,6 +32,7 @@ def test_trigger_connection(
         {
             "host": "some_host",
             "port": "8000",
+            "poll_interval": 0,
         }
     )
     responses.add(
@@ -74,6 +75,7 @@ def test_sync_and_poll(
             "host": "some_host",
             "port": "8000",
             "forward_logs": forward_logs,
+            "poll_interval": 0,
         }
     )
 
@@ -135,6 +137,7 @@ def test_start_sync_bad_out_fail(
         {
             "host": "some_host",
             "port": "8000",
+            "poll_interval": 0,
         }
     )
     responses.add(
@@ -155,6 +158,7 @@ def test_get_connection_details_bad_out_fail(
         {
             "host": "some_host",
             "port": "8000",
+            "poll_interval": 0,
         }
     )
     responses.add(
@@ -179,6 +183,7 @@ def test_get_job_status_bad_out_fail(
         {
             "host": "some_host",
             "port": "8000",
+            "poll_interval": 0,
         }
     )
     if forward_logs:
@@ -198,6 +203,7 @@ def test_get_job_status_bad_out_fail(
                     "host": "some_host",
                     "port": "8000",
                     "forward_logs": False,
+                    "poll_interval": 0,
                 }
             )
         )
@@ -231,6 +237,7 @@ def test_logging_multi_attempts(
         {
             "host": "some_host",
             "port": "8000",
+            "poll_interval": 0,
         }
     )
     responses.add(
@@ -310,6 +317,7 @@ def test_assets(
             "host": "some_host",
             "port": "8000",
             "forward_logs": forward_logs,
+            "poll_interval": 0,
         }
     )
     responses.add(
@@ -371,6 +379,7 @@ def test_sync_and_poll_termination(
             "port": "8000",
             "forward_logs": forward_logs,
             "cancel_sync_on_run_termination": cancel_sync_on_run_termination,
+            "poll_interval": 0,
         }
     )
     responses.add(
@@ -434,6 +443,7 @@ def test_sync_and_poll_timeout(
             "port": "8000",
             "forward_logs": forward_logs,
             "cancel_sync_on_run_termination": cancel_sync_on_run_termination,
+            "poll_interval": 0,
         }
     )
     responses.add(
@@ -516,6 +526,7 @@ def test_normalization_support(
         {
             "host": "some_host",
             "port": "8000",
+            "poll_interval": 0,
         }
     )
     # See https://airbyte-public-api-docs.s3.us-east-2.amazonaws.com/rapidoc-api-docs.html#post-/v1/destination_definition_specifications/get


### PR DESCRIPTION
Our airbyte tests were taking upward of 20 minutes because the default poll interval is 10 seconds. This instead makes the poll interval configurable on the resource and configures all of our test resources to poll for 0 seconds because they're operating against a mock.