### PR TITLE
Short-circuit earlier for partitioned assets with no partition key in stale resolution

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -599,8 +599,6 @@ class GrapheneAssetNode(graphene.ObjectType):
     ) -> Any:  # (GrapheneAssetStaleStatus)
         if partition:
             self._validate_partitions_existence()
-        # The status loader does not support querying for the stale status of a
-        # partitioned asset without specifying a partition, so we return here.
         return self.stale_status_loader.get_status(self._external_asset_node.asset_key, partition)
 
     def resolve_staleStatusByPartition(


### PR DESCRIPTION
## Summary & Motivation

Should prevent a certain class of performance issues associated with partitioned assets on asset catalog: https://elementl-workspace.slack.com/archives/C03CCE471E0/p1693538279955379

## How I Tested These Changes

Existing test suite
