### PR TITLE
Fix an issue when schedules that set their cron schedules to a list failed to hash during the scheduler tick

### DIFF
--- a/python_modules/dagster/dagster/_scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/_scheduler/scheduler.py
@@ -245,12 +245,12 @@ def launch_scheduled_runs(
     # Remove any schedule states that were previously created with AUTOMATICALLY_RUNNING
     # and can no longer be found in the workspace (so that if they are later added
     # back again, their timestamps will start at the correct place)
-    states_to_delete = {
+    states_to_delete = [
         schedule_state
         for selector_id, schedule_state in all_schedule_states.items()
         if selector_id not in schedules
         and schedule_state.status == InstigatorStatus.AUTOMATICALLY_RUNNING
-    }
+    ]
     for state in states_to_delete:
         location_name = state.origin.external_repository_origin.code_location_origin.location_name
         # don't clean up auto running state if its location is an error state

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
@@ -528,7 +528,7 @@ def always_running_schedule(context):
 
 
 @schedule(
-    cron_schedule="@daily",
+    cron_schedule=["@daily", "0 0 * * 5"],
     job_name="the_job",
     execution_timezone="UTC",
     default_status=DefaultScheduleStatus.STOPPED,


### PR DESCRIPTION
Summary:
Setting this to a set instead of a list caused it to try to hash the namedtuple, which fails if the cron schedule is set to a list (which does not hash) rather than a string (which does)

Test Plan:
Modified test case that was failing before, now passes

## Summary & Motivation

## How I Tested These Changes
