### PR TITLE
[dagster dev] report exceptions on shutdown

### DIFF
--- a/python_modules/dagster/dagster/_cli/dev.py
+++ b/python_modules/dagster/dagster/_cli/dev.py
@@ -194,7 +194,11 @@ def dev_command(
                         f" {daemon_process.returncode}"
                     )
 
+        except KeyboardInterrupt:
+            logger.info("KeyboardInterrupt received")
         except:
+            logger.exception("An unexpected exception has occurred")
+        finally:
             logger.info("Shutting down Dagster services...")
             interrupt_ipc_subprocess(daemon_process)
             interrupt_ipc_subprocess(webserver_process)


### PR DESCRIPTION
currently we hide the exceptions we raise

## How I Tested These Changes
ctrl+C
```
2023-09-06 10:07:48 -0500 - dagster - INFO - KeyboardInterrupt received
2023-09-06 10:07:48 -0500 - dagster - INFO - Shutting down Dagster services...
2023-09-06 10:07:48 -0500 - dagster.daemon - INFO - Daemon threads shut down.
2023-09-06 10:07:48 -0500 - dagster - INFO - Dagster services shut down.
```
kill daemon / webserver process

```
2023-09-06 10:08:21 -0500 - dagster - ERROR - An unexpected exception has occurred
Traceback (most recent call last):
  File "/Users/alangenfeld/dagster/python_modules/dagster/dagster/_cli/dev.py", line 192, in dev_command
    raise Exception(
Exception: dagster-daemon process shut down unexpectedly with return code 0
2023-09-06 10:08:21 -0500 - dagster - INFO - Shutting down Dagster services...
2023-09-06 10:08:21 -0500 - dagster - INFO - Dagster services shut down.
```
