### PR TITLE
Add a "--log-level" arg to "dagster-daemon run" and "dagster dev"

### DIFF
--- a/integration_tests/test_suites/daemon-test-suite/dagster_dev_command_tests/test_dagster_dev_command.py
+++ b/integration_tests/test_suites/daemon-test-suite/dagster_dev_command_tests/test_dagster_dev_command.py
@@ -46,6 +46,8 @@ def test_dagster_dev_command_workspace():
                         ),
                         "--dagit-port",
                         str(dagit_port),
+                        "--log-level",
+                        "debug",
                     ],
                     cwd=tempdir,
                 )

--- a/integration_tests/test_suites/daemon-test-suite/test_daemon.py
+++ b/integration_tests/test_suites/daemon-test-suite/test_daemon.py
@@ -14,7 +14,7 @@ def test_heartbeat():
     with instance_for_test() as instance:
         assert all_daemons_healthy(instance) is False
 
-        with start_daemon():
+        with start_daemon(log_level="debug"):
             time.sleep(5)
             assert all_daemons_healthy(instance) is True
 

--- a/integration_tests/test_suites/daemon-test-suite/utils.py
+++ b/integration_tests/test_suites/daemon-test-suite/utils.py
@@ -5,10 +5,11 @@ from dagster._serdes.ipc import interrupt_ipc_subprocess, open_ipc_subprocess
 
 
 @contextlib.contextmanager
-def start_daemon(timeout=60, workspace_file=None):
+def start_daemon(timeout=60, workspace_file=None, log_level=None):
     p = open_ipc_subprocess(
         ["dagster-daemon", "run"]
         + (["--python-file", workspace_file] if workspace_file else ["--empty-workspace"])
+        + (["--log-level", log_level] if log_level else [])
     )
     try:
         yield

--- a/python_modules/dagster-webserver/dagster_webserver/cli.py
+++ b/python_modules/dagster-webserver/dagster_webserver/cli.py
@@ -133,7 +133,7 @@ DEFAULT_POOL_RECYCLE = 3600  # 1 hr
 )
 @click.option(
     "--log-level",
-    help="Set the log level for the uvicorn web server.",
+    help="Set the log level for the web server.",
     show_default=True,
     default="warning",
     type=click.Choice(
@@ -170,7 +170,11 @@ def dagster_webserver(
     if suppress_warnings:
         os.environ["PYTHONWARNINGS"] = "ignore"
 
-    configure_loggers()
+    dagster_log_level = log_level.upper()
+    if dagster_log_level == "TRACE":  # uvicorn-specific level
+        dagster_log_level = "DEBUG"
+
+    configure_loggers(log_level=dagster_log_level)
     logger = logging.getLogger(WEBSERVER_LOGGER_NAME)
 
     if sys.argv[0].endswith("dagit"):

--- a/python_modules/dagster/dagster/_cli/dev.py
+++ b/python_modules/dagster/dagster/_cli/dev.py
@@ -61,6 +61,13 @@ def dev_command_options(f):
     type=click.Choice(["critical", "error", "warning", "info", "debug"], case_sensitive=False),
 )
 @click.option(
+    "--log-level",
+    help="Set the log level for dagster services.",
+    show_default=True,
+    default="info",
+    type=click.Choice(["critical", "error", "warning", "info", "debug"], case_sensitive=False),
+)
+@click.option(
     "--port",
     "--dagit-port",
     "-p",
@@ -79,6 +86,7 @@ def dev_command_options(f):
 )
 def dev_command(
     code_server_log_level: str,
+    log_level: str,
     port: Optional[str],
     host: Optional[str],
     **kwargs: ClickArgValue,
@@ -93,7 +101,7 @@ def dev_command(
             ' running "pip install dagster-webserver" in your Python environment.'
         )
 
-    configure_loggers()
+    configure_loggers(log_level=log_level.upper())
     logger = logging.getLogger("dagster")
 
     # Sanity check workspace args
@@ -154,10 +162,11 @@ def dev_command(
             [sys.executable, "-m", "dagster_webserver"]
             + (["--port", port] if port else [])
             + (["--host", host] if host else [])
+            + (["--log-level", log_level])
             + args
         )
         daemon_process = open_ipc_subprocess(
-            [sys.executable, "-m", "dagster._daemon", "run"] + args
+            [sys.executable, "-m", "dagster._daemon", "run", "--log-level", log_level] + args
         )
         try:
             while True:

--- a/python_modules/dagster/dagster/_daemon/controller.py
+++ b/python_modules/dagster/dagster/_daemon/controller.py
@@ -89,6 +89,7 @@ def daemon_controller_from_instance(
     ] = create_daemons_from_instance,
     error_interval_seconds: int = DEFAULT_DAEMON_ERROR_INTERVAL_SECONDS,
     code_server_log_level: str = "info",
+    log_level: str = "info",
 ) -> Iterator["DagsterDaemonController"]:
     check.inst_param(instance, "instance", DagsterInstance)
     check.inst_param(workspace_load_target, "workspace_load_target", WorkspaceLoadTarget)
@@ -113,6 +114,7 @@ def daemon_controller_from_instance(
                 heartbeat_tolerance_seconds=heartbeat_tolerance_seconds,
                 error_interval_seconds=error_interval_seconds,
                 grpc_server_registry=grpc_server_registry,
+                log_level=log_level,
             )
         )
 
@@ -142,6 +144,7 @@ class DagsterDaemonController(AbstractContextManager):
         heartbeat_tolerance_seconds: float = DEFAULT_DAEMON_HEARTBEAT_TOLERANCE_SECONDS,
         error_interval_seconds: int = DEFAULT_DAEMON_ERROR_INTERVAL_SECONDS,
         handler: str = "default",
+        log_level: str = "info",
     ):
         self._daemon_uuid = str(uuid.uuid4())
 
@@ -167,7 +170,7 @@ class DagsterDaemonController(AbstractContextManager):
 
         self._daemon_shutdown_event = threading.Event()
 
-        configure_loggers(handler=handler)
+        configure_loggers(handler=handler, log_level=log_level.upper())
 
         self._logger = logging.getLogger("dagster.daemon")
         self._logger.info(

--- a/python_modules/dagster/dagster/_utils/log.py
+++ b/python_modules/dagster/dagster/_utils/log.py
@@ -249,17 +249,17 @@ def configure_loggers(handler="default", log_level="INFO"):
         "loggers": {
             "dagster": {
                 "handlers": [handler],
-                "level": "INFO",
+                "level": log_level,
             },
             # Only one of dagster or dagster-webserver will be used at a time. We configure them
             # both here to avoid a dependency on the dagster-webserver package.
             "dagit": {
                 "handlers": [handler],
-                "level": "INFO",
+                "level": log_level,
             },
             "dagster-webserver": {
                 "handlers": [handler],
-                "level": "INFO",
+                "level": log_level,
             },
         },
     }


### PR DESCRIPTION
Summary:
Surprised we have gotten this far without this. Let you run dagit and/or the daemon with debug logs enabled.

Test Plan:
Smattering of new BK tests to verify no breakage from new cli arg
Manually run:
"dagster dev --log-level debug"
"dagster-daemon run --log-level debug"
"dagit --log-level debug"
"dagit --log-level trace"

and each of those commands with no log level arg, inspect log output for correct level

## Summary & Motivation

## How I Tested These Changes
