### PR TITLE
[ui] Reimplement CodeMirror wrapper

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/components/DagsterCodeMirrorStyle.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/DagsterCodeMirrorStyle.tsx
@@ -1,0 +1,125 @@
+import {createGlobalStyle} from 'styled-components';
+
+import {Colors} from './Colors';
+import {Icons} from './Icon';
+import {FontFamily} from './styles';
+
+export const DagsterCodeMirrorStyle = createGlobalStyle`
+  .CodeMirror-gutter-elt {
+    .CodeMirror-lint-marker-error {
+      background-image: none;
+      background: ${Colors.Red500};
+      mask-image: url(${Icons.error});
+      mask-size: cover;
+      margin-bottom: 2px;
+    }
+  }
+
+  .CodeMirror-hint,
+  .CodeMirror-lint-marker-error,
+  .CodeMirror-lint-marker-warning,
+  .CodeMirror-lint-message-error,
+  .CodeMirror-lint-message-warning {
+    font-family: ${FontFamily.monospace};
+    font-size: 16px;
+  }
+
+  .CodeMirror.cm-s-dagster {
+    font-family: ${FontFamily.monospace};
+    font-size: 16px;
+
+    /* Note: Theme overrides */
+    &.cm-s-default .cm-comment {
+      color: #999;
+    }
+
+    .cm-atom {
+      color: ${Colors.Blue700};
+    }
+
+    .cm-comment {
+      color: ${Colors.Gray400};
+    }
+
+    .cm-meta {
+      color: ${Colors.Gray700};
+    }
+
+    .cm-number {
+      color: ${Colors.Red700};
+    }
+
+    .cm-string {
+      color: ${Colors.Green700};
+    }
+
+    .cm-string-2 {
+      color: ${Colors.Olive700};
+    }
+
+    .cm-variable-2 {
+      color: ${Colors.Blue500};
+    }
+
+    .cm-keyword {
+      color: ${Colors.Yellow700};
+    }
+
+    .CodeMirror-selected {
+      background-color: ${Colors.Blue50};
+    }
+
+    .CodeMirror-gutters {
+      background-color: ${Colors.Gray50};
+    }
+
+    .cm-indent {
+      display: inline-block;
+
+      &.cm-zero {
+        box-shadow: -1px 0 0 ${Colors.Green200};
+      }
+
+      &.cm-one {
+        box-shadow: -1px 0 0 ${Colors.Blue100};
+      }
+
+      &.cm-two {
+        box-shadow: -1px 0 0 ${Colors.LightPurple};
+      }
+
+      &.cm-three {
+        box-shadow: -1px 0 0 ${Colors.Red200};
+      }
+
+      &.cm-four {
+        box-shadow: -1px 0 0 ${Colors.Yellow200};
+      }
+
+      &.cm-five {
+        box-shadow: -1px 0 0 ${Colors.Olive200};
+      }
+
+      &.cm-six {
+        box-shadow: -1px 0 0 ${Colors.Gray300};
+      }
+    }
+  }
+
+  div.CodeMirror-lint-tooltip {
+    background: rgba(255, 247, 231, 1);
+    border: 1px solid ${Colors.Gray200};
+  }
+
+  .CodeMirror-lint-message {
+    background: transparent;
+  }
+  .CodeMirror-lint-message.CodeMirror-lint-message-error {
+    background: transparent;
+  }
+
+  /* Ensure that hints aren't vertically cutoff*/
+  .CodeMirror-hint div {
+    max-height: none !important;
+  }
+`;

