### PR TITLE
Pydantic 2 compat layer

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -359,7 +359,8 @@ LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
         pytest_tox_factors=[
             "api_tests",
             "cli_tests",
-            "core_tests",
+            "core_tests_pydantic1",
+            "core_tests_pydantic2",
             "storage_tests_sqlalchemy_1_3",
             "storage_tests_sqlalchemy_1_4",
             "daemon_sensor_tests",

--- a/docs/content/concepts/configuration/advanced-config-types.mdx
+++ b/docs/content/concepts/configuration/advanced-config-types.mdx
@@ -170,8 +170,12 @@ result = materialize(
         {
             "average_age": MyNestedConfig(
                 user_data={
-                    "Alice": UserData(age=10, email="alice@gmail.com", profile_picture_url=...),
-                    "Bob": UserData(age=20, email="bob@gmail.com", profile_picture_url=...),
+                    "Alice": UserData(
+                        age=10, email="alice@gmail.com", profile_picture_url=...
+                    ),
+                    "Bob": UserData(
+                        age=20, email="bob@gmail.com", profile_picture_url=...
+                    ),
                 }
             )
         }

--- a/docs/content/concepts/configuration/config-schema.mdx
+++ b/docs/content/concepts/configuration/config-schema.mdx
@@ -174,7 +174,9 @@ def greeting_job():
     print_greeting()
 
 op_result = greeting_job.execute_in_process(
-    run_config=RunConfig({"print_greeting": MyOpConfig(nonexistent_config_value=1)}),
+    run_config=RunConfig(
+        {"print_greeting": MyOpConfig(nonexistent_config_value=1)}
+    ),
 )
 
 asset_result = materialize(

--- a/examples/docs_snippets/docs_snippets/guides/dagster/pythonic_config/pythonic_config.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/pythonic_config/pythonic_config.py
@@ -45,7 +45,7 @@ def permissive_schema_config() -> None:
         return requests.get("https://my-api.com/listings", params=url_params).json()
 
     # can pass in any fields, including those not defined in the schema
-    filtered_listings(FilterConfig(title="hotel", beds=4))  # type: ignore
+    filtered_listings(FilterConfig(title="hotel", beds=4))
     # end_permissive_schema_config
 
 
@@ -164,8 +164,12 @@ def nested_schema_config() -> None:
             {
                 "average_age": MyNestedConfig(
                     user_data={
-                        "Alice": UserData(age=10, email="alice@gmail.com", profile_picture_url=...),  # type: ignore
-                        "Bob": UserData(age=20, email="bob@gmail.com", profile_picture_url=...),  # type: ignore
+                        "Alice": UserData(
+                            age=10, email="alice@gmail.com", profile_picture_url=...
+                        ),
+                        "Bob": UserData(
+                            age=20, email="bob@gmail.com", profile_picture_url=...
+                        ),
                     }
                 )
             }
@@ -285,12 +289,14 @@ def execute_with_bad_config() -> None:
         print_greeting()
 
     op_result = greeting_job.execute_in_process(
-        run_config=RunConfig({"print_greeting": MyOpConfig(nonexistent_config_value=1)}),  # type: ignore
+        run_config=RunConfig(
+            {"print_greeting": MyOpConfig(nonexistent_config_value=1)}
+        ),
     )
 
     asset_result = materialize(
         [greeting],
-        run_config=RunConfig({"greeting": MyAssetConfig(nonexistent_config_value=1)}),  # type: ignore
+        run_config=RunConfig({"greeting": MyAssetConfig(nonexistent_config_value=1)}),
     )
 
     # end_execute_with_bad_config

--- a/helm/dagster/schema/setup.py
+++ b/helm/dagster/schema/setup.py
@@ -16,7 +16,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["schema_tests"]),
-    install_requires=["click", "pydantic>=1.10.0"],
+    install_requires=["click", "pydantic>=1.10.0,<2.0.0"],
     extras_require={
         "test": [
             # remove pin once minimum supported kubernetes version is 1.19

--- a/pyright/master/exclude.txt
+++ b/pyright/master/exclude.txt
@@ -11,3 +11,4 @@ examples/assets_smoke_test
 examples/project_analytics
 examples/project_dagster_university_start
 examples/tutorial
+helm

--- a/pyright/master/requirements-pinned.txt
+++ b/pyright/master/requirements-pinned.txt
@@ -377,7 +377,7 @@ pyasn1==0.5.0
 pyasn1-modules==0.3.0
 pycparser==2.21
 pycryptodomex==3.18.0
-pydantic==1.10.12
+pydantic==2.3.0
 pydata-google-auth==1.8.2
 pyflakes==3.1.0
 Pygments==2.16.1

--- a/pyright/master/requirements-pinned.txt
+++ b/pyright/master/requirements-pinned.txt
@@ -377,7 +377,7 @@ pyasn1==0.5.0
 pyasn1-modules==0.3.0
 pycparser==2.21
 pycryptodomex==3.18.0
-pydantic==2.3.0
+pydantic==1.10.12
 pydata-google-auth==1.8.2
 pyflakes==3.1.0
 Pygments==2.16.1

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_top_level_resources.ambr
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_top_level_resources.ambr
@@ -5,14 +5,14 @@
       'configFields': list([
         dict({
           'configType': dict({
-            'key': 'StringSourceType',
+            'key': 'Noneable.StringSourceType',
           }),
           'description': None,
           'name': 'a_string',
         }),
         dict({
           'configType': dict({
-            'key': 'StringSourceType',
+            'key': 'Noneable.StringSourceType',
           }),
           'description': None,
           'name': 'an_unset_string',
@@ -42,14 +42,14 @@
       'configFields': list([
         dict({
           'configType': dict({
-            'key': 'StringSourceType',
+            'key': 'Noneable.StringSourceType',
           }),
           'description': None,
           'name': 'a_string',
         }),
         dict({
           'configType': dict({
-            'key': 'StringSourceType',
+            'key': 'Noneable.StringSourceType',
           }),
           'description': None,
           'name': 'an_unset_string',
@@ -97,14 +97,14 @@
           'configFields': list([
             dict({
               'configType': dict({
-                'key': 'StringSourceType',
+                'key': 'Noneable.StringSourceType',
               }),
               'description': None,
               'name': 'a_string',
             }),
             dict({
               'configType': dict({
-                'key': 'StringSourceType',
+                'key': 'Noneable.StringSourceType',
               }),
               'description': None,
               'name': 'an_unset_string',
@@ -129,14 +129,14 @@
           'configFields': list([
             dict({
               'configType': dict({
-                'key': 'StringSourceType',
+                'key': 'Noneable.StringSourceType',
               }),
               'description': None,
               'name': 'a_string',
             }),
             dict({
               'configType': dict({
-                'key': 'StringSourceType',
+                'key': 'Noneable.StringSourceType',
               }),
               'description': None,
               'name': 'an_unset_string',
@@ -161,14 +161,14 @@
           'configFields': list([
             dict({
               'configType': dict({
-                'key': 'StringSourceType',
+                'key': 'Noneable.StringSourceType',
               }),
               'description': None,
               'name': 'a_string',
             }),
             dict({
               'configType': dict({
-                'key': 'StringSourceType',
+                'key': 'Noneable.StringSourceType',
               }),
               'description': None,
               'name': 'an_unset_string',

--- a/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
@@ -21,13 +21,7 @@ from typing import (
     cast,
 )
 
-import pydantic
 from pydantic.fields import FieldInfo
-
-try:
-    from pydantic_core import PydanticUndefined  # type: ignore
-except:
-    PydanticUndefined = None
 from typing_extensions import Annotated, TypeAlias, TypeGuard, get_args, get_origin
 
 from dagster import (
@@ -83,9 +77,6 @@ except ImportError:
         pass
 
 
-USING_PYDANTIC_2 = int(pydantic.__version__.split(".")[0]) >= 2
-
-
 from abc import ABC, abstractmethod
 
 from pydantic import BaseModel
@@ -105,6 +96,13 @@ from dagster._core.definitions.resource_definition import (
 )
 from dagster._core.storage.io_manager import IOManager, IOManagerDefinition
 
+from .pydantic_compat_layer import (
+    USING_PYDANTIC_2,
+    ModelFieldCompat,
+    PydanticUndefined,
+    model_config,
+    model_fields,
+)
 from .typing_utils import BaseConfigMeta, BaseResourceMeta, LateBoundTypesForResourceTypeChecking
 from .utils import safe_is_subclass
 
@@ -114,93 +112,6 @@ INTERNAL_MARKER = "__internal__"
 
 # ensure that this ends with the internal marker so we can do a single check
 assert CACHED_METHOD_FIELD_SUFFIX.endswith(INTERNAL_MARKER)
-
-
-class ModelFieldCompat:
-    """Wraps a Pydantic model field to provide a consistent interface for accessing
-    metadata and annotations between Pydantic 1 and 2.
-    """
-
-    def __init__(self, field):
-        self.field = field
-
-    @property
-    def annotation(self):
-        return self.field.annotation
-
-    @property
-    def metadata(self):
-        return getattr(self.field, "metadata", None)
-
-    @property
-    def alias(self):
-        return self.field.alias
-
-    @property
-    def default(self):
-        return self.field.default
-
-    @property
-    def description(self):
-        # Pydantic 1.x
-        field_info = getattr(self.field, "field_info", None)
-        if field_info:
-            return field_info.description
-
-        # Pydantic 2.x
-        return getattr(self.field, "description", None)
-
-    def is_required(self):
-        # Pydantic 2.x
-        if hasattr(self.field, "is_required"):
-            return self.field.is_required()
-
-        # Pydantic 1.x
-        return self.field.required
-
-    @property
-    def discriminator(self):
-        # Pydantic 2.x
-        if hasattr(self.field, "discriminator"):
-            return self.field.discriminator
-
-        # Pydantic 1.x
-        return getattr(self.field, "discriminator_key", None)
-
-
-def model_fields(model) -> Dict[str, ModelFieldCompat]:
-    """Returns a dictionary of fields for a given pydantic model, wrapped
-    in a compat class to provide a consistent interface between Pydantic 1 and 2.
-    """
-    fields = getattr(model, "model_fields", None)
-    if not fields:
-        fields = getattr(model, "__fields__")
-
-    return {k: ModelFieldCompat(v) for k, v in fields.items()}
-
-
-class Pydantic1ConfigWrapper:
-    """Config wrapper for Pydantic 1 style model config, which provides a
-    Pydantic 2 style interface for accessing mopdel config values.
-    """
-
-    def __init__(self, config):
-        self._config = config
-
-    def get(self, key):
-        return getattr(self._config, key)
-
-
-def model_config(model: Type[BaseModel]):
-    """Returns the config for a given pydantic model, wrapped such that it has
-    a Pydantic 2-style interface for accessing config values.
-    """
-    # Pydantic 2.x
-    if hasattr(model, "model_config"):
-        return getattr(model, "model_config")
-
-    # Pydantic 1.x
-    return Pydantic1ConfigWrapper(getattr(model, "__config__"))
 
 
 class MakeConfigCacheable(BaseModel):

--- a/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
@@ -153,10 +153,11 @@ class ModelFieldCompat:
 
 def model_fields(model: Type[BaseModel]) -> Dict[str, ModelFieldCompat]:
     """Returns a dictionary of fields for a given pydantic model."""
-    return {
-        k: ModelFieldCompat(v)
-        for k, v in (getattr(model, "model_fields", getattr(model, "__fields__"))).items()
-    }
+    fields = getattr(model, "model_fields", None)
+    if not fields:
+        fields = getattr(model, "__fields__")
+
+    return {k: ModelFieldCompat(v) for k, v in fields.items()}
 
 
 class OldConfigWrapper:

--- a/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
@@ -1626,6 +1626,7 @@ def _config_type_for_type_on_pydantic_field(
         potential_dagster_type = get_args(potential_dagster_type)[0]
 
     try:
+        # Pydantic 1.x
         from pydantic import ConstrainedFloat, ConstrainedInt, ConstrainedStr
 
         # special case pydantic constrained types to their source equivalents
@@ -1637,6 +1638,7 @@ def _config_type_for_type_on_pydantic_field(
         elif safe_is_subclass(potential_dagster_type, ConstrainedInt):
             return IntSource
     except ImportError:
+        # These types do not exist in Pydantic 2.x
         pass
 
     if safe_is_subclass(get_origin(potential_dagster_type), List):

--- a/python_modules/dagster/dagster/_config/pythonic_config/pydantic_compat_layer.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/pydantic_compat_layer.py
@@ -5,10 +5,13 @@ from typing import (
 
 import pydantic
 
+PydanticUndefined = None
 try:
-    from pydantic_core import PydanticUndefined as PydanticUndefined  # type: ignore
+    from pydantic_core import PydanticUndefined as _PydanticUndefined  # type: ignore
+
+    PydanticUndefined = _PydanticUndefined
 except:
-    PydanticUndefined = None
+    pass
 
 
 from pydantic import BaseModel
@@ -109,12 +112,12 @@ def model_config(model: Type[BaseModel]):
 
 try:
     # Pydantic 2.x
-    from pydantic import model_validator as compat_model_validator  # type: ignore
+    from pydantic import model_validator as model_validator  # type: ignore
 except ImportError:
     # Pydantic 1.x
     from pydantic import root_validator
 
-    def compat_model_validator(mode="before"):
+    def model_validator(mode="before"):
         """Mimics the Pydantic 2.x model_validator decorator, which is used to
         define validation logic for a Pydantic model. This decorator is used
         to wrap a validation function which is called before or after the
@@ -129,3 +132,6 @@ except ImportError:
             )
 
         return _decorate
+
+
+compat_model_validator = model_validator

--- a/python_modules/dagster/dagster/_config/pythonic_config/pydantic_compat_layer.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/pydantic_compat_layer.py
@@ -1,0 +1,131 @@
+from typing import (
+    Dict,
+    Type,
+)
+
+import pydantic
+
+try:
+    from pydantic_core import PydanticUndefined as PydanticUndefined  # type: ignore
+except:
+    PydanticUndefined = None
+
+
+from pydantic import BaseModel
+
+from .attach_other_object_to_context import (
+    IAttachDifferentObjectToOpContext as IAttachDifferentObjectToOpContext,
+)
+
+USING_PYDANTIC_2 = int(pydantic.__version__.split(".")[0]) >= 2
+
+
+class ModelFieldCompat:
+    """Wraps a Pydantic model field to provide a consistent interface for accessing
+    metadata and annotations between Pydantic 1 and 2.
+    """
+
+    def __init__(self, field):
+        self.field = field
+
+    @property
+    def annotation(self):
+        return self.field.annotation
+
+    @property
+    def metadata(self):
+        return getattr(self.field, "metadata", None)
+
+    @property
+    def alias(self):
+        return self.field.alias
+
+    @property
+    def default(self):
+        return self.field.default
+
+    @property
+    def description(self):
+        # Pydantic 1.x
+        field_info = getattr(self.field, "field_info", None)
+        if field_info:
+            return field_info.description
+
+        # Pydantic 2.x
+        return getattr(self.field, "description", None)
+
+    def is_required(self):
+        # Pydantic 2.x
+        if hasattr(self.field, "is_required"):
+            return self.field.is_required()
+
+        # Pydantic 1.x
+        return self.field.required
+
+    @property
+    def discriminator(self):
+        # Pydantic 2.x
+        if hasattr(self.field, "discriminator"):
+            return self.field.discriminator
+
+        # Pydantic 1.x
+        return getattr(self.field, "discriminator_key", None)
+
+
+def model_fields(model) -> Dict[str, ModelFieldCompat]:
+    """Returns a dictionary of fields for a given pydantic model, wrapped
+    in a compat class to provide a consistent interface between Pydantic 1 and 2.
+    """
+    fields = getattr(model, "model_fields", None)
+    if not fields:
+        fields = getattr(model, "__fields__")
+
+    return {k: ModelFieldCompat(v) for k, v in fields.items()}
+
+
+class Pydantic1ConfigWrapper:
+    """Config wrapper for Pydantic 1 style model config, which provides a
+    Pydantic 2 style interface for accessing mopdel config values.
+    """
+
+    def __init__(self, config):
+        self._config = config
+
+    def get(self, key):
+        return getattr(self._config, key)
+
+
+def model_config(model: Type[BaseModel]):
+    """Returns the config for a given pydantic model, wrapped such that it has
+    a Pydantic 2-style interface for accessing config values.
+    """
+    # Pydantic 2.x
+    if hasattr(model, "model_config"):
+        return getattr(model, "model_config")
+
+    # Pydantic 1.x
+    return Pydantic1ConfigWrapper(getattr(model, "__config__"))
+
+
+try:
+    # Pydantic 2.x
+    from pydantic import model_validator as compat_model_validator  # type: ignore
+except ImportError:
+    # Pydantic 1.x
+    from pydantic import root_validator
+
+    def compat_model_validator(mode="before"):
+        """Mimics the Pydantic 2.x model_validator decorator, which is used to
+        define validation logic for a Pydantic model. This decorator is used
+        to wrap a validation function which is called before or after the
+        model is constructed.
+        """
+
+        def _decorate(func):
+            return (
+                root_validator(pre=True)(func)
+                if mode == "before"
+                else root_validator(post=False)(func)
+            )
+
+        return _decorate

--- a/python_modules/dagster/dagster/_config/pythonic_config/typing_utils.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/typing_utils.py
@@ -8,8 +8,10 @@ from dagster._core.errors import DagsterInvalidDagsterTypeInPythonicConfigDefini
 from .utils import safe_is_subclass
 
 try:
+    # Pydantic 2.x
     from pydantic.main import ModelMetaclass
 except ImportError:
+    # Pydantic 1.x
     from pydantic._internal._model_construction import ModelMetaclass
 
 if TYPE_CHECKING:

--- a/python_modules/dagster/dagster/_config/pythonic_config/typing_utils.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/typing_utils.py
@@ -60,13 +60,6 @@ class LateBoundTypesForResourceTypeChecking:
 class BaseConfigMeta(ModelMetaclass):
     def __new__(cls, name, bases, namespaces, **kwargs) -> Any:
         annotations = namespaces.get("__annotations__", {})
-        # for field in annotations:
-        #     if not field.startswith("__"):
-        #         # Check if the annotation is a ResourceDependency
-        #         if annotations[field] == str:
-        #             annotations[field] = Union[str, EnvVar]
-
-        # namespaces["__annotations__"] = annotations
 
         # Need try/catch because DagsterType may not be loaded when some of the base Config classes are
         # being created
@@ -118,7 +111,6 @@ class BaseResourceMeta(BaseConfigMeta):
                     get_origin(annotations[field])
                     == LateBoundTypesForResourceTypeChecking.get_resource_rep_type()
                 ):
-                    # arg = get_args(annotations[field])[0]
                     # If so, we treat it as a Union of a PartialResource and a Resource
                     # for Pydantic's sake.
                     annotations[field] = Annotated[Any, "resource_dependency"]

--- a/python_modules/dagster/dagster/_config/pythonic_config/typing_utils.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/typing_utils.py
@@ -12,7 +12,7 @@ try:
     from pydantic.main import ModelMetaclass
 except ImportError:
     # Pydantic 1.x
-    from pydantic._internal._model_construction import ModelMetaclass
+    from pydantic._internal._model_construction import ModelMetaclass  # type: ignore
 
 if TYPE_CHECKING:
     from dagster._config.pythonic_config import PartialResource
@@ -59,7 +59,7 @@ class LateBoundTypesForResourceTypeChecking:
 
 
 @dataclass_transform(kw_only_default=True, field_specifiers=(Field,))
-class BaseConfigMeta(ModelMetaclass):
+class BaseConfigMeta(ModelMetaclass):  # type: ignore
     def __new__(cls, name, bases, namespaces, **kwargs) -> Any:
         annotations = namespaces.get("__annotations__", {})
 

--- a/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_basic_pythonic_config.py
+++ b/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_basic_pythonic_config.py
@@ -741,7 +741,7 @@ def test_structured_run_config_optional() -> None:
         a_struct_config_op()
 
     a_job.execute_in_process(
-        RunConfig(ops={"a_struct_config_op": ANewConfigOpConfig(a_string=None)})  # type: ignore
+        RunConfig(ops={"a_struct_config_op": ANewConfigOpConfig(a_string=None)})
     )
     assert executed["yes"]
 
@@ -850,7 +850,7 @@ def test_structured_run_config_assets_optional() -> None:
         [my_asset],
         run_config=RunConfig(
             ops={
-                "my_asset": AnAssetConfig(),  # type: ignore
+                "my_asset": AnAssetConfig(),
             }
         ),
     )

--- a/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_constraints.py
+++ b/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_constraints.py
@@ -10,19 +10,26 @@ def test_str_min_length() -> None:
         a_str: str = Field(min_length=2, max_length=10)
 
     AStringConfig(a_str="foo")
-    with pytest.raises(ValidationError, match="ensure this value has at least 2 characters"):
+    with pytest.raises(ValidationError, match=" at least 2 characters"):
         AStringConfig(a_str="f")
-    with pytest.raises(ValidationError, match="ensure this value has at most 10 characters"):
+    with pytest.raises(ValidationError, match=" at most 10 characters"):
         AStringConfig(a_str="foofoofoofoofoo")
 
 
 def test_str_regex() -> None:
-    class AStringConfig(Config):
-        a_str: str = Field(regex=r"^(foo)+$")
+    try:
+
+        class AStringConfig(Config):  # type: ignore
+            a_str: str = Field(regex=r"^(foo)+$")
+
+    except:
+
+        class AStringConfig(Config):
+            a_str: str = Field(pattern=r"^(foo)+$")
 
     AStringConfig(a_str="foo")
     AStringConfig(a_str="foofoofoo")
-    with pytest.raises(ValidationError, match="string does not match regex"):
+    with pytest.raises(ValidationError, match="match"):
         AStringConfig(a_str="bar")
 
 
@@ -31,9 +38,9 @@ def test_int_gtlt() -> None:
         an_int: int = Field(gt=0, lt=10)
 
     AnIntConfig(an_int=5)
-    with pytest.raises(ValidationError, match="ensure this value is less than 10"):
+    with pytest.raises(ValidationError, match=" less than 10"):
         AnIntConfig(an_int=10)
-    with pytest.raises(ValidationError, match="ensure this value is greater than 0"):
+    with pytest.raises(ValidationError, match=" greater than 0"):
         AnIntConfig(an_int=0)
 
 
@@ -44,9 +51,9 @@ def test_int_gele() -> None:
     AnIntConfig(an_int=5)
     AnIntConfig(an_int=10)
     AnIntConfig(an_int=0)
-    with pytest.raises(ValidationError, match="ensure this value is less than or equal to 10"):
+    with pytest.raises(ValidationError, match=" less than or equal to 10"):
         AnIntConfig(an_int=11)
-    with pytest.raises(ValidationError, match="ensure this value is greater than or equal to 0"):
+    with pytest.raises(ValidationError, match=" greater than or equal to 0"):
         AnIntConfig(an_int=-1)
 
 
@@ -58,9 +65,9 @@ def test_int_multiple() -> None:
     AnIntConfig(an_int=10)
     AnIntConfig(an_int=0)
     AnIntConfig(an_int=-5)
-    with pytest.raises(ValidationError, match="ensure this value is a multiple of 5"):
+    with pytest.raises(ValidationError, match=" a multiple of 5"):
         AnIntConfig(an_int=4)
-    with pytest.raises(ValidationError, match="ensure this value is a multiple of 5"):
+    with pytest.raises(ValidationError, match=" a multiple of 5"):
         AnIntConfig(an_int=-4)
 
 
@@ -69,9 +76,9 @@ def test_float_gtlt() -> None:
         a_float: float = Field(gt=0, lt=10)
 
     AnFloatConfig(a_float=5)
-    with pytest.raises(ValidationError, match="ensure this value is less than 10"):
+    with pytest.raises(ValidationError, match=" less than 10"):
         AnFloatConfig(a_float=10)
-    with pytest.raises(ValidationError, match="ensure this value is greater than 0"):
+    with pytest.raises(ValidationError, match=" greater than 0"):
         AnFloatConfig(a_float=0)
 
 
@@ -82,9 +89,9 @@ def test_float_gele() -> None:
     AnFloatConfig(a_float=5)
     AnFloatConfig(a_float=10)
     AnFloatConfig(a_float=0)
-    with pytest.raises(ValidationError, match="ensure this value is less than or equal to 10"):
+    with pytest.raises(ValidationError, match=" less than or equal to 10"):
         AnFloatConfig(a_float=11)
-    with pytest.raises(ValidationError, match="ensure this value is greater than or equal to 0"):
+    with pytest.raises(ValidationError, match=" greater than or equal to 0"):
         AnFloatConfig(a_float=-1)
 
 
@@ -95,10 +102,9 @@ def test_float_multiple() -> None:
     AnFloatConfig(a_float=1)
     AnFloatConfig(a_float=0.5)
     AnFloatConfig(a_float=0)
-    AnFloatConfig(a_float=-3)
-    with pytest.raises(ValidationError, match="ensure this value is a multiple of 0.5"):
+    with pytest.raises(ValidationError, match=" a multiple of 0.5"):
         AnFloatConfig(a_float=0.25)
-    with pytest.raises(ValidationError, match="ensure this value is a multiple of 0.5"):
+    with pytest.raises(ValidationError, match=" a multiple of 0.5"):
         AnFloatConfig(a_float=-0.3)
 
 
@@ -107,12 +113,13 @@ def test_list_length() -> None:
         a_list: List[int] = Field(min_items=2, max_items=10)
 
     AListConfig(a_list=[1, 2])
-    with pytest.raises(ValidationError, match="ensure this value has at least 2 items"):
+    with pytest.raises(ValidationError, match=" at least 2 items"):
         AListConfig(a_list=[1])
-    with pytest.raises(ValidationError, match="ensure this value has at most 10 items"):
+    with pytest.raises(ValidationError, match=" at most 10 items"):
         AListConfig(a_list=[1] * 11)
 
 
+@pytest.mark.skip("removed in pydantic 2")
 def test_list_uniqueness() -> None:
     class AListConfig(Config):
         a_list: List[int] = Field(unique_items=True)
@@ -131,18 +138,25 @@ def test_with_constr() -> None:
         a_str: constr(min_length=2, max_length=10)  # type: ignore
 
     AStringConfig(a_str="foo")
-    with pytest.raises(ValidationError, match="ensure this value has at least 2 characters"):
+    with pytest.raises(ValidationError, match=" at least 2 characters"):
         AStringConfig(a_str="f")
-    with pytest.raises(ValidationError, match="ensure this value has at most 10 characters"):
+    with pytest.raises(ValidationError, match=" at most 10 characters"):
         AStringConfig(a_str="foofoofoofoofoo")
 
 
 def test_with_conlist() -> None:
-    class AListConfig(Config):
-        a_list: conlist(int, min_items=2, max_items=10)  # type: ignore
+    try:
+
+        class AListConfig(Config):  # type: ignore
+            a_list: conlist(int, min_length=2, max_length=10)  # type: ignore
+
+    except:
+
+        class AListConfig(Config):
+            a_list: conlist(int, min_items=2, max_items=10)  # type: ignore
 
     AListConfig(a_list=[1, 2])
-    with pytest.raises(ValidationError, match="ensure this value has at least 2 items"):
+    with pytest.raises(ValidationError, match=" at least 2 items"):
         AListConfig(a_list=[1])
-    with pytest.raises(ValidationError, match="ensure this value has at most 10 items"):
+    with pytest.raises(ValidationError, match=" at most 10 items"):
         AListConfig(a_list=[1] * 11)

--- a/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_constraints.py
+++ b/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_constraints.py
@@ -2,6 +2,7 @@ from typing import List
 
 import pytest
 from dagster._config.pythonic_config import Config
+from dagster._config.pythonic_config.pydantic_compat_layer import USING_PYDANTIC_2
 from pydantic import Field, ValidationError, conlist, constr
 
 
@@ -119,7 +120,7 @@ def test_list_length() -> None:
         AListConfig(a_list=[1] * 11)
 
 
-@pytest.mark.skip("removed in pydantic 2")
+@pytest.mark.skipif(USING_PYDANTIC_2, "Removed in pydantic 2")
 def test_list_uniqueness() -> None:
     class AListConfig(Config):
         a_list: List[int] = Field(unique_items=True)

--- a/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_constraints.py
+++ b/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_constraints.py
@@ -120,7 +120,7 @@ def test_list_length() -> None:
         AListConfig(a_list=[1] * 11)
 
 
-@pytest.mark.skipif(USING_PYDANTIC_2, "Removed in pydantic 2")
+@pytest.mark.skipif(USING_PYDANTIC_2, reason="Removed in pydantic 2")
 def test_list_uniqueness() -> None:
     class AListConfig(Config):
         a_list: List[int] = Field(unique_items=True)

--- a/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_errors.py
+++ b/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_errors.py
@@ -389,6 +389,7 @@ def test_trying_to_set_a_field_resource() -> None:
         my_resource.my_str = "bar"
 
 
+@pytest.mark.skip(reason="Does not throw error in Pydantic 2")
 def test_trying_to_set_an_undefined_field() -> None:
     class MyConfig(Config):
         my_str: str
@@ -405,6 +406,7 @@ def test_trying_to_set_an_undefined_field() -> None:
         my_config._my_random_other_field = "bar"  # noqa: SLF001
 
 
+@pytest.mark.skip(reason="Does not throw error in Pydantic 2")
 def test_trying_to_set_an_undefined_field_resource() -> None:
     class MyResource(ConfigurableResource):
         my_str: str

--- a/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_errors.py
+++ b/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_errors.py
@@ -10,6 +10,7 @@ from dagster import (
     sensor,
 )
 from dagster._config.pythonic_config import ConfigurableResource, ConfigurableResourceFactory
+from dagster._config.pythonic_config.pydantic_compat_layer import USING_PYDANTIC_2
 from dagster._core.definitions.resource_definition import ResourceDefinition
 from dagster._core.errors import (
     DagsterInvalidDagsterTypeInPythonicConfigDefinitionError,
@@ -389,7 +390,7 @@ def test_trying_to_set_a_field_resource() -> None:
         my_resource.my_str = "bar"
 
 
-@pytest.mark.skip(reason="Does not throw error in Pydantic 2")
+@pytest.mark.skipif(USING_PYDANTIC_2, reason="Does not throw error in Pydantic 2")
 def test_trying_to_set_an_undefined_field() -> None:
     class MyConfig(Config):
         my_str: str
@@ -406,7 +407,7 @@ def test_trying_to_set_an_undefined_field() -> None:
         my_config._my_random_other_field = "bar"  # noqa: SLF001
 
 
-@pytest.mark.skip(reason="Does not throw error in Pydantic 2")
+@pytest.mark.skipif(USING_PYDANTIC_2, reason="Does not throw error in Pydantic 2")
 def test_trying_to_set_an_undefined_field_resource() -> None:
     class MyResource(ConfigurableResource):
         my_str: str

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_general_pythonic_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_general_pythonic_resources.py
@@ -100,7 +100,7 @@ def test_invalid_config() -> None:
     with pytest.raises(
         ValidationError,
     ):
-        MyResource(foo="why")  # pyright: ignore[reportGeneralTypeIssues]
+        MyResource(foo="why")
 
 
 @pytest.mark.skipif(sys.version_info < (3, 8), reason="requires python3.8")

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -103,7 +103,7 @@ setup(
         "docstring-parser",
         "universal_pathlib",
         # https://github.com/pydantic/pydantic/issues/5821
-        "pydantic != 1.10.7,<2.0.0",
+        "pydantic!=1.10.7",
     ],
     extras_require={
         "docker": ["docker"],

--- a/python_modules/dagster/tox.ini
+++ b/python_modules/dagster/tox.ini
@@ -14,6 +14,8 @@ deps =
   storage_tests_sqlalchemy_1_3: sqlalchemy<1.4
   storage_tests_sqlalchemy_1_4: sqlalchemy<2
   general_tests_old_protobuf: protobuf<4
+  core_tests_pydantic1:  pydantic!=1.10.7,<2.0.0
+  core_tests_pydantic2:  pydantic>=2.0.0
   -e ../dagster-test
   -e .[mypy,test,pyright]
 allowlist_externals =
@@ -23,7 +25,8 @@ commands =
 
   api_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/api_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
   cli_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/cli_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
-  core_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/core_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
+  core_tests_pydantic1: pytest -c ../../pyproject.toml -vv ./dagster_tests/core_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
+  core_tests_pydantic2: pytest -c ../../pyproject.toml -vv ./dagster_tests/core_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
   type_signature_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/core_tests  {env:COVERAGE_ARGS} --durations 10 {posargs} -m 'typesignature'
   storage_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/storage_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
   definitions_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/definitions_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}

--- a/python_modules/dagster/tox.ini
+++ b/python_modules/dagster/tox.ini
@@ -16,6 +16,7 @@ deps =
   general_tests_old_protobuf: protobuf<4
   core_tests_pydantic1:  pydantic!=1.10.7,<2.0.0
   core_tests_pydantic2:  pydantic>=2.0.0
+  type_signature_tests:  pydantic!=1.10.7,<2.0.0
   -e ../dagster-test
   -e .[mypy,test,pyright]
 allowlist_externals =

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/resources.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/resources.py
@@ -6,27 +6,11 @@ from dagster import (
     IAttachDifferentObjectToOpContext,
     resource,
 )
+from dagster._config.pythonic_config.pydantic_compat_layer import compat_model_validator
 from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from pydantic import Field
 
 from .databricks import DatabricksClient
-
-try:
-    # Pydantic 2.x
-    from pydantic import model_validator  # type: ignore
-except ImportError:
-    # Pydantic 1.x
-    from pydantic import root_validator
-
-    def model_validator(mode="before"):
-        def _decorate(func):
-            return (
-                root_validator(pre=True)(func)
-                if mode == "before"
-                else root_validator(post=False)(func)
-            )
-
-        return _decorate
 
 
 class OauthCredentials(Config):
@@ -62,7 +46,7 @@ class DatabricksClientResource(ConfigurableResource, IAttachDifferentObjectToOpC
         ),
     )
 
-    @model_validator(mode="before")
+    @compat_model_validator(mode="before")
     def has_token_or_oauth_credentials(cls, values):
         token = values.get("token")
         oauth_credentials = values.get("oauth_credentials")

--- a/python_modules/libraries/dagster-datahub/dagster_datahub/resources.py
+++ b/python_modules/libraries/dagster-datahub/dagster_datahub/resources.py
@@ -93,7 +93,9 @@ class DatahubKafkaEmitterResource(ConfigurableResource):
 
     def get_emitter(self) -> DatahubKafkaEmitter:
         return DatahubKafkaEmitter(
-            KafkaEmitterConfig.parse_obj(self._convert_to_config_dictionary())
+            KafkaEmitterConfig.parse_obj(
+                {k: v for k, v in self._convert_to_config_dictionary().items() if v is not None}
+            )
         )
 
 

--- a/python_modules/libraries/dagster-datahub/setup.py
+++ b/python_modules/libraries/dagster-datahub/setup.py
@@ -40,6 +40,7 @@ setup(
         f"dagster{pin}",
         "packaging",
         "requests",
+        "pydantic>=1.10.0,<2.0.0",
     ],
     extras_require={},
     zip_safe=False,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resources_v2.py
@@ -56,7 +56,7 @@ def test_dbt_cli_manifest_argument(manifest: DbtManifestParam) -> None:
 
 
 def test_dbt_cli_project_dir_path() -> None:
-    dbt = DbtCliResource(project_dir=Path(TEST_PROJECT_DIR))  # type: ignore
+    dbt = DbtCliResource(project_dir=Path(TEST_PROJECT_DIR))
 
     assert dbt.cli(["run"]).is_successful()
 
@@ -143,7 +143,7 @@ def test_dbt_profile_configuration() -> None:
 def test_dbt_profile_dir_configuration(profiles_dir: Union[str, Path]) -> None:
     dbt = DbtCliResource(
         project_dir=TEST_PROJECT_DIR,
-        profiles_dir=profiles_dir,  # type: ignore
+        profiles_dir=profiles_dir,
     )
 
     assert dbt.cli(["parse"]).is_successful()

--- a/python_modules/libraries/dagster-ge/setup.py
+++ b/python_modules/libraries/dagster-ge/setup.py
@@ -36,11 +36,5 @@ setup(
         "pandas",
         "great_expectations >=0.11.9, !=0.12.8, !=0.13.17, !=0.13.27, <0.17.12",
     ],
-    extras_require={
-        "test": [
-            # https://github.com/great-expectations/great_expectations/issues/7990
-            "typing_extensions<4.6.0",
-        ],
-    },
     zip_safe=False,
 )

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
@@ -17,7 +17,14 @@ from dagster._annotations import public
 from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._core.storage.event_log.sql_event_log import SqlDbConnection
 from dagster._utils.cached_method import cached_method
-from pydantic import Field, root_validator, validator
+from pydantic import Field, validator
+
+try:
+    from pydantic import model_validator
+except:
+    from pydantic import root_validator
+
+    model_validator = root_validator
 
 try:
     import snowflake.connector
@@ -271,7 +278,7 @@ class SnowflakeResource(ConfigurableResource, IAttachDifferentObjectToOpContext)
             )
         return v
 
-    @root_validator
+    @model_validator
     def validate_authentication(cls, values):
         auths_set = 0
         auths_set += 1 if values.get("password") is not None else 0

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
@@ -14,28 +14,11 @@ from dagster import (
     resource,
 )
 from dagster._annotations import public
+from dagster._config.pythonic_config.pydantic_compat_layer import compat_model_validator
 from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._core.storage.event_log.sql_event_log import SqlDbConnection
 from dagster._utils.cached_method import cached_method
 from pydantic import Field, validator
-
-try:
-    # Pydantic 2.x
-    from pydantic import model_validator  # type: ignore
-except ImportError:
-    # Pydantic 1.x
-    from pydantic import root_validator
-
-    def model_validator(mode="before"):
-        def _decorate(func):
-            return (
-                root_validator(pre=True)(func)
-                if mode == "before"
-                else root_validator(post=False)(func)
-            )
-
-        return _decorate
-
 
 try:
     import snowflake.connector
@@ -289,7 +272,7 @@ class SnowflakeResource(ConfigurableResource, IAttachDifferentObjectToOpContext)
             )
         return v
 
-    @model_validator(mode="before")
+    @compat_model_validator(mode="before")
     def validate_authentication(cls, values):
         auths_set = 0
         auths_set += 1 if values.get("password") is not None else 0

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
@@ -21,7 +21,7 @@ from pydantic import Field, validator
 
 try:
     # Pydantic 2.x
-    from pydantic import model_validator
+    from pydantic import model_validator  # type: ignore
 except ImportError:
     # Pydantic 1.x
     from pydantic import root_validator

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
@@ -20,8 +20,10 @@ from dagster._utils.cached_method import cached_method
 from pydantic import Field, validator
 
 try:
+    # Pydantic 2.x
     from pydantic import model_validator
 except ImportError:
+    # Pydantic 1.x
     from pydantic import root_validator
 
     def model_validator(mode="before"):


### PR DESCRIPTION
## Summary

Implements a compat layer which allows Dagster to be used with Pydantic 1.x and Pydantic 2.x. Addresses #15162.

See #15793 for a straight Pydantic 2.x port which does not introduce a compat layer. This PR takes those changes & builds in a layer to get them to work with Pydantic 1.x.

Most of the changes here involve moving away from analyzing the Pydantic `Field` model, which was largely dropped in 2.x, in favor of directly analyzing the type annotation itself. This allows us to clean up the logic slightly, and meant the port is not too painful.

## Test Plan

Run existing unit tests against Pydantic 1.x and 2.x. TODO: More new unit tests to explicitly test behavior which the changes in this PR touch most.