### PR TITLE
Bring back the info output on the dagster-webserver CLI

### DIFF
--- a/integration_tests/test_suites/daemon-test-suite/dagster_dev_command_tests/test_dagster_dev_command.py
+++ b/integration_tests/test_suites/daemon-test-suite/dagster_dev_command_tests/test_dagster_dev_command.py
@@ -48,8 +48,6 @@ def test_dagster_dev_command_workspace():
                         str(dagit_port),
                         "--log-level",
                         "debug",
-                        "--webserver-log-level",
-                        "trace",
                     ],
                     cwd=tempdir,
                 )

--- a/python_modules/dagster-webserver/dagster_webserver/cli.py
+++ b/python_modules/dagster-webserver/dagster_webserver/cli.py
@@ -132,13 +132,21 @@ DEFAULT_POOL_RECYCLE = 3600  # 1 hr
     is_flag=True,
 )
 @click.option(
-    "--log-level",
-    help="Set the log level for the web server.",
+    "--uvicorn-log-level",
+    "--log-level",  # Back-compat
+    help="Set the log level for the uvicorn web server.",
     show_default=True,
     default="warning",
     type=click.Choice(
         ["critical", "error", "warning", "info", "debug", "trace"], case_sensitive=False
     ),
+)
+@click.option(
+    "--dagster-log-level",
+    help="Set the log level for dagster log events.",
+    show_default=True,
+    default="warning",
+    type=click.Choice(["critical", "error", "warning", "info", "debug"], case_sensitive=False),
 )
 @click.option(
     "--code-server-log-level",
@@ -162,7 +170,8 @@ def dagster_webserver(
     db_pool_recycle: int,
     read_only: bool,
     suppress_warnings: bool,
-    log_level: str,
+    uvicorn_log_level: str,
+    dagster_log_level: str,
     code_server_log_level: str,
     instance_ref: Optional[str],
     **kwargs: ClickArgValue,
@@ -170,11 +179,7 @@ def dagster_webserver(
     if suppress_warnings:
         os.environ["PYTHONWARNINGS"] = "ignore"
 
-    dagster_log_level = log_level.upper()
-    if dagster_log_level == "TRACE":  # uvicorn-specific level
-        dagster_log_level = "DEBUG"
-
-    configure_loggers(log_level=dagster_log_level)
+    configure_loggers(log_level=dagster_log_level.upper())
     logger = logging.getLogger(WEBSERVER_LOGGER_NAME)
 
     if sys.argv[0].endswith("dagit"):
@@ -199,7 +204,7 @@ def dagster_webserver(
             code_server_log_level=code_server_log_level,
         ) as workspace_process_context:
             host_dagster_ui_with_workspace_process_context(
-                workspace_process_context, host, port, path_prefix, log_level
+                workspace_process_context, host, port, path_prefix, uvicorn_log_level
             )
 
 

--- a/python_modules/dagster/dagster/_cli/dev.py
+++ b/python_modules/dagster/dagster/_cli/dev.py
@@ -61,15 +61,6 @@ def dev_command_options(f):
     type=click.Choice(["critical", "error", "warning", "info", "debug"], case_sensitive=False),
 )
 @click.option(
-    "--webserver-log-level",
-    help="Set the log level for the Dagster webserver.",
-    show_default=True,
-    default="warning",
-    type=click.Choice(
-        ["critical", "error", "warning", "info", "debug", "trace"], case_sensitive=False
-    ),
-)
-@click.option(
     "--log-level",
     help="Set the log level for dagster services.",
     show_default=True,
@@ -95,7 +86,6 @@ def dev_command_options(f):
 )
 def dev_command(
     code_server_log_level: str,
-    webserver_log_level: str,
     log_level: str,
     port: Optional[str],
     host: Optional[str],
@@ -172,7 +162,7 @@ def dev_command(
             [sys.executable, "-m", "dagster_webserver"]
             + (["--port", port] if port else [])
             + (["--host", host] if host else [])
-            + (["--log-level", webserver_log_level])
+            + (["--dagster-log-level", log_level])
             + args
         )
         daemon_process = open_ipc_subprocess(


### PR DESCRIPTION
Summary:
since uvicorn INFO output is spammy but dagster INFO output is not (and adding a WARNING about what port you're running on seems like overkill), split it out into two separate CLI args: --dagster-log-level and --uvicorn-log-level. Not in love with this solution but it was the best I could find that still allowed customziing each of the various knobs while leaving the default dagster dev experience reasonable.

Test Plan:
Run default 'dagster dev' command - see info level dagster logs in dagster-webserver, but no uvicorn logs
Run 'dagster-webserver --uvicorn-log-level INFO --dagster-log-level WARNING` - see just uvicorn logs at the INFO level
Run 'dagster dev --log-level DEBUG` - see it affect both daemon output and dagster webserver logs, but not uvicorn traces

## Summary & Motivation

## How I Tested These Changes