--- a/js_modules/dagster-ui/packages/ui-components/src/components/NewConfigEditor.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/NewConfigEditor.tsx
@@ -1,0 +1,214 @@
+import 'codemirror/addon/comment/comment';
+import 'codemirror/addon/dialog/dialog';
+import 'codemirror/addon/fold/foldgutter';
+import 'codemirror/addon/fold/foldgutter.css';
+import 'codemirror/addon/fold/indent-fold';
+import 'codemirror/addon/hint/show-hint';
+import 'codemirror/addon/hint/show-hint.css';
+import 'codemirror/addon/lint/lint.css';
+import 'codemirror/addon/search/jump-to-line';
+import 'codemirror/addon/search/search';
+import 'codemirror/addon/search/searchcursor';
+import 'codemirror/keymap/sublime';
+
+import debounce from 'lodash/debounce';
+import * as React from 'react';
+import {createGlobalStyle} from 'styled-components';
+import * as yaml from 'yaml';
+
+import {StyledRawCodeMirror} from './StyledRawCodeMirror';
+import {patchLint} from './configeditor/codemirror-yaml/lint';
+import {
+  YamlModeValidateFunction,
+  expandAutocompletionContextAtCursor,
+  findRangeInDocumentFromPath,
+  YamlModeValidationResult,
+} from './configeditor/codemirror-yaml/mode';
+import {ConfigEditorHelpContext} from './configeditor/types/ConfigEditorHelpContext';
+import {ConfigSchema} from './configeditor/types/ConfigSchema';
+
+export {isHelpContextEqual} from './configeditor/isHelpContextEqual';
+export {ConfigEditorHelp} from './configeditor/ConfigEditorHelp';
+
+export type {ConfigEditorHelpContext, ConfigSchema, YamlModeValidationResult};
+
+patchLint();
+
+interface ConfigEditorProps {
+  configCode: string;
+  readOnly: boolean;
+  configSchema?: ConfigSchema | null;
+
+  checkConfig: YamlModeValidateFunction;
+  onConfigChange: (newValue: string) => void;
+  onHelpContextChange: (helpContext: ConfigEditorHelpContext | null) => void;
+}
+
+const AUTO_COMPLETE_AFTER_KEY = /^[a-zA-Z0-9_@(]$/;
+const performLint = debounce((editor: any) => {
+  editor.performLint();
+}, 1000);
+
+const performInitialPass = (
+  editor: CodeMirror.Editor,
+  onHelpContextChange: (helpContext: ConfigEditorHelpContext | null) => void,
+) => {
+  // update the gutter and redlining
+  performLint(editor);
+
+  // update the contextual help based on the configSchema and content
+  const {context} = expandAutocompletionContextAtCursor(editor);
+  onHelpContextChange(context ? {type: context.closestMappingType} : null);
+};
+
+const ConfigEditorStyle = createGlobalStyle`
+  .CodeMirror.cm-s-config-editor {
+    height: initial;
+    position: absolute;
+    inset: 0;
+  }
+`;
+
+export type ConfigEditorHandle = {
+  moveCursor: (line: number, ch: number) => void;
+  moveCursorToPath: (path: string[]) => void;
+};
+
+export const NewConfigEditor = React.forwardRef<ConfigEditorHandle, ConfigEditorProps>(
+  (props, ref) => {
+    const {
+      configCode,
+      checkConfig,
+      readOnly,
+      configSchema,
+      onConfigChange,
+      onHelpContextChange,
+    } = props;
+    const editor = React.useRef<CodeMirror.Editor | null>(null);
+
+    React.useImperativeHandle(
+      ref,
+      () => {
+        const moveCursor = (line: number, ch: number) => {
+          if (!editor.current) {
+            return;
+          }
+
+          editor.current.setCursor(line, ch, {scroll: false});
+          const {clientHeight} = editor.current.getScrollInfo();
+          const {left, top} = editor.current.cursorCoords(true, 'local');
+          const offsetFromTop = 20;
+
+          editor.current?.scrollIntoView({
+            left,
+            right: left,
+            top: top - offsetFromTop,
+            bottom: top + (clientHeight - offsetFromTop),
+          });
+          editor.current.focus();
+        };
+
+        const moveCursorToPath = (path: string[]) => {
+          if (!editor.current) {
+            return;
+          }
+          const codeMirrorDoc = editor.current.getDoc();
+          const yamlDoc = yaml.parseDocument(configCode);
+          const range = findRangeInDocumentFromPath(yamlDoc, path, 'key');
+          if (!range) {
+            return;
+          }
+          const from = codeMirrorDoc.posFromIndex(range ? range.start : 0) as CodeMirror.Position;
+          moveCursor(from.line, from.ch);
+        };
+
+        return {moveCursor, moveCursorToPath};
+      },
+      [configCode],
+    );
+
+    const options = React.useMemo(() => {
+      return {
+        mode: 'yaml',
+        lineNumbers: true,
+        readOnly,
+        indentUnit: 2,
+        smartIndent: true,
+        showCursorWhenSelecting: true,
+        lintOnChange: false,
+        lint: {
+          checkConfig,
+          lintOnChange: false,
+          onUpdateLinting: false,
+        },
+        hintOptions: {
+          completeSingle: false,
+          schema: configSchema,
+        },
+        keyMap: 'sublime',
+        extraKeys: {
+          'Cmd-Space': (editor: any) => editor.showHint({completeSingle: true}),
+          'Ctrl-Space': (editor: any) => editor.showHint({completeSingle: true}),
+          'Alt-Space': (editor: any) => editor.showHint({completeSingle: true}),
+          'Shift-Tab': (editor: any) => editor.execCommand('indentLess'),
+          Tab: (editor: any) => editor.execCommand('indentMore'),
+          // Persistent search box in Query Editor
+          'Cmd-F': 'findPersistent',
+          'Ctrl-F': 'findPersistent',
+        },
+        gutters: ['CodeMirror-foldgutter', 'CodeMirror-lint-markers', 'CodeMirror-linenumbers'],
+        foldGutter: true,
+      };
+    }, [checkConfig, configSchema, readOnly]);
+
+    const handlers = React.useMemo(() => {
+      return {
+        onReady: (editorInstance: CodeMirror.Editor) => {
+          editor.current = editorInstance;
+          performInitialPass(editorInstance, onHelpContextChange);
+        },
+        onChange: (editorInstance: CodeMirror.Editor) => {
+          onConfigChange(editorInstance.getValue());
+          performLint(editorInstance);
+        },
+        onCursorActivity: (editorInstance: CodeMirror.Editor) => {
+          if (editorInstance.getSelection().length) {
+            onHelpContextChange(null);
+          } else {
+            const {context} = expandAutocompletionContextAtCursor(editorInstance);
+            onHelpContextChange(context ? {type: context.closestMappingType} : null);
+          }
+        },
+        onBlur: (editorInstance: CodeMirror.Editor) => {
+          performLint(editorInstance);
+        },
+        onKeyUp: (editorInstance: CodeMirror.Editor, event: Event) => {
+          if (event instanceof KeyboardEvent && AUTO_COMPLETE_AFTER_KEY.test(event.key)) {
+            editorInstance.execCommand('autocomplete');
+          }
+        },
+      };
+    }, [onConfigChange, onHelpContextChange]);
+
+    // Unfortunately, CodeMirror is too intense to be simulated in the JSDOM "virtual" DOM.
+    // Until we run tests against something like selenium, trying to render the editor in
+    // tests have to stop here.
+    if (process.env.NODE_ENV === 'test') {
+      return <span />;
+    }
+
+    return (
+      <div style={{flex: 1, position: 'relative'}}>
+        <ConfigEditorStyle />
+        <StyledRawCodeMirror
+          value={configCode}
+          theme={['config-editor']}
+          options={options}
+          handlers={handlers}
+        />
+      </div>
+    );
+  },
+);
+
+NewConfigEditor.displayName = 'NewConfigEditor';

--- a/js_modules/dagster-ui/packages/ui-components/src/components/RawCodeMirror.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/RawCodeMirror.tsx
@@ -1,0 +1,85 @@
+import 'codemirror/lib/codemirror.css';
+
+import CodeMirror from 'codemirror';
+import * as React from 'react';
+
+type CodeMirrorHandlers = {
+  onReady?: (instance: CodeMirror.Editor) => void;
+  onChange?: (instance: CodeMirror.Editor) => void;
+  onBlur?: (instance: CodeMirror.Editor) => void;
+  onCursorActivity?: (instance: CodeMirror.Editor) => void;
+  onKeyUp?: (instance: CodeMirror.Editor, event: Event) => void;
+};
+
+interface Props {
+  value: string;
+  options?: CodeMirror.EditorConfiguration;
+  handlers?: CodeMirrorHandlers;
+}
+
+export const RawCodeMirror = (props: Props) => {
+  const {value, options, handlers} = props;
+  const cm = React.useRef<CodeMirror.EditorFromTextArea | null>(null);
+
+  React.useEffect(() => {
+    if (value !== cm.current?.getValue()) {
+      cm.current?.setValue(value);
+    }
+  }, [value]);
+
+  const ref = React.useCallback(
+    (node: HTMLTextAreaElement | null) => {
+      if (!node) {
+        return;
+      }
+
+      if (cm.current) {
+        return;
+      }
+
+      cm.current = CodeMirror.fromTextArea(node, {
+        value,
+        ...options,
+      });
+
+      if (!handlers) {
+        return;
+      }
+
+      if (handlers.onChange) {
+        cm.current.on('change', handlers.onChange);
+      }
+
+      if (handlers.onBlur) {
+        cm.current.on('blur', handlers.onBlur);
+      }
+
+      if (handlers.onCursorActivity) {
+        cm.current.on('cursorActivity', handlers.onCursorActivity);
+      }
+
+      if (handlers.onKeyUp) {
+        cm.current.on('keyup', handlers.onKeyUp);
+      }
+
+      if (handlers.onReady) {
+        handlers.onReady(cm.current);
+      }
+    },
+    [value, options, handlers],
+  );
+
+  React.useEffect(() => {
+    // Check current options and update if necessary.
+    if (cm.current && options) {
+      Object.entries(options).forEach(([key, value]) => {
+        const castKey = key as keyof CodeMirror.EditorConfiguration;
+        if (cm.current?.getOption(castKey) !== value) {
+          cm.current?.setOption(castKey, value);
+        }
+      });
+    }
+  }, [options]);
+
+  return <textarea ref={ref} />;
+};

--- a/js_modules/dagster-ui/packages/ui-components/src/components/StyledRawCodeMirror.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/StyledRawCodeMirror.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+
+import {DagsterCodeMirrorStyle} from './DagsterCodeMirrorStyle';
+import {RawCodeMirror} from './RawCodeMirror';
+
+const makeThemeString = (theme: string[] = []) => [...theme, 'dagster'].join(' ');
+
+interface ThemeProp {
+  theme?: string[];
+}
+
+export const StyledRawCodeMirror = (
+  props: React.ComponentProps<typeof RawCodeMirror> & ThemeProp,
+) => {
+  const {options, theme, ...rest} = props;
+  return (
+    <>
+      <DagsterCodeMirrorStyle />
+      <RawCodeMirror {...rest} options={{...options, theme: makeThemeString(theme)}} />
+    </>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-components/src/components/__stories__/StyledRawCodeMirror.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/__stories__/StyledRawCodeMirror.stories.tsx
@@ -1,0 +1,52 @@
+import {Meta} from '@storybook/react';
+import CodeMirror from 'codemirror';
+import * as React from 'react';
+
+import {StyledRawCodeMirror} from '../StyledRawCodeMirror';
+
+// eslint-disable-next-line import/no-default-export
+export default {
+  title: 'StyledRawCodeMirror',
+  component: StyledRawCodeMirror,
+} as Meta;
+
+export const Default = () => {
+  const [value, setValue] = React.useState('');
+  const onChange = React.useCallback((editor: CodeMirror.Editor) => {
+    setValue(editor.getValue());
+  }, []);
+
+  const onReady = React.useCallback((editor: CodeMirror.Editor) => {
+    console.log('Ready!', editor);
+  }, []);
+
+  const options = React.useMemo(
+    () => ({
+      lineNumbers: true,
+      readOnly: false,
+    }),
+    [],
+  );
+
+  const handlers = React.useMemo(
+    () => ({
+      onChange,
+      onReady,
+    }),
+    [onChange, onReady],
+  );
+
+  return <StyledRawCodeMirror value={value} options={options} handlers={handlers} />;
+};
+
+export const ReadOnly = () => {
+  const options = React.useMemo(
+    () => ({
+      lineNumbers: true,
+      readOnly: true,
+    }),
+    [],
+  );
+
+  return <StyledRawCodeMirror value={`hello\n  world`} options={options} />;
+};

--- a/js_modules/dagster-ui/packages/ui-components/src/index.ts
+++ b/js_modules/dagster-ui/packages/ui-components/src/index.ts
@@ -22,6 +22,7 @@ export * from './components/MainContent';
 export * from './components/Menu';
 export * from './components/MetadataTable';
 export * from './components/MiddleTruncate';
+export * from './components/NewConfigEditor';
 export * from './components/NonIdealState';
 export * from './components/Page';
 export * from './components/PageHeader';


### PR DESCRIPTION
## Summary & Motivation

Implement our own React wrapper for CodeMirror 5. It turns out that react-codemirror2 has some bugs that appear related to React 18, so if we just set up the CodeMirror ourselves, we should be able to sidestep the existing problems and more effectively debug anything else that comes up.

This will also hopefully help set us up to upgrade to CodeMirror 6 much more easily.

In this PR, I have replaced the existing Launchpad config editor with the new implementation.

## How I Tested These Changes

Using Storybook example for the new CodeMirror component, test basic text editing.

View a Launchpad in Dagster. Verify:

- Scaffolding the config works correctly
- The config is used properly for autocomplete
- All basic editing behavior is correct
- Newline entry and multiple cursors work correctly
- Syntax highlighting is correct
