### PR TITLE
[externals] Interface for loading external-side params

### DIFF
--- a/python_modules/dagster-externals/dagster_externals/__init__.py
+++ b/python_modules/dagster-externals/dagster_externals/__init__.py
@@ -19,6 +19,7 @@ from dagster_externals._protocol import (
     ExternalExecutionDataProvenance as ExternalExecutionDataProvenance,
     ExternalExecutionExtras as ExternalExecutionExtras,
     ExternalExecutionMessage as ExternalExecutionMessage,
+    ExternalExecutionParams as ExternalExecutionParams,
     ExternalExecutionPartitionKeyRange as ExternalExecutionPartitionKeyRange,
     ExternalExecutionTimeWindow as ExternalExecutionTimeWindow,
 )

--- a/python_modules/dagster-externals/dagster_externals/_io/base.py
+++ b/python_modules/dagster-externals/dagster_externals/_io/base.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
-from typing import Iterator
+from typing import Generic, Iterator, TypeVar
 
 from .._protocol import (
     ExternalExecutionContextData,
@@ -10,20 +10,25 @@ from .._protocol import (
 
 
 class ExternalExecutionContextLoader(ABC):
-    @contextmanager
-    def setup(self, params: ExternalExecutionParams) -> Iterator[None]:
-        yield
-
     @abstractmethod
-    def load_context(self) -> ExternalExecutionContextData:
+    @contextmanager
+    def load_context(
+        self, params: ExternalExecutionParams
+    ) -> Iterator[ExternalExecutionContextData]:
         ...
 
 
-class ExternalExecutionMessageWriter(ABC):
-    @contextmanager
-    def setup(self, params: ExternalExecutionParams) -> Iterator[None]:
-        yield
+T_MessageChannel = TypeVar("T_MessageChannel", bound="ExternalExecutionMessageWriterChannel")
 
+
+class ExternalExecutionMessageWriter(ABC, Generic[T_MessageChannel]):
+    @abstractmethod
+    @contextmanager
+    def open(self, params: ExternalExecutionParams) -> Iterator[T_MessageChannel]:
+        ...
+
+
+class ExternalExecutionMessageWriterChannel(ABC, Generic[T_MessageChannel]):
     @abstractmethod
     def write_message(self, message: ExternalExecutionMessage) -> None:
         ...

--- a/python_modules/dagster-externals/dagster_externals/_io/base.py
+++ b/python_modules/dagster-externals/dagster_externals/_io/base.py
@@ -5,20 +5,35 @@ from typing import Iterator
 from .._protocol import (
     ExternalExecutionContextData,
     ExternalExecutionMessage,
+    ExternalExecutionParams,
 )
 
 
 class ExternalExecutionContextLoader(ABC):
     @contextmanager
-    def scoped_context(self) -> Iterator["ExternalExecutionContextData"]:
-        yield self.load_context()
+    def setup(self, params: ExternalExecutionParams) -> Iterator[None]:
+        yield
 
     @abstractmethod
     def load_context(self) -> ExternalExecutionContextData:
-        raise NotImplementedError()
+        ...
 
 
 class ExternalExecutionMessageWriter(ABC):
+    @contextmanager
+    def setup(self, params: ExternalExecutionParams) -> Iterator[None]:
+        yield
+
     @abstractmethod
     def write_message(self, message: ExternalExecutionMessage) -> None:
+        ...
+
+
+class ExternalExecutionParamLoader(ABC):
+    @abstractmethod
+    def load_context_params(self) -> ExternalExecutionParams:
+        ...
+
+    @abstractmethod
+    def load_messages_params(self) -> ExternalExecutionParams:
         ...

--- a/python_modules/dagster-externals/dagster_externals/_io/default.py
+++ b/python_modules/dagster-externals/dagster_externals/_io/default.py
@@ -1,57 +1,82 @@
 import json
+from contextlib import contextmanager
+from typing import Iterator, Optional
 
 from .._protocol import (
     DAGSTER_EXTERNALS_ENV_KEYS,
     ExternalExecutionContextData,
     ExternalExecutionMessage,
+    ExternalExecutionParams,
 )
 from .._util import DagsterExternalsError, param_from_env_var
-from .base import ExternalExecutionContextLoader, ExternalExecutionMessageWriter
+from .base import (
+    ExternalExecutionContextLoader,
+    ExternalExecutionMessageWriter,
+    ExternalExecutionParamLoader,
+)
 
 
 class ExternalExecutionFileContextLoader(ExternalExecutionContextLoader):
-    def load_context(self) -> ExternalExecutionContextData:
-        path = self._get_path_from_env()
-        with open(path, "r") as f:
-            return json.load(f)
+    _path: Optional[str] = None
 
-    def _get_path_from_env(self) -> str:
+    @contextmanager
+    def setup(self, params: ExternalExecutionParams) -> Iterator[None]:
+        self._validate_path_params(params)
+        self._path = params["path"]
+        yield
+
+    def _validate_path_params(self, params: ExternalExecutionParams) -> None:
         try:
-            context_injector_params = param_from_env_var("context")
-            assert isinstance(context_injector_params, dict)
-            assert isinstance(context_injector_params.get("path"), str)
-            return context_injector_params["path"]
+            assert isinstance(params.get("path"), str)
         except AssertionError:
-            raise DagsterExternalsError(
-                f"`{self.__class__.__name__}` requires a `path` key in the"
-                f" {DAGSTER_EXTERNALS_ENV_KEYS['context_injector']} environment variable be a JSON"
-                " object with a string `path` property."
-            )
+            raise DagsterExternalsError(_validation_error_message(self, "context"))
+
+    @property
+    def path(self) -> str:
+        assert self._path is not None
+        return self._path
+
+    def load_context(self) -> ExternalExecutionContextData:
+        with open(self.path, "r") as f:
+            return json.load(f)
 
 
 class ExternalExecutionFileMessageWriter(ExternalExecutionMessageWriter):
-    def __init__(self):
-        self._path = None
+    _path: Optional[str] = None
+
+    @contextmanager
+    def setup(self, params: ExternalExecutionParams) -> Iterator[None]:
+        self._validate_path_params(params)
+        self._path = params["path"]
+        yield
+
+    def _validate_path_params(self, params: ExternalExecutionParams) -> None:
+        try:
+            assert isinstance(params.get("path"), str)
+        except AssertionError:
+            raise DagsterExternalsError(_validation_error_message(self, "context"))
+
+    @property
+    def path(self) -> str:
+        assert self._path is not None
+        return self._path
 
     def write_message(self, message: ExternalExecutionMessage) -> None:
         with open(self.path, "a") as f:
             f.write(json.dumps(message) + "\n")
 
-    @property
-    def path(self) -> str:
-        if self._path is None:
-            self._path = self._get_path_from_env()
-        return self._path
 
-    def _get_path_from_env(self) -> str:
-        try:
-            context_injector_params = param_from_env_var("messages")
-            assert isinstance(context_injector_params, dict)
-            assert isinstance(context_injector_params.get("path"), str)
-            return context_injector_params["path"]
-        except AssertionError:
-            raise DagsterExternalsError(
-                f"`{self.__class__.__name__}` requires a `path` key in the"
-                f" {DAGSTER_EXTERNALS_ENV_KEYS['message_reader']} environment variable be a JSON"
-                " object with a string `path` property."
-            )
+def _validation_error_message(obj: object, param: str) -> str:
+    return (
+        f"`{obj.__class__.__name__}` requires a `path` key in the"
+        f" {DAGSTER_EXTERNALS_ENV_KEYS[param]} environment variable be a JSON"
+        " object with a string `path` property."
+    )
+
+
+class ExternalExecutionEnvVarParamLoader(ExternalExecutionParamLoader):
+    def load_context_params(self) -> ExternalExecutionParams:
+        return param_from_env_var("context")
+
+    def load_messages_params(self) -> ExternalExecutionParams:
+        return param_from_env_var("messages")

--- a/python_modules/dagster-externals/dagster_externals/_io/env.py
+++ b/python_modules/dagster-externals/dagster_externals/_io/env.py
@@ -1,11 +1,33 @@
+from contextlib import contextmanager
+from typing import Iterator, Optional
+
 from .._protocol import (
+    DAGSTER_EXTERNALS_ENV_KEYS,
     ExternalExecutionContextData,
+    ExternalExecutionParams,
 )
-from .._util import param_from_env_var
+from .._util import DagsterExternalsError
 from .base import ExternalExecutionContextLoader
 
 
 class ExternalExecutionEnvContextLoader(ExternalExecutionContextLoader):
+    _data: Optional[ExternalExecutionContextData] = None
+
+    @contextmanager
+    def setup(self, params: ExternalExecutionParams) -> Iterator[None]:
+        self._validate_params(params)
+        self._data = params["data"]
+        yield
+
+    def _validate_params(self, params: ExternalExecutionParams) -> None:
+        try:
+            assert isinstance(params.get("data"), dict)
+        except AssertionError:
+            raise DagsterExternalsError(
+                f"`{self.__class__.__name__}` requires a `data` key in the"
+                f" {DAGSTER_EXTERNALS_ENV_KEYS['context']} environment variable."
+            )
+
     def load_context(self) -> ExternalExecutionContextData:
-        data = param_from_env_var("context")
-        return data["context_data"]
+        assert self._data is not None
+        return self._data

--- a/python_modules/dagster-externals/dagster_externals/_protocol.py
+++ b/python_modules/dagster-externals/dagster_externals/_protocol.py
@@ -3,6 +3,8 @@ from typing import Any, Mapping, Optional, Sequence
 from typing_extensions import Final, TypeAlias, TypedDict
 
 ExternalExecutionExtras: TypeAlias = Mapping[str, Any]
+ExternalExecutionParams: TypeAlias = Mapping[str, Any]
+
 
 ENV_KEY_PREFIX: Final = "DAGSTER_EXTERNALS_"
 

--- a/python_modules/dagster-externals/dagster_externals/_util.py
+++ b/python_modules/dagster-externals/dagster_externals/_util.py
@@ -3,12 +3,13 @@ import json
 import os
 import warnings
 import zlib
-from typing import TYPE_CHECKING, Any, Optional, Sequence, TypeVar
+from typing import TYPE_CHECKING, Any, Optional, Sequence, Type, TypeVar
 
 from ._protocol import (
     ENV_KEY_PREFIX,
     ExternalExecutionContextData,
     ExternalExecutionExtras,
+    ExternalExecutionParams,
 )
 
 if TYPE_CHECKING:
@@ -70,6 +71,18 @@ def assert_param_type(value: T, expected_type: Any, method: str, param: str) -> 
         raise DagsterExternalsError(
             f"Invalid type for parameter `{param}` of `{method}`. Expected `{expected_type}`, got"
             f" `{type(value)}`."
+        )
+    return value
+
+
+def assert_env_param_type(
+    env_params: ExternalExecutionParams, key: str, expected_type: Type[T], cls: Type
+) -> T:
+    value = env_params.get(key)
+    if not isinstance(value, expected_type):
+        raise DagsterExternalsError(
+            f"Invalid type for parameter `{key}` passed from orchestration side to"
+            f" `{cls.__name__}`. Expected `{expected_type}`, got `{type(value)}`."
         )
     return value
 

--- a/python_modules/dagster-externals/dagster_externals_tests/test_context.py
+++ b/python_modules/dagster-externals/dagster_externals_tests/test_context.py
@@ -28,7 +28,7 @@ def _make_external_execution_context(**kwargs):
     kwargs = {**TEST_EXTERNAL_EXECUTION_CONTEXT_DEFAULTS, **kwargs}
     return ExternalExecutionContext(
         data=ExternalExecutionContextData(**kwargs),
-        message_writer=MagicMock(),
+        message_channel=MagicMock(),
     )
 
 

--- a/python_modules/dagster/dagster/_core/external_execution/resource.py
+++ b/python_modules/dagster/dagster/_core/external_execution/resource.py
@@ -1,21 +1,19 @@
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Iterator, Mapping, Optional
+from typing import TYPE_CHECKING, Iterator, Mapping, Optional
 
 from dagster_externals import (
     DAGSTER_EXTERNALS_ENV_KEYS,
     ExternalExecutionExtras,
+    ExternalExecutionParams,
     encode_env_var,
 )
-from typing_extensions import TypeAlias
 
 from dagster._config.pythonic_config import ConfigurableResource
 from dagster._core.execution.context.compute import OpExecutionContext
 
 if TYPE_CHECKING:
     from dagster._core.external_execution.context import ExternalExecutionOrchestrationContext
-
-ExternalExecutionParams: TypeAlias = Mapping[str, Any]
 
 
 class ExternalExecutionResource(ConfigurableResource, ABC):

--- a/python_modules/dagster/dagster/_core/external_execution/utils.py
+++ b/python_modules/dagster/dagster/_core/external_execution/utils.py
@@ -4,12 +4,11 @@ from contextlib import contextmanager
 from threading import Event, Thread
 from typing import TYPE_CHECKING, Iterator, Mapping
 
-from dagster_externals import DAGSTER_EXTERNALS_ENV_KEYS, encode_env_var
+from dagster_externals import DAGSTER_EXTERNALS_ENV_KEYS, ExternalExecutionParams, encode_env_var
 
 from dagster._core.external_execution.resource import (
     ExternalExecutionContextInjector,
     ExternalExecutionMessageReader,
-    ExternalExecutionParams,
 )
 from dagster._utils import tail_file
 
@@ -40,7 +39,7 @@ class ExternalExecutionEnvContextInjector(ExternalExecutionContextInjector):
         self,
         context: "ExternalExecutionOrchestrationContext",
     ) -> Iterator[ExternalExecutionParams]:
-        yield {"context_data": context.get_data()}
+        yield {"data": context.get_data()}
 
 
 class ExternalExecutionFileMessageReader(ExternalExecutionMessageReader):


### PR DESCRIPTION
## Summary & Motivation

- Add `ExternalExecutionParamLoader`, an ext-side interface for extracting params consumed by `ExternalExecutionContextLoader` and `ExternalExecutionMessageWriter` from "the environment" (defined broadly as the runtime context). A `param_loader` can be passed to `init_dagster_externals` alongside a `context_loader` and `message_writer`. The default is to read from environment variables.
- Remove `ExternalExecutionContextLoader.scoped_context`, make `load_context` a context manager that takes `ExternalExecutionParams`.
- Factor out an additional `ExternalExecutionMessageWriterChannel` class from `ExternalExecutionMessageWriter`. `ExternalExecutionMessageWriter` now has an `open` context manager method that takes `ExternalExecutionParams` and yields an `ExternalExecutionMessageWriterChannel`.

This is an ext-side solution to the "currying problem" where we need to run loader/writer initialization routines for two sets of parameters:

1. Params needed to instantiate the class on the ext side (e.g. a write interval for blob message writers)
2. Params passed over from the orchestration side (e.g. the S3 bucket to write to)

Prior to this PR, the means of reading type (2) was coupled to a loader/writer class. This PR decouples the functionality such that loader/readers need not concern themselves with _how_ parameters are passed from the orch side-- that is handled separately by the `ExternalExecutionParamLoader`. I assume in the majority of cases users won't need to worry about this at all because the default environment-variable-based implementation will be sufficient.

## How I Tested These Changes

Existing test suite.
