### PR TITLE
[RFC][Overview Assets] Fetching status for 1 asset at a time.

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useLiveDataForAssetKeysBatcher.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useLiveDataForAssetKeysBatcher.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+
+import {AssetKeyInput} from '../graphql/types';
+
+import {buildLiveData} from './Utils';
+export const useLiveDataForAssetKeysBatcher = (assetKeys: AssetKeyInput[], batchSize = 1) => {
+  const [_, forceRerender] = React.useReducer((s) => s + 1, 0);
+  const currentBatchIndexRef = React.useRef(0);
+  const currentBatchIndex = currentBatchIndexRef.current;
+
+  function setBatchIndex(nextIndex: number) {
+    currentBatchIndexRef.current = nextIndex;
+    forceRerender();
+  }
+
+  const prevAssetKeys = React.useRef(assetKeys);
+  if (prevAssetKeys.current !== assetKeys) {
+    currentBatchIndexRef.current = 0;
+    prevAssetKeys.current = assetKeys;
+  }
+
+  const numberOfBatches = React.useMemo(() => {
+    // Try fetching 50 at a time
+    return assetKeys.length / batchSize;
+  }, [assetKeys.length, batchSize]);
+
+  const currentBatch = React.useMemo(() => {
+    const startIndex = currentBatchIndex * batchSize;
+    return assetKeys.slice(startIndex, startIndex + batchSize);
+  }, [assetKeys, currentBatchIndex, batchSize]);
+
+  const allLiveDataByNodeRef = React.useRef<ReturnType<typeof buildLiveData>>({});
+
+  return {
+    currentBatch,
+    setBatchData: React.useCallback((liveDataByNode: typeof allLiveDataByNodeRef.current) => {
+      allLiveDataByNodeRef.current = Object.assign(
+        {},
+        allLiveDataByNodeRef.current,
+        liveDataByNode,
+      );
+      return allLiveDataByNodeRef.current;
+    }, []),
+    allLiveDataByNode: allLiveDataByNodeRef.current,
+    nextBatch: React.useCallback(() => {
+      setBatchIndex((currentBatchIndexRef.current + 1) % numberOfBatches);
+    }, []),
+    isLastBatch: numberOfBatches === currentBatchIndex + 1,
+  };
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useLiveDataForAssetKeysBatcher.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useLiveDataForAssetKeysBatcher.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import {AssetKeyInput} from '../graphql/types';
 
 import {buildLiveData} from './Utils';
-export const useLiveDataForAssetKeysBatcher = (assetKeys: AssetKeyInput[], batchSize = 1) => {
+export const useLiveDataForAssetKeysBatcher = (assetKeys: AssetKeyInput[], batchSize = 50) => {
   const [_, forceRerender] = React.useReducer((s) => s + 1, 0);
   const currentBatchIndexRef = React.useRef(0);
   const currentBatchIndex = currentBatchIndexRef.current;

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewAssetsRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewAssetsRoot.tsx
@@ -222,7 +222,7 @@ function VirtualRow({height, start, group}: RowProps) {
     group.assets,
   ]);
 
-  const {liveDataByNode} = useLiveDataForAssetKeys(assetKeys);
+  const {liveDataByNode} = useLiveDataForAssetKeys(assetKeys, true);
 
   const statuses = React.useMemo(() => {
     type assetType = typeof group['assets'][0];
@@ -297,32 +297,39 @@ function VirtualRow({height, start, group}: RowProps) {
 
   const {containerProps, viewport} = useViewport();
 
+  const isBatchStillLoading = assetKeys.length !== Object.keys(liveDataByNode).length;
+
   return (
     <Row $height={height} $start={start}>
       <RowGrid border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}>
         <Cell>
-          <Box flex={{direction: 'column', gap: 2}}>
-            <Box flex={{direction: 'row', gap: 8}}>
-              <Icon name="asset_group" />
-              {group.groupName ? (
-                <Link
-                  style={{fontWeight: 700}}
-                  to={workspacePathFromAddress(repoAddress, `/asset-groups/${group.groupName}`)}
-                >
-                  {group.groupName}
-                </Link>
-              ) : (
-                UNGROUPED_ASSETS
-              )}
+          <Box flex={{direction: 'row', justifyContent: 'space-between', grow: 1}}>
+            <Box flex={{direction: 'column', gap: 2, grow: 1}}>
+              <Box flex={{direction: 'row', gap: 8}}>
+                <Icon name="asset_group" />
+                {group.groupName ? (
+                  <Link
+                    style={{fontWeight: 700}}
+                    to={workspacePathFromAddress(repoAddress, `/asset-groups/${group.groupName}`)}
+                  >
+                    {group.groupName}
+                  </Link>
+                ) : (
+                  UNGROUPED_ASSETS
+                )}
+              </Box>
+              <div {...containerProps}>
+                <RepositoryLinkWrapper maxWidth={viewport.width}>
+                  <RepositoryLink repoAddress={repoAddress} showRefresh={false} />
+                </RepositoryLinkWrapper>
+              </div>
             </Box>
-            <div {...containerProps}>
-              <RepositoryLinkWrapper maxWidth={viewport.width}>
-                <RepositoryLink repoAddress={repoAddress} showRefresh={false} />
-              </RepositoryLinkWrapper>
-            </div>
+            <Box flex={{direction: 'column', justifyContent: 'center'}}>
+              {isBatchStillLoading ? <Spinner purpose="body-text" /> : null}
+            </Box>
           </Box>
         </Cell>
-        <Cell isLoading={!!statuses.loading}>
+        <Cell>
           {statuses.missing.length ? (
             <SelectOnHover
               assets={statuses.missing}
@@ -352,7 +359,7 @@ function VirtualRow({height, start, group}: RowProps) {
             0
           )}
         </Cell>
-        <Cell isLoading={!!statuses.loading}>
+        <Cell>
           {statuses.failed.length ? (
             <SelectOnHover
               assets={statuses.failed}
@@ -384,7 +391,7 @@ function VirtualRow({height, start, group}: RowProps) {
             0
           )}
         </Cell>
-        <Cell isLoading={!!statuses.loading}>
+        <Cell>
           {statuses.inprogress.length ? (
             <SelectOnHover
               assets={statuses.inprogress}
@@ -404,7 +411,7 @@ function VirtualRow({height, start, group}: RowProps) {
             0
           )}
         </Cell>
-        <Cell isLoading={!!statuses.loading}>
+        <Cell>
           {statuses.successful.length ? (
             <SelectOnHover
               assets={statuses.successful}
@@ -448,16 +455,10 @@ const RowGrid = styled(Box)`
   }
 `;
 
-const Cell = ({children, isLoading}: {children: React.ReactNode; isLoading?: boolean}) => {
+const Cell = ({children}: {children: React.ReactNode}) => {
   return (
     <RowCell style={{color: Colors.Gray900}}>
-      {isLoading ? (
-        <Box flex={{justifyContent: 'center', alignItems: 'center'}} style={{height: '82px'}}>
-          <Spinner purpose="body-text" />
-        </Box>
-      ) : (
-        <Box flex={{direction: 'row', alignItems: 'center', grow: 1}}>{children}</Box>
-      )}
+      <Box flex={{direction: 'row', alignItems: 'center', grow: 1}}>{children}</Box>
     </RowCell>
   );
 };


### PR DESCRIPTION
## Summary & Motivation

A certain Dagster user has thousands of assets inside of a single group and currently we're fetching all of the assets of a group at once. This PR changes the logic to instead fetch a single asset at a time per group. 

This is a bandaid of sorts for the time being. Will deploy this to dogfood to get a better sense of how it performs for our dogfood test orgs. I tried fetching in bigger batches of 1 but some of the queries were still timing out. I'm consdering making this configurable via an org setting.

## How I Tested These Changes
Shadow dagit (which is extremely slow)

<img width="1494" alt="Screenshot 2023-08-31 at 2 15 17 PM" src="https://github.com/dagster-io/dagster/assets/2286579/3b17ebd8-70ef-4dd5-b85a-7ef9761fb09a">

