### PR TITLE
[time-window-partitions] Fix deserialization of TimeWindowPartitionsSubset after start date changes

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
@@ -219,7 +219,8 @@ class AssetDaemonCursor(NamedTuple):
                 ):
                     subset = partitions_def.empty_subset()
             except:
-                handled_root_partitions_by_asset_key[key] = partitions_def.empty_subset()
+                subset = partitions_def.empty_subset()
+            handled_root_partitions_by_asset_key[key] = subset
         return cls(
             latest_storage_id=latest_storage_id,
             handled_root_asset_keys={

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
@@ -17,6 +17,10 @@ from typing import (
 
 import dagster._check as check
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
+from dagster._core.definitions.time_window_partitions import (
+    TimeWindowPartitionsDefinition,
+    TimeWindowPartitionsSubset,
+)
 
 from .asset_graph import AssetGraph
 from .partition import (
@@ -201,9 +205,19 @@ class AssetDaemonCursor(NamedTuple):
             try:
                 # in the case that the partitions def has changed, we may not be able to deserialize
                 # the corresponding subset. in this case, we just use an empty subset
-                handled_root_partitions_by_asset_key[key] = partitions_def.deserialize_subset(
-                    serialized_subset
-                )
+                subset = partitions_def.deserialize_subset(serialized_subset)
+                # this covers the case in which the start date has changed for a time-partitioned
+                # asset. in reality, we should be using the can_deserialize method but because we
+                # are not storing the serializable unique id, we can't do that.
+                if (
+                    isinstance(subset, TimeWindowPartitionsSubset)
+                    and isinstance(partitions_def, TimeWindowPartitionsDefinition)
+                    and any(
+                        time_window.start < partitions_def.start
+                        for time_window in subset.included_time_windows
+                    )
+                ):
+                    subset = partitions_def.empty_subset()
             except:
                 handled_root_partitions_by_asset_key[key] = partitions_def.empty_subset()
         return cls(

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -1586,31 +1586,6 @@ class TimeWindowPartitionsSubset(PartitionsSubset):
         ):  # version 1
             time_windows = tuples_to_time_windows(loaded["time_windows"])
             num_partitions = loaded["num_partitions"]
-            # this can happen if the partition subset was serialized with a partition definition
-            # that had an older start date than the current one
-            if any(time_window.start < partitions_def.start for time_window in time_windows):
-                # filter out time windows that are before the start date
-                filtered_time_windows = []
-                for time_window in time_windows:
-                    if time_window.start < partitions_def.start:
-                        if time_window.end <= partitions_def.start:
-                            continue
-                        else:
-                            filtered_time_windows.append(
-                                TimeWindow(
-                                    start=partitions_def.start,
-                                    end=time_window.end,
-                                )
-                            )
-                    else:
-                        filtered_time_windows.append(time_window)
-                time_windows = filtered_time_windows
-                # must recalculate num_partitions
-                num_partitions = sum(
-                    len(partitions_def.get_partition_keys_in_time_window(time_window))
-                    for time_window in time_windows
-                )
-
         else:
             raise DagsterInvalidDeserializationVersionError(
                 f"Attempted to deserialize partition subset with version {loaded.get('version')},"

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
@@ -163,6 +163,7 @@ class AssetReconciliationScenario(
             ),
             ("expected_evaluations", Optional[Sequence[AssetEvaluationSpec]]),
             ("requires_respect_materialization_data_versions", bool),
+            ("supports_with_external_asset_graph", bool),
         ],
     )
 ):
@@ -184,6 +185,7 @@ class AssetReconciliationScenario(
         ] = None,
         expected_evaluations: Optional[Sequence[AssetEvaluationSpec]] = None,
         requires_respect_materialization_data_versions: bool = False,
+        supports_with_external_asset_graph: bool = True,
     ) -> "AssetReconciliationScenario":
         # For scenarios with no auto-materialize policies, we infer auto-materialize policies
         # and add them to the assets.
@@ -219,6 +221,7 @@ class AssetReconciliationScenario(
             code_locations=code_locations,
             expected_evaluations=expected_evaluations,
             requires_respect_materialization_data_versions=requires_respect_materialization_data_versions,
+            supports_with_external_asset_graph=supports_with_external_asset_graph,
         )
 
     def _get_code_location_origin(

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/exotic_partition_mapping_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/exotic_partition_mapping_scenarios.py
@@ -298,7 +298,7 @@ exotic_partition_mapping_scenarios = {
             unevaluated_runs=[],
         ),
         expected_run_requests=[],
-        current_time=create_pendulum_time(year=2020, month=1, day=3, hour=4),
+        current_time=create_pendulum_time(year=2020, month=1, day=3, hour=4, minute=4),
     ),
     "self_dependency_prior_partition_materialized": AssetReconciliationScenario(
         assets=one_asset_self_dependency,

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/exotic_partition_mapping_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/exotic_partition_mapping_scenarios.py
@@ -72,6 +72,13 @@ one_asset_self_dependency = [
         deps={"asset1": TimeWindowPartitionMapping(start_offset=-1, end_offset=-1)},
     )
 ]
+one_asset_self_dependency_later_start_date = [
+    asset_def(
+        "asset1",
+        partitions_def=DailyPartitionsDefinition(start_date="2023-01-01"),
+        deps={"asset1": TimeWindowPartitionMapping(start_offset=-1, end_offset=-1)},
+    )
+]
 
 root_assets_different_partitions_same_downstream = [
     asset_def("root1", partitions_def=two_partitions_partitions_def),
@@ -302,6 +309,17 @@ exotic_partition_mapping_scenarios = {
         ),
         expected_run_requests=[run_request(asset_keys=["asset1"], partition_key="2020-01-02")],
         current_time=create_pendulum_time(year=2020, month=1, day=3, hour=4),
+    ),
+    "self_dependency_start_date_changed": AssetReconciliationScenario(
+        assets=one_asset_self_dependency_later_start_date,
+        unevaluated_runs=[],
+        cursor_from=AssetReconciliationScenario(
+            assets=one_asset_self_dependency,
+            unevaluated_runs=[],
+            expected_run_requests=[run_request(asset_keys=["asset1"], partition_key="2020-01-01")],
+            current_time=create_pendulum_time(year=2020, month=1, day=2, hour=4),
+        ),
+        expected_run_requests=[run_request(asset_keys=["asset1"], partition_key="2023-01-01")],
     ),
     "self_dependency_multipartitioned": AssetReconciliationScenario(
         assets=multipartitioned_self_dependency,

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/exotic_partition_mapping_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/exotic_partition_mapping_scenarios.py
@@ -320,6 +320,8 @@ exotic_partition_mapping_scenarios = {
             current_time=create_pendulum_time(year=2020, month=1, day=2, hour=4),
         ),
         expected_run_requests=[run_request(asset_keys=["asset1"], partition_key="2023-01-01")],
+        # this date changing business is not handled by the current implementation of the test
+        supports_with_external_asset_graph=False,
     ),
     "self_dependency_multipartitioned": AssetReconciliationScenario(
         assets=multipartitioned_self_dependency,

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon.py
@@ -24,6 +24,8 @@ def instance():
 )
 def test_reconcile_with_external_asset_graph(scenario_item, instance):
     scenario_name, scenario = scenario_item
+    if not scenario.supports_with_external_asset_graph:
+        pytest.skip("Scenario does not support with_external_asset_graph")
     run_requests, _, _ = scenario.do_sensor_scenario(
         instance, scenario_name=scenario_name, with_external_asset_graph=True
     )


### PR DESCRIPTION
## Summary & Motivation

In cases where the start date is updated after a TimeWinodwPartitionsSubset is serialized, our deserialization process is incorrect, as the older time windows are no longer relevant.

Some things to think about:

1. was any other part of the system relying on this behavior?
2. should we error instead? i.e., should this sort of logic just be inside of "can_deserialize"?

## How I Tested These Changes
