### PR TITLE
[ext] Add typed metadata support to dagster-ext

### DIFF
--- a/python_modules/dagster-ext/dagster_ext/__init__.py
+++ b/python_modules/dagster-ext/dagster_ext/__init__.py
@@ -18,6 +18,7 @@ from typing import (
     ClassVar,
     Generic,
     Iterator,
+    Literal,
     Mapping,
     Optional,
     Sequence,
@@ -26,6 +27,7 @@ from typing import (
     TypedDict,
     TypeVar,
     cast,
+    get_args,
 )
 
 if TYPE_CHECKING:
@@ -92,6 +94,23 @@ class ExtDataProvenance(TypedDict):
     code_version: str
     input_data_versions: Mapping[str, str]
     is_user_provided: bool
+
+
+ExtMetadataType = Literal[
+    "text",
+    "url",
+    "path",
+    "notebook",
+    "json",
+    "md",
+    "float",
+    "int",
+    "bool",
+    "dagster_run",
+    "asset",
+    "table",
+    "null",
+]
 
 
 # ########################
@@ -210,6 +229,17 @@ def _assert_opt_env_param_type(
 
 def _assert_param_value(value: _T, expected_values: Sequence[_T], method: str, param: str) -> _T:
     if value not in expected_values:
+        raise DagsterExtError(
+            f"Invalid value for parameter `{param}` of `{method}`. Expected one of"
+            f" `{expected_values}`, got `{value}`."
+        )
+    return value
+
+
+def _assert_opt_param_value(
+    value: _T, expected_values: Sequence[_T], method: str, param: str
+) -> _T:
+    if value is not None and value not in expected_values:
         raise DagsterExtError(
             f"Invalid value for parameter `{param}` of `{method}`. Expected one of"
             f" `{expected_values}`, got `{value}`."
@@ -668,15 +698,23 @@ class ExtContext:
     # ##### WRITE
 
     def report_asset_metadata(
-        self, label: str, value: Any, asset_key: Optional[str] = None
+        self,
+        label: str,
+        value: Any,
+        type: Optional[ExtMetadataType] = None,  # noqa: A002
+        asset_key: Optional[str] = None,
     ) -> None:
         asset_key = _resolve_optionally_passed_asset_key(
             self._data, asset_key, "report_asset_metadata"
         )
         label = _assert_param_type(label, str, "report_asset_metadata", "label")
         value = _assert_param_json_serializable(value, "report_asset_metadata", "value")
+        _type = _assert_opt_param_value(
+            type, get_args(ExtMetadataType), "report_asset_metadata", "type"
+        )
         self._write_message(
-            "report_asset_metadata", {"asset_key": asset_key, "label": label, "value": value}
+            "report_asset_metadata",
+            {"asset_key": asset_key, "label": label, "value": value, "type": _type},
         )
 
     def report_asset_data_version(self, data_version: str, asset_key: Optional[str] = None) -> None:

--- a/python_modules/dagster-ext/dagster_ext/__init__.py
+++ b/python_modules/dagster-ext/dagster_ext/__init__.py
@@ -108,7 +108,6 @@ ExtMetadataType = Literal[
     "bool",
     "dagster_run",
     "asset",
-    "table",
     "null",
 ]
 
@@ -701,7 +700,7 @@ class ExtContext:
         self,
         label: str,
         value: Any,
-        type: Optional[ExtMetadataType] = None,  # noqa: A002
+        metadata_type: Optional[ExtMetadataType] = None,
         asset_key: Optional[str] = None,
     ) -> None:
         asset_key = _resolve_optionally_passed_asset_key(
@@ -709,12 +708,12 @@ class ExtContext:
         )
         label = _assert_param_type(label, str, "report_asset_metadata", "label")
         value = _assert_param_json_serializable(value, "report_asset_metadata", "value")
-        _type = _assert_opt_param_value(
-            type, get_args(ExtMetadataType), "report_asset_metadata", "type"
+        metadata_type = _assert_opt_param_value(
+            metadata_type, get_args(ExtMetadataType), "report_asset_metadata", "type"
         )
         self._write_message(
             "report_asset_metadata",
-            {"asset_key": asset_key, "label": label, "value": value, "type": _type},
+            {"asset_key": asset_key, "label": label, "value": value, "type": metadata_type},
         )
 
     def report_asset_data_version(self, data_version: str, asset_key: Optional[str] = None) -> None:

--- a/python_modules/dagster-ext/dagster_ext_tests/test_context.py
+++ b/python_modules/dagster-ext/dagster_ext_tests/test_context.py
@@ -79,7 +79,8 @@ def test_single_asset_context():
     assert context.code_version_by_asset_key == {"foo": "beta"}
     assert context.provenance == foo_provenance
     assert context.provenance_by_asset_key == {"foo": foo_provenance}
-    context.report_asset_metadata("bar", "baz")
+    context.report_asset_metadata("bar", "boo")
+    context.report_asset_metadata("baz", 2, "int")
     context.report_asset_data_version("bar")
 
     _assert_unknown_asset_key(context, "report_asset_metadata", "bar", "baz", asset_key="fake")

--- a/python_modules/dagster-ext/dagster_ext_tests/test_external_execution.py
+++ b/python_modules/dagster-ext/dagster_ext_tests/test_external_execution.py
@@ -16,6 +16,7 @@ from dagster._core.definitions.data_version import (
 )
 from dagster._core.definitions.decorators.asset_decorator import asset
 from dagster._core.definitions.materialize import materialize
+from dagster._core.definitions.metadata import MarkdownMetadataValue
 from dagster._core.errors import DagsterExternalExecutionError
 from dagster._core.execution.context.compute import AssetExecutionContext
 from dagster._core.execution.context.invocation import build_asset_context
@@ -76,7 +77,7 @@ def external_script() -> Iterator[str]:
         context = ExtContext.get()
         context.log("hello world")
         time.sleep(0.1)  # sleep to make sure that we encompass multiple intervals for blob store IO
-        context.report_asset_metadata("bar", context.get_extra("bar"))
+        context.report_asset_metadata("bar", context.get_extra("bar"), type="md")
         context.report_asset_data_version("alpha")
 
     with temp_script(script_fn) as script_path:
@@ -154,6 +155,7 @@ def test_ext_subprocess(
         )
         mat = instance.get_latest_materialization_event(foo.key)
         assert mat and mat.asset_materialization
+        assert isinstance(mat.asset_materialization.metadata["bar"], MarkdownMetadataValue)
         assert mat.asset_materialization.metadata["bar"].value == "baz"
         assert mat.asset_materialization.tags
         assert mat.asset_materialization.tags[DATA_VERSION_TAG] == "alpha"

--- a/python_modules/dagster/dagster/_check/__init__.py
+++ b/python_modules/dagster/dagster/_check/__init__.py
@@ -883,6 +883,31 @@ def is_list(
 
 
 # ########################
+# ##### LITERAL
+# ########################
+
+
+def literal_param(
+    obj: T, param_name: str, values: Sequence[object], additional_message: Optional[str] = None
+) -> T:
+    additional_message = " " + additional_message if additional_message else ""
+    if obj not in values:
+        raise _param_value_mismatch_exception(obj, values, param_name, additional_message)
+    return obj
+
+
+def opt_literal_param(
+    obj: T, param_name: str, values: Sequence[object], additional_message: Optional[str] = None
+) -> T:
+    additional_message = " " + additional_message if additional_message else ""
+    if obj is not None and obj not in values:
+        raise _param_value_mismatch_exception(
+            obj, values, param_name, additional_message, allow_none=True
+        )
+    return obj
+
+
+# ########################
 # ##### MAPPING
 # ########################
 
@@ -1642,6 +1667,21 @@ def _element_check_error(
     additional_message = " " + additional_message if additional_message else ""
     return ElementCheckError(
         f"Value {value!r} from key {key} is not a {ttype!r}. Dict: {ddict!r}.{additional_message}"
+    )
+
+
+def _param_value_mismatch_exception(
+    obj: object,
+    values: Sequence[object],
+    param_name: str,
+    additional_message: Optional[str] = None,
+    allow_none: bool = False,
+) -> ParameterCheckError:
+    allow_none_clause = " or None" if allow_none else ""
+    additional_message = " " + additional_message if additional_message else ""
+    return ParameterCheckError(
+        f'Param "{param_name}" is not equal to one of {values}{allow_none_clause}. Got'
+        f" {obj!r}.{additional_message}"
     )
 
 

--- a/python_modules/dagster/dagster/_check/__init__.py
+++ b/python_modules/dagster/dagster/_check/__init__.py
@@ -890,7 +890,6 @@ def is_list(
 def literal_param(
     obj: T, param_name: str, values: Sequence[object], additional_message: Optional[str] = None
 ) -> T:
-    additional_message = " " + additional_message if additional_message else ""
     if obj not in values:
         raise _param_value_mismatch_exception(obj, values, param_name, additional_message)
     return obj
@@ -899,10 +898,9 @@ def literal_param(
 def opt_literal_param(
     obj: T, param_name: str, values: Sequence[object], additional_message: Optional[str] = None
 ) -> T:
-    additional_message = " " + additional_message if additional_message else ""
     if obj is not None and obj not in values:
         raise _param_value_mismatch_exception(
-            obj, values, param_name, additional_message, allow_none=True
+            obj, values, param_name, additional_message, optional=True
         )
     return obj
 
@@ -1675,9 +1673,9 @@ def _param_value_mismatch_exception(
     values: Sequence[object],
     param_name: str,
     additional_message: Optional[str] = None,
-    allow_none: bool = False,
+    optional: bool = False,
 ) -> ParameterCheckError:
-    allow_none_clause = " or None" if allow_none else ""
+    allow_none_clause = " or None" if optional else ""
     additional_message = " " + additional_message if additional_message else ""
     return ParameterCheckError(
         f'Param "{param_name}" is not equal to one of {values}{allow_none_clause}. Got'

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -410,6 +410,20 @@ class OpExecutionContext(AbstractComputeExecutionContext):
             metadata=metadata, output_name=output_name, mapping_key=mapping_key
         )
 
+    def merge_output_metadata(
+        self,
+        metadata: Mapping[str, Any],
+        output_name: Optional[str] = None,
+        mapping_key: Optional[str] = None,
+    ) -> None:
+        metadata = check.mapping_param(metadata, "metadata", key_type=str)
+        output_name = check.opt_str_param(output_name, "output_name")
+        mapping_key = check.opt_str_param(mapping_key, "mapping_key")
+
+        self._step_execution_context.add_output_metadata(
+            metadata=metadata, output_name=output_name, mapping_key=mapping_key, merge=True
+        )
+
     def get_output_metadata(
         self, output_name: str, mapping_key: Optional[str] = None
     ) -> Optional[Mapping[str, Any]]:

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_op.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_op.py
@@ -916,6 +916,20 @@ def test_metadata_logging_multiple_entries():
         execute_op_in_graph(basic)
 
 
+def test_metadata_logging_multiple_entries_with_merge():
+    @op
+    def basic(context):
+        context.merge_output_metadata({"foo": "bar"})
+        context.merge_output_metadata({"baz": "bat"})
+
+    result = execute_op_in_graph(basic)
+    assert result.success
+    events = result.events_for_node("basic")
+    assert len(events[1].event_specific_data.metadata) == 2
+    assert events[1].event_specific_data.metadata["foo"].text == "bar"
+    assert events[1].event_specific_data.metadata["baz"].text == "bat"
+
+
 def test_log_event_multi_output():
     @op(out={"out1": Out(), "out2": Out()})
     def the_op(context):


### PR DESCRIPTION
## Summary & Motivation

Adds a `metadata_type` field to `report_asset_metadata`. This takes a string literal (specified in the `ExtMetadataType` type alias). These strings correspond to static methods on `MetadataValue` that construct metadata values of the target type.

## How I Tested These Changes

Modified unit tests.
