### PR TITLE
observable source asset: don't call handle_output

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -396,6 +396,7 @@ class AssetLayer(NamedTuple):
         graph_def: GraphDefinition,
         assets_defs_by_outer_node_handle: Mapping[NodeHandle, "AssetsDefinition"],
         asset_checks_defs_by_node_handle: Mapping[NodeHandle, "AssetChecksDefinition"],
+        observable_source_assets_by_node_handle: Mapping[NodeHandle, "SourceAsset"],
         source_assets: Sequence["SourceAsset"],
         resolved_asset_deps: "ResolvedAssetDependencies",
     ) -> "AssetLayer":
@@ -543,6 +544,25 @@ class AssetLayer(NamedTuple):
         }
 
         source_assets_by_key = {source_asset.key: source_asset for source_asset in source_assets}
+        for node_handle, source_asset in observable_source_assets_by_node_handle.items():
+            node_def = cast(NodeDefinition, source_asset.node_def)
+            check.invariant(len(node_def.output_defs) == 1)
+            output_name = node_def.output_defs[0].name
+            # resolve graph output to the op output it comes from
+            inner_output_def, inner_node_handle = node_def.resolve_output_to_origin(
+                output_name, handle=node_handle
+            )
+            node_output_handle = NodeOutputHandle(
+                check.not_none(inner_node_handle), inner_output_def.name
+            )
+
+            asset_info_by_output[node_output_handle] = AssetOutputInfo(
+                source_asset.key,
+                partitions_fn=None,
+                partitions_def=source_asset.partitions_def,
+                is_required=True,
+                code_version=inner_output_def.code_version,
+            )
 
         assets_defs_by_node_handle: Dict[NodeHandle, "AssetsDefinition"] = {
             # nodes for assets
@@ -580,7 +600,7 @@ class AssetLayer(NamedTuple):
     def upstream_assets_for_asset(self, asset_key: AssetKey) -> AbstractSet[AssetKey]:
         check.invariant(
             asset_key in self.asset_deps,
-            "AssetKey '{asset_key}' is not produced by this JobDefinition.",
+            f"AssetKey '{asset_key}' is not produced by this JobDefinition.",
         )
         return self.asset_deps[asset_key]
 
@@ -690,6 +710,9 @@ class AssetLayer(NamedTuple):
             and self.source_assets_by_key[asset_key].is_observable
         )
 
+    def is_materializable_for_asset(self, asset_key: AssetKey) -> bool:
+        return asset_key in self.assets_defs_by_key
+
     def is_graph_backed_asset(self, asset_key: AssetKey) -> bool:
         assets_def = self.assets_defs_by_key.get(asset_key)
         return False if assets_def is None else isinstance(assets_def.node_def, GraphDefinition)
@@ -716,6 +739,13 @@ class AssetLayer(NamedTuple):
         self, node_handle: NodeHandle, output_name: str
     ) -> Optional[AssetOutputInfo]:
         return self.asset_info_by_node_output_handle.get(NodeOutputHandle(node_handle, output_name))
+
+    def asset_key_for_output(self, node_handle: NodeHandle, output_name: str) -> Optional[AssetKey]:
+        asset_info = self.asset_info_for_output(node_handle, output_name)
+        if asset_info:
+            return asset_info.key
+        else:
+            return None
 
     def asset_check_key_for_output(
         self, node_handle: NodeHandle, output_name: str

--- a/python_modules/dagster/dagster/_core/definitions/assets_job.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets_job.py
@@ -210,12 +210,19 @@ def build_assets_job(
             *(asset.node_def for asset in assets),
             *(asset_check.node_def for asset_check in asset_checks),
         ]
+        observable_source_assets_by_node_handle = {}
     else:
-        node_defs = [
-            asset.node_def
-            for asset in source_assets
-            if isinstance(asset, SourceAsset) and asset.is_observable and asset.node_def is not None
-        ]
+        node_defs = []
+        observable_source_assets_by_node_handle: Mapping[NodeHandle, SourceAsset] = {}
+        for asset in source_assets:
+            if (
+                isinstance(asset, SourceAsset)
+                and asset.is_observable
+                and asset.node_def is not None
+            ):
+                node_defs.append(asset.node_def)
+                node_handle = NodeHandle(asset.node_def.name, parent=None)
+                observable_source_assets_by_node_handle[node_handle] = asset
 
     graph = GraphDefinition(
         name=name,
@@ -233,6 +240,7 @@ def build_assets_job(
         source_assets=resolved_source_assets,
         resolved_asset_deps=resolved_asset_deps,
         assets_defs_by_outer_node_handle=assets_defs_by_node_handle,
+        observable_source_assets_by_node_handle=observable_source_assets_by_node_handle,
     )
 
     all_resource_defs = get_all_resource_defs(assets, resolved_source_assets, wrapped_resource_defs)

--- a/python_modules/dagster/dagster/_core/execution/context/system.py
+++ b/python_modules/dagster/dagster/_core/execution/context/system.py
@@ -1272,6 +1272,16 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
             known_state=self._known_state,
         )
 
+    def output_observes_source_asset(self, output_name: str) -> bool:
+        """Returns True if this step observes a source asset."""
+        asset_layer = self.job_def.asset_layer
+        if asset_layer is None:
+            return False
+        asset_key = asset_layer.asset_key_for_output(self.node_handle, output_name)
+        if asset_key is None:
+            return False
+        return asset_layer.is_observable_for_asset(asset_key)
+
 
 class TypeCheckContext:
     """The ``context`` object available to a type check function on a DagsterType."""

--- a/python_modules/dagster/dagster/_core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external_data.py
@@ -1493,7 +1493,9 @@ def external_asset_nodes_from_defs(
         asset_info_by_node_output = asset_layer.asset_info_by_node_output_handle
 
         for node_output_handle, asset_info in asset_info_by_node_output.items():
-            if not asset_info.is_required:
+            if not asset_info.is_required or not asset_layer.is_materializable_for_asset(
+                asset_info.key
+            ):
                 continue
             output_key = asset_info.key
             if output_key not in op_names_by_asset_key:


### PR DESCRIPTION
## Summary & Motivation

Fixes #16234

What's going on in this PR:
- Makes it so that the `AssetLayer` is aware of which node outputs correspond to source asset observations
- If a node output corresponds to a source asset observation, don't invoke the IO manager on it

## How I Tested These Changes
