### PR TITLE
add asset_key property to context

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -449,9 +449,10 @@ class OpExecutionContext(AbstractComputeExecutionContext):
     @public
     @property
     def asset_key(self) -> AssetKey:
+        """The AssetKey for the current asset. In a multi_asset, use asset_key_for_output instead."""
         if self.has_assets_def and len(self.assets_def.keys_by_output_name.keys()) > 1:
-            check.failed(
-                "Cannot call `context.asset_key` on a multi_asset. Use"
+            raise DagsterInvariantViolationError(
+                "Cannot call `context.asset_key` in a multi_asset. Use"
                 " `context.asset_key_for_output` instead."
             )
         return self.asset_key_for_output()

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -452,10 +452,13 @@ class OpExecutionContext(AbstractComputeExecutionContext):
         """The AssetKey for the current asset. In a multi_asset, use asset_key_for_output instead."""
         if self.has_assets_def and len(self.assets_def.keys_by_output_name.keys()) > 1:
             raise DagsterInvariantViolationError(
-                "Cannot call `context.asset_key` in a multi_asset. Use"
+                "Cannot call `context.asset_key` in a multi_asset with more than one asset. Use"
                 " `context.asset_key_for_output` instead."
             )
-        return self.asset_key_for_output()
+        # pass in the output name to handle the case when a multi_asset has a single AssetOut
+        return self.asset_key_for_output(
+            output_name=list(self.assets_def.keys_by_output_name.keys())[0]
+        )
 
     @public
     @property

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -449,6 +449,11 @@ class OpExecutionContext(AbstractComputeExecutionContext):
     @public
     @property
     def asset_key(self) -> AssetKey:
+        if self.has_assets_def and len(self.assets_def.keys_by_output_name.keys()) > 1:
+            check.failed(
+                "Cannot call `context.asset_key` on a multi_asset. Use"
+                " `context.asset_key_for_output` instead."
+            )
         return self.asset_key_for_output()
 
     @public

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -448,6 +448,11 @@ class OpExecutionContext(AbstractComputeExecutionContext):
 
     @public
     @property
+    def asset_key(self) -> AssetKey:
+        return self.asset_key_for_output()
+
+    @public
+    @property
     def has_assets_def(self) -> bool:
         """If there is a backing AssetsDefinition for what is currently executing."""
         assets_def = self.job_def.asset_layer.assets_def_for_node(self.node_handle)

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -1663,7 +1663,7 @@ def test_return_materialization():
     def logged(context: AssetExecutionContext):
         context.log_event(
             AssetMaterialization(
-                asset_key=context.asset_key_for_output(),
+                asset_key=context.asset_key,
                 metadata={"one": 1},
             )
         )

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -1995,3 +1995,29 @@ def test_asset_spec_deps():
         )
         def use_internal_deps():
             ...
+
+
+def test_asset_key_on_context():
+    @asset
+    def test_asset_key_on_context(context: AssetExecutionContext):
+        assert context.asset_key == AssetKey(["test_asset_key_on_context"])
+
+    @asset(key_prefix=["a_prefix"])
+    def test_asset_key_on_context_with_prefix(context: AssetExecutionContext):
+        assert context.asset_key == AssetKey(["a_prefix", "test_asset_key_on_context_with_prefix"])
+
+    materialize([test_asset_key_on_context, test_asset_key_on_context_with_prefix])
+
+
+def test_multi_asset_asset_key_on_context():
+    @multi_asset(
+        outs={
+            "my_string_asset": AssetOut(),
+            "my_int_asset": AssetOut(),
+        }
+    )
+    def asset_key_context(context: AssetExecutionContext):
+        return context.asset_key, 12
+
+    with pytest.raises(DagsterInvariantViolationError):
+        materialize([asset_key_context])

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
@@ -854,7 +854,7 @@ def test_graph_asset_group_name_for_multiple_assets():
 def test_execute_graph_asset():
     @op(out={"x": Out(), "y": Out()})
     def x_op(context):
-        assert context.asset_key == AssetKey("x_asset")
+        assert context.asset_key_for_output("x") == AssetKey("x_asset")
         return 1, 2
 
     @graph(out={"x": GraphOut(), "y": GraphOut()})

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
@@ -86,7 +86,7 @@ def _asset_keys_for_node(result, node_name):
 def test_single_asset_job():
     @asset
     def asset1(context):
-        assert context.asset_key_for_output() == AssetKey(["asset1"])
+        assert context.asset_key == AssetKey(["asset1"])
         return 1
 
     job = build_assets_job("a", [asset1])
@@ -854,7 +854,7 @@ def test_graph_asset_group_name_for_multiple_assets():
 def test_execute_graph_asset():
     @op(out={"x": Out(), "y": Out()})
     def x_op(context):
-        assert context.asset_key_for_output("x") == AssetKey("x_asset")
+        assert context.asset_key == AssetKey("x_asset")
         return 1, 2
 
     @graph(out={"x": GraphOut(), "y": GraphOut()})

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_dynamic_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_dynamic_partitions.py
@@ -90,7 +90,7 @@ def test_dynamic_partitioned_asset_dep():
     @asset(partitions_def=partitions_def, deps=[asset1])
     def asset2(context):
         assert context.partition_key == "apple"
-        assert context.asset_key_for_output() == "apple"
+        assert context.asset_key == "apple"
         assert context.asset_keys_for_output() == ["apple"]
         assert context.asset_key_for_input() == "apple"
         assert context.asset_keys_for_input() == ["apple"]


### PR DESCRIPTION
## Summary & Motivation
Adds an `asset_key` property to `OpExectutionContext`/`AssetExecutionContext` 

## How I Tested These Changes
updated existing usages of `context.asset_key_for_output()` to `context.asset_key`