### PR TITLE
Add Missing Argument Defaults to _build_slack_blocks_and_text

### DIFF
--- a/python_modules/libraries/dagster-slack/dagster_slack/sensors.py
+++ b/python_modules/libraries/dagster-slack/dagster_slack/sensors.py
@@ -40,8 +40,8 @@ T = TypeVar("T", RunFailureSensorContext, FreshnessPolicySensorContext)
 def _build_slack_blocks_and_text(
     context: T,
     text_fn: Callable[[T], str],
-    blocks_fn: Optional[Callable[[T], List[Dict[Any, Any]]]],
-    webserver_base_url: Optional[str],
+    blocks_fn: Optional[Callable[[T], List[Dict[Any, Any]]]] = None,
+    webserver_base_url: Optional[str] = None,
 ) -> Tuple[List[Dict[str, Any]], str]:
     main_body_text = text_fn(context)
     blocks: List[Dict[Any, Any]] = []


### PR DESCRIPTION
## Summary & Motivation
- `blocks_fn` and `webserver_base_url` within `_build_slack_blocks_and_text` are annotated as `Optional` 
- These args are missing defaults of `= None`

## How I Tested These Changes
- `if blocks_fn` and `if webserver_base_url` branches already exist within the method body, so it should be fine for these to be nullable 