### PR TITLE
[ui] Asset checks UI refinement

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode.tsx
@@ -140,7 +140,7 @@ const AssetCheckIconsOrdered: {type: AssetCheckIconType; content: React.ReactNod
   },
   {
     type: 'NOT_EVALUATED',
-    content: <Icon name="changes_present" color={Colors.Gray700} />,
+    content: <Icon name="dot" color={Colors.Gray500} />,
   },
   {
     type: 'ERROR',

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetSidebarActivitySummary.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetSidebarActivitySummary.tsx
@@ -1,5 +1,4 @@
 import {Body, Box, Colors, Icon, Spinner, Table} from '@dagster-io/ui-components';
-import qs from 'qs';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
 
@@ -181,20 +180,10 @@ export const AssetSidebarActivitySummary: React.FC<Props> = ({
                 <tr key={check.name}>
                   <td style={{paddingLeft: 24}}>{check.name}</td>
                   <td>
-                    {check.executionForLatestMaterialization === null ? (
-                      <AssetCheckStatusTag notChecked={true} />
-                    ) : (
-                      <Link
-                        to={`/runs/${check.executionForLatestMaterialization.runId}?${qs.stringify({
-                          logs: check.name,
-                        })}`}
-                      >
-                        <AssetCheckStatusTag
-                          severity={check.executionForLatestMaterialization.evaluation?.severity}
-                          status={check.executionForLatestMaterialization.status}
-                        />
-                      </Link>
-                    )}
+                    <AssetCheckStatusTag
+                      check={check}
+                      execution={check.executionForLatestMaterialization}
+                    />
                   </td>
                 </tr>
               ))}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetCheckDetailModal.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetCheckDetailModal.tsx
@@ -185,10 +185,7 @@ const AssetCheckDetailModalImpl = ({
                     )}
                   </td>
                   <td>
