### PR TITLE
Fix missing env var in the quickstart_gcp example

### DIFF
--- a/examples/quickstart_gcp/quickstart_gcp/__init__.py
+++ b/examples/quickstart_gcp/quickstart_gcp/__init__.py
@@ -20,7 +20,9 @@ defs = Definitions(
         # Read about using environment variables and secrets in Dagster:
         #   https://docs.dagster.io/guides/dagster/using-environment-variables-and-secrets
         "io_manager": BigQueryPandasIOManager(
-            project=EnvVar("BIGQUERY_PROJECT_ID"), dataset="hackernews"
+            project=EnvVar("BIGQUERY_PROJECT_ID"),
+            dataset="hackernews",
+            gcp_credentials=EnvVar("BIGQUERY_SERVICE_ACCOUNT_CREDENTIALS"),
         )
     },
     schedules=[daily_refresh_schedule],


### PR DESCRIPTION
Summary:
A user reported that we ask for this env var during the NUX, but then never use it - passing it through to this resource fixes.

Could use some help with verifying ourselves that it works for us the same way it did for them though.

## Summary & Motivation

## How I Tested These Changes
