### PR TITLE
use correct return types for some partition key methods on context

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -9,6 +9,7 @@ from typing import (
     Optional,
     Sequence,
     Set,
+    Union,
     cast,
 )
 
@@ -557,7 +558,7 @@ class OpExecutionContext(AbstractComputeExecutionContext):
         return self._step_execution_context.asset_partition_key_range_for_input(input_name)
 
     @public
-    def asset_partition_key_for_input(self, input_name: str) -> str:
+    def asset_partition_key_for_input(self, input_name: str) -> Union[str, Mapping[str, str]]:
         """Returns the partition key of the upstream asset corresponding to the given input."""
         return self._step_execution_context.asset_partition_key_for_input(input_name)
 

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -33,6 +33,7 @@ from dagster._core.definitions.events import (
     UserEvent,
 )
 from dagster._core.definitions.job_definition import JobDefinition
+from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionKey
 from dagster._core.definitions.op_definition import OpDefinition
 from dagster._core.definitions.partition import PartitionsDefinition
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
@@ -558,7 +559,7 @@ class OpExecutionContext(AbstractComputeExecutionContext):
         return self._step_execution_context.asset_partition_key_range_for_input(input_name)
 
     @public
-    def asset_partition_key_for_input(self, input_name: str) -> Union[str, Mapping[str, str]]:
+    def asset_partition_key_for_input(self, input_name: str) -> Union[str, MultiPartitionKey]:
         """Returns the partition key of the upstream asset corresponding to the given input."""
         return self._step_execution_context.asset_partition_key_for_input(input_name)
 

--- a/python_modules/dagster/dagster/_core/execution/context/system.py
+++ b/python_modules/dagster/dagster/_core/execution/context/system.py
@@ -34,7 +34,10 @@ from dagster._core.definitions.events import AssetKey, AssetLineageInfo
 from dagster._core.definitions.hook_definition import HookDefinition
 from dagster._core.definitions.job_base import IJob
 from dagster._core.definitions.job_definition import JobDefinition
-from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionsDefinition
+from dagster._core.definitions.multi_dimensional_partitions import (
+    MultiPartitionKey,
+    MultiPartitionsDefinition,
+)
 from dagster._core.definitions.op_definition import OpDefinition
 from dagster._core.definitions.partition import PartitionsDefinition, PartitionsSubset
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
@@ -1107,7 +1110,7 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
 
         check.failed("The input has no asset partitions")
 
-    def asset_partition_key_for_input(self, input_name: str) -> Union[str, Mapping[str, str]]:
+    def asset_partition_key_for_input(self, input_name: str) -> Union[str, MultiPartitionKey]:
         start, end = self.asset_partition_key_range_for_input(input_name)
         if start == end:
             return start

--- a/python_modules/dagster/dagster/_core/execution/context/system.py
+++ b/python_modules/dagster/dagster/_core/execution/context/system.py
@@ -1107,7 +1107,7 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
 
         check.failed("The input has no asset partitions")
 
-    def asset_partition_key_for_input(self, input_name: str) -> str:
+    def asset_partition_key_for_input(self, input_name: str) -> Union[str, Mapping[str, str]]:
         start, end = self.asset_partition_key_range_for_input(input_name)
         if start == end:
             return start


### PR DESCRIPTION
## Summary & Motivation

The `asset_partition_key_for_input` method on the context can return a `MultiPartitionKey` when an asset has a multi partition definition. However, the type signature for the method only says a string can be returned. This makes pyright unhappy. 

This PR updates the return annotation so that `context.asset_partition_key_for_input("asset").keys_by_dimension` doesn't cause the linter to complain

## How I Tested These Changes
