### PR TITLE
s/is_orchestration_active/is_dagster_ext_process/g

### DIFF
--- a/python_modules/dagster-ext/dagster_ext/__init__.py
+++ b/python_modules/dagster-ext/dagster_ext/__init__.py
@@ -49,11 +49,10 @@ def _param_name_to_env_key(key: str) -> str:
 
 # ##### PARAMETERS
 
-IS_LAUNCHED_DAGSTER_EXT_PROCESS_ENV_VAR = "IS_LAUNCHED_DAGSTER_EXT_PROCESS"
+IS_DAGSTER_EXT_PROCESS_ENV_VAR = "IS_DAGSTER_EXT_PROCESS"
 
 DAGSTER_EXT_ENV_KEYS = {
-    k: _param_name_to_env_key(k)
-    for k in (IS_LAUNCHED_DAGSTER_EXT_PROCESS_ENV_VAR, "context", "messages")
+    k: _param_name_to_env_key(k) for k in (IS_DAGSTER_EXT_PROCESS_ENV_VAR, "context", "messages")
 }
 
 
@@ -257,8 +256,8 @@ def _env_var_to_param_name(env_var: str) -> str:
     return env_var[len(_ENV_KEY_PREFIX) :].lower()
 
 
-def is_launched_ext_process() -> bool:
-    return _param_from_env_var(IS_LAUNCHED_DAGSTER_EXT_PROCESS_ENV_VAR)
+def is_dagster_ext_process() -> bool:
+    return _param_from_env_var(IS_DAGSTER_EXT_PROCESS_ENV_VAR)
 
 
 def _emit_orchestration_inactive_warning() -> None:
@@ -524,7 +523,7 @@ def init_dagster_ext(
     if ExtContext.is_initialized():
         return ExtContext.get()
 
-    if is_launched_ext_process():
+    if is_dagster_ext_process():
         param_loader = param_loader or ExtEnvVarParamLoader()
         context_params = param_loader.load_context_params()
         messages_params = param_loader.load_messages_params()

--- a/python_modules/dagster-ext/dagster_ext/__init__.py
+++ b/python_modules/dagster-ext/dagster_ext/__init__.py
@@ -49,8 +49,11 @@ def _param_name_to_env_key(key: str) -> str:
 
 # ##### PARAMETERS
 
+IS_LAUNCHED_DAGSTER_EXT_PROCESS_ENV_VAR = "IS_LAUNCHED_DAGSTER_EXT_PROCESS"
+
 DAGSTER_EXT_ENV_KEYS = {
-    k: _param_name_to_env_key(k) for k in ("is_orchestration_active", "context", "messages")
+    k: _param_name_to_env_key(k)
+    for k in (IS_LAUNCHED_DAGSTER_EXT_PROCESS_ENV_VAR, "context", "messages")
 }
 
 
@@ -254,8 +257,8 @@ def _env_var_to_param_name(env_var: str) -> str:
     return env_var[len(_ENV_KEY_PREFIX) :].lower()
 
 
-def is_dagster_orchestration_active() -> bool:
-    return _param_from_env_var("is_orchestration_active")
+def is_launched_ext_process() -> bool:
+    return _param_from_env_var(IS_LAUNCHED_DAGSTER_EXT_PROCESS_ENV_VAR)
 
 
 def _emit_orchestration_inactive_warning() -> None:
@@ -521,7 +524,7 @@ def init_dagster_ext(
     if ExtContext.is_initialized():
         return ExtContext.get()
 
-    if is_dagster_orchestration_active():
+    if is_launched_ext_process():
         param_loader = param_loader or ExtEnvVarParamLoader()
         context_params = param_loader.load_context_params()
         messages_params = param_loader.load_messages_params()

--- a/python_modules/dagster-ext/dagster_ext_tests/test_external_execution.py
+++ b/python_modules/dagster-ext/dagster_ext_tests/test_external_execution.py
@@ -201,10 +201,10 @@ def test_ext_no_orchestration():
         from dagster_ext import (
             ExtContext,
             init_dagster_ext,
-            is_dagster_orchestration_active,
+            is_launched_ext_process,
         )
 
-        assert not is_dagster_orchestration_active()
+        assert not is_launched_ext_process()
 
         init_dagster_ext()
         context = ExtContext.get()

--- a/python_modules/dagster-ext/dagster_ext_tests/test_external_execution.py
+++ b/python_modules/dagster-ext/dagster_ext_tests/test_external_execution.py
@@ -201,10 +201,10 @@ def test_ext_no_orchestration():
         from dagster_ext import (
             ExtContext,
             init_dagster_ext,
-            is_launched_ext_process,
+            is_dagster_ext_process,
         )
 
-        assert not is_launched_ext_process()
+        assert not is_dagster_ext_process()
 
         init_dagster_ext()
         context = ExtContext.get()

--- a/python_modules/dagster/dagster/_core/ext/client.py
+++ b/python_modules/dagster/dagster/_core/ext/client.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Iterator, Mapping, Optional
 
 from dagster_ext import (
     DAGSTER_EXT_ENV_KEYS,
-    IS_LAUNCHED_DAGSTER_EXT_PROCESS_ENV_VAR,
+    IS_DAGSTER_EXT_PROCESS_ENV_VAR,
     ExtExtras,
     ExtParams,
     encode_env_var,
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 
 class ExtClient(ABC):
     def get_base_env(self) -> Mapping[str, str]:
-        return {DAGSTER_EXT_ENV_KEYS[IS_LAUNCHED_DAGSTER_EXT_PROCESS_ENV_VAR]: encode_env_var(True)}
+        return {DAGSTER_EXT_ENV_KEYS[IS_DAGSTER_EXT_PROCESS_ENV_VAR]: encode_env_var(True)}
 
     @abstractmethod
     def run(

--- a/python_modules/dagster/dagster/_core/ext/client.py
+++ b/python_modules/dagster/dagster/_core/ext/client.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Iterator, Mapping, Optional
 
 from dagster_ext import (
     DAGSTER_EXT_ENV_KEYS,
+    IS_LAUNCHED_DAGSTER_EXT_PROCESS_ENV_VAR,
     ExtExtras,
     ExtParams,
     encode_env_var,
@@ -17,7 +18,7 @@ if TYPE_CHECKING:
 
 class ExtClient(ABC):
     def get_base_env(self) -> Mapping[str, str]:
-        return {DAGSTER_EXT_ENV_KEYS["is_orchestration_active"]: encode_env_var(True)}
+        return {DAGSTER_EXT_ENV_KEYS[IS_LAUNCHED_DAGSTER_EXT_PROCESS_ENV_VAR]: encode_env_var(True)}
 
     @abstractmethod
     def run(


### PR DESCRIPTION
## Summary & Motivation

is_dagster_orchestration active is not a particularly accurate name to describe the state of an ext process and the underlying environment variable that signals that an ext client launched the compute. This proposes instead that we name this state `is_dagster_ext_process` and the underlying env var `IS_DAGSTER_EXT_PROCESS`

## How I Tested These Changes

BK
