### PR TITLE
Fix/databricks step launcher

### DIFF
--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks.py
@@ -378,6 +378,7 @@ class DatabricksJobRunner:
                         # "libraries": [compute.Library.from_dict(lib) for lib in libraries],
                         "libraries": libraries,
                         **task,
+                        "task_key": "dagster-task",
                     },
                 )
             ],

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_databricks.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_databricks.py
@@ -27,6 +27,7 @@ def test_databricks_submit_job_existing_cluster(mock_submit_run, databricks_run_
     task = databricks_run_config.pop("task")
     expected_task = jobs.SubmitTask.from_dict(task)
     expected_task.existing_cluster_id = databricks_run_config["cluster"]["existing"]
+    expected_task.task_key = "dagster-task"
     expected_task.libraries = [
         compute.Library(pypi=compute.PythonPyPiLibrary(package=f"dagster=={dagster.__version__}")),
         compute.Library(
@@ -74,6 +75,7 @@ def test_databricks_submit_job_new_cluster(mock_submit_run, databricks_run_confi
 
     task = databricks_run_config.pop("task")
     expected_task = jobs.SubmitTask.from_dict(task)
+    expected_task.task_key = "dagster-task"
     expected_task.new_cluster = compute.ClusterSpec(
         node_type_id=NEW_CLUSTER["nodes"]["node_types"]["node_type_id"],
         spark_version=NEW_CLUSTER["spark_version"],


### PR DESCRIPTION
## Summary & Motivation

[This PR (#14673)](https://github.com/dagster-io/dagster/pull/14673) broke the Databricks step launcher due to an incomplete implementation of the new databricks-sdk API. I cherry-picked my fixes from [another PR](https://github.com/dagster-io/dagster/pull/16155) that seems like it may have been lost in the ether.

## How I Tested These Changes
Spun up a new environment with dagster / dagster-databricks 1.4.11 and launched a job with an op that uses the `databricks_pyspark_step_launcher`