### PR TITLE
[ui] Some backfill page cleanup

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/ParentUpdatedLink.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/ParentUpdatedLink.tsx
@@ -1,11 +1,11 @@
 import {ButtonLink, Box} from '@dagster-io/ui-components';
 import * as React from 'react';
 
+import {VirtualizedItemListForDialog} from '../../ui/VirtualizedItemListForDialog';
 import {AssetLink} from '../AssetLink';
 import {AssetKey} from '../types';
 
 import {AssetKeysDialog, AssetKeysDialogEmptyState, AssetKeysDialogHeader} from './AssetKeysDialog';
-import {VirtualizedAssetListForDialog} from './VirtualizedAssetListForDialog';
 import {AssetDetailType, detailTypeToLabel} from './assetDetailUtils';
 import {useFilterAssetKeys} from './assetFilters';
 
@@ -66,8 +66,8 @@ export const ParentUpdatedLink = ({updatedAssetKeys, willUpdateAssetKeys}: Props
               }
             />
           ) : (
-            <VirtualizedAssetListForDialog
-              assetKeys={filteredAssetKeys}
+            <VirtualizedItemListForDialog
+              items={filteredAssetKeys}
               renderItem={(item) => (
                 <Box flex={{direction: 'row', alignItems: 'center', gap: 8}}>
                   <AssetLink path={item.assetKey.path} icon="asset" />

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/WaitingOnAssetKeysLink.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/WaitingOnAssetKeysLink.tsx
@@ -1,11 +1,11 @@
 import {ButtonLink} from '@dagster-io/ui-components';
 import * as React from 'react';
 
+import {VirtualizedItemListForDialog} from '../../ui/VirtualizedItemListForDialog';
 import {AssetLink} from '../AssetLink';
 import {AssetKey} from '../types';
 
 import {AssetKeysDialog, AssetKeysDialogEmptyState, AssetKeysDialogHeader} from './AssetKeysDialog';
-import {VirtualizedAssetListForDialog} from './VirtualizedAssetListForDialog';
 import {useFilterAssetKeys} from './assetFilters';
 
 interface Props {
@@ -46,8 +46,8 @@ export const WaitingOnAssetKeysLink = ({assetKeys}: Props) => {
               }
             />
           ) : (
-            <VirtualizedAssetListForDialog
-              assetKeys={filteredAssetKeys}
+            <VirtualizedItemListForDialog
+              items={filteredAssetKeys}
               renderItem={(item: AssetKey) => <AssetLink path={item.path} icon="asset" />}
             />
           )

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types.tsx
@@ -20,4 +20,5 @@ export interface AssetViewParams {
   asOf?: string;
   evaluation?: string;
   checkDetail?: string;
+  default_range?: string;
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/BackfillPartitionsRequestedDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/BackfillPartitionsRequestedDialog.tsx
@@ -1,8 +1,12 @@
-import {Button, DialogBody, DialogFooter, Dialog, FontFamily, Box} from '@dagster-io/ui-components';
+import {Button, DialogFooter, Dialog, FontFamily} from '@dagster-io/ui-components';
 import * as React from 'react';
+
+import {TruncatedTextWithFullTextOnHover} from '../nav/getLeftNavItemsForOption';
+import {VirtualizedItemListForDialog} from '../ui/VirtualizedItemListForDialog';
 
 import {BackfillTableFragment} from './types/BackfillTable.types';
 
+const COLLATOR = new Intl.Collator(navigator.language, {sensitivity: 'base', numeric: true});
 interface Props {
   backfill?: BackfillTableFragment;
   onClose: () => void;
@@ -19,18 +23,36 @@ export const BackfillPartitionsRequestedDialog = ({backfill, onClose}: Props) =>
       }
       onClose={onClose}
     >
-      <DialogBody>
-        {backfill && backfill.partitionNames ? (
-          <Box flex={{direction: 'column', gap: 8}} style={{maxHeight: '80vh', overflowY: 'auto'}}>
-            {backfill.partitionNames.map((partitionName) => (
-              <div key={partitionName}>{partitionName}</div>
-            ))}
-          </Box>
-        ) : null}
-      </DialogBody>
+      <DialogContent partitionNames={backfill?.partitionNames || []} />
       <DialogFooter topBorder>
         <Button onClick={onClose}>Done</Button>
       </DialogFooter>
     </Dialog>
+  );
+};
+
+interface DialogContentProps {
+  partitionNames: string[];
+}
+
+// Separate component so that we can delay sorting until render.
+const DialogContent = (props: DialogContentProps) => {
+  const {partitionNames} = props;
+
+  const sorted = React.useMemo(() => {
+    return [...(partitionNames || [])].sort((a, b) => COLLATOR.compare(a, b));
+  }, [partitionNames]);
+
+  return (
+    <div style={{height: '340px', overflow: 'hidden'}}>
+      <VirtualizedItemListForDialog
+        items={sorted}
+        renderItem={(partitionName) => (
+          <div key={partitionName}>
+            <TruncatedTextWithFullTextOnHover text={partitionName} />
+          </div>
+        )}
+      />
+    </div>
   );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/__tests__/BackfillPage.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/__tests__/BackfillPage.test.tsx
@@ -142,7 +142,7 @@ describe('BackfillPage', () => {
     // Check if the loaded content is displayed
     const detailRow = await screen.findByTestId('backfill-page-details');
 
-    expect(screen.getByText('Partition Selection')).toBeVisible();
+    expect(screen.getByText('Partition selection')).toBeVisible();
     expect(screen.getByText('Asset name')).toBeVisible();
 
     expect(getByText(detailRow, 'Jan 1, 1970, 12:16:40 AM')).toBeVisible();
@@ -215,7 +215,7 @@ describe('PartitionSelection', () => {
     expect(getByText('3...4')).toBeInTheDocument();
   });
 
-  it('renders the numPartitions in a ButtonLink when neither rootAssetTargetedPartitions nor rootAssetTargetedRanges are provided', async () => {
+  it('renders the numPartitions when neither rootAssetTargetedPartitions nor rootAssetTargetedRanges are provided', async () => {
     const {getByText} = render(<PartitionSelection numPartitions={2} />);
 
     expect(getByText('2 partitions')).toBeInTheDocument();

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/AssetKeyTagCollection.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/AssetKeyTagCollection.tsx
@@ -6,7 +6,6 @@ import {
   Dialog,
   DialogFooter,
   Icon,
-  Table,
   Tag,
 } from '@dagster-io/ui-components';
 import * as React from 'react';
@@ -15,6 +14,7 @@ import {Link} from 'react-router-dom';
 import {displayNameForAssetKey, tokenForAssetKey} from '../asset-graph/Utils';
 import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
 import {AssetKey} from '../assets/types';
+import {VirtualizedItemListForDialog} from '../ui/VirtualizedItemListForDialog';
 
 const MAX_ASSET_TAGS = 3;
 
@@ -41,36 +41,17 @@ export const AssetKeyTagCollection: React.FC<{
         style={{minWidth: '400px', maxWidth: '80vw', maxHeight: '70vh'}}
         isOpen={showMore}
       >
-        {showMore ? (
-          <Box
-            padding={{bottom: 12}}
-            border={{side: 'bottom', color: Colors.KeylineGray, width: 1}}
-            style={{overflowY: 'auto'}}
-            background={Colors.White}
-          >
-            <Table>
-              <thead>
-                <tr>
-                  <th>Asset key</th>
-                </tr>
-              </thead>
-              <tbody>
-                {assetKeys.map((assetKey, ii) => (
-                  <tr key={`${tokenForAssetKey(assetKey)}-${ii}`}>
-                    <td>
-                      <Link to={assetDetailsPathForKey(assetKey)} key={tokenForAssetKey(assetKey)}>
-                        {displayNameForAssetKey(assetKey)}
-                      </Link>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </Table>
-          </Box>
-        ) : null}
-        <DialogFooter>
-          <Button intent="primary" autoFocus onClick={() => setShowMore(false)}>
-            OK
+        <div style={{height: '340px', overflow: 'hidden'}}>
+          <VirtualizedItemListForDialog
+            items={assetKeys}
+            renderItem={(assetKey: AssetKey) => (
+              <Link to={assetDetailsPathForKey(assetKey)}>{displayNameForAssetKey(assetKey)}</Link>
+            )}
+          />
+        </div>
+        <DialogFooter topBorder>
+          <Button autoFocus onClick={() => setShowMore(false)}>
+            Done
           </Button>
         </DialogFooter>
       </Dialog>
@@ -99,8 +80,8 @@ export const AssetKeyTagCollection: React.FC<{
   }
 
   return (
-    <Box flex={{direction: 'row', gap: 8}}>
-      <Icon color={Colors.Gray400} name="asset" size={16} style={{marginTop: 2}} />
+    <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
+      <Icon color={Colors.Gray400} name="asset" size={16} />
       <Box style={{flex: 1}} flex={{wrap: 'wrap', display: 'inline-flex'}}>
         {displayed.map((assetKey, idx) => (
           <Link

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/VirtualizedItemListForDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/VirtualizedItemListForDialog.tsx
@@ -2,38 +2,38 @@ import {Box, Colors} from '@dagster-io/ui-components';
 import {useVirtualizer} from '@tanstack/react-virtual';
 import * as React from 'react';
 
-import {Container, Inner, Row} from '../../ui/VirtualizedTable';
+import {Container, Inner, Row} from './VirtualizedTable';
 
-interface Props<A> {
-  assetKeys: A[];
-  renderItem: (assetKey: A) => React.ReactNode;
+interface Props<T> {
+  items: T[];
+  renderItem: (item: T) => React.ReactNode;
 }
 
-export function VirtualizedAssetListForDialog<A>({assetKeys, renderItem}: Props<A>) {
+export function VirtualizedItemListForDialog<A>({items, renderItem}: Props<A>) {
   const container = React.useRef<HTMLDivElement | null>(null);
 
   const rowVirtualizer = useVirtualizer({
-    count: assetKeys.length,
+    count: items.length,
     getScrollElement: () => container.current,
     estimateSize: () => 40,
     overscan: 10,
   });
 
   const totalHeight = rowVirtualizer.getTotalSize();
-  const items = rowVirtualizer.getVirtualItems();
+  const virtualItems = rowVirtualizer.getVirtualItems();
 
   return (
     <Container ref={container} style={{padding: '8px 24px'}}>
       <Inner $totalHeight={totalHeight}>
-        {items.map(({index, key, size, start}) => {
-          const assetKey = assetKeys[index]!;
+        {virtualItems.map(({index, key, size, start}) => {
+          const assetKey = items[index]!;
           return (
             <Row $height={size} $start={start} key={key}>
               <Box
                 style={{height: '100%'}}
                 flex={{direction: 'row', alignItems: 'center'}}
                 border={
-                  index < assetKeys.length - 1
+                  index < items.length - 1
                     ? {side: 'bottom', width: 1, color: Colors.KeylineGray}
                     : null
                 }


### PR DESCRIPTION
## Summary & Motivation

A handful of changes and cleanup items on the backfill table and backfill page.

- Virtualize the partition and asset key tables from these pages, reusing the component created for auto-materialization. It's just a generic virtualized item list anyway, so we can go ahead and reuse it here. (I moved and renamed the component to give it generic characteristics.)
- When linking to an asset from the backfill page where a backfill is for a range, link to that default range on the asset page itself.
- When a backfill header just shows the names of partitions that have been backfilled (with no dialog) use a `Tag` to give the partition names some separation. It's not perfect, but it seemed a little weird to just stick a comma between them.
- Some alignment tweaks.

<img width="557" alt="Screenshot 2023-09-05 at 9 51 06 AM" src="https://github.com/dagster-io/dagster/assets/2823852/e70676ab-e89b-4b36-89d2-8ad2fe337dc2">
<img width="580" alt="Screenshot 2023-09-05 at 9 50 58 AM" src="https://github.com/dagster-io/dagster/assets/2823852/c995a16f-7345-4a9f-a22e-2031e269b661">

## How I Tested These Changes

View Backfill page. Click to view assets affected by a backfill, verify dialog with virtualized contents. Verify same when clicking the link to see the affected partitions.

Click into a backfill, verify same dialog and virtualization behavior when looking at the list of affected partitions.

Click into a backfill that uses a partition range. Click to the asset, verify that the range is applied to the querystring of the URL and loads as the selected range on the asset page.
