### PR TITLE
Feature/updated init scripts schema

### DIFF
--- a/python_modules/libraries/dagster-databricks/dagster_databricks/configs.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/configs.py
@@ -273,9 +273,43 @@ def _define_cluster_log_conf() -> Field:
         is_required=False,
     )
 
+def _define_workspace_storage_info() -> Field:
+    return Field(
+        Shape(
+            fields={
+                "destination": Field(
+                    String,
+                    description=(
+                        "The path to the directory in the workspace where the notebook is located."
+                    ),
+                    is_required=True,
+                )
+            }
+        ),
+        description="Workspace storage information",
+    )
+
+def _define_volumes_storage_info() -> Field:
+    return Field(
+        Shape(
+            fields={
+                "destination": Field(
+                    String,
+                    description=(
+                        "The path to the directory in the workspace where the notebook is located."
+                    ),
+                    is_required=True,
+                )
+            }
+        ),
+        description="Workspace storage information",
+    )
 
 def _define_init_script():
-    return Selector({"dbfs": _define_dbfs_storage_info(), "s3": _define_s3_storage_info()})
+    return Selector({"dbfs": _define_dbfs_storage_info(),
+                     "s3": _define_s3_storage_info(),
+                     "workspace": _define_workspace_storage_info(),
+                     "volumes": _define_volumes_storage_info()})
 
 
 def _define_node_types() -> Field:

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/configs.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/configs.py
@@ -273,6 +273,7 @@ def _define_cluster_log_conf() -> Field:
         is_required=False,
     )
 
+
 def _define_workspace_storage_info() -> Field:
     return Field(
         Shape(
@@ -288,6 +289,7 @@ def _define_workspace_storage_info() -> Field:
         ),
         description="Workspace storage information",
     )
+
 
 def _define_volumes_storage_info() -> Field:
     return Field(
@@ -305,11 +307,16 @@ def _define_volumes_storage_info() -> Field:
         description="Workspace storage information",
     )
 
+
 def _define_init_script():
-    return Selector({"dbfs": _define_dbfs_storage_info(),
-                     "s3": _define_s3_storage_info(),
-                     "workspace": _define_workspace_storage_info(),
-                     "volumes": _define_volumes_storage_info()})
+    return Selector(
+        {
+            "dbfs": _define_dbfs_storage_info(),
+            "s3": _define_s3_storage_info(),
+            "workspace": _define_workspace_storage_info(),
+            "volumes": _define_volumes_storage_info(),
+        }
+    )
 
 
 def _define_node_types() -> Field:


### PR DESCRIPTION
## Summary & Motivation

Databricks has deprecated the `dbfs` method of referencing init scripts, and now most documentation suggests that `workspace` or `volume` init scripts be used instead. This conversation on slack indicates community interest in having these options enabled. I'll work on a more full-featured PR to include some of the other additions to the `jobs/runs/submit` endpoint this week.

## How I Tested These Changes

Spun up a local Dagster instance with `dagster==1.4.11` and my version of `dagster-databricks` installed. Launched jobs with config referencing init scripts in volumes and workspace. Confirmed that init scripts were configured in cluster config

Note - this includes commit cherry-picked from [this PR](https://github.com/dagster-io/dagster/pull/16311), necessary to get the step launcher working again.