### PR TITLE
[bug] Fix issue in which incorrect run requests would be made for partitioned observable source assets with different partitions defs

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -788,7 +788,8 @@ def get_auto_observe_run_requests(
         ):
             assets_to_auto_observe.add(asset_key)
 
-    partitions_def_and_asset_key_groups = []
+    # create groups of asset keys that share the same repository AND the same partitions definition
+    partitions_def_and_asset_key_groups: List[Sequence[AssetKey]] = []
     for repository_asset_keys in asset_graph.split_asset_keys_by_repository(assets_to_auto_observe):
         asset_keys_by_partitions_def = defaultdict(list)
         for asset_key in repository_asset_keys:
@@ -796,10 +797,8 @@ def get_auto_observe_run_requests(
             asset_keys_by_partitions_def[partitions_def].append(asset_key)
         partitions_def_and_asset_key_groups.extend(asset_keys_by_partitions_def.values())
 
-    ret = [
+    return [
         RunRequest(asset_selection=list(asset_keys), tags=run_tags)
         for asset_keys in partitions_def_and_asset_key_groups
         if len(asset_keys) > 0
     ]
-    print(ret)
-    return ret

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -788,8 +788,18 @@ def get_auto_observe_run_requests(
         ):
             assets_to_auto_observe.add(asset_key)
 
-    return [
+    partitions_def_and_asset_key_groups = []
+    for repository_asset_keys in asset_graph.split_asset_keys_by_repository(assets_to_auto_observe):
+        asset_keys_by_partitions_def = defaultdict(list)
+        for asset_key in repository_asset_keys:
+            partitions_def = asset_graph.get_partitions_def(asset_key)
+            asset_keys_by_partitions_def[partitions_def].append(asset_key)
+        partitions_def_and_asset_key_groups.extend(asset_keys_by_partitions_def.values())
+
+    ret = [
         RunRequest(asset_selection=list(asset_keys), tags=run_tags)
-        for asset_keys in asset_graph.split_asset_keys_by_repository(assets_to_auto_observe)
+        for asset_keys in partitions_def_and_asset_key_groups
         if len(asset_keys) > 0
     ]
+    print(ret)
+    return ret

--- a/python_modules/dagster/dagster/_core/definitions/external_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/external_asset_graph.py
@@ -11,6 +11,7 @@ from typing import (
     Set,
     Tuple,
 )
+import dagster._check as check
 
 from dagster._core.definitions.assets_job import ASSET_BASE_JOB_PREFIX
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
@@ -228,17 +229,55 @@ class ExternalAssetGraph(AssetGraph):
     def get_asset_keys_for_job(self, job_name: str) -> Sequence[AssetKey]:
         return self._asset_keys_by_job_name[job_name]
 
-    def get_implicit_job_name_for_assets(self, asset_keys: Iterable[AssetKey]) -> Optional[str]:
+    def get_implicit_job_name_for_assets(
+        self,
+        asset_keys: Iterable[AssetKey],
+        external_repo: ExternalRepository,
+    ) -> Optional[str]:
         """Returns the name of the asset base job that contains all the given assets, or None if there is no such
         job.
 
         Note: all asset_keys should be in the same repository.
         """
-        for job_name in sorted(self._asset_keys_by_job_name.keys()):
-            if not job_name.startswith(ASSET_BASE_JOB_PREFIX):
-                continue
-            if all(asset_key in self._asset_keys_by_job_name[job_name] for asset_key in asset_keys):
-                return job_name
+        if all(self.is_observable(asset_key) for asset_key in asset_keys):
+            # for observable source assets, we need to select the job based on the partitions def
+            target_partitions_defs = {
+                self.get_partitions_def(asset_key) for asset_key in asset_keys
+            }
+            check.invariant(len(target_partitions_defs) == 1, "Expected exactly one partitions def")
+            target_partitions_def = next(iter(target_partitions_defs))
+
+            # create a mapping from job name to the partitions def of that job
+            partitions_def_by_job_name = {}
+            for (
+                external_partition_set_data
+            ) in external_repo.external_repository_data.external_partition_set_datas:
+                if external_partition_set_data.external_partitions_data is None:
+                    partitions_def = None
+                else:
+                    partitions_def = (
+                        external_partition_set_data.external_partitions_data.get_partitions_definition()
+                    )
+                partitions_def_by_job_name[external_partition_set_data.job_name] = partitions_def
+            # add any jobs that don't have a partitions def
+            for external_job in external_repo.get_all_external_jobs():
+                job_name = external_job.external_job_data.name
+                if job_name not in partitions_def_by_job_name:
+                    partitions_def_by_job_name[job_name] = None
+            # find the job that matches the expected partitions definition
+            for job_name, external_partitions_def in partitions_def_by_job_name.items():
+                if not job_name.startswith(ASSET_BASE_JOB_PREFIX):
+                    continue
+                if external_partitions_def == target_partitions_def:
+                    return job_name
+        else:
+            for job_name in sorted(self._asset_keys_by_job_name.keys()):
+                if not job_name.startswith(ASSET_BASE_JOB_PREFIX):
+                    continue
+                if all(
+                    asset_key in self._asset_keys_by_job_name[job_name] for asset_key in asset_keys
+                ):
+                    return job_name
         return None
 
     def split_asset_keys_by_repository(

--- a/python_modules/dagster/dagster/_core/definitions/external_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/external_asset_graph.py
@@ -272,7 +272,9 @@ class ExternalAssetGraph(AssetGraph):
             for job_name, external_partitions_def in partitions_def_by_job_name.items():
                 if not job_name.startswith(ASSET_BASE_JOB_PREFIX):
                     continue
-                if external_partitions_def == target_partitions_def:
+                if external_partitions_def == target_partitions_def and all(
+                    asset_key in self._asset_keys_by_job_name[job_name] for asset_key in asset_keys
+                ):
                     return job_name
         else:
             for job_name in sorted(self._asset_keys_by_job_name.keys()):

--- a/python_modules/dagster/dagster/_core/definitions/external_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/external_asset_graph.py
@@ -232,7 +232,7 @@ class ExternalAssetGraph(AssetGraph):
     def get_implicit_job_name_for_assets(
         self,
         asset_keys: Iterable[AssetKey],
-        external_repo: ExternalRepository,
+        external_repo: Optional[ExternalRepository],
     ) -> Optional[str]:
         """Returns the name of the asset base job that contains all the given assets, or None if there is no such
         job.
@@ -240,6 +240,11 @@ class ExternalAssetGraph(AssetGraph):
         Note: all asset_keys should be in the same repository.
         """
         if all(self.is_observable(asset_key) for asset_key in asset_keys):
+            check.invariant(
+                external_repo is not None,
+                "external_repo must be passed in when getting job names for observable source"
+                " assets",
+            )
             # for observable source assets, we need to select the job based on the partitions def
             target_partitions_defs = {
                 self.get_partitions_def(asset_key) for asset_key in asset_keys

--- a/python_modules/dagster/dagster/_core/definitions/external_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/external_asset_graph.py
@@ -11,8 +11,8 @@ from typing import (
     Set,
     Tuple,
 )
-import dagster._check as check
 
+import dagster._check as check
 from dagster._core.definitions.assets_job import ASSET_BASE_JOB_PREFIX
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.host_representation.external import ExternalRepository
@@ -240,11 +240,10 @@ class ExternalAssetGraph(AssetGraph):
         Note: all asset_keys should be in the same repository.
         """
         if all(self.is_observable(asset_key) for asset_key in asset_keys):
-            check.invariant(
-                external_repo is not None,
-                "external_repo must be passed in when getting job names for observable source"
-                " assets",
-            )
+            if external_repo is None:
+                check.failed(
+                    "external_repo must be passed in when getting job names for observable assets"
+                )
             # for observable source assets, we need to select the job based on the partitions def
             target_partitions_defs = {
                 self.get_partitions_def(asset_key) for asset_key in asset_keys

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
@@ -288,10 +288,14 @@ class RepositoryDefinition:
             i = 0
             while self.has_job(f"{ASSET_BASE_JOB_PREFIX}_{i}"):
                 base_job = self.get_job(f"{ASSET_BASE_JOB_PREFIX}_{i}")
+                partitions_def = base_job.partitions_def
 
                 if all(
                     key in base_job.asset_layer.assets_defs_by_key
-                    or base_job.asset_layer.is_observable_for_asset(key)
+                    or (
+                        base_job.asset_layer.is_observable_for_asset(key)
+                        and partitions_def == base_job.asset_layer.partitions_def_for_asset(key)
+                    )
                     for key in asset_keys
                 ):
                     return base_job

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
@@ -288,14 +288,10 @@ class RepositoryDefinition:
             i = 0
             while self.has_job(f"{ASSET_BASE_JOB_PREFIX}_{i}"):
                 base_job = self.get_job(f"{ASSET_BASE_JOB_PREFIX}_{i}")
-                partitions_def = base_job.partitions_def
 
                 if all(
                     key in base_job.asset_layer.assets_defs_by_key
-                    or (
-                        base_job.asset_layer.is_observable_for_asset(key)
-                        and partitions_def == base_job.asset_layer.partitions_def_for_asset(key)
-                    )
+                    or base_job.asset_layer.is_observable_for_asset(key)
                     for key in asset_keys
                 ):
                     return base_job

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_external_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_external_asset_graph.py
@@ -210,8 +210,13 @@ def test_partitioned_source_asset():
 
 
 def test_get_implicit_job_name_for_assets():
-    asset_graph = ExternalAssetGraph.from_workspace(make_context(["defs1", "defs2"]))
-    assert asset_graph.get_implicit_job_name_for_assets([asset1.key]) == "__ASSET_JOB"
+    workspace = make_context(["defs1", "defs2"])
+    defs1_repo = workspace.code_locations[0]
+    asset_graph = ExternalAssetGraph.from_workspace(workspace)
+    assert (
+        asset_graph.get_implicit_job_name_for_assets([asset1.key], external_repo=workspace)
+        == "__ASSET_JOB"
+    )
     assert asset_graph.get_implicit_job_name_for_assets([asset2.key]) == "__ASSET_JOB"
     assert asset_graph.get_implicit_job_name_for_assets([asset1.key, asset2.key]) == "__ASSET_JOB"
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_external_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_external_asset_graph.py
@@ -210,40 +210,52 @@ def test_partitioned_source_asset():
 
 
 def test_get_implicit_job_name_for_assets():
-    workspace = make_context(["defs1", "defs2"])
-    defs1_repo = workspace.code_locations[0]
-    asset_graph = ExternalAssetGraph.from_workspace(workspace)
+    asset_graph = ExternalAssetGraph.from_workspace(make_context(["defs1", "defs2"]))
     assert (
-        asset_graph.get_implicit_job_name_for_assets([asset1.key], external_repo=workspace)
+        asset_graph.get_implicit_job_name_for_assets([asset1.key], external_repo=None)
         == "__ASSET_JOB"
     )
-    assert asset_graph.get_implicit_job_name_for_assets([asset2.key]) == "__ASSET_JOB"
-    assert asset_graph.get_implicit_job_name_for_assets([asset1.key, asset2.key]) == "__ASSET_JOB"
+    assert (
+        asset_graph.get_implicit_job_name_for_assets([asset2.key], external_repo=None)
+        == "__ASSET_JOB"
+    )
+    assert (
+        asset_graph.get_implicit_job_name_for_assets([asset1.key, asset2.key], external_repo=None)
+        == "__ASSET_JOB"
+    )
 
     asset_graph = ExternalAssetGraph.from_workspace(make_context(["partitioned_defs"]))
     assert (
-        asset_graph.get_implicit_job_name_for_assets([downstream_of_partitioned_source.key])
+        asset_graph.get_implicit_job_name_for_assets(
+            [downstream_of_partitioned_source.key], external_repo=None
+        )
         == "__ASSET_JOB_0"
     )
 
     asset_graph = ExternalAssetGraph.from_workspace(make_context(["different_partitions_defs"]))
     assert (
-        asset_graph.get_implicit_job_name_for_assets([static_partitioned_asset.key])
-        == "__ASSET_JOB_0"
-    )
-    assert (
-        asset_graph.get_implicit_job_name_for_assets([other_static_partitioned_asset.key])
+        asset_graph.get_implicit_job_name_for_assets(
+            [static_partitioned_asset.key], external_repo=None
+        )
         == "__ASSET_JOB_0"
     )
     assert (
         asset_graph.get_implicit_job_name_for_assets(
-            [static_partitioned_asset.key, other_static_partitioned_asset.key]
+            [other_static_partitioned_asset.key], external_repo=None
+        )
+        == "__ASSET_JOB_0"
+    )
+    assert (
+        asset_graph.get_implicit_job_name_for_assets(
+            [static_partitioned_asset.key, other_static_partitioned_asset.key], external_repo=None
         )
         == "__ASSET_JOB_0"
     )
 
     assert (
-        asset_graph.get_implicit_job_name_for_assets([downstream_of_partitioned_source.key])
+        asset_graph.get_implicit_job_name_for_assets(
+            [downstream_of_partitioned_source.key], external_repo=None
+        )
         == "__ASSET_JOB_1"
     )
 
@@ -253,7 +265,8 @@ def test_get_implicit_job_name_for_assets():
                 static_partitioned_asset.key,
                 other_static_partitioned_asset.key,
                 downstream_of_partitioned_source.key,
-            ]
+            ],
+            external_repo=None,
         )
         is None
     )

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_external_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_external_asset_graph.py
@@ -16,6 +16,7 @@ from dagster import (
 )
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.definitions.backfill_policy import BackfillPolicy
+from dagster._core.definitions.decorators.source_asset_decorator import observable_source_asset
 from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
 from dagster._core.host_representation import InProcessCodeLocationOrigin
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
@@ -76,7 +77,24 @@ def downstream_of_partitioned_source():
     pass
 
 
-partitioned_defs = Definitions(assets=[partitioned_source, downstream_of_partitioned_source])
+@observable_source_asset(partitions_def=DailyPartitionsDefinition(start_date="2011-01-01"))
+def partitioned_observable_source1():
+    pass
+
+
+@observable_source_asset(partitions_def=DailyPartitionsDefinition(start_date="2022-01-01"))
+def partitioned_observable_source2():
+    pass
+
+
+partitioned_defs = Definitions(
+    assets=[
+        partitioned_source,
+        downstream_of_partitioned_source,
+        partitioned_observable_source1,
+        partitioned_observable_source2,
+    ]
+)
 
 static_partition = partitions_def = StaticPartitionsDefinition(["foo", "bar"])
 
@@ -224,10 +242,27 @@ def test_get_implicit_job_name_for_assets():
         == "__ASSET_JOB"
     )
 
-    asset_graph = ExternalAssetGraph.from_workspace(make_context(["partitioned_defs"]))
+    partitioned_defs_workspace = make_context(["partitioned_defs"])
+    asset_graph = ExternalAssetGraph.from_workspace(partitioned_defs_workspace)
+    external_repo = list(partitioned_defs_workspace.code_locations[0].get_repositories().values())[
+        0
+    ]
     assert (
         asset_graph.get_implicit_job_name_for_assets(
-            [downstream_of_partitioned_source.key], external_repo=None
+            [downstream_of_partitioned_source.key], external_repo=external_repo
+        )
+        == "__ASSET_JOB_1"
+    )
+    # shares a partitions_def with the above
+    assert (
+        asset_graph.get_implicit_job_name_for_assets(
+            [partitioned_observable_source2.key], external_repo=external_repo
+        )
+        == "__ASSET_JOB_1"
+    )
+    assert (
+        asset_graph.get_implicit_job_name_for_assets(
+            [partitioned_observable_source1.key], external_repo=external_repo
         )
         == "__ASSET_JOB_0"
     )

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/auto_observe_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/auto_observe_scenarios.py
@@ -28,6 +28,13 @@ def partitioned_observable_source_asset():
     return DataVersionsByPartition({"b": "1", "c": "5"})
 
 
+@observable_source_asset(
+    auto_observe_interval_minutes=30, partitions_def=StaticPartitionsDefinition(["a", "b"])
+)
+def partitioned_observable_source_asset2():
+    return DataVersionsByPartition({"a": "1"})
+
+
 auto_observe_scenarios = {
     "auto_observe_single_asset": AssetReconciliationScenario(
         [],
@@ -71,6 +78,14 @@ auto_observe_scenarios = {
         expected_run_requests=[
             run_request(asset_keys=["asset1"]),
             run_request(asset_keys=["asset2"]),
+        ],
+    ),
+    "auto_observe_two_assets_different_partitions_defs": AssetReconciliationScenario(
+        unevaluated_runs=[],
+        assets=[partitioned_observable_source_asset, partitioned_observable_source_asset2],
+        expected_run_requests=[
+            run_request(asset_keys=["partitioned_observable_source_asset"]),
+            run_request(asset_keys=["partitioned_observable_source_asset2"]),
         ],
     ),
 }


### PR DESCRIPTION
## Summary & Motivation

The get_implicit_job_def_for_assets function does not take into account the fact that ALL asset jobs have ALL partitioned observable source assets within them. This updates the function to make sure we're getting a job that matches the expected partitions definition


## How I Tested These Changes
