### PR TITLE
fix: use type name when displaying resource requirement exception

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/resource_requirement.py
+++ b/python_modules/dagster/dagster/_core/definitions/resource_requirement.py
@@ -224,11 +224,12 @@ def ensure_requirements_satisfied(
     # Error if resource defs don't provide the correct resource key
     for requirement in requirements:
         if not requirement.resources_contain_key(resource_defs):
+            requirement_expected_type_name = requirement.expected_type.__name__
             raise DagsterInvalidDefinitionError(
                 f"{requirement.describe_requirement()} was not provided. Please"
-                f" provide a {requirement.expected_type} to key '{requirement.key}', or change"
+                f" provide a {requirement_expected_type_name} to key '{requirement.key}', or change"
                 " the required key to one of the following keys which points to an"
-                f" {requirement.expected_type}:"
+                f" {requirement_expected_type_name}:"
                 f" {requirement.keys_of_expected_type(resource_defs)}"
             )
 


### PR DESCRIPTION
## Summary & Motivation
Change the following:

```
dagster._core.errors.DagsterInvalidDefinitionError: resource with key 'dbt' required by op 'sca_custom_assets' was not provided. Please provide a <class 'dagster._core.definitions.resource_definition.ResourceDefinition'> to key 'dbt', or change the required key to one of the following keys which points to an <class 'dagster._core.definitions.resource_definition.ResourceDefinition'>: ['io_manager']
```

to:

```
dagster._core.errors.DagsterInvalidDefinitionError: resource with key 'dbt' required by op 'sca_custom_assets' was not provided. Please provide a ResourceDefinition to key 'dbt', or change the required key to one of the following keys which points to an ResourceDefinition: ['io_manager']
```

The "or change the required key..." should probably be changed as well. Seeing the magic string `"io_manager"` here doesn't make sense, and recommendations to use an IOManager key should only be made if the current resource requirement is an io manager.

## How I Tested These Changes
local
