### PR TITLE
[ext] fix k8s restart policy setting and re-enable tests

### DIFF
--- a/integration_tests/test_suites/k8s-test-suite/tests/test_external_asset.py
+++ b/integration_tests/test_suites/k8s-test-suite/tests/test_external_asset.py
@@ -21,10 +21,8 @@ if TYPE_CHECKING:
     )
 
 
-@pytest.mark.skip("passes locally, BK debug in progress")
 @pytest.mark.default
 def test_ext_k8s_pod(namespace, cluster_provider):
-    kubernetes.config.load_kube_config(cluster_provider.kubeconfig_file)
     docker_image = get_test_project_docker_image()
 
     @asset
@@ -119,7 +117,6 @@ class ExtConfigMapContextInjector(ExtContextInjector):
         }
 
 
-@pytest.mark.skip("passes locally, BK debug in progress")
 @pytest.mark.default
 def test_ext_k8s_pod_file_inject(namespace, cluster_provider):
     # a convoluted test to
@@ -127,7 +124,6 @@ def test_ext_k8s_pod_file_inject(namespace, cluster_provider):
     # - preserve file injection via config map code
 
     docker_image = get_test_project_docker_image()
-    kubernetes.config.load_kube_config(cluster_provider.kubeconfig_file)
 
     @asset
     def number_y(

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/external_resource.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/external_resource.py
@@ -196,6 +196,13 @@ def build_pod_body(
     if "containers" not in spec:
         spec["containers"] = [{}]
 
+    if "restart_policy" not in spec:
+        spec["restart_policy"] = "Never"
+    elif spec["restart_policy"] == "Always":
+        raise DagsterInvariantViolationError(
+            "A restart policy of Always is not allowed, computations are expected to complete."
+        )
+
     if "image" not in spec["containers"][0] and not image:
         raise DagsterInvariantViolationError(
             "Must specify image property or provide base_pod_spec with one set."

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_client.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_client.py
@@ -739,9 +739,7 @@ def test_valid_failure_waiting_reasons():
         pod_name = "a_pod"
         with pytest.raises(DagsterK8sError) as exc_info:
             mock_client.wait_for_pod(pod_name=pod_name, namespace="namespace")
-        assert str(exc_info.value) == 'Failed: Reason="{reason}" Message="bad things"'.format(
-            reason=reason
-        )
+        assert f'Failed: Reason="{reason}" Message="bad things"' in str(exc_info.value)
 
 
 def test_bad_waiting_state():

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_ext_pod.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_ext_pod.py
@@ -15,6 +15,7 @@ def test_pod_building():
         base_pod_meta=None,
     )
     assert pod.spec.containers[0].image == test_image
+    assert pod.spec.restart_policy == "Never"
 
     # expected common case
     pod = build_pod_body(
@@ -165,3 +166,24 @@ def test_pod_building():
     )
     assert pod.metadata.labels["app.kubernetes.io/name"] == "custom"
     assert pod.metadata.labels["app.kubernetes.io/instance"] == "dagster"
+
+    # restart policy
+    pod = build_pod_body(
+        pod_name="test",
+        image=test_image,
+        command=["echo", "hello"],
+        env_vars={},
+        base_pod_spec={"restartPolicy": "OnFailure"},
+        base_pod_meta=None,
+    )
+    assert pod.spec.restart_policy == "OnFailure"
+
+    with pytest.raises(DagsterInvariantViolationError):
+        build_pod_body(
+            pod_name="test",
+            image=test_image,
+            command=["echo", "hello"],
+            env_vars={},
+            base_pod_spec={"restart_policy": "Always"},
+            base_pod_meta=None,
+        )


### PR DESCRIPTION
* for restart policy apply a default `Never` and ensure its not `Always` 
* improve debug info output when `wait_for_pod` raises 
* re-enable tests

## How I Tested These Changes

tests