### PR TITLE
Add tags to asset planned events

### DIFF
--- a/python_modules/dagster/dagster/_core/events/__init__.py
+++ b/python_modules/dagster/dagster/_core/events/__init__.py
@@ -1488,14 +1488,15 @@ class StepMaterializationData(
 class AssetMaterializationPlannedData(
     NamedTuple(
         "_AssetMaterializationPlannedData",
-        [("asset_key", AssetKey), ("partition", Optional[str])],
+        [("asset_key", AssetKey), ("partition", Optional[str]), ("tags", Mapping[str, str])],
     )
 ):
-    def __new__(cls, asset_key: AssetKey, partition: Optional[str] = None):
+    def __new__(cls, asset_key: AssetKey, partition: Optional[str] = None, tags=None):
         return super(AssetMaterializationPlannedData, cls).__new__(
             cls,
             asset_key=check.inst_param(asset_key, "asset_key", AssetKey),
             partition=check.opt_str_param(partition, "partition"),
+            tags=check.opt_mapping_param(tags, "tags", key_type=str, value_type=str),
         )
 
 

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -1320,7 +1320,7 @@ class DagsterInstance(DynamicPartitionsStore):
                                 f"{job_name} intends to materialize asset {asset_key.to_string()}"
                             ),
                             event_specific_data=AssetMaterializationPlannedData(
-                                asset_key, partition=partition
+                                asset_key, partition=partition, tags=step.tags
                             ),
                             step_key=execution_plan_snapshot.get_step_key_for_asset_key(asset_key),
                         )


### PR DESCRIPTION
This provides an easy way to retrieve tag information specific to an asset, without having to dig through the execution plan snapshot.
