### PR TITLE
[auto-materialize] Display historic AMP rules

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeMiddlePanel.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeMiddlePanel.tsx
@@ -115,7 +115,7 @@ export const AutomaterializeMiddlePanel = (props: Props) => {
     );
   }
 
-  const rules =
+  const currentRules =
     (data?.assetNodeOrError.__typename === 'AssetNode' &&
       data.assetNodeOrError.autoMaterializePolicy?.rules) ||
     [];
@@ -126,7 +126,7 @@ export const AutomaterializeMiddlePanel = (props: Props) => {
 
   return (
     <AutomaterializeMiddlePanelWithData
-      rules={rules}
+      currentRules={currentRules}
       assetHasDefinedPartitions={assetHasDefinedPartitions}
       selectedEvaluation={selectedEvaluation}
     />
@@ -134,11 +134,11 @@ export const AutomaterializeMiddlePanel = (props: Props) => {
 };
 
 export const AutomaterializeMiddlePanelWithData = ({
-  rules,
+  currentRules,
   selectedEvaluation,
   assetHasDefinedPartitions,
 }: {
-  rules: AutoMaterializeRule[];
+  currentRules: AutoMaterializeRule[];
   selectedEvaluation: NoConditionsMetEvaluation | AutoMaterializeAssetEvaluationRecord;
   assetHasDefinedPartitions: boolean;
 }) => {
@@ -150,6 +150,11 @@ export const AutomaterializeMiddlePanelWithData = ({
     selectedEvaluation?.__typename === 'AutoMaterializeAssetEvaluationRecord'
       ? selectedEvaluation.rulesWithRuleEvaluations
       : [];
+  const rules =
+    selectedEvaluation?.__typename === 'AutoMaterializeAssetEvaluationRecord' &&
+    selectedEvaluation.rules
+      ? selectedEvaluation.rules
+      : currentRules;
 
   const headerRight = () => {
     if (runIds.length === 0) {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/GetEvaluationsQuery.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/GetEvaluationsQuery.tsx
@@ -10,6 +10,7 @@ export const GET_EVALUATIONS_QUERY = gql`
           rules {
             description
             decisionType
+            className
           }
         }
       }
@@ -40,12 +41,18 @@ export const GET_EVALUATIONS_QUERY = gql`
     rulesWithRuleEvaluations {
       ...RuleWithEvaluationsFragment
     }
+    rules {
+      description
+      decisionType
+      className
+    }
   }
 
   fragment RuleWithEvaluationsFragment on AutoMaterializeRuleWithRuleEvaluations {
     rule {
       description
       decisionType
+      className
     }
     ruleEvaluations {
       evaluationData {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/RuleEvaluationOutcomes.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/RuleEvaluationOutcomes.tsx
@@ -95,13 +95,13 @@ export const RuleEvaluationOutcomes = ({
           details={section.details}
         >
           <Box flex={{direction: 'column', gap: 8}}>
-            {(groupedRules[section.decisionType] || []).map(({description}) => {
+            {(groupedRules[section.decisionType] || []).map(({description}, idx) => {
               const evaluations =
                 ruleEvaluations.find((e) => e.rule?.description === description)?.ruleEvaluations ||
                 [];
               return (
                 <RuleEvaluationOutcome
-                  key={description}
+                  key={idx}
                   text={description}
                   met={evaluations.length > 0}
                   rightElement={

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/types/GetEvaluationsQuery.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/types/GetEvaluationsQuery.types.ts
@@ -20,6 +20,7 @@ export type GetEvaluationsQuery = {
             __typename: 'AutoMaterializeRule';
             description: string;
             decisionType: Types.AutoMaterializeDecisionType;
+            className: string;
           }>;
         } | null;
       }
@@ -44,6 +45,7 @@ export type GetEvaluationsQuery = {
               __typename: 'AutoMaterializeRule';
               description: string;
               decisionType: Types.AutoMaterializeDecisionType;
+              className: string;
             };
             ruleEvaluations: Array<{
               __typename: 'AutoMaterializeRuleEvaluation';
@@ -68,6 +70,12 @@ export type GetEvaluationsQuery = {
                 | null;
             }>;
           }>;
+          rules: Array<{
+            __typename: 'AutoMaterializeRule';
+            description: string;
+            decisionType: Types.AutoMaterializeDecisionType;
+            className: string;
+          }> | null;
         }>;
       }
     | null;
@@ -88,6 +96,7 @@ export type AutoMaterializeEvaluationRecordItemFragment = {
       __typename: 'AutoMaterializeRule';
       description: string;
       decisionType: Types.AutoMaterializeDecisionType;
+      className: string;
     };
     ruleEvaluations: Array<{
       __typename: 'AutoMaterializeRuleEvaluation';
@@ -109,6 +118,12 @@ export type AutoMaterializeEvaluationRecordItemFragment = {
         | null;
     }>;
   }>;
+  rules: Array<{
+    __typename: 'AutoMaterializeRule';
+    description: string;
+    decisionType: Types.AutoMaterializeDecisionType;
+    className: string;
+  }> | null;
 };
 
 export type RuleWithEvaluationsFragment = {
@@ -117,6 +132,7 @@ export type RuleWithEvaluationsFragment = {
     __typename: 'AutoMaterializeRule';
     description: string;
     decisionType: Types.AutoMaterializeDecisionType;
+    className: string;
   };
   ruleEvaluations: Array<{
     __typename: 'AutoMaterializeRuleEvaluation';

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -728,6 +728,7 @@ enum AutoMaterializePolicyType {
 type AutoMaterializeRule {
   description: String!
   decisionType: AutoMaterializeDecisionType!
+  className: String!
 }
 
 enum AutoMaterializeDecisionType {
@@ -3178,6 +3179,7 @@ type AutoMaterializeAssetEvaluationRecord {
   rulesWithRuleEvaluations: [AutoMaterializeRuleWithRuleEvaluations!]!
   timestamp: Float!
   runIds: [String!]!
+  rules: [AutoMaterializeRule!]
 }
 
 type AutoMaterializeRuleWithRuleEvaluations {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -445,6 +445,7 @@ export type AutoMaterializeAssetEvaluationRecord = {
   numDiscarded: Scalars['Int'];
   numRequested: Scalars['Int'];
   numSkipped: Scalars['Int'];
+  rules: Maybe<Array<AutoMaterializeRule>>;
   rulesWithRuleEvaluations: Array<AutoMaterializeRuleWithRuleEvaluations>;
   runIds: Array<Scalars['String']>;
   timestamp: Scalars['Float'];
@@ -480,6 +481,7 @@ export enum AutoMaterializePolicyType {
 
 export type AutoMaterializeRule = {
   __typename: 'AutoMaterializeRule';
+  className: Scalars['String'];
   decisionType: AutoMaterializeDecisionType;
   description: Scalars['String'];
 };
@@ -5112,6 +5114,7 @@ export const buildAutoMaterializeAssetEvaluationRecord = (
     numRequested:
       overrides && overrides.hasOwnProperty('numRequested') ? overrides.numRequested! : 2522,
     numSkipped: overrides && overrides.hasOwnProperty('numSkipped') ? overrides.numSkipped! : 6444,
+    rules: overrides && overrides.hasOwnProperty('rules') ? overrides.rules! : [],
     rulesWithRuleEvaluations:
       overrides && overrides.hasOwnProperty('rulesWithRuleEvaluations')
         ? overrides.rulesWithRuleEvaluations!
@@ -5167,6 +5170,8 @@ export const buildAutoMaterializeRule = (
   relationshipsToOmit.add('AutoMaterializeRule');
   return {
     __typename: 'AutoMaterializeRule',
+    className:
+      overrides && overrides.hasOwnProperty('className') ? overrides.className! : 'voluptatibus',
     decisionType:
       overrides && overrides.hasOwnProperty('decisionType')
         ? overrides.decisionType!

--- a/python_modules/dagster-graphql/dagster_graphql/schema/auto_materialize_asset_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/auto_materialize_asset_evaluations.py
@@ -181,6 +181,7 @@ class GrapheneAutoMaterializeAssetEvaluationRecord(graphene.ObjectType):
     rulesWithRuleEvaluations = non_null_list(GrapheneAutoMaterializeRuleWithRuleEvaluations)
     timestamp = graphene.NonNull(graphene.Float)
     runIds = non_null_list(graphene.String)
+    rules = graphene.Field(graphene.List(graphene.NonNull(GrapheneAutoMaterializeRule)))
 
     class Meta:
         name = "AutoMaterializeAssetEvaluationRecord"
@@ -201,6 +202,14 @@ class GrapheneAutoMaterializeAssetEvaluationRecord(graphene.ObjectType):
             ),
             timestamp=record.timestamp,
             runIds=record.evaluation.run_ids,
+            rules=(
+                [
+                    GrapheneAutoMaterializeRule(snapshot)
+                    for snapshot in record.evaluation.rule_snapshots
+                ]
+                if record.evaluation.rule_snapshots is not None
+                else None  # Return None if no rules serialized in evaluation
+            ),
         )
 
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/auto_materialize_policy.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/auto_materialize_policy.py
@@ -18,6 +18,7 @@ GrapheneAutoMaterializeDecisionType = graphene.Enum.from_enum(AutoMaterializeDec
 class GrapheneAutoMaterializeRule(graphene.ObjectType):
     description = graphene.NonNull(graphene.String)
     decisionType = graphene.NonNull(GrapheneAutoMaterializeDecisionType)
+    className = graphene.NonNull(graphene.String)
 
     class Meta:
         name = "AutoMaterializeRule"
@@ -26,6 +27,7 @@ class GrapheneAutoMaterializeRule(graphene.ObjectType):
         super().__init__(
             decisionType=auto_materialize_rule_snapshot.decision_type,
             description=auto_materialize_rule_snapshot.description,
+            className=auto_materialize_rule_snapshot.class_name,
         )
 
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_auto_materialize_asset_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_auto_materialize_asset_evaluations.py
@@ -64,6 +64,11 @@ query GetEvaluationsQuery($assetKey: AssetKeyInput!, $limit: Int!, $cursor: Stri
                         }
                     }
                 }
+                rules {
+                    decisionType
+                    description
+                    className
+                }
             }
             currentEvaluationId
         }
@@ -73,6 +78,54 @@ query GetEvaluationsQuery($assetKey: AssetKeyInput!, $limit: Int!, $cursor: Stri
 
 
 class TestAutoMaterializeAssetEvaluations(ExecutingGraphQLContextTestMatrix):
+    def test_get_historic_rules(self, graphql_context: WorkspaceRequestContext):
+        check.not_none(
+            graphql_context.instance.schedule_storage
+        ).add_auto_materialize_asset_evaluations(
+            evaluation_id=10,
+            asset_evaluations=[
+                AutoMaterializeAssetEvaluation(
+                    asset_key=AssetKey("asset_one"),
+                    partition_subsets_by_condition=[],
+                    num_requested=0,
+                    num_skipped=0,
+                    num_discarded=0,
+                    rule_snapshots=None,
+                ),
+                AutoMaterializeAssetEvaluation(
+                    asset_key=AssetKey("asset_two"),
+                    partition_subsets_by_condition=[],
+                    num_requested=1,
+                    num_skipped=0,
+                    num_discarded=0,
+                    rule_snapshots=[AutoMaterializeRule.materialize_on_missing().to_snapshot()],
+                ),
+            ],
+        )
+
+        results = execute_dagster_graphql(
+            graphql_context,
+            QUERY,
+            variables={"assetKey": {"path": ["asset_one"]}, "limit": 10, "cursor": None},
+        )
+        assert len(results.data["autoMaterializeAssetEvaluationsOrError"]["records"]) == 1
+        assert results.data["autoMaterializeAssetEvaluationsOrError"]["records"][0]["rules"] is None
+
+        results = execute_dagster_graphql(
+            graphql_context,
+            QUERY,
+            variables={"assetKey": {"path": ["asset_two"]}, "limit": 10, "cursor": None},
+        )
+        assert len(results.data["autoMaterializeAssetEvaluationsOrError"]["records"]) == 1
+        assert (
+            len(results.data["autoMaterializeAssetEvaluationsOrError"]["records"][0]["rules"]) == 1
+        )
+        rule = results.data["autoMaterializeAssetEvaluationsOrError"]["records"][0]["rules"][0]
+
+        assert rule["decisionType"] == "MATERIALIZE"
+        assert rule["description"] == "materialization is missing"
+        assert rule["className"] == "MaterializeOnMissingRule"
+
     def _test_get_evaluations(self, graphql_context: WorkspaceRequestContext):
         results = execute_dagster_graphql(
             graphql_context,

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -508,10 +508,9 @@ class AssetDaemonContext:
                         check.failed(f"Expected auto materialize policy on asset {asset_key}")
 
                     evaluations_by_key[neighbor_key] = evaluation._replace(
-                        asset_key=neighbor_key
-                    )._replace(
-                        rule_snapshots=auto_materialize_policy.rule_snapshots
-                    )  # Neighbors can have different rule snapshots
+                        asset_key=neighbor_key,
+                        rule_snapshots=auto_materialize_policy.rule_snapshots,  # Neighbors can have different rule snapshots
+                    )
                     will_materialize_mapping[neighbor_key] = {
                         ap._replace(asset_key=neighbor_key) for ap in to_materialize_for_asset
                     }

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_policy.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_policy.py
@@ -1,12 +1,5 @@
 from enum import Enum
-from typing import (
-    TYPE_CHECKING,
-    AbstractSet,
-    Dict,
-    FrozenSet,
-    NamedTuple,
-    Optional,
-)
+from typing import TYPE_CHECKING, AbstractSet, Dict, FrozenSet, NamedTuple, Optional, Sequence
 
 import dagster._check as check
 from dagster._annotations import experimental, public
@@ -18,7 +11,10 @@ from dagster._serdes.serdes import (
 )
 
 if TYPE_CHECKING:
-    from dagster._core.definitions.auto_materialize_rule import AutoMaterializeRule
+    from dagster._core.definitions.auto_materialize_rule import (
+        AutoMaterializeRule,
+        AutoMaterializeRuleSnapshot,
+    )
 
 
 class AutoMaterializePolicySerializer(NamedTupleSerializer):
@@ -237,3 +233,7 @@ class AutoMaterializePolicy(
         if AutoMaterializeRule.materialize_on_parent_updated() in self.rules:
             return AutoMaterializePolicyType.EAGER
         return AutoMaterializePolicyType.LAZY
+
+    @property
+    def rule_snapshots(self) -> Sequence["AutoMaterializeRuleSnapshot"]:
+        return [rule.to_snapshot() for rule in self.rules]

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -631,6 +631,7 @@ class AutoMaterializeAssetEvaluation(NamedTuple):
     num_skipped: int
     num_discarded: int
     run_ids: Set[str] = set()
+    rule_snapshots: Optional[Sequence[AutoMaterializeRuleSnapshot]] = None
 
     @staticmethod
     def from_rule_evaluation_results(
@@ -644,6 +645,11 @@ class AutoMaterializeAssetEvaluation(NamedTuple):
         num_discarded: int,
         dynamic_partitions_store: "DynamicPartitionsStore",
     ) -> "AutoMaterializeAssetEvaluation":
+        auto_materialize_policy = asset_graph.auto_materialize_policies_by_key.get(asset_key)
+
+        if not auto_materialize_policy:
+            check.failed(f"Expected auto materialize policy on asset {asset_key}")
+
         partitions_def = asset_graph.get_partitions_def(asset_key)
         if partitions_def is None:
             return AutoMaterializeAssetEvaluation(
@@ -655,6 +661,7 @@ class AutoMaterializeAssetEvaluation(NamedTuple):
                 num_requested=num_requested,
                 num_skipped=num_skipped,
                 num_discarded=num_discarded,
+                rule_snapshots=auto_materialize_policy.rule_snapshots,
             )
         else:
             return AutoMaterializeAssetEvaluation(
@@ -675,6 +682,7 @@ class AutoMaterializeAssetEvaluation(NamedTuple):
                 num_requested=num_requested,
                 num_skipped=num_skipped,
                 num_discarded=num_discarded,
+                rule_snapshots=auto_materialize_policy.rule_snapshots,
             )
 
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_fast.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_fast.py
@@ -54,6 +54,12 @@ def test_reconciliation(scenario, respect_materialization_data_versions):
                     partition_subsets_by_condition=sorted(
                         evaluation.partition_subsets_by_condition, key=repr
                     )
+                )._replace(
+                    rule_snapshots=(
+                        sorted(evaluation.rule_snapshots, key=repr)
+                        if evaluation.rule_snapshots
+                        else None
+                    )
                 )
                 for evaluation in evaluations
             ],


### PR DESCRIPTION
Currently, the UI uses the current set of automaterialize rules for every past evaluation. This PR modifies the existing behavior by:

- serializing the existent rules as part of the asset evaluation
- loading the serialized rules in the UI, using the current set of rules when rules were not serialized in the evaluation for backcompat