### PR TITLE
Add pyarrow to dependencies

### DIFF
--- a/docs/content/integrations/dbt/using-dbt-with-dagster/upstream-assets.mdx
+++ b/docs/content/integrations/dbt/using-dbt-with-dagster/upstream-assets.mdx
@@ -35,7 +35,7 @@ You'll:
 The Dagster asset that you write will fetch data using [Pandas](https://pandas.pydata.org/) and write it out to your DuckDB warehouse using [DuckDB's Python API](https://duckdb.org/docs/api/python/overview.html). To use these, you'll need to install them:
 
 ```shell
-pip install pandas duckdb
+pip install pandas duckdb pyarrow
 ```
 
 ---


### PR DESCRIPTION
## Summary & Motivation

duckdb.InvalidInputException: Invalid Input Error: Required module 'pandas.core.arrays.arrow.dtype' failed to import, due to the following Python exception:
ModuleNotFoundError: No module named 'pandas.core.arrays.arrow.dtype'

## How I Tested These Changes

https://elementl-workspace.slack.com/archives/C03E60FPJCU/p1694013481428789