### PR TITLE
Do not pass message reader into ExtClient.run

### DIFF
--- a/python_modules/dagster-ext/dagster_ext_tests/test_external_execution.py
+++ b/python_modules/dagster-ext/dagster_ext_tests/test_external_execution.py
@@ -1,5 +1,4 @@
 import inspect
-import os
 import re
 import shutil
 import subprocess
@@ -138,7 +137,7 @@ def test_ext_subprocess(
     if message_reader_spec == "default":
         message_reader = None
     elif message_reader_spec == "user/file":
-        message_reader = ExtFileMessageReader(os.path.join(tmpdir, "output"))
+        message_reader = ExtFileMessageReader()
     elif message_reader_spec == "user/s3":
         message_reader = ExtS3MessageReader(
             bucket=_S3_TEST_BUCKET, client=s3_client, interval=0.001
@@ -154,14 +153,13 @@ def test_ext_subprocess(
             cmd,
             context=context,
             extras=extras,
-            message_reader=message_reader,
             env={
                 "CONTEXT_INJECTOR_SPEC": context_injector_spec,
                 "MESSAGE_READER_SPEC": message_reader_spec,
             },
         )
 
-    resource = ExtSubprocess(context_injector=context_injector)
+    resource = ExtSubprocess(context_injector=context_injector, message_reader=message_reader)
 
     with instance_for_test() as instance:
         materialize(

--- a/python_modules/dagster-ext/dagster_ext_tests/test_external_execution.py
+++ b/python_modules/dagster-ext/dagster_ext_tests/test_external_execution.py
@@ -38,7 +38,6 @@ from dagster._core.ext.subprocess import (
 )
 from dagster._core.ext.utils import (
     ExtEnvContextInjector,
-    ExtFileMessageReader,
     ExtTempFileContextInjector,
     ExtTempFileMessageReader,
     ext_protocol,

--- a/python_modules/dagster-ext/dagster_ext_tests/test_external_execution.py
+++ b/python_modules/dagster-ext/dagster_ext_tests/test_external_execution.py
@@ -137,7 +137,7 @@ def test_ext_subprocess(
     if message_reader_spec == "default":
         message_reader = None
     elif message_reader_spec == "user/file":
-        message_reader = ExtFileMessageReader()
+        message_reader = ExtTempFileMessageReader()
     elif message_reader_spec == "user/s3":
         message_reader = ExtS3MessageReader(
             bucket=_S3_TEST_BUCKET, client=s3_client, interval=0.001

--- a/python_modules/dagster/dagster/_core/ext/subprocess.py
+++ b/python_modules/dagster/dagster/_core/ext/subprocess.py
@@ -28,7 +28,8 @@ class _ExtSubprocess(ExtClient):
     Args:
         env (Optional[Mapping[str, str]]): An optional dict of environment variables to pass to the subprocess.
         cwd (Optional[str]): Working directory in which to launch the subprocess command.
-        context_injector (Optional[ExtContextInjector]): An context injector to use to inject context into the subprocess. Defaults to ExtFileContextInjector.
+        context_injector (Optional[ExtContextInjector]): An context injector to use to inject context into the subprocess. Defaults to ExtTempFileContextInjector.
+        message_reader (Optional[ExtContextInjector]): An context injector to use to read messages from  the subprocess. Defaults to ExtTempFileMessageReader.
     """
 
     def __init__(
@@ -36,6 +37,7 @@ class _ExtSubprocess(ExtClient):
         env: Optional[Mapping[str, str]] = None,
         cwd: Optional[str] = None,
         context_injector: Optional[ExtContextInjector] = None,
+        message_reader: Optional[ExtMessageReader] = None,
     ):
         self.env = check.opt_mapping_param(env, "env", key_type=str, value_type=str)
         self.cwd = check.opt_str_param(cwd, "cwd")
@@ -47,6 +49,14 @@ class _ExtSubprocess(ExtClient):
             )
             or ExtTempFileContextInjector()
         )
+        self.message_reader = (
+            check.opt_inst_param(
+                message_reader,
+                "message_reader",
+                ExtMessageReader,
+            )
+            or ExtTempFileMessageReader()
+        )
 
     def run(
         self,
@@ -54,14 +64,13 @@ class _ExtSubprocess(ExtClient):
         *,
         context: OpExecutionContext,
         extras: Optional[ExtExtras] = None,
-        message_reader: Optional[ExtMessageReader] = None,
         env: Optional[Mapping[str, str]] = None,
         cwd: Optional[str] = None,
     ) -> None:
         with ext_protocol(
             context=context,
             context_injector=self.context_injector,
-            message_reader=message_reader or ExtTempFileMessageReader(),
+            message_reader=self.message_reader,
             extras=extras,
         ) as ext_context:
             process = Popen(

--- a/python_modules/dagster/dagster/_core/ext/utils.py
+++ b/python_modules/dagster/dagster/_core/ext/utils.py
@@ -36,6 +36,7 @@ _CONTEXT_INJECTOR_FILENAME = "context"
 _MESSAGE_READER_FILENAME = "messages"
 
 _CONTEXT_INJECTOR_FILENAME = "context"
+_MESSAGE_READER_FILENAME = "messages"
 
 
 class ExtFileContextInjector(ExtContextInjector):
@@ -74,7 +75,7 @@ class ExtEnvContextInjector(ExtContextInjector):
 
 class ExtFileMessageReader(ExtMessageReader):
     def __init__(self, path: str):
-        self._path = path
+        self._path = check.str_param(path, "path")
 
     @contextmanager
     def read_messages(

--- a/python_modules/libraries/dagster-docker/dagster_docker_tests/test_external_asset.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker_tests/test_external_asset.py
@@ -5,7 +5,6 @@ import pytest
 from dagster import AssetExecutionContext, asset, materialize
 from dagster._core.ext.utils import (
     ExtFileContextInjector,
-    ExtFileMessageReader,
 )
 from dagster_docker.external_resource import ExtDocker
 from dagster_test.test_project import (
@@ -66,7 +65,6 @@ def test_file_io():
         find_local_test_image(docker_image)
 
     with tempfile.TemporaryDirectory() as tempdir:
-        message_reader = ExtFileMessageReader(os.path.join(tempdir, "messages"))
 
         @asset
         def number_x(
@@ -99,7 +97,6 @@ def test_file_io():
                 ],
                 registry=registry,
                 context=context,
-                message_reader=message_reader,
                 extras={"storage_root": container_storage, "multiplier": 2},
                 container_kwargs={
                     "environment": {"PYTHONPATH": "/dagster_test/toys/external_execution/"},


### PR DESCRIPTION
## Summary & Motivation

Similar to #16354, change the message reader class so it can be instantiated at client construction time, rather than requiring a temporary directory already exist.  This ends up simplifying some code paths that had to account the readers could be created on demand. Instead all these codepaths not assume a single reader instance is passed in and always there. 

## How I Tested These Changes

BK