### PR TITLE
[ui] Fix small issues with backfill actions menu, show on backfill details page

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -32,11 +32,11 @@ import {
 } from '../asset-graph/Utils';
 import {AssetKey} from '../assets/types';
 import {LaunchBackfillParams, PartitionDefinitionType} from '../graphql/types';
-import {LAUNCH_PARTITION_BACKFILL_MUTATION} from '../instance/BackfillUtils';
+import {LAUNCH_PARTITION_BACKFILL_MUTATION} from '../instance/backfill/BackfillUtils';
 import {
   LaunchPartitionBackfillMutation,
   LaunchPartitionBackfillMutationVariables,
-} from '../instance/types/BackfillUtils.types';
+} from '../instance/backfill/types/BackfillUtils.types';
 import {CONFIG_PARTITION_SELECTION_QUERY} from '../launchpad/ConfigEditorConfigPicker';
 import {useLaunchPadHooks} from '../launchpad/LaunchpadHooksContext';
 import {TagEditor, TagContainer} from '../launchpad/TagEditor';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__fixtures__/LaunchAssetExecutionButton.fixtures.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__fixtures__/LaunchAssetExecutionButton.fixtures.ts
@@ -13,8 +13,8 @@ import {
   buildInstance,
   buildRunLauncher,
 } from '../../graphql/types';
-import {LAUNCH_PARTITION_BACKFILL_MUTATION} from '../../instance/BackfillUtils';
-import {LaunchPartitionBackfillMutation} from '../../instance/types/BackfillUtils.types';
+import {LAUNCH_PARTITION_BACKFILL_MUTATION} from '../../instance/backfill/BackfillUtils';
+import {LaunchPartitionBackfillMutation} from '../../instance/backfill/types/BackfillUtils.types';
 import {CONFIG_PARTITION_SELECTION_QUERY} from '../../launchpad/ConfigEditorConfigPicker';
 import {ConfigPartitionSelectionQuery} from '../../launchpad/types/ConfigEditorConfigPicker.types';
 import {LAUNCH_PIPELINE_EXECUTION_MUTATION} from '../../runs/RunUtils';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/LaunchAssetExecutionButton.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/LaunchAssetExecutionButton.test.tsx
