### PR TITLE
Add versions to dagster dbt scaffold `setup.py`

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/include/setup.py.jinja
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/include/setup.py.jinja
@@ -12,9 +12,9 @@ setup(
     },
     {%- endif %}
     install_requires=[
-        "dagster",
-        "dagster-cloud",
-        "dagster-dbt",
+        "dagster>=1.4.0",
+        "dagster-cloud>=1.4.0",
+        "dagster-dbt>=0.20.0",
         "dbt-core>=1.4.0",
         {% for dbt_adapter in dbt_adapter_packages -%}
         "{{ dbt_adapter }}",
@@ -23,6 +23,11 @@ setup(
     extras_require={
         "dev": [
             "dagster-webserver",
+        ]
+    },
+    entry_points = {
+        'console_scripts': [
+            "dagster = dagster.cli:main",
         ]
     },
 )


### PR DESCRIPTION
Transient constraints cause pip to sometimes install dagster=0.0.1, instead we want to lock the version in at >1.4.X.

Users are also seeing a `No module named dagster.__main__` error. I wasn't able to repro this, but [stack overflow](https://stackoverflow.com/questions/71191907/no-module-named-x-main-x-is-a-package-and-cannot-be-directly-executed-w) suggests we add the following lines to `setup.py`, which we do in other libraries:
```
entry_points = {
      'console_scripts': [
          "dagster = dagster.cli:main",
      ]
 }
```