### PR TITLE
[ui] Sort asset keys in places where they are presented in dialogs

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/Utils.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/Utils.tsx
@@ -1,6 +1,7 @@
 import {pathVerticalDiagonal, pathHorizontalDiagonal} from '@vx/shape';
 
 import {featureEnabled, FeatureFlag} from '../app/Flags';
+import {COMMON_COLLATOR} from '../app/Util';
 import {
   AssetCheckExecutionResolvedStatus,
   AssetCheckSeverity,
@@ -246,7 +247,7 @@ export function displayNameForAssetKey(key: {path: string[]}) {
 }
 
 export function sortAssetKeys(a: {path: string[]}, b: {path: string[]}) {
-  return displayNameForAssetKey(a).localeCompare(displayNameForAssetKey(b));
+  return COMMON_COLLATOR.compare(displayNameForAssetKey(a), displayNameForAssetKey(b));
 }
 
 export function stepKeyForAsset(definition: {opNames: string[]}) {

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/Utils.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/Utils.tsx
@@ -245,6 +245,10 @@ export function displayNameForAssetKey(key: {path: string[]}) {
   return key.path.join(' / ');
 }
 
+export function sortAssetKeys(a: {path: string[]}, b: {path: string[]}) {
+  return displayNameForAssetKey(a).localeCompare(displayNameForAssetKey(b));
+}
+
 export function stepKeyForAsset(definition: {opNames: string[]}) {
   // Used for linking to the run with this step highlighted. We only support highlighting
   // a single step, so just use the first one.

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/ParentUpdatedLink.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/ParentUpdatedLink.tsx
@@ -1,7 +1,7 @@
 import {ButtonLink, Box} from '@dagster-io/ui-components';
 import * as React from 'react';
 
-import {displayNameForAssetKey, sortAssetKeys} from '../../asset-graph/Utils';
+import {sortAssetKeys} from '../../asset-graph/Utils';
 import {VirtualizedItemListForDialog} from '../../ui/VirtualizedItemListForDialog';
 import {AssetLink} from '../AssetLink';
 import {AssetKey} from '../types';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/ParentUpdatedLink.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/ParentUpdatedLink.tsx
@@ -1,6 +1,7 @@
 import {ButtonLink, Box} from '@dagster-io/ui-components';
 import * as React from 'react';
 
+import {displayNameForAssetKey, sortAssetKeys} from '../../asset-graph/Utils';
 import {VirtualizedItemListForDialog} from '../../ui/VirtualizedItemListForDialog';
 import {AssetLink} from '../AssetLink';
 import {AssetKey} from '../types';
@@ -27,11 +28,11 @@ export const ParentUpdatedLink = ({updatedAssetKeys, willUpdateAssetKeys}: Props
 
   const filteredAssetKeys: AssetKeyDetail[] = React.useMemo(() => {
     return [
-      ...filteredUpdatedAssetKeys.map((assetKey) => ({
+      ...filteredUpdatedAssetKeys.sort(sortAssetKeys).map((assetKey) => ({
         assetKey,
         detailType: AssetDetailType.Updated,
       })),
-      ...filteredWillUpdateAssetKeys.map((assetKey) => ({
+      ...filteredWillUpdateAssetKeys.sort(sortAssetKeys).map((assetKey) => ({
         assetKey,
         detailType: AssetDetailType.WillUpdate,
       })),

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/ParentUpdatedPartitionLink.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/ParentUpdatedPartitionLink.tsx
@@ -1,6 +1,7 @@
 import {ButtonLink, Box, Tag, Caption} from '@dagster-io/ui-components';
 import * as React from 'react';
 
+import {displayNameForAssetKey, sortAssetKeys} from '../../asset-graph/Utils';
 import {AssetLink} from '../AssetLink';
 import {AssetKey} from '../types';
 
@@ -33,14 +34,14 @@ export const ParentUpdatedPartitionLink = ({updatedAssetKeys, willUpdateAssetKey
         return [
           partitionName,
           [
-            ...(updatedAssetKeys[partitionName]?.map((assetKey) => ({
+            ...(updatedAssetKeys[partitionName] || []).sort(sortAssetKeys).map((assetKey) => ({
               assetKey,
               detailType: AssetDetailType.Updated,
-            })) || []),
-            ...(willUpdateAssetKeys[partitionName]?.map((assetKey) => ({
+            })),
+            ...(willUpdateAssetKeys[partitionName] || []).sort(sortAssetKeys).map((assetKey) => ({
               assetKey,
               detailType: AssetDetailType.WillUpdate,
-            })) || []),
+            })),
           ],
         ];
       }),

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/ParentUpdatedPartitionLink.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/ParentUpdatedPartitionLink.tsx
@@ -1,7 +1,7 @@
 import {ButtonLink, Box, Tag, Caption} from '@dagster-io/ui-components';
 import * as React from 'react';
 
-import {displayNameForAssetKey, sortAssetKeys} from '../../asset-graph/Utils';
+import {sortAssetKeys} from '../../asset-graph/Utils';
 import {AssetLink} from '../AssetLink';
 import {AssetKey} from '../types';
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/VirtualizedAssetPartitionListForDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/VirtualizedAssetPartitionListForDialog.tsx
@@ -3,6 +3,7 @@ import {useVirtualizer} from '@tanstack/react-virtual';
 import * as React from 'react';
 import styled from 'styled-components';
 
+import {COMMON_COLLATOR} from '../../app/Util';
 import {Container, Inner, Row} from '../../ui/VirtualizedTable';
 
 interface Props<A> {
@@ -32,7 +33,9 @@ export function VirtualizedAssetPartitionListForDialog<A>({
 
   const allRows = React.useMemo(() => {
     const rows = [] as Row<A>[];
-    const partitionNames = Object.keys(assetKeysByPartition).sort();
+    const partitionNames = Object.keys(assetKeysByPartition).sort((a, b) =>
+      COMMON_COLLATOR.compare(a, b),
+    );
     partitionNames.forEach((partitionName) => {
       const assetKeys = assetKeysByPartition[partitionName]!;
       const expanded = expandedPartitions.has(partitionName);

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/VirtualizedAssetPartitionListForDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/VirtualizedAssetPartitionListForDialog.tsx
@@ -32,7 +32,9 @@ export function VirtualizedAssetPartitionListForDialog<A>({
 
   const allRows = React.useMemo(() => {
     const rows = [] as Row<A>[];
-    Object.entries(assetKeysByPartition).forEach(([partitionName, assetKeys]) => {
+    const partitionNames = Object.keys(assetKeysByPartition).sort();
+    partitionNames.forEach((partitionName) => {
+      const assetKeys = assetKeysByPartition[partitionName]!;
       const expanded = expandedPartitions.has(partitionName);
       rows.push({type: 'partition-name', partitionName, expanded, assetCount: assetKeys.length});
       if (expanded) {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/WaitingOnAssetKeysPartitionLink.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/WaitingOnAssetKeysPartitionLink.tsx
@@ -24,7 +24,7 @@ export const WaitingOnAssetKeysPartitionLink = ({assetKeysByPartition}: Props) =
     return Object.fromEntries(
       filteredPartitionNames.map((partitionName) => [
         partitionName,
-        assetKeysByPartition[partitionName]!.sort(sortAssetKeys),
+        [...assetKeysByPartition[partitionName]!].sort(sortAssetKeys),
       ]),
     );
   }, [assetKeysByPartition, filteredPartitionNames]);

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/WaitingOnAssetKeysPartitionLink.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/WaitingOnAssetKeysPartitionLink.tsx
@@ -1,6 +1,7 @@
 import {ButtonLink, Box, Tag, Caption} from '@dagster-io/ui-components';
 import * as React from 'react';
 
+import {displayNameForAssetKey, sortAssetKeys} from '../../asset-graph/Utils';
 import {AssetLink} from '../AssetLink';
 import {AssetKey} from '../types';
 
@@ -23,7 +24,7 @@ export const WaitingOnAssetKeysPartitionLink = ({assetKeysByPartition}: Props) =
     return Object.fromEntries(
       filteredPartitionNames.map((partitionName) => [
         partitionName,
-        assetKeysByPartition[partitionName]!,
+        assetKeysByPartition[partitionName]!.sort(sortAssetKeys),
       ]),
     );
   }, [assetKeysByPartition, filteredPartitionNames]);

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/WaitingOnAssetKeysPartitionLink.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/WaitingOnAssetKeysPartitionLink.tsx
@@ -1,7 +1,7 @@
 import {ButtonLink, Box, Tag, Caption} from '@dagster-io/ui-components';
 import * as React from 'react';
 
-import {displayNameForAssetKey, sortAssetKeys} from '../../asset-graph/Utils';
+import {sortAssetKeys} from '../../asset-graph/Utils';
 import {AssetLink} from '../AssetLink';
 import {AssetKey} from '../types';
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/assetFilters.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/assetFilters.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import {sortAssetKeys} from '../../asset-graph/Utils';
 import {AssetKey} from '../types';
 
 export const useFilterAssetKeys = (assetKeys: AssetKey[], queryString: string) => {
@@ -8,9 +9,11 @@ export const useFilterAssetKeys = (assetKeys: AssetKey[], queryString: string) =
     if (queryLowercase === '') {
       return assetKeys;
     }
-    return assetKeys.filter((assetKey) =>
-      assetKey.path.some((part) => part.toLowerCase().includes(queryLowercase)),
-    );
+    return assetKeys
+      .filter((assetKey) =>
+        assetKey.path.some((part) => part.toLowerCase().includes(queryLowercase)),
+      )
+      .sort(sortAssetKeys);
   }, [assetKeys, queryLowercase]);
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetExecutionButton.tsx
@@ -20,6 +20,7 @@ import {
   displayNameForAssetKey,
   isHiddenAssetGroupJob,
   LiveData,
+  sortAssetKeys,
   toGraphId,
   tokenForAssetKey,
 } from '../asset-graph/Utils';
@@ -527,9 +528,7 @@ function getAnchorAssetForPartitionMappedBackfill(assets: LaunchAssetExecutionAs
 
   const partitionedRoots = roots
     .filter((r) => !!r.partitionDefinition)
-    .sort((a, b) =>
-      displayNameForAssetKey(a.assetKey).localeCompare(displayNameForAssetKey(b.assetKey)),
-    );
+    .sort((a, b) => sortAssetKeys(a.assetKey, b.assetKey));
 
   if (!partitionedRoots.length) {
     return null;


### PR DESCRIPTION
## Summary & Motivation

This is a small front-end fix for part of the discussion in https://elementl-workspace.slack.com/archives/C04UD72HHQX/p1693971381498569. When we display a list of asset keys or partitions from the AMP page, sort the data before display.

The last remaining piece is to investigate whether the backend returns `assetNodeOrError.autoMaterializePolicy?.rules` in random orders across refreshes. 

## How I Tested These Changes

Viewed AMP page manually