### PR TITLE
[ui] Asset checks UI in the DAG and sidebar, improved log rendering

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode.tsx
@@ -174,7 +174,7 @@ const AssetNodeChecksRow: React.FC<{
       status === undefined
         ? 'NOT_EVALUATED'
         : status === AssetCheckExecutionResolvedStatus.FAILED
-        ? c.severity === AssetCheckSeverity.WARN
+        ? c.executionForLatestMaterialization?.evaluation?.severity === AssetCheckSeverity.WARN
           ? 'WARN'
           : 'ERROR'
         : status === AssetCheckExecutionResolvedStatus.EXECUTION_FAILED

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode.tsx
@@ -152,7 +152,7 @@ const AssetCheckIconsOrdered: {type: AssetCheckIconType; content: React.ReactNod
   },
   {
     type: AssetCheckExecutionResolvedStatus.SKIPPED,
-    content: <Icon name="check_circle" color={Colors.Green700} />,
+    content: <Icon name="dot" color={Colors.Gray500} />,
   },
   {
     type: AssetCheckExecutionResolvedStatus.SUCCEEDED,

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNodeStatusContent.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNodeStatusContent.tsx
@@ -1,0 +1,369 @@
+import {Body, Colors, Icon, Spinner} from '@dagster-io/ui-components';
+import React from 'react';
+import {Link} from 'react-router-dom';
+
+import {
+  StyleForAssetPartitionStatus,
+  partitionCountString,
+} from '../assets/AssetNodePartitionCounts';
+import {AssetPartitionStatusDot} from '../assets/AssetPartitionList';
+import {AssetPartitionStatus} from '../assets/AssetPartitionStatus';
+import {OverdueLineagePopover, isAssetOverdue} from '../assets/OverdueTag';
+import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
+import {AssetKeyInput} from '../graphql/types';
+import {TimestampDisplay} from '../schedules/TimestampDisplay';
+
+import {AssetLatestRunSpinner, AssetRunLink} from './AssetRunLinking';
+import {LiveDataForNode, stepKeyForAsset} from './Utils';
+
+export enum StatusCase {
+  LOADING = 'LOADING',
+  SOURCE_OBSERVING = 'SOURCE_OBSERVING',
+  SOURCE_OBSERVED = 'SOURCE_OBSERVED',
+  SOURCE_NEVER_OBSERVED = 'SOURCE_NEVER_OBSERVED',
+  SOURCE_NO_STATE = 'SOURCE_NO_STATE',
+  MATERIALIZING = 'MATERIALIZING',
+  LATE_OR_FAILED = 'LATE_OR_FAILED',
+  NEVER_MATERIALIZED = 'NEVER_MATERIALIZED',
+  MATERIALIZED = 'MATERIALIZED',
+  PARTITIONS_FAILED = 'PARTITIONS_FAILED',
+  PARTITIONS_MISSING = 'PARTITIONS_MISSING',
+  PARTITIONS_MATERIALIZED = 'PARTITIONS_MATERIALIZED',
+}
+
+type AssetNodeStatusContent = {
+  case: StatusCase;
+  background: string;
+  border: string;
+  content: React.ReactNode;
+
+  numPartitions?: number;
+  numMissing?: number;
+  numFailed?: number;
+  numMaterialized?: number;
+  numMaterializing?: number;
+};
+
+const LOADING_STATUS_CONTENT: AssetNodeStatusContent = {
+  case: StatusCase.LOADING,
+  background: Colors.Gray100,
+  border: Colors.Gray300,
+  content: (
+    <>
+      <Spinner purpose="caption-text" />
+      <span style={{flex: 1, color: Colors.Gray800}}>Loading...</span>
+    </>
+  ),
+};
+
+type StatusContentArgs = {
+  assetKey: AssetKeyInput;
+  definition: {opNames: string[]; isSource: boolean; isObservable: boolean};
+  liveData: LiveDataForNode | null | undefined;
+  expanded?: boolean;
+};
+
+export function buildAssetNodeStatusContent({
+  assetKey,
+  definition,
+  liveData,
+  expanded,
+}: StatusContentArgs): AssetNodeStatusContent {
+  return definition.isSource
+    ? _buildSourceAssetNodeStatusContent({
+        assetKey,
+        definition,
+        liveData,
+        expanded,
+      })
+    : _buildAssetNodeStatusContent({
+        assetKey,
+        definition,
+        liveData,
+        expanded,
+      });
+}
+
+export function _buildSourceAssetNodeStatusContent({
+  definition,
+  liveData,
+  expanded,
+}: StatusContentArgs): AssetNodeStatusContent {
+  if (!liveData) {
+    return LOADING_STATUS_CONTENT;
+  }
+
+  const {inProgressRunIds, unstartedRunIds} = liveData;
+  const materializingRunId = inProgressRunIds[0] || unstartedRunIds[0];
+
+  if (materializingRunId) {
+    return {
+      case: StatusCase.SOURCE_OBSERVING,
+      background: Colors.Gray100,
+      border: Colors.Gray300,
+      content: (
+        <>
+          <AssetLatestRunSpinner liveData={liveData} purpose="caption-text" />
+          <span style={{flex: 1}} color={Colors.Gray800}>
+            Observing...
+          </span>
+          {expanded && <SpacerDot />}
+          <AssetRunLink runId={materializingRunId} />
+        </>
+      ),
+    };
+  }
+  if (liveData?.lastObservation) {
+    return {
+      case: StatusCase.SOURCE_OBSERVED,
+      background: Colors.Gray100,
+      border: Colors.Gray300,
+      content: (
+        <>
+          {expanded && <AssetPartitionStatusDot status={[AssetPartitionStatus.MISSING]} />}
+          <span>Observed</span>
+          {expanded && <SpacerDot />}
+          <span style={{textAlign: 'right', overflow: 'hidden'}}>
+            <AssetRunLink
+              runId={liveData.lastObservation.runId}
+              event={{
+                stepKey: stepKeyForAsset(definition),
+                timestamp: liveData.lastObservation.timestamp,
+              }}
+            >
+              <TimestampDisplay
+                timestamp={Number(liveData.lastObservation.timestamp) / 1000}
+                timeFormat={{showSeconds: false, showTimezone: false}}
+              />
+            </AssetRunLink>
+          </span>
+        </>
+      ),
+    };
+  }
+  if (definition.isObservable) {
+    return {
+      case: StatusCase.SOURCE_NEVER_OBSERVED,
+      background: Colors.Gray100,
+      border: Colors.Gray300,
+      content: (
+        <>
+          {expanded && (
+            <Icon
+              name="partition_missing"
+              color={Colors.Gray300}
+              style={{marginRight: -2}}
+              size={12}
+            />
+          )}
+          <span>Never observed</span>
+          {!expanded && <span>–</span>}
+        </>
+      ),
+    };
+  }
+
+  return {
+    case: StatusCase.SOURCE_NO_STATE,
+    background: Colors.Gray100,
+    border: Colors.Gray300,
+    content: <span>–</span>,
+  };
+}
+
+export function _buildAssetNodeStatusContent({
+  assetKey,
+  definition,
+  liveData,
+  expanded,
+}: StatusContentArgs): AssetNodeStatusContent {
+  if (!liveData) {
+    return LOADING_STATUS_CONTENT;
+  }
+
+  const {
+    lastMaterialization,
+    runWhichFailedToMaterialize,
+    inProgressRunIds,
+    unstartedRunIds,
+  } = liveData;
+
+  const materializingRunId = inProgressRunIds[0] || unstartedRunIds[0];
+  const overdue = isAssetOverdue(liveData);
+
+  if (materializingRunId) {
+    // Note: this value is undefined for unpartitioned assets
+    const numMaterializing = liveData.partitionStats?.numMaterializing;
+
+    return {
+      case: StatusCase.MATERIALIZING,
+      background: Colors.Blue50,
+      border: Colors.Blue500,
+      numMaterializing,
+      content: (
+        <>
+          <div style={{marginLeft: -1, marginRight: -1}}>
+            <AssetLatestRunSpinner liveData={liveData} purpose="caption-text" />
+          </div>
+          <span style={{flex: 1}} color={Colors.Gray800}>
+            {numMaterializing === 1
+              ? `Materializing 1 partition...`
+              : numMaterializing
+              ? `Materializing ${numMaterializing} partitions...`
+              : `Materializing...`}
+          </span>
+          {expanded && <SpacerDot />}
+          {!numMaterializing || numMaterializing === 1 ? (
+            <AssetRunLink runId={materializingRunId} />
+          ) : undefined}
+        </>
+      ),
+    };
+  }
+
+  if (liveData.partitionStats) {
+    const {numPartitions, numMaterialized, numFailed} = liveData.partitionStats;
+    const numMissing = numPartitions - numFailed - numMaterialized;
+    const {background, foreground, border} = StyleForAssetPartitionStatus[
+      overdue || numFailed
+        ? AssetPartitionStatus.FAILED
+        : numMissing
+        ? AssetPartitionStatus.MISSING
+        : AssetPartitionStatus.MATERIALIZED
+    ];
+    const statusCase =
+      overdue || numFailed
+        ? StatusCase.PARTITIONS_FAILED
+        : numMissing
+        ? StatusCase.PARTITIONS_MISSING
+        : StatusCase.PARTITIONS_MATERIALIZED;
+
+    return {
+      case: statusCase,
+      background,
+      border,
+      numPartitions,
+      numMissing,
+      numFailed,
+      numMaterialized,
+      content: (
+        <Link
+          to={assetDetailsPathForKey(assetKey, {view: 'partitions'})}
+          style={{color: foreground}}
+          target="_blank"
+          rel="noreferrer"
+        >
+          {overdue ? (
+            <OverdueLineagePopover assetKey={assetKey} liveData={liveData}>
+              Overdue
+            </OverdueLineagePopover>
+          ) : (
+            partitionCountString(numPartitions)
+          )}
+        </Link>
+      ),
+    };
+  }
+
+  const lastMaterializationLink = lastMaterialization ? (
+    <span style={{overflow: 'hidden'}}>
+      <AssetRunLink
+        runId={lastMaterialization.runId}
+        event={{stepKey: stepKeyForAsset(definition), timestamp: lastMaterialization.timestamp}}
+      >
+        <TimestampDisplay
+          timestamp={Number(lastMaterialization.timestamp) / 1000}
+          timeFormat={{showSeconds: false, showTimezone: false}}
+        />
+      </AssetRunLink>
+    </span>
+  ) : undefined;
+
+  if (runWhichFailedToMaterialize || overdue) {
+    return {
+      case: StatusCase.LATE_OR_FAILED,
+      background: Colors.Red50,
+      border: Colors.Red500,
+      content: (
+        <>
+          {expanded && (
+            <Icon
+              name="partition_failure"
+              color={Colors.Red500}
+              style={{marginRight: -2}}
+              size={12}
+            />
+          )}
+
+          {overdue && runWhichFailedToMaterialize ? (
+            <OverdueLineagePopover assetKey={assetKey} liveData={liveData}>
+              <span style={{color: Colors.Red700}}>Failed, Overdue</span>
+            </OverdueLineagePopover>
+          ) : overdue ? (
+            <OverdueLineagePopover assetKey={assetKey} liveData={liveData}>
+              <span style={{color: Colors.Red700}}>Overdue</span>
+            </OverdueLineagePopover>
+          ) : runWhichFailedToMaterialize ? (
+            <span style={{color: Colors.Red700}}>Failed</span>
+          ) : undefined}
+
+          {expanded && <SpacerDot />}
+
+          {runWhichFailedToMaterialize ? (
+            <span style={{overflow: 'hidden'}}>
+              <AssetRunLink runId={runWhichFailedToMaterialize.id}>
+                <TimestampDisplay
+                  timestamp={Number(runWhichFailedToMaterialize.endTime)}
+                  timeFormat={{showSeconds: false, showTimezone: false}}
+                />
+              </AssetRunLink>
+            </span>
+          ) : (
+            lastMaterializationLink
+          )}
+        </>
+      ),
+    };
+  }
+
+  if (!lastMaterialization) {
+    return {
+      case: StatusCase.NEVER_MATERIALIZED,
+      background: Colors.Yellow50,
+      border: Colors.Yellow500,
+      content: (
+        <>
+          {expanded && (
+            <Icon
+              name="partition_missing"
+              color={Colors.Yellow500}
+              style={{marginRight: -2}}
+              size={12}
+            />
+          )}
+          <span style={{color: Colors.Yellow700}}>Never materialized</span>
+        </>
+      ),
+    };
+  }
+
+  return {
+    case: StatusCase.MATERIALIZED,
+    background: Colors.Green50,
+    border: Colors.Green500,
+    content: (
+      <>
+        {expanded && <AssetPartitionStatusDot status={[AssetPartitionStatus.MATERIALIZED]} />}
+        <span style={{color: Colors.Green700}}>Materialized</span>
+        {expanded && <SpacerDot />}
+        {lastMaterializationLink}
+      </>
+    ),
+  };
+}
+
+const SpacerDot = () => (
+  <Body color={Colors.KeylineGray} style={{marginLeft: -3, marginRight: -3}}>
+    •
+  </Body>
+);

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNodeStatusContent.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNodeStatusContent.tsx
@@ -35,8 +35,10 @@ export enum StatusCase {
   PARTITIONS_MATERIALIZED = 'PARTITIONS_MATERIALIZED',
 }
 
+export type AssetNodeStatusContent = ReturnType<typeof buildAssetNodeStatusContent>;
+
 const LOADING_STATUS_CONTENT = {
-  case: StatusCase.LOADING,
+  case: StatusCase.LOADING as const,
   background: Colors.Gray100,
   border: Colors.Gray300,
   content: (
@@ -89,7 +91,7 @@ export function _buildSourceAssetNodeStatusContent({
 
   if (materializingRunId) {
     return {
-      case: StatusCase.SOURCE_OBSERVING,
+      case: StatusCase.SOURCE_OBSERVING as const,
       background: Colors.Gray100,
       border: Colors.Gray300,
       content: (
@@ -106,7 +108,7 @@ export function _buildSourceAssetNodeStatusContent({
   }
   if (liveData?.lastObservation) {
     return {
-      case: StatusCase.SOURCE_OBSERVED,
+      case: StatusCase.SOURCE_OBSERVED as const,
       background: Colors.Gray100,
       border: Colors.Gray300,
       content: (
@@ -134,7 +136,7 @@ export function _buildSourceAssetNodeStatusContent({
   }
   if (definition.isObservable) {
     return {
-      case: StatusCase.SOURCE_NEVER_OBSERVED,
+      case: StatusCase.SOURCE_NEVER_OBSERVED as const,
       background: Colors.Gray100,
       border: Colors.Gray300,
       content: (
@@ -155,7 +157,7 @@ export function _buildSourceAssetNodeStatusContent({
   }
 
   return {
-    case: StatusCase.SOURCE_NO_STATE,
+    case: StatusCase.SOURCE_NO_STATE as const,
     background: Colors.Gray100,
     border: Colors.Gray300,
     content: <span>–</span>,
@@ -194,7 +196,7 @@ export function _buildAssetNodeStatusContent({
     const numMaterializing = liveData.partitionStats?.numMaterializing;
 
     return {
-      case: StatusCase.MATERIALIZING,
+      case: StatusCase.MATERIALIZING as const,
       background: Colors.Blue50,
       border: Colors.Blue500,
       numMaterializing,
@@ -231,10 +233,10 @@ export function _buildAssetNodeStatusContent({
     ];
     const statusCase =
       overdue || numFailed
-        ? StatusCase.PARTITIONS_FAILED
+        ? (StatusCase.PARTITIONS_FAILED as const)
         : numMissing
-        ? StatusCase.PARTITIONS_MISSING
-        : StatusCase.PARTITIONS_MATERIALIZED;
+        ? (StatusCase.PARTITIONS_MISSING as const)
+        : (StatusCase.PARTITIONS_MATERIALIZED as const);
 
     return {
       case: statusCase,
@@ -279,7 +281,7 @@ export function _buildAssetNodeStatusContent({
 
   if (runWhichFailedToMaterialize || overdue || checksFailed) {
     return {
-      case: StatusCase.LATE_OR_FAILED,
+      case: StatusCase.LATE_OR_FAILED as const,
       background: Colors.Red50,
       border: Colors.Red500,
       content: (
@@ -328,7 +330,7 @@ export function _buildAssetNodeStatusContent({
 
   if (!lastMaterialization) {
     return {
-      case: StatusCase.NEVER_MATERIALIZED,
+      case: StatusCase.NEVER_MATERIALIZED as const,
       background: Colors.Yellow50,
       border: Colors.Yellow500,
       content: (
@@ -348,7 +350,7 @@ export function _buildAssetNodeStatusContent({
   }
 
   return {
-    case: StatusCase.MATERIALIZED,
+    case: StatusCase.MATERIALIZED as const,
     background: Colors.Green50,
     border: Colors.Green500,
     content: (

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNodeStatusContent.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNodeStatusContent.tsx
@@ -186,7 +186,7 @@ export function _buildAssetNodeStatusContent({
   const checksFailed = liveData.assetChecks.some(
     (c) =>
       (c.executionForLatestMaterialization?.status === AssetCheckExecutionResolvedStatus.FAILED &&
-        c.severity === AssetCheckSeverity.ERROR) ||
+        c.executionForLatestMaterialization?.evaluation?.severity === AssetCheckSeverity.ERROR) ||
       c.executionForLatestMaterialization?.status ===
         AssetCheckExecutionResolvedStatus.EXECUTION_FAILED,
   );

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNodeStatusContent.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNodeStatusContent.tsx
@@ -35,20 +35,7 @@ export enum StatusCase {
   PARTITIONS_MATERIALIZED = 'PARTITIONS_MATERIALIZED',
 }
 
-type AssetNodeStatusContent = {
-  case: StatusCase;
-  background: string;
-  border: string;
-  content: React.ReactNode;
-
-  numPartitions?: number;
-  numMissing?: number;
-  numFailed?: number;
-  numMaterialized?: number;
-  numMaterializing?: number;
-};
-
-const LOADING_STATUS_CONTENT: AssetNodeStatusContent = {
+const LOADING_STATUS_CONTENT = {
   case: StatusCase.LOADING,
   background: Colors.Gray100,
   border: Colors.Gray300,
@@ -72,7 +59,7 @@ export function buildAssetNodeStatusContent({
   definition,
   liveData,
   expanded,
-}: StatusContentArgs): AssetNodeStatusContent {
+}: StatusContentArgs) {
   return definition.isSource
     ? _buildSourceAssetNodeStatusContent({
         assetKey,
@@ -92,7 +79,7 @@ export function _buildSourceAssetNodeStatusContent({
   definition,
   liveData,
   expanded,
-}: StatusContentArgs): AssetNodeStatusContent {
+}: StatusContentArgs) {
   if (!liveData) {
     return LOADING_STATUS_CONTENT;
   }
@@ -180,7 +167,7 @@ export function _buildAssetNodeStatusContent({
   definition,
   liveData,
   expanded,
-}: StatusContentArgs): AssetNodeStatusContent {
+}: StatusContentArgs) {
   if (!liveData) {
     return LOADING_STATUS_CONTENT;
   }

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetRunLogObserver.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetRunLogObserver.tsx
@@ -102,6 +102,9 @@ const SingleRunLogObserver: React.FC<{
             ) {
               return {assetKey: m.assetKey} as ObservedEvent;
             }
+            if (m.__typename === 'AssetCheckEvaluationEvent') {
+              return {assetKey: m.evaluation.assetKey} as ObservedEvent;
+            }
             if (
               (m.__typename === 'ExecutionStepFailureEvent' ||
                 m.__typename === 'ExecutionStepStartEvent') &&
@@ -131,6 +134,13 @@ export const ASSET_LIVE_RUN_LOGS_SUBSCRIPTION = gql`
           ... on AssetMaterializationPlannedEvent {
             assetKey {
               path
+            }
+          }
+          ... on AssetCheckEvaluationEvent {
+            evaluation {
+              assetKey {
+                path
+              }
             }
           }
           ... on MaterializationEvent {

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/Utils.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/Utils.tsx
@@ -160,10 +160,12 @@ export interface LiveDataForNode {
   } | null;
   assetChecks: {
     name: string;
-    severity: AssetCheckSeverity;
     executionForLatestMaterialization: {
       runId: string;
       status: AssetCheckExecutionResolvedStatus;
+      evaluation: {
+        severity: AssetCheckSeverity;
+      } | null;
     } | null;
   }[];
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/Utils.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/Utils.tsx
@@ -1,7 +1,14 @@
 import {pathVerticalDiagonal, pathHorizontalDiagonal} from '@vx/shape';
 
 import {featureEnabled, FeatureFlag} from '../app/Flags';
-import {Maybe, RunStatus, StaleCauseCategory, StaleStatus} from '../graphql/types';
+import {
+  AssetCheckExecutionResolvedStatus,
+  AssetCheckSeverity,
+  Maybe,
+  RunStatus,
+  StaleCauseCategory,
+  StaleStatus,
+} from '../graphql/types';
 
 import {
   AssetNodeKeyFragment,
@@ -153,6 +160,10 @@ export interface LiveDataForNode {
     numPartitions: number;
     numFailed: number;
   } | null;
+  assetChecks: {
+    severity: AssetCheckSeverity;
+    executionForLatestMaterialization: {status: AssetCheckExecutionResolvedStatus};
+  }[];
 }
 
 export const MISSING_LIVE_DATA: LiveDataForNode = {
@@ -209,6 +220,7 @@ export const buildLiveDataForNode = (
         ? latestRunForAsset.status
         : null,
     lastObservation,
+    assetChecks: assetNode.assetChecks,
     staleStatus: assetNode.staleStatus,
     staleCauses: assetNode.staleCauses,
     stepKey: stepKeyForAsset(assetNode),

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/Utils.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/Utils.tsx
@@ -10,18 +10,16 @@ import {
   StaleStatus,
 } from '../graphql/types';
 
-import {
-  AssetNodeKeyFragment,
-  AssetNodeLiveFragment,
-  AssetNodeLiveMaterializationFragment,
-  AssetNodeLiveFreshnessInfoFragment,
-  AssetNodeLiveObservationFragment,
-} from './types/AssetNode.types';
+import {AssetNodeKeyFragment} from './types/AssetNode.types';
 import {AssetNodeForGraphQueryFragment} from './types/useAssetGraphData.types';
 import {
   AssetLatestInfoFragment,
   AssetLatestInfoRunFragment,
   AssetGraphLiveQuery,
+  AssetNodeLiveFragment,
+  AssetNodeLiveFreshnessInfoFragment,
+  AssetNodeLiveMaterializationFragment,
+  AssetNodeLiveObservationFragment,
 } from './types/useLiveDataForAssetKeys.types';
 
 type AssetNode = AssetNodeForGraphQueryFragment;
@@ -161,8 +159,12 @@ export interface LiveDataForNode {
     numFailed: number;
   } | null;
   assetChecks: {
+    name: string;
     severity: AssetCheckSeverity;
-    executionForLatestMaterialization: {status: AssetCheckExecutionResolvedStatus};
+    executionForLatestMaterialization: {
+      runId: string;
+      status: AssetCheckExecutionResolvedStatus;
+    } | null;
   }[];
 }
 
@@ -177,6 +179,7 @@ export const MISSING_LIVE_DATA: LiveDataForNode = {
   partitionStats: null,
   staleStatus: null,
   staleCauses: [],
+  assetChecks: [],
   stepKey: '',
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__fixtures__/AssetNode.fixtures.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__fixtures__/AssetNode.fixtures.ts
@@ -179,42 +179,52 @@ export const LiveDataForNodeMaterializedWithChecks: LiveDataForNode = {
   assetChecks: [
     {
       name: 'check_1',
-      severity: AssetCheckSeverity.WARN,
       executionForLatestMaterialization: {
         runId: '1234',
         status: AssetCheckExecutionResolvedStatus.FAILED,
+        evaluation: {
+          severity: AssetCheckSeverity.WARN,
+        },
       },
     },
     {
       name: 'check_2',
-      severity: AssetCheckSeverity.ERROR,
       executionForLatestMaterialization: {
         runId: '1234',
         status: AssetCheckExecutionResolvedStatus.FAILED,
+        evaluation: {
+          severity: AssetCheckSeverity.ERROR,
+        },
       },
     },
     {
       name: 'check_3',
-      severity: AssetCheckSeverity.WARN,
       executionForLatestMaterialization: {
         runId: '1234',
         status: AssetCheckExecutionResolvedStatus.IN_PROGRESS,
+        evaluation: {
+          severity: AssetCheckSeverity.WARN,
+        },
       },
     },
     {
       name: 'check_4',
-      severity: AssetCheckSeverity.WARN,
       executionForLatestMaterialization: {
         runId: '1234',
         status: AssetCheckExecutionResolvedStatus.SKIPPED,
+        evaluation: {
+          severity: AssetCheckSeverity.WARN,
+        },
       },
     },
     {
       name: 'check_5',
-      severity: AssetCheckSeverity.WARN,
       executionForLatestMaterialization: {
         runId: '1234',
         status: AssetCheckExecutionResolvedStatus.SUCCEEDED,
+        evaluation: {
+          severity: AssetCheckSeverity.WARN,
+        },
       },
     },
   ],
@@ -225,7 +235,7 @@ export const LiveDataForNodeMaterializedWithChecks: LiveDataForNode = {
 export const LiveDataForNodeMaterializedWithChecksOk: LiveDataForNode = {
   ...LiveDataForNodeMaterializedWithChecks,
   assetChecks: LiveDataForNodeMaterializedWithChecks.assetChecks.filter(
-    (c) => c.severity !== AssetCheckSeverity.ERROR,
+    (c) => c.executionForLatestMaterialization?.evaluation?.severity !== AssetCheckSeverity.ERROR,
   ),
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__fixtures__/AssetNode.fixtures.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__fixtures__/AssetNode.fixtures.ts
@@ -1,4 +1,11 @@
-import {RunStatus, StaleStatus, StaleCause, StaleCauseCategory} from '../../graphql/types';
+import {
+  RunStatus,
+  StaleStatus,
+  StaleCause,
+  StaleCauseCategory,
+  AssetCheckSeverity,
+  AssetCheckExecutionResolvedStatus,
+} from '../../graphql/types';
 import {LiveDataForNode} from '../Utils';
 import {AssetNodeFragment} from '../types/AssetNode.types';
 
@@ -153,6 +160,73 @@ export const LiveDataForNodeMaterialized: LiveDataForNode = {
   assetChecks: [],
   freshnessInfo: null,
   partitionStats: null,
+};
+
+export const LiveDataForNodeMaterializedWithChecks: LiveDataForNode = {
+  stepKey: 'asset1',
+  unstartedRunIds: [],
+  inProgressRunIds: [],
+  lastMaterialization: {
+    __typename: 'MaterializationEvent',
+    runId: 'ABCDEF',
+    timestamp: TIMESTAMP,
+  },
+  lastMaterializationRunStatus: null,
+  lastObservation: null,
+  runWhichFailedToMaterialize: null,
+  staleStatus: StaleStatus.FRESH,
+  staleCauses: [],
+  assetChecks: [
+    {
+      name: 'check_1',
+      severity: AssetCheckSeverity.WARN,
+      executionForLatestMaterialization: {
+        runId: '1234',
+        status: AssetCheckExecutionResolvedStatus.FAILED,
+      },
+    },
+    {
+      name: 'check_2',
+      severity: AssetCheckSeverity.ERROR,
+      executionForLatestMaterialization: {
+        runId: '1234',
+        status: AssetCheckExecutionResolvedStatus.FAILED,
+      },
+    },
+    {
+      name: 'check_3',
+      severity: AssetCheckSeverity.WARN,
+      executionForLatestMaterialization: {
+        runId: '1234',
+        status: AssetCheckExecutionResolvedStatus.IN_PROGRESS,
+      },
+    },
+    {
+      name: 'check_4',
+      severity: AssetCheckSeverity.WARN,
+      executionForLatestMaterialization: {
+        runId: '1234',
+        status: AssetCheckExecutionResolvedStatus.SKIPPED,
+      },
+    },
+    {
+      name: 'check_5',
+      severity: AssetCheckSeverity.WARN,
+      executionForLatestMaterialization: {
+        runId: '1234',
+        status: AssetCheckExecutionResolvedStatus.SUCCEEDED,
+      },
+    },
+  ],
+  freshnessInfo: null,
+  partitionStats: null,
+};
+
+export const LiveDataForNodeMaterializedWithChecksOk: LiveDataForNode = {
+  ...LiveDataForNodeMaterializedWithChecks,
+  assetChecks: LiveDataForNodeMaterializedWithChecks.assetChecks.filter(
+    (c) => c.severity !== AssetCheckSeverity.ERROR,
+  ),
 };
 
 export const LiveDataForNodeMaterializedAndStale: LiveDataForNode = {
@@ -631,6 +705,18 @@ export const AssetNodeScenariosBase = [
     liveData: LiveDataForNodeFailedAndOverdue,
     definition: AssetNodeFragmentBasic,
     expectedText: ['Failed, Overdue', 'Jan'],
+  },
+  {
+    title: 'Materialized with Checks (Ok)',
+    liveData: LiveDataForNodeMaterializedWithChecksOk,
+    definition: AssetNodeFragmentBasic,
+    expectedText: ['Materialized', 'Checks'],
+  },
+  {
+    title: 'Materialized with Checks (Failed)',
+    liveData: LiveDataForNodeMaterializedWithChecks,
+    definition: AssetNodeFragmentBasic,
+    expectedText: ['Materialized', 'Checks'],
   },
 ];
 

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__fixtures__/AssetNode.fixtures.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__fixtures__/AssetNode.fixtures.ts
@@ -81,6 +81,7 @@ export const LiveDataForNodeRunStartedNotMaterializing: LiveDataForNode = {
   runWhichFailedToMaterialize: null,
   staleStatus: null,
   staleCauses: [],
+  assetChecks: [],
   freshnessInfo: null,
   partitionStats: null,
 };
@@ -95,6 +96,7 @@ export const LiveDataForNodeRunStartedMaterializing: LiveDataForNode = {
   runWhichFailedToMaterialize: null,
   staleStatus: null,
   staleCauses: [],
+  assetChecks: [],
   freshnessInfo: null,
   partitionStats: null,
 };
@@ -114,6 +116,7 @@ export const LiveDataForNodeRunFailed: LiveDataForNode = {
   },
   staleStatus: null,
   staleCauses: [],
+  assetChecks: [],
   freshnessInfo: null,
   partitionStats: null,
 };
@@ -128,6 +131,7 @@ export const LiveDataForNodeNeverMaterialized: LiveDataForNode = {
   runWhichFailedToMaterialize: null,
   staleStatus: StaleStatus.MISSING,
   staleCauses: [],
+  assetChecks: [],
   freshnessInfo: null,
   partitionStats: null,
 };
@@ -146,6 +150,7 @@ export const LiveDataForNodeMaterialized: LiveDataForNode = {
   runWhichFailedToMaterialize: null,
   staleStatus: StaleStatus.FRESH,
   staleCauses: [],
+  assetChecks: [],
   freshnessInfo: null,
   partitionStats: null,
 };
@@ -164,6 +169,7 @@ export const LiveDataForNodeMaterializedAndStale: LiveDataForNode = {
   runWhichFailedToMaterialize: null,
   staleStatus: StaleStatus.STALE,
   staleCauses: [MockStaleReasonCode],
+  assetChecks: [],
   freshnessInfo: null,
   partitionStats: null,
 };
@@ -182,6 +188,7 @@ export const LiveDataForNodeMaterializedAndStaleAndOverdue: LiveDataForNode = {
   runWhichFailedToMaterialize: null,
   staleStatus: StaleStatus.STALE,
   staleCauses: [MockStaleReasonCode],
+  assetChecks: [],
   freshnessInfo: {
     __typename: 'AssetFreshnessInfo',
     currentMinutesLate: 12,
@@ -203,6 +210,7 @@ export const LiveDataForNodeMaterializedAndStaleAndFresh: LiveDataForNode = {
   runWhichFailedToMaterialize: null,
   staleStatus: StaleStatus.STALE,
   staleCauses: [MockStaleReasonCode, MockStaleReasonData],
+  assetChecks: [],
   freshnessInfo: {
     __typename: 'AssetFreshnessInfo',
     currentMinutesLate: 0,
@@ -224,6 +232,7 @@ export const LiveDataForNodeMaterializedAndFresh: LiveDataForNode = {
   runWhichFailedToMaterialize: null,
   staleStatus: StaleStatus.FRESH,
   staleCauses: [],
+  assetChecks: [],
   freshnessInfo: {
     __typename: 'AssetFreshnessInfo',
     currentMinutesLate: 0,
@@ -245,6 +254,7 @@ export const LiveDataForNodeMaterializedAndOverdue: LiveDataForNode = {
   runWhichFailedToMaterialize: null,
   staleStatus: StaleStatus.FRESH,
   staleCauses: [],
+  assetChecks: [],
   freshnessInfo: {
     __typename: 'AssetFreshnessInfo',
     currentMinutesLate: 12,
@@ -267,6 +277,7 @@ export const LiveDataForNodeFailedAndOverdue: LiveDataForNode = {
   },
   staleStatus: StaleStatus.FRESH,
   staleCauses: [],
+  assetChecks: [],
   freshnessInfo: {
     __typename: 'AssetFreshnessInfo',
     currentMinutesLate: 12,
@@ -284,6 +295,7 @@ export const LiveDataForNodeSourceNeverObserved: LiveDataForNode = {
   runWhichFailedToMaterialize: null,
   staleStatus: StaleStatus.MISSING,
   staleCauses: [],
+  assetChecks: [],
   freshnessInfo: null,
 
   partitionStats: null,
@@ -299,6 +311,7 @@ export const LiveDataForNodeSourceObservationRunning: LiveDataForNode = {
   runWhichFailedToMaterialize: null,
   staleStatus: StaleStatus.MISSING,
   staleCauses: [],
+  assetChecks: [],
   freshnessInfo: null,
   partitionStats: null,
 };
@@ -316,6 +329,7 @@ export const LiveDataForNodeSourceObservedUpToDate: LiveDataForNode = {
   runWhichFailedToMaterialize: null,
   staleStatus: StaleStatus.FRESH,
   staleCauses: [],
+  assetChecks: [],
   freshnessInfo: null,
 
   partitionStats: null,
@@ -335,6 +349,7 @@ export const LiveDataForNodePartitionedSomeMissing: LiveDataForNode = {
   runWhichFailedToMaterialize: null,
   staleStatus: StaleStatus.FRESH,
   staleCauses: [],
+  assetChecks: [],
   freshnessInfo: null,
   partitionStats: {
     numMaterialized: 6,
@@ -358,6 +373,7 @@ export const LiveDataForNodePartitionedSomeFailed: LiveDataForNode = {
   runWhichFailedToMaterialize: null,
   staleStatus: StaleStatus.FRESH,
   staleCauses: [],
+  assetChecks: [],
   freshnessInfo: null,
   partitionStats: {
     numMaterialized: 6,
@@ -381,6 +397,7 @@ export const LiveDataForNodePartitionedNoneMissing: LiveDataForNode = {
   runWhichFailedToMaterialize: null,
   staleStatus: StaleStatus.FRESH,
   staleCauses: [],
+  assetChecks: [],
   freshnessInfo: null,
   partitionStats: {
     numMaterialized: 1500,
@@ -400,6 +417,7 @@ export const LiveDataForNodePartitionedNeverMaterialized: LiveDataForNode = {
   runWhichFailedToMaterialize: null,
   staleStatus: StaleStatus.MISSING,
   staleCauses: [],
+  assetChecks: [],
   freshnessInfo: null,
   partitionStats: {
     numMaterialized: 0,
@@ -419,6 +437,7 @@ export const LiveDataForNodePartitionedMaterializing: LiveDataForNode = {
   runWhichFailedToMaterialize: null,
   staleStatus: StaleStatus.MISSING,
   staleCauses: [],
+  assetChecks: [],
   freshnessInfo: null,
   partitionStats: {
     numMaterialized: 0,
@@ -442,6 +461,7 @@ export const LiveDataForNodePartitionedStale: LiveDataForNode = {
   runWhichFailedToMaterialize: null,
   staleStatus: StaleStatus.STALE,
   staleCauses: [MockStaleReasonData],
+  assetChecks: [],
   freshnessInfo: null,
   partitionStats: {
     numMaterialized: 1500,
@@ -465,6 +485,7 @@ export const LiveDataForNodePartitionedOverdue: LiveDataForNode = {
   runWhichFailedToMaterialize: null,
   staleStatus: StaleStatus.FRESH,
   staleCauses: [],
+  assetChecks: [],
   freshnessInfo: {
     __typename: 'AssetFreshnessInfo',
     currentMinutesLate: 12,
@@ -491,6 +512,7 @@ export const LiveDataForNodePartitionedFresh: LiveDataForNode = {
   runWhichFailedToMaterialize: null,
   staleStatus: StaleStatus.FRESH,
   staleCauses: [],
+  assetChecks: [],
   freshnessInfo: {
     __typename: 'AssetFreshnessInfo',
     currentMinutesLate: 0,
@@ -518,6 +540,7 @@ export const LiveDataForNodePartitionedLatestRunFailed: LiveDataForNode = {
   },
   staleStatus: null,
   staleCauses: [],
+  assetChecks: [],
   freshnessInfo: null,
   partitionStats: {
     numMaterialized: 1495,

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__stories__/SidebarAssetInfo.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__stories__/SidebarAssetInfo.stories.tsx
@@ -17,6 +17,10 @@ import {
 import {WorkspaceProvider} from '../../workspace/WorkspaceContext';
 import {SIDEBAR_ASSET_QUERY, SidebarAssetInfo} from '../SidebarAssetInfo';
 import {GraphNode} from '../Utils';
+import {
+  LiveDataForNodeMaterialized,
+  LiveDataForNodeMaterializedWithChecks,
+} from '../__fixtures__/AssetNode.fixtures';
 import {SidebarAssetQuery} from '../types/SidebarAssetInfo.types';
 
 // eslint-disable-next-line import/no-default-export
@@ -261,6 +265,17 @@ export const AssetWithGraphName = () => {
       <SidebarAssetInfo
         graphNode={buildGraphNodeMock({graphName: 'op_graph'})}
         liveData={undefined}
+      />
+    </TestContainer>
+  );
+};
+
+export const AssetWithAssetChecks = () => {
+  return (
+    <TestContainer>
+      <SidebarAssetInfo
+        graphNode={buildGraphNodeMock({})}
+        liveData={LiveDataForNodeMaterializedWithChecks}
       />
     </TestContainer>
   );

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__stories__/SidebarAssetInfo.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__stories__/SidebarAssetInfo.stories.tsx
@@ -17,10 +17,7 @@ import {
 import {WorkspaceProvider} from '../../workspace/WorkspaceContext';
 import {SIDEBAR_ASSET_QUERY, SidebarAssetInfo} from '../SidebarAssetInfo';
 import {GraphNode} from '../Utils';
-import {
-  LiveDataForNodeMaterialized,
-  LiveDataForNodeMaterializedWithChecks,
-} from '../__fixtures__/AssetNode.fixtures';
+import {LiveDataForNodeMaterializedWithChecks} from '../__fixtures__/AssetNode.fixtures';
 import {SidebarAssetQuery} from '../types/SidebarAssetInfo.types';
 
 // eslint-disable-next-line import/no-default-export

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/types/AssetNode.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/types/AssetNode.types.ts
@@ -15,6 +15,15 @@ export type AssetNodeLiveFragment = {
     runId: string;
   }>;
   assetObservations: Array<{__typename: 'ObservationEvent'; timestamp: string; runId: string}>;
+  assetChecks: Array<{
+    __typename: 'AssetCheck';
+    severity: Types.AssetCheckSeverity;
+    executionForLatestMaterialization: {
+      __typename: 'AssetCheckExecution';
+      id: string;
+      status: Types.AssetCheckExecutionResolvedStatus;
+    } | null;
+  }>;
   freshnessInfo: {__typename: 'AssetFreshnessInfo'; currentMinutesLate: number | null} | null;
   staleCauses: Array<{
     __typename: 'StaleCause';

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/types/AssetNode.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/types/AssetNode.types.ts
@@ -2,62 +2,6 @@
 
 import * as Types from '../../graphql/types';
 
-export type AssetNodeLiveFragment = {
-  __typename: 'AssetNode';
-  id: string;
-  opNames: Array<string>;
-  staleStatus: Types.StaleStatus | null;
-  repository: {__typename: 'Repository'; id: string};
-  assetKey: {__typename: 'AssetKey'; path: Array<string>};
-  assetMaterializations: Array<{
-    __typename: 'MaterializationEvent';
-    timestamp: string;
-    runId: string;
-  }>;
-  assetObservations: Array<{__typename: 'ObservationEvent'; timestamp: string; runId: string}>;
-  assetChecks: Array<{
-    __typename: 'AssetCheck';
-    severity: Types.AssetCheckSeverity;
-    executionForLatestMaterialization: {
-      __typename: 'AssetCheckExecution';
-      id: string;
-      status: Types.AssetCheckExecutionResolvedStatus;
-    } | null;
-  }>;
-  freshnessInfo: {__typename: 'AssetFreshnessInfo'; currentMinutesLate: number | null} | null;
-  staleCauses: Array<{
-    __typename: 'StaleCause';
-    reason: string;
-    category: Types.StaleCauseCategory;
-    key: {__typename: 'AssetKey'; path: Array<string>};
-    dependency: {__typename: 'AssetKey'; path: Array<string>} | null;
-  }>;
-  partitionStats: {
-    __typename: 'PartitionStats';
-    numMaterialized: number;
-    numMaterializing: number;
-    numPartitions: number;
-    numFailed: number;
-  } | null;
-};
-
-export type AssetNodeLiveFreshnessInfoFragment = {
-  __typename: 'AssetFreshnessInfo';
-  currentMinutesLate: number | null;
-};
-
-export type AssetNodeLiveMaterializationFragment = {
-  __typename: 'MaterializationEvent';
-  timestamp: string;
-  runId: string;
-};
-
-export type AssetNodeLiveObservationFragment = {
-  __typename: 'ObservationEvent';
-  timestamp: string;
-  runId: string;
-};
-
 export type AssetNodeFragment = {
   __typename: 'AssetNode';
   id: string;

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/types/AssetRunLogObserver.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/types/AssetRunLogObserver.types.ts
@@ -16,7 +16,13 @@ export type AssetLiveRunLogsSubscription = {
           | {__typename: 'AlertFailureEvent'}
           | {__typename: 'AlertStartEvent'}
           | {__typename: 'AlertSuccessEvent'}
-          | {__typename: 'AssetCheckEvaluationEvent'}
+          | {
+              __typename: 'AssetCheckEvaluationEvent';
+              evaluation: {
+                __typename: 'AssetCheckEvaluation';
+                assetKey: {__typename: 'AssetKey'; path: Array<string>};
+              };
+            }
           | {__typename: 'AssetCheckEvaluationPlannedEvent'}
           | {
               __typename: 'AssetMaterializationPlannedEvent';

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/types/useLiveDataForAssetKeys.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/types/useLiveDataForAssetKeys.types.ts
@@ -22,6 +22,64 @@ export type AssetLatestInfoRunFragment = {
   id: string;
 };
 
+export type AssetNodeLiveFragment = {
+  __typename: 'AssetNode';
+  id: string;
+  opNames: Array<string>;
+  staleStatus: Types.StaleStatus | null;
+  repository: {__typename: 'Repository'; id: string};
+  assetKey: {__typename: 'AssetKey'; path: Array<string>};
+  assetMaterializations: Array<{
+    __typename: 'MaterializationEvent';
+    timestamp: string;
+    runId: string;
+  }>;
+  assetObservations: Array<{__typename: 'ObservationEvent'; timestamp: string; runId: string}>;
+  assetChecks: Array<{
+    __typename: 'AssetCheck';
+    name: string;
+    severity: Types.AssetCheckSeverity;
+    executionForLatestMaterialization: {
+      __typename: 'AssetCheckExecution';
+      id: string;
+      runId: string;
+      status: Types.AssetCheckExecutionResolvedStatus;
+    } | null;
+  }>;
+  freshnessInfo: {__typename: 'AssetFreshnessInfo'; currentMinutesLate: number | null} | null;
+  staleCauses: Array<{
+    __typename: 'StaleCause';
+    reason: string;
+    category: Types.StaleCauseCategory;
+    key: {__typename: 'AssetKey'; path: Array<string>};
+    dependency: {__typename: 'AssetKey'; path: Array<string>} | null;
+  }>;
+  partitionStats: {
+    __typename: 'PartitionStats';
+    numMaterialized: number;
+    numMaterializing: number;
+    numPartitions: number;
+    numFailed: number;
+  } | null;
+};
+
+export type AssetNodeLiveFreshnessInfoFragment = {
+  __typename: 'AssetFreshnessInfo';
+  currentMinutesLate: number | null;
+};
+
+export type AssetNodeLiveMaterializationFragment = {
+  __typename: 'MaterializationEvent';
+  timestamp: string;
+  runId: string;
+};
+
+export type AssetNodeLiveObservationFragment = {
+  __typename: 'ObservationEvent';
+  timestamp: string;
+  runId: string;
+};
+
 export type AssetGraphLiveQueryVariables = Types.Exact<{
   assetKeys: Array<Types.AssetKeyInput> | Types.AssetKeyInput;
 }>;
@@ -43,10 +101,12 @@ export type AssetGraphLiveQuery = {
     assetObservations: Array<{__typename: 'ObservationEvent'; timestamp: string; runId: string}>;
     assetChecks: Array<{
       __typename: 'AssetCheck';
+      name: string;
       severity: Types.AssetCheckSeverity;
       executionForLatestMaterialization: {
         __typename: 'AssetCheckExecution';
         id: string;
+        runId: string;
         status: Types.AssetCheckExecutionResolvedStatus;
       } | null;
     }>;

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/types/useLiveDataForAssetKeys.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/types/useLiveDataForAssetKeys.types.ts
@@ -41,6 +41,15 @@ export type AssetGraphLiveQuery = {
       runId: string;
     }>;
     assetObservations: Array<{__typename: 'ObservationEvent'; timestamp: string; runId: string}>;
+    assetChecks: Array<{
+      __typename: 'AssetCheck';
+      severity: Types.AssetCheckSeverity;
+      executionForLatestMaterialization: {
+        __typename: 'AssetCheckExecution';
+        id: string;
+        status: Types.AssetCheckExecutionResolvedStatus;
+      } | null;
+    }>;
     freshnessInfo: {__typename: 'AssetFreshnessInfo'; currentMinutesLate: number | null} | null;
     staleCauses: Array<{
       __typename: 'StaleCause';

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/types/useLiveDataForAssetKeys.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/types/useLiveDataForAssetKeys.types.ts
@@ -38,12 +38,12 @@ export type AssetNodeLiveFragment = {
   assetChecks: Array<{
     __typename: 'AssetCheck';
     name: string;
-    severity: Types.AssetCheckSeverity;
     executionForLatestMaterialization: {
       __typename: 'AssetCheckExecution';
       id: string;
       runId: string;
       status: Types.AssetCheckExecutionResolvedStatus;
+      evaluation: {__typename: 'AssetCheckEvaluation'; severity: Types.AssetCheckSeverity} | null;
     } | null;
   }>;
   freshnessInfo: {__typename: 'AssetFreshnessInfo'; currentMinutesLate: number | null} | null;
@@ -102,12 +102,12 @@ export type AssetGraphLiveQuery = {
     assetChecks: Array<{
       __typename: 'AssetCheck';
       name: string;
-      severity: Types.AssetCheckSeverity;
       executionForLatestMaterialization: {
         __typename: 'AssetCheckExecution';
         id: string;
         runId: string;
         status: Types.AssetCheckExecutionResolvedStatus;
+        evaluation: {__typename: 'AssetCheckEvaluation'; severity: Types.AssetCheckSeverity} | null;
       } | null;
     }>;
     freshnessInfo: {__typename: 'AssetFreshnessInfo'; currentMinutesLate: number | null} | null;

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useLiveDataForAssetKeys.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useLiveDataForAssetKeys.tsx
@@ -147,11 +147,13 @@ const ASSET_NODE_LIVE_FRAGMENT = gql`
     }
     assetChecks {
       name
-      severity
       executionForLatestMaterialization {
         id
         runId
         status
+        evaluation {
+          severity
+        }
       }
     }
     freshnessInfo {

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useLiveDataForAssetKeys.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useLiveDataForAssetKeys.tsx
@@ -6,7 +6,6 @@ import {useQueryRefreshAtInterval} from '../app/QueryRefresh';
 import {AssetKeyInput} from '../graphql/types';
 import {useDidLaunchEvent} from '../runs/RunUtils';
 
-import {ASSET_NODE_LIVE_FRAGMENT} from './AssetNode';
 import {observeAssetEventsInRuns} from './AssetRunLogObserver';
 import {buildLiveData, tokenForAssetKey} from './Utils';
 import {
@@ -120,6 +119,68 @@ export const ASSET_LATEST_INFO_FRAGMENT = gql`
     status
     endTime
     id
+  }
+`;
+
+const ASSET_NODE_LIVE_FRAGMENT = gql`
+  fragment AssetNodeLiveFragment on AssetNode {
+    id
+    opNames
+    repository {
+      id
+    }
+    assetKey {
+      path
+    }
+    assetMaterializations(limit: 1) {
+      ...AssetNodeLiveMaterialization
+    }
+    assetObservations(limit: 1) {
+      ...AssetNodeLiveObservation
+    }
+    assetChecks {
+      name
+      severity
+      executionForLatestMaterialization {
+        id
+        runId
+        status
+      }
+    }
+    freshnessInfo {
+      ...AssetNodeLiveFreshnessInfo
+    }
+    staleStatus
+    staleCauses {
+      key {
+        path
+      }
+      reason
+      category
+      dependency {
+        path
+      }
+    }
+    partitionStats {
+      numMaterialized
+      numMaterializing
+      numPartitions
+      numFailed
+    }
+  }
+
+  fragment AssetNodeLiveFreshnessInfo on AssetFreshnessInfo {
+    currentMinutesLate
+  }
+
+  fragment AssetNodeLiveMaterialization on MaterializationEvent {
+    timestamp
+    runId
+  }
+
+  fragment AssetNodeLiveObservation on ObservationEvent {
+    timestamp
+    runId
   }
 `;
 

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useLiveDataForAssetKeys.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useLiveDataForAssetKeys.tsx
@@ -78,7 +78,14 @@ export function useLiveDataForAssetKeys(assetKeys: AssetKeyInput[]) {
     const assetKeyTokens = new Set(assetKeys.map(tokenForAssetKey));
     const assetStepKeys = new Set(liveResult.data?.assetNodes.flatMap((n) => n.opNames) || []);
     const runInProgressId = uniq(
-      Object.values(liveDataByNode).flatMap((p) => [...p.unstartedRunIds, ...p.inProgressRunIds]),
+      Object.values(liveDataByNode).flatMap((p) => [
+        ...p.unstartedRunIds,
+        ...p.inProgressRunIds,
+        ...p.assetChecks
+          .map((c) => c.executionForLatestMaterialization)
+          .filter(Boolean)
+          .map((e) => e!.runId),
+      ]),
     ).sort();
 
     const unobserve = observeAssetEventsInRuns(runInProgressId, (events) => {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeList.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeList.tsx
@@ -45,7 +45,7 @@ export const AssetNodeList: React.FC<{
 };
 
 const Container = styled(Box)`
-  height: 154px;
+  height: 195px;
   overflow-x: auto;
   width: 100%;
   white-space: nowrap;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetSidebarActivitySummary.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetSidebarActivitySummary.tsx
@@ -190,7 +190,7 @@ export const AssetSidebarActivitySummary: React.FC<Props> = ({
                         })}`}
                       >
                         <AssetCheckStatusTag
-                          severity={check.severity}
+                          severity={check.executionForLatestMaterialization.evaluation?.severity}
                           status={check.executionForLatestMaterialization.status}
                         />
                       </Link>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetSidebarActivitySummary.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetSidebarActivitySummary.tsx
@@ -1,4 +1,6 @@
-import {Body, Box, Colors, Icon, Spinner} from '@dagster-io/ui-components';
+import qs from 'querystring';
+
+import {Body, Box, Colors, Icon, Spinner, Table} from '@dagster-io/ui-components';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
 
@@ -16,6 +18,7 @@ import {CurrentRunsBanner} from './CurrentRunsBanner';
 import {FailedRunSinceMaterializationBanner} from './FailedRunSinceMaterializationBanner';
 import {LatestMaterializationMetadata} from './LastMaterializationMetadata';
 import {OverdueTag, freshnessPolicyDescription} from './OverdueTag';
+import {AssetCheckStatusTag} from './asset-checks/AssetCheckStatusTag';
 import {assetDetailsPathForKey} from './assetDetailsPathForKey';
 import {useGroupedEvents} from './groupByPartition';
 import {useRecentAssetEvents} from './useRecentAssetEvents';
@@ -165,6 +168,41 @@ export const AssetSidebarActivitySummary: React.FC<Props> = ({
           columnCount={1}
         />
       </SidebarSection>
+      {liveData && liveData.assetChecks.length > 0 && (
+        <SidebarSection title="Checks">
+          <Box padding={{horizontal: 24, vertical: 12}}>
+            <Link to={assetDetailsPathForKey(asset.assetKey, {view: 'checks'})}>
+              View all check details
+            </Link>
+          </Box>
+
+          <Table $compact>
+            <tbody>
+              {liveData.assetChecks.map((check) => (
+                <tr key={check.name}>
+                  <td style={{paddingLeft: 24}}>{check.name}</td>
+                  <td>
+                    {check.executionForLatestMaterialization === null ? (
+                      <AssetCheckStatusTag notChecked={true} />
+                    ) : (
+                      <Link
+                        to={`/runs/${check.executionForLatestMaterialization.runId}?${qs.stringify({
+                          logs: check.name,
+                        })}`}
+                      >
+                        <AssetCheckStatusTag
+                          severity={check.severity}
+                          status={check.executionForLatestMaterialization.status}
+                        />
+                      </Link>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </Table>
+        </SidebarSection>
+      )}
     </>
   );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetSidebarActivitySummary.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetSidebarActivitySummary.tsx
@@ -1,6 +1,5 @@
-import qs from 'querystring';
-
 import {Body, Box, Colors, Icon, Spinner, Table} from '@dagster-io/ui-components';
+import qs from 'qs';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
@@ -221,7 +221,6 @@ export const AssetView = ({assetKey}: Props) => {
       <AssetChecks
         assetKey={assetKey}
         lastMaterializationTimestamp={lastMaterialization?.timestamp}
-        lastMaterializationRunId={lastMaterialization?.runId}
       />
     );
   };

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__fixtures__/AssetTables.fixtures.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__fixtures__/AssetTables.fixtures.ts
@@ -92,7 +92,7 @@ export const SingleAssetQueryMaterializedWithLatestRun: MockedResponse<AssetGrap
               __typename: 'MaterializationEvent',
             },
           ],
-
+          assetChecks: [],
           freshnessInfo: null,
           assetObservations: [
             {
@@ -145,6 +145,7 @@ export const SingleAssetQueryMaterializedStaleAndLate: MockedResponse<AssetGraph
             path: ['late_asset'],
             __typename: 'AssetKey',
           },
+          assetChecks: [],
           assetMaterializations: [
             {
               timestamp: '1674603891025',
@@ -207,6 +208,7 @@ export const SingleAssetQueryLastRunFailed: MockedResponse<AssetGraphLiveQuery> 
             path: ['run_failing_asset'],
             __typename: 'AssetKey',
           },
+          assetChecks: [],
           assetMaterializations: [
             {
               timestamp: '1666373060112',

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetCheckStatusTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetCheckStatusTag.tsx
@@ -1,6 +1,7 @@
 import {Box, Spinner, Tag} from '@dagster-io/ui-components';
 import * as React from 'react';
 
+import {assertUnreachable} from '../../app/Util';
 import {AssetCheckExecutionResolvedStatus, AssetCheckSeverity} from '../../graphql/types';
 
 export const AssetCheckStatusTag = ({
@@ -14,6 +15,9 @@ export const AssetCheckStatusTag = ({
 }) => {
   if (notChecked) {
     return <Tag>Not checked</Tag>;
+  }
+  if (!status) {
+    return null;
   }
   const isWarn = severity === AssetCheckSeverity.WARN;
   switch (status) {
@@ -40,6 +44,10 @@ export const AssetCheckStatusTag = ({
           Passed
         </Tag>
       );
+    case AssetCheckExecutionResolvedStatus.SKIPPED:
+      return <Tag icon="dot">Skipped</Tag>;
+    default:
+      assertUnreachable(status);
   }
   return null;
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetChecks.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetChecks.tsx
@@ -20,12 +20,10 @@ import {AssetChecksQuery, AssetChecksQueryVariables} from './types/AssetChecks.t
 
 export const AssetChecks = ({
   lastMaterializationTimestamp,
-  lastMaterializationRunId,
   assetKey,
 }: {
   assetKey: AssetKey;
   lastMaterializationTimestamp: string | undefined;
-  lastMaterializationRunId: string | undefined;
 }) => {
   const formatDatetime = useFormatDateTime();
   const lastMaterializationDate = React.useMemo(
@@ -46,7 +44,7 @@ export const AssetChecks = ({
   useQueryRefreshAtInterval(queryResult, FIFTEEN_SECONDS);
 
   const [openCheck, setOpenCheck] = useQueryPersistedState<string | undefined>({
-    queryKey: 'check_detail',
+    queryKey: 'checkDetail',
   });
   function content() {
     if (!data) {
@@ -60,13 +58,7 @@ export const AssetChecks = ({
     if (!checks.length) {
       return <NoChecks />;
     }
-    return (
-      <VirtualizedAssetCheckTable
-        assetKey={assetKey}
-        rows={checks}
-        lastMaterializationRunId={lastMaterializationRunId}
-      />
-    );
+    return <VirtualizedAssetCheckTable assetKey={assetKey} rows={checks} />;
   }
 
   const {AssetChecksBanner} = useContext(AssetFeatureContext);
@@ -140,7 +132,7 @@ export const ASSET_CHECKS_QUERY = gql`
         checks {
           name
           description
-          executions(limit: 1, cursor: "") {
+          executionForLatestMaterialization {
             ...AssetCheckExecutionFragment
           }
         }

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/__stories__/AssetChecks.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/__stories__/AssetChecks.stories.tsx
@@ -12,7 +12,6 @@ import {
   TestAssetCheck,
   testAssetKey,
   testLatestMaterializationTimeStamp,
-  testLatestMaterializationRunId,
   TestAssetCheckWarning,
   TestAssetCheckNoExecutions,
 } from '../__fixtures__/AssetChecks.fixtures';
@@ -36,7 +35,6 @@ const Component = ({mocks}: {mocks: MockedResponse[]}) => {
           <AssetChecks
             assetKey={testAssetKey}
             lastMaterializationTimestamp={testLatestMaterializationTimeStamp.toString()}
-            lastMaterializationRunId={testLatestMaterializationRunId.toString()}
           />
         </AssetFeatureProvider>
       </MockedProvider>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/types/AssetChecks.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/types/AssetChecks.types.ts
@@ -16,7 +16,7 @@ export type AssetChecksQuery = {
           __typename: 'AssetCheck';
           name: string;
           description: string | null;
-          executions: Array<{
+          executionForLatestMaterialization: {
             __typename: 'AssetCheckExecution';
             id: string;
             runId: string;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/types/AssetChecks.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/types/AssetChecks.types.ts
@@ -154,7 +154,7 @@ export type AssetChecksQuery = {
                   }
               >;
             } | null;
-          }>;
+          } | null;
         }>;
       };
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types.tsx
@@ -19,5 +19,5 @@ export interface AssetViewParams {
   time?: string;
   asOf?: string;
   evaluation?: string;
-  check_detail?: string;
+  checkDetail?: string;
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -841,14 +841,8 @@ type AssetCheck {
   name: String!
   assetKey: AssetKey!
   description: String
-  severity: AssetCheckSeverity!
   executions(limit: Int!, cursor: String): [AssetCheckExecution!]!
   executionForLatestMaterialization: AssetCheckExecution
-}
-
-enum AssetCheckSeverity {
-  WARN
-  ERROR
 }
 
 type AssetCheckExecution {
@@ -873,13 +867,19 @@ type AssetCheckEvaluation {
   assetKey: AssetKey!
   targetMaterialization: AssetCheckEvaluationTargetMaterializationData
   metadataEntries: [MetadataEntry!]!
-  success: Boolean
+  severity: AssetCheckSeverity!
+  success: Boolean!
 }
 
 type AssetCheckEvaluationTargetMaterializationData {
   storageId: Int!
   runId: String!
   timestamp: Float!
+}
+
+enum AssetCheckSeverity {
+  WARN
+  ERROR
 }
 
 enum EvaluationErrorReason {
@@ -1203,27 +1203,6 @@ type AssetCheckEvaluationEvent implements MessageEvent & StepEvent {
   evaluation: AssetCheckEvaluation!
 }
 
-<<<<<<< HEAD
-type AssetCheckEvaluation {
-  timestamp: Float!
-  targetMaterialization: AssetCheckEvaluationTargetMaterializationData
-  metadataEntries: [MetadataEntry!]!
-  severity: AssetCheckSeverity!
-}
-
-type AssetCheckEvaluationTargetMaterializationData {
-  storageId: Int!
-  runId: String!
-  timestamp: Float!
-}
-
-enum AssetCheckSeverity {
-  WARN
-  ERROR
-}
-
-=======
->>>>>>> c18d8b9ed1 (Split AssetNodeStatusContent into a separate file)
 type PipelineRunLogsSubscriptionFailure {
   message: String!
   missingRunId: String
@@ -3235,33 +3214,6 @@ type AssetChecks {
   checks: [AssetCheck!]!
 }
 
-<<<<<<< HEAD
-type AssetCheck {
-  name: String!
-  assetKey: AssetKey!
-  description: String
-  executions(limit: Int!, cursor: String): [AssetCheckExecution!]!
-  executionForLatestMaterialization: AssetCheckExecution
-}
-
-type AssetCheckExecution {
-  id: String!
-  runId: String!
-  status: AssetCheckExecutionResolvedStatus!
-  evaluation: AssetCheckEvaluation
-  timestamp: Float!
-}
-
-enum AssetCheckExecutionResolvedStatus {
-  IN_PROGRESS
-  SUCCEEDED
-  FAILED
-  EXECUTION_FAILED
-  SKIPPED
-}
-
-=======
->>>>>>> c18d8b9ed1 (Split AssetNodeStatusContent into a separate file)
 type AssetCheckNeedsMigrationError implements Error {
   message: String!
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -869,8 +869,11 @@ enum AssetCheckExecutionResolvedStatus {
 
 type AssetCheckEvaluation {
   timestamp: Float!
+  checkName: String!
+  assetKey: AssetKey!
   targetMaterialization: AssetCheckEvaluationTargetMaterializationData
   metadataEntries: [MetadataEntry!]!
+  success: Boolean
 }
 
 type AssetCheckEvaluationTargetMaterializationData {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -687,6 +687,7 @@ type AssetNode {
   type: DagsterType
   hasMaterializePermission: Boolean!
   hasAssetChecks: Boolean!
+  assetChecks: [AssetCheck!]!
 }
 
 type MaterializationUpstreamDataVersion {
@@ -834,6 +835,48 @@ enum StaleCauseCategory {
   CODE
   DATA
   DEPENDENCIES
+}
+
+type AssetCheck {
+  name: String!
+  assetKey: AssetKey!
+  description: String
+  severity: AssetCheckSeverity!
+  executions(limit: Int!, cursor: String): [AssetCheckExecution!]!
+  executionForLatestMaterialization: AssetCheckExecution
+}
+
+enum AssetCheckSeverity {
+  WARN
+  ERROR
+}
+
+type AssetCheckExecution {
+  id: String!
+  runId: String!
+  status: AssetCheckExecutionResolvedStatus!
+  evaluation: AssetCheckEvaluation
+  timestamp: Float!
+}
+
+enum AssetCheckExecutionResolvedStatus {
+  IN_PROGRESS
+  SUCCEEDED
+  FAILED
+  EXECUTION_FAILED
+  SKIPPED
+}
+
+type AssetCheckEvaluation {
+  timestamp: Float!
+  targetMaterialization: AssetCheckEvaluationTargetMaterializationData
+  metadataEntries: [MetadataEntry!]!
+}
+
+type AssetCheckEvaluationTargetMaterializationData {
+  storageId: Int!
+  runId: String!
+  timestamp: Float!
 }
 
 enum EvaluationErrorReason {
@@ -1157,6 +1200,7 @@ type AssetCheckEvaluationEvent implements MessageEvent & StepEvent {
   evaluation: AssetCheckEvaluation!
 }
 
+<<<<<<< HEAD
 type AssetCheckEvaluation {
   timestamp: Float!
   targetMaterialization: AssetCheckEvaluationTargetMaterializationData
@@ -1175,6 +1219,8 @@ enum AssetCheckSeverity {
   ERROR
 }
 
+=======
+>>>>>>> c18d8b9ed1 (Split AssetNodeStatusContent into a separate file)
 type PipelineRunLogsSubscriptionFailure {
   message: String!
   missingRunId: String
@@ -3186,6 +3232,7 @@ type AssetChecks {
   checks: [AssetCheck!]!
 }
 
+<<<<<<< HEAD
 type AssetCheck {
   name: String!
   assetKey: AssetKey!
@@ -3210,6 +3257,8 @@ enum AssetCheckExecutionResolvedStatus {
   SKIPPED
 }
 
+=======
+>>>>>>> c18d8b9ed1 (Split AssetNodeStatusContent into a separate file)
 type AssetCheckNeedsMigrationError implements Error {
   message: String!
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -134,6 +134,7 @@ export type AssetCheckEvaluation = {
   checkName: Scalars['String'];
   metadataEntries: Array<MetadataEntry>;
   severity: AssetCheckSeverity;
+  success: Scalars['Boolean'];
   targetMaterialization: Maybe<AssetCheckEvaluationTargetMaterializationData>;
   timestamp: Scalars['Float'];
 };
@@ -4450,6 +4451,7 @@ export const buildAssetCheckEvaluation = (
       overrides && overrides.hasOwnProperty('severity')
         ? overrides.severity!
         : AssetCheckSeverity.ERROR,
+    success: overrides && overrides.hasOwnProperty('success') ? overrides.success! : true,
     targetMaterialization:
       overrides && overrides.hasOwnProperty('targetMaterialization')
         ? overrides.targetMaterialization!

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -282,6 +282,7 @@ export type AssetMetadataEntry = MetadataEntry & {
 
 export type AssetNode = {
   __typename: 'AssetNode';
+  assetChecks: Array<AssetCheck>;
   assetKey: AssetKey;
   assetMaterializationUsedData: Array<MaterializationUpstreamDataVersion>;
   assetMaterializations: Array<MaterializationEvent>;
@@ -4795,6 +4796,7 @@ export const buildAssetNode = (
   relationshipsToOmit.add('AssetNode');
   return {
     __typename: 'AssetNode',
+    assetChecks: overrides && overrides.hasOwnProperty('assetChecks') ? overrides.assetChecks! : [],
     assetKey:
       overrides && overrides.hasOwnProperty('assetKey')
         ? overrides.assetKey!

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -130,6 +130,8 @@ export type AssetCheckExecutionsArgs = {
 
 export type AssetCheckEvaluation = {
   __typename: 'AssetCheckEvaluation';
+  assetKey: AssetKey;
+  checkName: Scalars['String'];
   metadataEntries: Array<MetadataEntry>;
   severity: AssetCheckSeverity;
   targetMaterialization: Maybe<AssetCheckEvaluationTargetMaterializationData>;
@@ -4435,6 +4437,13 @@ export const buildAssetCheckEvaluation = (
   relationshipsToOmit.add('AssetCheckEvaluation');
   return {
     __typename: 'AssetCheckEvaluation',
+    assetKey:
+      overrides && overrides.hasOwnProperty('assetKey')
+        ? overrides.assetKey!
+        : relationshipsToOmit.has('AssetKey')
+        ? ({} as AssetKey)
+        : buildAssetKey({}, relationshipsToOmit),
+    checkName: overrides && overrides.hasOwnProperty('checkName') ? overrides.checkName! : 'sed',
     metadataEntries:
       overrides && overrides.hasOwnProperty('metadataEntries') ? overrides.metadataEntries! : [],
     severity:

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewAssetsRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewAssetsRoot.tsx
@@ -19,7 +19,7 @@ import styled from 'styled-components';
 import {PythonErrorInfo} from '../app/PythonErrorInfo';
 import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../app/QueryRefresh';
 import {useTrackPageView} from '../app/analytics';
-import {StatusCase, buildAssetNodeStatusContent} from '../asset-graph/AssetNode';
+import {StatusCase, buildAssetNodeStatusContent} from '../asset-graph/AssetNodeStatusContent';
 import {displayNameForAssetKey, toGraphId} from '../asset-graph/Utils';
 import {useLiveDataForAssetKeys} from '../asset-graph/useLiveDataForAssetKeys';
 import {partitionCountString} from '../assets/AssetNodePartitionCounts';

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/LogsRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/LogsRow.tsx
@@ -187,6 +187,22 @@ export const LOGS_ROW_STRUCTURED_FRAGMENT = gql`
       externalStdoutUrl
       externalStderrUrl
     }
+    ... on AssetCheckEvaluationEvent {
+      evaluation {
+        checkName
+        success
+        timestamp
+        assetKey {
+          path
+        }
+        targetMaterialization {
+          timestamp
+        }
+        metadataEntries {
+          ...MetadataEntryFragment
+        }
+      }
+    }
   }
 
   ${METADATA_ENTRY_FRAGMENT}

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/LogsRowStructuredContent.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/LogsRowStructuredContent.tsx
@@ -21,7 +21,10 @@ import {MetadataEntryFragment} from '../metadata/types/MetadataEntry.types';
 import {EventTypeColumn} from './LogsRowComponents';
 import {IRunMetadataDict} from './RunMetadataProvider';
 import {eventTypeToDisplayType} from './getRunFilterProviders';
-import {LogsRowStructuredFragment} from './types/LogsRow.types';
+import {
+  LogsRowStructuredFragment,
+  LogsRowStructuredFragment_AssetCheckEvaluationEvent_,
+} from './types/LogsRow.types';
 
 interface IStructuredContentProps {
   node: LogsRowStructuredFragment;
@@ -247,7 +250,7 @@ export const LogsRowStructuredContent: React.FC<IStructuredContentProps> = ({nod
     case 'AssetCheckEvaluationPlannedEvent':
       return <DefaultContent message={node.message} eventType={eventType} />;
     case 'AssetCheckEvaluationEvent':
-      return <DefaultContent message={node.message} eventType={eventType} />;
+      return <AssetCheckEvaluationContent node={node} eventType={eventType} />;
     default:
       // This allows us to check that the switch is exhaustive because the union type should
       // have been narrowed following each successive case to `never` at this point.
@@ -418,6 +421,36 @@ const StepUpForRetryContent: React.FC<{
         {errorCause}
       </Box>
     </>
+  );
+};
+
+const AssetCheckEvaluationContent: React.FC<{
+  node: LogsRowStructuredFragment_AssetCheckEvaluationEvent_;
+  eventType: string;
+}> = ({node, eventType}) => {
+  const {checkName, success, metadataEntries, targetMaterialization, assetKey} = node.evaluation;
+
+  const checkLink = assetDetailsPathForKey(assetKey, {
+    view: 'checks',
+    checkDetail: checkName,
+  });
+
+  const matLink = assetDetailsPathForKey(assetKey, {
+    view: 'events',
+    asOf: targetMaterialization ? `${targetMaterialization.timestamp}` : undefined,
+  });
+
+  return (
+    <DefaultContent message="" eventType={eventType}>
+      <div>
+        <div>
+          Check <MetadataEntryLink to={checkLink}>{checkName}</MetadataEntryLink>
+          {` ${success ? 'succeeded' : 'failed'} for materialization of `}
+          <MetadataEntryLink to={matLink}>{displayNameForAssetKey(assetKey)}</MetadataEntryLink>.
+        </div>
+        <MetadataEntries entries={metadataEntries} />
+      </div>
+    </DefaultContent>
   );
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunUtils.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunUtils.tsx
@@ -40,7 +40,7 @@ export function linkToRunEvent(
   return `/runs/${run.id}?${qs.stringify({
     focusedTime: event.timestamp ? Number(event.timestamp) : undefined,
     selection: event.stepKey,
-    logs: `step:${event.stepKey}`,
+    logs: event.stepKey ? `step:${event.stepKey}` : '',
   })}`;
 }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/LogsProvider.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/LogsProvider.types.ts
@@ -55,6 +55,143 @@ export type PipelineRunLogsSubscription = {
               level: Types.LogLevel;
               stepKey: string | null;
               eventType: Types.DagsterEventType | null;
+              evaluation: {
+                __typename: 'AssetCheckEvaluation';
+                checkName: string;
+                success: boolean | null;
+                timestamp: number;
+                assetKey: {__typename: 'AssetKey'; path: Array<string>};
+                targetMaterialization: {
+                  __typename: 'AssetCheckEvaluationTargetMaterializationData';
+                  timestamp: number;
+                } | null;
+                metadataEntries: Array<
+                  | {
+                      __typename: 'AssetMetadataEntry';
+                      label: string;
+                      description: string | null;
+                      assetKey: {__typename: 'AssetKey'; path: Array<string>};
+                    }
+                  | {
+                      __typename: 'BoolMetadataEntry';
+                      boolValue: boolean | null;
+                      label: string;
+                      description: string | null;
+                    }
+                  | {
+                      __typename: 'FloatMetadataEntry';
+                      floatValue: number | null;
+                      label: string;
+                      description: string | null;
+                    }
+                  | {
+                      __typename: 'IntMetadataEntry';
+                      intValue: number | null;
+                      intRepr: string;
+                      label: string;
+                      description: string | null;
+                    }
+                  | {
+                      __typename: 'JsonMetadataEntry';
+                      jsonString: string;
+                      label: string;
+                      description: string | null;
+                    }
+                  | {
+                      __typename: 'MarkdownMetadataEntry';
+                      mdStr: string;
+                      label: string;
+                      description: string | null;
+                    }
+                  | {
+                      __typename: 'NotebookMetadataEntry';
+                      path: string;
+                      label: string;
+                      description: string | null;
+                    }
+                  | {__typename: 'NullMetadataEntry'; label: string; description: string | null}
+                  | {
+                      __typename: 'PathMetadataEntry';
+                      path: string;
+                      label: string;
+                      description: string | null;
+                    }
+                  | {
+                      __typename: 'PipelineRunMetadataEntry';
+                      runId: string;
+                      label: string;
+                      description: string | null;
+                    }
+                  | {
+                      __typename: 'PythonArtifactMetadataEntry';
+                      module: string;
+                      name: string;
+                      label: string;
+                      description: string | null;
+                    }
+                  | {
+                      __typename: 'TableMetadataEntry';
+                      label: string;
+                      description: string | null;
+                      table: {
+                        __typename: 'Table';
+                        records: Array<string>;
+                        schema: {
+                          __typename: 'TableSchema';
+                          columns: Array<{
+                            __typename: 'TableColumn';
+                            name: string;
+                            description: string | null;
+                            type: string;
+                            constraints: {
+                              __typename: 'TableColumnConstraints';
+                              nullable: boolean;
+                              unique: boolean;
+                              other: Array<string>;
+                            };
+                          }>;
+                          constraints: {
+                            __typename: 'TableConstraints';
+                            other: Array<string>;
+                          } | null;
+                        };
+                      };
+                    }
+                  | {
+                      __typename: 'TableSchemaMetadataEntry';
+                      label: string;
+                      description: string | null;
+                      schema: {
+                        __typename: 'TableSchema';
+                        columns: Array<{
+                          __typename: 'TableColumn';
+                          name: string;
+                          description: string | null;
+                          type: string;
+                          constraints: {
+                            __typename: 'TableColumnConstraints';
+                            nullable: boolean;
+                            unique: boolean;
+                            other: Array<string>;
+                          };
+                        }>;
+                        constraints: {__typename: 'TableConstraints'; other: Array<string>} | null;
+                      };
+                    }
+                  | {
+                      __typename: 'TextMetadataEntry';
+                      text: string;
+                      label: string;
+                      description: string | null;
+                    }
+                  | {
+                      __typename: 'UrlMetadataEntry';
+                      url: string;
+                      label: string;
+                      description: string | null;
+                    }
+                >;
+              };
             }
           | {
               __typename: 'AssetCheckEvaluationPlannedEvent';
@@ -2534,6 +2671,140 @@ export type RunLogsSubscriptionSuccessFragment = {
         level: Types.LogLevel;
         stepKey: string | null;
         eventType: Types.DagsterEventType | null;
+        evaluation: {
+          __typename: 'AssetCheckEvaluation';
+          checkName: string;
+          success: boolean | null;
+          timestamp: number;
+          assetKey: {__typename: 'AssetKey'; path: Array<string>};
+          targetMaterialization: {
+            __typename: 'AssetCheckEvaluationTargetMaterializationData';
+            timestamp: number;
+          } | null;
+          metadataEntries: Array<
+            | {
+                __typename: 'AssetMetadataEntry';
+                label: string;
+                description: string | null;
+                assetKey: {__typename: 'AssetKey'; path: Array<string>};
+              }
+            | {
+                __typename: 'BoolMetadataEntry';
+                boolValue: boolean | null;
+                label: string;
+                description: string | null;
+              }
+            | {
+                __typename: 'FloatMetadataEntry';
+                floatValue: number | null;
+                label: string;
+                description: string | null;
+              }
+            | {
+                __typename: 'IntMetadataEntry';
+                intValue: number | null;
+                intRepr: string;
+                label: string;
+                description: string | null;
+              }
+            | {
+                __typename: 'JsonMetadataEntry';
+                jsonString: string;
+                label: string;
+                description: string | null;
+              }
+            | {
+                __typename: 'MarkdownMetadataEntry';
+                mdStr: string;
+                label: string;
+                description: string | null;
+              }
+            | {
+                __typename: 'NotebookMetadataEntry';
+                path: string;
+                label: string;
+                description: string | null;
+              }
+            | {__typename: 'NullMetadataEntry'; label: string; description: string | null}
+            | {
+                __typename: 'PathMetadataEntry';
+                path: string;
+                label: string;
+                description: string | null;
+              }
+            | {
+                __typename: 'PipelineRunMetadataEntry';
+                runId: string;
+                label: string;
+                description: string | null;
+              }
+            | {
+                __typename: 'PythonArtifactMetadataEntry';
+                module: string;
+                name: string;
+                label: string;
+                description: string | null;
+              }
+            | {
+                __typename: 'TableMetadataEntry';
+                label: string;
+                description: string | null;
+                table: {
+                  __typename: 'Table';
+                  records: Array<string>;
+                  schema: {
+                    __typename: 'TableSchema';
+                    columns: Array<{
+                      __typename: 'TableColumn';
+                      name: string;
+                      description: string | null;
+                      type: string;
+                      constraints: {
+                        __typename: 'TableColumnConstraints';
+                        nullable: boolean;
+                        unique: boolean;
+                        other: Array<string>;
+                      };
+                    }>;
+                    constraints: {__typename: 'TableConstraints'; other: Array<string>} | null;
+                  };
+                };
+              }
+            | {
+                __typename: 'TableSchemaMetadataEntry';
+                label: string;
+                description: string | null;
+                schema: {
+                  __typename: 'TableSchema';
+                  columns: Array<{
+                    __typename: 'TableColumn';
+                    name: string;
+                    description: string | null;
+                    type: string;
+                    constraints: {
+                      __typename: 'TableColumnConstraints';
+                      nullable: boolean;
+                      unique: boolean;
+                      other: Array<string>;
+                    };
+                  }>;
+                  constraints: {__typename: 'TableConstraints'; other: Array<string>} | null;
+                };
+              }
+            | {
+                __typename: 'TextMetadataEntry';
+                text: string;
+                label: string;
+                description: string | null;
+              }
+            | {
+                __typename: 'UrlMetadataEntry';
+                url: string;
+                label: string;
+                description: string | null;
+              }
+          >;
+        };
       }
     | {
         __typename: 'AssetCheckEvaluationPlannedEvent';
@@ -4961,6 +5232,143 @@ export type RunLogsQuery = {
               level: Types.LogLevel;
               stepKey: string | null;
               eventType: Types.DagsterEventType | null;
+              evaluation: {
+                __typename: 'AssetCheckEvaluation';
+                checkName: string;
+                success: boolean | null;
+                timestamp: number;
+                assetKey: {__typename: 'AssetKey'; path: Array<string>};
+                targetMaterialization: {
+                  __typename: 'AssetCheckEvaluationTargetMaterializationData';
+                  timestamp: number;
+                } | null;
+                metadataEntries: Array<
+                  | {
+                      __typename: 'AssetMetadataEntry';
+                      label: string;
+                      description: string | null;
+                      assetKey: {__typename: 'AssetKey'; path: Array<string>};
+                    }
+                  | {
+                      __typename: 'BoolMetadataEntry';
+                      boolValue: boolean | null;
+                      label: string;
+                      description: string | null;
+                    }
+                  | {
+                      __typename: 'FloatMetadataEntry';
+                      floatValue: number | null;
+                      label: string;
+                      description: string | null;
+                    }
+                  | {
+                      __typename: 'IntMetadataEntry';
+                      intValue: number | null;
+                      intRepr: string;
+                      label: string;
+                      description: string | null;
+                    }
+                  | {
+                      __typename: 'JsonMetadataEntry';
+                      jsonString: string;
+                      label: string;
+                      description: string | null;
+                    }
+                  | {
+                      __typename: 'MarkdownMetadataEntry';
+                      mdStr: string;
+                      label: string;
+                      description: string | null;
+                    }
+                  | {
+                      __typename: 'NotebookMetadataEntry';
+                      path: string;
+                      label: string;
+                      description: string | null;
+                    }
+                  | {__typename: 'NullMetadataEntry'; label: string; description: string | null}
+                  | {
+                      __typename: 'PathMetadataEntry';
+                      path: string;
+                      label: string;
+                      description: string | null;
+                    }
+                  | {
+                      __typename: 'PipelineRunMetadataEntry';
+                      runId: string;
+                      label: string;
+                      description: string | null;
+                    }
+                  | {
+                      __typename: 'PythonArtifactMetadataEntry';
+                      module: string;
+                      name: string;
+                      label: string;
+                      description: string | null;
+                    }
+                  | {
+                      __typename: 'TableMetadataEntry';
+                      label: string;
+                      description: string | null;
+                      table: {
+                        __typename: 'Table';
+                        records: Array<string>;
+                        schema: {
+                          __typename: 'TableSchema';
+                          columns: Array<{
+                            __typename: 'TableColumn';
+                            name: string;
+                            description: string | null;
+                            type: string;
+                            constraints: {
+                              __typename: 'TableColumnConstraints';
+                              nullable: boolean;
+                              unique: boolean;
+                              other: Array<string>;
+                            };
+                          }>;
+                          constraints: {
+                            __typename: 'TableConstraints';
+                            other: Array<string>;
+                          } | null;
+                        };
+                      };
+                    }
+                  | {
+                      __typename: 'TableSchemaMetadataEntry';
+                      label: string;
+                      description: string | null;
+                      schema: {
+                        __typename: 'TableSchema';
+                        columns: Array<{
+                          __typename: 'TableColumn';
+                          name: string;
+                          description: string | null;
+                          type: string;
+                          constraints: {
+                            __typename: 'TableColumnConstraints';
+                            nullable: boolean;
+                            unique: boolean;
+                            other: Array<string>;
+                          };
+                        }>;
+                        constraints: {__typename: 'TableConstraints'; other: Array<string>} | null;
+                      };
+                    }
+                  | {
+                      __typename: 'TextMetadataEntry';
+                      text: string;
+                      label: string;
+                      description: string | null;
+                    }
+                  | {
+                      __typename: 'UrlMetadataEntry';
+                      url: string;
+                      label: string;
+                      description: string | null;
+                    }
+                >;
+              };
             }
           | {
               __typename: 'AssetCheckEvaluationPlannedEvent';

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/LogsProvider.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/LogsProvider.types.ts
@@ -58,7 +58,7 @@ export type PipelineRunLogsSubscription = {
               evaluation: {
                 __typename: 'AssetCheckEvaluation';
                 checkName: string;
-                success: boolean | null;
+                success: boolean;
                 timestamp: number;
                 assetKey: {__typename: 'AssetKey'; path: Array<string>};
                 targetMaterialization: {
@@ -2674,7 +2674,7 @@ export type RunLogsSubscriptionSuccessFragment = {
         evaluation: {
           __typename: 'AssetCheckEvaluation';
           checkName: string;
-          success: boolean | null;
+          success: boolean;
           timestamp: number;
           assetKey: {__typename: 'AssetKey'; path: Array<string>};
           targetMaterialization: {
@@ -5235,7 +5235,7 @@ export type RunLogsQuery = {
               evaluation: {
                 __typename: 'AssetCheckEvaluation';
                 checkName: string;
-                success: boolean | null;
+                success: boolean;
                 timestamp: number;
                 assetKey: {__typename: 'AssetKey'; path: Array<string>};
                 targetMaterialization: {

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/LogsRow.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/LogsRow.types.ts
@@ -36,6 +36,125 @@ export type LogsRowStructuredFragment_AssetCheckEvaluationEvent_ = {
   timestamp: string;
   level: Types.LogLevel;
   stepKey: string | null;
+  evaluation: {
+    __typename: 'AssetCheckEvaluation';
+    checkName: string;
+    success: boolean | null;
+    timestamp: number;
+    assetKey: {__typename: 'AssetKey'; path: Array<string>};
+    targetMaterialization: {
+      __typename: 'AssetCheckEvaluationTargetMaterializationData';
+      timestamp: number;
+    } | null;
+    metadataEntries: Array<
+      | {
+          __typename: 'AssetMetadataEntry';
+          label: string;
+          description: string | null;
+          assetKey: {__typename: 'AssetKey'; path: Array<string>};
+        }
+      | {
+          __typename: 'BoolMetadataEntry';
+          boolValue: boolean | null;
+          label: string;
+          description: string | null;
+        }
+      | {
+          __typename: 'FloatMetadataEntry';
+          floatValue: number | null;
+          label: string;
+          description: string | null;
+        }
+      | {
+          __typename: 'IntMetadataEntry';
+          intValue: number | null;
+          intRepr: string;
+          label: string;
+          description: string | null;
+        }
+      | {
+          __typename: 'JsonMetadataEntry';
+          jsonString: string;
+          label: string;
+          description: string | null;
+        }
+      | {
+          __typename: 'MarkdownMetadataEntry';
+          mdStr: string;
+          label: string;
+          description: string | null;
+        }
+      | {
+          __typename: 'NotebookMetadataEntry';
+          path: string;
+          label: string;
+          description: string | null;
+        }
+      | {__typename: 'NullMetadataEntry'; label: string; description: string | null}
+      | {__typename: 'PathMetadataEntry'; path: string; label: string; description: string | null}
+      | {
+          __typename: 'PipelineRunMetadataEntry';
+          runId: string;
+          label: string;
+          description: string | null;
+        }
+      | {
+          __typename: 'PythonArtifactMetadataEntry';
+          module: string;
+          name: string;
+          label: string;
+          description: string | null;
+        }
+      | {
+          __typename: 'TableMetadataEntry';
+          label: string;
+          description: string | null;
+          table: {
+            __typename: 'Table';
+            records: Array<string>;
+            schema: {
+              __typename: 'TableSchema';
+              columns: Array<{
+                __typename: 'TableColumn';
+                name: string;
+                description: string | null;
+                type: string;
+                constraints: {
+                  __typename: 'TableColumnConstraints';
+                  nullable: boolean;
+                  unique: boolean;
+                  other: Array<string>;
+                };
+              }>;
+              constraints: {__typename: 'TableConstraints'; other: Array<string>} | null;
+            };
+          };
+        }
+      | {
+          __typename: 'TableSchemaMetadataEntry';
+          label: string;
+          description: string | null;
+          schema: {
+            __typename: 'TableSchema';
+            columns: Array<{
+              __typename: 'TableColumn';
+              name: string;
+              description: string | null;
+              type: string;
+              constraints: {
+                __typename: 'TableColumnConstraints';
+                nullable: boolean;
+                unique: boolean;
+                other: Array<string>;
+              };
+            }>;
+            constraints: {__typename: 'TableConstraints'; other: Array<string>} | null;
+          };
+        }
+      | {__typename: 'TextMetadataEntry'; text: string; label: string; description: string | null}
+      | {__typename: 'UrlMetadataEntry'; url: string; label: string; description: string | null}
+    >;
+  };
 };
 
 export type LogsRowStructuredFragment_AssetCheckEvaluationPlannedEvent_ = {

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/LogsRow.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/LogsRow.types.ts
@@ -39,7 +39,7 @@ export type LogsRowStructuredFragment_AssetCheckEvaluationEvent_ = {
   evaluation: {
     __typename: 'AssetCheckEvaluation';
     checkName: string;
-    success: boolean | null;
+    success: boolean;
     timestamp: number;
     assetKey: {__typename: 'AssetKey'; path: Array<string>};
     targetMaterialization: {

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/LogsScrollingTable.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/LogsScrollingTable.types.ts
@@ -36,6 +36,125 @@ export type LogsScrollingTableMessageFragment_AssetCheckEvaluationEvent_ = {
   timestamp: string;
   level: Types.LogLevel;
   stepKey: string | null;
+  evaluation: {
+    __typename: 'AssetCheckEvaluation';
+    checkName: string;
+    success: boolean | null;
+    timestamp: number;
+    assetKey: {__typename: 'AssetKey'; path: Array<string>};
+    targetMaterialization: {
+      __typename: 'AssetCheckEvaluationTargetMaterializationData';
+      timestamp: number;
+    } | null;
+    metadataEntries: Array<
+      | {
+          __typename: 'AssetMetadataEntry';
+          label: string;
+          description: string | null;
+          assetKey: {__typename: 'AssetKey'; path: Array<string>};
+        }
+      | {
+          __typename: 'BoolMetadataEntry';
+          boolValue: boolean | null;
+          label: string;
+          description: string | null;
+        }
+      | {
+          __typename: 'FloatMetadataEntry';
+          floatValue: number | null;
+          label: string;
+          description: string | null;
+        }
+      | {
+          __typename: 'IntMetadataEntry';
+          intValue: number | null;
+          intRepr: string;
+          label: string;
+          description: string | null;
+        }
+      | {
+          __typename: 'JsonMetadataEntry';
+          jsonString: string;
+          label: string;
+          description: string | null;
+        }
+      | {
+          __typename: 'MarkdownMetadataEntry';
+          mdStr: string;
+          label: string;
+          description: string | null;
+        }
+      | {
+          __typename: 'NotebookMetadataEntry';
+          path: string;
+          label: string;
+          description: string | null;
+        }
+      | {__typename: 'NullMetadataEntry'; label: string; description: string | null}
+      | {__typename: 'PathMetadataEntry'; path: string; label: string; description: string | null}
+      | {
+          __typename: 'PipelineRunMetadataEntry';
+          runId: string;
+          label: string;
+          description: string | null;
+        }
+      | {
+          __typename: 'PythonArtifactMetadataEntry';
+          module: string;
+          name: string;
+          label: string;
+          description: string | null;
+        }
+      | {
+          __typename: 'TableMetadataEntry';
+          label: string;
+          description: string | null;
+          table: {
+            __typename: 'Table';
+            records: Array<string>;
+            schema: {
+              __typename: 'TableSchema';
+              columns: Array<{
+                __typename: 'TableColumn';
+                name: string;
+                description: string | null;
+                type: string;
+                constraints: {
+                  __typename: 'TableColumnConstraints';
+                  nullable: boolean;
+                  unique: boolean;
+                  other: Array<string>;
+                };
+              }>;
+              constraints: {__typename: 'TableConstraints'; other: Array<string>} | null;
+            };
+          };
+        }
+      | {
+          __typename: 'TableSchemaMetadataEntry';
+          label: string;
+          description: string | null;
+          schema: {
+            __typename: 'TableSchema';
+            columns: Array<{
+              __typename: 'TableColumn';
+              name: string;
+              description: string | null;
+              type: string;
+              constraints: {
+                __typename: 'TableColumnConstraints';
+                nullable: boolean;
+                unique: boolean;
+                other: Array<string>;
+              };
+            }>;
+            constraints: {__typename: 'TableConstraints'; other: Array<string>} | null;
+          };
+        }
+      | {__typename: 'TextMetadataEntry'; text: string; label: string; description: string | null}
+      | {__typename: 'UrlMetadataEntry'; url: string; label: string; description: string | null}
+    >;
+  };
 };
 
 export type LogsScrollingTableMessageFragment_AssetCheckEvaluationPlannedEvent_ = {

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/LogsScrollingTable.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/LogsScrollingTable.types.ts
@@ -39,7 +39,7 @@ export type LogsScrollingTableMessageFragment_AssetCheckEvaluationEvent_ = {
   evaluation: {
     __typename: 'AssetCheckEvaluation';
     checkName: string;
-    success: boolean | null;
+    success: boolean;
     timestamp: number;
     assetKey: {__typename: 'AssetKey'; path: Array<string>};
     targetMaterialization: {

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunFragments.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunFragments.types.ts
@@ -96,7 +96,7 @@ export type RunDagsterRunEventFragment_AssetCheckEvaluationEvent_ = {
   evaluation: {
     __typename: 'AssetCheckEvaluation';
     checkName: string;
-    success: boolean | null;
+    success: boolean;
     timestamp: number;
     assetKey: {__typename: 'AssetKey'; path: Array<string>};
     targetMaterialization: {

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunFragments.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunFragments.types.ts
@@ -93,6 +93,125 @@ export type RunDagsterRunEventFragment_AssetCheckEvaluationEvent_ = {
   level: Types.LogLevel;
   stepKey: string | null;
   eventType: Types.DagsterEventType | null;
+  evaluation: {
+    __typename: 'AssetCheckEvaluation';
+    checkName: string;
+    success: boolean | null;
+    timestamp: number;
+    assetKey: {__typename: 'AssetKey'; path: Array<string>};
+    targetMaterialization: {
+      __typename: 'AssetCheckEvaluationTargetMaterializationData';
+      timestamp: number;
+    } | null;
+    metadataEntries: Array<
+      | {
+          __typename: 'AssetMetadataEntry';
+          label: string;
+          description: string | null;
+          assetKey: {__typename: 'AssetKey'; path: Array<string>};
+        }
+      | {
+          __typename: 'BoolMetadataEntry';
+          boolValue: boolean | null;
+          label: string;
+          description: string | null;
+        }
+      | {
+          __typename: 'FloatMetadataEntry';
+          floatValue: number | null;
+          label: string;
+          description: string | null;
+        }
+      | {
+          __typename: 'IntMetadataEntry';
+          intValue: number | null;
+          intRepr: string;
+          label: string;
+          description: string | null;
+        }
+      | {
+          __typename: 'JsonMetadataEntry';
+          jsonString: string;
+          label: string;
+          description: string | null;
+        }
+      | {
+          __typename: 'MarkdownMetadataEntry';
+          mdStr: string;
+          label: string;
+          description: string | null;
+        }
+      | {
+          __typename: 'NotebookMetadataEntry';
+          path: string;
+          label: string;
+          description: string | null;
+        }
+      | {__typename: 'NullMetadataEntry'; label: string; description: string | null}
+      | {__typename: 'PathMetadataEntry'; path: string; label: string; description: string | null}
+      | {
+          __typename: 'PipelineRunMetadataEntry';
+          runId: string;
+          label: string;
+          description: string | null;
+        }
+      | {
+          __typename: 'PythonArtifactMetadataEntry';
+          module: string;
+          name: string;
+          label: string;
+          description: string | null;
+        }
+      | {
+          __typename: 'TableMetadataEntry';
+          label: string;
+          description: string | null;
+          table: {
+            __typename: 'Table';
+            records: Array<string>;
+            schema: {
+              __typename: 'TableSchema';
+              columns: Array<{
+                __typename: 'TableColumn';
+                name: string;
+                description: string | null;
+                type: string;
+                constraints: {
+                  __typename: 'TableColumnConstraints';
+                  nullable: boolean;
+                  unique: boolean;
+                  other: Array<string>;
+                };
+              }>;
+              constraints: {__typename: 'TableConstraints'; other: Array<string>} | null;
+            };
+          };
+        }
+      | {
+          __typename: 'TableSchemaMetadataEntry';
+          label: string;
+          description: string | null;
+          schema: {
+            __typename: 'TableSchema';
+            columns: Array<{
+              __typename: 'TableColumn';
+              name: string;
+              description: string | null;
+              type: string;
+              constraints: {
+                __typename: 'TableColumnConstraints';
+                nullable: boolean;
+                unique: boolean;
+                other: Array<string>;
+              };
+            }>;
+            constraints: {__typename: 'TableConstraints'; other: Array<string>} | null;
+          };
+        }
+      | {__typename: 'TextMetadataEntry'; text: string; label: string; description: string | null}
+      | {__typename: 'UrlMetadataEntry'; url: string; label: string; description: string | null}
+    >;
+  };
 };
 
 export type RunDagsterRunEventFragment_AssetCheckEvaluationPlannedEvent_ = {

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedAssetRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedAssetRow.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components';
 
-import {buildAssetNodeStatusContent} from '../asset-graph/AssetNode';
+import {buildAssetNodeStatusContent} from '../asset-graph/AssetNodeStatusContent';
 import {AssetRunLink} from '../asset-graph/AssetRunLinking';
 import {MISSING_LIVE_DATA, toGraphId, tokenForAssetKey} from '../asset-graph/Utils';
 import {useLiveDataForAssetKeys} from '../asset-graph/useLiveDataForAssetKeys';

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/events.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/events.py
@@ -424,7 +424,9 @@ def from_dagster_event_record(event_record: EventLogEntry, pipeline_name: str) -
             assetKey=data.asset_key, checkName=data.check_name, **basic_params
         )
     elif dagster_event.event_type == DagsterEventType.ASSET_CHECK_EVALUATION:
-        return GrapheneAssetCheckEvaluationEvent(evaluation=event_record, **basic_params)
+        from  ..schema.asset_checks import GrapheneAssetCheckEvaluation
+        evaluation = GrapheneAssetCheckEvaluation(event_record)
+        return GrapheneAssetCheckEvaluationEvent(evaluation=evaluation, **basic_params)
 
     else:
         raise Exception(f"Unknown DAGSTER_EVENT type {dagster_event.event_type} found in logs")

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/events.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/events.py
@@ -424,7 +424,8 @@ def from_dagster_event_record(event_record: EventLogEntry, pipeline_name: str) -
             assetKey=data.asset_key, checkName=data.check_name, **basic_params
         )
     elif dagster_event.event_type == DagsterEventType.ASSET_CHECK_EVALUATION:
-        from  ..schema.asset_checks import GrapheneAssetCheckEvaluation
+        from ..schema.asset_checks import GrapheneAssetCheckEvaluation
+
         evaluation = GrapheneAssetCheckEvaluation(event_record)
         return GrapheneAssetCheckEvaluationEvent(evaluation=evaluation, **basic_params)
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_checks.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_checks.py
@@ -53,6 +53,7 @@ class GrapheneAssetCheckEvaluation(graphene.ObjectType):
     targetMaterialization = graphene.Field(GrapheneAssetCheckEvaluationTargetMaterializationData)
     metadataEntries = non_null_list(GrapheneMetadataEntry)
     severity = graphene.NonNull(GrapheneAssetCheckSeverity)
+    success = graphene.NonNull(graphene.Boolean)
 
     class Meta:
         name = "AssetCheckEvaluation"
@@ -73,7 +74,9 @@ class GrapheneAssetCheckEvaluation(graphene.ObjectType):
 
         self.metadataEntries = list(iterate_metadata_entries(evaluation_data.metadata))
         self.severity = evaluation_data.severity
-
+        self.success = evaluation_data.success
+        self.checkName = evaluation_data.check_name
+        self.assetKey = evaluation_data.asset_key
 
 
 class GrapheneAssetCheckExecution(graphene.ObjectType):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_checks.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_checks.py
@@ -75,6 +75,7 @@ class GrapheneAssetCheckEvaluation(graphene.ObjectType):
         self.severity = evaluation_data.severity
 
 
+
 class GrapheneAssetCheckExecution(graphene.ObjectType):
     id = graphene.NonNull(graphene.String)
     runId = graphene.NonNull(graphene.String)

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_checks.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_checks.py
@@ -48,6 +48,8 @@ class GrapheneAssetCheckEvaluation(graphene.ObjectType):
     timestamp = graphene.Field(
         graphene.NonNull(graphene.Float), description="When the check evaluation was stored"
     )
+    checkName = graphene.NonNull(graphene.String)
+    assetKey = graphene.NonNull(GrapheneAssetKey)
     targetMaterialization = graphene.Field(GrapheneAssetCheckEvaluationTargetMaterializationData)
     metadataEntries = non_null_list(GrapheneMetadataEntry)
     severity = graphene.NonNull(GrapheneAssetCheckSeverity)
@@ -62,7 +64,6 @@ class GrapheneAssetCheckEvaluation(graphene.ObjectType):
             AssetCheckEvaluation,
             check.not_none(evaluation_event.dagster_event).event_specific_data,
         )
-
         target_materialization_data = evaluation_data.target_materialization_data
         self.targetMaterialization = (
             GrapheneAssetCheckEvaluationTargetMaterializationData(target_materialization_data)

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -31,7 +31,7 @@ from dagster._core.workspace.permissions import Permissions
 from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
 
 from dagster_graphql.implementation.events import iterate_metadata_entries
-from dagster_graphql.implementation.fetch_asset_checks import has_asset_checks
+from dagster_graphql.implementation.fetch_asset_checks import fetch_asset_checks, has_asset_checks
 from dagster_graphql.implementation.fetch_assets import (
     get_asset_materializations,
     get_asset_observations,
@@ -59,6 +59,7 @@ from ..implementation.loader import (
     CrossRepoAssetDependedByLoader,
     StaleStatusLoader,
 )
+from ..schema.asset_checks import GrapheneAssetCheck, GrapheneAssetCheckNeedsMigrationError
 from . import external
 from .asset_key import GrapheneAssetKey
 from .auto_materialize_policy import GrapheneAutoMaterializePolicy
@@ -265,6 +266,7 @@ class GrapheneAssetNode(graphene.ObjectType):
     # the acutal checks are listed in the assetChecksOrError resolver. We use this boolean
     # to show/hide the checks tab. We plan to remove this field once we always show the checks tab.
     hasAssetChecks = graphene.NonNull(graphene.Boolean)
+    assetChecks = non_null_list(GrapheneAssetCheck)
 
     class Meta:
         name = "AssetNode"
@@ -1088,6 +1090,12 @@ class GrapheneAssetNode(graphene.ObjectType):
 
     def resolve_hasAssetChecks(self, graphene_info: ResolveInfo) -> bool:
         return has_asset_checks(graphene_info, self._external_asset_node.asset_key)
+
+    def resolve_assetChecks(self, graphene_info: ResolveInfo) -> List[GrapheneAssetCheck]:
+        res = fetch_asset_checks(graphene_info, self._external_asset_node.asset_key)
+        if isinstance(res, GrapheneAssetCheckNeedsMigrationError):
+            return []
+        return res.checks
 
 
 class GrapheneAssetGroup(graphene.ObjectType):


### PR DESCRIPTION
## Summary & Motivation

This PR provides an initial UI for asset checks on the DAG and in the asset sidebar. It also improves the rendering of asset checks in the run logs (linking to check, asset key, showing run metadata)

I also updated the subscription to run logs on the asset graph pages so that the asset graph will live reload when long-running asset checks complete.


<img width="730" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/24e7b939-e04c-4f5c-bcf3-344313fb1bba">
<img width="1060" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/49e11656-9f65-40d6-91cf-2998c9fcf604">
<img width="1109" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/54cde88d-5074-484d-bb74-3ecd947a3521">



## How I Tested These Changes

I tested these changes manually using the toys repo and by updating our storybooks for AssetNode and the asset sidebar to run through test cases.
