### PR TITLE
feat(dbt): make `manifest` optional when invoking `DbtCliResource.cli`

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resources_v2.py
@@ -39,7 +39,7 @@ manifest = json.loads(manifest_path.read_bytes())
 @pytest.mark.parametrize("command", ["run", "parse"])
 def test_dbt_cli(global_config_flags: List[str], command: str) -> None:
     dbt = DbtCliResource(project_dir=TEST_PROJECT_DIR, global_config_flags=global_config_flags)
-    dbt_cli_invocation = dbt.cli([command], manifest=manifest)
+    dbt_cli_invocation = dbt.cli([command])
 
     assert dbt_cli_invocation.process.args == ["dbt", *global_config_flags, command]
     assert dbt_cli_invocation.is_successful()
@@ -51,18 +51,18 @@ def test_dbt_cli(global_config_flags: List[str], command: str) -> None:
 def test_dbt_cli_manifest_argument(manifest: DbtManifestParam) -> None:
     dbt = DbtCliResource(project_dir=TEST_PROJECT_DIR)
 
-    assert dbt.cli(["run"], manifest=manifest).is_successful()
+    assert dbt.cli(["run"]).is_successful()
 
 
 def test_dbt_cli_project_dir_path() -> None:
     dbt = DbtCliResource(project_dir=Path(TEST_PROJECT_DIR))  # type: ignore
 
-    assert dbt.cli(["run"], manifest=manifest).is_successful()
+    assert dbt.cli(["run"]).is_successful()
 
 
 def test_dbt_cli_failure() -> None:
     dbt = DbtCliResource(project_dir=TEST_PROJECT_DIR)
-    dbt_cli_invocation = dbt.cli(["run", "--selector", "nonexistent"], manifest=manifest)
+    dbt_cli_invocation = dbt.cli(["run", "--selector", "nonexistent"])
 
     with pytest.raises(DagsterDbtCliRuntimeError):
         dbt_cli_invocation.wait()
@@ -75,7 +75,7 @@ def test_dbt_cli_failure() -> None:
 # as
 def test_dbt_cli_subprocess_cleanup(caplog: pytest.LogCaptureFixture) -> None:
     dbt = DbtCliResource(project_dir=TEST_PROJECT_DIR)
-    dbt_cli_invocation_1 = dbt.cli(["run"], manifest=manifest)
+    dbt_cli_invocation_1 = dbt.cli(["run"])
 
     assert dbt_cli_invocation_1.process.returncode is None
 
@@ -87,7 +87,7 @@ def test_dbt_cli_subprocess_cleanup(caplog: pytest.LogCaptureFixture) -> None:
 
     caplog.clear()
 
-    dbt_cli_invocation_2 = dbt.cli(["run"], manifest=manifest).wait()
+    dbt_cli_invocation_2 = dbt.cli(["run"]).wait()
 
     atexit._run_exitfuncs()  # ruff: noqa: SLF001
 
@@ -99,8 +99,8 @@ def test_dbt_cli_subprocess_cleanup(caplog: pytest.LogCaptureFixture) -> None:
 def test_dbt_cli_get_artifact() -> None:
     dbt = DbtCliResource(project_dir=TEST_PROJECT_DIR)
 
-    dbt_cli_invocation_1 = dbt.cli(["run"], manifest=manifest).wait()
-    dbt_cli_invocation_2 = dbt.cli(["compile"], manifest=manifest).wait()
+    dbt_cli_invocation_1 = dbt.cli(["run"]).wait()
+    dbt_cli_invocation_2 = dbt.cli(["compile"]).wait()
 
     # `dbt run` produces a manifest.json and run_results.json
     manifest_json_1 = dbt_cli_invocation_1.get_artifact("manifest.json")
@@ -125,7 +125,7 @@ def test_dbt_cli_get_artifact() -> None:
 def test_dbt_profile_configuration() -> None:
     dbt = DbtCliResource(project_dir=TEST_PROJECT_DIR, profile="duckdb", target="dev")
 
-    dbt_cli_invocation = dbt.cli(["parse"], manifest=manifest).wait()
+    dbt_cli_invocation = dbt.cli(["parse"]).wait()
 
     assert dbt_cli_invocation.process.args == [
         "dbt",
@@ -145,22 +145,22 @@ def test_dbt_profile_dir_configuration(profiles_dir: Union[str, Path]) -> None:
         profiles_dir=profiles_dir,  # type: ignore
     )
 
-    assert dbt.cli(["parse"], manifest=manifest).is_successful()
+    assert dbt.cli(["parse"]).is_successful()
 
     dbt = DbtCliResource(
         project_dir=TEST_PROJECT_DIR, profiles_dir=f"{TEST_PROJECT_DIR}/nonexistent"
     )
 
     with pytest.raises(DagsterDbtCliRuntimeError):
-        dbt.cli(["parse"], manifest=manifest).wait()
+        dbt.cli(["parse"]).wait()
 
 
 def test_dbt_without_partial_parse() -> None:
     dbt = DbtCliResource(project_dir=TEST_PROJECT_DIR)
 
-    dbt.cli(["clean"], manifest=manifest).wait()
+    dbt.cli(["clean"]).wait()
 
-    dbt_cli_compile_without_partial_parse_invocation = dbt.cli(["compile"], manifest=manifest)
+    dbt_cli_compile_without_partial_parse_invocation = dbt.cli(["compile"])
 
     assert dbt_cli_compile_without_partial_parse_invocation.is_successful()
     assert any(
@@ -172,10 +172,10 @@ def test_dbt_without_partial_parse() -> None:
 def test_dbt_with_partial_parse() -> None:
     dbt = DbtCliResource(project_dir=TEST_PROJECT_DIR)
 
-    dbt.cli(["clean"], manifest=manifest).wait()
+    dbt.cli(["clean"]).wait()
 
     # Run `dbt compile` to generate the partial parse file
-    dbt_cli_compile_invocation = dbt.cli(["compile"], manifest=manifest).wait()
+    dbt_cli_compile_invocation = dbt.cli(["compile"]).wait()
 
     # Copy the partial parse file to the target directory
     partial_parse_file_path = Path(
@@ -187,7 +187,7 @@ def test_dbt_with_partial_parse() -> None:
     shutil.copy(partial_parse_file_path, Path(TEST_PROJECT_DIR, "target", PARTIAL_PARSE_FILE_NAME))
 
     # Assert that partial parsing was used.
-    dbt_cli_compile_with_partial_parse_invocation = dbt.cli(["compile"], manifest=manifest).wait()
+    dbt_cli_compile_with_partial_parse_invocation = dbt.cli(["compile"]).wait()
 
     assert dbt_cli_compile_with_partial_parse_invocation.is_successful()
     assert not any(
@@ -292,8 +292,8 @@ def test_dbt_cli_default_selection(exclude: Optional[str]) -> None:
 
 def test_dbt_cli_op_execution() -> None:
     @op
-    def my_dbt_op(context: OpExecutionContext, dbt: DbtCliResource):
-        dbt.cli(["run"], context=context, manifest=manifest).wait()
+    def my_dbt_op(dbt: DbtCliResource):
+        dbt.cli(["run"]).wait()
 
     @job
     def my_dbt_job():


### PR DESCRIPTION
## Summary & Motivation
Resolves https://github.com/dagster-io/dagster/issues/15233.

The manifest is still required if users want to emit Dagster events associated with dbt tests. If the user invokes `DbtCliResource` to emit these Dagster events without a manifest, then log message indicating that no Dagster events will be generated for dbt tests. 

## How I Tested These Changes
pytest
