### PR TITLE
Allow OpExecutionContext.add_output_metadata to be called multiple times per output

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -368,6 +368,7 @@ class OpExecutionContext(AbstractComputeExecutionContext):
         else:
             check.failed(f"Unexpected event {event}")
 
+    @public
     def add_output_metadata(
         self,
         metadata: Mapping[str, Any],
@@ -376,11 +377,14 @@ class OpExecutionContext(AbstractComputeExecutionContext):
     ) -> None:
         """Add metadata to one of the outputs of an op.
 
-        This can only be used once per output in the body of an op. Using this method with the same output_name more than once within an op will result in an error.
+        This can be invoked multiple times per output in the body of an op. If the same key is
+        passed multiple times, the value associated with the last call will be used.
 
         Args:
             metadata (Mapping[str, Any]): The metadata to attach to the output
             output_name (Optional[str]): The name of the output to attach metadata to. If there is only one output on the op, then this argument does not need to be provided. The metadata will automatically be attached to the only output.
+            mapping_key (Optional[str]): The mapping key of the output to attach metadata to. If the
+                output is not dynamic, this argument does not need to be provided.
 
         **Examples:**
 
@@ -408,20 +412,6 @@ class OpExecutionContext(AbstractComputeExecutionContext):
 
         self._step_execution_context.add_output_metadata(
             metadata=metadata, output_name=output_name, mapping_key=mapping_key
-        )
-
-    def merge_output_metadata(
-        self,
-        metadata: Mapping[str, Any],
-        output_name: Optional[str] = None,
-        mapping_key: Optional[str] = None,
-    ) -> None:
-        metadata = check.mapping_param(metadata, "metadata", key_type=str)
-        output_name = check.opt_str_param(output_name, "output_name")
-        mapping_key = check.opt_str_param(mapping_key, "mapping_key")
-
-        self._step_execution_context.add_output_metadata(
-            metadata=metadata, output_name=output_name, mapping_key=mapping_key, merge=True
         )
 
     def get_output_metadata(

--- a/python_modules/dagster/dagster/_core/execution/context/system.py
+++ b/python_modules/dagster/dagster/_core/execution/context/system.py
@@ -738,7 +738,6 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
         metadata: Mapping[str, Any],
         output_name: Optional[str] = None,
         mapping_key: Optional[str] = None,
-        merge: bool = False,
     ) -> None:
         if output_name is None and len(self.op_def.output_defs) == 1:
             output_def = self.op_def.output_defs[0]
@@ -768,16 +767,6 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
                 f"In {self.op_def.node_type_str} '{self.op.name}', attempted to log metadata"
                 f" for dynamic output '{output_def.name}' without providing a mapping key. When"
                 " logging metadata for a dynamic output, it is necessary to provide a mapping key."
-            )
-
-        if (
-            not merge
-            and output_name in self._output_metadata
-            and (mapping_key is None or mapping_key in self._output_metadata[output_name])
-        ):
-            raise DagsterInvariantViolationError(
-                f"In {self.op_def.node_type_str} '{self.op.name}', attempted to log metadata for"
-                f" output '{output_name}' more than once."
             )
 
         if mapping_key:

--- a/python_modules/dagster/dagster/_core/ext/context.py
+++ b/python_modules/dagster/dagster/_core/ext/context.py
@@ -46,7 +46,7 @@ class ExtMessageHandler:
         key = AssetKey.from_user_string(asset_key)
         output_name = self._context.output_for_asset_key(key)
         metadata_value = self._resolve_metadata_value(value, type)
-        self._context.merge_output_metadata({label: metadata_value}, output_name)
+        self._context.add_output_metadata({label: metadata_value}, output_name)
 
     def _resolve_metadata_value(
         self, value: Any, metadata_type: Optional[ExtMetadataType]

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_op.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_op.py
@@ -906,28 +906,16 @@ def test_metadata_logging():
 def test_metadata_logging_multiple_entries():
     @op
     def basic(context):
-        context.add_output_metadata({"foo": "bar"})
-        context.add_output_metadata({"baz": "bat"})
-
-    with pytest.raises(
-        DagsterInvariantViolationError,
-        match="In op 'basic', attempted to log metadata for output 'result' more than once.",
-    ):
-        execute_op_in_graph(basic)
-
-
-def test_metadata_logging_multiple_entries_with_merge():
-    @op
-    def basic(context):
-        context.merge_output_metadata({"foo": "bar"})
-        context.merge_output_metadata({"baz": "bat"})
+        context.add_output_metadata({"foo": "first_value"})
+        context.add_output_metadata({"foo": "second_value"})  # overwrites first
+        context.add_output_metadata({"boo": "bot"})
 
     result = execute_op_in_graph(basic)
     assert result.success
     events = result.events_for_node("basic")
     assert len(events[1].event_specific_data.metadata) == 2
-    assert events[1].event_specific_data.metadata["foo"].text == "bar"
-    assert events[1].event_specific_data.metadata["baz"].text == "bat"
+    assert events[1].event_specific_data.metadata["foo"].text == "second_value"
+    assert events[1].event_specific_data.metadata["boo"].text == "bot"
 
 
 def test_log_event_multi_output():


### PR DESCRIPTION
## Summary & Motivation

`OpExecutionContext.add_output_metadata` imposes a restriction that it can only be called once-per-output. It's unclear to me what the reason for this restriction is, and it complicates the implementation of metadata reporting in `dagster-ext`. This PR removes the restriction.

cc @dpeng817 since it looks like you added `add_output_metadata` way back in #6530 

## How I Tested These Changes

Modified existing unit tests.