### PR TITLE
Dagster k8s better handling of failed jobs

### DIFF
--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/executor.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/executor.py
@@ -531,7 +531,7 @@ def create_k8s_job_task(celery_app, **task_kwargs):
             try:
                 raw_logs = api_client.retrieve_pod_logs(pod_name, namespace=job_namespace)
                 logs += raw_logs.split("\n")
-            except kubernetes.client.rest.ApiException:
+            except kubernetes.client.exceptions.ApiException:
                 instance.report_engine_event(
                     "Encountered unexpected error while fetching pod logs for Kubernetes job {}, "
                     "Pod name {} for step {}. Will attempt to continue with other pods.".format(

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
@@ -395,7 +395,9 @@ class DagsterKubernetesClient:
                 break
 
             # status.failed represents the number of pods which reached phase Failed.
-            if status.failed and status.failed > 0:
+            # if there are any active runs do not raise an exception. This happens when the job
+            # is created with a backoff_limit > 0.
+            if (status.active is None or status.active == 0) and status.failed and status.failed > 0:
                 raise DagsterK8sError(
                     "Encountered failed job pods for job {job_name} with status: {status}, "
                     "in namespace {namespace}".format(

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
@@ -397,7 +397,11 @@ class DagsterKubernetesClient:
             # status.failed represents the number of pods which reached phase Failed.
             # if there are any active runs do not raise an exception. This happens when the job
             # is created with a backoff_limit > 0.
-            if (status.active is None or status.active == 0) and status.failed and status.failed > 0:
+            if (
+                (status.active is None or status.active == 0)
+                and status.failed
+                and status.failed > 0
+            ):
                 raise DagsterK8sError(
                     "Encountered failed job pods for job {job_name} with status: {status}, "
                     "in namespace {namespace}".format(

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
@@ -671,22 +671,13 @@ class DagsterKubernetesClient:
         #
         # https://github.com/kubernetes-client/python/issues/811
 
-        try:
-            return self.core_api.read_namespaced_pod_log(
-                name=pod_name,
-                namespace=namespace,
-                container=container_name,
-                _preload_content=False,
-                **kwargs,
-            ).data.decode("utf-8")
-
-        except kubernetes.client.ApiException as exc:
-            self.logger(
-                f'Could not retrieve logs of container "{container_name}" in pod "{pod_name}".\n'
-                f"Exception: {exc}"
-            )
-
-            return ""
+        return self.core_api.read_namespaced_pod_log(
+            name=pod_name,
+            namespace=namespace,
+            container=container_name,
+            _preload_content=False,
+            **kwargs,
+        ).data.decode("utf-8")
 
     def _get_container_status_str(self, container_status):
         state = container_status.state

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_client.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_client.py
@@ -384,6 +384,26 @@ def test_long_running_job():
     assert len(mock_client.sleeper.mock_calls) == 1
 
 
+def test_job_succeded_after_failure():
+    mock_client = create_mocked_client()
+
+    job_name = "a_job"
+    namespace = "a_namespace"
+
+    a_job_metadata = V1ObjectMeta(name=job_name)
+
+    a_job_is_launched_list = V1JobList(items=[V1Job(metadata=a_job_metadata)])
+    mock_client.batch_api.list_namespaced_job.side_effect = [a_job_is_launched_list]
+
+    # failed job
+    failed_job = V1Job(metadata=a_job_metadata, status=V1JobStatus(active=1, failed=1, succeeded=0))
+    completed_job = V1Job(metadata=a_job_metadata, status=V1JobStatus(active=0, failed=0, succeeded=1))
+    mock_client.batch_api.read_namespaced_job_status.side_effect = [failed_job, completed_job]
+
+    mock_client.wait_for_job_success(job_name, namespace)
+
+    assert len(mock_client.batch_api.read_namespaced_job_status.mock_calls) == 2
+
 ###
 # retrieve_pod_logs
 ###

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_client.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_client.py
@@ -397,12 +397,15 @@ def test_job_succeded_after_failure():
 
     # failed job
     failed_job = V1Job(metadata=a_job_metadata, status=V1JobStatus(active=1, failed=1, succeeded=0))
-    completed_job = V1Job(metadata=a_job_metadata, status=V1JobStatus(active=0, failed=0, succeeded=1))
+    completed_job = V1Job(
+        metadata=a_job_metadata, status=V1JobStatus(active=0, failed=0, succeeded=1)
+    )
     mock_client.batch_api.read_namespaced_job_status.side_effect = [failed_job, completed_job]
 
     mock_client.wait_for_job_success(job_name, namespace)
 
     assert len(mock_client.batch_api.read_namespaced_job_status.mock_calls) == 2
+
 
 ###
 # retrieve_pod_logs

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_client.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_client.py
@@ -423,34 +423,6 @@ def test_retrieve_pod_logs():
     assert mock_client.retrieve_pod_logs("pod", "namespace") == "a_string"
 
 
-def test_retrieve_pod_logs_deleted_pod():
-    """Tests that no logs are returned when the Kubernetes API responds with an error status code."""
-    mock_client = create_mocked_client()
-    pod_name = "pod"
-    namespace_name = "namespace"
-    exception_msg = "error"
-    container_name = "container"
-
-    mock_client.core_api.read_namespaced_pod_log.side_effect = [
-        kubernetes.client.ApiException(exception_msg)
-    ]
-
-    assert (
-        mock_client.retrieve_pod_logs(
-            pod_name=pod_name, namespace=namespace_name, container_name=container_name
-        )
-        == ""
-    )
-
-    assert_logger_calls(
-        mock_client.logger,
-        [
-            f'Could not retrieve logs of container "{container_name}" in pod "{pod_name}".\n'
-            f"Exception: ({exception_msg})\nReason: None\n"
-        ],
-    )
-
-
 def _pod_list_for_container_status(container_status):
     return V1PodList(items=[V1Pod(status=V1PodStatus(container_statuses=[container_status]))])
 

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_client.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_client.py
@@ -425,7 +425,6 @@ def test_retrieve_pod_logs():
 
 def test_retrieve_pod_logs_deleted_pod():
     """Tests that no logs are returned when the Kubernetes API responds with an error status code."""
-
     mock_client = create_mocked_client()
     pod_name = "pod"
     namespace_name = "namespace"

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_client.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_client.py
@@ -3,7 +3,6 @@ from collections import namedtuple
 from unittest import mock
 
 import kubernetes
-import kubernetes.client
 import pytest
 from dagster_k8s.client import (
     DagsterK8sAPIRetryLimitExceeded,


### PR DESCRIPTION
## Summary & Motivation

Hello,

This is a relatively minor change to library `dagster-k8s` such that it deals better with cases in which the Kubernetes job has both failed and active jobs. In this way situations such as those described in #6236 are better handled.

This is the first time contributing to this project. I have followed the [contributing guide](https://docs.dagster.io/community/contributing) and hopefully everything is fine.

I look forward to your comments!

## How I Tested These Changes

I prepared the new unit test by running an existing job on Kubernetes with `backoff_limit: 3` and deleting the pod manually to trigger re-execution. Without this change exception `DagsterK8sError` is raised as:

```
dagster_k8s.client.DagsterK8sError: Encountered failed job pods for job dagster-step-4042dc71c0e6a277db11063e58ed74b1-1 with status: {'active': 1,
 'completed_indexes': None,
 'completion_time': None,
 'conditions': None,
 'failed': 1,
 'ready': 0,
 'start_time': datetime.datetime(2023, 9, 3, 16, 50, 10, tzinfo=tzlocal()),
 'succeeded': None,
 'uncounted_terminated_pods': {'failed': None, 'succeeded': None}}, in namespace <namespace>

  File "/usr/local/lib/python3.10/site-packages/dagster_celery_k8s/executor.py", line 450, in _execute_step_k8s_job
    api_client.wait_for_job_success(
  File "/usr/local/lib/python3.10/site-packages/dagster_k8s/client.py", line 350, in wait_for_job_success
    self.wait_for_running_job_to_succeed(
  File "/usr/local/lib/python3.10/site-packages/dagster_k8s/client.py", line 399, in wait_for_running_job_to_succeed
    raise DagsterK8sError(
```

I monitored using `kubectl` what was running and Kubernetes correctly started a new pod, which means that dictionary `status` contains `active: 1`. Therefore, I added the new statement to the conditional as you can see in the diff. In the unit test two jobs are returned with these properties to test that the job is correctly recognized as successful.

The changes to `retrieve_pod_logs` are needed because when pods are deleted and restarted, for example because the node is drained, its logs can no longer be retrieved (or the pod is in a state that does not return any logs) and instead an exception is raised:

```
kubernetes.client.exceptions.ApiException: (400)
Reason: Bad Request
HTTP response headers: HTTPHeaderDict({'Audit-Id': '5c51576a-42e6-4072-8f16-2e53f86534c3', 'Cache-Control': 'no-cache, private', 'Content-Type': 'application/json', 'Date': 'Sun, 03 Sep 2023 16:51:10 GMT', 'Content-Length': '240'})
HTTP response body: b'{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"container \\"dagster\\" in pod \\"dagster-step-4042dc71c0e6a277db11063e58ed74b1-1-8kh59\\" is waiting to start: ContainerCreating","reason":"BadRequest","code":400}\n'


  File "/usr/local/lib/python3.10/site-packages/dagster_celery_k8s/executor.py", line 532, in _execute_step_k8s_job
    raw_logs = api_client.retrieve_pod_logs(pod_name, namespace=job_namespace)
  File "/usr/local/lib/python3.10/site-packages/dagster_k8s/client.py", line 667, in retrieve_pod_logs
    return self.core_api.read_namespaced_pod_log(
  File "/usr/local/lib/python3.10/site-packages/kubernetes/client/api/core_v1_api.py", line 23957, in read_namespaced_pod_log
    return self.read_namespaced_pod_log_with_http_info(name, namespace, **kwargs)  # noqa: E501
  File "/usr/local/lib/python3.10/site-packages/kubernetes/client/api/core_v1_api.py", line 24076, in read_namespaced_pod_log_with_http_info
    return self.api_client.call_api(
  File "/usr/local/lib/python3.10/site-packages/kubernetes/client/api_client.py", line 348, in call_api
    return self.__call_api(resource_path, method,
  File "/usr/local/lib/python3.10/site-packages/kubernetes/client/api_client.py", line 180, in __call_api
    response_data = self.request(
  File "/usr/local/lib/python3.10/site-packages/kubernetes/client/api_client.py", line 373, in request
    return self.rest_client.GET(url,
  File "/usr/local/lib/python3.10/site-packages/kubernetes/client/rest.py", line 241, in GET
    return self.request("GET", url,
  File "/usr/local/lib/python3.10/site-packages/kubernetes/client/rest.py", line 235, in request
    raise ApiException(http_resp=r)
```

With this change the log is not retrieved (an empty string is instead returned, suggestions welcome to better handle this scenario) but the exception is not raised further.