### PR TITLE
Make all ExtClients plain-ole-python objects

### DIFF
--- a/python_modules/dagster/dagster/_core/ext/client.py
+++ b/python_modules/dagster/dagster/_core/ext/client.py
@@ -9,18 +9,13 @@ from dagster_ext import (
     encode_env_var,
 )
 
-from dagster import ResourceParam
 from dagster._core.execution.context.compute import OpExecutionContext
 
 if TYPE_CHECKING:
     from dagster._core.ext.context import ExtOrchestrationContext
 
 
-class ExtClientBase(ABC):
-    pass
-
-
-class ExtClient(ResourceParam[ExtClientBase]):
+class ExtClient(ABC):
     def get_base_env(self) -> Mapping[str, str]:
         return {DAGSTER_EXT_ENV_KEYS["is_orchestration_active"]: encode_env_var(True)}
 

--- a/python_modules/dagster/dagster/_core/ext/client.py
+++ b/python_modules/dagster/dagster/_core/ext/client.py
@@ -9,14 +9,18 @@ from dagster_ext import (
     encode_env_var,
 )
 
-from dagster._config.pythonic_config import ConfigurableResource
+from dagster import ResourceParam
 from dagster._core.execution.context.compute import OpExecutionContext
 
 if TYPE_CHECKING:
     from dagster._core.ext.context import ExtOrchestrationContext
 
 
-class ExtClient(ConfigurableResource, ABC):
+class ExtClientBase(ABC):
+    pass
+
+
+class ExtClient(ResourceParam[ExtClientBase]):
     def get_base_env(self) -> Mapping[str, str]:
         return {DAGSTER_EXT_ENV_KEYS["is_orchestration_active"]: encode_env_var(True)}
 

--- a/python_modules/dagster/dagster/_core/ext/subprocess.py
+++ b/python_modules/dagster/dagster/_core/ext/subprocess.py
@@ -29,6 +29,16 @@ _MESSAGE_READER_FILENAME = "messages"
 
 
 class _ExtSubprocess(ExtClient):
+    """An ext client that runs a subprocess with the given command and environment.
+
+    By default parameters are injected via environment variables. And then context is passed via
+    a temp file, and structured messages are read from from a temp file.
+
+    Args:
+        env (Optional[Mapping[str, str]]): An optional dict of environment variables to pass to the subprocess.
+        cwd (Optional[str]): Working directory in which to launch the subprocess command.
+    """
+
     def __init__(self, env: Optional[Mapping[str, str]] = None, cwd: Optional[str] = None):
         self.env = check.opt_mapping_param(env, "env", key_type=str, value_type=str)
         self.cwd = check.opt_str_param(cwd, "cwd")

--- a/python_modules/dagster/dagster/_core/ext/subprocess.py
+++ b/python_modules/dagster/dagster/_core/ext/subprocess.py
@@ -5,8 +5,8 @@ from subprocess import Popen
 from typing import Iterator, Mapping, Optional, Sequence, Union
 
 from dagster_ext import ExtExtras
-from pydantic import Field
 
