### PR TITLE
[ui] Backfill status tag

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/instance/BackfillRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/BackfillRow.tsx
@@ -33,6 +33,7 @@ import {buildRepoAddress} from '../workspace/buildRepoAddress';
 import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
 import {workspacePathFromAddress, workspacePipelinePath} from '../workspace/workspacePath';
 
+import {BackfillStatusTagForPage} from './BackfillStatusTagForPage';
 import {
   PartitionStatusesForBackfillFragment,
   SingleBackfillCountsQuery,
@@ -448,12 +449,16 @@ export const BackfillStatusTag = ({
   backfill,
   counts,
 }: {
-  backfill: Pick<BackfillTableFragment, 'status' | 'error' | 'partitionNames'>;
+  backfill: BackfillTableFragment;
   counts: {[status: string]: number} | null;
 }) => {
+  if (backfill.isAssetBackfill) {
+    return <BackfillStatusTagForPage backfill={backfill} />;
+  }
+
   switch (backfill.status) {
     case BulkActionStatus.REQUESTED:
-      return <Tag>In Progress</Tag>;
+      return <Tag>In progress</Tag>;
     case BulkActionStatus.FAILED:
       return (
         <Box margin={{bottom: 12}}>

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/BackfillStatusTagForPage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/BackfillStatusTagForPage.tsx
@@ -1,0 +1,58 @@
+import {Box, Tag} from '@dagster-io/ui-components';
+import * as React from 'react';
+import styled from 'styled-components';
+
+import {showCustomAlert} from '../app/CustomAlertProvider';
+import {PythonErrorInfo} from '../app/PythonErrorInfo';
+import {PythonErrorFragment} from '../app/types/PythonErrorFragment.types';
+import {BulkActionStatus} from '../graphql/types';
+
+type BackfillState = {
+  status: BulkActionStatus;
+  error: PythonErrorFragment | null;
+};
+
+export const BackfillStatusTagForPage = ({backfill}: {backfill: BackfillState}) => {
+  const {status, error} = backfill;
+  function errorState(status: string) {
+    return (
+      <Box margin={{bottom: 12}}>
+        <TagButton
+          onClick={() =>
+            error && showCustomAlert({title: 'Error', body: <PythonErrorInfo error={error} />})
+          }
+        >
+          <Tag intent="danger">{status}</Tag>
+        </TagButton>
+      </Box>
+    );
+  }
+
+  switch (status) {
+    case BulkActionStatus.REQUESTED:
+      return <Tag>In progress</Tag>;
+
+    case BulkActionStatus.CANCELING:
+      return errorState('Canceling');
+    case BulkActionStatus.CANCELED:
+      return errorState('Canceled');
+    case BulkActionStatus.FAILED:
+      return errorState('Failed');
+    case BulkActionStatus.COMPLETED:
+      return <Tag intent="success">Completed</Tag>;
+    default:
+      return <Tag>{status}</Tag>;
+  }
+};
+
+const TagButton = styled.button`
+  border: none;
+  background: none;
+  cursor: pointer;
+  padding: 0;
+  margin: 0;
+
+  :focus {
+    outline: none;
+  }
+`;

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillPage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillPage.tsx
@@ -13,6 +13,7 @@ import {
   ButtonLink,
   DialogBody,
   NonIdealState,
+  Heading,
 } from '@dagster-io/ui-components';
 import dayjs from 'dayjs';
 import duration from 'dayjs/plugin/duration';
@@ -21,7 +22,6 @@ import React from 'react';
 import {Link, useParams} from 'react-router-dom';
 import styled from 'styled-components';
 
-import {showCustomAlert} from '../../app/CustomAlertProvider';
 import {PYTHON_ERROR_FRAGMENT} from '../../app/PythonErrorFragment';
 import {PythonErrorInfo} from '../../app/PythonErrorInfo';
 import {QueryRefreshCountdown, useQueryRefreshAtInterval} from '../../app/QueryRefresh';
@@ -35,6 +35,7 @@ import {TruncatedTextWithFullTextOnHover} from '../../nav/getLeftNavItemsForOpti
 import {RunFilterToken, runsPathWithFilters} from '../../runs/RunsFilterInput';
 import {testId} from '../../testing/testId';
 import {numberFormatter} from '../../ui/formatters';
+import {BackfillStatusTagForPage} from '../BackfillStatusTagForPage';
 
 import {
   BackfillStatusesByAssetQuery,
@@ -178,7 +179,7 @@ export const BackfillPage = () => {
               />
             }
           />
-          <Detail label="Status" detail={<StatusLabel backfill={backfill} />} />
+          <Detail label="Status" detail={<BackfillStatusTagForPage backfill={backfill} />} />
         </Box>
         <Table>
           <thead>
@@ -273,13 +274,13 @@ export const BackfillPage = () => {
     <Page>
       <PageHeader
         title={
-          <div style={{fontSize: '18px'}}>
+          <Heading>
             <Link to="/overview/backfills" style={{color: Colors.Gray700}}>
               Backfills
             </Link>
             {' / '}
             {backfillId}
-          </div>
+          </Heading>
         }
         right={isInProgress ? <QueryRefreshCountdown refreshState={refreshState} /> : null}
       />
@@ -294,38 +295,6 @@ const Detail = ({label, detail}: {label: JSX.Element | string; detail: JSX.Eleme
     <div>{detail}</div>
   </Box>
 );
-
-const StatusLabel = ({backfill}: {backfill: PartitionBackfillFragment}) => {
-  function errorState(status: string) {
-    return (
-      <Box margin={{bottom: 12}}>
-        <TagButton
-          onClick={() =>
-            backfill.error &&
-            showCustomAlert({title: 'Error', body: <PythonErrorInfo error={backfill.error} />})
-          }
-        >
-          <Tag intent="danger">{status}</Tag>
-        </TagButton>
-      </Box>
-    );
-  }
-  switch (backfill.status) {
-    case BulkActionStatus.REQUESTED:
-      return <Tag>In Progress</Tag>;
-
-    case BulkActionStatus.CANCELING:
-      return errorState('Canceling');
-    case BulkActionStatus.CANCELED:
-      return errorState('Canceled');
-    case BulkActionStatus.FAILED:
-      return errorState('Failed');
-    case BulkActionStatus.COMPLETED:
-      return <Tag intent="success">Completed</Tag>;
-    default:
-      return <Tag>{backfill.status}</Tag>;
-  }
-};
 
 function StatusBar({
   targeted,
@@ -540,15 +509,3 @@ const formatDuration = (duration: number) => {
   }
   return result.trim();
 };
-
-const TagButton = styled.button`
-  border: none;
-  background: none;
-  cursor: pointer;
-  padding: 0;
-  margin: 0;
-
-  :focus {
-    outline: none;
-  }
-`;

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/__tests__/BackfillPage.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/__tests__/BackfillPage.test.tsx
@@ -146,7 +146,7 @@ describe('BackfillPage', () => {
     expect(screen.getByText('Asset name')).toBeVisible();
 
     expect(getByText(detailRow, 'Jan 1, 1970, 12:16:40 AM')).toBeVisible();
-    expect(getByText(detailRow, 'In Progress')).toBeVisible();
+    expect(getByText(detailRow, 'In progress')).toBeVisible();
 
     const assetARow = await screen.findByTestId('backfill-asset-row-assetA');
     // Check if the correct data is displayed


### PR DESCRIPTION
## Summary & Motivation

Use backfill page status tag in the backfill table row for asset backfills. This is to make the status consistent for these backfills.

<img width="1125" alt="Screenshot 2023-09-01 at 12 48 47 PM" src="https://github.com/dagster-io/dagster/assets/2823852/0d3f22f6-44bf-4833-81dd-be46b1cb9d67">
<img width="1120" alt="Screenshot 2023-09-01 at 12 35 12 PM" src="https://github.com/dagster-io/dagster/assets/2823852/50b1b26d-d2e0-48e6-97e7-97b79e3b0497">


## How I Tested These Changes

Kick off an asset backfill, cancel it partway through. Verify that it appears as "Complete" in the table and on the backfill page.
