### PR TITLE
[auto-materialize] Add implicit AMPs to tests

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -312,7 +312,7 @@ class AssetDaemonContext:
             - The set of AssetKeyPartitionKeys that should be discarded.
         """
         auto_materialize_policy = check.not_none(
-            self.get_implicit_auto_materialize_policy(asset_key)
+            self.asset_graph.auto_materialize_policies_by_key.get(asset_key)
         )
 
         # the results of evaluating individual rules

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -53,6 +53,34 @@ if TYPE_CHECKING:
     from dagster._utils.caching_instance_queryer import CachingInstanceQueryer  # expensive import
 
 
+def get_implicit_auto_materialize_policy(
+    asset_key: AssetKey, asset_graph: AssetGraph
+) -> Optional[AutoMaterializePolicy]:
+    """For backcompat with pre-auto materialize policy graphs, assume a default scope of 1 day."""
+    auto_materialize_policy = asset_graph.get_auto_materialize_policy(asset_key)
+    if auto_materialize_policy is None:
+        time_partitions_def = get_time_partitions_def(asset_graph.get_partitions_def(asset_key))
+        if time_partitions_def is None:
+            max_materializations_per_minute = None
+        elif time_partitions_def.schedule_type == ScheduleType.HOURLY:
+            max_materializations_per_minute = 24
+        else:
+            max_materializations_per_minute = 1
+        rules = {
+            AutoMaterializeRule.materialize_on_missing(),
+            AutoMaterializeRule.materialize_on_required_for_freshness(),
+            AutoMaterializeRule.skip_on_parent_outdated(),
+            AutoMaterializeRule.skip_on_parent_missing(),
+        }
+        if not bool(asset_graph.get_downstream_freshness_policies(asset_key=asset_key)):
+            rules.add(AutoMaterializeRule.materialize_on_parent_updated())
+        return AutoMaterializePolicy(
+            rules=rules,
+            max_materializations_per_minute=max_materializations_per_minute,
+        )
+    return auto_materialize_policy
+
+
 class AssetDaemonContext:
     def __init__(
         self,
@@ -134,35 +162,6 @@ class AssetDaemonContext:
     @property
     def respect_materialization_data_versions(self) -> bool:
         return self._respect_materialization_data_versions
-
-    def get_implicit_auto_materialize_policy(
-        self, asset_key: AssetKey
-    ) -> Optional[AutoMaterializePolicy]:
-        """For backcompat with pre-auto materialize policy graphs, assume a default scope of 1 day."""
-        auto_materialize_policy = self.asset_graph.get_auto_materialize_policy(asset_key)
-        if auto_materialize_policy is None:
-            time_partitions_def = get_time_partitions_def(
-                self.asset_graph.get_partitions_def(asset_key)
-            )
-            if time_partitions_def is None:
-                max_materializations_per_minute = None
-            elif time_partitions_def.schedule_type == ScheduleType.HOURLY:
-                max_materializations_per_minute = 24
-            else:
-                max_materializations_per_minute = 1
-            rules = {
-                AutoMaterializeRule.materialize_on_missing(),
-                AutoMaterializeRule.materialize_on_required_for_freshness(),
-                AutoMaterializeRule.skip_on_parent_outdated(),
-                AutoMaterializeRule.skip_on_parent_missing(),
-            }
-            if not bool(self.asset_graph.get_downstream_freshness_policies(asset_key=asset_key)):
-                rules.add(AutoMaterializeRule.materialize_on_parent_updated())
-            return AutoMaterializePolicy(
-                rules=rules,
-                max_materializations_per_minute=max_materializations_per_minute,
-            )
-        return auto_materialize_policy
 
     @cached_method
     def _get_never_handled_and_newly_handled_root_asset_partitions(

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
@@ -6,6 +6,7 @@ import os
 import random
 import sys
 from typing import (
+    AbstractSet,
     Iterable,
     List,
     Mapping,
@@ -41,7 +42,10 @@ from dagster import (
     observable_source_asset,
     repository,
 )
-from dagster._core.definitions.asset_daemon_context import AssetDaemonContext
+from dagster._core.definitions.asset_daemon_context import (
+    AssetDaemonContext,
+    get_implicit_auto_materialize_policy,
+)
 from dagster._core.definitions.asset_daemon_cursor import AssetDaemonCursor
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
@@ -138,21 +142,84 @@ class AssetEvaluationSpec(NamedTuple):
         )
 
 
-class AssetReconciliationScenario(NamedTuple):
-    unevaluated_runs: Sequence[RunSpec]
-    assets: Optional[Sequence[Union[SourceAsset, AssetsDefinition]]]
-    between_runs_delta: Optional[datetime.timedelta] = None
-    evaluation_delta: Optional[datetime.timedelta] = None
-    cursor_from: Optional["AssetReconciliationScenario"] = None
-    current_time: Optional[datetime.datetime] = None
-    asset_selection: Optional[AssetSelection] = None
-    active_backfill_targets: Optional[Sequence[Mapping[AssetKey, PartitionsSubset]]] = None
-    dagster_runs: Optional[Sequence[DagsterRun]] = None
-    event_log_entries: Optional[Sequence[EventLogEntry]] = None
-    expected_run_requests: Optional[Sequence[RunRequest]] = None
-    code_locations: Optional[Mapping[str, Sequence[Union[SourceAsset, AssetsDefinition]]]] = None
-    expected_evaluations: Optional[Sequence[AssetEvaluationSpec]] = None
-    requires_respect_materialization_data_versions: bool = False
+class AssetReconciliationScenario(
+    NamedTuple(
+        "_AssetReconciliationScenario",
+        [
+            ("unevaluated_runs", Sequence[RunSpec]),
+            ("assets", Optional[Sequence[Union[SourceAsset, AssetsDefinition]]]),
+            ("between_runs_delta", Optional[datetime.timedelta]),
+            ("evaluation_delta", Optional[datetime.timedelta]),
+            ("cursor_from", Optional["AssetReconciliationScenario"]),
+            ("current_time", Optional[datetime.datetime]),
+            ("asset_selection", Optional[AssetSelection]),
+            ("active_backfill_targets", Optional[Sequence[Mapping[AssetKey, PartitionsSubset]]]),
+            ("dagster_runs", Optional[Sequence[DagsterRun]]),
+            ("event_log_entries", Optional[Sequence[EventLogEntry]]),
+            ("expected_run_requests", Optional[Sequence[RunRequest]]),
+            (
+                "code_locations",
+                Optional[Mapping[str, Sequence[Union[SourceAsset, AssetsDefinition]]]],
+            ),
+            ("expected_evaluations", Optional[Sequence[AssetEvaluationSpec]]),
+            ("requires_respect_materialization_data_versions", bool),
+        ],
+    )
+):
+    def __new__(
+        cls,
+        unevaluated_runs: Sequence[RunSpec],
+        assets: Optional[Sequence[Union[SourceAsset, AssetsDefinition]]],
+        between_runs_delta: Optional[datetime.timedelta] = None,
+        evaluation_delta: Optional[datetime.timedelta] = None,
+        cursor_from: Optional["AssetReconciliationScenario"] = None,
+        current_time: Optional[datetime.datetime] = None,
+        asset_selection: Optional[AssetSelection] = None,
+        active_backfill_targets: Optional[Sequence[Mapping[AssetKey, PartitionsSubset]]] = None,
+        dagster_runs: Optional[Sequence[DagsterRun]] = None,
+        event_log_entries: Optional[Sequence[EventLogEntry]] = None,
+        expected_run_requests: Optional[Sequence[RunRequest]] = None,
+        code_locations: Optional[
+            Mapping[str, Sequence[Union[SourceAsset, AssetsDefinition]]]
+        ] = None,
+        expected_evaluations: Optional[Sequence[AssetEvaluationSpec]] = None,
+        requires_respect_materialization_data_versions: bool = False,
+    ) -> "AssetReconciliationScenario":
+        # For scenarios with no auto-materialize policies, we infer auto-materialize policies
+        # and add them to the assets.
+        assets_with_implicit_policies = assets
+        if assets and all(
+            (isinstance(a, AssetsDefinition) and not a.auto_materialize_policies_by_key)
+            or isinstance(a, SourceAsset)
+            for a in assets
+        ):
+            asset_graph = AssetGraph.from_assets(assets)
+            target_asset_keys = (
+                asset_selection.resolve(asset_graph)
+                if asset_selection
+                else asset_graph.materializable_asset_keys
+            )
+            assets_with_implicit_policies = with_implicit_auto_materialize_policies(
+                assets, asset_graph, target_asset_keys
+            )
+
+        return super(AssetReconciliationScenario, cls).__new__(
+            cls,
+            unevaluated_runs=unevaluated_runs,
+            assets=assets_with_implicit_policies,
+            between_runs_delta=between_runs_delta,
+            evaluation_delta=evaluation_delta,
+            cursor_from=cursor_from,
+            current_time=current_time,
+            asset_selection=asset_selection,
+            active_backfill_targets=active_backfill_targets,
+            dagster_runs=dagster_runs,
+            event_log_entries=event_log_entries,
+            expected_run_requests=expected_run_requests,
+            code_locations=code_locations,
+            expected_evaluations=expected_evaluations,
+            requires_respect_materialization_data_versions=requires_respect_materialization_data_versions,
+        )
 
     def _get_code_location_origin(
         self, scenario_name, location_name=None
@@ -584,3 +651,34 @@ def observable_source_asset_def(
             )
 
     return _observable
+
+
+def with_implicit_auto_materialize_policies(
+    assets_defs: Sequence[Union[SourceAsset, AssetsDefinition]],
+    asset_graph: AssetGraph,
+    targeted_assets: Optional[AbstractSet[AssetKey]] = None,
+) -> Sequence[AssetsDefinition]:
+    """Accepts a list of assets, adding implied auto-materialize policies to targeted assets
+    if policies do not exist.
+    """
+    ret = []
+    for assets_def in assets_defs:
+        if (
+            isinstance(assets_def, AssetsDefinition)
+            and not assets_def.auto_materialize_policies_by_key
+        ):
+            targeted_keys = (
+                assets_def.keys & targeted_assets if targeted_assets else assets_def.keys
+            )
+            auto_materialize_policies_by_key = {}
+            for key in targeted_keys:
+                policy = get_implicit_auto_materialize_policy(key, asset_graph)
+                if policy:
+                    auto_materialize_policies_by_key[key] = policy
+
+            ret.append(
+                assets_def.with_attributes(auto_materialize_policy=auto_materialize_policies_by_key)
+            )
+        else:
+            ret.append(assets_def)
+    return ret

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/auto_materialize_policy_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/auto_materialize_policy_scenarios.py
@@ -297,7 +297,9 @@ auto_materialize_policy_scenarios = {
             assets=lazy_assets_nothing_dep,
             unevaluated_runs=[run(["asset1"])],
             expected_run_requests=[run_request(asset_keys=["asset2", "asset3"])],
+            asset_selection=AssetSelection.keys("asset2", "asset3"),
         ),
+        asset_selection=AssetSelection.keys("asset2", "asset3"),
         unevaluated_runs=[run(["asset2", "asset3"], failed_asset_keys=["asset2", "asset3"])],
         # should not run again
         expected_run_requests=[],

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_fast.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_fast.py
@@ -86,9 +86,7 @@ def test_reconciliation(scenario, respect_materialization_data_versions):
 
 @pytest.mark.parametrize(
     "scenario",
-    [
-        ASSET_RECONCILIATION_SCENARIOS["freshness_complex_subsettable"],
-    ],
+    [ASSET_RECONCILIATION_SCENARIOS["freshness_complex_subsettable"]],
 )
 def test_reconciliation_no_tags(scenario):
     # simulates an environment where asset_event_tags cannot be added


### PR DESCRIPTION
Previously, in asset reconciliation tests, we would infer the auto materialize policy for assets that did not have one defined. This PR adjusts behavior to instead assert that an auto-materialize policy is defined on an asset that we expect to yield an evaluation for. Legacy reconciliation tests with no AMPs now infer the AMP at scenario construction time.

This also improves testing as AMPs now exist on the asset definition (instead of being inferred) and ensures we aren't evaluating assets with no AMP.

Necessary for: https://github.com/dagster-io/dagster/pull/16250