### PR TITLE
Move context injector and message reader to resource init

### DIFF
--- a/python_modules/dagster-ext/dagster_ext_tests/test_external_execution.py
+++ b/python_modules/dagster-ext/dagster_ext_tests/test_external_execution.py
@@ -137,8 +137,6 @@ def test_ext_subprocess(
             cmd,
             context=context,
             extras=extras,
-            # context_injector=context_injector,
-            # message_reader=message_reader,
             env={
                 "CONTEXT_INJECTOR_SPEC": context_injector_spec,
                 "MESSAGE_READER_SPEC": message_reader_spec,

--- a/python_modules/dagster-ext/dagster_ext_tests/test_external_execution.py
+++ b/python_modules/dagster-ext/dagster_ext_tests/test_external_execution.py
@@ -137,15 +137,15 @@ def test_ext_subprocess(
             cmd,
             context=context,
             extras=extras,
-            context_injector=context_injector,
-            message_reader=message_reader,
+            # context_injector=context_injector,
+            # message_reader=message_reader,
             env={
                 "CONTEXT_INJECTOR_SPEC": context_injector_spec,
                 "MESSAGE_READER_SPEC": message_reader_spec,
             },
         )
 
-    resource = ExtSubprocess()
+    resource = ExtSubprocess(context_injector=context_injector, message_reader=message_reader)
     with instance_for_test() as instance:
         materialize(
             [foo],


### PR DESCRIPTION
## Summary & Motivation

IMO it doesn't make sense to allow the user to vary the context injector and the message read on every run call. I think it introduces undue flexibility which ends up causing confusion. Instead this changes `ExtSubprocess` to take an injector and a reader in the `__init__` function.

## How I Tested These Changes

BK
