### PR TITLE
Make partition_key available on TypeCheckContext (#16094)

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -559,6 +559,7 @@ class BoundOpExecutionContext(OpExecutionContext):
             self.log,
             ScopedResourcesBuilder(resources._asdict()),
             dagster_type,
+            self._partition_key,
         )
 
     def get_mapping_key(self) -> Optional[str]:

--- a/python_modules/dagster/dagster/_core/execution/context/system.py
+++ b/python_modules/dagster/dagster/_core/execution/context/system.py
@@ -468,8 +468,14 @@ class PlanExecutionContext(IPlanContext):
         return ASSET_PARTITION_RANGE_START_TAG in self._plan_data.dagster_run.tags
 
     def for_type(self, dagster_type: DagsterType) -> "TypeCheckContext":
+        partition_key = self.partition_key if self.has_partitions else None
+
         return TypeCheckContext(
-            self.run_id, self.log, self._execution_data.scoped_resources_builder, dagster_type
+            self.run_id,
+            self.log,
+            self._execution_data.scoped_resources_builder,
+            dagster_type,
+            partition_key,
         )
 
 
@@ -1244,10 +1250,12 @@ class TypeCheckContext:
         log_manager: DagsterLogManager,
         scoped_resources_builder: ScopedResourcesBuilder,
         dagster_type: DagsterType,
+        partition_key: Optional[str] = None,
     ):
         self._run_id = run_id
         self._log = log_manager
         self._resources = scoped_resources_builder.build(dagster_type.required_resource_keys)
+        self._partition_key = partition_key
 
     @public
     @property
@@ -1266,6 +1274,12 @@ class TypeCheckContext:
     def log(self) -> DagsterLogManager:
         """Centralized log dispatch from user code."""
         return self._log
+
+    @public
+    @property
+    def partition_key(self) -> Optional[str]:
+        """Partition key of current run."""
+        return self._partition_key
 
 
 class DagsterTypeLoaderContext(StepExecutionContext):


### PR DESCRIPTION
## Summary & Motivation
Adding `partition_key` to `TypeCheckContext` allows storing checks results from `DagsterType` by `partition_key` in some persistent storage.
## How I Tested These Changes
I wrote a few tests and checked that vscode autocomplete is capable of seeing `partition_key` [when dagster is added as a  dependency with `--editable` option](https://python-poetry.org/docs/cli/#add).