### PR TITLE
Raise informative error when UPathIOManager cannot persist single-run backfill output

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
@@ -436,7 +436,15 @@ class UPathIOManager(MemoizableIOManager):
 
         if context.has_asset_partitions:
             paths = self._get_paths_for_partitions(context)
-            assert len(paths) == 1
+
+            check.invariant(
+                len(paths) == 1,
+                f"The current IO manager {type(self)} does not support persisting an output"
+                " associated with multiple partitions. This error is likely occurring because a"
+                " backfill was launched using the 'single run' option. Instead, launch the"
+                " backfill with the 'multiple runs' option.",
+            )
+
             path = list(paths.values())[0]
         else:
             path = self._get_path(context)


### PR DESCRIPTION
Previously, users who launched single run backfills via the UI would receive an obscure `assert len(paths) == 1` failure when executing with a `UPathIOManager`. The cause of this error is that the `UPathIOManager` cannot handle outputs that correspond to multiple partitions (https://github.com/dagster-io/dagster/issues/14332). 

For now, this PR improves the error messaging to better describe the cause of the error.
