### PR TITLE
asset checks execution timestamp

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -3198,6 +3198,7 @@ type AssetCheckExecution {
   runId: String!
   status: AssetCheckExecutionResolvedStatus!
   evaluation: AssetCheckEvaluation
+  timestamp: Float!
 }
 
 enum AssetCheckExecutionResolvedStatus {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -175,6 +175,7 @@ export type AssetCheckExecution = {
   id: Scalars['String'];
   runId: Scalars['String'];
   status: AssetCheckExecutionResolvedStatus;
+  timestamp: Scalars['Float'];
 };
 
 export enum AssetCheckExecutionResolvedStatus {
@@ -4536,6 +4537,7 @@ export const buildAssetCheckExecution = (
       overrides && overrides.hasOwnProperty('status')
         ? overrides.status!
         : AssetCheckExecutionResolvedStatus.EXECUTION_FAILED,
+    timestamp: overrides && overrides.hasOwnProperty('timestamp') ? overrides.timestamp! : 2.57,
   };
 };
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_checks.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_checks.py
@@ -42,7 +42,9 @@ class GrapheneAssetCheckEvaluationTargetMaterializationData(graphene.ObjectType)
 
 
 class GrapheneAssetCheckEvaluation(graphene.ObjectType):
-    timestamp = graphene.NonNull(graphene.Float)
+    timestamp = graphene.Field(
+        graphene.NonNull(graphene.Float), description="When the check evaluation was stored"
+    )
     targetMaterialization = graphene.Field(GrapheneAssetCheckEvaluationTargetMaterializationData)
     metadataEntries = non_null_list(GrapheneMetadataEntry)
 
@@ -72,6 +74,9 @@ class GrapheneAssetCheckExecution(graphene.ObjectType):
     runId = graphene.NonNull(graphene.String)
     status = graphene.NonNull(GrapheneAssetCheckExecutionResolvedStatus)
     evaluation = graphene.Field(GrapheneAssetCheckEvaluation)
+    timestamp = graphene.Field(
+        graphene.NonNull(graphene.Float), description="When the check run started"
+    )
 
     class Meta:
         name = "AssetCheckExecution"
@@ -90,6 +95,7 @@ class GrapheneAssetCheckExecution(graphene.ObjectType):
             if execution.evaluation_event
             else None
         )
+        self.timestamp = execution.create_timestamp
 
 
 GrapheneAssetCheckSeverity = graphene.Enum.from_enum(AssetCheckSeverity)


### PR DESCRIPTION
Currently we only surface timestamps for completed checks. I think for checks that haven't completed, we should show a timestamp for when their execution started