+from dagster._core.definitions.resource_annotation import ResourceParam
 from dagster._core.errors import DagsterExternalExecutionError
 from dagster._core.execution.context.compute import OpExecutionContext
 from dagster._core.ext.client import (
@@ -27,14 +27,10 @@ _CONTEXT_INJECTOR_FILENAME = "context"
 _MESSAGE_READER_FILENAME = "messages"
 
 
-class ExtSubprocess(ExtClient):
-    cwd: Optional[str] = Field(
-        default=None, description="Working directory in which to launch the subprocess command."
-    )
-    env: Optional[Mapping[str, str]] = Field(
-        default=None,
-        description="An optional dict of environment variables to pass to the subprocess.",
-    )
+class _ExtSubprocess(ExtClient):
+    def __init__(self, env: Optional[Mapping[str, str]] = None, cwd: Optional[str] = None):
+        self.env = env
+        self.cwd = cwd
 
     def run(
         self,
@@ -88,3 +84,6 @@ class ExtSubprocess(ExtClient):
                 message_reader.read_messages(external_context)
             )
             yield io_params_as_env_vars(context_injector_params, message_reader_params)
+
+
+ExtSubprocess = ResourceParam[_ExtSubprocess]

--- a/python_modules/dagster/dagster/_core/ext/subprocess.py
+++ b/python_modules/dagster/dagster/_core/ext/subprocess.py
@@ -6,6 +6,7 @@ from typing import Iterator, Mapping, Optional, Sequence, Union
 
 from dagster_ext import ExtExtras
 
+from dagster import _check as check
 from dagster._core.definitions.resource_annotation import ResourceParam
 from dagster._core.errors import DagsterExternalExecutionError
 from dagster._core.execution.context.compute import OpExecutionContext
@@ -29,8 +30,8 @@ _MESSAGE_READER_FILENAME = "messages"
 
 class _ExtSubprocess(ExtClient):
     def __init__(self, env: Optional[Mapping[str, str]] = None, cwd: Optional[str] = None):
-        self.env = env
-        self.cwd = cwd
+        self.env = check.opt_mapping_param(env, "env", key_type=str, value_type=str)
+        self.cwd = check.opt_str_param(cwd, "cwd")
 
     def run(
         self,

--- a/python_modules/libraries/dagster-docker/dagster_docker/external_resource.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/external_resource.py
@@ -46,6 +46,10 @@ class _ExtDocker(ExtClient):
 
     By default context is injected via environment variables and messages are parsed out of the
     log stream and other logs are forwarded to stdout of the orchestration process.
+
+    Args:
+        env (Optional[Mapping[str, str]]): An optional dict of environment variables to pass to the subprocess.
+        register (Optional[Mapping[str, str]]): An optional dict of registry credentials to login the docker client.
     """
 
     def __init__(

--- a/python_modules/libraries/dagster-docker/dagster_docker/external_resource.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/external_resource.py
@@ -2,7 +2,11 @@ from contextlib import contextmanager
 from typing import Any, Iterator, Mapping, Optional, Sequence, Tuple, Union
 
 import docker
-from dagster import OpExecutionContext, ResourceParam
+from dagster import (
+    OpExecutionContext,
+    ResourceParam,
+    _check as check,
+)
 from dagster._core.ext.client import (
     ExtClient,
     ExtContextInjector,
@@ -47,8 +51,8 @@ class _ExtDocker(ExtClient):
     def __init__(
         self, env: Optional[Mapping[str, str]] = None, registry: Optional[Mapping[str, str]] = None
     ):
-        self.env = env
-        self.registry = registry
+        self.env = check.opt_mapping_param(env, "env", key_type=str, value_type=str)
+        self.registry = check.opt_mapping_param(registry, "registry", key_type=str, value_type=str)
 
     def run(
         self,

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/external_resource.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/external_resource.py
@@ -4,7 +4,10 @@ from contextlib import contextmanager
 from typing import Any, Iterator, Mapping, Optional, Sequence, Union
 
 import kubernetes
-from dagster import OpExecutionContext
+from dagster import (
+    OpExecutionContext,
+    _check as check,
+)
 from dagster._core.definitions.resource_annotation import ResourceParam
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.ext.client import (
@@ -78,7 +81,7 @@ class _ExtK8sPod(ExtClient):
     """
 
     def __init__(self, env: Optional[Mapping[str, str]] = None):
-        self.env = env
+        self.env = check.opt_mapping_param(env, "env", key_type=str, value_type=str)
 
     def run(
         self,

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/external_resource.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/external_resource.py
@@ -78,6 +78,9 @@ class _ExtK8sPod(ExtClient):
 
     The first container within the containers list of the pod spec is expected (or set) to be
     the container prepared for ext protocol communication.
+
+    Args:
+        env (Optional[Mapping[str, str]]): An optional dict of environment variables to pass to the subprocess.
     """
 
     def __init__(self, env: Optional[Mapping[str, str]] = None):


### PR DESCRIPTION
## Summary & Motivation

Making this class hierarchy not inherit from `ConfigurableResource`. To avoid forcing users from using `ResourceParam`, with every use, I am proposing a pattern where we export the annotated type. We could support this more directly and ergonomically in the framework, but I think this the user-facing behavior we want for ext users.

## How I Tested These Changes

BK
