### PR TITLE
asset checks execution for latest materialization

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -3186,6 +3186,7 @@ type AssetCheck {
   description: String
   severity: AssetCheckSeverity!
   executions(limit: Int!, cursor: String): [AssetCheckExecution!]!
+  executionForLatestMaterialization: AssetCheckExecution
 }
 
 enum AssetCheckSeverity {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -118,6 +118,7 @@ export type AssetCheck = {
   __typename: 'AssetCheck';
   assetKey: AssetKey;
   description: Maybe<Scalars['String']>;
+  executionForLatestMaterialization: Maybe<AssetCheckExecution>;
   executions: Array<AssetCheckExecution>;
   name: Scalars['String'];
   severity: AssetCheckSeverity;
@@ -4413,6 +4414,12 @@ export const buildAssetCheck = (
         : buildAssetKey({}, relationshipsToOmit),
     description:
       overrides && overrides.hasOwnProperty('description') ? overrides.description! : 'omnis',
+    executionForLatestMaterialization:
+      overrides && overrides.hasOwnProperty('executionForLatestMaterialization')
+        ? overrides.executionForLatestMaterialization!
+        : relationshipsToOmit.has('AssetCheckExecution')
+        ? ({} as AssetCheckExecution)
+        : buildAssetCheckExecution({}, relationshipsToOmit),
     executions: overrides && overrides.hasOwnProperty('executions') ? overrides.executions! : [],
     name: overrides && overrides.hasOwnProperty('name') ? overrides.name! : 'dignissimos',
     severity:

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_checks.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_checks.py
@@ -1,7 +1,8 @@
-from typing import TYPE_CHECKING, List, Optional, Union
+from typing import TYPE_CHECKING, List, Optional, Union, cast
 
 import dagster._check as check
 from dagster import AssetKey
+from dagster._core.definitions.asset_check_evaluation import AssetCheckEvaluation
 from dagster._core.host_representation.external_data import ExternalAssetCheck
 from dagster._core.instance import DagsterInstance
 from dagster._core.storage.asset_check_execution_record import (
@@ -102,3 +103,92 @@ def fetch_executions(
         res.append(GrapheneAssetCheckExecution(execution, resolved_status))
 
     return res
+
+
+def _execution_targets_latest_materialization(
+    instance: DagsterInstance,
+    external_asset_check: ExternalAssetCheck,
+    execution: AssetCheckExecutionRecord,
+    resolved_status: AssetCheckExecutionResolvedStatus,
+) -> bool:
+    # always show in progress checks
+    if resolved_status == AssetCheckExecutionResolvedStatus.IN_PROGRESS:
+        return True
+
+    records = instance.get_asset_records([external_asset_check.asset_key])
+    latest_materialization = records[0].asset_entry.last_materialization_record if records else None
+
+    if not latest_materialization:
+        # asset hasn't been materialized yet, so no reason to hide the check
+        return True
+
+    if resolved_status in [
+        AssetCheckExecutionResolvedStatus.SUCCEEDED,
+        AssetCheckExecutionResolvedStatus.FAILED,
+    ]:
+        evaluation = cast(
+            AssetCheckEvaluation,
+            check.not_none(
+                check.not_none(execution.evaluation_event).dagster_event
+            ).event_specific_data,
+        )
+        if not evaluation.target_materialization_data:
+            # check ran before the materialization was created
+            return False
+
+        # if the check matches the latest materialization, then show it
+        return (
+            evaluation.target_materialization_data.storage_id == latest_materialization.storage_id
+        )
+
+    # in this case the evaluation didn't complete, so we don't have target_materialization_data
+    elif resolved_status in [
+        AssetCheckExecutionResolvedStatus.EXECUTION_FAILED,
+        AssetCheckExecutionResolvedStatus.SKIPPED,
+    ]:
+        # if the check is executed in the same run as the materialization, then show it
+        latest_materialization_run_id = latest_materialization.event_log_entry.run_id
+        if latest_materialization_run_id == execution.run_id:
+            return True
+
+        # As a last ditch effort, check if the check's run was launched after the materialization's
+        latest_materialization_run_record = instance.get_run_record_by_id(
+            latest_materialization_run_id
+        )
+        execution_run_record = instance.get_run_record_by_id(execution.run_id)
+        return bool(
+            latest_materialization_run_record
+            and execution_run_record
+            and execution_run_record.create_timestamp
+            > latest_materialization_run_record.create_timestamp
+        )
+
+    else:
+        check.failed(f"Unexpected check status {resolved_status}")
+
+
+def fetch_execution_for_latest_materialization(
+    instance: DagsterInstance, external_asset_check: ExternalAssetCheck
+) -> Optional[GrapheneAssetCheckExecution]:
+    # we hide executions if they aren't for the latest asset materialization.
+    # currently we only consider the most recently launched check.
+
+    executions = instance.event_log_storage.get_asset_check_executions(
+        asset_key=external_asset_check.asset_key,
+        check_name=external_asset_check.name,
+        limit=1,
+        cursor=None,
+    )
+    if not executions:
+        return None
+
+    execution = executions[0]
+    resolved_status = _get_asset_check_execution_status(instance, execution)
+
+    return (
+        GrapheneAssetCheckExecution(execution, resolved_status)
+        if _execution_targets_latest_materialization(
+            instance, external_asset_check, execution, resolved_status
+        )
+        else None
+    )

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_checks.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_checks.py
@@ -105,6 +105,7 @@ class GrapheneAssetCheck(graphene.ObjectType):
         limit=graphene.NonNull(graphene.Int),
         cursor=graphene.String(),
     )
+    executionForLatestMaterialization = graphene.Field(GrapheneAssetCheckExecution)
 
     class Meta:
         name = "AssetCheck"
@@ -133,6 +134,17 @@ class GrapheneAssetCheck(graphene.ObjectType):
 
         return fetch_executions(
             graphene_info.context.instance, self._asset_check, kwargs["limit"], kwargs.get("cursor")
+        )
+
+    def resolve_executionForLatestMaterialization(
+        self, graphene_info: ResolveInfo
+    ) -> Optional[GrapheneAssetCheckExecution]:
+        from dagster_graphql.implementation.fetch_asset_checks import (
+            fetch_execution_for_latest_materialization,
+        )
+
+        return fetch_execution_for_latest_materialization(
+            graphene_info.context.instance, self._asset_check
         )
 
 


### PR DESCRIPTION
Resolves the bug where EXECUTION_FAILED checks aren't displayed- once we update the front end to use this new resolver

add a field `executionForLatestMaterialization` to GrapheneAssetCheck. The front end can use this to display the current status of checks in the checks tab and on asset nodes. If null, then it's not checked for latest materialization.

Currently the front end queries `evaluations` for the latest materialization, then does a subset of this logic to determine if it should be shown or hidden. The logic is rather nuanced and better on the backend where we can batch it in a future diff.

So we have `executionForLatestMaterialization` for the status in relation to materializations, and `executions` for the execution history modal