-                    <AssetCheckStatusTag
-                      status={execution.status}
-                      severity={execution.evaluation?.severity}
-                    />
+                    <AssetCheckStatusTag check={check} execution={execution} />
                   </td>
                   <td>
                     <MetadataCell metadataEntries={execution.evaluation?.metadataEntries} />

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetCheckStatusTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetCheckStatusTag.tsx
@@ -84,7 +84,7 @@ export const AssetCheckStatusTag = ({
       data={{key: '', value: ''}}
       actions={[
         {
-          label: 'View in Run Logs',
+          label: 'View in run logs',
           to: `/runs/${runId}?${qs.stringify({logs: check.name})}`,
         },
       ]}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetCheckStatusTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetCheckStatusTag.tsx
@@ -1,53 +1,95 @@
-import {Box, Spinner, Tag} from '@dagster-io/ui-components';
+import {BaseTag, Box, Colors, Icon, Spinner, Tag} from '@dagster-io/ui-components';
+import qs from 'qs';
 import * as React from 'react';
 
 import {assertUnreachable} from '../../app/Util';
 import {AssetCheckExecutionResolvedStatus, AssetCheckSeverity} from '../../graphql/types';
+import {TagActionsPopover} from '../../ui/TagActions';
 
 export const AssetCheckStatusTag = ({
-  status,
-  severity,
-  notChecked,
+  check,
+  execution,
 }: {
-  status?: AssetCheckExecutionResolvedStatus;
-  severity?: AssetCheckSeverity;
-  notChecked?: boolean;
+  check: {
+    name: string;
+  };
+  execution: {
+    runId: string;
+    status: AssetCheckExecutionResolvedStatus;
+    evaluation?: {
+      severity: AssetCheckSeverity;
+    } | null;
+  } | null;
 }) => {
-  if (notChecked) {
-    return <Tag>Not checked</Tag>;
+  // Note: this uses BaseTag for a "grayer" style than the default tag intent
+  if (!execution) {
+    return (
+      <BaseTag
+        textColor={Colors.Gray700}
+        fillColor={Colors.Gray100}
+        icon={<Icon name="dot" color={Colors.Gray500} />}
+        label="Not evaluated"
+      />
+    );
   }
+
+  const {status, runId, evaluation} = execution;
   if (!status) {
     return null;
   }
-  const isWarn = severity === AssetCheckSeverity.WARN;
-  switch (status) {
-    case AssetCheckExecutionResolvedStatus.IN_PROGRESS:
-      return (
-        <Tag intent="primary">
-          <Box flex={{direction: 'row', alignItems: 'center', gap: 4}}>
-            <Spinner purpose="body-text" />
-            Running
-          </Box>
-        </Tag>
-      );
-    case AssetCheckExecutionResolvedStatus.FAILED:
-      return (
-        <Tag icon={isWarn ? 'warning_outline' : 'cancel'} intent={isWarn ? 'warning' : 'danger'}>
-          Failed
-        </Tag>
-      );
-    case AssetCheckExecutionResolvedStatus.EXECUTION_FAILED:
-      return <Tag intent={isWarn ? 'warning' : 'danger'}>Execution failed</Tag>;
-    case AssetCheckExecutionResolvedStatus.SUCCEEDED:
-      return (
-        <Tag icon="check_circle" intent="success">
-          Passed
-        </Tag>
-      );
-    case AssetCheckExecutionResolvedStatus.SKIPPED:
-      return <Tag icon="dot">Skipped</Tag>;
-    default:
-      assertUnreachable(status);
-  }
-  return null;
+
+  const renderTag = () => {
+    const isWarn = evaluation?.severity === AssetCheckSeverity.WARN;
+    switch (status) {
+      case AssetCheckExecutionResolvedStatus.IN_PROGRESS:
+        return (
+          <Tag intent="primary">
+            <Box flex={{direction: 'row', alignItems: 'center', gap: 4}}>
+              <Spinner purpose="body-text" />
+              Running
+            </Box>
+          </Tag>
+        );
+      case AssetCheckExecutionResolvedStatus.FAILED:
+        return isWarn ? (
+          <Tag icon="warning_outline" intent="warning">
+            Warning
+          </Tag>
+        ) : (
+          <Tag icon="cancel" intent="danger">
+            Failed
+          </Tag>
+        );
+      case AssetCheckExecutionResolvedStatus.EXECUTION_FAILED:
+        return (
+          <Tag intent={isWarn ? 'warning' : 'danger'} icon="changes_present">
+            Execution failed
+          </Tag>
+        );
+      case AssetCheckExecutionResolvedStatus.SUCCEEDED:
+        return (
+          <Tag icon="check_circle" intent="success">
+            Passed
+          </Tag>
+        );
+      case AssetCheckExecutionResolvedStatus.SKIPPED:
+        return <Tag icon="dot">Skipped</Tag>;
+      default:
+        assertUnreachable(status);
+    }
+  };
+
+  return (
+    <TagActionsPopover
+      data={{key: '', value: ''}}
+      actions={[
+        {
+          label: 'View in Run Logs',
+          to: `/runs/${runId}?${qs.stringify({logs: check.name})}`,
+        },
+      ]}
+    >
+      {renderTag()}
+    </TagActionsPopover>
+  );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetChecks.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetChecks.tsx
@@ -1,12 +1,14 @@
 import {gql, useQuery} from '@apollo/client';
 import {Body2, Box, Colors, Tag} from '@dagster-io/ui-components';
 import React, {useContext} from 'react';
+import {Link} from 'react-router-dom';
 
 import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../../app/QueryRefresh';
 import {useQueryPersistedState} from '../../hooks/useQueryPersistedState';
 import {LoadingSpinner} from '../../ui/Loading';
 import {useFormatDateTime} from '../../ui/useFormatDateTime';
 import {AssetFeatureContext} from '../AssetFeatureContext';
+import {assetDetailsPathForKey} from '../assetDetailsPathForKey';
 import {AssetKey} from '../types';
 
 import {
@@ -86,24 +88,31 @@ export const AssetChecks = ({
         <Box flex={{direction: 'row', alignItems: 'center', gap: 6}}>
           <Body2>Latest materialization:</Body2>
 
-          <Tag icon="materialization">
-            {lastMaterializationDate ? (
-              <>
-                {formatDatetime(lastMaterializationDate, {
-                  month: 'short',
-                  day: 'numeric',
-                  year: isCurrentYear ? undefined : 'numeric',
-                })}{' '}
-                at{' '}
-                {formatDatetime(lastMaterializationDate, {
-                  hour: 'numeric',
-                  minute: 'numeric',
-                })}
-              </>
-            ) : (
-              'None'
-            )}
-          </Tag>
+          <Link
+            to={assetDetailsPathForKey(assetKey, {
+              time: lastMaterializationTimestamp,
+              view: 'events',
+            })}
+          >
+            <Tag icon="materialization">
+              {lastMaterializationDate ? (
+                <>
+                  {formatDatetime(lastMaterializationDate, {
+                    month: 'short',
+                    day: 'numeric',
+                    year: isCurrentYear ? undefined : 'numeric',
+                  })}{' '}
+                  at{' '}
+                  {formatDatetime(lastMaterializationDate, {
+                    hour: 'numeric',
+                    minute: 'numeric',
+                  })}
+                </>
+              ) : (
+                'None'
+              )}
+            </Tag>
+          </Link>
         </Box>
         {/* TODO: Enable once the mutations are ready */}
         {/* {data && 'checks' in data.assetChecksOrError! && data.assetChecksOrError.checks.length ? (

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetChecks.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetChecks.tsx
@@ -4,9 +4,9 @@ import React, {useContext} from 'react';
 import {Link} from 'react-router-dom';
 
 import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../../app/QueryRefresh';
+import {Timestamp} from '../../app/time/Timestamp';
 import {useQueryPersistedState} from '../../hooks/useQueryPersistedState';
 import {LoadingSpinner} from '../../ui/Loading';
-import {useFormatDateTime} from '../../ui/useFormatDateTime';
 import {AssetFeatureContext} from '../AssetFeatureContext';
 import {assetDetailsPathForKey} from '../assetDetailsPathForKey';
 import {AssetKey} from '../types';
@@ -27,16 +27,6 @@ export const AssetChecks = ({
   assetKey: AssetKey;
   lastMaterializationTimestamp: string | undefined;
 }) => {
-  const formatDatetime = useFormatDateTime();
-  const lastMaterializationDate = React.useMemo(
-    () => (lastMaterializationTimestamp ? new Date(parseInt(lastMaterializationTimestamp)) : null),
-    [lastMaterializationTimestamp],
-  );
-  const isCurrentYear = React.useMemo(
-    () => lastMaterializationDate?.getFullYear() === new Date().getFullYear(),
-    [lastMaterializationDate],
-  );
-
   const queryResult = useQuery<AssetChecksQuery, AssetChecksQueryVariables>(ASSET_CHECKS_QUERY, {
     variables: {
       assetKey,
@@ -88,31 +78,20 @@ export const AssetChecks = ({
         <Box flex={{direction: 'row', alignItems: 'center', gap: 6}}>
           <Body2>Latest materialization:</Body2>
 
-          <Link
-            to={assetDetailsPathForKey(assetKey, {
-              time: lastMaterializationTimestamp,
-              view: 'events',
-            })}
-          >
-            <Tag icon="materialization">
-              {lastMaterializationDate ? (
-                <>
-                  {formatDatetime(lastMaterializationDate, {
-                    month: 'short',
-                    day: 'numeric',
-                    year: isCurrentYear ? undefined : 'numeric',
-                  })}{' '}
-                  at{' '}
-                  {formatDatetime(lastMaterializationDate, {
-                    hour: 'numeric',
-                    minute: 'numeric',
-                  })}
-                </>
-              ) : (
-                'None'
-              )}
-            </Tag>
-          </Link>
+          {lastMaterializationTimestamp ? (
+            <Link
+              to={assetDetailsPathForKey(assetKey, {
+                time: lastMaterializationTimestamp,
+                view: 'events',
+              })}
+            >
+              <Tag icon="materialization">
+                <Timestamp timestamp={{ms: Number(lastMaterializationTimestamp)}} />
+              </Tag>
+            </Link>
+          ) : (
+            <Tag icon="materialization">None </Tag>
+          )}
         </Box>
         {/* TODO: Enable once the mutations are ready */}
         {/* {data && 'checks' in data.assetChecksOrError! && data.assetChecksOrError.checks.length ? (

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/VirtualizedAssetCheckTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/VirtualizedAssetCheckTable.tsx
@@ -61,7 +61,7 @@ export const VirtualizedAssetCheckTable: React.FC<Props> = ({assetKey, rows}: Pr
   );
 };
 
-const TEMPLATE_COLUMNS = '2fr 120px 1fr 1fr';
+const TEMPLATE_COLUMNS = '2fr 150px 1fr 1fr';
 
 interface AssetCheckRowProps {
   assetKey: AssetKeyInput;
@@ -73,15 +73,6 @@ interface AssetCheckRowProps {
 export const VirtualizedAssetCheckRow = ({assetKey, height, start, row}: AssetCheckRowProps) => {
   const execution = row.executionForLatestMaterialization;
   const timestamp = execution?.evaluation?.timestamp;
-
-  const status = React.useMemo(() => {
-    if (!execution) {
-      return <AssetCheckStatusTag notChecked={true} />;
-    }
-    return (
-      <AssetCheckStatusTag status={execution.status} severity={execution.evaluation?.severity} />
-    );
-  }, [execution]);
 
   return (
     <Row $height={height} $start={start} data-testid={testId(`row-#TODO_USE_CHECK_ID`)}>
@@ -100,7 +91,9 @@ export const VirtualizedAssetCheckRow = ({assetKey, height, start, row}: AssetCh
           </Box>
         </RowCell>
         <RowCell style={{flexDirection: 'row', alignItems: 'center'}}>
-          <div>{status}</div>
+          <div>
+            <AssetCheckStatusTag check={row} execution={row.executionForLatestMaterialization} />
+          </div>
         </RowCell>
         <RowCell style={{flexDirection: 'row', alignItems: 'center'}}>
           {timestamp ? (

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/TagEditor.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/TagEditor.tsx
@@ -14,7 +14,8 @@ import styled from 'styled-components';
 
 import {PipelineRunTag} from '../app/ExecutionSessionStorage';
 import {ShortcutHandler} from '../app/ShortcutHandler';
-import {RunTag, TagAction} from '../runs/RunTag';
+import {RunTag} from '../runs/RunTag';
+import {TagAction} from '../ui/TagActions';
 
 interface ITagEditorProps {
   tagsFromDefinition?: PipelineRunTag[];

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/LogsScrollingTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/LogsScrollingTable.tsx
@@ -60,7 +60,10 @@ function filterLogs(logs: LogsProviderLogs, filter: LogFilter, filterStepKeys: s
   const filteredNodes = logs.allNodes.filter((node) => {
     // These events are used to determine which assets a run will materialize and are not intended
     // to be displayed in the Dagster UI. Pagination is offset based, so we remove these logs client-side.
-    if (node.__typename === 'AssetMaterializationPlannedEvent') {
+    if (
+      node.__typename === 'AssetMaterializationPlannedEvent' ||
+      node.__typename === 'AssetCheckEvaluationPlannedEvent'
+    ) {
       return false;
     }
     const l = logNodeLevel(node);

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunTag.tsx
@@ -1,7 +1,8 @@
-import {Box, Caption, Colors, IconName, Popover, Tag} from '@dagster-io/ui-components';
+import {IconName, Tag} from '@dagster-io/ui-components';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components';
+
+import {TagAction, TagActionsPopover} from '../ui/TagActions';
 
 export enum DagsterTag {
   Automaterialize = 'dagster/auto_materialize',
@@ -39,11 +40,6 @@ export type TagType = {
   link?: string;
   pinned?: boolean;
   originalKey?: string;
-};
-
-export type TagAction = {
-  label: React.ReactNode;
-  onClick: (tag: TagType) => any;
 };
 
 interface IRunTagProps {
@@ -120,54 +116,11 @@ export const RunTag = ({tag, actions}: IRunTagProps) => {
 
   if (actions?.length) {
     return (
-      <Popover
-        content={<TagActions actions={actions} tag={tag} />}
-        hoverOpenDelay={100}
-        hoverCloseDelay={100}
-        placement="top"
-        interactionKind="hover"
-      >
+      <TagActionsPopover actions={actions} data={tag}>
         {tagElement}
-      </Popover>
+      </TagActionsPopover>
     );
   }
 
   return tagElement;
 };
-
-const TagActions = ({tag, actions}: {tag: TagType; actions: TagAction[]}) => (
-  <ActionContainer background={Colors.Gray900} flex={{direction: 'row'}}>
-    {actions.map(({label, onClick}, ii) => (
-      <TagButton key={ii} onClick={() => onClick(tag)}>
-        <Caption>{label}</Caption>
-      </TagButton>
-    ))}
-  </ActionContainer>
-);
-
-const ActionContainer = styled(Box)`
-  border-radius: 8px;
-  overflow: hidden;
-`;
-
-const TagButton = styled.button`
-  border: none;
-  background: ${Colors.Dark};
-  color: ${Colors.Gray100};
-  cursor: pointer;
-  padding: 8px 12px;
-  text-align: left;
-
-  :not(:last-child) {
-    box-shadow: -1px 0 0 inset ${Colors.Gray600};
-  }
-
-  :focus {
-    outline: none;
-  }
-
-  :hover {
-    background-color: ${Colors.Gray800};
-    color: ${Colors.White};
-  }
-`;

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunTags.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunTags.tsx
@@ -4,8 +4,9 @@ import * as React from 'react';
 import {showSharedToaster} from '../app/DomUtils';
 import {useCopyToClipboard} from '../app/browser';
 import {__ASSET_JOB_PREFIX} from '../asset-graph/Utils';
+import {TagAction} from '../ui/TagActions';
 
-import {DagsterTag, RunTag, TagAction, TagType} from './RunTag';
+import {DagsterTag, RunTag, TagType} from './RunTag';
 import {RunFilterToken} from './RunsFilterInput';
 
 // Sort these tags to the start of the list.

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/TagActions.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/TagActions.tsx
@@ -1,0 +1,83 @@
+import {Box, Caption, Colors, Popover} from '@dagster-io/ui-components';
+import * as React from 'react';
+import {Link} from 'react-router-dom';
+import styled from 'styled-components';
+
+import {TagType} from '../runs/RunTag';
+
+export type TagAction =
+  | {
+      label: React.ReactNode;
+      onClick: (tag: TagType) => any; // click action
+    }
+  | {
+      label: React.ReactNode;
+      to: string; // link-style action (supports cmd-click for new tab)
+    };
+
+export const TagActions = ({data, actions}: {data: TagType; actions: TagAction[]}) => (
+  <ActionContainer background={Colors.Gray900} flex={{direction: 'row'}}>
+    {actions.map((action, ii) =>
+      'to' in action ? (
+        <Link to={action.to} key={ii}>
+          <TagButton>
+            <Caption>{action.label}</Caption>
+          </TagButton>
+        </Link>
+      ) : (
+        <TagButton key={ii} onClick={() => action.onClick(data)}>
+          <Caption>{action.label}</Caption>
+        </TagButton>
+      ),
+    )}
+  </ActionContainer>
+);
+
+export const TagActionsPopover = ({
+  data,
+  actions,
+  children,
+}: {
+  data: TagType;
+  actions: TagAction[];
+  children: React.ReactNode;
+}) => {
+  return (
+    <Popover
+      content={<TagActions actions={actions} data={data} />}
+      hoverOpenDelay={100}
+      hoverCloseDelay={100}
+      placement="top"
+      interactionKind="hover"
+    >
+      {children}
+    </Popover>
+  );
+};
+
+const ActionContainer = styled(Box)`
+  border-radius: 8px;
+  overflow: hidden;
+`;
+
+const TagButton = styled.button`
+  border: none;
+  background: ${Colors.Dark};
+  color: ${Colors.Gray100};
+  cursor: pointer;
+  padding: 8px 12px;
+  text-align: left;
+
+  :not(:last-child) {
+    box-shadow: -1px 0 0 inset ${Colors.Gray600};
+  }
+
+  :focus {
+    outline: none;
+  }
+
+  :hover {
+    background-color: ${Colors.Gray800};
+    color: ${Colors.White};
+  }
+`;


### PR DESCRIPTION
## Summary & Motivation

Related: https://www.notion.so/dagster/Asset-checks-UI-followups-8c188b748d0f449ca72a9e5ddf264090

This is a small PR with some tweaks to the asset checks UI. It also moves the "run tag popover" to a more generic "tag popover" UI component that we can re-use to add actions to the asset checks tags as shown in the screenshots below!

- These tags now offer the same actions everywhere and it's a tooltipped action rather than a direct click:

<img width="1013" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/6de1202a-8d29-4aed-8515-0af5432c33bf">

- This is now clickable

<img width="351" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/f489b271-5c6a-4102-8d25-0c7c6a2e4092">

- Never run checks have the correct empty dot here 

<img width="301" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/902ee507-3e0f-4282-bbcf-9b88b49cda2a">

- The "Empty" and Warning states here match the updated designs
<img width="508" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/2c72cddb-d7e3-4c09-8a97-f622dcc2063f">
<img width="520" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/c6f7ba46-bd0b-486b-b0e0-3d4b6c324ae7">

- The "check planned" events are hidden in the run logs

## How I Tested These Changes

Tested manually in Dagit UI