### PR TITLE
Make injectors take no params and move tempdir handling to body of inject_context

### DIFF
--- a/python_modules/dagster-ext/dagster_ext_tests/test_external_execution.py
+++ b/python_modules/dagster-ext/dagster_ext_tests/test_external_execution.py
@@ -130,7 +130,7 @@ def test_ext_subprocess(
     if context_injector_spec == "default":
         context_injector = None
     elif context_injector_spec == "user/file":
-        context_injector = ExtFileContextInjector(os.path.join(tmpdir, "input"))
+        context_injector = ExtFileContextInjector()
     elif context_injector_spec == "user/env":
         context_injector = ExtEnvContextInjector()
     else:
@@ -155,7 +155,6 @@ def test_ext_subprocess(
             cmd,
             context=context,
             extras=extras,
-            context_injector=context_injector,
             message_reader=message_reader,
             env={
                 "CONTEXT_INJECTOR_SPEC": context_injector_spec,
@@ -163,7 +162,8 @@ def test_ext_subprocess(
             },
         )
 
-    resource = ExtSubprocess()
+    resource = ExtSubprocess(context_injector=context_injector)
+
     with instance_for_test() as instance:
         materialize(
             [foo],

--- a/python_modules/dagster-ext/dagster_ext_tests/test_external_execution.py
+++ b/python_modules/dagster-ext/dagster_ext_tests/test_external_execution.py
@@ -130,7 +130,7 @@ def test_ext_subprocess(
     if context_injector_spec == "default":
         context_injector = None
     elif context_injector_spec == "user/file":
-        context_injector = ExtFileContextInjector()
+        context_injector = ExtTempFileContextInjector()
     elif context_injector_spec == "user/env":
         context_injector = ExtEnvContextInjector()
     else:

--- a/python_modules/dagster-ext/dagster_ext_tests/test_external_execution.py
+++ b/python_modules/dagster-ext/dagster_ext_tests/test_external_execution.py
@@ -39,7 +39,6 @@ from dagster._core.ext.subprocess import (
 )
 from dagster._core.ext.utils import (
     ExtEnvContextInjector,
-    ExtFileContextInjector,
     ExtFileMessageReader,
     ExtTempFileContextInjector,
     ExtTempFileMessageReader,

--- a/python_modules/dagster/dagster/_core/ext/client.py
+++ b/python_modules/dagster/dagster/_core/ext/client.py
@@ -15,9 +15,6 @@ if TYPE_CHECKING:
 
 
 class ExtClient(ABC):
-    # def get_base_env(self) -> Mapping[str, str]:
-    #     return {DAGSTER_EXT_ENV_KEYS["is_orchestration_active"]: encode_env_var(True)}
-
     @abstractmethod
     def run(
         self,

--- a/python_modules/dagster/dagster/_core/ext/client.py
+++ b/python_modules/dagster/dagster/_core/ext/client.py
@@ -15,13 +15,15 @@ if TYPE_CHECKING:
 
 
 class ExtClient(ABC):
+    # def get_base_env(self) -> Mapping[str, str]:
+    #     return {DAGSTER_EXT_ENV_KEYS["is_orchestration_active"]: encode_env_var(True)}
+
     @abstractmethod
     def run(
         self,
         *,
         context: OpExecutionContext,
         extras: Optional[ExtExtras] = None,
-        context_injector: Optional["ExtContextInjector"] = None,
         message_reader: Optional["ExtMessageReader"] = None,
     ) -> None:
         ...

--- a/python_modules/dagster/dagster/_core/ext/subprocess.py
+++ b/python_modules/dagster/dagster/_core/ext/subprocess.py
@@ -18,8 +18,6 @@ from dagster._core.ext.utils import (
     ext_protocol,
 )
 
-_MESSAGE_READER_FILENAME = "messages"
-
 
 class _ExtSubprocess(ExtClient):
     """An ext client that runs a subprocess with the given command and environment.
@@ -62,7 +60,7 @@ class _ExtSubprocess(ExtClient):
     ) -> None:
         with ext_protocol(
             context=context,
-            context_injector=self.context_injector or ExtTempFileContextInjector(),
+            context_injector=self.context_injector,
             message_reader=message_reader or ExtTempFileMessageReader(),
             extras=extras,
         ) as ext_context:

--- a/python_modules/dagster/dagster/_core/ext/utils.py
+++ b/python_modules/dagster/dagster/_core/ext/utils.py
@@ -32,9 +32,11 @@ from dagster._utils import tail_file
 _CONTEXT_INJECTOR_FILENAME = "context"
 _MESSAGE_READER_FILENAME = "messages"
 
+_CONTEXT_INJECTOR_FILENAME = "context"
+
 
 class ExtFileContextInjector(ExtContextInjector):
-    def __init__(self, path: str):
+    def __init__(self, path):
         self._path = path
 
     @contextmanager

--- a/python_modules/dagster/dagster/_core/ext/utils.py
+++ b/python_modules/dagster/dagster/_core/ext/utils.py
@@ -17,7 +17,10 @@ from dagster_ext import (
     ExtParams,
 )
 
-from dagster import OpExecutionContext
+from dagster import (
+    OpExecutionContext,
+    _check as check,
+)
 from dagster._core.ext.client import (
     ExtContextInjector,
     ExtMessageReader,
@@ -36,8 +39,8 @@ _CONTEXT_INJECTOR_FILENAME = "context"
 
 
 class ExtFileContextInjector(ExtContextInjector):
-    def __init__(self, path):
-        self._path = path
+    def __init__(self, path: str):
+        self._path = check.str_param(path, "path")
 
     @contextmanager
     def inject_context(self, context_data: "ExtContextData") -> Iterator[ExtParams]:

--- a/python_modules/libraries/dagster-docker/dagster_docker/external_resource.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/external_resource.py
@@ -67,8 +67,6 @@ class _ExtDocker(ExtClient):
     ):
         self.env = check.opt_mapping_param(env, "env", key_type=str, value_type=str)
         self.registry = check.opt_mapping_param(registry, "registry", key_type=str, value_type=str)
-<<<<<<< HEAD
-=======
         self.context_injector = (
             check.opt_inst_param(
                 context_injector,
@@ -77,7 +75,6 @@ class _ExtDocker(ExtClient):
             )
             or ExtEnvContextInjector()
         )
->>>>>>> 78e3d21037 (self review)
 
     def run(
         self,
@@ -113,8 +110,7 @@ class _ExtDocker(ExtClient):
             message_Reader (Optional[ExtMessageReader]):
                 Override the default ext protocol message reader.
         """
-<<<<<<< HEAD
-        context_injector = context_injector or ExtEnvContextInjector()
+        context_injector = self.context_injector
         message_reader = message_reader or DockerLogsMessageReader()
 
         with ext_protocol(
@@ -123,13 +119,6 @@ class _ExtDocker(ExtClient):
             message_reader=message_reader,
             extras=extras,
         ) as ext_context:
-=======
-        ext_context = ExtOrchestrationContext(context=context, extras=extras)
-        with self._setup_ext_protocol(ext_context, message_reader) as (
-            ext_env,
-            message_reader,
-        ):
->>>>>>> 78e3d21037 (self review)
             client = docker.client.from_env()
             registry = registry or self.registry
             if registry:
@@ -194,24 +183,5 @@ class _ExtDocker(ExtClient):
             **kwargs,
         )
 
-<<<<<<< HEAD
-=======
-    @contextmanager
-    def _setup_ext_protocol(
-        self,
-        external_context: ExtOrchestrationContext,
-        message_reader: Optional[ExtMessageReader],
-    ) -> Iterator[Tuple[Mapping[str, str], ExtMessageReader]]:
-        message_reader = message_reader or DockerLogsMessageReader()
-
-        with self.context_injector.inject_context(
-            external_context,
-        ) as ci_params, message_reader.read_messages(
-            external_context,
-        ) as mr_params:
-            protocol_envs = io_params_as_env_vars(ci_params, mr_params)
-            yield protocol_envs, message_reader
-
->>>>>>> 78e3d21037 (self review)
 
 ExtDocker = ResourceParam[_ExtDocker]

--- a/python_modules/libraries/dagster-docker/dagster_docker/external_resource.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/external_resource.py
@@ -60,10 +60,24 @@ class _ExtDocker(ExtClient):
     """
 
     def __init__(
-        self, env: Optional[Mapping[str, str]] = None, registry: Optional[Mapping[str, str]] = None
+        self,
+        env: Optional[Mapping[str, str]] = None,
+        registry: Optional[Mapping[str, str]] = None,
+        context_injector: Optional[ExtContextInjector] = None,
     ):
         self.env = check.opt_mapping_param(env, "env", key_type=str, value_type=str)
         self.registry = check.opt_mapping_param(registry, "registry", key_type=str, value_type=str)
+<<<<<<< HEAD
+=======
+        self.context_injector = (
+            check.opt_inst_param(
+                context_injector,
+                "context_injector",
+                ExtContextInjector,
+            )
+            or ExtEnvContextInjector()
+        )
+>>>>>>> 78e3d21037 (self review)
 
     def run(
         self,
@@ -75,7 +89,6 @@ class _ExtDocker(ExtClient):
         registry: Optional[Mapping[str, str]] = None,
         container_kwargs: Optional[Mapping[str, Any]] = None,
         extras: Optional[ExtExtras] = None,
-        context_injector: Optional[ExtContextInjector] = None,
         message_reader: Optional[ExtMessageReader] = None,
     ) -> None:
         """Create a docker container and run it to completion, enriched with the ext protocol.
@@ -100,6 +113,7 @@ class _ExtDocker(ExtClient):
             message_Reader (Optional[ExtMessageReader]):
                 Override the default ext protocol message reader.
         """
+<<<<<<< HEAD
         context_injector = context_injector or ExtEnvContextInjector()
         message_reader = message_reader or DockerLogsMessageReader()
 
@@ -109,6 +123,13 @@ class _ExtDocker(ExtClient):
             message_reader=message_reader,
             extras=extras,
         ) as ext_context:
+=======
+        ext_context = ExtOrchestrationContext(context=context, extras=extras)
+        with self._setup_ext_protocol(ext_context, message_reader) as (
+            ext_env,
+            message_reader,
+        ):
+>>>>>>> 78e3d21037 (self review)
             client = docker.client.from_env()
             registry = registry or self.registry
             if registry:
@@ -173,5 +194,24 @@ class _ExtDocker(ExtClient):
             **kwargs,
         )
 
+<<<<<<< HEAD
+=======
+    @contextmanager
+    def _setup_ext_protocol(
+        self,
+        external_context: ExtOrchestrationContext,
+        message_reader: Optional[ExtMessageReader],
+    ) -> Iterator[Tuple[Mapping[str, str], ExtMessageReader]]:
+        message_reader = message_reader or DockerLogsMessageReader()
+
+        with self.context_injector.inject_context(
+            external_context,
+        ) as ci_params, message_reader.read_messages(
+            external_context,
+        ) as mr_params:
+            protocol_envs = io_params_as_env_vars(ci_params, mr_params)
+            yield protocol_envs, message_reader
+
+>>>>>>> 78e3d21037 (self review)
 
 ExtDocker = ResourceParam[_ExtDocker]

--- a/python_modules/libraries/dagster-docker/dagster_docker/external_resource.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/external_resource.py
@@ -110,12 +110,11 @@ class _ExtDocker(ExtClient):
             message_Reader (Optional[ExtMessageReader]):
                 Override the default ext protocol message reader.
         """
-        context_injector = self.context_injector
         message_reader = message_reader or DockerLogsMessageReader()
 
         with ext_protocol(
             context=context,
-            context_injector=context_injector,
+            context_injector=self.context_injector,
             message_reader=message_reader,
             extras=extras,
         ) as ext_context:

--- a/python_modules/libraries/dagster-docker/dagster_docker_tests/test_external_asset.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker_tests/test_external_asset.py
@@ -3,7 +3,7 @@ import tempfile
 
 import pytest
 from dagster import AssetExecutionContext, asset, materialize
-from dagster._core.ext.utils import ExtFileContextInjector, ExtFileMessageReader
+from dagster._core.ext.utils import ExtFileContextInjector, ExtFileMessageReader, ExtTempFileContextInjector
 from dagster_docker.external_resource import ExtDocker
 from dagster_test.test_project import (
     IS_BUILDKITE,
@@ -106,7 +106,7 @@ def test_file_io():
 
         result = materialize(
             [number_x],
-            resources={"ext_docker": ExtDocker(context_injector=ExtFileContextInjector())},
+            resources={"ext_docker": ExtDocker(context_injector=ExtTempFileContextInjector())},
             raise_on_error=False,
         )
         assert result.success

--- a/python_modules/libraries/dagster-docker/dagster_docker_tests/test_external_asset.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker_tests/test_external_asset.py
@@ -4,8 +4,8 @@ import tempfile
 import pytest
 from dagster import AssetExecutionContext, asset, materialize
 from dagster._core.ext.utils import (
+    ExtFileContextInjector,
     ExtFileMessageReader,
-    ExtTempFileContextInjector,
 )
 from dagster_docker.external_resource import ExtDocker
 from dagster_test.test_project import (
@@ -109,7 +109,11 @@ def test_file_io():
 
         result = materialize(
             [number_x],
-            resources={"ext_docker": ExtDocker(context_injector=ExtTempFileContextInjector())},
+            resources={
+                "ext_docker": ExtDocker(
+                    context_injector=ExtFileContextInjector(os.path.join(tempdir, "context"))
+                )
+            },
             raise_on_error=False,
         )
         assert result.success

--- a/python_modules/libraries/dagster-docker/dagster_docker_tests/test_external_asset.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker_tests/test_external_asset.py
@@ -3,7 +3,10 @@ import tempfile
 
 import pytest
 from dagster import AssetExecutionContext, asset, materialize
-from dagster._core.ext.utils import ExtFileContextInjector, ExtFileMessageReader, ExtTempFileContextInjector
+from dagster._core.ext.utils import (
+    ExtFileMessageReader,
+    ExtTempFileContextInjector,
+)
 from dagster_docker.external_resource import ExtDocker
 from dagster_test.test_project import (
     IS_BUILDKITE,

--- a/python_modules/libraries/dagster-docker/dagster_docker_tests/test_external_asset.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker_tests/test_external_asset.py
@@ -63,7 +63,6 @@ def test_file_io():
         find_local_test_image(docker_image)
 
     with tempfile.TemporaryDirectory() as tempdir:
-        context_injector = ExtFileContextInjector(os.path.join(tempdir, "context"))
         message_reader = ExtFileMessageReader(os.path.join(tempdir, "messages"))
 
         @asset
@@ -97,7 +96,6 @@ def test_file_io():
                 ],
                 registry=registry,
                 context=context,
-                context_injector=context_injector,
                 message_reader=message_reader,
                 extras={"storage_root": container_storage, "multiplier": 2},
                 container_kwargs={
@@ -108,7 +106,7 @@ def test_file_io():
 
         result = materialize(
             [number_x],
-            resources={"ext_docker": ExtDocker()},
+            resources={"ext_docker": ExtDocker(context_injector=ExtFileContextInjector())},
             raise_on_error=False,
         )
         assert result.success

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/external_resource.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/external_resource.py
@@ -146,13 +146,12 @@ class _ExtK8sPod(ExtClient):
         """
         client = DagsterKubernetesClient.production_client()
 
-        context_injector = self.context_injector
         message_reader = message_reader or K8sPodLogsMessageReader()
 
         with ext_protocol(
             context=context,
             extras=extras,
-            context_injector=context_injector,
+            context_injector=self.context_injector,
             message_reader=message_reader,
         ) as ext_process:
             namespace = namespace or "default"

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/external_resource.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/external_resource.py
@@ -43,6 +43,7 @@ def get_pod_name(run_id: str, op_name: str):
 
 DEFAULT_CONTAINER_NAME = "dagster-ext-execution"
 
+
 class K8sPodLogsMessageReader(ExtMessageReader):
     @contextmanager
     def read_messages(
@@ -206,7 +207,7 @@ def build_pod_body(
         "name": pod_name,
     }
     if "labels" in meta:
-        meta["labels"] = {**get_common_labels(), **meta["labels"]} # type: ignore
+        meta["labels"] = {**get_common_labels(), **meta["labels"]}  # type: ignore
     else:
         meta["labels"] = get_common_labels()
 


### PR DESCRIPTION
## Summary & Motivation

We want to restructure the ext clients so that they receive the context injector arguments as `__init__` time, rather than as a parameter to run. However right now in some cases (namely the file case) the context injector has to be constructed when the temp directory is already created. This moves the temp dir creation logic into the `inject_context` method itself. This makes the `__init__` trivial. The downside is that we create two tempdirs, one for the message reader and one for the context injector. However that in my judgement is immateriai

## How I Tested These Changes

BK
