### PR TITLE
Asset check selection

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -2177,6 +2177,7 @@ input PipelineSelector {
   repositoryLocationName: String!
   solidSelection: [String!]
   assetSelection: [AssetKeyInput!]
+  assetCheckSelection: [AssetCheckHandleInput!]
 }
 
 input RepositorySelector {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -2100,6 +2100,12 @@ input JobOrPipelineSelector {
   repositoryLocationName: String!
   solidSelection: [String!]
   assetSelection: [AssetKeyInput!]
+  assetCheckSelection: [AssetCheckHandleInput!]
+}
+
+input AssetCheckHandleInput {
+  assetKey: AssetKeyInput!
+  name: String!
 }
 
 input ExecutionTag {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -2691,6 +2691,7 @@ export type PipelineRuns = {
 };
 
 export type PipelineSelector = {
+  assetCheckSelection?: InputMaybe<Array<AssetCheckHandleInput>>;
   assetSelection?: InputMaybe<Array<AssetKeyInput>>;
   pipelineName: Scalars['String'];
   repositoryLocationName: Scalars['String'];
@@ -9441,6 +9442,10 @@ export const buildPipelineSelector = (
   const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
   relationshipsToOmit.add('PipelineSelector');
   return {
+    assetCheckSelection:
+      overrides && overrides.hasOwnProperty('assetCheckSelection')
+        ? overrides.assetCheckSelection!
+        : [],
     assetSelection:
       overrides && overrides.hasOwnProperty('assetSelection') ? overrides.assetSelection! : [],
     pipelineName:

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -190,6 +190,11 @@ export enum AssetCheckExecutionResolvedStatus {
   SUCCEEDED = 'SUCCEEDED',
 }
 
+export type AssetCheckHandleInput = {
+  assetKey: AssetKeyInput;
+  name: Scalars['String'];
+};
+
 export type AssetCheckNeedsMigrationError = Error & {
   __typename: 'AssetCheckNeedsMigrationError';
   message: Scalars['String'];
@@ -1606,6 +1611,7 @@ export type JobSolidHandlesArgs = {
 };
 
 export type JobOrPipelineSelector = {
+  assetCheckSelection?: InputMaybe<Array<AssetCheckHandleInput>>;
   assetSelection?: InputMaybe<Array<AssetKeyInput>>;
   jobName?: InputMaybe<Scalars['String']>;
   pipelineName?: InputMaybe<Scalars['String']>;
@@ -4560,6 +4566,23 @@ export const buildAssetCheckExecution = (
   };
 };
 
+export const buildAssetCheckHandleInput = (
+  overrides?: Partial<AssetCheckHandleInput>,
+  _relationshipsToOmit: Set<string> = new Set(),
+): AssetCheckHandleInput => {
+  const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
+  relationshipsToOmit.add('AssetCheckHandleInput');
+  return {
+    assetKey:
+      overrides && overrides.hasOwnProperty('assetKey')
+        ? overrides.assetKey!
+        : relationshipsToOmit.has('AssetKeyInput')
+        ? ({} as AssetKeyInput)
+        : buildAssetKeyInput({}, relationshipsToOmit),
+    name: overrides && overrides.hasOwnProperty('name') ? overrides.name! : 'aliquam',
+  };
+};
+
 export const buildAssetCheckNeedsMigrationError = (
   overrides?: Partial<AssetCheckNeedsMigrationError>,
   _relationshipsToOmit: Set<string> = new Set(),
@@ -7253,6 +7276,10 @@ export const buildJobOrPipelineSelector = (
   const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
   relationshipsToOmit.add('JobOrPipelineSelector');
   return {
+    assetCheckSelection:
+      overrides && overrides.hasOwnProperty('assetCheckSelection')
+        ? overrides.assetCheckSelection!
+        : [],
     assetSelection:
       overrides && overrides.hasOwnProperty('assetSelection') ? overrides.assetSelection! : [],
     jobName: overrides && overrides.hasOwnProperty('jobName') ? overrides.jobName! : 'quia',

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/run_lifecycle.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/run_lifecycle.py
@@ -91,6 +91,11 @@ def create_valid_pipeline_run(
             if execution_params.selector.asset_selection
             else None
         ),
+        asset_check_selection=(
+            frozenset(execution_params.selector.asset_check_selection)
+            if execution_params.selector.asset_check_selection
+            else None
+        ),
         op_selection=execution_params.selector.op_selection,
         resolved_op_selection=(
             frozenset(execution_params.selector.op_selection)

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
@@ -22,6 +22,7 @@ from typing import (
 )
 
 import dagster._check as check
+from dagster._core.definitions.asset_check_spec import AssetCheckHandle
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.selector import GraphSelector, JobSubsetSelector
 from dagster._core.workspace.context import BaseWorkspaceRequestContext
@@ -145,6 +146,9 @@ class UserFacingGraphQLError(Exception):
 
 def pipeline_selector_from_graphql(data: Mapping[str, Any]) -> JobSubsetSelector:
     asset_selection = cast(Optional[Iterable[Dict[str, List[str]]]], data.get("assetSelection"))
+    asset_check_selection = cast(
+        Optional[Iterable[Dict[str, Any]]], data.get("assetCheckSelection")
+    )
     return JobSubsetSelector(
         location_name=data["repositoryLocationName"],
         repository_name=data["repositoryName"],
@@ -153,6 +157,14 @@ def pipeline_selector_from_graphql(data: Mapping[str, Any]) -> JobSubsetSelector
         asset_selection=(
             [AssetKey.from_graphql_input(asset_key) for asset_key in asset_selection]
             if asset_selection
+            else None
+        ),
+        asset_check_selection=(
+            [
+                AssetCheckHandle.from_graphql_input(asset_check)
+                for asset_check in asset_check_selection
+            ]
+            if asset_check_selection
             else None
         ),
     )

--- a/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
@@ -14,6 +14,14 @@ class GrapheneAssetKeyInput(graphene.InputObjectType):
         name = "AssetKeyInput"
 
 
+class GrapheneAssetCheckHandleInput(graphene.InputObjectType):
+    assetKey = graphene.NonNull(GrapheneAssetKeyInput)
+    name = graphene.NonNull(graphene.String)
+
+    class Meta:
+        name = "AssetCheckHandleInput"
+
+
 class GrapheneExecutionTag(graphene.InputObjectType):
     key = graphene.NonNull(graphene.String)
     value = graphene.NonNull(graphene.String)
@@ -112,6 +120,7 @@ class GrapheneJobOrPipelineSelector(graphene.InputObjectType):
     repositoryLocationName = graphene.NonNull(graphene.String)
     solidSelection = graphene.List(graphene.NonNull(graphene.String))
     assetSelection = graphene.List(graphene.NonNull(GrapheneAssetKeyInput))
+    assetCheckSelection = graphene.List(graphene.NonNull(GrapheneAssetCheckHandleInput))
 
     class Meta:
         description = """This type represents the fields necessary to identify a job or pipeline"""

--- a/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
@@ -84,6 +84,7 @@ class GraphenePipelineSelector(graphene.InputObjectType):
     repositoryLocationName = graphene.NonNull(graphene.String)
     solidSelection = graphene.List(graphene.NonNull(graphene.String))
     assetSelection = graphene.List(graphene.NonNull(GrapheneAssetKeyInput))
+    assetCheckSelection = graphene.List(graphene.NonNull(GrapheneAssetCheckHandleInput))
 
     class Meta:
         description = """This type represents the fields necessary to identify a

--- a/python_modules/dagster-graphql/dagster_graphql/test/utils.py
+++ b/python_modules/dagster-graphql/dagster_graphql/test/utils.py
@@ -37,6 +37,11 @@ class GqlAssetKey(TypedDict):
     path: Sequence[str]
 
 
+class GqlAssetCheckHandle(TypedDict):
+    assetKey: GqlAssetKey
+    name: str
+
+
 def main_repo_location_name() -> str:
     return "test_location"
 
@@ -174,6 +179,7 @@ def infer_job_or_pipeline_selector(
     pipeline_name: str,
     op_selection: Optional[Sequence[str]] = None,
     asset_selection: Optional[Sequence[GqlAssetKey]] = None,
+    asset_check_selection: Optional[Sequence[GqlAssetCheckHandle]] = None,
 ) -> Selector:
     selector = infer_repository_selector(graphql_context)
     selector.update(
@@ -181,6 +187,7 @@ def infer_job_or_pipeline_selector(
             "pipelineName": pipeline_name,
             "solidSelection": op_selection,
             "assetSelection": asset_selection,
+            "assetCheckSelection": asset_check_selection,
         }
     )
     return selector

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_all_snapshot_ids.ambr
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_all_snapshot_ids.ambr
@@ -1170,7 +1170,7 @@
           "input_def_snaps": [
             {
               "__class__": "InputDefSnap",
-              "dagster_type_key": "Nothing",
+              "dagster_type_key": "Any",
               "description": null,
               "name": "asset_1"
             }
@@ -1495,6 +1495,1170 @@
   '''
 # ---
 # name: test_all_snapshot_ids[100]
+  '''
+  {
+    "__class__": "PipelineSnapshot",
+    "config_schema_snapshot": {
+      "__class__": "ConfigSchemaSnapshot",
+      "all_config_snaps_by_key": {
+        "Any": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Any",
+          "key": "Any",
+          "kind": {
+            "__enum__": "ConfigTypeKind.ANY"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Bool": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Bool",
+          "key": "Bool",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.BOOL"
+          },
+          "type_param_keys": null
+        },
+        "Float": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Float",
+          "key": "Float",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.FLOAT"
+          },
+          "type_param_keys": null
+        },
+        "Int": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Int",
+          "key": "Int",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.INT"
+          },
+          "type_param_keys": null
+        },
+        "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Bool",
+            "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59"
+          ]
+        },
+        "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Float",
+            "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3"
+          ]
+        },
+        "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Int",
+            "Selector.a9799b971d12ace70a2d8803c883c863417d0725"
+          ]
+        },
+        "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "String",
+            "Selector.e04723c9d9937e3ab21206435b22247cfbe58269"
+          ]
+        },
+        "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "disabled",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "enabled",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Int"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Bool"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Float"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Any"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.081354663b9d4b8fbfd1cb8e358763912953913f": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "\"INFO\"",
+              "description": "The logger's threshold.",
+              "is_required": false,
+              "name": "log_level",
+              "type_key": "String"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "\"dagster\"",
+              "description": "The name of your logger.",
+              "is_required": false,
+              "name": "name",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.09d73f0755bf4752d3f121837669c8660dcf451e": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"retries\": {\"enabled\": {}}}",
+              "description": "Execute all steps in a single process.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
+              "description": "The default colored console logger.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
+              "is_required": false,
+              "name": "io_manager",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.27d4be3152e89c65ecb4ce8c588d8226cc827e0d": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"adder\": {}, \"op_1\": {}, \"op_2\": {}, \"plus_one\": {}}",
+              "description": null,
+              "is_required": false,
+              "name": "ops",
+              "type_key": "Shape.5403fe5383515d106ffe3bb7f1a927b1cbb4e8a9"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.27d4be3152e89c65ecb4ce8c588d8226cc827e0d",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.360ea318ffe78a111434a5bb7409ef66c9692290": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
+              "description": "Configure how steps are executed within a run.",
+              "is_required": false,
+              "name": "execution",
+              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Configure how loggers emit messages within a run.",
+              "is_required": false,
+              "name": "loggers",
+              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"plus_one\": {}, \"subgraph\": {\"ops\": {\"adder\": {}, \"op_1\": {}, \"op_2\": {}, \"plus_one\": {}}}}",
+              "description": "Configure runtime parameters for ops or assets.",
+              "is_required": false,
+              "name": "ops",
+              "type_key": "Shape.42ddf3fac74380a93f8508f2a0f6450afb177d35"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"io_manager\": {}}",
+              "description": "Configure how shared resources are implemented within a run.",
+              "is_required": false,
+              "name": "resources",
+              "type_key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.360ea318ffe78a111434a5bb7409ef66c9692290",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.42ddf3fac74380a93f8508f2a0f6450afb177d35": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "plus_one",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"ops\": {\"adder\": {}, \"op_1\": {}, \"op_2\": {}, \"plus_one\": {}}}",
+              "description": null,
+              "is_required": false,
+              "name": "subgraph",
+              "type_key": "Shape.27d4be3152e89c65ecb4ce8c588d8226cc827e0d"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.42ddf3fac74380a93f8508f2a0f6450afb177d35",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "[DEPRECATED]",
+              "is_required": false,
+              "name": "marker_to_close",
+              "type_key": "String"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"enabled\": {}}",
+              "description": "Whether retries are enabled or not. By default, retries are enabled.",
+              "is_required": false,
+              "name": "retries",
+              "type_key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "path",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.5403fe5383515d106ffe3bb7f1a927b1cbb4e8a9": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "adder",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "op_1",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "op_2",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "plus_one",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.5403fe5383515d106ffe3bb7f1a927b1cbb4e8a9",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.743e47901855cb245064dd633e217bfcb49a11a7": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [],
+          "given_name": null,
+          "key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "console",
+              "type_key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "String": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "String",
+          "key": "String",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.STRING"
+          },
+          "type_param_keys": null
+        }
+      }
+    },
+    "dagster_type_namespace_snapshot": {
+      "__class__": "DagsterTypeNamespaceSnapshot",
+      "all_dagster_type_snaps_by_key": {
+        "Any": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Any",
+          "is_builtin": true,
+          "key": "Any",
+          "kind": {
+            "__enum__": "DagsterTypeKind.ANY"
+          },
+          "loader_schema_key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
+          "materializer_schema_key": null,
+          "name": "Any",
+          "type_param_keys": []
+        },
+        "Bool": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Bool",
+          "is_builtin": true,
+          "key": "Bool",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "materializer_schema_key": null,
+          "name": "Bool",
+          "type_param_keys": []
+        },
+        "Float": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Float",
+          "is_builtin": true,
+          "key": "Float",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "materializer_schema_key": null,
+          "name": "Float",
+          "type_param_keys": []
+        },
+        "Int": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Int",
+          "is_builtin": true,
+          "key": "Int",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "materializer_schema_key": null,
+          "name": "Int",
+          "type_param_keys": []
+        },
+        "Nothing": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Nothing",
+          "is_builtin": true,
+          "key": "Nothing",
+          "kind": {
+            "__enum__": "DagsterTypeKind.NOTHING"
+          },
+          "loader_schema_key": null,
+          "materializer_schema_key": null,
+          "name": "Nothing",
+          "type_param_keys": []
+        },
+        "String": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "String",
+          "is_builtin": true,
+          "key": "String",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "materializer_schema_key": null,
+          "name": "String",
+          "type_param_keys": []
+        }
+      }
+    },
+    "dep_structure_snapshot": {
+      "__class__": "DependencyStructureSnapshot",
+      "solid_invocation_snaps": [
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "num",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": [
+                {
+                  "__class__": "OutputHandleSnap",
+                  "output_name": "result",
+                  "solid_name": "subgraph"
+                }
+              ]
+            }
+          ],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "plus_one",
+          "solid_name": "plus_one",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "subgraph",
+          "solid_name": "subgraph",
+          "tags": {}
+        }
+      ]
+    },
+    "description": null,
+    "graph_def_name": "nested_job",
+    "lineage_snapshot": null,
+    "mode_def_snaps": [
+      {
+        "__class__": "ModeDefSnap",
+        "description": null,
+        "logger_def_snaps": [
+          {
+            "__class__": "LoggerDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
+              "description": "The default colored console logger.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
+            },
+            "description": "The default colored console logger.",
+            "name": "console"
+          }
+        ],
+        "name": "default",
+        "resource_def_snaps": [
+          {
+            "__class__": "ResourceDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            },
+            "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
+            "name": "io_manager"
+          }
+        ],
+        "root_config_key": "Shape.360ea318ffe78a111434a5bb7409ef66c9692290"
+      }
+    ],
+    "name": "nested_job",
+    "solid_definitions_snapshot": {
+      "__class__": "SolidDefinitionsSnapshot",
+      "composite_solid_def_snaps": [
+        {
+          "__class__": "CompositeSolidDefSnap",
+          "config_field_snap": null,
+          "dep_structure_snapshot": {
+            "__class__": "DependencyStructureSnapshot",
+            "solid_invocation_snaps": [
+              {
+                "__class__": "SolidInvocationSnap",
+                "input_dep_snaps": [
+                  {
+                    "__class__": "InputDependencySnap",
+                    "input_name": "num1",
+                    "is_dynamic_collect": false,
+                    "upstream_output_snaps": [
+                      {
+                        "__class__": "OutputHandleSnap",
+                        "output_name": "result",
+                        "solid_name": "op_1"
+                      }
+                    ]
+                  },
+                  {
+                    "__class__": "InputDependencySnap",
+                    "input_name": "num2",
+                    "is_dynamic_collect": false,
+                    "upstream_output_snaps": [
+                      {
+                        "__class__": "OutputHandleSnap",
+                        "output_name": "result",
+                        "solid_name": "op_2"
+                      }
+                    ]
+                  }
+                ],
+                "is_dynamic_mapped": false,
+                "solid_def_name": "adder",
+                "solid_name": "adder",
+                "tags": {}
+              },
+              {
+                "__class__": "SolidInvocationSnap",
+                "input_dep_snaps": [],
+                "is_dynamic_mapped": false,
+                "solid_def_name": "op_1",
+                "solid_name": "op_1",
+                "tags": {}
+              },
+              {
+                "__class__": "SolidInvocationSnap",
+                "input_dep_snaps": [],
+                "is_dynamic_mapped": false,
+                "solid_def_name": "op_2",
+                "solid_name": "op_2",
+                "tags": {}
+              },
+              {
+                "__class__": "SolidInvocationSnap",
+                "input_dep_snaps": [
+                  {
+                    "__class__": "InputDependencySnap",
+                    "input_name": "num",
+                    "is_dynamic_collect": false,
+                    "upstream_output_snaps": [
+                      {
+                        "__class__": "OutputHandleSnap",
+                        "output_name": "result",
+                        "solid_name": "adder"
+                      }
+                    ]
+                  }
+                ],
+                "is_dynamic_mapped": false,
+                "solid_def_name": "plus_one",
+                "solid_name": "plus_one",
+                "tags": {}
+              }
+            ]
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "input_mapping_snaps": [],
+          "name": "subgraph",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "output_mapping_snaps": [
+            {
+              "__class__": "OutputMappingSnap",
+              "external_output_name": "result",
+              "mapped_output_name": "result",
+              "mapped_solid_name": "plus_one"
+            }
+          ],
+          "tags": {}
+        }
+      ],
+      "solid_def_snaps": [
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Int",
+              "description": null,
+              "name": "num1"
+            },
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Int",
+              "description": null,
+              "name": "num2"
+            }
+          ],
+          "name": "adder",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "op_1",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "op_2",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Int",
+              "description": null,
+              "name": "num"
+            }
+          ],
+          "name": "plus_one",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        }
+      ]
+    },
+    "tags": {}
+  }
+  '''
+# ---
+# name: test_all_snapshot_ids[101]
+  '8e137c24b2245e55025e1cc7b71a42b99425dbec'
+# ---
+# name: test_all_snapshot_ids[102]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -2412,10 +3576,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[101]
+# name: test_all_snapshot_ids[103]
   'ab8f4b864ee53d2d9304b85f7a368aad7f678f29'
 # ---
-# name: test_all_snapshot_ids[102]
+# name: test_all_snapshot_ids[104]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -3269,10 +4433,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[103]
+# name: test_all_snapshot_ids[105]
   '98a8e544c66ff337c2aef1334603df0a3b1c7434'
 # ---
-# name: test_all_snapshot_ids[104]
+# name: test_all_snapshot_ids[106]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -4195,10 +5359,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[105]
+# name: test_all_snapshot_ids[107]
   'b56e5292632a8b4ab9839c8c0a512c79a2fcfea5'
 # ---
-# name: test_all_snapshot_ids[106]
+# name: test_all_snapshot_ids[108]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -5052,865 +6216,8 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[107]
-  'd65a072229c6e8fc80db02c8d06067f3b0b48305'
-# ---
-# name: test_all_snapshot_ids[108]
-  '''
-  {
-    "__class__": "PipelineSnapshot",
-    "config_schema_snapshot": {
-      "__class__": "ConfigSchemaSnapshot",
-      "all_config_snaps_by_key": {
-        "Any": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Any",
-          "key": "Any",
-          "kind": {
-            "__enum__": "ConfigTypeKind.ANY"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Bool": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Bool",
-          "key": "Bool",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.BOOL"
-          },
-          "type_param_keys": null
-        },
-        "Float": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Float",
-          "key": "Float",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.FLOAT"
-          },
-          "type_param_keys": null
-        },
-        "Int": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Int",
-          "key": "Int",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.INT"
-          },
-          "type_param_keys": null
-        },
-        "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Bool",
-            "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59"
-          ]
-        },
-        "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Float",
-            "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3"
-          ]
-        },
-        "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Int",
-            "Selector.a9799b971d12ace70a2d8803c883c863417d0725"
-          ]
-        },
-        "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "String",
-            "Selector.e04723c9d9937e3ab21206435b22247cfbe58269"
-          ]
-        },
-        "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "disabled",
-              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "enabled",
-              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Int"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Bool"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Float"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Any"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.081354663b9d4b8fbfd1cb8e358763912953913f": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "\"INFO\"",
-              "description": "The logger's threshold.",
-              "is_required": false,
-              "name": "log_level",
-              "type_key": "String"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "\"dagster\"",
-              "description": "The name of your logger.",
-              "is_required": false,
-              "name": "name",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.09d73f0755bf4752d3f121837669c8660dcf451e": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"retries\": {\"enabled\": {}}}",
-              "description": "Execute all steps in a single process.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
-              "description": "The default colored console logger.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
-              "is_required": false,
-              "name": "io_manager",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.371436c5d8b89776d9104fde2ac322ae806be8dd": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
-              "description": "Configure how steps are executed within a run.",
-              "is_required": false,
-              "name": "execution",
-              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": "Configure how loggers emit messages within a run.",
-              "is_required": false,
-              "name": "loggers",
-              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"asset_yields_observation\": {}}",
-              "description": "Configure runtime parameters for ops or assets.",
-              "is_required": false,
-              "name": "ops",
-              "type_key": "Shape.72aa8546e0029d52a6bfce93acd5d0b917139098"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"io_manager\": {}}",
-              "description": "Configure how shared resources are implemented within a run.",
-              "is_required": false,
-              "name": "resources",
-              "type_key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.371436c5d8b89776d9104fde2ac322ae806be8dd",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": "[DEPRECATED]",
-              "is_required": false,
-              "name": "marker_to_close",
-              "type_key": "String"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"enabled\": {}}",
-              "description": "Whether retries are enabled or not. By default, retries are enabled.",
-              "is_required": false,
-              "name": "retries",
-              "type_key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "path",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.72aa8546e0029d52a6bfce93acd5d0b917139098": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "asset_yields_observation",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.72aa8546e0029d52a6bfce93acd5d0b917139098",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.743e47901855cb245064dd633e217bfcb49a11a7": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Any"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [],
-          "given_name": null,
-          "key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "console",
-              "type_key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "String": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "String",
-          "key": "String",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.STRING"
-          },
-          "type_param_keys": null
-        }
-      }
-    },
-    "dagster_type_namespace_snapshot": {
-      "__class__": "DagsterTypeNamespaceSnapshot",
-      "all_dagster_type_snaps_by_key": {
-        "Any": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Any",
-          "is_builtin": true,
-          "key": "Any",
-          "kind": {
-            "__enum__": "DagsterTypeKind.ANY"
-          },
-          "loader_schema_key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
-          "materializer_schema_key": null,
-          "name": "Any",
-          "type_param_keys": []
-        },
-        "Bool": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Bool",
-          "is_builtin": true,
-          "key": "Bool",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "materializer_schema_key": null,
-          "name": "Bool",
-          "type_param_keys": []
-        },
-        "Float": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Float",
-          "is_builtin": true,
-          "key": "Float",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "materializer_schema_key": null,
-          "name": "Float",
-          "type_param_keys": []
-        },
-        "Int": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Int",
-          "is_builtin": true,
-          "key": "Int",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "materializer_schema_key": null,
-          "name": "Int",
-          "type_param_keys": []
-        },
-        "Nothing": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Nothing",
-          "is_builtin": true,
-          "key": "Nothing",
-          "kind": {
-            "__enum__": "DagsterTypeKind.NOTHING"
-          },
-          "loader_schema_key": null,
-          "materializer_schema_key": null,
-          "name": "Nothing",
-          "type_param_keys": []
-        },
-        "String": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "String",
-          "is_builtin": true,
-          "key": "String",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "materializer_schema_key": null,
-          "name": "String",
-          "type_param_keys": []
-        }
-      }
-    },
-    "dep_structure_snapshot": {
-      "__class__": "DependencyStructureSnapshot",
-      "solid_invocation_snaps": [
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "asset_yields_observation",
-          "solid_name": "asset_yields_observation",
-          "tags": {}
-        }
-      ]
-    },
-    "description": null,
-    "graph_def_name": "observation_job",
-    "lineage_snapshot": null,
-    "mode_def_snaps": [
-      {
-        "__class__": "ModeDefSnap",
-        "description": null,
-        "logger_def_snaps": [
-          {
-            "__class__": "LoggerDefSnap",
-            "config_field_snap": {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
-              "description": "The default colored console logger.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
-            },
-            "description": "The default colored console logger.",
-            "name": "console"
-          }
-        ],
-        "name": "default",
-        "resource_def_snaps": [
-          {
-            "__class__": "ResourceDefSnap",
-            "config_field_snap": {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Any"
-            },
-            "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
-            "name": "io_manager"
-          }
-        ],
-        "root_config_key": "Shape.371436c5d8b89776d9104fde2ac322ae806be8dd"
-      }
-    ],
-    "name": "observation_job",
-    "solid_definitions_snapshot": {
-      "__class__": "SolidDefinitionsSnapshot",
-      "composite_solid_def_snaps": [],
-      "solid_def_snaps": [
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [],
-          "name": "asset_yields_observation",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        }
-      ]
-    },
-    "tags": {}
-  }
-  '''
-# ---
 # name: test_all_snapshot_ids[109]
-  '1b7d2d5d96a0b0728a8ac667c6217dea173e6c77'
+  'd65a072229c6e8fc80db02c8d06067f3b0b48305'
 # ---
 # name: test_all_snapshot_ids[10]
   '''
@@ -7097,7 +7404,7 @@
           "input_def_snaps": [
             {
               "__class__": "InputDefSnap",
-              "dagster_type_key": "Nothing",
+              "dagster_type_key": "Any",
               "description": null,
               "name": "asset_1"
             }
@@ -7429,6 +7736,863 @@
   '''
 # ---
 # name: test_all_snapshot_ids[110]
+  '''
+  {
+    "__class__": "PipelineSnapshot",
+    "config_schema_snapshot": {
+      "__class__": "ConfigSchemaSnapshot",
+      "all_config_snaps_by_key": {
+        "Any": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Any",
+          "key": "Any",
+          "kind": {
+            "__enum__": "ConfigTypeKind.ANY"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Bool": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Bool",
+          "key": "Bool",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.BOOL"
+          },
+          "type_param_keys": null
+        },
+        "Float": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Float",
+          "key": "Float",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.FLOAT"
+          },
+          "type_param_keys": null
+        },
+        "Int": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Int",
+          "key": "Int",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.INT"
+          },
+          "type_param_keys": null
+        },
+        "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Bool",
+            "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59"
+          ]
+        },
+        "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Float",
+            "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3"
+          ]
+        },
+        "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Int",
+            "Selector.a9799b971d12ace70a2d8803c883c863417d0725"
+          ]
+        },
+        "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "String",
+            "Selector.e04723c9d9937e3ab21206435b22247cfbe58269"
+          ]
+        },
+        "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "disabled",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "enabled",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Int"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Bool"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Float"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Any"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.081354663b9d4b8fbfd1cb8e358763912953913f": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "\"INFO\"",
+              "description": "The logger's threshold.",
+              "is_required": false,
+              "name": "log_level",
+              "type_key": "String"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "\"dagster\"",
+              "description": "The name of your logger.",
+              "is_required": false,
+              "name": "name",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.09d73f0755bf4752d3f121837669c8660dcf451e": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"retries\": {\"enabled\": {}}}",
+              "description": "Execute all steps in a single process.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
+              "description": "The default colored console logger.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
+              "is_required": false,
+              "name": "io_manager",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.371436c5d8b89776d9104fde2ac322ae806be8dd": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
+              "description": "Configure how steps are executed within a run.",
+              "is_required": false,
+              "name": "execution",
+              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Configure how loggers emit messages within a run.",
+              "is_required": false,
+              "name": "loggers",
+              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"asset_yields_observation\": {}}",
+              "description": "Configure runtime parameters for ops or assets.",
+              "is_required": false,
+              "name": "ops",
+              "type_key": "Shape.72aa8546e0029d52a6bfce93acd5d0b917139098"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"io_manager\": {}}",
+              "description": "Configure how shared resources are implemented within a run.",
+              "is_required": false,
+              "name": "resources",
+              "type_key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.371436c5d8b89776d9104fde2ac322ae806be8dd",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "[DEPRECATED]",
+              "is_required": false,
+              "name": "marker_to_close",
+              "type_key": "String"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"enabled\": {}}",
+              "description": "Whether retries are enabled or not. By default, retries are enabled.",
+              "is_required": false,
+              "name": "retries",
+              "type_key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "path",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.72aa8546e0029d52a6bfce93acd5d0b917139098": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "asset_yields_observation",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.72aa8546e0029d52a6bfce93acd5d0b917139098",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.743e47901855cb245064dd633e217bfcb49a11a7": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [],
+          "given_name": null,
+          "key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "console",
+              "type_key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "String": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "String",
+          "key": "String",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.STRING"
+          },
+          "type_param_keys": null
+        }
+      }
+    },
+    "dagster_type_namespace_snapshot": {
+      "__class__": "DagsterTypeNamespaceSnapshot",
+      "all_dagster_type_snaps_by_key": {
+        "Any": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Any",
+          "is_builtin": true,
+          "key": "Any",
+          "kind": {
+            "__enum__": "DagsterTypeKind.ANY"
+          },
+          "loader_schema_key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
+          "materializer_schema_key": null,
+          "name": "Any",
+          "type_param_keys": []
+        },
+        "Bool": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Bool",
+          "is_builtin": true,
+          "key": "Bool",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "materializer_schema_key": null,
+          "name": "Bool",
+          "type_param_keys": []
+        },
+        "Float": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Float",
+          "is_builtin": true,
+          "key": "Float",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "materializer_schema_key": null,
+          "name": "Float",
+          "type_param_keys": []
+        },
+        "Int": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Int",
+          "is_builtin": true,
+          "key": "Int",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "materializer_schema_key": null,
+          "name": "Int",
+          "type_param_keys": []
+        },
+        "Nothing": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Nothing",
+          "is_builtin": true,
+          "key": "Nothing",
+          "kind": {
+            "__enum__": "DagsterTypeKind.NOTHING"
+          },
+          "loader_schema_key": null,
+          "materializer_schema_key": null,
+          "name": "Nothing",
+          "type_param_keys": []
+        },
+        "String": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "String",
+          "is_builtin": true,
+          "key": "String",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "materializer_schema_key": null,
+          "name": "String",
+          "type_param_keys": []
+        }
+      }
+    },
+    "dep_structure_snapshot": {
+      "__class__": "DependencyStructureSnapshot",
+      "solid_invocation_snaps": [
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "asset_yields_observation",
+          "solid_name": "asset_yields_observation",
+          "tags": {}
+        }
+      ]
+    },
+    "description": null,
+    "graph_def_name": "observation_job",
+    "lineage_snapshot": null,
+    "mode_def_snaps": [
+      {
+        "__class__": "ModeDefSnap",
+        "description": null,
+        "logger_def_snaps": [
+          {
+            "__class__": "LoggerDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
+              "description": "The default colored console logger.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
+            },
+            "description": "The default colored console logger.",
+            "name": "console"
+          }
+        ],
+        "name": "default",
+        "resource_def_snaps": [
+          {
+            "__class__": "ResourceDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            },
+            "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
+            "name": "io_manager"
+          }
+        ],
+        "root_config_key": "Shape.371436c5d8b89776d9104fde2ac322ae806be8dd"
+      }
+    ],
+    "name": "observation_job",
+    "solid_definitions_snapshot": {
+      "__class__": "SolidDefinitionsSnapshot",
+      "composite_solid_def_snaps": [],
+      "solid_def_snaps": [
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "asset_yields_observation",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        }
+      ]
+    },
+    "tags": {}
+  }
+  '''
+# ---
+# name: test_all_snapshot_ids[111]
+  '1b7d2d5d96a0b0728a8ac667c6217dea173e6c77'
+# ---
+# name: test_all_snapshot_ids[112]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -8282,10 +9446,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[111]
+# name: test_all_snapshot_ids[113]
   '7efca79de5186cfdf88f49cf5f8c981c48fa2c93'
 # ---
-# name: test_all_snapshot_ids[112]
+# name: test_all_snapshot_ids[114]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -9139,10 +10303,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[113]
+# name: test_all_snapshot_ids[115]
   '88c326b7e07c8c537ecd8086fd6429436a46c66f'
 # ---
-# name: test_all_snapshot_ids[114]
+# name: test_all_snapshot_ids[116]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -10042,10 +11206,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[115]
+# name: test_all_snapshot_ids[117]
   'a73f4941b2735f3a261d9617abaaed09a88aaebc'
 # ---
-# name: test_all_snapshot_ids[116]
+# name: test_all_snapshot_ids[118]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -10947,10 +12111,13 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[117]
+# name: test_all_snapshot_ids[119]
   '11f4785f61153adc6cca6935748af3807b59eee9'
 # ---
-# name: test_all_snapshot_ids[118]
+# name: test_all_snapshot_ids[11]
+  '2e4ca8bba25c19cf4581c37c9e406caf4e595e9f'
+# ---
+# name: test_all_snapshot_ids[120]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -11852,13 +13019,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[119]
+# name: test_all_snapshot_ids[121]
   '2b43566d7b3de2138b12c91b6953d6f1ddde0140'
 # ---
-# name: test_all_snapshot_ids[11]
-  '048980479b7d20c6f9e5af2796529391fed42d80'
-# ---
-# name: test_all_snapshot_ids[120]
+# name: test_all_snapshot_ids[122]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -13095,10 +14259,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[121]
+# name: test_all_snapshot_ids[123]
   '728ab5201b611eddf16a949174470c76a353c3be'
 # ---
-# name: test_all_snapshot_ids[122]
+# name: test_all_snapshot_ids[124]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -14257,10 +15421,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[123]
+# name: test_all_snapshot_ids[125]
   '9a9a09da6b3a1dbab13bfde5e155c0f097dd22a5'
 # ---
-# name: test_all_snapshot_ids[124]
+# name: test_all_snapshot_ids[126]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -15328,10 +16492,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[125]
+# name: test_all_snapshot_ids[127]
   'f347f3d93efff88c83539160011b75771fb73b95'
 # ---
-# name: test_all_snapshot_ids[126]
+# name: test_all_snapshot_ids[128]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -16317,865 +17481,8 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[127]
-  'ca68b52613bfcadc230b3dc1ec7e1045f9bc5836'
-# ---
-# name: test_all_snapshot_ids[128]
-  '''
-  {
-    "__class__": "PipelineSnapshot",
-    "config_schema_snapshot": {
-      "__class__": "ConfigSchemaSnapshot",
-      "all_config_snaps_by_key": {
-        "Any": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Any",
-          "key": "Any",
-          "kind": {
-            "__enum__": "ConfigTypeKind.ANY"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Bool": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Bool",
-          "key": "Bool",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.BOOL"
-          },
-          "type_param_keys": null
-        },
-        "Float": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Float",
-          "key": "Float",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.FLOAT"
-          },
-          "type_param_keys": null
-        },
-        "Int": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Int",
-          "key": "Int",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.INT"
-          },
-          "type_param_keys": null
-        },
-        "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Bool",
-            "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59"
-          ]
-        },
-        "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Float",
-            "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3"
-          ]
-        },
-        "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Int",
-            "Selector.a9799b971d12ace70a2d8803c883c863417d0725"
-          ]
-        },
-        "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "String",
-            "Selector.e04723c9d9937e3ab21206435b22247cfbe58269"
-          ]
-        },
-        "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "disabled",
-              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "enabled",
-              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Int"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Bool"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Float"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Any"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.081354663b9d4b8fbfd1cb8e358763912953913f": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "\"INFO\"",
-              "description": "The logger's threshold.",
-              "is_required": false,
-              "name": "log_level",
-              "type_key": "String"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "\"dagster\"",
-              "description": "The name of your logger.",
-              "is_required": false,
-              "name": "name",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.09d73f0755bf4752d3f121837669c8660dcf451e": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"retries\": {\"enabled\": {}}}",
-              "description": "Execute all steps in a single process.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
-              "description": "The default colored console logger.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
-              "is_required": false,
-              "name": "io_manager",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.1baaa7ea6f13caf1cca874c6f4cc8581ad88d08a": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
-              "description": "Configure how steps are executed within a run.",
-              "is_required": false,
-              "name": "execution",
-              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": "Configure how loggers emit messages within a run.",
-              "is_required": false,
-              "name": "loggers",
-              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"noop_op\": {}}",
-              "description": "Configure runtime parameters for ops or assets.",
-              "is_required": false,
-              "name": "ops",
-              "type_key": "Shape.242592fa9f0be8d5908506e918e119be06358618"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"io_manager\": {}}",
-              "description": "Configure how shared resources are implemented within a run.",
-              "is_required": false,
-              "name": "resources",
-              "type_key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.1baaa7ea6f13caf1cca874c6f4cc8581ad88d08a",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.242592fa9f0be8d5908506e918e119be06358618": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "noop_op",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.242592fa9f0be8d5908506e918e119be06358618",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": "[DEPRECATED]",
-              "is_required": false,
-              "name": "marker_to_close",
-              "type_key": "String"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"enabled\": {}}",
-              "description": "Whether retries are enabled or not. By default, retries are enabled.",
-              "is_required": false,
-              "name": "retries",
-              "type_key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "path",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.743e47901855cb245064dd633e217bfcb49a11a7": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Any"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [],
-          "given_name": null,
-          "key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "console",
-              "type_key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "String": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "String",
-          "key": "String",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.STRING"
-          },
-          "type_param_keys": null
-        }
-      }
-    },
-    "dagster_type_namespace_snapshot": {
-      "__class__": "DagsterTypeNamespaceSnapshot",
-      "all_dagster_type_snaps_by_key": {
-        "Any": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Any",
-          "is_builtin": true,
-          "key": "Any",
-          "kind": {
-            "__enum__": "DagsterTypeKind.ANY"
-          },
-          "loader_schema_key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
-          "materializer_schema_key": null,
-          "name": "Any",
-          "type_param_keys": []
-        },
-        "Bool": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Bool",
-          "is_builtin": true,
-          "key": "Bool",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "materializer_schema_key": null,
-          "name": "Bool",
-          "type_param_keys": []
-        },
-        "Float": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Float",
-          "is_builtin": true,
-          "key": "Float",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "materializer_schema_key": null,
-          "name": "Float",
-          "type_param_keys": []
-        },
-        "Int": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Int",
-          "is_builtin": true,
-          "key": "Int",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "materializer_schema_key": null,
-          "name": "Int",
-          "type_param_keys": []
-        },
-        "Nothing": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Nothing",
-          "is_builtin": true,
-          "key": "Nothing",
-          "kind": {
-            "__enum__": "DagsterTypeKind.NOTHING"
-          },
-          "loader_schema_key": null,
-          "materializer_schema_key": null,
-          "name": "Nothing",
-          "type_param_keys": []
-        },
-        "String": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "String",
-          "is_builtin": true,
-          "key": "String",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "materializer_schema_key": null,
-          "name": "String",
-          "type_param_keys": []
-        }
-      }
-    },
-    "dep_structure_snapshot": {
-      "__class__": "DependencyStructureSnapshot",
-      "solid_invocation_snaps": [
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "noop_op",
-          "solid_name": "noop_op",
-          "tags": {}
-        }
-      ]
-    },
-    "description": null,
-    "graph_def_name": "simple_graph",
-    "lineage_snapshot": null,
-    "mode_def_snaps": [
-      {
-        "__class__": "ModeDefSnap",
-        "description": null,
-        "logger_def_snaps": [
-          {
-            "__class__": "LoggerDefSnap",
-            "config_field_snap": {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
-              "description": "The default colored console logger.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
-            },
-            "description": "The default colored console logger.",
-            "name": "console"
-          }
-        ],
-        "name": "default",
-        "resource_def_snaps": [
-          {
-            "__class__": "ResourceDefSnap",
-            "config_field_snap": {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Any"
-            },
-            "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
-            "name": "io_manager"
-          }
-        ],
-        "root_config_key": "Shape.1baaa7ea6f13caf1cca874c6f4cc8581ad88d08a"
-      }
-    ],
-    "name": "simple_job_a",
-    "solid_definitions_snapshot": {
-      "__class__": "SolidDefinitionsSnapshot",
-      "composite_solid_def_snaps": [],
-      "solid_def_snaps": [
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [],
-          "name": "noop_op",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        }
-      ]
-    },
-    "tags": {}
-  }
-  '''
-# ---
 # name: test_all_snapshot_ids[129]
-  '4fbe2b21985de715173a8d630c5d1506a0c7f040'
+  'ca68b52613bfcadc230b3dc1ec7e1045f9bc5836'
 # ---
 # name: test_all_snapshot_ids[12]
   '''
@@ -18356,7 +18663,7 @@
           "input_def_snaps": [
             {
               "__class__": "InputDefSnap",
-              "dagster_type_key": "Nothing",
+              "dagster_type_key": "Any",
               "description": null,
               "name": "asset_1"
             }
@@ -19503,7 +19810,7 @@
         "root_config_key": "Shape.1baaa7ea6f13caf1cca874c6f4cc8581ad88d08a"
       }
     ],
-    "name": "simple_job_b",
+    "name": "simple_job_a",
     "solid_definitions_snapshot": {
       "__class__": "SolidDefinitionsSnapshot",
       "composite_solid_def_snaps": [],
@@ -19542,9 +19849,866 @@
   '''
 # ---
 # name: test_all_snapshot_ids[131]
-  'c58bbee5967b5e43b907f2ee09bfa26b5b017899'
+  '4fbe2b21985de715173a8d630c5d1506a0c7f040'
 # ---
 # name: test_all_snapshot_ids[132]
+  '''
+  {
+    "__class__": "PipelineSnapshot",
+    "config_schema_snapshot": {
+      "__class__": "ConfigSchemaSnapshot",
+      "all_config_snaps_by_key": {
+        "Any": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Any",
+          "key": "Any",
+          "kind": {
+            "__enum__": "ConfigTypeKind.ANY"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Bool": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Bool",
+          "key": "Bool",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.BOOL"
+          },
+          "type_param_keys": null
+        },
+        "Float": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Float",
+          "key": "Float",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.FLOAT"
+          },
+          "type_param_keys": null
+        },
+        "Int": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Int",
+          "key": "Int",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.INT"
+          },
+          "type_param_keys": null
+        },
+        "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Bool",
+            "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59"
+          ]
+        },
+        "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Float",
+            "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3"
+          ]
+        },
+        "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Int",
+            "Selector.a9799b971d12ace70a2d8803c883c863417d0725"
+          ]
+        },
+        "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "String",
+            "Selector.e04723c9d9937e3ab21206435b22247cfbe58269"
+          ]
+        },
+        "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "disabled",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "enabled",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Int"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Bool"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Float"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Any"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.081354663b9d4b8fbfd1cb8e358763912953913f": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "\"INFO\"",
+              "description": "The logger's threshold.",
+              "is_required": false,
+              "name": "log_level",
+              "type_key": "String"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "\"dagster\"",
+              "description": "The name of your logger.",
+              "is_required": false,
+              "name": "name",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.09d73f0755bf4752d3f121837669c8660dcf451e": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"retries\": {\"enabled\": {}}}",
+              "description": "Execute all steps in a single process.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
+              "description": "The default colored console logger.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
+              "is_required": false,
+              "name": "io_manager",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.1baaa7ea6f13caf1cca874c6f4cc8581ad88d08a": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
+              "description": "Configure how steps are executed within a run.",
+              "is_required": false,
+              "name": "execution",
+              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Configure how loggers emit messages within a run.",
+              "is_required": false,
+              "name": "loggers",
+              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"noop_op\": {}}",
+              "description": "Configure runtime parameters for ops or assets.",
+              "is_required": false,
+              "name": "ops",
+              "type_key": "Shape.242592fa9f0be8d5908506e918e119be06358618"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"io_manager\": {}}",
+              "description": "Configure how shared resources are implemented within a run.",
+              "is_required": false,
+              "name": "resources",
+              "type_key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.1baaa7ea6f13caf1cca874c6f4cc8581ad88d08a",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.242592fa9f0be8d5908506e918e119be06358618": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "noop_op",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.242592fa9f0be8d5908506e918e119be06358618",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "[DEPRECATED]",
+              "is_required": false,
+              "name": "marker_to_close",
+              "type_key": "String"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"enabled\": {}}",
+              "description": "Whether retries are enabled or not. By default, retries are enabled.",
+              "is_required": false,
+              "name": "retries",
+              "type_key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "path",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.743e47901855cb245064dd633e217bfcb49a11a7": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [],
+          "given_name": null,
+          "key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "console",
+              "type_key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "String": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "String",
+          "key": "String",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.STRING"
+          },
+          "type_param_keys": null
+        }
+      }
+    },
+    "dagster_type_namespace_snapshot": {
+      "__class__": "DagsterTypeNamespaceSnapshot",
+      "all_dagster_type_snaps_by_key": {
+        "Any": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Any",
+          "is_builtin": true,
+          "key": "Any",
+          "kind": {
+            "__enum__": "DagsterTypeKind.ANY"
+          },
+          "loader_schema_key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
+          "materializer_schema_key": null,
+          "name": "Any",
+          "type_param_keys": []
+        },
+        "Bool": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Bool",
+          "is_builtin": true,
+          "key": "Bool",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "materializer_schema_key": null,
+          "name": "Bool",
+          "type_param_keys": []
+        },
+        "Float": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Float",
+          "is_builtin": true,
+          "key": "Float",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "materializer_schema_key": null,
+          "name": "Float",
+          "type_param_keys": []
+        },
+        "Int": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Int",
+          "is_builtin": true,
+          "key": "Int",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "materializer_schema_key": null,
+          "name": "Int",
+          "type_param_keys": []
+        },
+        "Nothing": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Nothing",
+          "is_builtin": true,
+          "key": "Nothing",
+          "kind": {
+            "__enum__": "DagsterTypeKind.NOTHING"
+          },
+          "loader_schema_key": null,
+          "materializer_schema_key": null,
+          "name": "Nothing",
+          "type_param_keys": []
+        },
+        "String": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "String",
+          "is_builtin": true,
+          "key": "String",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "materializer_schema_key": null,
+          "name": "String",
+          "type_param_keys": []
+        }
+      }
+    },
+    "dep_structure_snapshot": {
+      "__class__": "DependencyStructureSnapshot",
+      "solid_invocation_snaps": [
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "noop_op",
+          "solid_name": "noop_op",
+          "tags": {}
+        }
+      ]
+    },
+    "description": null,
+    "graph_def_name": "simple_graph",
+    "lineage_snapshot": null,
+    "mode_def_snaps": [
+      {
+        "__class__": "ModeDefSnap",
+        "description": null,
+        "logger_def_snaps": [
+          {
+            "__class__": "LoggerDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
+              "description": "The default colored console logger.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
+            },
+            "description": "The default colored console logger.",
+            "name": "console"
+          }
+        ],
+        "name": "default",
+        "resource_def_snaps": [
+          {
+            "__class__": "ResourceDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            },
+            "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
+            "name": "io_manager"
+          }
+        ],
+        "root_config_key": "Shape.1baaa7ea6f13caf1cca874c6f4cc8581ad88d08a"
+      }
+    ],
+    "name": "simple_job_b",
+    "solid_definitions_snapshot": {
+      "__class__": "SolidDefinitionsSnapshot",
+      "composite_solid_def_snaps": [],
+      "solid_def_snaps": [
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "noop_op",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        }
+      ]
+    },
+    "tags": {}
+  }
+  '''
+# ---
+# name: test_all_snapshot_ids[133]
+  'c58bbee5967b5e43b907f2ee09bfa26b5b017899'
+# ---
+# name: test_all_snapshot_ids[134]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -20398,10 +21562,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[133]
+# name: test_all_snapshot_ids[135]
   '9109ebc6447db70cdcd17a7bf8b90ec61ffd02fe'
 # ---
-# name: test_all_snapshot_ids[134]
+# name: test_all_snapshot_ids[136]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -21255,10 +22419,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[135]
+# name: test_all_snapshot_ids[137]
   '673ec5c1c0fce5ffec0506edd32bcdbd018e79bb'
 # ---
-# name: test_all_snapshot_ids[136]
+# name: test_all_snapshot_ids[138]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -22391,10 +23555,13 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[137]
+# name: test_all_snapshot_ids[139]
   '1087cd246d853fe095a4eaaf1d64f38a6648835b'
 # ---
-# name: test_all_snapshot_ids[138]
+# name: test_all_snapshot_ids[13]
+  'a7b5f1144bcfb81694485c5625bb57848a4bf431'
+# ---
+# name: test_all_snapshot_ids[140]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -23248,13 +24415,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[139]
+# name: test_all_snapshot_ids[141]
   '927cbfcff5af3bd40ebed1cae3eed1baf4c3547f'
 # ---
-# name: test_all_snapshot_ids[13]
-  '2416fbe583045014f1f615d260b36223f7e91e42'
-# ---
-# name: test_all_snapshot_ids[140]
+# name: test_all_snapshot_ids[142]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -24110,10 +25274,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[141]
+# name: test_all_snapshot_ids[143]
   '8e516c94a1e0d32aabc7ea8d8fc27d68afdb45cf'
 # ---
-# name: test_all_snapshot_ids[142]
+# name: test_all_snapshot_ids[144]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -25031,10 +26195,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[143]
+# name: test_all_snapshot_ids[145]
   'ad883aacd52aa8f195f3f099041955fbc5acf349'
 # ---
-# name: test_all_snapshot_ids[144]
+# name: test_all_snapshot_ids[146]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -25952,10 +27116,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[145]
+# name: test_all_snapshot_ids[147]
   'b4c6cefd99a913393f6f7ce00ccd26a12803867f'
 # ---
-# name: test_all_snapshot_ids[146]
+# name: test_all_snapshot_ids[148]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -26935,10 +28099,928 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[147]
+# name: test_all_snapshot_ids[149]
   '4b4b18dca82ef0567492f476ff2bcbbf7392206d'
 # ---
-# name: test_all_snapshot_ids[148]
+# name: test_all_snapshot_ids[14]
+  '''
+  {
+    "__class__": "PipelineSnapshot",
+    "config_schema_snapshot": {
+      "__class__": "ConfigSchemaSnapshot",
+      "all_config_snaps_by_key": {
+        "Any": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Any",
+          "key": "Any",
+          "kind": {
+            "__enum__": "ConfigTypeKind.ANY"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Bool": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Bool",
+          "key": "Bool",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.BOOL"
+          },
+          "type_param_keys": null
+        },
+        "Float": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Float",
+          "key": "Float",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.FLOAT"
+          },
+          "type_param_keys": null
+        },
+        "Int": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Int",
+          "key": "Int",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.INT"
+          },
+          "type_param_keys": null
+        },
+        "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Bool",
+            "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59"
+          ]
+        },
+        "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Float",
+            "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3"
+          ]
+        },
+        "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Int",
+            "Selector.a9799b971d12ace70a2d8803c883c863417d0725"
+          ]
+        },
+        "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "String",
+            "Selector.e04723c9d9937e3ab21206435b22247cfbe58269"
+          ]
+        },
+        "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "disabled",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "enabled",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Int"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Bool"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Float"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Any"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.0085e1edfe95a01b7da760762270b74915ed73ae": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
+              "description": "Configure how steps are executed within a run.",
+              "is_required": false,
+              "name": "execution",
+              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Configure how loggers emit messages within a run.",
+              "is_required": false,
+              "name": "loggers",
+              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"asset_1\": {}, \"asset_1_my_check\": {}}",
+              "description": "Configure runtime parameters for ops or assets.",
+              "is_required": false,
+              "name": "ops",
+              "type_key": "Shape.66163a8edd296ea88be0d18c3c1fb48ce59acdcb"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"io_manager\": {}}",
+              "description": "Configure how shared resources are implemented within a run.",
+              "is_required": false,
+              "name": "resources",
+              "type_key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.0085e1edfe95a01b7da760762270b74915ed73ae",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.081354663b9d4b8fbfd1cb8e358763912953913f": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "\"INFO\"",
+              "description": "The logger's threshold.",
+              "is_required": false,
+              "name": "log_level",
+              "type_key": "String"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "\"dagster\"",
+              "description": "The name of your logger.",
+              "is_required": false,
+              "name": "name",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.09d73f0755bf4752d3f121837669c8660dcf451e": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"retries\": {\"enabled\": {}}}",
+              "description": "Execute all steps in a single process.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
+              "description": "The default colored console logger.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
+              "is_required": false,
+              "name": "io_manager",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "[DEPRECATED]",
+              "is_required": false,
+              "name": "marker_to_close",
+              "type_key": "String"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"enabled\": {}}",
+              "description": "Whether retries are enabled or not. By default, retries are enabled.",
+              "is_required": false,
+              "name": "retries",
+              "type_key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "path",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.66163a8edd296ea88be0d18c3c1fb48ce59acdcb": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "asset_1",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "asset_1_my_check",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.66163a8edd296ea88be0d18c3c1fb48ce59acdcb",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.743e47901855cb245064dd633e217bfcb49a11a7": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [],
+          "given_name": null,
+          "key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "console",
+              "type_key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "String": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "String",
+          "key": "String",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.STRING"
+          },
+          "type_param_keys": null
+        }
+      }
+    },
+    "dagster_type_namespace_snapshot": {
+      "__class__": "DagsterTypeNamespaceSnapshot",
+      "all_dagster_type_snaps_by_key": {
+        "Any": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Any",
+          "is_builtin": true,
+          "key": "Any",
+          "kind": {
+            "__enum__": "DagsterTypeKind.ANY"
+          },
+          "loader_schema_key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
+          "materializer_schema_key": null,
+          "name": "Any",
+          "type_param_keys": []
+        },
+        "Bool": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Bool",
+          "is_builtin": true,
+          "key": "Bool",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "materializer_schema_key": null,
+          "name": "Bool",
+          "type_param_keys": []
+        },
+        "Float": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Float",
+          "is_builtin": true,
+          "key": "Float",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "materializer_schema_key": null,
+          "name": "Float",
+          "type_param_keys": []
+        },
+        "Int": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Int",
+          "is_builtin": true,
+          "key": "Int",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "materializer_schema_key": null,
+          "name": "Int",
+          "type_param_keys": []
+        },
+        "Nothing": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Nothing",
+          "is_builtin": true,
+          "key": "Nothing",
+          "kind": {
+            "__enum__": "DagsterTypeKind.NOTHING"
+          },
+          "loader_schema_key": null,
+          "materializer_schema_key": null,
+          "name": "Nothing",
+          "type_param_keys": []
+        },
+        "String": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "String",
+          "is_builtin": true,
+          "key": "String",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "materializer_schema_key": null,
+          "name": "String",
+          "type_param_keys": []
+        }
+      }
+    },
+    "dep_structure_snapshot": {
+      "__class__": "DependencyStructureSnapshot",
+      "solid_invocation_snaps": [
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "asset_1",
+          "solid_name": "asset_1",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "asset_1",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": [
+                {
+                  "__class__": "OutputHandleSnap",
+                  "output_name": "result",
+                  "solid_name": "asset_1"
+                }
+              ]
+            }
+          ],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "asset_1_my_check",
+          "solid_name": "asset_1_my_check",
+          "tags": {}
+        }
+      ]
+    },
+    "description": null,
+    "graph_def_name": "asset_check_job",
+    "lineage_snapshot": null,
+    "mode_def_snaps": [
+      {
+        "__class__": "ModeDefSnap",
+        "description": null,
+        "logger_def_snaps": [
+          {
+            "__class__": "LoggerDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
+              "description": "The default colored console logger.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
+            },
+            "description": "The default colored console logger.",
+            "name": "console"
+          }
+        ],
+        "name": "default",
+        "resource_def_snaps": [
+          {
+            "__class__": "ResourceDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            },
+            "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
+            "name": "io_manager"
+          }
+        ],
+        "root_config_key": "Shape.0085e1edfe95a01b7da760762270b74915ed73ae"
+      }
+    ],
+    "name": "asset_check_job",
+    "solid_definitions_snapshot": {
+      "__class__": "SolidDefinitionsSnapshot",
+      "composite_solid_def_snaps": [],
+      "solid_def_snaps": [
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "asset_1",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "name": "asset_1"
+            }
+          ],
+          "name": "asset_1_my_check",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        }
+      ]
+    },
+    "tags": {}
+  }
+  '''
+# ---
+# name: test_all_snapshot_ids[150]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -28020,10 +30102,13 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[149]
+# name: test_all_snapshot_ids[151]
   '56eb8d6bacee6e5580100ffc965e875c761acee5'
 # ---
-# name: test_all_snapshot_ids[14]
+# name: test_all_snapshot_ids[15]
+  '5fa196ed54278fba950c197d013630f4cf0061e8'
+# ---
+# name: test_all_snapshot_ids[16]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -28877,10 +30962,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[15]
+# name: test_all_snapshot_ids[17]
   '9699a524d810d89264bf60d01dab3c751fe47461'
 # ---
-# name: test_all_snapshot_ids[16]
+# name: test_all_snapshot_ids[18]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -29674,10 +31759,13 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[17]
+# name: test_all_snapshot_ids[19]
   'cd81ec29a7fde8a337dc04fb109dd707a2962d18'
 # ---
-# name: test_all_snapshot_ids[18]
+# name: test_all_snapshot_ids[1]
+  'b601f0d5da1b7bfa200694bb349cfe6e21e8b6d8'
+# ---
+# name: test_all_snapshot_ids[20]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -30659,13 +32747,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[19]
+# name: test_all_snapshot_ids[21]
   '1f3478e419b57370edfc5959b967300b91ad776c'
 # ---
-# name: test_all_snapshot_ids[1]
-  '77dd812c7dfd75fe60bbcf6df96103072d4d5525'
-# ---
-# name: test_all_snapshot_ids[20]
+# name: test_all_snapshot_ids[22]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -31590,10 +33675,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[21]
+# name: test_all_snapshot_ids[23]
   'ac30d35b2d3b8c25490824aaa8dac2281ad4f860'
 # ---
-# name: test_all_snapshot_ids[22]
+# name: test_all_snapshot_ids[24]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -32969,10 +35054,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[23]
+# name: test_all_snapshot_ids[25]
   'd9f6d85793df3d9df94d4aedb21bb659c1202bda'
 # ---
-# name: test_all_snapshot_ids[24]
+# name: test_all_snapshot_ids[26]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -34035,10 +36120,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[25]
+# name: test_all_snapshot_ids[27]
   '9041a32e00b2c27d78e168f10272a992f819e88d'
 # ---
-# name: test_all_snapshot_ids[26]
+# name: test_all_snapshot_ids[28]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -35039,1012 +37124,8 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[27]
-  '9d2930f7c072c5a01688d84b725c49d4ae718c65'
-# ---
-# name: test_all_snapshot_ids[28]
-  '''
-  {
-    "__class__": "PipelineSnapshot",
-    "config_schema_snapshot": {
-      "__class__": "ConfigSchemaSnapshot",
-      "all_config_snaps_by_key": {
-        "Any": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Any",
-          "key": "Any",
-          "kind": {
-            "__enum__": "ConfigTypeKind.ANY"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Bool": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Bool",
-          "key": "Bool",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.BOOL"
-          },
-          "type_param_keys": null
-        },
-        "Float": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Float",
-          "key": "Float",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.FLOAT"
-          },
-          "type_param_keys": null
-        },
-        "Int": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Int",
-          "key": "Int",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.INT"
-          },
-          "type_param_keys": null
-        },
-        "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Bool",
-            "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59"
-          ]
-        },
-        "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Float",
-            "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3"
-          ]
-        },
-        "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Int",
-            "Selector.a9799b971d12ace70a2d8803c883c863417d0725"
-          ]
-        },
-        "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "String",
-            "Selector.e04723c9d9937e3ab21206435b22247cfbe58269"
-          ]
-        },
-        "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "disabled",
-              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "enabled",
-              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Int"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Bool"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Float"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Any"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.081354663b9d4b8fbfd1cb8e358763912953913f": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "\"INFO\"",
-              "description": "The logger's threshold.",
-              "is_required": false,
-              "name": "log_level",
-              "type_key": "String"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "\"dagster\"",
-              "description": "The name of your logger.",
-              "is_required": false,
-              "name": "name",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.09d73f0755bf4752d3f121837669c8660dcf451e": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"retries\": {\"enabled\": {}}}",
-              "description": "Execute all steps in a single process.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.0d55d94dd294f7cd436b52feb520b9840c4f91dc": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "sum_op",
-              "type_key": "Shape.b19e2683be41355cdd22d1d489ae36749b14bef0"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "sum_sq_op",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.0d55d94dd294f7cd436b52feb520b9840c4f91dc",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
-              "description": "The default colored console logger.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
-              "is_required": false,
-              "name": "io_manager",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": "[DEPRECATED]",
-              "is_required": false,
-              "name": "marker_to_close",
-              "type_key": "String"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"enabled\": {}}",
-              "description": "Whether retries are enabled or not. By default, retries are enabled.",
-              "is_required": false,
-              "name": "retries",
-              "type_key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "path",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.743e47901855cb245064dd633e217bfcb49a11a7": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Any"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.a6b36b26d836a5c5ddb7f8906ae2a817c0063a89": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "num",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.a6b36b26d836a5c5ddb7f8906ae2a817c0063a89",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.b19e2683be41355cdd22d1d489ae36749b14bef0": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Any"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "inputs",
-              "type_key": "Shape.a6b36b26d836a5c5ddb7f8906ae2a817c0063a89"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.b19e2683be41355cdd22d1d489ae36749b14bef0",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.d4670f68893bf551d7398bd94d97daec11f9bb2b": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
-              "description": "Configure how steps are executed within a run.",
-              "is_required": false,
-              "name": "execution",
-              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": "Configure how loggers emit messages within a run.",
-              "is_required": false,
-              "name": "loggers",
-              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": "Configure runtime parameters for ops or assets.",
-              "is_required": true,
-              "name": "ops",
-              "type_key": "Shape.0d55d94dd294f7cd436b52feb520b9840c4f91dc"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"io_manager\": {}}",
-              "description": "Configure how shared resources are implemented within a run.",
-              "is_required": false,
-              "name": "resources",
-              "type_key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.d4670f68893bf551d7398bd94d97daec11f9bb2b",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [],
-          "given_name": null,
-          "key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "console",
-              "type_key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "String": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "String",
-          "key": "String",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.STRING"
-          },
-          "type_param_keys": null
-        }
-      }
-    },
-    "dagster_type_namespace_snapshot": {
-      "__class__": "DagsterTypeNamespaceSnapshot",
-      "all_dagster_type_snaps_by_key": {
-        "Any": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Any",
-          "is_builtin": true,
-          "key": "Any",
-          "kind": {
-            "__enum__": "DagsterTypeKind.ANY"
-          },
-          "loader_schema_key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
-          "materializer_schema_key": null,
-          "name": "Any",
-          "type_param_keys": []
-        },
-        "Bool": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Bool",
-          "is_builtin": true,
-          "key": "Bool",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "materializer_schema_key": null,
-          "name": "Bool",
-          "type_param_keys": []
-        },
-        "Float": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Float",
-          "is_builtin": true,
-          "key": "Float",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "materializer_schema_key": null,
-          "name": "Float",
-          "type_param_keys": []
-        },
-        "Int": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Int",
-          "is_builtin": true,
-          "key": "Int",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "materializer_schema_key": null,
-          "name": "Int",
-          "type_param_keys": []
-        },
-        "Nothing": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Nothing",
-          "is_builtin": true,
-          "key": "Nothing",
-          "kind": {
-            "__enum__": "DagsterTypeKind.NOTHING"
-          },
-          "loader_schema_key": null,
-          "materializer_schema_key": null,
-          "name": "Nothing",
-          "type_param_keys": []
-        },
-        "PoorMansDataFrame": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "PoorMansDataFrame",
-          "is_builtin": false,
-          "key": "PoorMansDataFrame",
-          "kind": {
-            "__enum__": "DagsterTypeKind.REGULAR"
-          },
-          "loader_schema_key": "String",
-          "materializer_schema_key": null,
-          "name": "PoorMansDataFrame",
-          "type_param_keys": []
-        },
-        "String": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "String",
-          "is_builtin": true,
-          "key": "String",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "materializer_schema_key": null,
-          "name": "String",
-          "type_param_keys": []
-        }
-      }
-    },
-    "dep_structure_snapshot": {
-      "__class__": "DependencyStructureSnapshot",
-      "solid_invocation_snaps": [
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [
-            {
-              "__class__": "InputDependencySnap",
-              "input_name": "num",
-              "is_dynamic_collect": false,
-              "upstream_output_snaps": []
-            }
-          ],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "sum_op",
-          "solid_name": "sum_op",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [
-            {
-              "__class__": "InputDependencySnap",
-              "input_name": "sum_df",
-              "is_dynamic_collect": false,
-              "upstream_output_snaps": [
-                {
-                  "__class__": "OutputHandleSnap",
-                  "output_name": "result",
-                  "solid_name": "sum_op"
-                }
-              ]
-            }
-          ],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "sum_sq_op",
-          "solid_name": "sum_sq_op",
-          "tags": {}
-        }
-      ]
-    },
-    "description": null,
-    "graph_def_name": "csv_hello_world_df_input",
-    "lineage_snapshot": null,
-    "mode_def_snaps": [
-      {
-        "__class__": "ModeDefSnap",
-        "description": null,
-        "logger_def_snaps": [
-          {
-            "__class__": "LoggerDefSnap",
-            "config_field_snap": {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
-              "description": "The default colored console logger.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
-            },
-            "description": "The default colored console logger.",
-            "name": "console"
-          }
-        ],
-        "name": "default",
-        "resource_def_snaps": [
-          {
-            "__class__": "ResourceDefSnap",
-            "config_field_snap": {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Any"
-            },
-            "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
-            "name": "io_manager"
-          }
-        ],
-        "root_config_key": "Shape.d4670f68893bf551d7398bd94d97daec11f9bb2b"
-      }
-    ],
-    "name": "csv_hello_world_df_input",
-    "solid_definitions_snapshot": {
-      "__class__": "SolidDefinitionsSnapshot",
-      "composite_solid_def_snaps": [],
-      "solid_def_snaps": [
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [
-            {
-              "__class__": "InputDefSnap",
-              "dagster_type_key": "PoorMansDataFrame",
-              "description": null,
-              "name": "num"
-            }
-          ],
-          "name": "sum_op",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "PoorMansDataFrame",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [
-            {
-              "__class__": "InputDefSnap",
-              "dagster_type_key": "PoorMansDataFrame",
-              "description": null,
-              "name": "sum_df"
-            }
-          ],
-          "name": "sum_sq_op",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "PoorMansDataFrame",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        }
-      ]
-    },
-    "tags": {}
-  }
-  '''
-# ---
 # name: test_all_snapshot_ids[29]
-  'a28dd9e490e08f05fab6ab1309de27da5cd3eb0f'
+  '9d2930f7c072c5a01688d84b725c49d4ae718c65'
 # ---
 # name: test_all_snapshot_ids[2]
   '''
@@ -37265,7 +38346,7 @@
           "input_def_snaps": [
             {
               "__class__": "InputDefSnap",
-              "dagster_type_key": "Nothing",
+              "dagster_type_key": "Any",
               "description": null,
               "name": "asset_1"
             }
@@ -37651,6 +38732,1010 @@
   '''
 # ---
 # name: test_all_snapshot_ids[30]
+  '''
+  {
+    "__class__": "PipelineSnapshot",
+    "config_schema_snapshot": {
+      "__class__": "ConfigSchemaSnapshot",
+      "all_config_snaps_by_key": {
+        "Any": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Any",
+          "key": "Any",
+          "kind": {
+            "__enum__": "ConfigTypeKind.ANY"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Bool": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Bool",
+          "key": "Bool",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.BOOL"
+          },
+          "type_param_keys": null
+        },
+        "Float": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Float",
+          "key": "Float",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.FLOAT"
+          },
+          "type_param_keys": null
+        },
+        "Int": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Int",
+          "key": "Int",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.INT"
+          },
+          "type_param_keys": null
+        },
+        "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Bool",
+            "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59"
+          ]
+        },
+        "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Float",
+            "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3"
+          ]
+        },
+        "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Int",
+            "Selector.a9799b971d12ace70a2d8803c883c863417d0725"
+          ]
+        },
+        "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "String",
+            "Selector.e04723c9d9937e3ab21206435b22247cfbe58269"
+          ]
+        },
+        "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "disabled",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "enabled",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Int"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Bool"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Float"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Any"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.081354663b9d4b8fbfd1cb8e358763912953913f": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "\"INFO\"",
+              "description": "The logger's threshold.",
+              "is_required": false,
+              "name": "log_level",
+              "type_key": "String"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "\"dagster\"",
+              "description": "The name of your logger.",
+              "is_required": false,
+              "name": "name",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.09d73f0755bf4752d3f121837669c8660dcf451e": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"retries\": {\"enabled\": {}}}",
+              "description": "Execute all steps in a single process.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.0d55d94dd294f7cd436b52feb520b9840c4f91dc": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "sum_op",
+              "type_key": "Shape.b19e2683be41355cdd22d1d489ae36749b14bef0"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "sum_sq_op",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.0d55d94dd294f7cd436b52feb520b9840c4f91dc",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
+              "description": "The default colored console logger.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
+              "is_required": false,
+              "name": "io_manager",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "[DEPRECATED]",
+              "is_required": false,
+              "name": "marker_to_close",
+              "type_key": "String"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"enabled\": {}}",
+              "description": "Whether retries are enabled or not. By default, retries are enabled.",
+              "is_required": false,
+              "name": "retries",
+              "type_key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "path",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.743e47901855cb245064dd633e217bfcb49a11a7": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.a6b36b26d836a5c5ddb7f8906ae2a817c0063a89": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "num",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.a6b36b26d836a5c5ddb7f8906ae2a817c0063a89",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.b19e2683be41355cdd22d1d489ae36749b14bef0": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "inputs",
+              "type_key": "Shape.a6b36b26d836a5c5ddb7f8906ae2a817c0063a89"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.b19e2683be41355cdd22d1d489ae36749b14bef0",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.d4670f68893bf551d7398bd94d97daec11f9bb2b": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
+              "description": "Configure how steps are executed within a run.",
+              "is_required": false,
+              "name": "execution",
+              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Configure how loggers emit messages within a run.",
+              "is_required": false,
+              "name": "loggers",
+              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "Configure runtime parameters for ops or assets.",
+              "is_required": true,
+              "name": "ops",
+              "type_key": "Shape.0d55d94dd294f7cd436b52feb520b9840c4f91dc"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"io_manager\": {}}",
+              "description": "Configure how shared resources are implemented within a run.",
+              "is_required": false,
+              "name": "resources",
+              "type_key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.d4670f68893bf551d7398bd94d97daec11f9bb2b",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [],
+          "given_name": null,
+          "key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "console",
+              "type_key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "String": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "String",
+          "key": "String",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.STRING"
+          },
+          "type_param_keys": null
+        }
+      }
+    },
+    "dagster_type_namespace_snapshot": {
+      "__class__": "DagsterTypeNamespaceSnapshot",
+      "all_dagster_type_snaps_by_key": {
+        "Any": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Any",
+          "is_builtin": true,
+          "key": "Any",
+          "kind": {
+            "__enum__": "DagsterTypeKind.ANY"
+          },
+          "loader_schema_key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
+          "materializer_schema_key": null,
+          "name": "Any",
+          "type_param_keys": []
+        },
+        "Bool": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Bool",
+          "is_builtin": true,
+          "key": "Bool",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "materializer_schema_key": null,
+          "name": "Bool",
+          "type_param_keys": []
+        },
+        "Float": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Float",
+          "is_builtin": true,
+          "key": "Float",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "materializer_schema_key": null,
+          "name": "Float",
+          "type_param_keys": []
+        },
+        "Int": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Int",
+          "is_builtin": true,
+          "key": "Int",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "materializer_schema_key": null,
+          "name": "Int",
+          "type_param_keys": []
+        },
+        "Nothing": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Nothing",
+          "is_builtin": true,
+          "key": "Nothing",
+          "kind": {
+            "__enum__": "DagsterTypeKind.NOTHING"
+          },
+          "loader_schema_key": null,
+          "materializer_schema_key": null,
+          "name": "Nothing",
+          "type_param_keys": []
+        },
+        "PoorMansDataFrame": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "PoorMansDataFrame",
+          "is_builtin": false,
+          "key": "PoorMansDataFrame",
+          "kind": {
+            "__enum__": "DagsterTypeKind.REGULAR"
+          },
+          "loader_schema_key": "String",
+          "materializer_schema_key": null,
+          "name": "PoorMansDataFrame",
+          "type_param_keys": []
+        },
+        "String": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "String",
+          "is_builtin": true,
+          "key": "String",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "materializer_schema_key": null,
+          "name": "String",
+          "type_param_keys": []
+        }
+      }
+    },
+    "dep_structure_snapshot": {
+      "__class__": "DependencyStructureSnapshot",
+      "solid_invocation_snaps": [
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "num",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": []
+            }
+          ],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "sum_op",
+          "solid_name": "sum_op",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "sum_df",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": [
+                {
+                  "__class__": "OutputHandleSnap",
+                  "output_name": "result",
+                  "solid_name": "sum_op"
+                }
+              ]
+            }
+          ],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "sum_sq_op",
+          "solid_name": "sum_sq_op",
+          "tags": {}
+        }
+      ]
+    },
+    "description": null,
+    "graph_def_name": "csv_hello_world_df_input",
+    "lineage_snapshot": null,
+    "mode_def_snaps": [
+      {
+        "__class__": "ModeDefSnap",
+        "description": null,
+        "logger_def_snaps": [
+          {
+            "__class__": "LoggerDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
+              "description": "The default colored console logger.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
+            },
+            "description": "The default colored console logger.",
+            "name": "console"
+          }
+        ],
+        "name": "default",
+        "resource_def_snaps": [
+          {
+            "__class__": "ResourceDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            },
+            "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
+            "name": "io_manager"
+          }
+        ],
+        "root_config_key": "Shape.d4670f68893bf551d7398bd94d97daec11f9bb2b"
+      }
+    ],
+    "name": "csv_hello_world_df_input",
+    "solid_definitions_snapshot": {
+      "__class__": "SolidDefinitionsSnapshot",
+      "composite_solid_def_snaps": [],
+      "solid_def_snaps": [
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "PoorMansDataFrame",
+              "description": null,
+              "name": "num"
+            }
+          ],
+          "name": "sum_op",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "PoorMansDataFrame",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "PoorMansDataFrame",
+              "description": null,
+              "name": "sum_df"
+            }
+          ],
+          "name": "sum_sq_op",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "PoorMansDataFrame",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        }
+      ]
+    },
+    "tags": {}
+  }
+  '''
+# ---
+# name: test_all_snapshot_ids[31]
+  'a28dd9e490e08f05fab6ab1309de27da5cd3eb0f'
+# ---
+# name: test_all_snapshot_ids[32]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -38587,10 +40672,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[31]
+# name: test_all_snapshot_ids[33]
   'a62baecf830886bfa322863f86bbd7344ef9c359'
 # ---
-# name: test_all_snapshot_ids[32]
+# name: test_all_snapshot_ids[34]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -39655,10 +41740,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[33]
+# name: test_all_snapshot_ids[35]
   '2bc0dc6a7c8ccb4ec4352fde1925f82521d71675'
 # ---
-# name: test_all_snapshot_ids[34]
+# name: test_all_snapshot_ids[36]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -40512,10 +42597,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[35]
+# name: test_all_snapshot_ids[37]
   '458a303a0e8d51f99eb8417d4be851f0b982b5a5'
 # ---
-# name: test_all_snapshot_ids[36]
+# name: test_all_snapshot_ids[38]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -41502,10 +43587,13 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[37]
+# name: test_all_snapshot_ids[39]
   '9224ed1364dbf02ced98648c1f9637686e8a1a29'
 # ---
-# name: test_all_snapshot_ids[38]
+# name: test_all_snapshot_ids[3]
+  '04ad904e132aa78afcc1d8769b62ea842d783264'
+# ---
+# name: test_all_snapshot_ids[40]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -42710,13 +44798,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[39]
+# name: test_all_snapshot_ids[41]
   'db3c9e009bad031bbf9b5f278cc09b691a00eaec'
 # ---
-# name: test_all_snapshot_ids[3]
-  'c149b77a06b422c58cd443729e213b77e9364719'
-# ---
-# name: test_all_snapshot_ids[40]
+# name: test_all_snapshot_ids[42]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -43634,10 +45719,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[41]
+# name: test_all_snapshot_ids[43]
   '6650ed807e4b516f8100a8933b134c401b4dd4ff'
 # ---
-# name: test_all_snapshot_ids[42]
+# name: test_all_snapshot_ids[44]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -44955,10 +47040,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[43]
+# name: test_all_snapshot_ids[45]
   'f871b53e30b83794c20d128b5cf209f63eb603d3'
 # ---
-# name: test_all_snapshot_ids[44]
+# name: test_all_snapshot_ids[46]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -45812,10 +47897,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[45]
+# name: test_all_snapshot_ids[47]
   'a8c59968b6bfc4a69dfeddadb403ef103814d7bd'
 # ---
-# name: test_all_snapshot_ids[46]
+# name: test_all_snapshot_ids[48]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -46797,1099 +48882,8 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[47]
-  '8063efa9c804f1ca24f243d02c895bb881a3f552'
-# ---
-# name: test_all_snapshot_ids[48]
-  '''
-  {
-    "__class__": "PipelineSnapshot",
-    "config_schema_snapshot": {
-      "__class__": "ConfigSchemaSnapshot",
-      "all_config_snaps_by_key": {
-        "Any": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Any",
-          "key": "Any",
-          "kind": {
-            "__enum__": "ConfigTypeKind.ANY"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Bool": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Bool",
-          "key": "Bool",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.BOOL"
-          },
-          "type_param_keys": null
-        },
-        "Float": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Float",
-          "key": "Float",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.FLOAT"
-          },
-          "type_param_keys": null
-        },
-        "Int": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Int",
-          "key": "Int",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.INT"
-          },
-          "type_param_keys": null
-        },
-        "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Bool",
-            "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59"
-          ]
-        },
-        "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Float",
-            "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3"
-          ]
-        },
-        "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Int",
-            "Selector.a9799b971d12ace70a2d8803c883c863417d0725"
-          ]
-        },
-        "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "String",
-            "Selector.e04723c9d9937e3ab21206435b22247cfbe58269"
-          ]
-        },
-        "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "disabled",
-              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "enabled",
-              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Int"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Bool"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Float"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Any"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.081354663b9d4b8fbfd1cb8e358763912953913f": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "\"INFO\"",
-              "description": "The logger's threshold.",
-              "is_required": false,
-              "name": "log_level",
-              "type_key": "String"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "\"dagster\"",
-              "description": "The name of your logger.",
-              "is_required": false,
-              "name": "name",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.09d73f0755bf4752d3f121837669c8660dcf451e": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"retries\": {\"enabled\": {}}}",
-              "description": "Execute all steps in a single process.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
-              "description": "The default colored console logger.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
-              "is_required": false,
-              "name": "io_manager",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": "[DEPRECATED]",
-              "is_required": false,
-              "name": "marker_to_close",
-              "type_key": "String"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"enabled\": {}}",
-              "description": "Whether retries are enabled or not. By default, retries are enabled.",
-              "is_required": false,
-              "name": "retries",
-              "type_key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "path",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.70eba867e7006ecee70800c0c134ab1adea76b41": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "bar",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "baz",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "foo",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "foo_bar",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "unconnected",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.70eba867e7006ecee70800c0c134ab1adea76b41",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.743e47901855cb245064dd633e217bfcb49a11a7": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Any"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.bfeeba35ad944a2ac9fd65c0cc72c28cccc5cf6e": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
-              "description": "Configure how steps are executed within a run.",
-              "is_required": false,
-              "name": "execution",
-              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": "Configure how loggers emit messages within a run.",
-              "is_required": false,
-              "name": "loggers",
-              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"bar\": {}, \"baz\": {}, \"foo\": {}, \"foo_bar\": {}, \"unconnected\": {}}",
-              "description": "Configure runtime parameters for ops or assets.",
-              "is_required": false,
-              "name": "ops",
-              "type_key": "Shape.70eba867e7006ecee70800c0c134ab1adea76b41"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"io_manager\": {}}",
-              "description": "Configure how shared resources are implemented within a run.",
-              "is_required": false,
-              "name": "resources",
-              "type_key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.bfeeba35ad944a2ac9fd65c0cc72c28cccc5cf6e",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [],
-          "given_name": null,
-          "key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "console",
-              "type_key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "String": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "String",
-          "key": "String",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.STRING"
-          },
-          "type_param_keys": null
-        }
-      }
-    },
-    "dagster_type_namespace_snapshot": {
-      "__class__": "DagsterTypeNamespaceSnapshot",
-      "all_dagster_type_snaps_by_key": {
-        "Any": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Any",
-          "is_builtin": true,
-          "key": "Any",
-          "kind": {
-            "__enum__": "DagsterTypeKind.ANY"
-          },
-          "loader_schema_key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
-          "materializer_schema_key": null,
-          "name": "Any",
-          "type_param_keys": []
-        },
-        "Bool": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Bool",
-          "is_builtin": true,
-          "key": "Bool",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "materializer_schema_key": null,
-          "name": "Bool",
-          "type_param_keys": []
-        },
-        "Float": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Float",
-          "is_builtin": true,
-          "key": "Float",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "materializer_schema_key": null,
-          "name": "Float",
-          "type_param_keys": []
-        },
-        "Int": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Int",
-          "is_builtin": true,
-          "key": "Int",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "materializer_schema_key": null,
-          "name": "Int",
-          "type_param_keys": []
-        },
-        "Nothing": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Nothing",
-          "is_builtin": true,
-          "key": "Nothing",
-          "kind": {
-            "__enum__": "DagsterTypeKind.NOTHING"
-          },
-          "loader_schema_key": null,
-          "materializer_schema_key": null,
-          "name": "Nothing",
-          "type_param_keys": []
-        },
-        "String": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "String",
-          "is_builtin": true,
-          "key": "String",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "materializer_schema_key": null,
-          "name": "String",
-          "type_param_keys": []
-        }
-      }
-    },
-    "dep_structure_snapshot": {
-      "__class__": "DependencyStructureSnapshot",
-      "solid_invocation_snaps": [
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "bar",
-          "solid_name": "bar",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [
-            {
-              "__class__": "InputDependencySnap",
-              "input_name": "foo_bar",
-              "is_dynamic_collect": false,
-              "upstream_output_snaps": [
-                {
-                  "__class__": "OutputHandleSnap",
-                  "output_name": "result",
-                  "solid_name": "foo_bar"
-                }
-              ]
-            }
-          ],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "baz",
-          "solid_name": "baz",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "foo",
-          "solid_name": "foo",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [
-            {
-              "__class__": "InputDependencySnap",
-              "input_name": "bar",
-              "is_dynamic_collect": false,
-              "upstream_output_snaps": [
-                {
-                  "__class__": "OutputHandleSnap",
-                  "output_name": "result",
-                  "solid_name": "bar"
-                }
-              ]
-            },
-            {
-              "__class__": "InputDependencySnap",
-              "input_name": "foo",
-              "is_dynamic_collect": false,
-              "upstream_output_snaps": [
-                {
-                  "__class__": "OutputHandleSnap",
-                  "output_name": "result",
-                  "solid_name": "foo"
-                }
-              ]
-            }
-          ],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "foo_bar",
-          "solid_name": "foo_bar",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "unconnected",
-          "solid_name": "unconnected",
-          "tags": {}
-        }
-      ]
-    },
-    "description": null,
-    "graph_def_name": "foo_job",
-    "lineage_snapshot": null,
-    "mode_def_snaps": [
-      {
-        "__class__": "ModeDefSnap",
-        "description": null,
-        "logger_def_snaps": [
-          {
-            "__class__": "LoggerDefSnap",
-            "config_field_snap": {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
-              "description": "The default colored console logger.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
-            },
-            "description": "The default colored console logger.",
-            "name": "console"
-          }
-        ],
-        "name": "default",
-        "resource_def_snaps": [
-          {
-            "__class__": "ResourceDefSnap",
-            "config_field_snap": {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Any"
-            },
-            "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
-            "name": "io_manager"
-          }
-        ],
-        "root_config_key": "Shape.bfeeba35ad944a2ac9fd65c0cc72c28cccc5cf6e"
-      }
-    ],
-    "name": "foo_job",
-    "solid_definitions_snapshot": {
-      "__class__": "SolidDefinitionsSnapshot",
-      "composite_solid_def_snaps": [],
-      "solid_def_snaps": [
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [],
-          "name": "bar",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [
-            {
-              "__class__": "InputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "name": "foo_bar"
-            }
-          ],
-          "name": "baz",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [],
-          "name": "foo",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [
-            {
-              "__class__": "InputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "name": "bar"
-            },
-            {
-              "__class__": "InputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "name": "foo"
-            }
-          ],
-          "name": "foo_bar",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [],
-          "name": "unconnected",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        }
-      ]
-    },
-    "tags": {}
-  }
-  '''
-# ---
 # name: test_all_snapshot_ids[49]
-  '8686ac202978e5594035fcfe0f90b6d83ef1a5eb'
+  '8063efa9c804f1ca24f243d02c895bb881a3f552'
 # ---
 # name: test_all_snapshot_ids[4]
   '''
@@ -49093,7 +50087,7 @@
           "input_def_snaps": [
             {
               "__class__": "InputDefSnap",
-              "dagster_type_key": "Nothing",
+              "dagster_type_key": "Any",
               "description": null,
               "name": "asset_1"
             }
@@ -49452,6 +50446,1097 @@
   '''
 # ---
 # name: test_all_snapshot_ids[50]
+  '''
+  {
+    "__class__": "PipelineSnapshot",
+    "config_schema_snapshot": {
+      "__class__": "ConfigSchemaSnapshot",
+      "all_config_snaps_by_key": {
+        "Any": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Any",
+          "key": "Any",
+          "kind": {
+            "__enum__": "ConfigTypeKind.ANY"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Bool": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Bool",
+          "key": "Bool",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.BOOL"
+          },
+          "type_param_keys": null
+        },
+        "Float": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Float",
+          "key": "Float",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.FLOAT"
+          },
+          "type_param_keys": null
+        },
+        "Int": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Int",
+          "key": "Int",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.INT"
+          },
+          "type_param_keys": null
+        },
+        "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Bool",
+            "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59"
+          ]
+        },
+        "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Float",
+            "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3"
+          ]
+        },
+        "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Int",
+            "Selector.a9799b971d12ace70a2d8803c883c863417d0725"
+          ]
+        },
+        "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "String",
+            "Selector.e04723c9d9937e3ab21206435b22247cfbe58269"
+          ]
+        },
+        "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "disabled",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "enabled",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Int"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Bool"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Float"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Any"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.081354663b9d4b8fbfd1cb8e358763912953913f": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "\"INFO\"",
+              "description": "The logger's threshold.",
+              "is_required": false,
+              "name": "log_level",
+              "type_key": "String"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "\"dagster\"",
+              "description": "The name of your logger.",
+              "is_required": false,
+              "name": "name",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.09d73f0755bf4752d3f121837669c8660dcf451e": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"retries\": {\"enabled\": {}}}",
+              "description": "Execute all steps in a single process.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
+              "description": "The default colored console logger.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
+              "is_required": false,
+              "name": "io_manager",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "[DEPRECATED]",
+              "is_required": false,
+              "name": "marker_to_close",
+              "type_key": "String"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"enabled\": {}}",
+              "description": "Whether retries are enabled or not. By default, retries are enabled.",
+              "is_required": false,
+              "name": "retries",
+              "type_key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "path",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.70eba867e7006ecee70800c0c134ab1adea76b41": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "bar",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "baz",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "foo",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "foo_bar",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "unconnected",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.70eba867e7006ecee70800c0c134ab1adea76b41",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.743e47901855cb245064dd633e217bfcb49a11a7": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.bfeeba35ad944a2ac9fd65c0cc72c28cccc5cf6e": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
+              "description": "Configure how steps are executed within a run.",
+              "is_required": false,
+              "name": "execution",
+              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Configure how loggers emit messages within a run.",
+              "is_required": false,
+              "name": "loggers",
+              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"bar\": {}, \"baz\": {}, \"foo\": {}, \"foo_bar\": {}, \"unconnected\": {}}",
+              "description": "Configure runtime parameters for ops or assets.",
+              "is_required": false,
+              "name": "ops",
+              "type_key": "Shape.70eba867e7006ecee70800c0c134ab1adea76b41"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"io_manager\": {}}",
+              "description": "Configure how shared resources are implemented within a run.",
+              "is_required": false,
+              "name": "resources",
+              "type_key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.bfeeba35ad944a2ac9fd65c0cc72c28cccc5cf6e",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [],
+          "given_name": null,
+          "key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "console",
+              "type_key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "String": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "String",
+          "key": "String",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.STRING"
+          },
+          "type_param_keys": null
+        }
+      }
+    },
+    "dagster_type_namespace_snapshot": {
+      "__class__": "DagsterTypeNamespaceSnapshot",
+      "all_dagster_type_snaps_by_key": {
+        "Any": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Any",
+          "is_builtin": true,
+          "key": "Any",
+          "kind": {
+            "__enum__": "DagsterTypeKind.ANY"
+          },
+          "loader_schema_key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
+          "materializer_schema_key": null,
+          "name": "Any",
+          "type_param_keys": []
+        },
+        "Bool": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Bool",
+          "is_builtin": true,
+          "key": "Bool",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "materializer_schema_key": null,
+          "name": "Bool",
+          "type_param_keys": []
+        },
+        "Float": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Float",
+          "is_builtin": true,
+          "key": "Float",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "materializer_schema_key": null,
+          "name": "Float",
+          "type_param_keys": []
+        },
+        "Int": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Int",
+          "is_builtin": true,
+          "key": "Int",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "materializer_schema_key": null,
+          "name": "Int",
+          "type_param_keys": []
+        },
+        "Nothing": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Nothing",
+          "is_builtin": true,
+          "key": "Nothing",
+          "kind": {
+            "__enum__": "DagsterTypeKind.NOTHING"
+          },
+          "loader_schema_key": null,
+          "materializer_schema_key": null,
+          "name": "Nothing",
+          "type_param_keys": []
+        },
+        "String": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "String",
+          "is_builtin": true,
+          "key": "String",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "materializer_schema_key": null,
+          "name": "String",
+          "type_param_keys": []
+        }
+      }
+    },
+    "dep_structure_snapshot": {
+      "__class__": "DependencyStructureSnapshot",
+      "solid_invocation_snaps": [
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "bar",
+          "solid_name": "bar",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "foo_bar",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": [
+                {
+                  "__class__": "OutputHandleSnap",
+                  "output_name": "result",
+                  "solid_name": "foo_bar"
+                }
+              ]
+            }
+          ],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "baz",
+          "solid_name": "baz",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "foo",
+          "solid_name": "foo",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "bar",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": [
+                {
+                  "__class__": "OutputHandleSnap",
+                  "output_name": "result",
+                  "solid_name": "bar"
+                }
+              ]
+            },
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "foo",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": [
+                {
+                  "__class__": "OutputHandleSnap",
+                  "output_name": "result",
+                  "solid_name": "foo"
+                }
+              ]
+            }
+          ],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "foo_bar",
+          "solid_name": "foo_bar",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "unconnected",
+          "solid_name": "unconnected",
+          "tags": {}
+        }
+      ]
+    },
+    "description": null,
+    "graph_def_name": "foo_job",
+    "lineage_snapshot": null,
+    "mode_def_snaps": [
+      {
+        "__class__": "ModeDefSnap",
+        "description": null,
+        "logger_def_snaps": [
+          {
+            "__class__": "LoggerDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
+              "description": "The default colored console logger.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
+            },
+            "description": "The default colored console logger.",
+            "name": "console"
+          }
+        ],
+        "name": "default",
+        "resource_def_snaps": [
+          {
+            "__class__": "ResourceDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            },
+            "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
+            "name": "io_manager"
+          }
+        ],
+        "root_config_key": "Shape.bfeeba35ad944a2ac9fd65c0cc72c28cccc5cf6e"
+      }
+    ],
+    "name": "foo_job",
+    "solid_definitions_snapshot": {
+      "__class__": "SolidDefinitionsSnapshot",
+      "composite_solid_def_snaps": [],
+      "solid_def_snaps": [
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "bar",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "name": "foo_bar"
+            }
+          ],
+          "name": "baz",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "foo",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "name": "bar"
+            },
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "name": "foo"
+            }
+          ],
+          "name": "foo_bar",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "unconnected",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        }
+      ]
+    },
+    "tags": {}
+  }
+  '''
+# ---
+# name: test_all_snapshot_ids[51]
+  '8686ac202978e5594035fcfe0f90b6d83ef1a5eb'
+# ---
+# name: test_all_snapshot_ids[52]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -50598,10 +52683,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[51]
+# name: test_all_snapshot_ids[53]
   '252960d8f0b17cdcd1efaa2b6803c10e7e851bfa'
 # ---
-# name: test_all_snapshot_ids[52]
+# name: test_all_snapshot_ids[54]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -51805,10 +53890,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[53]
+# name: test_all_snapshot_ids[55]
   '053169bccb033d2fc2fd11d13696b36a32c0e610'
 # ---
-# name: test_all_snapshot_ids[54]
+# name: test_all_snapshot_ids[56]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -52875,10 +54960,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[55]
+# name: test_all_snapshot_ids[57]
   'd603c1e9d8630c3aa099d79e0515968e7514384f'
 # ---
-# name: test_all_snapshot_ids[56]
+# name: test_all_snapshot_ids[58]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -53803,10 +55888,13 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[57]
+# name: test_all_snapshot_ids[59]
   'fd77a8459b2e767ea52b6a77574a79491326073d'
 # ---
-# name: test_all_snapshot_ids[58]
+# name: test_all_snapshot_ids[5]
+  '5f263b4f45d23757358a7262dee0e132cd58e650'
+# ---
+# name: test_all_snapshot_ids[60]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -54770,13 +56858,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[59]
+# name: test_all_snapshot_ids[61]
   'c6b504611b1ee7582092807ac90bdd4ac64bac3b'
 # ---
-# name: test_all_snapshot_ids[5]
-  '4ae3b87726e56a884dca5614ded634c8c419cbaf'
-# ---
-# name: test_all_snapshot_ids[60]
+# name: test_all_snapshot_ids[62]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -55632,10 +57717,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[61]
+# name: test_all_snapshot_ids[63]
   'dc190868e8887ba5ac3669da13473252cd0ab098'
 # ---
-# name: test_all_snapshot_ids[62]
+# name: test_all_snapshot_ids[64]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -56535,10 +58620,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[63]
+# name: test_all_snapshot_ids[65]
   '83469e8c700778e0c1e268f158672fca54d5896b'
 # ---
-# name: test_all_snapshot_ids[64]
+# name: test_all_snapshot_ids[66]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -57392,10 +59477,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[65]
+# name: test_all_snapshot_ids[67]
   'c4fee3a0c56b1ef6fcea9b64ceaacd06c4d5e216'
 # ---
-# name: test_all_snapshot_ids[66]
+# name: test_all_snapshot_ids[68]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -58295,917 +60380,8 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[67]
-  '643e2b02ca69b0087d15b448a9108d39d5b35036'
-# ---
-# name: test_all_snapshot_ids[68]
-  '''
-  {
-    "__class__": "PipelineSnapshot",
-    "config_schema_snapshot": {
-      "__class__": "ConfigSchemaSnapshot",
-      "all_config_snaps_by_key": {
-        "Any": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Any",
-          "key": "Any",
-          "kind": {
-            "__enum__": "ConfigTypeKind.ANY"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Bool": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Bool",
-          "key": "Bool",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.BOOL"
-          },
-          "type_param_keys": null
-        },
-        "Float": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Float",
-          "key": "Float",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.FLOAT"
-          },
-          "type_param_keys": null
-        },
-        "Int": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Int",
-          "key": "Int",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.INT"
-          },
-          "type_param_keys": null
-        },
-        "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Bool",
-            "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59"
-          ]
-        },
-        "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Float",
-            "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3"
-          ]
-        },
-        "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Int",
-            "Selector.a9799b971d12ace70a2d8803c883c863417d0725"
-          ]
-        },
-        "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "String",
-            "Selector.e04723c9d9937e3ab21206435b22247cfbe58269"
-          ]
-        },
-        "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "disabled",
-              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "enabled",
-              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Int"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Bool"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Float"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Any"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.081354663b9d4b8fbfd1cb8e358763912953913f": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "\"INFO\"",
-              "description": "The logger's threshold.",
-              "is_required": false,
-              "name": "log_level",
-              "type_key": "String"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "\"dagster\"",
-              "description": "The name of your logger.",
-              "is_required": false,
-              "name": "name",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.09d73f0755bf4752d3f121837669c8660dcf451e": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"retries\": {\"enabled\": {}}}",
-              "description": "Execute all steps in a single process.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
-              "description": "The default colored console logger.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
-              "is_required": false,
-              "name": "io_manager",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": "[DEPRECATED]",
-              "is_required": false,
-              "name": "marker_to_close",
-              "type_key": "String"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"enabled\": {}}",
-              "description": "Whether retries are enabled or not. By default, retries are enabled.",
-              "is_required": false,
-              "name": "retries",
-              "type_key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "path",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.743e47901855cb245064dd633e217bfcb49a11a7": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Any"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.8ca73f0ae5a27b2d717a94a2cba479568ddc79b2": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "config",
-              "type_key": "TestEnum"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.8ca73f0ae5a27b2d717a94a2cba479568ddc79b2",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.b214dc99bad5dc89e19e327bf3c9abcd56c353db": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "takes_an_enum",
-              "type_key": "Shape.8ca73f0ae5a27b2d717a94a2cba479568ddc79b2"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.b214dc99bad5dc89e19e327bf3c9abcd56c353db",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [],
-          "given_name": null,
-          "key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "console",
-              "type_key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.fd83dcfe0c9126a9b5956827a350611e935e0643": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
-              "description": "Configure how steps are executed within a run.",
-              "is_required": false,
-              "name": "execution",
-              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": "Configure how loggers emit messages within a run.",
-              "is_required": false,
-              "name": "loggers",
-              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": "Configure runtime parameters for ops or assets.",
-              "is_required": true,
-              "name": "ops",
-              "type_key": "Shape.b214dc99bad5dc89e19e327bf3c9abcd56c353db"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"io_manager\": {}}",
-              "description": "Configure how shared resources are implemented within a run.",
-              "is_required": false,
-              "name": "resources",
-              "type_key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.fd83dcfe0c9126a9b5956827a350611e935e0643",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "String": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "String",
-          "key": "String",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.STRING"
-          },
-          "type_param_keys": null
-        },
-        "TestEnum": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": [
-            {
-              "__class__": "ConfigEnumValueSnap",
-              "description": "An enum value.",
-              "value": "ENUM_VALUE_ONE"
-            },
-            {
-              "__class__": "ConfigEnumValueSnap",
-              "description": "An enum value.",
-              "value": "ENUM_VALUE_TWO"
-            },
-            {
-              "__class__": "ConfigEnumValueSnap",
-              "description": "An enum value.",
-              "value": "ENUM_VALUE_THREE"
-            }
-          ],
-          "fields": null,
-          "given_name": "TestEnum",
-          "key": "TestEnum",
-          "kind": {
-            "__enum__": "ConfigTypeKind.ENUM"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        }
-      }
-    },
-    "dagster_type_namespace_snapshot": {
-      "__class__": "DagsterTypeNamespaceSnapshot",
-      "all_dagster_type_snaps_by_key": {
-        "Any": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Any",
-          "is_builtin": true,
-          "key": "Any",
-          "kind": {
-            "__enum__": "DagsterTypeKind.ANY"
-          },
-          "loader_schema_key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
-          "materializer_schema_key": null,
-          "name": "Any",
-          "type_param_keys": []
-        },
-        "Bool": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Bool",
-          "is_builtin": true,
-          "key": "Bool",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "materializer_schema_key": null,
-          "name": "Bool",
-          "type_param_keys": []
-        },
-        "Float": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Float",
-          "is_builtin": true,
-          "key": "Float",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "materializer_schema_key": null,
-          "name": "Float",
-          "type_param_keys": []
-        },
-        "Int": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Int",
-          "is_builtin": true,
-          "key": "Int",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "materializer_schema_key": null,
-          "name": "Int",
-          "type_param_keys": []
-        },
-        "Nothing": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Nothing",
-          "is_builtin": true,
-          "key": "Nothing",
-          "kind": {
-            "__enum__": "DagsterTypeKind.NOTHING"
-          },
-          "loader_schema_key": null,
-          "materializer_schema_key": null,
-          "name": "Nothing",
-          "type_param_keys": []
-        },
-        "String": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "String",
-          "is_builtin": true,
-          "key": "String",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "materializer_schema_key": null,
-          "name": "String",
-          "type_param_keys": []
-        }
-      }
-    },
-    "dep_structure_snapshot": {
-      "__class__": "DependencyStructureSnapshot",
-      "solid_invocation_snaps": [
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "takes_an_enum",
-          "solid_name": "takes_an_enum",
-          "tags": {}
-        }
-      ]
-    },
-    "description": null,
-    "graph_def_name": "job_with_enum_config",
-    "lineage_snapshot": null,
-    "mode_def_snaps": [
-      {
-        "__class__": "ModeDefSnap",
-        "description": null,
-        "logger_def_snaps": [
-          {
-            "__class__": "LoggerDefSnap",
-            "config_field_snap": {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
-              "description": "The default colored console logger.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
-            },
-            "description": "The default colored console logger.",
-            "name": "console"
-          }
-        ],
-        "name": "default",
-        "resource_def_snaps": [
-          {
-            "__class__": "ResourceDefSnap",
-            "config_field_snap": {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Any"
-            },
-            "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
-            "name": "io_manager"
-          }
-        ],
-        "root_config_key": "Shape.fd83dcfe0c9126a9b5956827a350611e935e0643"
-      }
-    ],
-    "name": "job_with_enum_config",
-    "solid_definitions_snapshot": {
-      "__class__": "SolidDefinitionsSnapshot",
-      "composite_solid_def_snaps": [],
-      "solid_def_snaps": [
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": true,
-            "name": "config",
-            "type_key": "TestEnum"
-          },
-          "description": null,
-          "input_def_snaps": [],
-          "name": "takes_an_enum",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        }
-      ]
-    },
-    "tags": {}
-  }
-  '''
-# ---
 # name: test_all_snapshot_ids[69]
-  '158a79ab642707e63923c59c6abaf7960b36211e'
+  '643e2b02ca69b0087d15b448a9108d39d5b35036'
 # ---
 # name: test_all_snapshot_ids[6]
   '''
@@ -60481,7 +61657,7 @@
           "input_def_snaps": [
             {
               "__class__": "InputDefSnap",
-              "dagster_type_key": "Nothing",
+              "dagster_type_key": "Any",
               "description": null,
               "name": "asset_1"
             }
@@ -60914,6 +62090,915 @@
   '''
 # ---
 # name: test_all_snapshot_ids[70]
+  '''
+  {
+    "__class__": "PipelineSnapshot",
+    "config_schema_snapshot": {
+      "__class__": "ConfigSchemaSnapshot",
+      "all_config_snaps_by_key": {
+        "Any": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Any",
+          "key": "Any",
+          "kind": {
+            "__enum__": "ConfigTypeKind.ANY"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Bool": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Bool",
+          "key": "Bool",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.BOOL"
+          },
+          "type_param_keys": null
+        },
+        "Float": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Float",
+          "key": "Float",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.FLOAT"
+          },
+          "type_param_keys": null
+        },
+        "Int": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Int",
+          "key": "Int",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.INT"
+          },
+          "type_param_keys": null
+        },
+        "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Bool",
+            "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59"
+          ]
+        },
+        "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Float",
+            "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3"
+          ]
+        },
+        "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Int",
+            "Selector.a9799b971d12ace70a2d8803c883c863417d0725"
+          ]
+        },
+        "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "String",
+            "Selector.e04723c9d9937e3ab21206435b22247cfbe58269"
+          ]
+        },
+        "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "disabled",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "enabled",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Int"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Bool"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Float"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Any"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.081354663b9d4b8fbfd1cb8e358763912953913f": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "\"INFO\"",
+              "description": "The logger's threshold.",
+              "is_required": false,
+              "name": "log_level",
+              "type_key": "String"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "\"dagster\"",
+              "description": "The name of your logger.",
+              "is_required": false,
+              "name": "name",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.09d73f0755bf4752d3f121837669c8660dcf451e": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"retries\": {\"enabled\": {}}}",
+              "description": "Execute all steps in a single process.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
+              "description": "The default colored console logger.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
+              "is_required": false,
+              "name": "io_manager",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "[DEPRECATED]",
+              "is_required": false,
+              "name": "marker_to_close",
+              "type_key": "String"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"enabled\": {}}",
+              "description": "Whether retries are enabled or not. By default, retries are enabled.",
+              "is_required": false,
+              "name": "retries",
+              "type_key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "path",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.743e47901855cb245064dd633e217bfcb49a11a7": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.8ca73f0ae5a27b2d717a94a2cba479568ddc79b2": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "config",
+              "type_key": "TestEnum"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.8ca73f0ae5a27b2d717a94a2cba479568ddc79b2",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.b214dc99bad5dc89e19e327bf3c9abcd56c353db": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "takes_an_enum",
+              "type_key": "Shape.8ca73f0ae5a27b2d717a94a2cba479568ddc79b2"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.b214dc99bad5dc89e19e327bf3c9abcd56c353db",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [],
+          "given_name": null,
+          "key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "console",
+              "type_key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.fd83dcfe0c9126a9b5956827a350611e935e0643": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
+              "description": "Configure how steps are executed within a run.",
+              "is_required": false,
+              "name": "execution",
+              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Configure how loggers emit messages within a run.",
+              "is_required": false,
+              "name": "loggers",
+              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "Configure runtime parameters for ops or assets.",
+              "is_required": true,
+              "name": "ops",
+              "type_key": "Shape.b214dc99bad5dc89e19e327bf3c9abcd56c353db"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"io_manager\": {}}",
+              "description": "Configure how shared resources are implemented within a run.",
+              "is_required": false,
+              "name": "resources",
+              "type_key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.fd83dcfe0c9126a9b5956827a350611e935e0643",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "String": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "String",
+          "key": "String",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.STRING"
+          },
+          "type_param_keys": null
+        },
+        "TestEnum": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": [
+            {
+              "__class__": "ConfigEnumValueSnap",
+              "description": "An enum value.",
+              "value": "ENUM_VALUE_ONE"
+            },
+            {
+              "__class__": "ConfigEnumValueSnap",
+              "description": "An enum value.",
+              "value": "ENUM_VALUE_TWO"
+            },
+            {
+              "__class__": "ConfigEnumValueSnap",
+              "description": "An enum value.",
+              "value": "ENUM_VALUE_THREE"
+            }
+          ],
+          "fields": null,
+          "given_name": "TestEnum",
+          "key": "TestEnum",
+          "kind": {
+            "__enum__": "ConfigTypeKind.ENUM"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        }
+      }
+    },
+    "dagster_type_namespace_snapshot": {
+      "__class__": "DagsterTypeNamespaceSnapshot",
+      "all_dagster_type_snaps_by_key": {
+        "Any": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Any",
+          "is_builtin": true,
+          "key": "Any",
+          "kind": {
+            "__enum__": "DagsterTypeKind.ANY"
+          },
+          "loader_schema_key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
+          "materializer_schema_key": null,
+          "name": "Any",
+          "type_param_keys": []
+        },
+        "Bool": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Bool",
+          "is_builtin": true,
+          "key": "Bool",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "materializer_schema_key": null,
+          "name": "Bool",
+          "type_param_keys": []
+        },
+        "Float": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Float",
+          "is_builtin": true,
+          "key": "Float",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "materializer_schema_key": null,
+          "name": "Float",
+          "type_param_keys": []
+        },
+        "Int": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Int",
+          "is_builtin": true,
+          "key": "Int",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "materializer_schema_key": null,
+          "name": "Int",
+          "type_param_keys": []
+        },
+        "Nothing": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Nothing",
+          "is_builtin": true,
+          "key": "Nothing",
+          "kind": {
+            "__enum__": "DagsterTypeKind.NOTHING"
+          },
+          "loader_schema_key": null,
+          "materializer_schema_key": null,
+          "name": "Nothing",
+          "type_param_keys": []
+        },
+        "String": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "String",
+          "is_builtin": true,
+          "key": "String",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "materializer_schema_key": null,
+          "name": "String",
+          "type_param_keys": []
+        }
+      }
+    },
+    "dep_structure_snapshot": {
+      "__class__": "DependencyStructureSnapshot",
+      "solid_invocation_snaps": [
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "takes_an_enum",
+          "solid_name": "takes_an_enum",
+          "tags": {}
+        }
+      ]
+    },
+    "description": null,
+    "graph_def_name": "job_with_enum_config",
+    "lineage_snapshot": null,
+    "mode_def_snaps": [
+      {
+        "__class__": "ModeDefSnap",
+        "description": null,
+        "logger_def_snaps": [
+          {
+            "__class__": "LoggerDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
+              "description": "The default colored console logger.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
+            },
+            "description": "The default colored console logger.",
+            "name": "console"
+          }
+        ],
+        "name": "default",
+        "resource_def_snaps": [
+          {
+            "__class__": "ResourceDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            },
+            "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
+            "name": "io_manager"
+          }
+        ],
+        "root_config_key": "Shape.fd83dcfe0c9126a9b5956827a350611e935e0643"
+      }
+    ],
+    "name": "job_with_enum_config",
+    "solid_definitions_snapshot": {
+      "__class__": "SolidDefinitionsSnapshot",
+      "composite_solid_def_snaps": [],
+      "solid_def_snaps": [
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": true,
+            "name": "config",
+            "type_key": "TestEnum"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "takes_an_enum",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        }
+      ]
+    },
+    "tags": {}
+  }
+  '''
+# ---
+# name: test_all_snapshot_ids[71]
+  '158a79ab642707e63923c59c6abaf7960b36211e'
+# ---
+# name: test_all_snapshot_ids[72]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -61828,10 +63913,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[71]
+# name: test_all_snapshot_ids[73]
   '25eed9832eef95ee97a63357e836659193775b3d'
 # ---
-# name: test_all_snapshot_ids[72]
+# name: test_all_snapshot_ids[74]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -62776,10 +64861,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[73]
+# name: test_all_snapshot_ids[75]
   '6069db2378a5bcd370c5f8ce8e8ee51d997e3447'
 # ---
-# name: test_all_snapshot_ids[74]
+# name: test_all_snapshot_ids[76]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -63711,10 +65796,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[75]
+# name: test_all_snapshot_ids[77]
   'de3cee0b30bf45c5c28b57035caff8a592cb8a99'
 # ---
-# name: test_all_snapshot_ids[76]
+# name: test_all_snapshot_ids[78]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -64597,10 +66682,13 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[77]
+# name: test_all_snapshot_ids[79]
   '68f90c6bc3483e01ab1317573d90e23d0efe14a9'
 # ---
-# name: test_all_snapshot_ids[78]
+# name: test_all_snapshot_ids[7]
+  '6e7a3b47a4fdc52162082c9540ad65717e244de4'
+# ---
+# name: test_all_snapshot_ids[80]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -65500,13 +67588,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[79]
+# name: test_all_snapshot_ids[81]
   '1c4b82d393f7eacd9a358e3d82925d2afb9afbc0'
 # ---
-# name: test_all_snapshot_ids[7]
-  '194acca60b8e80a83cd155e2236eda505aab20ee'
-# ---
-# name: test_all_snapshot_ids[80]
+# name: test_all_snapshot_ids[82]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -66360,10 +68445,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[81]
+# name: test_all_snapshot_ids[83]
   'ab213b2b0286d659e9d7044d7dcec9b13d5b8bc7'
 # ---
-# name: test_all_snapshot_ids[82]
+# name: test_all_snapshot_ids[84]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -67217,10 +69302,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[83]
+# name: test_all_snapshot_ids[85]
   '87d32ef521015d8d415511a54b821524bc7a789f'
 # ---
-# name: test_all_snapshot_ids[84]
+# name: test_all_snapshot_ids[86]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -68182,10 +70267,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[85]
+# name: test_all_snapshot_ids[87]
   '06068d3cd0c89f54330c52e56f4e72a338f19a9f'
 # ---
-# name: test_all_snapshot_ids[86]
+# name: test_all_snapshot_ids[88]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -69183,929 +71268,8 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[87]
-  '10cfd966244a4e4064ff00517d3e012ad6ce4c7d'
-# ---
-# name: test_all_snapshot_ids[88]
-  '''
-  {
-    "__class__": "PipelineSnapshot",
-    "config_schema_snapshot": {
-      "__class__": "ConfigSchemaSnapshot",
-      "all_config_snaps_by_key": {
-        "Any": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Any",
-          "key": "Any",
-          "kind": {
-            "__enum__": "ConfigTypeKind.ANY"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Bool": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Bool",
-          "key": "Bool",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.BOOL"
-          },
-          "type_param_keys": null
-        },
-        "Float": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Float",
-          "key": "Float",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.FLOAT"
-          },
-          "type_param_keys": null
-        },
-        "Int": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Int",
-          "key": "Int",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.INT"
-          },
-          "type_param_keys": null
-        },
-        "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Bool",
-            "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59"
-          ]
-        },
-        "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Float",
-            "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3"
-          ]
-        },
-        "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Int",
-            "Selector.a9799b971d12ace70a2d8803c883c863417d0725"
-          ]
-        },
-        "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "String",
-            "Selector.e04723c9d9937e3ab21206435b22247cfbe58269"
-          ]
-        },
-        "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "disabled",
-              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "enabled",
-              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Int"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Bool"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Float"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Any"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.081354663b9d4b8fbfd1cb8e358763912953913f": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "\"INFO\"",
-              "description": "The logger's threshold.",
-              "is_required": false,
-              "name": "log_level",
-              "type_key": "String"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "\"dagster\"",
-              "description": "The name of your logger.",
-              "is_required": false,
-              "name": "name",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.09d73f0755bf4752d3f121837669c8660dcf451e": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"retries\": {\"enabled\": {}}}",
-              "description": "Execute all steps in a single process.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
-              "description": "The default colored console logger.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
-              "is_required": false,
-              "name": "io_manager",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": "[DEPRECATED]",
-              "is_required": false,
-              "name": "marker_to_close",
-              "type_key": "String"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"enabled\": {}}",
-              "description": "Whether retries are enabled or not. By default, retries are enabled.",
-              "is_required": false,
-              "name": "retries",
-              "type_key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "path",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.4d6705b295892273089d4134b6d270debdb03ce3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "op_asset_a",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "op_asset_b",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.4d6705b295892273089d4134b6d270debdb03ce3",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.68420c55741a33b18ef71c1b56d89e0ec12d5c06": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
-              "description": "Configure how steps are executed within a run.",
-              "is_required": false,
-              "name": "execution",
-              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": "Configure how loggers emit messages within a run.",
-              "is_required": false,
-              "name": "loggers",
-              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"op_asset_a\": {}, \"op_asset_b\": {}}",
-              "description": "Configure runtime parameters for ops or assets.",
-              "is_required": false,
-              "name": "ops",
-              "type_key": "Shape.4d6705b295892273089d4134b6d270debdb03ce3"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"io_manager\": {}}",
-              "description": "Configure how shared resources are implemented within a run.",
-              "is_required": false,
-              "name": "resources",
-              "type_key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.68420c55741a33b18ef71c1b56d89e0ec12d5c06",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.743e47901855cb245064dd633e217bfcb49a11a7": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Any"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [],
-          "given_name": null,
-          "key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "console",
-              "type_key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "String": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "String",
-          "key": "String",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.STRING"
-          },
-          "type_param_keys": null
-        }
-      }
-    },
-    "dagster_type_namespace_snapshot": {
-      "__class__": "DagsterTypeNamespaceSnapshot",
-      "all_dagster_type_snaps_by_key": {
-        "Any": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Any",
-          "is_builtin": true,
-          "key": "Any",
-          "kind": {
-            "__enum__": "DagsterTypeKind.ANY"
-          },
-          "loader_schema_key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
-          "materializer_schema_key": null,
-          "name": "Any",
-          "type_param_keys": []
-        },
-        "Bool": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Bool",
-          "is_builtin": true,
-          "key": "Bool",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "materializer_schema_key": null,
-          "name": "Bool",
-          "type_param_keys": []
-        },
-        "Float": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Float",
-          "is_builtin": true,
-          "key": "Float",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "materializer_schema_key": null,
-          "name": "Float",
-          "type_param_keys": []
-        },
-        "Int": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Int",
-          "is_builtin": true,
-          "key": "Int",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "materializer_schema_key": null,
-          "name": "Int",
-          "type_param_keys": []
-        },
-        "Nothing": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Nothing",
-          "is_builtin": true,
-          "key": "Nothing",
-          "kind": {
-            "__enum__": "DagsterTypeKind.NOTHING"
-          },
-          "loader_schema_key": null,
-          "materializer_schema_key": null,
-          "name": "Nothing",
-          "type_param_keys": []
-        },
-        "String": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "String",
-          "is_builtin": true,
-          "key": "String",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "materializer_schema_key": null,
-          "name": "String",
-          "type_param_keys": []
-        }
-      }
-    },
-    "dep_structure_snapshot": {
-      "__class__": "DependencyStructureSnapshot",
-      "solid_invocation_snaps": [
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "op_asset_a",
-          "solid_name": "op_asset_a",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [
-            {
-              "__class__": "InputDependencySnap",
-              "input_name": "num",
-              "is_dynamic_collect": false,
-              "upstream_output_snaps": [
-                {
-                  "__class__": "OutputHandleSnap",
-                  "output_name": "result",
-                  "solid_name": "op_asset_a"
-                }
-              ]
-            }
-          ],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "op_asset_b",
-          "solid_name": "op_asset_b",
-          "tags": {}
-        }
-      ]
-    },
-    "description": null,
-    "graph_def_name": "multi_asset_job",
-    "lineage_snapshot": null,
-    "mode_def_snaps": [
-      {
-        "__class__": "ModeDefSnap",
-        "description": null,
-        "logger_def_snaps": [
-          {
-            "__class__": "LoggerDefSnap",
-            "config_field_snap": {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
-              "description": "The default colored console logger.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
-            },
-            "description": "The default colored console logger.",
-            "name": "console"
-          }
-        ],
-        "name": "default",
-        "resource_def_snaps": [
-          {
-            "__class__": "ResourceDefSnap",
-            "config_field_snap": {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Any"
-            },
-            "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
-            "name": "io_manager"
-          }
-        ],
-        "root_config_key": "Shape.68420c55741a33b18ef71c1b56d89e0ec12d5c06"
-      }
-    ],
-    "name": "multi_asset_job",
-    "solid_definitions_snapshot": {
-      "__class__": "SolidDefinitionsSnapshot",
-      "composite_solid_def_snaps": [],
-      "solid_def_snaps": [
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [],
-          "name": "op_asset_a",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [
-            {
-              "__class__": "InputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "name": "num"
-            }
-          ],
-          "name": "op_asset_b",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        }
-      ]
-    },
-    "tags": {}
-  }
-  '''
-# ---
 # name: test_all_snapshot_ids[89]
-  'b7499dc1851fe912eb84bbbcead7d7db511e64d8'
+  '10cfd966244a4e4064ff00517d3e012ad6ce4c7d'
 # ---
 # name: test_all_snapshot_ids[8]
   '''
@@ -71279,7 +72443,7 @@
           "input_def_snaps": [
             {
               "__class__": "InputDefSnap",
-              "dagster_type_key": "Nothing",
+              "dagster_type_key": "Any",
               "description": null,
               "name": "asset_1"
             }
@@ -71606,6 +72770,927 @@
   '''
 # ---
 # name: test_all_snapshot_ids[90]
+  '''
+  {
+    "__class__": "PipelineSnapshot",
+    "config_schema_snapshot": {
+      "__class__": "ConfigSchemaSnapshot",
+      "all_config_snaps_by_key": {
+        "Any": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Any",
+          "key": "Any",
+          "kind": {
+            "__enum__": "ConfigTypeKind.ANY"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Bool": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Bool",
+          "key": "Bool",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.BOOL"
+          },
+          "type_param_keys": null
+        },
+        "Float": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Float",
+          "key": "Float",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.FLOAT"
+          },
+          "type_param_keys": null
+        },
+        "Int": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Int",
+          "key": "Int",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.INT"
+          },
+          "type_param_keys": null
+        },
+        "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Bool",
+            "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59"
+          ]
+        },
+        "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Float",
+            "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3"
+          ]
+        },
+        "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Int",
+            "Selector.a9799b971d12ace70a2d8803c883c863417d0725"
+          ]
+        },
+        "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "String",
+            "Selector.e04723c9d9937e3ab21206435b22247cfbe58269"
+          ]
+        },
+        "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "disabled",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "enabled",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Int"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Bool"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Float"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Any"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.081354663b9d4b8fbfd1cb8e358763912953913f": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "\"INFO\"",
+              "description": "The logger's threshold.",
+              "is_required": false,
+              "name": "log_level",
+              "type_key": "String"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "\"dagster\"",
+              "description": "The name of your logger.",
+              "is_required": false,
+              "name": "name",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.09d73f0755bf4752d3f121837669c8660dcf451e": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"retries\": {\"enabled\": {}}}",
+              "description": "Execute all steps in a single process.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
+              "description": "The default colored console logger.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
+              "is_required": false,
+              "name": "io_manager",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "[DEPRECATED]",
+              "is_required": false,
+              "name": "marker_to_close",
+              "type_key": "String"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"enabled\": {}}",
+              "description": "Whether retries are enabled or not. By default, retries are enabled.",
+              "is_required": false,
+              "name": "retries",
+              "type_key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "path",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.4d6705b295892273089d4134b6d270debdb03ce3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "op_asset_a",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "op_asset_b",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.4d6705b295892273089d4134b6d270debdb03ce3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.68420c55741a33b18ef71c1b56d89e0ec12d5c06": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
+              "description": "Configure how steps are executed within a run.",
+              "is_required": false,
+              "name": "execution",
+              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Configure how loggers emit messages within a run.",
+              "is_required": false,
+              "name": "loggers",
+              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"op_asset_a\": {}, \"op_asset_b\": {}}",
+              "description": "Configure runtime parameters for ops or assets.",
+              "is_required": false,
+              "name": "ops",
+              "type_key": "Shape.4d6705b295892273089d4134b6d270debdb03ce3"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"io_manager\": {}}",
+              "description": "Configure how shared resources are implemented within a run.",
+              "is_required": false,
+              "name": "resources",
+              "type_key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.68420c55741a33b18ef71c1b56d89e0ec12d5c06",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.743e47901855cb245064dd633e217bfcb49a11a7": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [],
+          "given_name": null,
+          "key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "console",
+              "type_key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "String": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "String",
+          "key": "String",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.STRING"
+          },
+          "type_param_keys": null
+        }
+      }
+    },
+    "dagster_type_namespace_snapshot": {
+      "__class__": "DagsterTypeNamespaceSnapshot",
+      "all_dagster_type_snaps_by_key": {
+        "Any": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Any",
+          "is_builtin": true,
+          "key": "Any",
+          "kind": {
+            "__enum__": "DagsterTypeKind.ANY"
+          },
+          "loader_schema_key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
+          "materializer_schema_key": null,
+          "name": "Any",
+          "type_param_keys": []
+        },
+        "Bool": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Bool",
+          "is_builtin": true,
+          "key": "Bool",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "materializer_schema_key": null,
+          "name": "Bool",
+          "type_param_keys": []
+        },
+        "Float": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Float",
+          "is_builtin": true,
+          "key": "Float",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "materializer_schema_key": null,
+          "name": "Float",
+          "type_param_keys": []
+        },
+        "Int": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Int",
+          "is_builtin": true,
+          "key": "Int",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "materializer_schema_key": null,
+          "name": "Int",
+          "type_param_keys": []
+        },
+        "Nothing": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Nothing",
+          "is_builtin": true,
+          "key": "Nothing",
+          "kind": {
+            "__enum__": "DagsterTypeKind.NOTHING"
+          },
+          "loader_schema_key": null,
+          "materializer_schema_key": null,
+          "name": "Nothing",
+          "type_param_keys": []
+        },
+        "String": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "String",
+          "is_builtin": true,
+          "key": "String",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "materializer_schema_key": null,
+          "name": "String",
+          "type_param_keys": []
+        }
+      }
+    },
+    "dep_structure_snapshot": {
+      "__class__": "DependencyStructureSnapshot",
+      "solid_invocation_snaps": [
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "op_asset_a",
+          "solid_name": "op_asset_a",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "num",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": [
+                {
+                  "__class__": "OutputHandleSnap",
+                  "output_name": "result",
+                  "solid_name": "op_asset_a"
+                }
+              ]
+            }
+          ],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "op_asset_b",
+          "solid_name": "op_asset_b",
+          "tags": {}
+        }
+      ]
+    },
+    "description": null,
+    "graph_def_name": "multi_asset_job",
+    "lineage_snapshot": null,
+    "mode_def_snaps": [
+      {
+        "__class__": "ModeDefSnap",
+        "description": null,
+        "logger_def_snaps": [
+          {
+            "__class__": "LoggerDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
+              "description": "The default colored console logger.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
+            },
+            "description": "The default colored console logger.",
+            "name": "console"
+          }
+        ],
+        "name": "default",
+        "resource_def_snaps": [
+          {
+            "__class__": "ResourceDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            },
+            "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
+            "name": "io_manager"
+          }
+        ],
+        "root_config_key": "Shape.68420c55741a33b18ef71c1b56d89e0ec12d5c06"
+      }
+    ],
+    "name": "multi_asset_job",
+    "solid_definitions_snapshot": {
+      "__class__": "SolidDefinitionsSnapshot",
+      "composite_solid_def_snaps": [],
+      "solid_def_snaps": [
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "op_asset_a",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "name": "num"
+            }
+          ],
+          "name": "op_asset_b",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        }
+      ]
+    },
+    "tags": {}
+  }
+  '''
+# ---
+# name: test_all_snapshot_ids[91]
+  'b7499dc1851fe912eb84bbbcead7d7db511e64d8'
+# ---
+# name: test_all_snapshot_ids[92]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -72528,10 +74613,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[91]
+# name: test_all_snapshot_ids[93]
   '52e9a3ca99126add43b9626288695fe94c05f8c5'
 # ---
-# name: test_all_snapshot_ids[92]
+# name: test_all_snapshot_ids[94]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -73518,10 +75603,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[93]
+# name: test_all_snapshot_ids[95]
   'c656e8e7694e5110568efa51930949e52595fcc5'
 # ---
-# name: test_all_snapshot_ids[94]
+# name: test_all_snapshot_ids[96]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -74551,10 +76636,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[95]
+# name: test_all_snapshot_ids[97]
   'c0668a7d87421329e47291f18575c0bfc0307acc'
 # ---
-# name: test_all_snapshot_ids[96]
+# name: test_all_snapshot_ids[98]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -75408,1173 +77493,9 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[97]
+# name: test_all_snapshot_ids[99]
   '913c310b609478d52a81ee83bdd4b095d0f2932d'
 # ---
-# name: test_all_snapshot_ids[98]
-  '''
-  {
-    "__class__": "PipelineSnapshot",
-    "config_schema_snapshot": {
-      "__class__": "ConfigSchemaSnapshot",
-      "all_config_snaps_by_key": {
-        "Any": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Any",
-          "key": "Any",
-          "kind": {
-            "__enum__": "ConfigTypeKind.ANY"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Bool": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Bool",
-          "key": "Bool",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.BOOL"
-          },
-          "type_param_keys": null
-        },
-        "Float": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Float",
-          "key": "Float",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.FLOAT"
-          },
-          "type_param_keys": null
-        },
-        "Int": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Int",
-          "key": "Int",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.INT"
-          },
-          "type_param_keys": null
-        },
-        "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Bool",
-            "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59"
-          ]
-        },
-        "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Float",
-            "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3"
-          ]
-        },
-        "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Int",
-            "Selector.a9799b971d12ace70a2d8803c883c863417d0725"
-          ]
-        },
-        "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "String",
-            "Selector.e04723c9d9937e3ab21206435b22247cfbe58269"
-          ]
-        },
-        "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "disabled",
-              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "enabled",
-              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Int"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Bool"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Float"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Any"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.081354663b9d4b8fbfd1cb8e358763912953913f": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "\"INFO\"",
-              "description": "The logger's threshold.",
-              "is_required": false,
-              "name": "log_level",
-              "type_key": "String"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "\"dagster\"",
-              "description": "The name of your logger.",
-              "is_required": false,
-              "name": "name",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.09d73f0755bf4752d3f121837669c8660dcf451e": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"retries\": {\"enabled\": {}}}",
-              "description": "Execute all steps in a single process.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
-              "description": "The default colored console logger.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
-              "is_required": false,
-              "name": "io_manager",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.27d4be3152e89c65ecb4ce8c588d8226cc827e0d": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"adder\": {}, \"op_1\": {}, \"op_2\": {}, \"plus_one\": {}}",
-              "description": null,
-              "is_required": false,
-              "name": "ops",
-              "type_key": "Shape.5403fe5383515d106ffe3bb7f1a927b1cbb4e8a9"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.27d4be3152e89c65ecb4ce8c588d8226cc827e0d",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.360ea318ffe78a111434a5bb7409ef66c9692290": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
-              "description": "Configure how steps are executed within a run.",
-              "is_required": false,
-              "name": "execution",
-              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": "Configure how loggers emit messages within a run.",
-              "is_required": false,
-              "name": "loggers",
-              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"plus_one\": {}, \"subgraph\": {\"ops\": {\"adder\": {}, \"op_1\": {}, \"op_2\": {}, \"plus_one\": {}}}}",
-              "description": "Configure runtime parameters for ops or assets.",
-              "is_required": false,
-              "name": "ops",
-              "type_key": "Shape.42ddf3fac74380a93f8508f2a0f6450afb177d35"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"io_manager\": {}}",
-              "description": "Configure how shared resources are implemented within a run.",
-              "is_required": false,
-              "name": "resources",
-              "type_key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.360ea318ffe78a111434a5bb7409ef66c9692290",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.42ddf3fac74380a93f8508f2a0f6450afb177d35": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "plus_one",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"ops\": {\"adder\": {}, \"op_1\": {}, \"op_2\": {}, \"plus_one\": {}}}",
-              "description": null,
-              "is_required": false,
-              "name": "subgraph",
-              "type_key": "Shape.27d4be3152e89c65ecb4ce8c588d8226cc827e0d"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.42ddf3fac74380a93f8508f2a0f6450afb177d35",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": "[DEPRECATED]",
-              "is_required": false,
-              "name": "marker_to_close",
-              "type_key": "String"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"enabled\": {}}",
-              "description": "Whether retries are enabled or not. By default, retries are enabled.",
-              "is_required": false,
-              "name": "retries",
-              "type_key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "path",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.5403fe5383515d106ffe3bb7f1a927b1cbb4e8a9": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "adder",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "op_1",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "op_2",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "plus_one",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.5403fe5383515d106ffe3bb7f1a927b1cbb4e8a9",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.743e47901855cb245064dd633e217bfcb49a11a7": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Any"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [],
-          "given_name": null,
-          "key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "console",
-              "type_key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "String": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "String",
-          "key": "String",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.STRING"
-          },
-          "type_param_keys": null
-        }
-      }
-    },
-    "dagster_type_namespace_snapshot": {
-      "__class__": "DagsterTypeNamespaceSnapshot",
-      "all_dagster_type_snaps_by_key": {
-        "Any": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Any",
-          "is_builtin": true,
-          "key": "Any",
-          "kind": {
-            "__enum__": "DagsterTypeKind.ANY"
-          },
-          "loader_schema_key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
-          "materializer_schema_key": null,
-          "name": "Any",
-          "type_param_keys": []
-        },
-        "Bool": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Bool",
-          "is_builtin": true,
-          "key": "Bool",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "materializer_schema_key": null,
-          "name": "Bool",
-          "type_param_keys": []
-        },
-        "Float": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Float",
-          "is_builtin": true,
-          "key": "Float",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "materializer_schema_key": null,
-          "name": "Float",
-          "type_param_keys": []
-        },
-        "Int": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Int",
-          "is_builtin": true,
-          "key": "Int",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "materializer_schema_key": null,
-          "name": "Int",
-          "type_param_keys": []
-        },
-        "Nothing": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Nothing",
-          "is_builtin": true,
-          "key": "Nothing",
-          "kind": {
-            "__enum__": "DagsterTypeKind.NOTHING"
-          },
-          "loader_schema_key": null,
-          "materializer_schema_key": null,
-          "name": "Nothing",
-          "type_param_keys": []
-        },
-        "String": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "String",
-          "is_builtin": true,
-          "key": "String",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "materializer_schema_key": null,
-          "name": "String",
-          "type_param_keys": []
-        }
-      }
-    },
-    "dep_structure_snapshot": {
-      "__class__": "DependencyStructureSnapshot",
-      "solid_invocation_snaps": [
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [
-            {
-              "__class__": "InputDependencySnap",
-              "input_name": "num",
-              "is_dynamic_collect": false,
-              "upstream_output_snaps": [
-                {
-                  "__class__": "OutputHandleSnap",
-                  "output_name": "result",
-                  "solid_name": "subgraph"
-                }
-              ]
-            }
-          ],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "plus_one",
-          "solid_name": "plus_one",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "subgraph",
-          "solid_name": "subgraph",
-          "tags": {}
-        }
-      ]
-    },
-    "description": null,
-    "graph_def_name": "nested_job",
-    "lineage_snapshot": null,
-    "mode_def_snaps": [
-      {
-        "__class__": "ModeDefSnap",
-        "description": null,
-        "logger_def_snaps": [
-          {
-            "__class__": "LoggerDefSnap",
-            "config_field_snap": {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
-              "description": "The default colored console logger.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
-            },
-            "description": "The default colored console logger.",
-            "name": "console"
-          }
-        ],
-        "name": "default",
-        "resource_def_snaps": [
-          {
-            "__class__": "ResourceDefSnap",
-            "config_field_snap": {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Any"
-            },
-            "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
-            "name": "io_manager"
-          }
-        ],
-        "root_config_key": "Shape.360ea318ffe78a111434a5bb7409ef66c9692290"
-      }
-    ],
-    "name": "nested_job",
-    "solid_definitions_snapshot": {
-      "__class__": "SolidDefinitionsSnapshot",
-      "composite_solid_def_snaps": [
-        {
-          "__class__": "CompositeSolidDefSnap",
-          "config_field_snap": null,
-          "dep_structure_snapshot": {
-            "__class__": "DependencyStructureSnapshot",
-            "solid_invocation_snaps": [
-              {
-                "__class__": "SolidInvocationSnap",
-                "input_dep_snaps": [
-                  {
-                    "__class__": "InputDependencySnap",
-                    "input_name": "num1",
-                    "is_dynamic_collect": false,
-                    "upstream_output_snaps": [
-                      {
-                        "__class__": "OutputHandleSnap",
-                        "output_name": "result",
-                        "solid_name": "op_1"
-                      }
-                    ]
-                  },
-                  {
-                    "__class__": "InputDependencySnap",
-                    "input_name": "num2",
-                    "is_dynamic_collect": false,
-                    "upstream_output_snaps": [
-                      {
-                        "__class__": "OutputHandleSnap",
-                        "output_name": "result",
-                        "solid_name": "op_2"
-                      }
-                    ]
-                  }
-                ],
-                "is_dynamic_mapped": false,
-                "solid_def_name": "adder",
-                "solid_name": "adder",
-                "tags": {}
-              },
-              {
-                "__class__": "SolidInvocationSnap",
-                "input_dep_snaps": [],
-                "is_dynamic_mapped": false,
-                "solid_def_name": "op_1",
-                "solid_name": "op_1",
-                "tags": {}
-              },
-              {
-                "__class__": "SolidInvocationSnap",
-                "input_dep_snaps": [],
-                "is_dynamic_mapped": false,
-                "solid_def_name": "op_2",
-                "solid_name": "op_2",
-                "tags": {}
-              },
-              {
-                "__class__": "SolidInvocationSnap",
-                "input_dep_snaps": [
-                  {
-                    "__class__": "InputDependencySnap",
-                    "input_name": "num",
-                    "is_dynamic_collect": false,
-                    "upstream_output_snaps": [
-                      {
-                        "__class__": "OutputHandleSnap",
-                        "output_name": "result",
-                        "solid_name": "adder"
-                      }
-                    ]
-                  }
-                ],
-                "is_dynamic_mapped": false,
-                "solid_def_name": "plus_one",
-                "solid_name": "plus_one",
-                "tags": {}
-              }
-            ]
-          },
-          "description": null,
-          "input_def_snaps": [],
-          "input_mapping_snaps": [],
-          "name": "subgraph",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "output_mapping_snaps": [
-            {
-              "__class__": "OutputMappingSnap",
-              "external_output_name": "result",
-              "mapped_output_name": "result",
-              "mapped_solid_name": "plus_one"
-            }
-          ],
-          "tags": {}
-        }
-      ],
-      "solid_def_snaps": [
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [
-            {
-              "__class__": "InputDefSnap",
-              "dagster_type_key": "Int",
-              "description": null,
-              "name": "num1"
-            },
-            {
-              "__class__": "InputDefSnap",
-              "dagster_type_key": "Int",
-              "description": null,
-              "name": "num2"
-            }
-          ],
-          "name": "adder",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [],
-          "name": "op_1",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [],
-          "name": "op_2",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [
-            {
-              "__class__": "InputDefSnap",
-              "dagster_type_key": "Int",
-              "description": null,
-              "name": "num"
-            }
-          ],
-          "name": "plus_one",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        }
-      ]
-    },
-    "tags": {}
-  }
-  '''
-# ---
-# name: test_all_snapshot_ids[99]
-  '8e137c24b2245e55025e1cc7b71a42b99425dbec'
-# ---
 # name: test_all_snapshot_ids[9]
-  'fecea634b65aad87fe0f284eace85c93cce0e30a'
+  '83550c493b290f45b1146188477ac99377d0d520'
 # ---

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_assets.ambr
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_assets.ambr
@@ -539,6 +539,11 @@
       dict({
         'freshnessInfo': None,
         'freshnessPolicy': None,
+        'id': 'test.test_repo.["asset_1"]',
+      }),
+      dict({
+        'freshnessInfo': None,
+        'freshnessPolicy': None,
         'id': 'test.test_repo.["downstream_dynamic_partitioned_asset"]',
       }),
       dict({
@@ -550,11 +555,6 @@
         'freshnessInfo': None,
         'freshnessPolicy': None,
         'id': 'test.test_repo.["fail_partition_materialization"]',
-      }),
-      dict({
-        'freshnessInfo': None,
-        'freshnessPolicy': None,
-        'id': 'test.test_repo.["asset_1"]',
       }),
       dict({
         'freshnessInfo': None,

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_solids.ambr
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_solids.ambr
@@ -138,6 +138,14 @@
           'invocations': list([
             dict({
               'pipeline': dict({
+                'name': 'asset_check_job',
+              }),
+              'solidHandle': dict({
+                'handleID': 'asset_1',
+              }),
+            }),
+            dict({
+              'pipeline': dict({
                 'name': 'failure_assets_job',
               }),
               'solidHandle': dict({
@@ -203,6 +211,14 @@
             dict({
               'pipeline': dict({
                 'name': '__ASSET_JOB_6',
+              }),
+              'solidHandle': dict({
+                'handleID': 'asset_1_my_check',
+              }),
+            }),
+            dict({
+              'pipeline': dict({
+                'name': 'asset_check_job',
               }),
               'solidHandle': dict({
                 'handleID': 'asset_1_my_check',

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
@@ -1907,7 +1907,7 @@ def define_asset_jobs():
 
 
 @asset_check(asset=asset_1, description="asset_1 check")
-def my_check():
+def my_check(asset_1):
     return AssetCheckResult(
         success=True,
         metadata={

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
@@ -1831,6 +1831,7 @@ def define_jobs():
         hanging_partition_asset_job,
         observation_job,
         failure_assets_job,
+        asset_check_job,
         foo_job,
         hanging_graph_asset_job,
         named_groups_job,
@@ -1914,6 +1915,9 @@ def my_check():
             "baz": "quux",
         },
     )
+
+
+asset_check_job = build_assets_job("asset_check_job", [asset_1], asset_checks=[my_check])
 
 
 def define_asset_checks():

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_checks.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_checks.py
@@ -1,5 +1,6 @@
 import time
 
+import pytest
 from dagster import AssetKey, DagsterEvent, DagsterEventType
 from dagster._core.definitions.asset_check_evaluation import (
     AssetCheckEvaluation,
@@ -634,10 +635,16 @@ class TestAssetChecks(ExecutingGraphQLContextTestMatrix):
         }
         new_materialization()
 
-    def test_launch_subset_with_only_check(self, graphql_context: WorkspaceRequestContext):
+    @pytest.mark.parametrize(
+        "job_name",
+        ["__ASSET_JOB_0", "asset_check_job"],
+    )
+    def test_launch_subset_with_only_check(
+        self, graphql_context: WorkspaceRequestContext, job_name
+    ):
         selector = infer_job_or_pipeline_selector(
             graphql_context,
-            "__ASSET_JOB_0",
+            job_name,
             asset_selection=[],
             asset_check_selection=[{"assetKey": {"path": ["asset_1"]}, "name": "my_check"}],
         )
@@ -673,3 +680,46 @@ class TestAssetChecks(ExecutingGraphQLContextTestMatrix):
         for log in logs:
             if log.dagster_event:
                 assert log.dagster_event.event_type != DagsterEventType.ASSET_MATERIALIZATION.value
+
+    def test_launch_subset_asset_and_included_check(self, graphql_context: WorkspaceRequestContext):
+        selector = infer_job_or_pipeline_selector(
+            graphql_context,
+            "asset_check_job",
+            asset_selection=[{"path": ["asset_1"]}],
+        )
+        result = execute_dagster_graphql(
+            graphql_context,
+            LAUNCH_PIPELINE_EXECUTION_MUTATION,
+            variables={
+                "executionParams": {
+                    "selector": selector,
+                    "mode": "default",
+                    "stepKeys": None,
+                }
+            },
+        )
+        print(result.data)  # ruff: noqa: T201
+        assert result.data["launchPipelineExecution"]["__typename"] == "LaunchRunSuccess"
+
+        run_id = result.data["launchPipelineExecution"]["run"]["runId"]
+        run = poll_for_finished_run(graphql_context.instance, run_id)
+
+        logs = graphql_context.instance.all_logs(run_id)
+        print(logs)  # ruff: noqa: T201
+        assert run.is_success
+
+        check_evaluations = [
+            log
+            for log in logs
+            if log.dagster_event
+            and log.dagster_event.event_type == DagsterEventType.ASSET_CHECK_EVALUATION
+        ]
+        assert len(check_evaluations) == 1
+
+        materializations = [
+            log
+            for log in logs
+            if log.dagster_event
+            and log.dagster_event.event_type == DagsterEventType.ASSET_MATERIALIZATION
+        ]
+        assert len(materializations) == 1

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_checks.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_checks.py
@@ -1,6 +1,5 @@
 import time
 
-import pytest
 from dagster import AssetKey, DagsterEvent, DagsterEventType
 from dagster._core.definitions.asset_check_evaluation import (
     AssetCheckEvaluation,

--- a/python_modules/dagster/dagster/_api/snapshot_execution_plan.py
+++ b/python_modules/dagster/dagster/_api/snapshot_execution_plan.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING, AbstractSet, Any, Mapping, Optional, Sequence
 
 import dagster._check as check
+from dagster._core.definitions.asset_check_spec import AssetCheckHandle
 from dagster._core.definitions.events import AssetKey
 from dagster._core.errors import DagsterUserCodeProcessError
 from dagster._core.execution.plan.state import KnownExecutionState
@@ -24,6 +25,7 @@ def sync_get_external_execution_plan_grpc(
     run_config: Mapping[str, Any],
     job_snapshot_id: str,
     asset_selection: Optional[AbstractSet[AssetKey]] = None,
+    asset_check_selection: Optional[AbstractSet[AssetCheckHandle]] = None,
     op_selection: Optional[Sequence[str]] = None,
     step_keys_to_execute: Optional[Sequence[str]] = None,
     known_state: Optional[KnownExecutionState] = None,
@@ -36,6 +38,9 @@ def sync_get_external_execution_plan_grpc(
     op_selection = check.opt_sequence_param(op_selection, "op_selection", of_type=str)
     asset_selection = check.opt_nullable_set_param(
         asset_selection, "asset_selection", of_type=AssetKey
+    )
+    asset_check_selection = check.opt_nullable_set_param(
+        asset_check_selection, "asset_check_selection", of_type=AssetCheckHandle
     )
     run_config = check.mapping_param(run_config, "run_config", key_type=str)
     check.opt_nullable_sequence_param(step_keys_to_execute, "step_keys_to_execute", of_type=str)
@@ -55,6 +60,7 @@ def sync_get_external_execution_plan_grpc(
                 known_state=known_state,
                 instance_ref=instance.get_ref() if instance and instance.is_persistent else None,
                 asset_selection=asset_selection,
+                asset_check_selection=asset_check_selection,
             )
         ),
         (ExecutionPlanSnapshot, ExecutionPlanSnapshotErrorData),

--- a/python_modules/dagster/dagster/_api/snapshot_job.py
+++ b/python_modules/dagster/dagster/_api/snapshot_job.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING, AbstractSet, Optional, Sequence
 
 import dagster._check as check
+from dagster._core.definitions.asset_check_spec import AssetCheckHandle
 from dagster._core.definitions.events import AssetKey
 from dagster._core.errors import DagsterUserCodeProcessError
 from dagster._core.host_representation.external_data import ExternalJobSubsetResult
@@ -17,6 +18,7 @@ def sync_get_external_job_subset_grpc(
     job_origin: ExternalJobOrigin,
     op_selection: Optional[Sequence[str]] = None,
     asset_selection: Optional[AbstractSet[AssetKey]] = None,
+    asset_check_selection: Optional[AbstractSet[AssetCheckHandle]] = None,
 ) -> ExternalJobSubsetResult:
     from dagster._grpc.client import DagsterGrpcClient
 
@@ -33,6 +35,7 @@ def sync_get_external_job_subset_grpc(
                 job_origin=job_origin,
                 op_selection=op_selection,
                 asset_selection=asset_selection,
+                asset_check_selection=asset_check_selection,
             ),
         ),
         ExternalJobSubsetResult,

--- a/python_modules/dagster/dagster/_cli/job.py
+++ b/python_modules/dagster/dagster/_cli/job.py
@@ -559,6 +559,7 @@ def _create_external_run(
         external_job_origin=external_job.get_external_origin(),
         job_code_origin=external_job.get_python_origin(),
         asset_selection=None,
+        asset_check_selection=None,
     )
 
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_check_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_spec.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import TYPE_CHECKING, NamedTuple, Optional, Union
+from typing import TYPE_CHECKING, Any, Mapping, NamedTuple, Optional, Union
 
 import dagster._check as check
 from dagster._annotations import PublicAttr, experimental
@@ -36,6 +36,13 @@ class AssetCheckHandle(NamedTuple):
 
     asset_key: PublicAttr[AssetKey]
     name: PublicAttr[str]
+
+    @staticmethod
+    def from_graphql_input(graphql_input: Mapping[str, Any]) -> "AssetCheckHandle":
+        return AssetCheckHandle(
+            asset_key=AssetKey.from_graphql_input(graphql_input["assetKey"]),
+            name=graphql_input["name"],
+        )
 
 
 @experimental

--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -817,16 +817,14 @@ def build_asset_selection_job(
                 for asset_check in asset_checks
                 if [spec for spec in asset_check.specs if spec.handle in asset_check_selection]
             ]
-        elif asset_selection is None:
-            # If assets were selected and checks were null, then include all checks on the selected assets
+        else:
+            # If assets were selected and checks weren't, then include all checks on the selected assets.
+            # Note: a future diff needs to add support for selecting assets, and not their checks.
             included_checks = [
                 asset_check
                 for asset_check in asset_checks
                 if asset_check.asset_key in check.not_none(asset_selection)
             ]
-        else:
-            # If checks were explicitly [], then exclude all checks
-            included_checks = []
 
     if partitions_def:
         for asset in included_assets:

--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -584,6 +584,10 @@ class AssetLayer(NamedTuple):
     def has_assets_defs(self) -> bool:
         return len(self.assets_defs_by_key) > 0
 
+    @property
+    def hash_asset_check_defs(self) -> bool:
+        return len(self.asset_checks_defs) > 0
+
     def has_assets_def_for_asset(self, asset_key: AssetKey) -> bool:
         return asset_key in self.assets_defs_by_key
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -789,18 +789,44 @@ def build_asset_selection_job(
         build_source_asset_observation_job,
     )
 
-    if asset_selection is not None:
-        (included_assets, excluded_assets) = _subset_assets_defs(assets, asset_selection)
-        included_checks = [
-            asset_check for asset_check in asset_checks if asset_check.asset_key in asset_selection
-        ]
-        included_source_assets = _subset_source_assets(source_assets, asset_selection)
+    asset_check_selection = (
+        asset_selection_data.asset_check_selection if asset_selection_data else None
+    )
 
-    else:
+    if not asset_selection and not asset_check_selection:
+        # no selections, include everything
         included_assets = list(assets)
         excluded_assets = []
-        included_checks = list(asset_checks)
         included_source_assets = []
+        included_checks = list(asset_checks)
+    else:
+        if asset_selection:
+            (included_assets, excluded_assets) = _subset_assets_defs(assets, asset_selection)
+            included_source_assets = _subset_source_assets(source_assets, asset_selection)
+        else:
+            # if checks were specified, then exclude all assets
+            included_assets = []
+            excluded_assets = list(assets)
+            included_source_assets = []
+
+        if asset_check_selection:
+            # NOTE: This filters to a checks def if any of the included specs are in the selection.
+            # This needs to change to fully subsetting checks in multi assets.
+            included_checks = [
+                asset_check
+                for asset_check in asset_checks
+                if [spec for spec in asset_check.specs if spec.handle in asset_check_selection]
+            ]
+        elif asset_selection is None:
+            # If assets were selected and checks were null, then include all checks on the selected assets
+            included_checks = [
+                asset_check
+                for asset_check in asset_checks
+                if asset_check.asset_key in check.not_none(asset_selection)
+            ]
+        else:
+            # If checks were explicitly [], then exclude all checks
+            included_checks = []
 
     if partitions_def:
         for asset in included_assets:

--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -586,7 +586,7 @@ class AssetLayer(NamedTuple):
 
     @property
     def hash_asset_check_defs(self) -> bool:
-        return len(self.asset_checks_defs) > 0
+        return len(self.asset_checks_defs_by_node_handle) > 0
 
     def has_assets_def_for_asset(self, asset_key: AssetKey) -> bool:
         return asset_key in self.assets_defs_by_key

--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -793,14 +793,14 @@ def build_asset_selection_job(
         asset_selection_data.asset_check_selection if asset_selection_data else None
     )
 
-    if not asset_selection and not asset_check_selection:
+    if asset_selection is None and asset_check_selection is None:
         # no selections, include everything
         included_assets = list(assets)
         excluded_assets = []
         included_source_assets = []
         included_checks = list(asset_checks)
     else:
-        if asset_selection:
+        if asset_selection is not None:
             (included_assets, excluded_assets) = _subset_assets_defs(assets, asset_selection)
             included_source_assets = _subset_source_assets(source_assets, asset_selection)
         else:
@@ -809,7 +809,7 @@ def build_asset_selection_job(
             excluded_assets = list(assets)
             included_source_assets = []
 
-        if asset_check_selection:
+        if asset_check_selection is not None:
             # NOTE: This filters to a checks def if any of the included specs are in the selection.
             # This needs to change to fully subsetting checks in multi assets.
             included_checks = [

--- a/python_modules/dagster/dagster/_core/definitions/job_base.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_base.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, AbstractSet, Iterable, Optional
 
 from typing_extensions import Self
 
+from dagster._core.definitions.asset_check_spec import AssetCheckHandle
 from dagster._core.definitions.events import AssetKey
 
 if TYPE_CHECKING:
@@ -26,6 +27,7 @@ class IJob(ABC):
         *,
         op_selection: Optional[Iterable[str]] = None,
         asset_selection: Optional[AbstractSet[AssetKey]] = None,
+        asset_check_selection: Optional[AbstractSet[AssetCheckHandle]] = None,
     ) -> "IJob":
         pass
 
@@ -59,10 +61,15 @@ class InMemoryJob(IJob):
         *,
         op_selection: Optional[Iterable[str]] = None,
         asset_selection: Optional[AbstractSet[AssetKey]] = None,
+        asset_check_selection: Optional[AbstractSet[AssetCheckHandle]] = None,
     ) -> Self:
         op_selection = set(op_selection) if op_selection else None
         return InMemoryJob(
-            self._job_def.get_subset(op_selection=op_selection, asset_selection=asset_selection)
+            self._job_def.get_subset(
+                op_selection=op_selection,
+                asset_selection=asset_selection,
+                asset_check_selection=asset_check_selection,
+            )
         )
 
     @property

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -757,9 +757,7 @@ class JobDefinition(IHasInternalInit):
         asset_check_selection: Optional[AbstractSet[AssetCheckHandle]] = None,
     ) -> Self:
         asset_selection = check.opt_set_param(asset_selection, "asset_selection", AssetKey)
-        asset_check_selection = check.opt_set_param(
-            asset_check_selection, "asset_check_selection", AssetCheckHandle
-        )
+        check.opt_set_param(asset_check_selection, "asset_check_selection", AssetCheckHandle)
 
         nonexistent_assets = [
             asset
@@ -785,7 +783,7 @@ class JobDefinition(IHasInternalInit):
 
         nonexistent_asset_checks = [
             asset_check
-            for asset_check in asset_check_selection
+            for asset_check in asset_check_selection or set()
             if asset_check not in all_check_handles
         ]
         nonexistent_asset_check_strings = [

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -26,6 +26,7 @@ from dagster._annotations import deprecated, experimental_param, public
 from dagster._config import Field, Shape, StringSource
 from dagster._config.config_type import ConfigType
 from dagster._config.validate import validate_config
+from dagster._core.definitions.asset_check_spec import AssetCheckHandle
 from dagster._core.definitions.dependency import (
     Node,
     NodeHandle,
@@ -734,24 +735,31 @@ class JobDefinition(IHasInternalInit):
         *,
         op_selection: Optional[Iterable[str]] = None,
         asset_selection: Optional[AbstractSet[AssetKey]] = None,
+        asset_check_selection: Optional[AbstractSet[AssetCheckHandle]] = None,
     ) -> Self:
         check.invariant(
-            not (op_selection and asset_selection),
-            "op_selection and asset_selection cannot both be provided as args to"
+            not (op_selection and (asset_selection or asset_check_selection)),
+            "op_selection cannot be provided with asset_selection or asset_check_selection to"
             " execute_in_process",
         )
         if op_selection:
             return self._get_job_def_for_op_selection(op_selection)
-        if asset_selection:
-            return self._get_job_def_for_asset_selection(asset_selection)
+        if asset_selection or asset_check_selection:
+            return self._get_job_def_for_asset_selection(
+                asset_selection=asset_selection, asset_check_selection=asset_check_selection
+            )
         else:
             return self
 
     def _get_job_def_for_asset_selection(
         self,
         asset_selection: Optional[AbstractSet[AssetKey]] = None,
+        asset_check_selection: Optional[AbstractSet[AssetCheckHandle]] = None,
     ) -> Self:
         asset_selection = check.opt_set_param(asset_selection, "asset_selection", AssetKey)
+        asset_check_selection = check.opt_set_param(
+            asset_check_selection, "asset_check_selection", AssetCheckHandle
+        )
 
         nonexistent_assets = [
             asset
@@ -769,8 +777,30 @@ class JobDefinition(IHasInternalInit):
                 "Assets provided in asset_selection argument "
                 f"{', '.join(nonexistent_asset_strings)} do not exist in parent asset group or job."
             )
+
+        all_check_handles = set()
+        for asset_checks_def in self.asset_layer.asset_checks_defs:
+            for spec in asset_checks_def.specs:
+                all_check_handles.add(spec.handle)
+
+        nonexistent_asset_checks = [
+            asset_check
+            for asset_check in asset_check_selection
+            if asset_check not in all_check_handles
+        ]
+        nonexistent_asset_check_strings = [
+            str(asset_check) for asset_check in nonexistent_asset_checks
+        ]
+        if nonexistent_asset_checks:
+            raise DagsterInvalidSubsetError(
+                "Asset checks provided in asset_check_selection argument"
+                f" {', '.join(nonexistent_asset_check_strings)} do not exist in parent asset group"
+                " or job."
+            )
+
         asset_selection_data = AssetSelectionData(
             asset_selection=asset_selection,
+            asset_check_selection=asset_check_selection,
             parent_job_def=self,
         )
 

--- a/python_modules/dagster/dagster/_core/definitions/reconstruct.py
+++ b/python_modules/dagster/dagster/_core/definitions/reconstruct.py
@@ -33,6 +33,7 @@ from dagster._core.code_pointer import (
     ModuleCodePointer,
     get_python_file_from_target,
 )
+from dagster._core.definitions.asset_check_spec import AssetCheckHandle
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.origin import (
     DEFAULT_DAGSTER_ENTRY_POINT,
@@ -208,6 +209,7 @@ class ReconstructableJob(
             ("job_name", str),
             ("op_selection", Optional[AbstractSet[str]]),
             ("asset_selection", Optional[AbstractSet[AssetKey]]),
+            ("asset_check_selection", Optional[AbstractSet[AssetCheckHandle]]),
         ],
     ),
     IJob,
@@ -231,6 +233,7 @@ class ReconstructableJob(
         job_name: str,
         op_selection: Optional[Iterable[str]] = None,
         asset_selection: Optional[AbstractSet[AssetKey]] = None,
+        asset_check_selection: Optional[AbstractSet[AssetCheckHandle]] = None,
     ):
         op_selection = set(op_selection) if op_selection else None
         return super(ReconstructableJob, cls).__new__(
@@ -240,6 +243,9 @@ class ReconstructableJob(
             op_selection=check.opt_nullable_set_param(op_selection, "op_selection", of_type=str),
             asset_selection=check.opt_nullable_set_param(
                 asset_selection, "asset_selection", AssetKey
+            ),
+            asset_check_selection=check.opt_nullable_set_param(
+                asset_check_selection, "asset_check_selection", AssetCheckHandle
             ),
         )
 
@@ -266,10 +272,12 @@ class ReconstructableJob(
         *,
         op_selection: Optional[Iterable[str]] = None,
         asset_selection: Optional[AbstractSet[AssetKey]] = None,
+        asset_check_selection: Optional[AbstractSet[AssetCheckHandle]] = None,
     ) -> Self:
-        if op_selection and asset_selection:
+        if op_selection and (asset_selection or asset_check_selection):
             check.failed(
-                "op_selection and asset_selection cannot both be provided as arguments",
+                "op_selection and asset_selection or asset_check_selection cannot both be provided"
+                " as arguments",
             )
         op_selection = set(op_selection) if op_selection else None
         return ReconstructableJob(
@@ -277,6 +285,7 @@ class ReconstructableJob(
             job_name=self.job_name,
             op_selection=op_selection,
             asset_selection=asset_selection,
+            asset_check_selection=asset_check_selection,
         )
 
     def describe(self) -> str:

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
@@ -15,6 +15,7 @@ from typing import (
 
 import dagster._check as check
 from dagster._annotations import public
+from dagster._core.definitions.asset_check_spec import AssetCheckHandle
 from dagster._core.definitions.asset_graph import AssetGraph, InternalAssetGraph
 from dagster._core.definitions.assets_job import (
     ASSET_BASE_JOB_PREFIX,
@@ -305,9 +306,14 @@ class RepositoryDefinition:
         job_name: str,
         op_selection: Optional[Iterable[str]] = None,
         asset_selection: Optional[AbstractSet[AssetKey]] = None,
+        asset_check_selection: Optional[AbstractSet[AssetCheckHandle]] = None,
     ):
         defn = self.get_job(job_name)
-        return defn.get_subset(op_selection=op_selection, asset_selection=asset_selection)
+        return defn.get_subset(
+            op_selection=op_selection,
+            asset_selection=asset_selection,
+            asset_check_selection=asset_check_selection,
+        )
 
     @public
     def load_asset_value(

--- a/python_modules/dagster/dagster/_core/definitions/run_config.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_config.py
@@ -227,6 +227,7 @@ def get_inputs_field(
         elif (
             # if you have asset definitions, input will be loaded from the source asset
             asset_layer.has_assets_defs
+            or asset_layer.hash_asset_check_defs
             and asset_layer.asset_key_for_input(handle, name)
             and not has_upstream
         ):

--- a/python_modules/dagster/dagster/_core/definitions/selector.py
+++ b/python_modules/dagster/dagster/_core/definitions/selector.py
@@ -3,6 +3,7 @@ from typing import AbstractSet, Iterable, NamedTuple, Optional, Sequence
 from typing_extensions import Self
 
 import dagster._check as check
+from dagster._core.definitions.asset_check_spec import AssetCheckHandle
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.repository_definition import SINGLETON_REPOSITORY_NAME
 from dagster._serdes import create_snapshot_id, whitelist_for_serdes
@@ -17,6 +18,7 @@ class JobSubsetSelector(
             ("job_name", str),
             ("op_selection", Optional[Sequence[str]]),
             ("asset_selection", Optional[AbstractSet[AssetKey]]),
+            ("asset_check_selection", Optional[AbstractSet[AssetCheckHandle]]),
         ],
     )
 ):
@@ -29,8 +31,10 @@ class JobSubsetSelector(
         job_name: str,
         op_selection: Optional[Sequence[str]],
         asset_selection: Optional[Iterable[AssetKey]] = None,
+        asset_check_selection: Optional[Iterable[AssetCheckHandle]] = None,
     ):
         asset_selection = set(asset_selection) if asset_selection else None
+        asset_check_selection = set(asset_check_selection) if asset_check_selection else None
         return super(JobSubsetSelector, cls).__new__(
             cls,
             location_name=check.str_param(location_name, "location_name"),
@@ -39,6 +43,9 @@ class JobSubsetSelector(
             op_selection=check.opt_nullable_sequence_param(op_selection, "op_selection", str),
             asset_selection=check.opt_nullable_set_param(
                 asset_selection, "asset_selection", AssetKey
+            ),
+            asset_check_selection=check.opt_nullable_set_param(
+                asset_check_selection, "asset_check_selection", AssetCheckHandle
             ),
         )
 

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -905,6 +905,7 @@ def submit_run_request(
         external_job_origin=external_job.get_external_origin(),
         job_code_origin=external_job.get_python_origin(),
         asset_selection=frozenset(run_request.asset_selection),
+        asset_check_selection=None,
     )
 
     instance.submit_run(run.run_id, workspace)

--- a/python_modules/dagster/dagster/_core/execution/job_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/job_backfill.py
@@ -334,6 +334,7 @@ def create_backfill_run(
         asset_selection=(
             frozenset(backfill_job.asset_selection) if backfill_job.asset_selection else None
         ),
+        asset_check_selection=None,
     )
 
 

--- a/python_modules/dagster/dagster/_core/host_representation/code_location.py
+++ b/python_modules/dagster/dagster/_core/host_representation/code_location.py
@@ -129,7 +129,11 @@ class CodeLocation(AbstractContextManager):
         an op selection is specified, which requires access to the underlying JobDefinition
         to generate the subsetted pipeline snapshot.
         """
-        if not selector.op_selection and not selector.asset_selection:
+        if (
+            not selector.op_selection
+            and not selector.asset_selection
+            and not selector.asset_check_selection
+        ):
             return self.get_repository(selector.repository_name).get_full_external_job(
                 selector.job_name
             )
@@ -369,6 +373,7 @@ class InProcessCodeLocation(CodeLocation):
             selector.job_name,
             selector.op_selection,
             selector.asset_selection,
+            selector.asset_check_selection,
         )
 
     def get_external_execution_plan(
@@ -393,6 +398,7 @@ class InProcessCodeLocation(CodeLocation):
             ).get_subset(
                 op_selection=external_job.resolved_op_selection,
                 asset_selection=external_job.asset_selection,
+                asset_check_selection=external_job.asset_check_selection,
             ),
             run_config=run_config,
             step_keys_to_execute=step_keys_to_execute,
@@ -731,6 +737,13 @@ class GrpcServerCodeLocation(CodeLocation):
             if external_job.asset_selection is not None
             else None
         )
+        asset_check_selection = (
+            frozenset(
+                check.opt_set_param(external_job.asset_check_selection, "asset_check_selection")
+            )
+            if external_job.asset_check_selection is not None
+            else None
+        )
 
         execution_plan_snapshot_or_error = sync_get_external_execution_plan_grpc(
             api_client=self.client,
@@ -738,6 +751,7 @@ class GrpcServerCodeLocation(CodeLocation):
             run_config=run_config,
             job_snapshot_id=external_job.identifying_job_snapshot_id,
             asset_selection=asset_selection,
+            asset_check_selection=asset_check_selection,
             op_selection=external_job.op_selection,
             step_keys_to_execute=step_keys_to_execute,
             known_state=known_state,
@@ -763,6 +777,7 @@ class GrpcServerCodeLocation(CodeLocation):
             job_handle.get_external_origin(),
             selector.op_selection,
             selector.asset_selection,
+            selector.asset_check_selection,
         )
 
     def get_external_partition_config(

--- a/python_modules/dagster/dagster/_core/host_representation/external.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external.py
@@ -16,6 +16,7 @@ from typing import (
 
 import dagster._check as check
 from dagster._config.snap import ConfigFieldSnap, ConfigSchemaSnapshot
+from dagster._core.definitions.asset_check_spec import AssetCheckHandle
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.metadata import (
     MetadataValue,
@@ -381,6 +382,14 @@ class ExternalJob(RepresentedJob):
     def asset_selection(self) -> Optional[AbstractSet[AssetKey]]:
         return (
             self._job_index.job_snapshot.lineage_snapshot.asset_selection
+            if self._job_index.job_snapshot.lineage_snapshot
+            else None
+        )
+
+    @property
+    def asset_check_selection(self) -> Optional[AbstractSet[AssetCheckHandle]]:
+        return (
+            self._job_index.job_snapshot.lineage_snapshot.asset_check_selection
             if self._job_index.job_snapshot.lineage_snapshot
             else None
         )

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -1589,6 +1589,7 @@ class DagsterInstance(DynamicPartitionsStore):
             parent_job_snapshot=external_job.parent_job_snapshot,
             op_selection=parent_run.op_selection,
             asset_selection=parent_run.asset_selection,
+            asset_check_selection=parent_run.asset_check_selection,
             external_job_origin=external_job.get_external_origin(),
             job_code_origin=external_job.get_python_origin(),
         )

--- a/python_modules/dagster/dagster/_core/selector/subset_selector.py
+++ b/python_modules/dagster/dagster/_core/selector/subset_selector.py
@@ -85,7 +85,7 @@ class AssetSelectionData(
         "_AssetSelectionData",
         [
             ("asset_selection", AbstractSet[AssetKey]),
-            ("asset_check_selection", AbstractSet[AssetCheckHandle]),
+            ("asset_check_selection", Optional[AbstractSet[AssetCheckHandle]]),
             ("parent_job_def", "JobDefinition"),
         ],
     )
@@ -101,17 +101,17 @@ class AssetSelectionData(
     def __new__(
         cls,
         asset_selection: AbstractSet[AssetKey],
-        asset_check_selection: AbstractSet[AssetCheckHandle],
+        asset_check_selection: Optional[AbstractSet[AssetCheckHandle]],
         parent_job_def: "JobDefinition",
     ):
         from dagster._core.definitions.job_definition import JobDefinition
 
+        check.opt_set_param(asset_check_selection, "asset_check_selection", AssetCheckHandle)
+
         return super(AssetSelectionData, cls).__new__(
             cls,
             asset_selection=check.set_param(asset_selection, "asset_selection", AssetKey),
-            asset_check_selection=check.set_param(
-                asset_check_selection, "asset_check_selection", AssetCheckHandle
-            ),
+            asset_check_selection=asset_check_selection,
             parent_job_def=check.inst_param(parent_job_def, "parent_job_def", JobDefinition),
         )
 

--- a/python_modules/dagster/dagster/_core/selector/subset_selector.py
+++ b/python_modules/dagster/dagster/_core/selector/subset_selector.py
@@ -23,6 +23,7 @@ from typing import (
 
 from typing_extensions import Literal, TypeAlias
 
+from dagster._core.definitions.asset_check_spec import AssetCheckHandle
 from dagster._core.definitions.dependency import DependencyStructure
 from dagster._core.definitions.events import AssetKey
 from dagster._core.errors import DagsterExecutionStepNotFoundError, DagsterInvalidSubsetError
@@ -84,6 +85,7 @@ class AssetSelectionData(
         "_AssetSelectionData",
         [
             ("asset_selection", AbstractSet[AssetKey]),
+            ("asset_check_selection", AbstractSet[AssetCheckHandle]),
             ("parent_job_def", "JobDefinition"),
         ],
     )
@@ -96,12 +98,20 @@ class AssetSelectionData(
             pipeline snapshot lineage.
     """
 
-    def __new__(cls, asset_selection: AbstractSet[AssetKey], parent_job_def: "JobDefinition"):
+    def __new__(
+        cls,
+        asset_selection: AbstractSet[AssetKey],
+        asset_check_selection: AbstractSet[AssetCheckHandle],
+        parent_job_def: "JobDefinition",
+    ):
         from dagster._core.definitions.job_definition import JobDefinition
 
         return super(AssetSelectionData, cls).__new__(
             cls,
             asset_selection=check.set_param(asset_selection, "asset_selection", AssetKey),
+            asset_check_selection=check.set_param(
+                asset_check_selection, "asset_check_selection", AssetCheckHandle
+            ),
             parent_job_def=check.inst_param(parent_job_def, "parent_job_def", JobDefinition),
         )
 

--- a/python_modules/dagster/dagster/_core/snap/job_snapshot.py
+++ b/python_modules/dagster/dagster/_core/snap/job_snapshot.py
@@ -21,6 +21,7 @@ from dagster._config import (
     Shape,
     get_builtin_scalar_by_name,
 )
+from dagster._core.definitions.asset_check_spec import AssetCheckHandle
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.job_definition import (
     JobDefinition,
@@ -176,6 +177,7 @@ class JobSnapshot(
                     cls.from_job_def(job_def.asset_selection_data.parent_job_def)
                 ),
                 asset_selection=job_def.asset_selection_data.asset_selection,
+                asset_check_selection=job_def.asset_selection_data.asset_check_selection,
             )
 
         return JobSnapshot(
@@ -417,6 +419,7 @@ class JobLineageSnapshot(
             ("op_selection", Optional[Sequence[str]]),
             ("resolved_op_selection", Optional[AbstractSet[str]]),
             ("asset_selection", Optional[AbstractSet[AssetKey]]),
+            ("asset_check_selection", Optional[AbstractSet[AssetCheckHandle]]),
         ],
     )
 ):
@@ -426,6 +429,7 @@ class JobLineageSnapshot(
         op_selection: Optional[Sequence[str]] = None,
         resolved_op_selection: Optional[AbstractSet[str]] = None,
         asset_selection: Optional[AbstractSet[AssetKey]] = None,
+        asset_check_selection: Optional[AbstractSet[AssetCheckHandle]] = None,
     ):
         check.opt_set_param(resolved_op_selection, "resolved_op_selection", of_type=str)
         return super(JobLineageSnapshot, cls).__new__(
@@ -434,4 +438,5 @@ class JobLineageSnapshot(
             op_selection,
             resolved_op_selection,
             asset_selection,
+            asset_check_selection,
         )

--- a/python_modules/dagster/dagster/_core/storage/dagster_run.py
+++ b/python_modules/dagster/dagster/_core/storage/dagster_run.py
@@ -17,6 +17,7 @@ from typing_extensions import Self
 
 import dagster._check as check
 from dagster._annotations import PublicAttr, public
+from dagster._core.definitions.asset_check_spec import AssetCheckHandle
 from dagster._core.definitions.events import AssetKey
 from dagster._core.origin import JobPythonOrigin
 from dagster._core.storage.tags import PARENT_RUN_ID_TAG, ROOT_RUN_ID_TAG
@@ -236,6 +237,7 @@ class DagsterRun(
             ("run_id", str),
             ("run_config", Mapping[str, object]),
             ("asset_selection", Optional[AbstractSet[AssetKey]]),
+            ("asset_check_selection", Optional[AbstractSet[AssetCheckHandle]]),
             ("op_selection", Optional[Sequence[str]]),
             ("resolved_op_selection", Optional[AbstractSet[str]]),
             ("step_keys_to_execute", Optional[Sequence[str]]),
@@ -261,6 +263,7 @@ class DagsterRun(
         run_id: Optional[str] = None,
         run_config: Optional[Mapping[str, object]] = None,
         asset_selection: Optional[AbstractSet[AssetKey]] = None,
+        asset_check_selection: Optional[AbstractSet[AssetCheckHandle]] = None,
         op_selection: Optional[Sequence[str]] = None,
         resolved_op_selection: Optional[AbstractSet[str]] = None,
         step_keys_to_execute: Optional[Sequence[str]] = None,
@@ -292,6 +295,9 @@ class DagsterRun(
         asset_selection = check.opt_nullable_set_param(
             asset_selection, "asset_selection", of_type=AssetKey
         )
+        asset_check_selection = check.opt_nullable_set_param(
+            asset_check_selection, "asset_check_selection", of_type=AssetCheckHandle
+        )
 
         # Placing this with the other imports causes a cyclic import
         # https://github.com/dagster-io/dagster/issues/3181
@@ -315,6 +321,7 @@ class DagsterRun(
             run_config=check.opt_mapping_param(run_config, "run_config", key_type=str),
             op_selection=op_selection,
             asset_selection=asset_selection,
+            asset_check_selection=asset_check_selection,
             resolved_op_selection=resolved_op_selection,
             step_keys_to_execute=step_keys_to_execute,
             status=check.opt_inst_param(

--- a/python_modules/dagster/dagster/_core/test_utils.py
+++ b/python_modules/dagster/dagster/_core/test_utils.py
@@ -149,6 +149,7 @@ def create_run_for_test(
     external_job_origin=None,
     job_code_origin=None,
     asset_selection=None,
+    asset_check_selection=None,
     op_selection=None,
 ):
     return instance.create_run(
@@ -167,6 +168,7 @@ def create_run_for_test(
         external_job_origin=external_job_origin,
         job_code_origin=job_code_origin,
         asset_selection=asset_selection,
+        asset_check_selection=asset_check_selection,
         op_selection=op_selection,
     )
 

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -273,6 +273,7 @@ def submit_asset_run(
         external_job_origin=external_job.get_external_origin(),
         job_code_origin=external_job.get_python_origin(),
         asset_selection=frozenset(asset_keys),
+        asset_check_selection=None,
     )
     instance.submit_run(run.run_id, workspace)
     return run

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -1027,4 +1027,5 @@ def _create_sensor_run(
         asset_selection=(
             frozenset(run_request.asset_selection) if run_request.asset_selection else None
         ),
+        asset_check_selection=None,
     )

--- a/python_modules/dagster/dagster/_grpc/impl.py
+++ b/python_modules/dagster/dagster/_grpc/impl.py
@@ -9,6 +9,7 @@ import pendulum
 
 import dagster._check as check
 from dagster._core.definitions import ScheduleEvaluationContext
+from dagster._core.definitions.asset_check_spec import AssetCheckHandle
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionsDefinition
@@ -264,12 +265,14 @@ def get_external_pipeline_subset_result(
     job_name: str,
     op_selection: Optional[Sequence[str]],
     asset_selection: Optional[AbstractSet[AssetKey]],
+    asset_check_selection: Optional[AbstractSet[AssetCheckHandle]],
 ):
     try:
         definition = repo_def.get_maybe_subset_job_def(
             job_name,
             op_selection=op_selection,
             asset_selection=asset_selection,
+            asset_check_selection=asset_check_selection,
         )
         external_job_data = external_job_data_from_def(definition)
         return ExternalJobSubsetResult(success=True, external_job_data=external_job_data)
@@ -504,6 +507,7 @@ def get_external_execution_plan_snapshot(
             job_name,
             op_selection=args.op_selection,
             asset_selection=args.asset_selection,
+            asset_check_selection=args.asset_check_selection,
         )
 
         return snapshot_from_execution_plan(

--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -584,6 +584,7 @@ class DagsterApiServer(DagsterApiServicer):
                     job_subset_snapshot_args.job_origin.job_name,
                     job_subset_snapshot_args.op_selection,
                     job_subset_snapshot_args.asset_selection,
+                    job_subset_snapshot_args.asset_check_selection,
                 )
             )
         except Exception:

--- a/python_modules/dagster/dagster/_grpc/types.py
+++ b/python_modules/dagster/dagster/_grpc/types.py
@@ -4,6 +4,7 @@ from typing import AbstractSet, Any, Mapping, NamedTuple, Optional, Sequence
 
 import dagster._check as check
 from dagster._core.code_pointer import CodePointer
+from dagster._core.definitions.asset_check_spec import AssetCheckHandle
 from dagster._core.definitions.events import AssetKey
 from dagster._core.execution.plan.state import KnownExecutionState
 from dagster._core.execution.retries import RetryMode
@@ -39,6 +40,7 @@ class ExecutionPlanSnapshotArgs(
             ("known_state", Optional[KnownExecutionState]),
             ("instance_ref", Optional[InstanceRef]),
             ("asset_selection", Optional[AbstractSet[AssetKey]]),
+            ("asset_check_selection", Optional[AbstractSet[AssetCheckHandle]]),
             ("mode", str),
         ],
     )
@@ -53,6 +55,7 @@ class ExecutionPlanSnapshotArgs(
         known_state: Optional[KnownExecutionState] = None,
         instance_ref: Optional[InstanceRef] = None,
         asset_selection: Optional[AbstractSet[AssetKey]] = None,
+        asset_check_selection: Optional[AbstractSet[AssetCheckHandle]] = None,
         mode: str = DEFAULT_MODE_NAME,
     ):
         return super(ExecutionPlanSnapshotArgs, cls).__new__(
@@ -69,6 +72,9 @@ class ExecutionPlanSnapshotArgs(
             instance_ref=check.opt_inst_param(instance_ref, "instance_ref", InstanceRef),
             asset_selection=check.opt_nullable_set_param(
                 asset_selection, "asset_selection", of_type=AssetKey
+            ),
+            asset_check_selection=check.opt_nullable_set_param(
+                asset_check_selection, "asset_check_selection", of_type=AssetCheckHandle
             ),
         )
 
@@ -480,6 +486,7 @@ class JobSubsetSnapshotArgs(
             ("job_origin", ExternalJobOrigin),
             ("op_selection", Optional[Sequence[str]]),
             ("asset_selection", Optional[AbstractSet[AssetKey]]),
+            ("asset_check_selection", Optional[AbstractSet[AssetCheckHandle]]),
         ],
     )
 ):
@@ -488,6 +495,7 @@ class JobSubsetSnapshotArgs(
         job_origin: ExternalJobOrigin,
         op_selection: Optional[Sequence[str]],
         asset_selection: Optional[AbstractSet[AssetKey]] = None,
+        asset_check_selection: Optional[AbstractSet[AssetCheckHandle]] = None,
     ):
         return super(JobSubsetSnapshotArgs, cls).__new__(
             cls,
@@ -496,6 +504,9 @@ class JobSubsetSnapshotArgs(
                 op_selection, "op_selection", of_type=str
             ),
             asset_selection=check.opt_nullable_set_param(asset_selection, "asset_selection"),
+            asset_check_selection=check.opt_nullable_set_param(
+                asset_check_selection, "asset_check_selection"
+            ),
         )
 
 

--- a/python_modules/dagster/dagster/_scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/_scheduler/scheduler.py
@@ -888,6 +888,7 @@ def _create_scheduler_run(
         asset_selection=(
             frozenset(run_request.asset_selection) if run_request.asset_selection else None
         ),
+        asset_check_selection=None,
     )
 
 

--- a/python_modules/dagster/dagster_tests/launcher_tests/test_default_run_launcher.py
+++ b/python_modules/dagster/dagster_tests/launcher_tests/test_default_run_launcher.py
@@ -222,6 +222,7 @@ def test_successful_run_from_pending(
         job_code_origin=external_job.get_python_origin(),
         asset_selection=None,
         op_selection=None,
+        asset_check_selection=None,
     )
 
     run_id = created_run.run_id

--- a/python_modules/dagster/dagster_tests/launcher_tests/test_persistent_grpc_run_launcher.py
+++ b/python_modules/dagster/dagster_tests/launcher_tests/test_persistent_grpc_run_launcher.py
@@ -148,6 +148,7 @@ def test_run_from_pending_repository():
                     job_code_origin=external_job.get_python_origin(),
                     asset_selection=None,
                     op_selection=None,
+                    asset_check_selection=None,
                 )
 
                 run_id = dagster_run.run_id


### PR DESCRIPTION
Enable executing specific checks by passing an `asset_check_selection` through an incredible number of layers.

Wrapping asset_selection and asset_check_selection would make type signatures a bit more concise, but I think there'd be a similar amount of distributed logic. This certainly doesn't help the situation, but I don't think it hurts it tooo much...

The initial intention is to support two cases from the front end:
- continue supporting the behavior that clicking materialize on an asset both materializes and runs checks. This looks like:
  - asset_selection is None, and asset_check_selection is None: execute all assets and checks in a job
  - asset_selection is [some asset], and asset_check_selection is None: execute some_asset and all checks on it
- support running an individual check
  - asset_selection is [], and asset_check_selection is [my_check]: execute only my_check

In the future we'll support
- materialize an asset without running checks
  - asset_selection is [my_asset], and asset_check_selection is []
- arbitrary combinations of checks and assets