@@ -5,7 +5,7 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import {CustomAlertProvider} from '../../app/CustomAlertProvider';
-import {LaunchPartitionBackfillMutation} from '../../instance/types/BackfillUtils.types';
+import {LaunchPartitionBackfillMutation} from '../../instance/backfill/types/BackfillUtils.types';
 import {LaunchPipelineExecutionMutation} from '../../runs/types/RunUtils.types';
 import {TestProvider} from '../../testing/TestProvider';
 import {

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceBackfills.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceBackfills.tsx
@@ -19,8 +19,8 @@ import {DaemonNotRunningAlertBody} from '../partitions/BackfillMessaging';
 import {useCursorPaginatedQuery} from '../runs/useCursorPaginatedQuery';
 import {Loading} from '../ui/Loading';
 
-import {BackfillTable, BACKFILL_TABLE_FRAGMENT} from './BackfillTable';
 import {INSTANCE_HEALTH_FRAGMENT} from './InstanceHealthFragment';
+import {BackfillTable, BACKFILL_TABLE_FRAGMENT} from './backfill/BackfillTable';
 import {
   InstanceBackfillsQuery,
   InstanceBackfillsQueryVariables,

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillActionsMenu.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillActionsMenu.tsx
@@ -1,10 +1,26 @@
-import {Menu, MenuItem, Popover} from '@dagster-io/ui-components';
+import {gql, useMutation} from '@apollo/client';
+import {Button, Group, Icon, Menu, MenuItem, Popover} from '@dagster-io/ui-components';
 import * as React from 'react';
 import {useHistory} from 'react-router-dom';
 
+import {showCustomAlert} from '../../app/CustomAlertProvider';
+import {showSharedToaster} from '../../app/DomUtils';
+import {PythonErrorInfo} from '../../app/PythonErrorInfo';
 import {BulkActionStatus, RunStatus} from '../../graphql/types';
 import {runsPathWithFilters} from '../../runs/RunsFilterInput';
-import {BackfillTableFragment} from '../types/BackfillTable.types';
+
+import {
+  BACKFILL_STEP_STATUS_DIALOG_BACKFILL_FRAGMENT,
+  BackfillStepStatusDialog,
+  backfillCanShowStepStatus,
+} from './BackfillStepStatusDialog';
+import {
+  BACKFILL_TERMINATION_DIALOG_BACKFILL_FRAGMENT,
+  BackfillTerminationDialog,
+} from './BackfillTerminationDialog';
+import {RESUME_BACKFILL_MUTATION} from './BackfillUtils';
+import {BackfillActionsBackfillFragment} from './types/BackfillActionsMenu.types';
+import {ResumeBackfillMutation, ResumeBackfillMutationVariables} from './types/BackfillUtils.types';
 
 export function backfillCanCancelSubmission(backfill: {
   hasCancelPermission: boolean;
@@ -16,6 +32,18 @@ export function backfillCanCancelSubmission(backfill: {
     backfill.hasCancelPermission &&
     ((backfill.isAssetBackfill && backfill.status === BulkActionStatus.REQUESTED) ||
       backfill.numCancelable > 0)
+  );
+}
+
+export function backfillCanResume(backfill: {
+  hasResumePermission: boolean;
+  status: BulkActionStatus;
+  partitionSet: {__typename: 'PartitionSet'} | null;
+}) {
+  return (
+    backfill.hasResumePermission &&
+    backfill.status === BulkActionStatus.FAILED &&
+    backfill.partitionSet
   );
 }
 
@@ -33,24 +61,14 @@ export function backfillCanCancelRuns(
 
 export const BackfillActionsMenu = ({
   backfill,
-  canCancelRuns,
-  canCancelSubmission,
-  onTerminateBackfill,
-  onResumeBackfill,
-  onShowStepStatus,
-  children,
+  counts,
+  refetch,
 }: {
-  children: React.ReactNode;
-  backfill: BackfillTableFragment;
-  canCancelRuns: boolean;
-  canCancelSubmission: boolean;
-  onTerminateBackfill: (backfill: BackfillTableFragment) => void;
-  onResumeBackfill: (backfill: BackfillTableFragment) => void;
-  onShowStepStatus: (backfill: BackfillTableFragment) => void;
+  backfill: BackfillActionsBackfillFragment;
+  counts: {[runStatus: string]: number} | null;
+  refetch: () => void;
 }) => {
   const history = useHistory();
-  const {hasResumePermission} = backfill;
-
   const runsUrl = runsPathWithFilters([
     {
       token: 'tag',
@@ -58,53 +76,120 @@ export const BackfillActionsMenu = ({
     },
   ]);
 
+  const [showTerminateDialog, setShowTerminateDialog] = React.useState(false);
+  const [showStepStatus, setShowStepStatus] = React.useState(false);
+  const [resumeBackfill] = useMutation<ResumeBackfillMutation, ResumeBackfillMutationVariables>(
+    RESUME_BACKFILL_MUTATION,
+  );
+
+  const resume = async () => {
+    const {data} = await resumeBackfill({variables: {backfillId: backfill.id}});
+    if (data && data.resumePartitionBackfill.__typename === 'ResumeBackfillSuccess') {
+      refetch();
+    } else if (data && data.resumePartitionBackfill.__typename === 'UnauthorizedError') {
+      await showSharedToaster({
+        message: (
+          <Group direction="column" spacing={4}>
+            <div>
+              Attempted to retry the backfill in read-only mode. This backfill was not retried.
+            </div>
+          </Group>
+        ),
+        icon: 'error',
+        intent: 'danger',
+      });
+    } else if (data && data.resumePartitionBackfill.__typename === 'PythonError') {
+      const error = data.resumePartitionBackfill;
+      await showSharedToaster({
+        message: <div>An unexpected error occurred. This backfill was not retried.</div>,
+        icon: 'error',
+        intent: 'danger',
+        action: {
+          text: 'View error',
+          onClick: () =>
+            showCustomAlert({
+              body: <PythonErrorInfo error={error} />,
+            }),
+        },
+      });
+    }
+  };
+
   return (
-    <Popover
-      content={
-        <Menu>
-          {canCancelSubmission ? (
+    <>
+      <Popover
+        content={
+          <Menu>
+            {backfillCanCancelSubmission(backfill) ? (
+              <MenuItem
+                text="Cancel backfill submission"
+                icon="cancel"
+                intent="danger"
+                onClick={() => setShowTerminateDialog(true)}
+              />
+            ) : backfillCanCancelRuns(backfill, counts) ? (
+              <MenuItem
+                text="Terminate unfinished runs"
+                icon="cancel"
+                intent="danger"
+                onClick={() => setShowTerminateDialog(true)}
+              />
+            ) : null}
+            {backfillCanResume(backfill) ? (
+              <MenuItem
+                text="Resume failed backfill"
+                title="Submits runs for all partitions in the backfill that do not have a corresponding run. Does not retry failed runs."
+                icon="refresh"
+                onClick={() => resume()}
+              />
+            ) : null}
             <MenuItem
-              text="Cancel backfill submission"
-              icon="cancel"
-              intent="danger"
-              onClick={() => onTerminateBackfill(backfill)}
+              text="View backfill runs"
+              icon="settings_backup_restore"
+              onClick={() => history.push(runsUrl)}
             />
-          ) : null}
-          {canCancelRuns ? (
-            <MenuItem
-              text="Terminate unfinished runs"
-              icon="cancel"
-              intent="danger"
-              onClick={() => onTerminateBackfill(backfill)}
-            />
-          ) : null}
-          {hasResumePermission &&
-          backfill.status === BulkActionStatus.FAILED &&
-          backfill.partitionSet ? (
-            <MenuItem
-              text="Resume failed backfill"
-              title="Submits runs for all partitions in the backfill that do not have a corresponding run. Does not retry failed runs."
-              icon="refresh"
-              onClick={() => onResumeBackfill(backfill)}
-            />
-          ) : null}
-          <MenuItem
-            text="View backfill runs"
-            icon="settings_backup_restore"
-            onClick={() => history.push(runsUrl)}
-          />
-          <MenuItem
-            text="View step status"
-            icon="view_list"
-            onClick={() => {
-              onShowStepStatus(backfill);
-            }}
-          />
-        </Menu>
-      }
-      position="bottom-right"
-    >
-      {children}
-    </Popover>
+            {backfillCanShowStepStatus(backfill) ? (
+              <MenuItem
+                text="View step status"
+                icon="view_list"
+                onClick={() => {
+                  setShowStepStatus(true);
+                }}
+              />
+            ) : null}
+          </Menu>
+        }
+        position="bottom-right"
+      >
+        <Button icon={<Icon name="expand_more" />} />
+      </Popover>
+
+      <BackfillStepStatusDialog
+        backfill={showStepStatus ? backfill : undefined}
+        onClose={() => setShowStepStatus(false)}
+      />
+      <BackfillTerminationDialog
+        backfill={showTerminateDialog ? backfill : undefined}
+        onClose={() => setShowTerminateDialog(false)}
+        onComplete={() => refetch()}
+      />
+    </>
   );
 };
+
+export const BACKFILL_ACTIONS_BACKFILL_FRAGMENT = gql`
+  fragment BackfillActionsBackfillFragment on PartitionBackfill {
+    id
+    hasCancelPermission
+    hasResumePermission
+    isAssetBackfill
+    status
+    numCancelable
+
+    ...BackfillStepStatusDialogBackfillFragment
+    ...BackfillTerminationDialogBackfillFragment
+  }
+
+  ${BACKFILL_STEP_STATUS_DIALOG_BACKFILL_FRAGMENT}
+  ${BACKFILL_TERMINATION_DIALOG_BACKFILL_FRAGMENT}
+`;

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillActionsMenu.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillActionsMenu.tsx
@@ -40,7 +40,7 @@ export function backfillCanResume(backfill: {
   status: BulkActionStatus;
   partitionSet: {__typename: 'PartitionSet'} | null;
 }) {
-  return (
+  return !!(
     backfill.hasResumePermission &&
     backfill.status === BulkActionStatus.FAILED &&
     backfill.partitionSet
@@ -115,51 +115,46 @@ export const BackfillActionsMenu = ({
     }
   };
 
+  const canCancelSubmission = backfillCanCancelSubmission(backfill);
+  const canCancelRuns = backfillCanCancelRuns(backfill, counts);
+
   return (
     <>
       <Popover
+        position="bottom-right"
         content={
           <Menu>
-            {backfillCanCancelSubmission(backfill) ? (
-              <MenuItem
-                text="Cancel backfill submission"
-                icon="cancel"
-                intent="danger"
-                onClick={() => setShowTerminateDialog(true)}
-              />
-            ) : backfillCanCancelRuns(backfill, counts) ? (
-              <MenuItem
-                text="Terminate unfinished runs"
-                icon="cancel"
-                intent="danger"
-                onClick={() => setShowTerminateDialog(true)}
-              />
-            ) : null}
-            {backfillCanResume(backfill) ? (
-              <MenuItem
-                text="Resume failed backfill"
-                title="Submits runs for all partitions in the backfill that do not have a corresponding run. Does not retry failed runs."
-                icon="refresh"
-                onClick={() => resume()}
-              />
-            ) : null}
             <MenuItem
               text="View backfill runs"
               icon="settings_backup_restore"
               onClick={() => history.push(runsUrl)}
             />
-            {backfillCanShowStepStatus(backfill) ? (
-              <MenuItem
-                text="View step status"
-                icon="view_list"
-                onClick={() => {
-                  setShowStepStatus(true);
-                }}
-              />
-            ) : null}
+            <MenuItem
+              disabled={!backfillCanShowStepStatus(backfill)}
+              text="View step status"
+              icon="view_list"
+              onClick={() => {
+                setShowStepStatus(true);
+              }}
+            />
+            <MenuItem
+              disabled={!backfillCanResume(backfill)}
+              text="Resume failed backfill"
+              title="Submits runs for all partitions in the backfill that do not have a corresponding run. Does not retry failed runs."
+              icon="refresh"
+              onClick={() => resume()}
+            />
+            <MenuItem
+              text={
+                canCancelSubmission ? 'Cancel backfill submission' : 'Terminate unfinished runs'
+              }
+              icon="cancel"
+              intent="danger"
+              disabled={!(canCancelSubmission || canCancelRuns)}
+              onClick={() => setShowTerminateDialog(true)}
+            />
           </Menu>
         }
-        position="bottom-right"
       >
         <Button icon={<Icon name="expand_more" />} />
       </Popover>

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillActionsMenu.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillActionsMenu.tsx
@@ -1,0 +1,110 @@
+import {Menu, MenuItem, Popover} from '@dagster-io/ui-components';
+import * as React from 'react';
+import {useHistory} from 'react-router-dom';
+
+import {BulkActionStatus, RunStatus} from '../../graphql/types';
+import {runsPathWithFilters} from '../../runs/RunsFilterInput';
+import {BackfillTableFragment} from '../types/BackfillTable.types';
+
+export function backfillCanCancelSubmission(backfill: {
+  hasCancelPermission: boolean;
+  isAssetBackfill: boolean;
+  status: BulkActionStatus;
+  numCancelable: number;
+}) {
+  return (
+    backfill.hasCancelPermission &&
+    ((backfill.isAssetBackfill && backfill.status === BulkActionStatus.REQUESTED) ||
+      backfill.numCancelable > 0)
+  );
+}
+
+export function backfillCanCancelRuns(
+  backfill: {hasCancelPermission: boolean},
+  counts: {[runStatus: string]: number} | null,
+) {
+  if (!backfill.hasCancelPermission || !counts) {
+    return false;
+  }
+  const queuedCount = counts[RunStatus.QUEUED] || 0;
+  const startedCount = counts[RunStatus.STARTED] || 0;
+  return queuedCount > 0 || startedCount > 0;
+}
+
+export const BackfillActionsMenu = ({
+  backfill,
+  canCancelRuns,
+  canCancelSubmission,
+  onTerminateBackfill,
+  onResumeBackfill,
+  onShowStepStatus,
+  children,
+}: {
+  children: React.ReactNode;
+  backfill: BackfillTableFragment;
+  canCancelRuns: boolean;
+  canCancelSubmission: boolean;
+  onTerminateBackfill: (backfill: BackfillTableFragment) => void;
+  onResumeBackfill: (backfill: BackfillTableFragment) => void;
+  onShowStepStatus: (backfill: BackfillTableFragment) => void;
+}) => {
+  const history = useHistory();
+  const {hasResumePermission} = backfill;
+
+  const runsUrl = runsPathWithFilters([
+    {
+      token: 'tag',
+      value: `dagster/backfill=${backfill.id}`,
+    },
+  ]);
+
+  return (
+    <Popover
+      content={
+        <Menu>
+          {canCancelSubmission ? (
+            <MenuItem
+              text="Cancel backfill submission"
+              icon="cancel"
+              intent="danger"
+              onClick={() => onTerminateBackfill(backfill)}
+            />
+          ) : null}
+          {canCancelRuns ? (
+            <MenuItem
+              text="Terminate unfinished runs"
+              icon="cancel"
+              intent="danger"
+              onClick={() => onTerminateBackfill(backfill)}
+            />
+          ) : null}
+          {hasResumePermission &&
+          backfill.status === BulkActionStatus.FAILED &&
+          backfill.partitionSet ? (
+            <MenuItem
+              text="Resume failed backfill"
+              title="Submits runs for all partitions in the backfill that do not have a corresponding run. Does not retry failed runs."
+              icon="refresh"
+              onClick={() => onResumeBackfill(backfill)}
+            />
+          ) : null}
+          <MenuItem
+            text="View backfill runs"
+            icon="settings_backup_restore"
+            onClick={() => history.push(runsUrl)}
+          />
+          <MenuItem
+            text="View step status"
+            icon="view_list"
+            onClick={() => {
+              onShowStepStatus(backfill);
+            }}
+          />
+        </Menu>
+      }
+      position="bottom-right"
+    >
+      {children}
+    </Popover>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillPage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillPage.tsx
@@ -35,8 +35,9 @@ import {RunFilterToken, runsPathWithFilters} from '../../runs/RunsFilterInput';
 import {testId} from '../../testing/testId';
 import {VirtualizedItemListForDialog} from '../../ui/VirtualizedItemListForDialog';
 import {numberFormatter} from '../../ui/formatters';
-import {BackfillStatusTagForPage} from '../BackfillStatusTagForPage';
 
+import {BackfillActionsMenu} from './BackfillActionsMenu';
+import {BackfillStatusTagForPage} from './BackfillStatusTagForPage';
 import {
   BackfillStatusesByAssetQuery,
   BackfillStatusesByAssetQueryVariables,
@@ -293,7 +294,28 @@ export const BackfillPage = () => {
             {backfillId}
           </Heading>
         }
-        right={isInProgress ? <QueryRefreshCountdown refreshState={refreshState} /> : null}
+        right={
+          <>
+            {isInProgress ? <QueryRefreshCountdown refreshState={refreshState} /> : null}
+            {canCancelSubmission ? (
+            <MenuItem
+              text="Cancel backfill submission"
+              icon="cancel"
+              intent="danger"
+              onClick={() => onTerminateBackfill(backfill)}
+            />
+          ) : null}
+          {canCancelRuns ? (
+            <MenuItem
+              text="Terminate unfinished runs"
+              icon="cancel"
+              intent="danger"
+              onClick={() => onTerminateBackfill(backfill)}
+            />
+          ) : null}
+
+          </>
+        }
       />
       {content()}
     </Page>

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillPage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillPage.tsx
@@ -36,7 +36,7 @@ import {testId} from '../../testing/testId';
 import {VirtualizedItemListForDialog} from '../../ui/VirtualizedItemListForDialog';
 import {numberFormatter} from '../../ui/formatters';
 
-import {BackfillActionsMenu} from './BackfillActionsMenu';
+import {BACKFILL_ACTIONS_BACKFILL_FRAGMENT, BackfillActionsMenu} from './BackfillActionsMenu';
 import {BackfillStatusTagForPage} from './BackfillStatusTagForPage';
 import {
   BackfillStatusesByAssetQuery,
@@ -54,37 +54,39 @@ export const BackfillPage = () => {
 
   const queryResult = useQuery<BackfillStatusesByAssetQuery, BackfillStatusesByAssetQueryVariables>(
     BACKFILL_DETAILS_QUERY,
-    {
-      variables: {backfillId},
-    },
+    {variables: {backfillId}},
   );
+
   const {data} = queryResult;
 
-  const backfill = data?.partitionBackfillOrError;
+  const backfill =
+    data?.partitionBackfillOrError.__typename === 'PartitionBackfill'
+      ? data.partitionBackfillOrError
+      : null;
 
-  let isInProgress = true;
-  if (backfill && backfill.__typename === 'PartitionBackfill') {
-    // for asset backfills, all of the requested runs have concluded in order for the status to be BulkActionStatus.COMPLETED
-    isInProgress = [BulkActionStatus.REQUESTED, BulkActionStatus.CANCELING].includes(
-      backfill.status,
-    );
-  }
+  // for asset backfills, all of the requested runs have concluded in order for the status to be BulkActionStatus.COMPLETED
+  const isInProgress = backfill
+    ? [BulkActionStatus.REQUESTED, BulkActionStatus.CANCELING].includes(backfill.status)
+    : true;
+
   const refreshState = useQueryRefreshAtInterval(queryResult, 10000, isInProgress);
 
   function content() {
-    if (!backfill || !data) {
+    if (!data || !data.partitionBackfillOrError) {
       return (
         <Box padding={64} data-testid={testId('page-loading-indicator')}>
           <Spinner purpose="page" />
         </Box>
       );
     }
-    if (backfill.__typename === 'PythonError') {
-      return <PythonErrorInfo error={backfill} />;
+    if (data.partitionBackfillOrError.__typename === 'PythonError') {
+      return <PythonErrorInfo error={data.partitionBackfillOrError} />;
     }
-    if (backfill.__typename === 'BackfillNotFoundError') {
-      return <NonIdealState icon="no-results" title={backfill.message} />;
+    if (data.partitionBackfillOrError.__typename === 'BackfillNotFoundError') {
+      return <NonIdealState icon="no-results" title={data.partitionBackfillOrError.message} />;
     }
+
+    const backfill = data.partitionBackfillOrError;
 
     function getRunsUrl(status: 'inProgress' | 'complete' | 'failed' | 'targeted') {
       const filters: RunFilterToken[] = [
@@ -295,26 +297,18 @@ export const BackfillPage = () => {
           </Heading>
         }
         right={
-          <>
+          <Box flex={{gap: 12, alignItems: 'center'}}>
             {isInProgress ? <QueryRefreshCountdown refreshState={refreshState} /> : null}
-            {canCancelSubmission ? (
-            <MenuItem
-              text="Cancel backfill submission"
-              icon="cancel"
-              intent="danger"
-              onClick={() => onTerminateBackfill(backfill)}
-            />
-          ) : null}
-          {canCancelRuns ? (
-            <MenuItem
-              text="Terminate unfinished runs"
-              icon="cancel"
-              intent="danger"
-              onClick={() => onTerminateBackfill(backfill)}
-            />
-          ) : null}
-
-          </>
+            {backfill ? (
+              <BackfillActionsMenu
+                backfill={backfill}
+                refetch={queryResult.refetch}
+                counts={Object.fromEntries(
+                  backfill.partitionStatusCounts.map((e) => [e.runStatus, e.count]),
+                )}
+              />
+            ) : null}
+          </Box>
         }
       />
       {content()}
@@ -400,8 +394,14 @@ export const BACKFILL_DETAILS_QUERY = gql`
     timestamp
     endTimestamp
     numPartitions
+    ...BackfillActionsBackfillFragment
+
     error {
       ...PythonErrorFragment
+    }
+    partitionStatusCounts {
+      runStatus
+      count
     }
     assetBackfillData {
       rootAssetTargetedRanges {
@@ -431,6 +431,7 @@ export const BACKFILL_DETAILS_QUERY = gql`
     }
   }
   ${PYTHON_ERROR_FRAGMENT}
+  ${BACKFILL_ACTIONS_BACKFILL_FRAGMENT}
 `;
 
 const COLLATOR = new Intl.Collator(navigator.language, {sensitivity: 'base', numeric: true});

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillPartitionsRequestedDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillPartitionsRequestedDialog.tsx
@@ -1,8 +1,8 @@
 import {Button, DialogFooter, Dialog, FontFamily} from '@dagster-io/ui-components';
 import * as React from 'react';
 
-import {TruncatedTextWithFullTextOnHover} from '../nav/getLeftNavItemsForOption';
-import {VirtualizedItemListForDialog} from '../ui/VirtualizedItemListForDialog';
+import {TruncatedTextWithFullTextOnHover} from '../../nav/getLeftNavItemsForOption';
+import {VirtualizedItemListForDialog} from '../../ui/VirtualizedItemListForDialog';
 
 import {BackfillTableFragment} from './types/BackfillTable.types';
 

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillRow.tsx
@@ -78,7 +78,8 @@ export const BackfillRow = ({
   // making the hooks below support an optional query function / result.
   const [statusQueryFn, statusQueryResult] = statusUnsupported
     ? NoBackfillStatusQuery
-    : (backfill.numPartitions || 0) > BACKFILL_PARTITIONS_COUNTS_THRESHOLD
+    : backfill.isAssetBackfill ||
+      (backfill.numPartitions || 0) > BACKFILL_PARTITIONS_COUNTS_THRESHOLD
     ? statusCounts
     : statusDetails;
 
@@ -145,7 +146,7 @@ export const BackfillRow = ({
       </td>
       <td>
         {backfill.isValidSerialization ? (
-          counts && statuses ? (
+          counts && statuses !== undefined ? (
             <BackfillRunStatus backfill={backfill} counts={counts} statuses={statuses} />
           ) : (
             <LoadingOrNone queryResult={statusQueryResult} noneString={'\u2013'} />

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillStatusTagForPage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillStatusTagForPage.tsx
@@ -2,10 +2,10 @@ import {Box, Tag} from '@dagster-io/ui-components';
 import * as React from 'react';
 import styled from 'styled-components';
 
-import {showCustomAlert} from '../app/CustomAlertProvider';
-import {PythonErrorInfo} from '../app/PythonErrorInfo';
-import {PythonErrorFragment} from '../app/types/PythonErrorFragment.types';
-import {BulkActionStatus} from '../graphql/types';
+import {showCustomAlert} from '../../app/CustomAlertProvider';
+import {PythonErrorInfo} from '../../app/PythonErrorInfo';
+import {PythonErrorFragment} from '../../app/types/PythonErrorFragment.types';
+import {BulkActionStatus} from '../../graphql/types';
 
 type BackfillState = {
   status: BulkActionStatus;

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillStepStatusDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillStepStatusDialog.tsx
@@ -1,3 +1,4 @@
+import {gql} from '@apollo/client';
 import {Button, DialogFooter, Dialog} from '@dagster-io/ui-components';
 import * as React from 'react';
 
@@ -9,19 +10,25 @@ import {buildRepoAddress} from '../../workspace/buildRepoAddress';
 import {repoAddressToSelector} from '../../workspace/repoAddressToSelector';
 import {RepoAddress} from '../../workspace/types';
 
-import {
-  BackfillTableFragment,
-  PartitionSetForBackfillTableFragment,
-} from './types/BackfillTable.types';
+import {BackfillStepStatusDialogBackfillFragment} from './types/BackfillStepStatusDialog.types';
 
 interface Props {
-  backfill?: BackfillTableFragment;
+  backfill?: BackfillStepStatusDialogBackfillFragment;
   onClose: () => void;
+}
+
+export function backfillCanShowStepStatus(
+  backfill?: BackfillStepStatusDialogBackfillFragment,
+): backfill is BackfillStepStatusDialogBackfillFragment & {
+  partitionSet: NonNullable<BackfillStepStatusDialogBackfillFragment['partitionSet']>;
+  partitionNames: string[];
+} {
+  return !!backfill && backfill.partitionSet !== null && backfill.partitionNames !== null;
 }
 
 export const BackfillStepStatusDialog = ({backfill, onClose}: Props) => {
   const content = () => {
-    if (!backfill?.partitionSet || backfill.partitionNames === null) {
+    if (!backfillCanShowStepStatus(backfill)) {
       return null;
     }
 
@@ -56,9 +63,24 @@ export const BackfillStepStatusDialog = ({backfill, onClose}: Props) => {
   );
 };
 
+export const BACKFILL_STEP_STATUS_DIALOG_BACKFILL_FRAGMENT = gql`
+  fragment BackfillStepStatusDialogBackfillFragment on PartitionBackfill {
+    id
+    partitionNames
+    partitionSet {
+      name
+      pipelineName
+      repositoryOrigin {
+        repositoryName
+        repositoryLocationName
+      }
+    }
+  }
+`;
+
 interface ContentProps {
-  backfill: BackfillTableFragment;
-  partitionSet: PartitionSetForBackfillTableFragment;
+  backfill: BackfillStepStatusDialogBackfillFragment;
+  partitionSet: NonNullable<BackfillStepStatusDialogBackfillFragment['partitionSet']>;
   partitionNames: string[];
   repoAddress: RepoAddress;
   onClose: () => void;

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillStepStatusDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillStepStatusDialog.tsx
@@ -1,13 +1,13 @@
 import {Button, DialogFooter, Dialog} from '@dagster-io/ui-components';
 import * as React from 'react';
 
-import {PartitionPerOpStatus} from '../partitions/PartitionStepStatus';
-import {usePartitionStepQuery} from '../partitions/usePartitionStepQuery';
-import {DagsterTag} from '../runs/RunTag';
-import {RunFilterToken} from '../runs/RunsFilterInput';
-import {buildRepoAddress} from '../workspace/buildRepoAddress';
-import {repoAddressToSelector} from '../workspace/repoAddressToSelector';
-import {RepoAddress} from '../workspace/types';
+import {PartitionPerOpStatus} from '../../partitions/PartitionStepStatus';
+import {usePartitionStepQuery} from '../../partitions/usePartitionStepQuery';
+import {DagsterTag} from '../../runs/RunTag';
+import {RunFilterToken} from '../../runs/RunsFilterInput';
+import {buildRepoAddress} from '../../workspace/buildRepoAddress';
+import {repoAddressToSelector} from '../../workspace/repoAddressToSelector';
+import {RepoAddress} from '../../workspace/types';
 
 import {
   BackfillTableFragment,

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillTable.tsx
@@ -2,10 +2,10 @@ import {gql, useMutation} from '@apollo/client';
 import {Group, Table} from '@dagster-io/ui-components';
 import * as React from 'react';
 
-import {showCustomAlert} from '../app/CustomAlertProvider';
-import {showSharedToaster} from '../app/DomUtils';
-import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
-import {PythonErrorInfo} from '../app/PythonErrorInfo';
+import {showCustomAlert} from '../../app/CustomAlertProvider';
+import {showSharedToaster} from '../../app/DomUtils';
+import {PYTHON_ERROR_FRAGMENT} from '../../app/PythonErrorFragment';
+import {PythonErrorInfo} from '../../app/PythonErrorInfo';
 
 import {BackfillPartitionsRequestedDialog} from './BackfillPartitionsRequestedDialog';
 import {BackfillRow} from './BackfillRow';

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillTerminationDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillTerminationDialog.tsx
@@ -9,17 +9,18 @@ import {TerminationDialog} from '../../runs/TerminationDialog';
 
 import {SINGLE_BACKFILL_STATUS_DETAILS_QUERY} from './BackfillRow';
 import {SingleBackfillQuery, SingleBackfillQueryVariables} from './types/BackfillRow.types';
-import {BackfillTableFragment} from './types/BackfillTable.types';
 import {
   CancelBackfillMutation,
   CancelBackfillMutationVariables,
+  BackfillTerminationDialogBackfillFragment,
 } from './types/BackfillTerminationDialog.types';
 
 interface Props {
-  backfill?: BackfillTableFragment;
+  backfill?: BackfillTerminationDialogBackfillFragment;
   onClose: () => void;
   onComplete: () => void;
 }
+
 export const BackfillTerminationDialog = ({backfill, onClose, onComplete}: Props) => {
   const [cancelBackfill] = useMutation<CancelBackfillMutation, CancelBackfillMutationVariables>(
     CANCEL_BACKFILL_MUTATION,
@@ -115,6 +116,15 @@ export const BackfillTerminationDialog = ({backfill, onClose, onComplete}: Props
     </>
   );
 };
+
+export const BACKFILL_TERMINATION_DIALOG_BACKFILL_FRAGMENT = gql`
+  fragment BackfillTerminationDialogBackfillFragment on PartitionBackfill {
+    id
+    status
+    isAssetBackfill
+    numCancelable
+  }
+`;
 
 const CANCEL_BACKFILL_MUTATION = gql`
   mutation CancelBackfill($backfillId: String!) {

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillTerminationDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillTerminationDialog.tsx
@@ -2,10 +2,10 @@ import {gql, useMutation, useQuery} from '@apollo/client';
 import {Button, DialogBody, DialogFooter, Dialog} from '@dagster-io/ui-components';
 import * as React from 'react';
 
-import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
-import {BulkActionStatus} from '../graphql/types';
-import {cancelableStatuses} from '../runs/RunStatuses';
-import {TerminationDialog} from '../runs/TerminationDialog';
+import {PYTHON_ERROR_FRAGMENT} from '../../app/PythonErrorFragment';
+import {BulkActionStatus} from '../../graphql/types';
+import {cancelableStatuses} from '../../runs/RunStatuses';
+import {TerminationDialog} from '../../runs/TerminationDialog';
 
 import {SINGLE_BACKFILL_STATUS_DETAILS_QUERY} from './BackfillRow';
 import {SingleBackfillQuery, SingleBackfillQueryVariables} from './types/BackfillRow.types';

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillUtils.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillUtils.tsx
@@ -1,6 +1,6 @@
 import {gql} from '@apollo/client';
 
-import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
+import {PYTHON_ERROR_FRAGMENT} from '../../app/PythonErrorFragment';
 
 export const RESUME_BACKFILL_MUTATION = gql`
   mutation resumeBackfill($backfillId: String!) {

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/__fixtures__/BackfillTable.fixtures.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/__fixtures__/BackfillTable.fixtures.ts
@@ -12,7 +12,7 @@ import {
   buildPartitionStatuses,
   buildPythonError,
   buildRepositoryOrigin,
-} from '../../graphql/types';
+} from '../../../graphql/types';
 import {
   SINGLE_BACKFILL_STATUS_COUNTS_QUERY,
   SINGLE_BACKFILL_STATUS_DETAILS_QUERY,

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/__stories__/BackfillTable.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/__stories__/BackfillTable.stories.tsx
@@ -1,7 +1,7 @@
 import {MockedProvider} from '@apollo/client/testing';
 import React from 'react';
 
-import {StorybookProvider} from '../../testing/StorybookProvider';
+import {StorybookProvider} from '../../../testing/StorybookProvider';
 import {BackfillTable} from '../BackfillTable';
 import {
   BackfillTableFragmentCancelledAssetsPartitionSetStatus,

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/__tests__/BackfillPage.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/__tests__/BackfillPage.test.tsx
@@ -17,6 +17,8 @@ import {
 } from '../../../graphql/types';
 import {BACKFILL_DETAILS_QUERY, BackfillPage, PartitionSelection} from '../BackfillPage';
 
+// This file must be mocked because Jest can't handle `import.meta.url`.
+jest.mock('../../../graph/asyncGraphLayout', () => ({}));
 jest.mock('../../../app/QueryRefresh', () => {
   return {
     useQueryRefreshAtInterval: jest.fn(),

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/__tests__/BackfillTable.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/__tests__/BackfillTable.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 import * as React from 'react';
 import {MemoryRouter} from 'react-router-dom';
 
-import * as Alerting from '../../app/CustomAlertProvider';
+import * as Alerting from '../../../app/CustomAlertProvider';
 import {BackfillTable} from '../BackfillTable';
 import {
   BackfillTableFragmentFailedErrorStatus,

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/__tests__/BackfillTable.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/__tests__/BackfillTable.test.tsx
@@ -12,7 +12,7 @@ import {
 } from '../__fixtures__/BackfillTable.fixtures';
 
 // This file must be mocked because Jest can't handle `import.meta.url`.
-jest.mock('../../graph/asyncGraphLayout', () => ({}));
+jest.mock('../../../graph/asyncGraphLayout', () => ({}));
 
 describe('BackfillTable', () => {
   it('allows you to click "Failed" backfills for error details', async () => {

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/types/BackfillActionsMenu.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/types/BackfillActionsMenu.types.ts
@@ -1,0 +1,24 @@
+// Generated GraphQL types, do not edit manually.
+
+import * as Types from '../../../graphql/types';
+
+export type BackfillActionsBackfillFragment = {
+  __typename: 'PartitionBackfill';
+  id: string;
+  hasCancelPermission: boolean;
+  hasResumePermission: boolean;
+  isAssetBackfill: boolean;
+  status: Types.BulkActionStatus;
+  numCancelable: number;
+  partitionNames: Array<string> | null;
+  partitionSet: {
+    __typename: 'PartitionSet';
+    name: string;
+    pipelineName: string;
+    repositoryOrigin: {
+      __typename: 'RepositoryOrigin';
+      repositoryName: string;
+      repositoryLocationName: string;
+    };
+  } | null;
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/types/BackfillPage.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/types/BackfillPage.types.ts
@@ -17,6 +17,11 @@ export type BackfillStatusesByAssetQuery = {
         timestamp: number;
         endTimestamp: number | null;
         numPartitions: number | null;
+        hasCancelPermission: boolean;
+        hasResumePermission: boolean;
+        isAssetBackfill: boolean;
+        numCancelable: number;
+        partitionNames: Array<string> | null;
         error: {
           __typename: 'PythonError';
           message: string;
@@ -27,6 +32,11 @@ export type BackfillStatusesByAssetQuery = {
             error: {__typename: 'PythonError'; message: string; stack: Array<string>};
           }>;
         } | null;
+        partitionStatusCounts: Array<{
+          __typename: 'PartitionStatusCounts';
+          runStatus: Types.RunStatus;
+          count: number;
+        }>;
         assetBackfillData: {
           __typename: 'AssetBackfillData';
           rootAssetTargetedPartitions: Array<string> | null;
@@ -53,6 +63,16 @@ export type BackfillStatusesByAssetQuery = {
               }
           >;
         } | null;
+        partitionSet: {
+          __typename: 'PartitionSet';
+          name: string;
+          pipelineName: string;
+          repositoryOrigin: {
+            __typename: 'RepositoryOrigin';
+            repositoryName: string;
+            repositoryLocationName: string;
+          };
+        } | null;
       }
     | {
         __typename: 'PythonError';
@@ -73,6 +93,11 @@ export type PartitionBackfillFragment = {
   timestamp: number;
   endTimestamp: number | null;
   numPartitions: number | null;
+  hasCancelPermission: boolean;
+  hasResumePermission: boolean;
+  isAssetBackfill: boolean;
+  numCancelable: number;
+  partitionNames: Array<string> | null;
   error: {
     __typename: 'PythonError';
     message: string;
@@ -83,6 +108,11 @@ export type PartitionBackfillFragment = {
       error: {__typename: 'PythonError'; message: string; stack: Array<string>};
     }>;
   } | null;
+  partitionStatusCounts: Array<{
+    __typename: 'PartitionStatusCounts';
+    runStatus: Types.RunStatus;
+    count: number;
+  }>;
   assetBackfillData: {
     __typename: 'AssetBackfillData';
     rootAssetTargetedPartitions: Array<string> | null;
@@ -108,5 +138,15 @@ export type PartitionBackfillFragment = {
           assetKey: {__typename: 'AssetKey'; path: Array<string>};
         }
     >;
+  } | null;
+  partitionSet: {
+    __typename: 'PartitionSet';
+    name: string;
+    pipelineName: string;
+    repositoryOrigin: {
+      __typename: 'RepositoryOrigin';
+      repositoryName: string;
+      repositoryLocationName: string;
+    };
   } | null;
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/types/BackfillRow.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/types/BackfillRow.types.ts
@@ -1,6 +1,6 @@
 // Generated GraphQL types, do not edit manually.
 
-import * as Types from '../../graphql/types';
+import * as Types from '../../../graphql/types';
 
 export type SingleBackfillCountsQueryVariables = Types.Exact<{
   backfillId: Types.Scalars['String'];

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/types/BackfillStepStatusDialog.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/types/BackfillStepStatusDialog.types.ts
@@ -1,0 +1,19 @@
+// Generated GraphQL types, do not edit manually.
+
+import * as Types from '../../../graphql/types';
+
+export type BackfillStepStatusDialogBackfillFragment = {
+  __typename: 'PartitionBackfill';
+  id: string;
+  partitionNames: Array<string> | null;
+  partitionSet: {
+    __typename: 'PartitionSet';
+    name: string;
+    pipelineName: string;
+    repositoryOrigin: {
+      __typename: 'RepositoryOrigin';
+      repositoryName: string;
+      repositoryLocationName: string;
+    };
+  } | null;
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/types/BackfillTable.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/types/BackfillTable.types.ts
@@ -7,25 +7,25 @@ export type BackfillTableFragment = {
   id: string;
   status: Types.BulkActionStatus;
   isAssetBackfill: boolean;
-  hasCancelPermission: boolean;
-  hasResumePermission: boolean;
-  numCancelable: number;
-  partitionNames: Array<string> | null;
   isValidSerialization: boolean;
+  partitionNames: Array<string> | null;
   numPartitions: number | null;
   timestamp: number;
   partitionSetName: string | null;
+  hasCancelPermission: boolean;
+  hasResumePermission: boolean;
+  numCancelable: number;
   partitionSet: {
     __typename: 'PartitionSet';
     id: string;
     name: string;
-    mode: string;
     pipelineName: string;
+    mode: string;
     repositoryOrigin: {
       __typename: 'RepositoryOrigin';
-      id: string;
       repositoryName: string;
       repositoryLocationName: string;
+      id: string;
     };
   } | null;
   assetSelection: Array<{__typename: 'AssetKey'; path: Array<string>}> | null;

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/types/BackfillTable.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/types/BackfillTable.types.ts
@@ -1,6 +1,6 @@
 // Generated GraphQL types, do not edit manually.
 
-import * as Types from '../../graphql/types';
+import * as Types from '../../../graphql/types';
 
 export type BackfillTableFragment = {
   __typename: 'PartitionBackfill';

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/types/BackfillTerminationDialog.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/types/BackfillTerminationDialog.types.ts
@@ -2,6 +2,14 @@
 
 import * as Types from '../../../graphql/types';
 
+export type BackfillTerminationDialogBackfillFragment = {
+  __typename: 'PartitionBackfill';
+  id: string;
+  status: Types.BulkActionStatus;
+  isAssetBackfill: boolean;
+  numCancelable: number;
+};
+
 export type CancelBackfillMutationVariables = Types.Exact<{
   backfillId: Types.Scalars['String'];
 }>;

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/types/BackfillTerminationDialog.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/types/BackfillTerminationDialog.types.ts
@@ -1,6 +1,6 @@
 // Generated GraphQL types, do not edit manually.
 
-import * as Types from '../../graphql/types';
+import * as Types from '../../../graphql/types';
 
 export type CancelBackfillMutationVariables = Types.Exact<{
   backfillId: Types.Scalars['String'];

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/types/BackfillUtils.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/types/BackfillUtils.types.ts
@@ -1,6 +1,6 @@
 // Generated GraphQL types, do not edit manually.
 
-import * as Types from '../../graphql/types';
+import * as Types from '../../../graphql/types';
 
 export type ResumeBackfillMutationVariables = Types.Exact<{
   backfillId: Types.Scalars['String'];

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/types/InstanceBackfills.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/types/InstanceBackfills.types.ts
@@ -54,10 +54,10 @@ export type InstanceBackfillsQuery = {
           timestamp: number;
           partitionSetName: string | null;
           isAssetBackfill: boolean;
+          partitionNames: Array<string> | null;
           hasCancelPermission: boolean;
           hasResumePermission: boolean;
           numCancelable: number;
-          partitionNames: Array<string> | null;
           partitionSet: {
             __typename: 'PartitionSet';
             id: string;

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/BackfillMessaging.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/BackfillMessaging.tsx
@@ -6,7 +6,7 @@ import * as React from 'react';
 import {showCustomAlert} from '../app/CustomAlertProvider';
 import {showSharedToaster} from '../app/DomUtils';
 import {PythonErrorInfo} from '../app/PythonErrorInfo';
-import {LaunchPartitionBackfillMutation} from '../instance/types/BackfillUtils.types';
+import {LaunchPartitionBackfillMutation} from '../instance/backfill/types/BackfillUtils.types';
 import {runsPathWithFilters} from '../runs/RunsFilterInput';
 
 import {

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/BackfillSelector.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/BackfillSelector.tsx
@@ -21,11 +21,11 @@ import {isTimeseriesPartition} from '../assets/MultipartitioningSupport';
 import {GanttChartMode} from '../gantt/GanttChart';
 import {buildLayout} from '../gantt/GanttChartLayout';
 import {PartitionDefinitionType, RunStatus} from '../graphql/types';
-import {LAUNCH_PARTITION_BACKFILL_MUTATION} from '../instance/BackfillUtils';
+import {LAUNCH_PARTITION_BACKFILL_MUTATION} from '../instance/backfill/BackfillUtils';
 import {
   LaunchPartitionBackfillMutation,
   LaunchPartitionBackfillMutationVariables,
-} from '../instance/types/BackfillUtils.types';
+} from '../instance/backfill/types/BackfillUtils.types';
 import {LaunchButton} from '../launchpad/LaunchButton';
 import {TagContainer, TagEditor} from '../launchpad/TagEditor';
 import {explodeCompositesInHandleGraph} from '../pipelines/CompositeSupport';

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/JobBackfillsTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/JobBackfillsTable.tsx
@@ -8,7 +8,7 @@ import {
 import React from 'react';
 
 import {RepositorySelector} from '../graphql/types';
-import {BackfillTable, BACKFILL_TABLE_FRAGMENT} from '../instance/BackfillTable';
+import {BackfillTable, BACKFILL_TABLE_FRAGMENT} from '../instance/backfill/BackfillTable';
 import {Loading} from '../ui/Loading';
 
 import {JobBackfillsQuery, JobBackfillsQueryVariables} from './types/JobBackfillsTable.types';

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/types/JobBackfillsTable.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/types/JobBackfillsTable.types.ts
@@ -21,25 +21,25 @@ export type JobBackfillsQuery = {
           id: string;
           status: Types.BulkActionStatus;
           isAssetBackfill: boolean;
-          hasCancelPermission: boolean;
-          hasResumePermission: boolean;
-          numCancelable: number;
-          partitionNames: Array<string> | null;
           isValidSerialization: boolean;
+          partitionNames: Array<string> | null;
           numPartitions: number | null;
           timestamp: number;
           partitionSetName: string | null;
+          hasCancelPermission: boolean;
+          hasResumePermission: boolean;
+          numCancelable: number;
           partitionSet: {
             __typename: 'PartitionSet';
             id: string;
             name: string;
-            mode: string;
             pipelineName: string;
+            mode: string;
             repositoryOrigin: {
               __typename: 'RepositoryOrigin';
-              id: string;
               repositoryName: string;
               repositoryLocationName: string;
+              id: string;
             };
           } | null;
           assetSelection: Array<{__typename: 'AssetKey'; path: Array<string>}> | null;


### PR DESCRIPTION
## Summary & Motivation

<img width="1403" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/eaf37ec3-7cc0-4a2d-815f-aaa7211c557b">

<img width="1414" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/77f9769f-6fd0-4fd8-b284-18e8a698aa4a">

This PR fixes several issues with the backfill actions dropdown on the backfill list page, and adds the backfill actions to the details page in the same spot that the actions menu appears in the Run details page.

- Both "Cancel submission" and "Terminate unfinished runs" could be shown at the same time, but they both do the same thing. I believe only one or the other is meant to appear at a time.

- The "Show step statuses" option appeared in some cases when clicking it would have no effect because of checks within the modal. I moved those checks (and all the others) into helper methods like `backfillCanCancelSubmission` and `backfillCanCancelRuns` so these tricky logical bits are reusable.

- The backend early-returns an empty result for `partitionStatuses` of asset backfills, but the UI was still asking for this for small backfills instead of asking for counts. Fixing this allows us to properly display the "Run status" column for asset backfills.
- 
<img width="803" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/7c79bbcd-170f-4ee8-8f49-0754af6eacbd">


This PR is a bit larger than it needed to be because I also took this opportunity to make the backfill action modals and the backfill actions menu use GraphQL fragments instead of re-using BackfillTableBackfillFragment, and moved a bunch of backfill related components from `src/instance` to `src/instance/backfill`, which seems like a more appropriate place.

## How I Tested These Changes

Extensively clicked through and launched + cancelled both asset and op job backfills. Viewed a backfill with a missing `partitionSet`, verify step statuses does not appear:

<img width="1425" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/5e2c8d07-bcfb-46bf-a260-16891da9acdc">


