### PR TITLE
[ui] Add feature context for Job page

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppProvider.tsx
@@ -29,6 +29,7 @@ import {SubscriptionClient} from 'subscriptions-transport-ws';
 import {AssetRunLogObserver} from '../asset-graph/AssetRunLogObserver';
 import {DeploymentStatusProvider, DeploymentStatusType} from '../instance/DeploymentStatusProvider';
 import {InstancePageContext} from '../instance/InstancePageContext';
+import {JobFeatureProvider} from '../pipelines/JobFeatureContext';
 import {WorkspaceProvider} from '../workspace/WorkspaceContext';
 
 import {AppContext} from './AppContext';
@@ -205,7 +206,9 @@ export const AppProvider: React.FC<AppProviderProps> = (props) => {
                       <CustomConfirmationProvider>
                         <AnalyticsContext.Provider value={analytics}>
                           <InstancePageContext.Provider value={instancePageValue}>
-                            <LayoutProvider>{props.children}</LayoutProvider>
+                            <JobFeatureProvider>
+                              <LayoutProvider>{props.children}</LayoutProvider>
+                            </JobFeatureProvider>
                           </InstancePageContext.Provider>
                         </AnalyticsContext.Provider>
                       </CustomConfirmationProvider>

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/JobFeatureContext.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/JobFeatureContext.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+
+import {RepoAddress} from '../workspace/types';
+
+import {JobTabConfig, JobTabConfigInput, buildJobTabs} from './JobTabs';
+import {PipelineOverviewRoot} from './PipelineOverviewRoot';
+
+export type JobViewFeatureInput = {
+  selectedTab: string;
+};
+
+export interface JobRouteFallthroughProps {
+  repoAddress: RepoAddress;
+}
+
+type JobFeatureContextType = {
+  tabBuilder: (input: JobTabConfigInput) => JobTabConfig[];
+  FallthroughRoute: (props: JobRouteFallthroughProps) => React.ReactElement;
+};
+
+export const JobFeatureContext = React.createContext<JobFeatureContextType>({
+  tabBuilder: () => [],
+  FallthroughRoute: () => <span />,
+});
+
+const FallthroughRoute = ({repoAddress}: JobRouteFallthroughProps) => {
+  return <PipelineOverviewRoot repoAddress={repoAddress} />;
+};
+
+export const JobFeatureProvider = ({children}: {children: React.ReactNode}) => {
+  const value = React.useMemo(() => {
+    return {
+      tabBuilder: buildJobTabs,
+      FallthroughRoute,
+    };
+  }, []);
+
+  return <JobFeatureContext.Provider value={value}>{children}</JobFeatureContext.Provider>;
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/JobTabs.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/JobTabs.tsx
@@ -1,0 +1,122 @@
+import {Tab, Tabs, Tooltip} from '@dagster-io/ui-components';
+import * as React from 'react';
+
+import {PermissionResult, PermissionsState, permissionResultForKey} from '../app/Permissions';
+import {TabLink} from '../ui/TabLink';
+import {RepoAddress} from '../workspace/types';
+import {workspacePathFromAddress} from '../workspace/workspacePath';
+
+import {ExplorerPath, explorerPathToString} from './PipelinePathUtils';
+
+export const DEFAULT_JOB_TAB_ORDER = ['overview', 'playground', 'runs', 'partitions'];
+
+interface Props {
+  repoAddress: RepoAddress;
+  isJob: boolean;
+  explorerPath: ExplorerPath;
+  matchingTab?: string;
+  permissions: PermissionsState;
+  tabs: JobTabConfig[];
+}
+
+export const JobTabs = (props: Props) => {
+  const {repoAddress, isJob, explorerPath, matchingTab = '', permissions, tabs} = props;
+
+  const explorerPathForTab = explorerPathToString({
+    ...explorerPath,
+    opNames: [],
+  });
+
+  const selectedTab = React.useMemo(() => {
+    return (
+      tabs.find((tab) => tab.pathComponent === matchingTab) ||
+      tabs.find((tab) => tab.pathComponent === '')
+    );
+  }, [matchingTab, tabs]);
+
+  return (
+    <Tabs size="large" selectedTabId={selectedTab!.id}>
+      {tabs
+        .filter((tab) => !tab.isHidden)
+        .map((tab) => {
+          const {id, title: text, getPermissionsResult} = tab;
+          const permissionsResult = getPermissionsResult ? getPermissionsResult(permissions) : null;
+          const disabled = !!(permissionsResult && !permissionsResult.enabled);
+          const title =
+            permissionsResult && disabled ? (
+              <Tooltip content={permissionsResult.disabledReason} placement="top">
+                {text}
+              </Tooltip>
+            ) : (
+              text
+            );
+
+          const href = workspacePathFromAddress(
+            repoAddress,
+            `/${isJob ? 'jobs' : 'pipelines'}/${explorerPathForTab}${tab.pathComponent}`,
+          );
+
+          if (disabled) {
+            return <Tab disabled key={id} id={id} title={title} />;
+          }
+
+          return <TabLink key={id} id={id} title={title} disabled={disabled} to={href} />;
+        })}
+    </Tabs>
+  );
+};
+
+export type JobTabConfigInput = {
+  hasLaunchpad: boolean;
+  hasPartitionSet: boolean;
+};
+
+export interface JobTabConfig {
+  id: string;
+  title: string;
+  pathComponent: string;
+  getPermissionsResult?: (permissionsState: PermissionsState) => PermissionResult;
+  isHidden?: boolean;
+}
+
+/**
+ * Define the default set of job tabs. These can then be ordered by the `tabBuilder` supplied
+ * via context. We provide a map here instead of an array so that the overriding context can easily
+ * define a new tab order without splicing or reordering a prebuilt array.
+ */
+export const buildJobTabMap = (input: JobTabConfigInput): Record<string, JobTabConfig> => {
+  const {hasLaunchpad, hasPartitionSet} = input;
+  return {
+    overview: {
+      id: 'overview',
+      title: 'Overview',
+      pathComponent: '',
+    },
+    playground: {
+      id: 'launchpad',
+      title: 'Launchpad',
+      pathComponent: 'playground',
+      getPermissionsResult: (permissionsState: PermissionsState) =>
+        permissionResultForKey(permissionsState, 'canLaunchPipelineExecution'),
+      isHidden: !hasLaunchpad,
+    },
+    runs: {
+      id: 'runs',
+      title: 'Runs',
+      pathComponent: 'runs',
+    },
+    partitions: {
+      id: 'partitions',
+      title: 'Partitions',
+      pathComponent: 'partitions',
+      isHidden: !hasPartitionSet,
+    },
+  };
+};
+
+export const buildJobTabs = (input: JobTabConfigInput): JobTabConfig[] => {
+  const tabConfigs = buildJobTabMap(input);
+  return DEFAULT_JOB_TAB_ORDER.map((tabId) => tabConfigs[tabId]).filter(
+    (tab): tab is JobTabConfig => !!tab && !tab.isHidden,
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelineRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelineRoot.tsx
@@ -8,8 +8,8 @@ import {PipelineNav} from '../nav/PipelineNav';
 import {PipelinePartitionsRoot} from '../partitions/PipelinePartitionsRoot';
 import {RepoAddress} from '../workspace/types';
 
+import {JobFeatureContext} from './JobFeatureContext';
 import {PipelineOrJobDisambiguationRoot} from './PipelineOrJobDisambiguationRoot';
-import {PipelineOverviewRoot} from './PipelineOverviewRoot';
 import {PipelineRunsRoot} from './PipelineRunsRoot';
 
 interface Props {
@@ -18,6 +18,7 @@ interface Props {
 
 export const PipelineRoot: React.FC<Props> = (props) => {
   const {repoAddress} = props;
+  const {FallthroughRoute} = React.useContext(JobFeatureContext);
 
   return (
     <div
@@ -93,7 +94,7 @@ export const PipelineRoot: React.FC<Props> = (props) => {
           )}
         />
         <Route path={['/locations/:repoPath/pipelines/(/?.*)', '/locations/:repoPath/jobs/(/?.*)']}>
-          <PipelineOverviewRoot repoAddress={repoAddress} />
+          <FallthroughRoute repoAddress={repoAddress} />
         </Route>
       </Switch>
     </div>

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/__tests__/PipelineNav.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/__tests__/PipelineNav.test.tsx
@@ -5,6 +5,7 @@ import {MemoryRouter} from 'react-router-dom';
 import {PipelineNav} from '../../nav/PipelineNav';
 import {TestPermissionsProvider} from '../../testing/TestPermissions';
 import {buildRepoAddress} from '../../workspace/buildRepoAddress';
+import {JobFeatureProvider} from '../JobFeatureContext';
 
 jest.mock('../../workspace/WorkspaceContext', () => ({
   ...jest.requireActual('../../workspace/WorkspaceContext'),
@@ -19,6 +20,11 @@ jest.mock('../../nav/RepositoryLink', () => ({
   RepositoryLink: () => <div />,
 }));
 
+// We don't actually want to import the PipelineOverviewRoot via context fallthrough.
+jest.mock('../PipelineOverviewRoot', () => ({
+  PipelineOverviewRoot: () => <div />,
+}));
+
 describe('PipelineNav', () => {
   const repoAddress = buildRepoAddress('bar', 'baz');
 
@@ -30,11 +36,13 @@ describe('PipelineNav', () => {
     };
 
     render(
-      <TestPermissionsProvider locationOverrides={locationOverrides}>
-        <MemoryRouter initialEntries={['/locations/bar@baz/jobs/foo/overview']}>
-          <PipelineNav repoAddress={repoAddress} />
-        </MemoryRouter>
-      </TestPermissionsProvider>,
+      <JobFeatureProvider>
+        <TestPermissionsProvider locationOverrides={locationOverrides}>
+          <MemoryRouter initialEntries={['/locations/bar@baz/jobs/foo/overview']}>
+            <PipelineNav repoAddress={repoAddress} />
+          </MemoryRouter>
+        </TestPermissionsProvider>
+      </JobFeatureProvider>,
     );
 
     const launchpadTab = await screen.findByRole('tab', {name: /launchpad/i});
@@ -49,11 +57,13 @@ describe('PipelineNav', () => {
     };
 
     render(
-      <TestPermissionsProvider locationOverrides={locationOverrides}>
-        <MemoryRouter initialEntries={['/locations/bar@baz/jobs/foo/overview']}>
-          <PipelineNav repoAddress={repoAddress} />
-        </MemoryRouter>
-      </TestPermissionsProvider>,
+      <JobFeatureProvider>
+        <TestPermissionsProvider locationOverrides={locationOverrides}>
+          <MemoryRouter initialEntries={['/locations/bar@baz/jobs/foo/overview']}>
+            <PipelineNav repoAddress={repoAddress} />
+          </MemoryRouter>
+        </TestPermissionsProvider>
+      </JobFeatureProvider>,
     );
 
     const launchpadTab = await screen.findByRole('tab', {name: /launchpad/i});

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/__tests__/PipelineRoot.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/__tests__/PipelineRoot.test.tsx
@@ -5,6 +5,7 @@ import {MemoryRouter} from 'react-router-dom';
 import {TestPermissionsProvider} from '../../testing/TestPermissions';
 import {buildRepoAddress} from '../../workspace/buildRepoAddress';
 import {repoAddressAsURLString} from '../../workspace/repoAddressAsString';
+import {JobFeatureProvider} from '../JobFeatureContext';
 import {PipelineRoot} from '../PipelineRoot';
 
 jest.mock('../../launchpad/LaunchpadAllowedRoot', () => ({
@@ -51,9 +52,11 @@ describe('PipelineRoot', () => {
 
   it('renders overview by default', async () => {
     render(
-      <MemoryRouter initialEntries={[path]}>
-        <PipelineRoot repoAddress={repoAddress} />
-      </MemoryRouter>,
+      <JobFeatureProvider>
+        <MemoryRouter initialEntries={[path]}>
+          <PipelineRoot repoAddress={repoAddress} />
+        </MemoryRouter>
+      </JobFeatureProvider>,
     );
 
     const overviewDummy = await screen.findByText(/pipeline overview placeholder/i);
@@ -68,11 +71,13 @@ describe('PipelineRoot', () => {
     };
 
     render(
-      <TestPermissionsProvider locationOverrides={locationPermissions}>
-        <MemoryRouter initialEntries={[`${path}/playground`]}>
-          <PipelineRoot repoAddress={repoAddress} />
-        </MemoryRouter>
-      </TestPermissionsProvider>,
+      <JobFeatureProvider>
+        <TestPermissionsProvider locationOverrides={locationPermissions}>
+          <MemoryRouter initialEntries={[`${path}/playground`]}>
+            <PipelineRoot repoAddress={repoAddress} />
+          </MemoryRouter>
+        </TestPermissionsProvider>
+      </JobFeatureProvider>,
     );
 
     const playgroundDummy = await screen.findByText(/launchpad allowed placeholder/i);
@@ -87,11 +92,13 @@ describe('PipelineRoot', () => {
     };
 
     render(
-      <TestPermissionsProvider locationOverrides={locationPermissions}>
-        <MemoryRouter initialEntries={[`${path}/playground`]}>
-          <PipelineRoot repoAddress={repoAddress} />
-        </MemoryRouter>
-      </TestPermissionsProvider>,
+      <JobFeatureProvider>
+        <TestPermissionsProvider locationOverrides={locationPermissions}>
+          <MemoryRouter initialEntries={[`${path}/playground`]}>
+            <PipelineRoot repoAddress={repoAddress} />
+          </MemoryRouter>
+        </TestPermissionsProvider>
+      </JobFeatureProvider>,
     );
 
     const overviewDummy = await screen.findByText(/pipeline or job disambiguation placeholder/i);


### PR DESCRIPTION
## Summary & Motivation

Similar to the newly added "asset feature" context provider, this adds a "job feature" context provider that allows setting the tabs on the Job page, as well as setting a fallthrough route to handle custom pages on the Job permalink.

## How I Tested These Changes

Verified that the Job page loads successfully in OSS. Same for snapshot pages. Navigate to tabs, verify that routes load properly.

Verified that it also loads successfully in Cloud, including with custom tab and route behavior.
