### PR TITLE
[cron] special case leap day schedule

### DIFF
--- a/python_modules/dagster/dagster/_utils/schedules.py
+++ b/python_modules/dagster/dagster/_utils/schedules.py
@@ -1,3 +1,4 @@
+import calendar
 import datetime
 import functools
 from typing import Iterator, Optional, Sequence, Union
@@ -55,6 +56,24 @@ def cron_string_iterator(
     start_offset: int = 0,
 ) -> Iterator[datetime.datetime]:
     """Generator of datetimes >= start_timestamp for the given cron string."""
+    # leap day special casing
+    if cron_string.endswith(" 29 2 *"):
+        min_hour, _ = cron_string.split(" 29 2 *")
+        day_before = f"{min_hour} 28 2 *"
+        # run the iterator for Feb 28th
+        for dt in cron_string_iterator(
+            start_timestamp=start_timestamp,
+            cron_string=day_before,
+            execution_timezone=execution_timezone,
+            start_offset=start_offset,
+        ):
+            # only return on leap years
+            if calendar.isleap(dt.year):
+                # shift 28th back to 29th
+                shifted_dt = dt + datetime.timedelta(days=1)
+                yield shifted_dt
+        return
+
     timezone_str = execution_timezone if execution_timezone else "UTC"
 
     utc_datetime = pytz.utc.localize(datetime.datetime.utcfromtimestamp(start_timestamp))

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_cron_string_iterator.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_cron_string_iterator.py
@@ -1,3 +1,5 @@
+import calendar
+
 import pytest
 from dagster._seven.compat.pendulum import create_pendulum_time, to_timezone
 from dagster._utils.schedules import cron_string_iterator
@@ -17,6 +19,25 @@ def test_cron_iterator_always_advances():
     next_datetime = next(cron_iter)
 
     assert next_datetime.timestamp() > start_timestamp
+
+
+def test_cron_iterator_leap_day():
+    tz = "Europe/Berlin"
+
+    start_timestamp = create_pendulum_time(2023, 3, 27, 1, 0, 0, tz=tz).timestamp()
+
+    cron_iter = cron_string_iterator(
+        start_timestamp + 1,
+        "2 4 29 2 *",
+        tz,
+    )
+
+    for _ in range(100):
+        next_datetime = next(cron_iter)
+        assert next_datetime.day == 29
+        assert calendar.isleap(next_datetime.year)
+        assert next_datetime.hour == 4
+        assert next_datetime.minute == 2
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Add special case handling for the cron schedule `X Y 29 2 *` which `cronitor` chokes on (at least with how we use it) by playing the  `X Y 28 2 *` cron and filtering out non leap years using `calendar.isleap` 

## How I Tested These Changes

added test