### PR TITLE
 [ext] Use default asset key for reporting methods

### DIFF
--- a/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/pure_assets_dsl/sql_script.py
+++ b/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/pure_assets_dsl/sql_script.py
@@ -15,5 +15,5 @@ if __name__ == "__main__":
 
     client = SomeSqlClient()
     client.query(sql)
-    context.report_asset_metadata(context.asset_key, "sql", sql)
+    context.report_asset_metadata("sql", sql)
     context.log(f"Ran {sql}")

--- a/python_modules/dagster-ext/dagster_ext/_context.py
+++ b/python_modules/dagster-ext/dagster_ext/_context.py
@@ -31,6 +31,7 @@ from ._util import (
     emit_orchestration_inactive_warning,
     get_mock,
     is_dagster_orchestration_active,
+    resolve_optionally_passed_asset_key,
 )
 
 
@@ -189,16 +190,22 @@ class ExtContext:
 
     # ##### WRITE
 
-    def report_asset_metadata(self, asset_key: str, label: str, value: Any) -> None:
-        asset_key = assert_param_type(asset_key, str, "report_asset_metadata", "asset_key")
+    def report_asset_metadata(
+        self, label: str, value: Any, asset_key: Optional[str] = None
+    ) -> None:
+        asset_key = resolve_optionally_passed_asset_key(
+            self._data, asset_key, "report_asset_metadata"
+        )
         label = assert_param_type(label, str, "report_asset_metadata", "label")
         value = assert_param_json_serializable(value, "report_asset_metadata", "value")
         self._write_message(
             "report_asset_metadata", {"asset_key": asset_key, "label": label, "value": value}
         )
 
-    def report_asset_data_version(self, asset_key: str, data_version: str) -> None:
-        asset_key = assert_param_type(asset_key, str, "report_asset_data_version", "asset_key")
+    def report_asset_data_version(self, data_version: str, asset_key: Optional[str] = None) -> None:
+        asset_key = resolve_optionally_passed_asset_key(
+            self._data, asset_key, "report_asset_data_version"
+        )
         data_version = assert_param_type(
             data_version, str, "report_asset_data_version", "data_version"
         )

--- a/python_modules/dagster-ext/dagster_ext_tests/test_external_execution.py
+++ b/python_modules/dagster-ext/dagster_ext_tests/test_external_execution.py
@@ -82,8 +82,8 @@ def external_script() -> Iterator[str]:
         context = ExtContext.get()
         context.log("hello world")
         time.sleep(0.1)  # sleep to make sure that we encompass multiple intervals for blob store IO
-        context.report_asset_metadata("foo", "bar", context.get_extra("bar"))
-        context.report_asset_data_version("foo", "alpha")
+        context.report_asset_metadata("bar", context.get_extra("bar"))
+        context.report_asset_data_version("alpha")
 
     with temp_script(script_fn) as script_path:
         yield script_path
@@ -215,8 +215,8 @@ def test_ext_no_orchestration():
         init_dagster_ext()
         context = ExtContext.get()
         context.log("hello world")
-        context.report_asset_metadata("foo", "bar", context.get_extra("bar"))
-        context.report_asset_data_version("foo", "alpha")
+        context.report_asset_metadata("bar", context.get_extra("bar"))
+        context.report_asset_data_version("alpha")
 
     with temp_script(script_fn) as script_path:
         cmd = ["python", script_path]

--- a/python_modules/dagster-test/dagster_test/toys/external_execution/numbers_example/number_sum.py
+++ b/python_modules/dagster-test/dagster_test/toys/external_execution/numbers_example/number_sum.py
@@ -10,4 +10,4 @@ value = number_x + number_y
 store_asset_value("number_sum", storage_root, value)
 
 context.log(f"{context.asset_key}: {number_x} + {number_y} = {value}")
-context.report_asset_data_version(context.asset_key, compute_data_version(value))
+context.report_asset_data_version(compute_data_version(value))

--- a/python_modules/dagster-test/dagster_test/toys/external_execution/numbers_example/number_x.py
+++ b/python_modules/dagster-test/dagster_test/toys/external_execution/numbers_example/number_x.py
@@ -10,4 +10,4 @@ value = 2 * multiplier
 store_asset_value("number_x", storage_root, value)
 
 context.log(f"{context.asset_key}: {2} * {multiplier} = {value}")
-context.report_asset_data_version(context.asset_key, compute_data_version(value))
+context.report_asset_data_version(compute_data_version(value))

--- a/python_modules/dagster-test/dagster_test/toys/external_execution/numbers_example/number_y.py
+++ b/python_modules/dagster-test/dagster_test/toys/external_execution/numbers_example/number_y.py
@@ -11,5 +11,5 @@ value = int(os.environ["NUMBER_Y"])
 store_asset_value("number_y", storage_root, value)
 
 context.log(f"{context.asset_key}: {value} read from $NUMBER_Y environment variable.")
-context.report_asset_metadata(context.asset_key, "is_even", value % 2 == 0)
-context.report_asset_data_version(context.asset_key, compute_data_version(value))
+context.report_asset_metadata("is_even", value % 2 == 0)
+context.report_asset_data_version(compute_data_version(value))


### PR DESCRIPTION
## Summary & Motivation

Make `ExtContext.report_asset_metadata` and `.report_asset_data_version` use a default asset key if there is only a single asset in scope, throw appropriate errors in other situations.

## How I Tested These Changes

New unit tests.