### PR TITLE
RFC: Ext rename (not for commit)

### DIFF
--- a/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/__init__.py
+++ b/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/__init__.py
@@ -1,10 +1,10 @@
 from dagster import Definitions
-from dagster._core.external_execution.subprocess import SubprocessExecutionResource
+from dagster._core.external_execution.subprocess import ExtSubprocess
 
 from .domain_specific_dsl.stocks_dsl import get_stocks_dsl_example_defs
 from .pure_assets_dsl.assets_dsl import get_asset_dsl_example_defs
 
 defs = Definitions(
     assets=get_asset_dsl_example_defs() + get_stocks_dsl_example_defs(),
-    resources={"subprocess_resource": SubprocessExecutionResource()},
+    resources={"ext_subprocess": ExtSubprocess()},
 )

--- a/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/domain_specific_dsl/stocks_dsl.py
+++ b/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/domain_specific_dsl/stocks_dsl.py
@@ -12,7 +12,7 @@ except ImportError:
 
 from dagster import AssetKey, AssetsDefinition, asset, file_relative_path, multi_asset
 from dagster._core.definitions.asset_spec import AssetSpec
-from dagster._core.external_execution.subprocess import SubprocessExecutionResource
+from dagster._core.external_execution.subprocess import ExtSubprocess
 
 
 def load_yaml(relative_path: str) -> Dict[str, Any]:
@@ -86,13 +86,11 @@ def assets_defs_from_stock_assets(stock_assets: StockAssets) -> List[AssetsDefin
     ticker_specs = [spec_for_stock_info(stock_info) for stock_info in stock_assets.stock_infos]
 
     @multi_asset(specs=ticker_specs)
-    def fetch_the_tickers(
-        context: AssetExecutionContext, subprocess_resource: SubprocessExecutionResource
-    ):
+    def fetch_the_tickers(context: AssetExecutionContext, ext_subprocess: ExtSubprocess):
         python_executable = shutil.which("python")
         assert python_executable is not None
         script_path = file_relative_path(__file__, "user_scripts/fetch_the_tickers.py")
-        subprocess_resource.run(
+        ext_subprocess.run(
             command=[python_executable, script_path], context=context, extras={"tickers": tickers}
         )
 

--- a/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/domain_specific_dsl/user_scripts/fetch_the_tickers.py
+++ b/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/domain_specific_dsl/user_scripts/fetch_the_tickers.py
@@ -1,5 +1,5 @@
-from dagster_externals import init_dagster_externals
+from dagster_externals import init_dagster_ext
 
-context = init_dagster_externals()
+context = init_dagster_ext()
 
 context.log(f"Got tickers: {context.extras['tickers']}")

--- a/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/pure_assets_dsl/assets_dsl.py
+++ b/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/pure_assets_dsl/assets_dsl.py
@@ -13,7 +13,7 @@ except ImportError:
     from yaml import Loader
 
 from dagster import AssetKey, asset
-from dagster._core.external_execution.subprocess import SubprocessExecutionResource
+from dagster._core.external_execution.subprocess import ExtSubprocess
 
 
 def load_yaml(relative_path) -> Dict[str, Any]:
@@ -39,13 +39,13 @@ def from_asset_entries(asset_entries: Dict[str, Any]) -> List[AssetsDefinition]:
         @asset(key=asset_key, deps=deps, description=description, group_name=group_name)
         def _assets_def(
             context: AssetExecutionContext,
-            subprocess_resource: SubprocessExecutionResource,
+            ext_subprocess: ExtSubprocess,
         ) -> None:
             # instead of querying a dummy client, do your real data processing here
 
             python_executable = shutil.which("python")
             assert python_executable is not None
-            subprocess_resource.run(
+            ext_subprocess.run(
                 command=[python_executable, file_relative_path(__file__, "sql_script.py"), sql],
                 context=context,
             )

--- a/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/pure_assets_dsl/sql_script.py
+++ b/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/pure_assets_dsl/sql_script.py
@@ -1,6 +1,6 @@
 import sys
 
-from dagster_externals import init_dagster_externals
+from dagster_externals import init_dagster_ext
 
 
 class SomeSqlClient:
@@ -11,7 +11,7 @@ class SomeSqlClient:
 if __name__ == "__main__":
     sql = sys.argv[1]
 
-    context = init_dagster_externals()
+    context = init_dagster_ext()
 
     client = SomeSqlClient()
     client.query(sql)

--- a/examples/experimental/assets_yaml_dsl/assets_yaml_dsl_tests/test_assets_dsl.py
+++ b/examples/experimental/assets_yaml_dsl/assets_yaml_dsl_tests/test_assets_dsl.py
@@ -5,7 +5,7 @@ from assets_yaml_dsl.pure_assets_dsl.assets_dsl import from_asset_entries
 from dagster import AssetsDefinition
 from dagster._core.definitions.events import AssetKey
 from dagster._core.execution.context.invocation import build_asset_context
-from dagster._core.external_execution.subprocess import SubprocessExecutionResource
+from dagster._core.external_execution.subprocess import ExtSubprocess
 
 
 def assets_defs_from_yaml(yaml_string) -> List[AssetsDefinition]:
@@ -69,7 +69,7 @@ assets:
     assert assets_defs
     assert len(assets_defs) == 1
     assets_def = assets_defs[0]
-    assets_def(context=build_asset_context(), subprocess_resource=SubprocessExecutionResource())
+    assets_def(context=build_asset_context(), ext_subprocess=ExtSubprocess())
 
 
 def test_basic_group() -> None:

--- a/examples/experimental/assets_yaml_dsl/assets_yaml_dsl_tests/test_stocks_dsl.py
+++ b/examples/experimental/assets_yaml_dsl/assets_yaml_dsl_tests/test_stocks_dsl.py
@@ -18,7 +18,7 @@ import yaml
 from assets_yaml_dsl.domain_specific_dsl.stocks_dsl import assets_defs_from_stock_assets
 from dagster import AssetKey
 from dagster._core.definitions import materialize
-from dagster._core.external_execution.subprocess import SubprocessExecutionResource
+from dagster._core.external_execution.subprocess import ExtSubprocess
 from examples.experimental.assets_yaml_dsl.assets_yaml_dsl.domain_specific_dsl.stocks_dsl import (
     build_stock_assets_object,
 )
@@ -54,6 +54,4 @@ def test_materialize_stocks_dsl():
     stocks_dsl_document = yaml.safe_load(EXAMPLE_TEXT)
     stock_assets = build_stock_assets_object(stocks_dsl_document)
     assets_defs = assets_defs_from_stock_assets(stock_assets)
-    assert materialize(
-        assets=assets_defs, resources={"subprocess_resource": SubprocessExecutionResource()}
-    ).success
+    assert materialize(assets=assets_defs, resources={"ext_subprocess": ExtSubprocess()}).success

--- a/python_modules/dagster-externals/dagster_externals/__init__.py
+++ b/python_modules/dagster-externals/dagster_externals/__init__.py
@@ -1,35 +1,33 @@
 from dagster_externals._context import (
-    ExternalExecutionContext as ExternalExecutionContext,
-    init_dagster_externals as init_dagster_externals,
+    ExtContext as ExtContext,
+    init_dagster_ext as init_dagster_ext,
 )
 from dagster_externals._io.base import (
-    ExternalExecutionContextLoader as ExternalExecutionContextLoader,
-    ExternalExecutionMessageWriter as ExternalExecutionMessageWriter,
+    ExtContextLoader as ExtContextLoader,
+    ExtMessageWriter as ExtMessageWriter,
 )
 from dagster_externals._io.default import (
-    ExternalExecutionFileContextLoader as ExternalExecutionFileContextLoader,
-    ExternalExecutionFileMessageWriter as ExternalExecutionFileMessageWriter,
+    ExtFileContextLoader as ExtFileContextLoader,
+    ExtFileMessageWriter as ExtFileMessageWriter,
 )
-from dagster_externals._io.env import (
-    ExternalExecutionEnvContextLoader as ExternalExecutionEnvContextLoader,
-)
+from dagster_externals._io.env import ExtEnvVarContextLoader as ExtEnvVarContextLoader
 from dagster_externals._io.s3 import (
-    ExternalExecutionS3MessageWriter as ExternalExecutionS3MessageWriter,
+    ExtS3MessageWriter as ExtS3MessageWriter,
 )
 from dagster_externals._protocol import (
     DAGSTER_EXTERNALS_ENV_KEYS as DAGSTER_EXTERNALS_ENV_KEYS,
-    ExternalExecutionContextData as ExternalExecutionContextData,
-    ExternalExecutionDataProvenance as ExternalExecutionDataProvenance,
-    ExternalExecutionExtras as ExternalExecutionExtras,
-    ExternalExecutionMessage as ExternalExecutionMessage,
-    ExternalExecutionParams as ExternalExecutionParams,
-    ExternalExecutionPartitionKeyRange as ExternalExecutionPartitionKeyRange,
-    ExternalExecutionTimeWindow as ExternalExecutionTimeWindow,
+    ExtContextData as ExtContextData,
+    ExtDataProvenance as ExtDataProvenance,
+    ExtExtras as ExtExtras,
+    ExtMessage as ExtMessage,
+    ExtParams as ExtParams,
+    ExtPartitionKeyRange as ExtPartitionKeyRange,
+    ExtTimeWindow as ExtTimeWindow,
 )
 from dagster_externals._util import (
-    DagsterExternalsError as DagsterExternalsError,
-    DagsterExternalsWarning as DagsterExternalsWarning,
+    ExtError as ExtError,
+    ExtWarning as ExtWarning,
     decode_env_var as decode_env_var,
     encode_env_var as encode_env_var,
-    is_dagster_orchestration_active as is_dagster_orchestration_active,
+    launched_by_ext_client as launched_by_ext_client,
 )

--- a/python_modules/dagster-externals/dagster_externals/_io/base.py
+++ b/python_modules/dagster-externals/dagster_externals/_io/base.py
@@ -48,11 +48,11 @@ class ExtParamLoader(ABC):
 
 
 T_BlobStoreMessageWriterChannel = TypeVar(
-    "T_BlobStoreMessageWriterChannel", bound="ExternalExecutionBlobStoreMessageWriterChannel"
+    "T_BlobStoreMessageWriterChannel", bound="ExtBlobStoreMessageWriterChannel"
 )
 
 
-class ExternalExecutionBlobStoreMessageWriter(ExtMessageWriter[T_BlobStoreMessageWriterChannel]):
+class ExtBlobStoreMessageWriter(ExtMessageWriter[T_BlobStoreMessageWriterChannel]):
     def __init__(self, *, interval: float = 10):
         self.interval = interval
 
@@ -67,7 +67,7 @@ class ExternalExecutionBlobStoreMessageWriter(ExtMessageWriter[T_BlobStoreMessag
         ...
 
 
-class ExternalExecutionBlobStoreMessageWriterChannel(ExtMessageWriterChannel):
+class ExtBlobStoreMessageWriterChannel(ExtMessageWriterChannel):
     def __init__(self, *, interval: float = 10):
         self._interval = interval
         self._lock = Lock()

--- a/python_modules/dagster-externals/dagster_externals/_io/default.py
+++ b/python_modules/dagster-externals/dagster_externals/_io/default.py
@@ -3,55 +3,51 @@ from contextlib import contextmanager
 from typing import Iterator, Optional
 
 from .._protocol import (
-    ExternalExecutionContextData,
-    ExternalExecutionMessage,
-    ExternalExecutionParams,
+    ExtContextData,
+    ExtMessage,
+    ExtParams,
 )
 from .._util import assert_env_param_type, param_from_env_var
 from .base import (
-    ExternalExecutionContextLoader,
-    ExternalExecutionMessageWriter,
-    ExternalExecutionMessageWriterChannel,
-    ExternalExecutionParamLoader,
+    ExtContextLoader,
+    ExtMessageWriter,
+    ExtMessageWriterChannel,
+    ExtParamLoader,
 )
 
 
-class ExternalExecutionFileContextLoader(ExternalExecutionContextLoader):
+class ExtFileContextLoader(ExtContextLoader):
     _path: Optional[str] = None
 
     @contextmanager
-    def load_context(
-        self, params: ExternalExecutionParams
-    ) -> Iterator[ExternalExecutionContextData]:
+    def load_context(self, params: ExtParams) -> Iterator[ExtContextData]:
         path = assert_env_param_type(params, "path", str, self.__class__)
         with open(path, "r") as f:
             data = json.load(f)
         yield data
 
 
-class ExternalExecutionFileMessageWriter(ExternalExecutionMessageWriter):
+class ExtFileMessageWriter(ExtMessageWriter):
     _path: Optional[str] = None
 
     @contextmanager
-    def open(
-        self, params: ExternalExecutionParams
-    ) -> Iterator["ExternalExecutionFileMessageChannel"]:
+    def open(self, params: ExtParams) -> Iterator["ExternalExecutionFileMessageChannel"]:
         path = assert_env_param_type(params, "path", str, self.__class__)
         yield ExternalExecutionFileMessageChannel(path)
 
 
-class ExternalExecutionFileMessageChannel(ExternalExecutionMessageWriterChannel):
+class ExternalExecutionFileMessageChannel(ExtMessageWriterChannel):
     def __init__(self, path: str):
         self._path = path
 
-    def write_message(self, message: ExternalExecutionMessage) -> None:
+    def write_message(self, message: ExtMessage) -> None:
         with open(self._path, "a") as f:
             f.write(json.dumps(message) + "\n")
 
 
-class ExternalExecutionEnvVarParamLoader(ExternalExecutionParamLoader):
-    def load_context_params(self) -> ExternalExecutionParams:
+class ExtEnvVarParamLoader(ExtParamLoader):
+    def load_context_params(self) -> ExtParams:
         return param_from_env_var("context")
 
-    def load_messages_params(self) -> ExternalExecutionParams:
+    def load_messages_params(self) -> ExtParams:
         return param_from_env_var("messages")

--- a/python_modules/dagster-externals/dagster_externals/_io/default.py
+++ b/python_modules/dagster-externals/dagster_externals/_io/default.py
@@ -31,12 +31,12 @@ class ExtFileMessageWriter(ExtMessageWriter):
     _path: Optional[str] = None
 
     @contextmanager
-    def open(self, params: ExtParams) -> Iterator["ExternalExecutionFileMessageChannel"]:
+    def open(self, params: ExtParams) -> Iterator["ExtFileMessageChannel"]:
         path = assert_env_param_type(params, "path", str, self.__class__)
-        yield ExternalExecutionFileMessageChannel(path)
+        yield ExtFileMessageChannel(path)
 
 
-class ExternalExecutionFileMessageChannel(ExtMessageWriterChannel):
+class ExtFileMessageChannel(ExtMessageWriterChannel):
     def __init__(self, path: str):
         self._path = path
 

--- a/python_modules/dagster-externals/dagster_externals/_io/env.py
+++ b/python_modules/dagster-externals/dagster_externals/_io/env.py
@@ -2,17 +2,15 @@ from contextlib import contextmanager
 from typing import Iterator, cast
 
 from .._protocol import (
-    ExternalExecutionContextData,
-    ExternalExecutionParams,
+    ExtContextData,
+    ExtParams,
 )
 from .._util import assert_env_param_type
-from .base import ExternalExecutionContextLoader
+from .base import ExtContextLoader
 
 
-class ExternalExecutionEnvContextLoader(ExternalExecutionContextLoader):
+class ExtEnvVarContextLoader(ExtContextLoader):
     @contextmanager
-    def load_context(
-        self, params: ExternalExecutionParams
-    ) -> Iterator["ExternalExecutionContextData"]:
+    def load_context(self, params: ExtParams) -> Iterator["ExtContextData"]:
         data = assert_env_param_type(params, "data", dict, self.__class__)
-        yield cast(ExternalExecutionContextData, data)
+        yield cast(ExtContextData, data)

--- a/python_modules/dagster-externals/dagster_externals/_io/s3.py
+++ b/python_modules/dagster-externals/dagster_externals/_io/s3.py
@@ -3,12 +3,12 @@ from typing import IO, Any, Optional
 from .._protocol import ExtParams
 from .._util import assert_env_param_type, assert_opt_env_param_type, assert_param_type
 from .base import (
-    ExternalExecutionBlobStoreMessageWriter,
-    ExternalExecutionBlobStoreMessageWriterChannel,
+    ExtBlobStoreMessageWriter,
+    ExtBlobStoreMessageWriterChannel,
 )
 
 
-class ExtS3MessageWriter(ExternalExecutionBlobStoreMessageWriter):
+class ExtS3MessageWriter(ExtBlobStoreMessageWriter):
     # client is a boto3.client("s3") object
     def __init__(self, client: Any, *, interval: float = 10):
         super().__init__(interval=interval)
@@ -20,10 +20,10 @@ class ExtS3MessageWriter(ExternalExecutionBlobStoreMessageWriter):
     def make_channel(
         self,
         params: ExtParams,
-    ) -> "ExternalExecutionS3MessageChannel":
+    ) -> "ExtS3MessageChannel":
         bucket = assert_env_param_type(params, "bucket", str, self.__class__)
         key_prefix = assert_opt_env_param_type(params, "key_prefix", str, self.__class__)
-        return ExternalExecutionS3MessageChannel(
+        return ExtS3MessageChannel(
             client=self._client,
             bucket=bucket,
             key_prefix=key_prefix,
@@ -31,7 +31,7 @@ class ExtS3MessageWriter(ExternalExecutionBlobStoreMessageWriter):
         )
 
 
-class ExternalExecutionS3MessageChannel(ExternalExecutionBlobStoreMessageWriterChannel):
+class ExtS3MessageChannel(ExtBlobStoreMessageWriterChannel):
     # client is a boto3.client("s3") object
     def __init__(
         self, client: Any, bucket: str, key_prefix: Optional[str], *, interval: float = 10

--- a/python_modules/dagster-externals/dagster_externals/_io/s3.py
+++ b/python_modules/dagster-externals/dagster_externals/_io/s3.py
@@ -1,6 +1,6 @@
 from typing import IO, Any, Optional
 
-from .._protocol import ExternalExecutionParams
+from .._protocol import ExtParams
 from .._util import assert_env_param_type, assert_opt_env_param_type, assert_param_type
 from .base import (
     ExternalExecutionBlobStoreMessageWriter,
@@ -8,7 +8,7 @@ from .base import (
 )
 
 
-class ExternalExecutionS3MessageWriter(ExternalExecutionBlobStoreMessageWriter):
+class ExtS3MessageWriter(ExternalExecutionBlobStoreMessageWriter):
     # client is a boto3.client("s3") object
     def __init__(self, client: Any, *, interval: float = 10):
         super().__init__(interval=interval)
@@ -19,7 +19,7 @@ class ExternalExecutionS3MessageWriter(ExternalExecutionBlobStoreMessageWriter):
 
     def make_channel(
         self,
-        params: ExternalExecutionParams,
+        params: ExtParams,
     ) -> "ExternalExecutionS3MessageChannel":
         bucket = assert_env_param_type(params, "bucket", str, self.__class__)
         key_prefix = assert_opt_env_param_type(params, "key_prefix", str, self.__class__)

--- a/python_modules/dagster-externals/dagster_externals/_protocol.py
+++ b/python_modules/dagster-externals/dagster_externals/_protocol.py
@@ -1,7 +1,7 @@
 from typing import Any, Mapping, Optional, Sequence, TypedDict
 
-ExternalExecutionExtras = Mapping[str, Any]
-ExternalExecutionParams = Mapping[str, Any]
+ExtExtras = Mapping[str, Any]
+ExtParams = Mapping[str, Any]
 
 
 ENV_KEY_PREFIX = "DAGSTER_EXTERNALS_"
@@ -14,14 +14,14 @@ def _param_name_to_env_key(key: str) -> str:
 # ##### PARAMETERS
 
 DAGSTER_EXTERNALS_ENV_KEYS = {
-    k: _param_name_to_env_key(k) for k in ("is_orchestration_active", "context", "messages")
+    k: _param_name_to_env_key(k) for k in ("launched_by_ext_client", "context", "messages")
 }
 
 
 # ##### MESSAGE
 
 
-class ExternalExecutionMessage(TypedDict):
+class ExtMessage(TypedDict):
     method: str
     params: Optional[Mapping[str, Any]]
 
@@ -29,30 +29,30 @@ class ExternalExecutionMessage(TypedDict):
 # ##### EXTERNAL EXECUTION CONTEXT
 
 
-class ExternalExecutionContextData(TypedDict):
+class ExtContextData(TypedDict):
     asset_keys: Optional[Sequence[str]]
     code_version_by_asset_key: Optional[Mapping[str, Optional[str]]]
-    provenance_by_asset_key: Optional[Mapping[str, Optional["ExternalExecutionDataProvenance"]]]
+    provenance_by_asset_key: Optional[Mapping[str, Optional["ExtDataProvenance"]]]
     partition_key: Optional[str]
-    partition_key_range: Optional["ExternalExecutionPartitionKeyRange"]
-    partition_time_window: Optional["ExternalExecutionTimeWindow"]
+    partition_key_range: Optional["ExtPartitionKeyRange"]
+    partition_time_window: Optional["ExtTimeWindow"]
     run_id: str
     job_name: Optional[str]
     retry_number: int
     extras: Mapping[str, Any]
 
 
-class ExternalExecutionPartitionKeyRange(TypedDict):
+class ExtPartitionKeyRange(TypedDict):
     start: str
     end: str
 
 
-class ExternalExecutionTimeWindow(TypedDict):
+class ExtTimeWindow(TypedDict):
     start: str  # timestamp
     end: str  # timestamp
 
 
-class ExternalExecutionDataProvenance(TypedDict):
+class ExtDataProvenance(TypedDict):
     code_version: str
     input_data_versions: Mapping[str, str]
     is_user_provided: bool

--- a/python_modules/dagster-externals/dagster_externals/_util.py
+++ b/python_modules/dagster-externals/dagster_externals/_util.py
@@ -7,9 +7,9 @@ from typing import TYPE_CHECKING, Any, Optional, Sequence, Type, TypeVar
 
 from ._protocol import (
     ENV_KEY_PREFIX,
-    ExternalExecutionContextData,
-    ExternalExecutionExtras,
-    ExternalExecutionParams,
+    ExtContextData,
+    ExtExtras,
+    ExtParams,
 )
 
 if TYPE_CHECKING:
@@ -18,17 +18,17 @@ if TYPE_CHECKING:
 T = TypeVar("T")
 
 
-class DagsterExternalsError(Exception):
+class ExtError(Exception):
     pass
 
 
-class DagsterExternalsWarning(Warning):
+class ExtWarning(Warning):
     pass
 
 
 def assert_not_none(value: Optional[T], desc: Optional[str] = None) -> T:
     if value is None:
-        raise DagsterExternalsError(f"Missing required property: {desc}")
+        raise ExtError(f"Missing required property: {desc}")
     return value
 
 
@@ -37,11 +37,11 @@ def assert_defined_asset_property(value: Optional[T], key: str) -> T:
 
 
 # This should only be called under the precondition that the current steps targets assets.
-def assert_single_asset(data: ExternalExecutionContextData, key: str) -> None:
+def assert_single_asset(data: ExtContextData, key: str) -> None:
     asset_keys = data["asset_keys"]
     assert asset_keys is not None
     if len(asset_keys) != 1:
-        raise DagsterExternalsError(f"`{key}` is undefined. Current step targets multiple assets.")
+        raise ExtError(f"`{key}` is undefined. Current step targets multiple assets.")
 
 
 def assert_defined_partition_property(value: Optional[T], key: str) -> T:
@@ -51,36 +51,32 @@ def assert_defined_partition_property(value: Optional[T], key: str) -> T:
 
 
 # This should only be called under the precondition that the current steps targets assets.
-def assert_single_partition(data: ExternalExecutionContextData, key: str) -> None:
+def assert_single_partition(data: ExtContextData, key: str) -> None:
     partition_key_range = data["partition_key_range"]
     assert partition_key_range is not None
     if partition_key_range["start"] != partition_key_range["end"]:
-        raise DagsterExternalsError(
-            f"`{key}` is undefined. Current step targets multiple partitions."
-        )
+        raise ExtError(f"`{key}` is undefined. Current step targets multiple partitions.")
 
 
-def assert_defined_extra(extras: ExternalExecutionExtras, key: str) -> Any:
+def assert_defined_extra(extras: ExtExtras, key: str) -> Any:
     if key not in extras:
-        raise DagsterExternalsError(f"Extra `{key}` is undefined. Extras must be provided by user.")
+        raise ExtError(f"Extra `{key}` is undefined. Extras must be provided by user.")
     return extras[key]
 
 
 def assert_param_type(value: T, expected_type: Any, method: str, param: str) -> T:
     if not isinstance(value, expected_type):
-        raise DagsterExternalsError(
+        raise ExtError(
             f"Invalid type for parameter `{param}` of `{method}`. Expected `{expected_type}`, got"
             f" `{type(value)}`."
         )
     return value
 
 
-def assert_env_param_type(
-    env_params: ExternalExecutionParams, key: str, expected_type: Type[T], cls: Type
-) -> T:
+def assert_env_param_type(env_params: ExtParams, key: str, expected_type: Type[T], cls: Type) -> T:
     value = env_params.get(key)
     if not isinstance(value, expected_type):
-        raise DagsterExternalsError(
+        raise ExtError(
             f"Invalid type for parameter `{key}` passed from orchestration side to"
             f" `{cls.__name__}`. Expected `{expected_type}`, got `{type(value)}`."
         )
@@ -88,11 +84,11 @@ def assert_env_param_type(
 
 
 def assert_opt_env_param_type(
-    env_params: ExternalExecutionParams, key: str, expected_type: Type[T], cls: Type
+    env_params: ExtParams, key: str, expected_type: Type[T], cls: Type
 ) -> Optional[T]:
     value = env_params.get(key)
     if value is not None and not isinstance(value, expected_type):
-        raise DagsterExternalsError(
+        raise ExtError(
             f"Invalid type for parameter `{key}` passed from orchestration side to"
             f" `{cls.__name__}`. Expected `Optional[{expected_type}]`, got `{type(value)}`."
         )
@@ -101,7 +97,7 @@ def assert_opt_env_param_type(
 
 def assert_param_value(value: T, expected_values: Sequence[T], method: str, param: str) -> T:
     if value not in expected_values:
-        raise DagsterExternalsError(
+        raise ExtError(
             f"Invalid value for parameter `{param}` of `{method}`. Expected one of"
             f" `{expected_values}`, got `{value}`."
         )
@@ -112,7 +108,7 @@ def assert_param_json_serializable(value: T, method: str, param: str) -> T:
     try:
         json.dumps(value)
     except (TypeError, OverflowError):
-        raise DagsterExternalsError(
+        raise ExtError(
             f"Invalid type for parameter `{param}` of `{method}`. Expected a JSON-serializable"
             f" type, got `{type(value)}`."
         )
@@ -145,8 +141,8 @@ def env_var_to_param_name(env_var: str) -> str:
     return env_var[len(ENV_KEY_PREFIX) :].lower()
 
 
-def is_dagster_orchestration_active() -> bool:
-    return param_from_env_var("is_orchestration_active")
+def launched_by_ext_client() -> bool:
+    return param_from_env_var("launched_by_ext_client")
 
 
 def emit_orchestration_inactive_warning() -> None:
@@ -154,7 +150,7 @@ def emit_orchestration_inactive_warning() -> None:
         "This process was not launched by a Dagster orchestration process. All calls to the"
         " `dagster-externals` context or attempts to initialize `dagster-externals` abstractions"
         " are no-ops.",
-        category=DagsterExternalsWarning,
+        category=ExtWarning,
     )
 
 

--- a/python_modules/dagster-externals/dagster_externals_tests/test_context.py
+++ b/python_modules/dagster-externals/dagster_externals_tests/test_context.py
@@ -1,16 +1,16 @@
 from unittest.mock import MagicMock
 
 import pytest
-from dagster_externals._context import ExternalExecutionContext
+from dagster_externals._context import ExtContext
 from dagster_externals._protocol import (
-    ExternalExecutionContextData,
-    ExternalExecutionDataProvenance,
-    ExternalExecutionPartitionKeyRange,
-    ExternalExecutionTimeWindow,
+    ExtContextData,
+    ExtDataProvenance,
+    ExtPartitionKeyRange,
+    ExtTimeWindow,
 )
-from dagster_externals._util import DagsterExternalsError
+from dagster_externals._util import ExtError
 
-TEST_EXTERNAL_EXECUTION_CONTEXT_DEFAULTS = ExternalExecutionContextData(
+TEST_EXTERNAL_EXECUTION_CONTEXT_DEFAULTS = ExtContextData(
     asset_keys=None,
     code_version_by_asset_key=None,
     provenance_by_asset_key=None,
@@ -26,14 +26,14 @@ TEST_EXTERNAL_EXECUTION_CONTEXT_DEFAULTS = ExternalExecutionContextData(
 
 def _make_external_execution_context(**kwargs):
     kwargs = {**TEST_EXTERNAL_EXECUTION_CONTEXT_DEFAULTS, **kwargs}
-    return ExternalExecutionContext(
-        data=ExternalExecutionContextData(**kwargs),
+    return ExtContext(
+        data=ExtContextData(**kwargs),
         message_channel=MagicMock(),
     )
 
 
 def _assert_undefined(context, key) -> None:
-    with pytest.raises(DagsterExternalsError, match=f"`{key}` is undefined"):
+    with pytest.raises(ExtError, match=f"`{key}` is undefined"):
         getattr(context, key)
 
 
@@ -50,7 +50,7 @@ def test_no_asset_context():
 
 
 def test_single_asset_context():
-    foo_provenance = ExternalExecutionDataProvenance(
+    foo_provenance = ExtDataProvenance(
         code_version="alpha", input_data_versions={"bar": "baz"}, is_user_provided=False
     )
 
@@ -70,7 +70,7 @@ def test_single_asset_context():
 
 
 def test_multi_asset_context():
-    foo_provenance = ExternalExecutionDataProvenance(
+    foo_provenance = ExtDataProvenance(
         code_version="alpha", input_data_versions={"bar": "baz"}, is_user_provided=False
     )
     bar_provenance = None
@@ -103,7 +103,7 @@ def test_no_partition_context():
 
 
 def test_single_partition_context():
-    partition_key_range = ExternalExecutionPartitionKeyRange(start="foo", end="foo")
+    partition_key_range = ExtPartitionKeyRange(start="foo", end="foo")
 
     context = _make_external_execution_context(
         partition_key="foo",
@@ -118,8 +118,8 @@ def test_single_partition_context():
 
 
 def test_multiple_partition_context():
-    partition_key_range = ExternalExecutionPartitionKeyRange(start="2023-01-01", end="2023-01-02")
-    time_window = ExternalExecutionTimeWindow(start="2023-01-01", end="2023-01-02")
+    partition_key_range = ExtPartitionKeyRange(start="2023-01-01", end="2023-01-02")
+    time_window = ExtTimeWindow(start="2023-01-01", end="2023-01-02")
 
     context = _make_external_execution_context(
         partition_key=None,
@@ -137,5 +137,5 @@ def test_extras_context():
     context = _make_external_execution_context(extras={"foo": "bar"})
 
     assert context.get_extra("foo") == "bar"
-    with pytest.raises(DagsterExternalsError, match="Extra `bar` is undefined"):
+    with pytest.raises(ExtError, match="Extra `bar` is undefined"):
         context.get_extra("bar")

--- a/python_modules/dagster-test/dagster_test/toys/external_execution/__init__.py
+++ b/python_modules/dagster-test/dagster_test/toys/external_execution/__init__.py
@@ -3,7 +3,7 @@ import sys
 
 from dagster import AssetExecutionContext, Config, Definitions, asset
 from dagster._core.external_execution.subprocess import (
-    SubprocessExecutionResource,
+    ExtSubprocess,
 )
 from pydantic import Field
 
@@ -32,17 +32,13 @@ class NumberConfig(Config):
 
 
 @asset
-def number_x(
-    context: AssetExecutionContext, ext: SubprocessExecutionResource, config: NumberConfig
-) -> None:
+def number_x(context: AssetExecutionContext, ext: ExtSubprocess, config: NumberConfig) -> None:
     extras = {**get_common_extras(context), "multiplier": config.multiplier}
     ext.run(command_for_asset("number_x"), context=context, extras=extras)
 
 
 @asset
-def number_y(
-    context: AssetExecutionContext, ext: SubprocessExecutionResource, config: NumberConfig
-):
+def number_y(context: AssetExecutionContext, ext: ExtSubprocess, config: NumberConfig):
     ext.run(
         command_for_asset("number_y"),
         context=context,
@@ -52,11 +48,11 @@ def number_y(
 
 
 @asset(deps=[number_x, number_y])
-def number_sum(context: AssetExecutionContext, ext: SubprocessExecutionResource) -> None:
+def number_sum(context: AssetExecutionContext, ext: ExtSubprocess) -> None:
     ext.run(command_for_asset("number_sum"), context=context, extras=get_common_extras(context))
 
 
-ext = SubprocessExecutionResource(
+ext = ExtSubprocess(
     env=get_env(),
 )
 

--- a/python_modules/dagster-test/dagster_test/toys/external_execution/numbers_example/number_sum.py
+++ b/python_modules/dagster-test/dagster_test/toys/external_execution/numbers_example/number_sum.py
@@ -1,8 +1,8 @@
-from dagster_externals import init_dagster_externals
+from dagster_externals import init_dagster_ext
 
 from .util import compute_data_version, load_asset_value, store_asset_value
 
-context = init_dagster_externals()
+context = init_dagster_ext()
 storage_root = context.get_extra("storage_root")
 number_y = load_asset_value("number_y", storage_root)
 number_x = load_asset_value("number_x", storage_root)

--- a/python_modules/dagster-test/dagster_test/toys/external_execution/numbers_example/number_x.py
+++ b/python_modules/dagster-test/dagster_test/toys/external_execution/numbers_example/number_x.py
@@ -1,8 +1,8 @@
-from dagster_externals import init_dagster_externals
+from dagster_externals import init_dagster_ext
 
 from .util import compute_data_version, store_asset_value
 
-context = init_dagster_externals()
+context = init_dagster_ext()
 storage_root = context.get_extra("storage_root")
 
 multiplier = context.get_extra("multiplier")

--- a/python_modules/dagster-test/dagster_test/toys/external_execution/numbers_example/number_y.py
+++ b/python_modules/dagster-test/dagster_test/toys/external_execution/numbers_example/number_y.py
@@ -1,10 +1,10 @@
 import os
 
-from dagster_externals import init_dagster_externals
+from dagster_externals import init_dagster_ext
 
 from .util import compute_data_version, store_asset_value
 
-context = init_dagster_externals()
+context = init_dagster_ext()
 storage_root = context.get_extra("storage_root")
 
 value = int(os.environ["NUMBER_Y"])

--- a/python_modules/dagster/dagster/_core/external_execution/resource.py
+++ b/python_modules/dagster/dagster/_core/external_execution/resource.py
@@ -4,8 +4,8 @@ from typing import TYPE_CHECKING, Iterator, Mapping, Optional
 
 from dagster_externals import (
     DAGSTER_EXTERNALS_ENV_KEYS,
-    ExternalExecutionExtras,
-    ExternalExecutionParams,
+    ExtExtras,
+    ExtParams,
     encode_env_var,
 )
 
@@ -13,38 +13,34 @@ from dagster._config.pythonic_config import ConfigurableResource
 from dagster._core.execution.context.compute import OpExecutionContext
 
 if TYPE_CHECKING:
-    from dagster._core.external_execution.context import ExternalExecutionOrchestrationContext
+    from dagster._core.external_execution.context import ExtOrchestrationContext
 
 
-class ExternalExecutionResource(ConfigurableResource, ABC):
+class ExtClient(ConfigurableResource, ABC):
     def get_base_env(self) -> Mapping[str, str]:
-        return {DAGSTER_EXTERNALS_ENV_KEYS["is_orchestration_active"]: encode_env_var(True)}
+        return {DAGSTER_EXTERNALS_ENV_KEYS["launched_by_ext_client"]: encode_env_var(True)}
 
     @abstractmethod
     def run(
         self,
         *,
         context: OpExecutionContext,
-        extras: Optional[ExternalExecutionExtras] = None,
-        context_injector: Optional["ExternalExecutionContextInjector"] = None,
-        message_reader: Optional["ExternalExecutionMessageReader"] = None,
+        extras: Optional[ExtExtras] = None,
+        context_injector: Optional["ExtContextInjector"] = None,
+        message_reader: Optional["ExtMessageReader"] = None,
     ) -> None:
         ...
 
 
-class ExternalExecutionContextInjector(ABC):
+class ExtContextInjector(ABC):
     @abstractmethod
     @contextmanager
-    def inject_context(
-        self, context: "ExternalExecutionOrchestrationContext"
-    ) -> Iterator[ExternalExecutionParams]:
+    def inject_context(self, context: "ExtOrchestrationContext") -> Iterator[ExtParams]:
         ...
 
 
-class ExternalExecutionMessageReader(ABC):
+class ExtMessageReader(ABC):
     @abstractmethod
     @contextmanager
-    def read_messages(
-        self, context: "ExternalExecutionOrchestrationContext"
-    ) -> Iterator[ExternalExecutionParams]:
+    def read_messages(self, context: "ExtOrchestrationContext") -> Iterator[ExtParams]:
         ...

--- a/python_modules/libraries/dagster-aws/dagster_aws/externals.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/externals.py
@@ -6,19 +6,19 @@ import boto3
 import dagster._check as check
 from botocore.exceptions import ClientError
 from dagster._core.external_execution.resource import (
-    ExternalExecutionParams,
+    ExtParams,
 )
-from dagster._core.external_execution.utils import ExternalExecutionBlobStoreMessageReader
+from dagster._core.external_execution.utils import ExtBlobStoreMessageReader
 
 
-class ExternalExecutionS3MessageReader(ExternalExecutionBlobStoreMessageReader):
+class ExtS3MessageReader(ExtBlobStoreMessageReader):
     def __init__(self, *, interval: int = 10, bucket: str, client: boto3.client):
         super().__init__(interval=interval)
         self.bucket = check.str_param(bucket, "bucket")
         self.key_prefix = "".join(random.choices(string.ascii_letters, k=30))
         self.client = client
 
-    def get_params(self) -> ExternalExecutionParams:
+    def get_params(self) -> ExtParams:
         return {"bucket": self.bucket, "key_prefix": self.key_prefix}
 
     def download_messages_chunk(self, index: int) -> Optional[str]:

--- a/python_modules/libraries/dagster-docker/dagster_docker_tests/test_external_asset.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker_tests/test_external_asset.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 from dagster import AssetExecutionContext, asset, materialize
-from dagster_docker.external_resource import DockerExecutionResource
+from dagster_docker.external_resource import ExtDocker
 from dagster_test.test_project import (
     IS_BUILDKITE,
     find_local_test_image,
@@ -25,7 +25,7 @@ def test_basic():
     @asset
     def number_x(
         context: AssetExecutionContext,
-        docker_resource: DockerExecutionResource,
+        docker_resource: ExtDocker,
     ):
         instance_storage = context.instance.storage_directory()
         host_storage = os.path.join(instance_storage, "number_example")
@@ -55,7 +55,7 @@ def test_basic():
 
     result = materialize(
         [number_x],
-        resources={"docker_resource": DockerExecutionResource()},
+        resources={"docker_resource": ExtDocker()},
         raise_on_error=False,
     )
     assert result.success


### PR DESCRIPTION
## Summary & Motivation

The purpose of this PR is to pressure test the "ext" name.

* Most of this is just changing ExternalExecution to Ext everywhere. E.g. `ExtContext.get()` rather than `ExternalExecution.get()`
* Also renamed `ExternalSubprocessResource` to just `ExtSubprocess`,  `DockerExecutionResource` to `ExtDocker`, and the base class to `ExtClient`. This implies a naming convention of Ext<ExecutionTarget> for clients. E.g. I think the k8s integration should have a class named `ExtK8sPod` and the resource key by convention should be `ext_k8s_pod`

This has given me more convention that it is a good name. Being able to use it as an adjective everywhere makes all these names pretty elegant.

## How I Tested These Changes

BK. Did not debug failing test.