### PR TITLE
allow @asset deps to take AssetDep

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_dep.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_dep.py
@@ -92,11 +92,9 @@ class AssetDep(
 
 
 def _get_asset_key(arg: "CoercibleToAssetDep") -> AssetKey:
-    if isinstance(arg, (AssetsDefinition, SourceAsset)):
+    if isinstance(arg, (AssetsDefinition, SourceAsset, AssetSpec)):
         return arg.key
-    elif isinstance(
-        arg, (AssetDep, AssetSpec)
-    ):  # TODO - move AssetSpec to above condition when https://github.com/dagster-io/dagster/pull/16544 merges
+    elif isinstance(arg, AssetDep):
         return arg.asset_key
     else:
         return AssetKey.from_coercible(arg)

--- a/python_modules/dagster/dagster/_core/definitions/asset_dep.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_dep.py
@@ -86,7 +86,7 @@ class AssetDep(
         )
 
     @staticmethod
-    def from_coercible(arg: "CoercibleToAssetDep"):
+    def from_coercible(arg: "CoercibleToAssetDep") -> "AssetDep":
         # if arg is AssetDep, return the original object to retain partition_mapping
         return arg if isinstance(arg, AssetDep) else AssetDep(asset=arg)
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_dep.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_dep.py
@@ -55,6 +55,7 @@ class AssetDep(
     def __new__(
         cls,
         asset: Union[CoercibleToAssetKey, AssetSpec, AssetsDefinition, SourceAsset],
+        *,
         partition_mapping: Optional[PartitionMapping] = None,
     ):
         if isinstance(asset, list):

--- a/python_modules/dagster/dagster/_core/definitions/asset_dep.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_dep.py
@@ -54,9 +54,15 @@ class AssetDep(
 
     def __new__(
         cls,
-        asset: CoercibleToAssetDep,
+        asset: Union[CoercibleToAssetKey, AssetSpec, AssetsDefinition, SourceAsset],
         partition_mapping: Optional[PartitionMapping] = None,
     ):
+        if isinstance(asset, list):
+            check.list_param(asset, "asset", of_type=str)
+        else:
+            check.inst_param(
+                asset, "asset", (AssetKey, str, AssetSpec, AssetsDefinition, SourceAsset)
+            )
         if isinstance(asset, AssetsDefinition) and len(asset.keys) > 1:
             # Only AssetsDefinition with a single asset can be passed
             raise DagsterInvalidDefinitionError(
@@ -80,7 +86,5 @@ class AssetDep(
 
     @staticmethod
     def from_coercible(arg: "CoercibleToAssetDep"):
-        if isinstance(arg, AssetDep):
-            # we need to retain the partition_mapping, so return the original object
-            return arg
-        return AssetDep(asset=arg)
+        # if arg is AssetDep, return the original object to retain partition_mapping
+        return arg if isinstance(arg, AssetDep) else AssetDep(asset=arg)

--- a/python_modules/dagster/dagster/_core/definitions/asset_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_spec.py
@@ -1,9 +1,7 @@
-from typing import TYPE_CHECKING, Any, Iterable, Mapping, NamedTuple, Optional, Union
+from typing import TYPE_CHECKING, Any, Iterable, Mapping, NamedTuple, Optional
 
 import dagster._check as check
 from dagster._annotations import PublicAttr, experimental
-from dagster._core.definitions.assets import AssetsDefinition
-from dagster._core.definitions.source_asset import SourceAsset
 from dagster._core.errors import DagsterInvariantViolationError
 
 from .auto_materialize_policy import AutoMaterializePolicy
@@ -15,7 +13,7 @@ from .freshness_policy import FreshnessPolicy
 from .metadata import MetadataUserInput
 
 if TYPE_CHECKING:
-    from dagster._core.definitions.asset_dep import AssetDep
+    from dagster._core.definitions.asset_dep import AssetDep, CoercibleToAssetDep
 
 
 @experimental
@@ -63,11 +61,7 @@ class AssetSpec(
         cls,
         key: CoercibleToAssetKey,
         *,
-        deps: Optional[
-            Iterable[
-                Union[CoercibleToAssetKey, "AssetSpec", AssetsDefinition, SourceAsset, "AssetDep"]
-            ]
-        ] = None,
+        deps: Optional[Iterable["CoercibleToAssetDep"]] = None,
         description: Optional[str] = None,
         metadata: Optional[MetadataUserInput] = None,
         skippable: bool = False,
@@ -81,10 +75,7 @@ class AssetSpec(
         dep_set = {}
         if deps:
             for dep in deps:
-                if not isinstance(dep, AssetDep):
-                    asset_dep = AssetDep(dep)
-                else:
-                    asset_dep = dep
+                asset_dep = AssetDep.from_coercible(dep)
 
                 # we cannot do deduplication via a set because MultiPartitionMappings have an internal
                 # dictionary that cannot be hashed. Instead deduplicate by making a dictionary and checking

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -1300,23 +1300,25 @@ def _deps_and_non_argument_deps_to_asset_deps(
 def _make_asset_deps(
     deps: Optional[Iterable[Union[AssetDep, CoercibleToAssetKey, AssetsDefinition, SourceAsset]]]
 ) -> Optional[Iterable[AssetDep]]:
-    if deps is None:
-        return None
-    dep_dict = {}
-    for dep in deps:
-        if not isinstance(dep, AssetDep):
-            asset_dep = AssetDep(dep)
-        else:
-            asset_dep = dep
+    with disable_dagster_warnings():
+        if deps is None:
+            return None
+        dep_dict = {}
+        for dep in deps:
+            if not isinstance(dep, AssetDep):
+                asset_dep = AssetDep(dep)
+            else:
+                asset_dep = dep
 
-        # we cannot do deduplication via a set because MultiPartitionMappings have an internal
-        # dictionary that cannot be hashed. Instead deduplicate by making a dictionary and checking
-        # for existing keys.
-        if asset_dep.asset_key in dep_dict.keys():
-            raise DagsterInvariantViolationError(
-                f"Cannot set a dependency on asset {asset_dep.asset_key} more than once per asset."
-            )
-        dep_dict[asset_dep.asset_key] = asset_dep
+            # we cannot do deduplication via a set because MultiPartitionMappings have an internal
+            # dictionary that cannot be hashed. Instead deduplicate by making a dictionary and checking
+            # for existing keys.
+            if asset_dep.asset_key in dep_dict.keys():
+                raise DagsterInvariantViolationError(
+                    f"Cannot set a dependency on asset {asset_dep.asset_key} more than once per"
+                    " asset."
+                )
+            dep_dict[asset_dep.asset_key] = asset_dep
 
     return list(dep_dict.values())
 

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -1236,15 +1236,14 @@ def _deps_and_non_argument_deps_to_asset_deps(
     with disable_dagster_warnings():
         if deps is not None:
             for dep in deps:
-                if isinstance(dep, AssetsDefinition):
+                if isinstance(dep, AssetsDefinition) and len(dep.keys) > 1:
                     # Only AssetsDefinition with a single asset can be passed
-                    if len(dep.keys) > 1:
-                        raise DagsterInvalidDefinitionError(
-                            "Cannot pass a multi_asset AssetsDefinition as an argument to deps."
-                            " Instead, specify dependencies on the assets created by the"
-                            " multi_asset via AssetKeys or strings. For the multi_asset"
-                            f" {dep.node_def.name}, the available keys are: {dep.keys}."
-                        )
+                    raise DagsterInvalidDefinitionError(
+                        "Cannot pass a multi_asset AssetsDefinition as an argument to deps."
+                        " Instead, specify dependencies on the assets created by the"
+                        " multi_asset via AssetKeys or strings. For the multi_asset"
+                        f" {dep.node_def.name}, the available keys are: {dep.keys}."
+                    )
                 else:
                     # confirm that dep is coercible to AssetDep
                     try:

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -1213,11 +1213,7 @@ def build_asset_outs(asset_outs: Mapping[str, AssetOut]) -> Mapping[AssetKey, Tu
     return outs_by_asset_key
 
 
-<<<<<<< HEAD
-def _deps_and_non_argument_deps_to_asset_deps(
-=======
 def _type_check_deps_and_non_argument_deps(
->>>>>>> 479391a1ab (add coercibleToAssetDep)
     deps: Optional[Iterable[CoercibleToAssetDep]],
     non_argument_deps: Optional[Union[Set[AssetKey], Set[str]]],
 ) -> Optional[Iterable[AssetDep]]:
@@ -1267,30 +1263,20 @@ def _type_check_deps_and_non_argument_deps(
     return _make_asset_deps(upstream_asset_deps)
 
 
-<<<<<<< HEAD
-def _make_asset_deps(deps: Optional[Iterable[CoercibleToAssetDep]]) -> Optional[Iterable[AssetDep]]:
-    if deps is None:
-        return None
-
-    with disable_dagster_warnings():
-        dep_dict = {}
-=======
 def _make_asset_deps(deps=Optional[Iterable[CoercibleToAssetDep]]) -> Iterable[AssetDep]:
     dep_dict = {}
     if deps:
->>>>>>> 479391a1ab (add coercibleToAssetDep)
         for dep in deps:
             asset_dep = AssetDep.from_coercible(dep)
 
-            # we cannot do deduplication via a set because MultiPartitionMappings have an internal
-            # dictionary that cannot be hashed. Instead deduplicate by making a dictionary and checking
-            # for existing keys.
-            if asset_dep.asset_key in dep_dict.keys():
-                raise DagsterInvariantViolationError(
-                    f"Cannot set a dependency on asset {asset_dep.asset_key} more than once per"
-                    " asset."
-                )
-            dep_dict[asset_dep.asset_key] = asset_dep
+        # we cannot do deduplication via a set because MultiPartitionMappings have an internal
+        # dictionary that cannot be hashed. Instead deduplicate by making a dictionary and checking
+        # for existing keys.
+        if asset_dep.asset_key in dep_dict.keys():
+            raise DagsterInvariantViolationError(
+                f"Cannot set a dependency on asset {asset_dep.asset_key} more than once per asset."
+            )
+        dep_dict[asset_dep.asset_key] = asset_dep
 
     return list(dep_dict.values())
 

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -21,7 +21,7 @@ from dagster._annotations import deprecated_param, experimental_param
 from dagster._builtins import Nothing
 from dagster._config import UserConfigSchema
 from dagster._core.decorator_utils import get_function_params, get_valid_name_permutations
-from dagster._core.definitions.asset_dep import AssetDep
+from dagster._core.definitions.asset_dep import AssetDep, CoercibleToAssetDep
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.definitions.config import ConfigMapping
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
@@ -30,7 +30,6 @@ from dagster._core.definitions.partition_mapping import PartitionMapping
 from dagster._core.definitions.resource_annotation import (
     get_resource_args,
 )
-from dagster._core.definitions.source_asset import SourceAsset
 from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvariantViolationError
 from dagster._core.types.dagster_type import DagsterType
 from dagster._utils.warnings import (
@@ -66,9 +65,7 @@ def asset(
     name: Optional[str] = ...,
     key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
     ins: Optional[Mapping[str, AssetIn]] = ...,
-    deps: Optional[
-        Iterable[Union[AssetDep, CoercibleToAssetKey, AssetsDefinition, SourceAsset]]
-    ] = ...,
+    deps: Optional[Iterable[CoercibleToAssetDep]] = ...,
     metadata: Optional[Mapping[str, Any]] = ...,
     description: Optional[str] = ...,
     config_schema: Optional[UserConfigSchema] = None,
@@ -106,9 +103,7 @@ def asset(
     name: Optional[str] = None,
     key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
     ins: Optional[Mapping[str, AssetIn]] = None,
-    deps: Optional[
-        Iterable[Union[AssetDep, CoercibleToAssetKey, AssetsDefinition, SourceAsset]]
-    ] = None,
+    deps: Optional[Iterable[CoercibleToAssetDep]] = None,
     metadata: Optional[ArbitraryMetadataMapping] = None,
     description: Optional[str] = None,
     config_schema: Optional[UserConfigSchema] = None,
@@ -469,7 +464,7 @@ def multi_asset(
     outs: Optional[Mapping[str, AssetOut]] = None,
     name: Optional[str] = None,
     ins: Optional[Mapping[str, AssetIn]] = None,
-    deps: Optional[Iterable[Union[CoercibleToAssetKey, AssetsDefinition, SourceAsset]]] = None,
+    deps: Optional[Iterable[CoercibleToAssetDep]] = None,
     description: Optional[str] = None,
     config_schema: Optional[UserConfigSchema] = None,
     required_resource_keys: Optional[Set[str]] = None,
@@ -1219,23 +1214,23 @@ def build_asset_outs(asset_outs: Mapping[str, AssetOut]) -> Mapping[AssetKey, Tu
 
 
 def _deps_and_non_argument_deps_to_asset_deps(
-    deps: Optional[Iterable[Union[AssetDep, CoercibleToAssetKey, AssetsDefinition, SourceAsset]]],
+    deps: Optional[Iterable[CoercibleToAssetDep]],
     non_argument_deps: Optional[Union[Set[AssetKey], Set[str]]],
-):
+) -> Optional[Iterable[AssetDep]]:
     """Helper function for managing deps and non_argument_deps while non_argument_deps is still an accepted parameter.
     Ensures:
     1. only one of deps and non_argument_deps is provided.
     2. multi assets AssetsDefinition is not passed to deps.
     3. deprecation warning is fired for non_argument_deps.
+
+    Converts the deps to `AssetDep`s
     """
     if non_argument_deps is not None and deps is not None:
         raise DagsterInvalidDefinitionError(
             "Cannot specify both deps and non_argument_deps to @asset. Use only deps instead."
         )
 
-    upstream_asset_deps: Optional[
-        Iterable[Union[AssetDep, CoercibleToAssetKey, AssetsDefinition, SourceAsset]]
-    ] = None
+    upstream_asset_deps: Optional[Iterable[CoercibleToAssetDep]] = None
     if deps is not None:
         for dep in deps:
             if isinstance(dep, AssetsDefinition):
@@ -1247,13 +1242,10 @@ def _deps_and_non_argument_deps_to_asset_deps(
                         f" via AssetKeys or strings. For the multi_asset {dep.node_def.name}, the"
                         f" available keys are: {dep.keys}."
                     )
-            elif isinstance(dep, (SourceAsset, AssetDep)):
-                # no additional type checking needed for SourceAssets or AssetDeps
-                continue
             else:
-                # confirm that dep is coercible to AssetKey
+                # confirm that dep is coercible to AssetDep
                 try:
-                    AssetKey.from_coercible(dep)
+                    AssetDep.from_coercible(dep)
                 except check.CheckError:
                     raise DagsterInvalidDefinitionError(
                         f"Cannot pass an instance of type {type(dep)} to deps parameter of @asset."
@@ -1271,15 +1263,14 @@ def _deps_and_non_argument_deps_to_asset_deps(
     return _make_asset_deps(upstream_asset_deps)
 
 
-def _make_asset_deps(
-    deps: Optional[Iterable[Union[AssetDep, CoercibleToAssetKey, AssetsDefinition, SourceAsset]]]
-) -> Optional[Iterable[AssetDep]]:
+def _make_asset_deps(deps: Optional[Iterable[CoercibleToAssetDep]]) -> Optional[Iterable[AssetDep]]:
+    if deps is None:
+        return None
+
     with disable_dagster_warnings():
-        if deps is None:
-            return None
         dep_dict = {}
         for dep in deps:
-            asset_dep = dep if isinstance(dep, AssetDep) else AssetDep(dep)
+            asset_dep = AssetDep.from_coercible(dep)
 
             # we cannot do deduplication via a set because MultiPartitionMappings have an internal
             # dictionary that cannot be hashed. Instead deduplicate by making a dictionary and checking

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -1213,7 +1213,11 @@ def build_asset_outs(asset_outs: Mapping[str, AssetOut]) -> Mapping[AssetKey, Tu
     return outs_by_asset_key
 
 
+<<<<<<< HEAD
 def _deps_and_non_argument_deps_to_asset_deps(
+=======
+def _type_check_deps_and_non_argument_deps(
+>>>>>>> 479391a1ab (add coercibleToAssetDep)
     deps: Optional[Iterable[CoercibleToAssetDep]],
     non_argument_deps: Optional[Union[Set[AssetKey], Set[str]]],
 ) -> Optional[Iterable[AssetDep]]:
@@ -1263,12 +1267,18 @@ def _deps_and_non_argument_deps_to_asset_deps(
     return _make_asset_deps(upstream_asset_deps)
 
 
+<<<<<<< HEAD
 def _make_asset_deps(deps: Optional[Iterable[CoercibleToAssetDep]]) -> Optional[Iterable[AssetDep]]:
     if deps is None:
         return None
 
     with disable_dagster_warnings():
         dep_dict = {}
+=======
+def _make_asset_deps(deps=Optional[Iterable[CoercibleToAssetDep]]) -> Iterable[AssetDep]:
+    dep_dict = {}
+    if deps:
+>>>>>>> 479391a1ab (add coercibleToAssetDep)
         for dep in deps:
             asset_dep = AssetDep.from_coercible(dep)
 

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -1,6 +1,7 @@
 from collections import Counter
 from inspect import Parameter
 from typing import (
+    AbstractSet,
     Any,
     Callable,
     Dict,
@@ -852,7 +853,7 @@ def stringify_asset_key_to_input_name(asset_key: AssetKey) -> str:
 def build_asset_ins(
     fn: Callable,
     asset_ins: Mapping[str, AssetIn],
-    deps: Optional[Set[AssetKey]],
+    deps: Optional[AbstractSet[AssetKey]],
 ) -> Mapping[AssetKey, Tuple[str, In]]:
     """Creates a mapping from AssetKey to (name of input, In object)."""
     deps = check.opt_set_param(deps, "deps", AssetKey)
@@ -1213,7 +1214,7 @@ def build_asset_outs(asset_outs: Mapping[str, AssetOut]) -> Mapping[AssetKey, Tu
     return outs_by_asset_key
 
 
-def _type_check_deps_and_non_argument_deps(
+def _deps_and_non_argument_deps_to_asset_deps(
     deps: Optional[Iterable[CoercibleToAssetDep]],
     non_argument_deps: Optional[Union[Set[AssetKey], Set[str]]],
 ) -> Optional[Iterable[AssetDep]]:

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -855,7 +855,7 @@ def build_asset_ins(
     deps: Optional[Set[AssetKey]],
 ) -> Mapping[AssetKey, Tuple[str, In]]:
     """Creates a mapping from AssetKey to (name of input, In object)."""
-    deps = check.opt_iterable_param(deps, "deps", AssetDep) or []
+    deps = check.opt_set_param(deps, "deps", AssetKey)
 
     new_input_args = get_function_params_without_context_or_config_or_resources(fn)
 
@@ -900,14 +900,14 @@ def build_asset_ins(
             In(metadata=metadata, input_manager_key=input_manager_key, dagster_type=dagster_type),
         )
 
-    for asset_dep in deps:
-        if asset_dep.asset_key in ins_by_asset_key:
+    for asset_key in deps:
+        if asset_key in ins_by_asset_key:
             raise DagsterInvalidDefinitionError(
-                f"deps value {asset_dep.asset_key} also declared as input/AssetIn"
+                f"deps value {asset_key} also declared as input/AssetIn"
             )
             # mypy doesn't realize that Nothing is a valid type here
-        ins_by_asset_key[asset_dep.asset_key] = (
-            stringify_asset_key_to_input_name(asset_dep.asset_key),
+        ins_by_asset_key[asset_key] = (
+            stringify_asset_key_to_input_name(asset_key),
             In(cast(type, Nothing)),
         )
 

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -618,7 +618,7 @@ def multi_asset(
         op_name = name or fn.__name__
 
         if asset_out_map and specs:
-            raise DagsterInvalidDefinitionError("Must specify only outs or assets but not both.")
+            raise DagsterInvalidDefinitionError("Must specify only outs or specs but not both.")
         elif specs:
             output_tuples_by_asset_key = {}
             for asset_spec in specs:
@@ -1279,7 +1279,7 @@ def _deps_and_non_argument_deps_to_asset_deps(
                 except check.CheckError:
                     raise DagsterInvalidDefinitionError(
                         f"Cannot pass an instance of type {type(dep)} to deps parameter of @asset."
-                        " Instead, pass AssetsDefinitions or AssetKeys."
+                        " Instead, pass AssetDeps, AssetsDefinitions, SourceAssets, or AssetKeys."
                     )
 
         upstream_asset_deps = deps

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -669,7 +669,11 @@ def multi_asset(
             asset_ins = build_asset_ins(fn, explicit_ins, deps=remaining_upstream_keys)
         else:
             asset_ins = build_asset_ins(
-                fn, ins or {}, deps={dep.asset_key for dep in upstream_asset_deps}
+                fn,
+                ins or {},
+                deps=(
+                    {dep.asset_key for dep in upstream_asset_deps} if upstream_asset_deps else set()
+                ),
             )
             output_tuples_by_asset_key = build_asset_outs(asset_out_map)
             # validate that the asset_deps make sense

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -211,7 +211,7 @@ def asset(
     """
 
     def create_asset():
-        upstream_asset_deps = _deps_and_non_argument_deps_to_asset_dep(
+        upstream_asset_deps = _deps_and_non_argument_deps_to_asset_deps(
             deps=deps, non_argument_deps=non_argument_deps
         )
 
@@ -588,7 +588,7 @@ def multi_asset(
 
     specs = check.opt_list_param(specs, "specs", of_type=AssetSpec)
 
-    upstream_asset_deps = _deps_and_non_argument_deps_to_asset_dep(
+    upstream_asset_deps = _deps_and_non_argument_deps_to_asset_deps(
         deps=deps, non_argument_deps=non_argument_deps
     )
 
@@ -1234,7 +1234,7 @@ def build_asset_outs(asset_outs: Mapping[str, AssetOut]) -> Mapping[AssetKey, Tu
     return outs_by_asset_key
 
 
-def _deps_and_non_argument_deps_to_asset_dep(
+def _deps_and_non_argument_deps_to_asset_deps(
     deps: Optional[Iterable[Union[AssetDep, CoercibleToAssetKey, AssetsDefinition, SourceAsset]]],
     non_argument_deps: Optional[Union[Set[AssetKey], Set[str]]],
 ):
@@ -1295,7 +1295,7 @@ def _make_asset_deps(
 ) -> Optional[Iterable[AssetDep]]:
     if deps is None:
         return None
-    dep_set = {}
+    dep_dict = {}
     for dep in deps:
         if not isinstance(dep, AssetDep):
             asset_dep = AssetDep(dep)
@@ -1305,27 +1305,13 @@ def _make_asset_deps(
         # we cannot do deduplication via a set because MultiPartitionMappings have an internal
         # dictionary that cannot be hashed. Instead deduplicate by making a dictionary and checking
         # for existing keys.
-        if asset_dep.asset_key in dep_set.keys():
+        if asset_dep.asset_key in dep_dict.keys():
             raise DagsterInvariantViolationError(
                 f"Cannot set a dependency on asset {asset_dep.asset_key} more than once per asset."
             )
-        dep_set[asset_dep.asset_key] = asset_dep
+        dep_dict[asset_dep.asset_key] = asset_dep
 
-    return list(dep_set.values())
-
-
-def _make_asset_keys(
-    deps: Optional[Iterable[Union[CoercibleToAssetKey, AssetsDefinition, SourceAsset]]]
-) -> Optional[Set[AssetKey]]:
-    """Convert all items to AssetKey in a set. By putting all of the AssetKeys in a set, it will also deduplicate them."""
-    if deps is None:
-        return deps
-
-    deps_asset_keys: Set[AssetKey] = set()
-    for dep in deps:
-        deps_asset_keys.add(AssetKey.from_coercible_or_definition(dep))
-
-    return deps_asset_keys
+    return list(dep_dict.values())
 
 
 def _validate_and_assign_output_names_to_check_specs(

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -1263,20 +1263,24 @@ def _type_check_deps_and_non_argument_deps(
     return _make_asset_deps(upstream_asset_deps)
 
 
-def _make_asset_deps(deps=Optional[Iterable[CoercibleToAssetDep]]) -> Iterable[AssetDep]:
-    dep_dict = {}
-    if deps:
+def _make_asset_deps(deps: Optional[Iterable[CoercibleToAssetDep]]) -> Optional[Iterable[AssetDep]]:
+    if deps is None:
+        return None
+
+    with disable_dagster_warnings():
+        dep_dict = {}
         for dep in deps:
             asset_dep = AssetDep.from_coercible(dep)
 
-        # we cannot do deduplication via a set because MultiPartitionMappings have an internal
-        # dictionary that cannot be hashed. Instead deduplicate by making a dictionary and checking
-        # for existing keys.
-        if asset_dep.asset_key in dep_dict.keys():
-            raise DagsterInvariantViolationError(
-                f"Cannot set a dependency on asset {asset_dep.asset_key} more than once per asset."
-            )
-        dep_dict[asset_dep.asset_key] = asset_dep
+            # we cannot do deduplication via a set because MultiPartitionMappings have an internal
+            # dictionary that cannot be hashed. Instead deduplicate by making a dictionary and checking
+            # for existing keys.
+            if asset_dep.asset_key in dep_dict.keys():
+                raise DagsterInvariantViolationError(
+                    f"Cannot set a dependency on asset {asset_dep.asset_key} more than once per"
+                    " asset."
+                )
+            dep_dict[asset_dep.asset_key] = asset_dep
 
     return list(dep_dict.values())
 

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -1232,26 +1232,29 @@ def _deps_and_non_argument_deps_to_asset_deps(
         )
 
     upstream_asset_deps: Optional[Iterable[CoercibleToAssetDep]] = None
-    if deps is not None:
-        for dep in deps:
-            if isinstance(dep, AssetsDefinition):
-                # Only AssetsDefinition with a single asset can be passed
-                if len(dep.keys) > 1:
-                    raise DagsterInvalidDefinitionError(
-                        "Cannot pass a multi_asset AssetsDefinition as an argument to deps."
-                        " Instead, specify dependencies on the assets created by the multi_asset"
-                        f" via AssetKeys or strings. For the multi_asset {dep.node_def.name}, the"
-                        f" available keys are: {dep.keys}."
-                    )
-            else:
-                # confirm that dep is coercible to AssetDep
-                try:
-                    AssetDep.from_coercible(dep)
-                except check.CheckError:
-                    raise DagsterInvalidDefinitionError(
-                        f"Cannot pass an instance of type {type(dep)} to deps parameter of @asset."
-                        " Instead, pass AssetDeps, AssetsDefinitions, SourceAssets, or AssetKeys."
-                    )
+
+    with disable_dagster_warnings():
+        if deps is not None:
+            for dep in deps:
+                if isinstance(dep, AssetsDefinition):
+                    # Only AssetsDefinition with a single asset can be passed
+                    if len(dep.keys) > 1:
+                        raise DagsterInvalidDefinitionError(
+                            "Cannot pass a multi_asset AssetsDefinition as an argument to deps."
+                            " Instead, specify dependencies on the assets created by the"
+                            " multi_asset via AssetKeys or strings. For the multi_asset"
+                            f" {dep.node_def.name}, the available keys are: {dep.keys}."
+                        )
+                else:
+                    # confirm that dep is coercible to AssetDep
+                    try:
+                        AssetDep.from_coercible(dep)
+                    except check.CheckError:
+                        raise DagsterInvalidDefinitionError(
+                            f"Cannot pass an instance of type {type(dep)} to deps parameter of"
+                            " @asset. Instead, pass AssetDeps, AssetsDefinitions, SourceAssets, or"
+                            " AssetKeys."
+                        )
 
         upstream_asset_deps = deps
 

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -1,7 +1,6 @@
 from collections import Counter
 from inspect import Parameter
 from typing import (
-    AbstractSet,
     Any,
     Callable,
     Dict,
@@ -22,6 +21,7 @@ from dagster._annotations import deprecated_param, experimental_param
 from dagster._builtins import Nothing
 from dagster._config import UserConfigSchema
 from dagster._core.decorator_utils import get_function_params, get_valid_name_permutations
+from dagster._core.definitions.asset_dep import AssetDep
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.definitions.config import ConfigMapping
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
@@ -30,7 +30,7 @@ from dagster._core.definitions.resource_annotation import (
     get_resource_args,
 )
 from dagster._core.definitions.source_asset import SourceAsset
-from dagster._core.errors import DagsterInvalidDefinitionError
+from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvariantViolationError
 from dagster._core.types.dagster_type import DagsterType
 from dagster._utils.warnings import (
     disable_dagster_warnings,
@@ -65,7 +65,9 @@ def asset(
     name: Optional[str] = ...,
     key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
     ins: Optional[Mapping[str, AssetIn]] = ...,
-    deps: Optional[Iterable[Union[CoercibleToAssetKey, AssetsDefinition, SourceAsset]]] = ...,
+    deps: Optional[
+        Iterable[Union[AssetDep, CoercibleToAssetKey, AssetsDefinition, SourceAsset]]
+    ] = ...,
     metadata: Optional[Mapping[str, Any]] = ...,
     description: Optional[str] = ...,
     config_schema: Optional[UserConfigSchema] = None,
@@ -103,7 +105,9 @@ def asset(
     name: Optional[str] = None,
     key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
     ins: Optional[Mapping[str, AssetIn]] = None,
-    deps: Optional[Iterable[Union[CoercibleToAssetKey, AssetsDefinition, SourceAsset]]] = None,
+    deps: Optional[
+        Iterable[Union[AssetDep, CoercibleToAssetKey, AssetsDefinition, SourceAsset]]
+    ] = None,
     metadata: Optional[ArbitraryMetadataMapping] = None,
     description: Optional[str] = None,
     config_schema: Optional[UserConfigSchema] = None,
@@ -150,7 +154,7 @@ def asset(
             contains letters, numbers, and _) and may not contain python reserved keywords.
         ins (Optional[Mapping[str, AssetIn]]): A dictionary that maps input names to information
             about the input.
-        deps (Optional[Sequence[Union[AssetsDefinition, SourceAsset, AssetKey, str]]]):
+        deps (Optional[Sequence[Union[AssetDep, AssetsDefinition, SourceAsset, AssetKey, str]]]):
             The assets that are upstream dependencies, but do not correspond to a parameter of the
             decorated function.
         config_schema (Optional[ConfigSchema): The configuration schema for the asset's underlying
@@ -215,7 +219,7 @@ def asset(
             name=cast(Optional[str], name),  # (mypy bug that it can't infer name is Optional[str])
             key_prefix=key_prefix,
             ins=ins,
-            deps=_make_asset_keys(upstream_asset_deps),
+            deps=_make_asset_deps(upstream_asset_deps),
             metadata=metadata,
             description=description,
             config_schema=config_schema,
@@ -258,7 +262,7 @@ class _Asset:
         name: Optional[str] = None,
         key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
         ins: Optional[Mapping[str, AssetIn]] = None,
-        deps: Optional[Set[AssetKey]] = None,
+        deps: Optional[Iterable[AssetDep]] = None,
         metadata: Optional[ArbitraryMetadataMapping] = None,
         description: Optional[str] = None,
         config_schema: Optional[UserConfigSchema] = None,
@@ -286,7 +290,7 @@ class _Asset:
             key_prefix = [key_prefix]
         self.key_prefix = key_prefix
         self.ins = ins or {}
-        self.deps = deps
+        self.deps = deps or []
         self.metadata = metadata
         self.description = description
         self.required_resource_keys = check.opt_set_param(
@@ -424,6 +428,22 @@ class _Asset:
             for input_name, asset_in in self.ins.items()
             if asset_in.partition_mapping is not None
         }
+
+        # Add PartitionMappings specified via AssetDeps to partition_mappings dictionary. Error on duplicates
+        for dep in self.deps:
+            if dep.partition_mapping is None:
+                continue
+            if partition_mappings.get(dep.asset_key, None) is None:
+                partition_mappings[dep.asset_key] = dep.partition_mapping
+                continue
+            if partition_mappings[dep.asset_key] == dep.partition_mapping:
+                continue
+            else:
+                raise DagsterInvalidDefinitionError(
+                    f"Two different PartitionMappings for {dep.asset_key} provided for"
+                    f" asset {self.key}. Please use the same PartitionMapping for"
+                    f" {dep.asset_key}."
+                )
 
         return AssetsDefinition.dagster_internal_init(
             keys_by_input_name=keys_by_input_name,
@@ -837,10 +857,10 @@ def stringify_asset_key_to_input_name(asset_key: AssetKey) -> str:
 def build_asset_ins(
     fn: Callable,
     asset_ins: Mapping[str, AssetIn],
-    deps: Optional[AbstractSet[AssetKey]],
+    deps: Optional[Iterable[AssetDep]],
 ) -> Mapping[AssetKey, Tuple[str, In]]:
     """Creates a mapping from AssetKey to (name of input, In object)."""
-    deps = check.opt_set_param(deps, "deps", AssetKey)
+    deps = check.opt_iterable_param(deps, "deps", AssetDep) or []
 
     new_input_args = get_function_params_without_context_or_config_or_resources(fn)
 
@@ -885,14 +905,14 @@ def build_asset_ins(
             In(metadata=metadata, input_manager_key=input_manager_key, dagster_type=dagster_type),
         )
 
-    for asset_key in deps:
-        if asset_key in ins_by_asset_key:
+    for asset_dep in deps:
+        if asset_dep.asset_key in ins_by_asset_key:
             raise DagsterInvalidDefinitionError(
-                f"deps value {asset_key} also declared as input/AssetIn"
+                f"deps value {asset_dep.asset_key} also declared as input/AssetIn"
             )
             # mypy doesn't realize that Nothing is a valid type here
-        ins_by_asset_key[asset_key] = (
-            stringify_asset_key_to_input_name(asset_key),
+        ins_by_asset_key[asset_dep.asset_key] = (
+            stringify_asset_key_to_input_name(asset_dep.asset_key),
             In(cast(type, Nothing)),
         )
 
@@ -1199,7 +1219,7 @@ def build_asset_outs(asset_outs: Mapping[str, AssetOut]) -> Mapping[AssetKey, Tu
 
 
 def _type_check_deps_and_non_argument_deps(
-    deps: Optional[Iterable[Union[CoercibleToAssetKey, AssetsDefinition, SourceAsset]]],
+    deps: Optional[Iterable[Union[AssetDep, CoercibleToAssetKey, AssetsDefinition, SourceAsset]]],
     non_argument_deps: Optional[Union[Set[AssetKey], Set[str]]],
 ):
     """Helper function for managing deps and non_argument_deps while non_argument_deps is still an accepted parameter.
@@ -1214,7 +1234,7 @@ def _type_check_deps_and_non_argument_deps(
         )
 
     upstream_asset_deps: Optional[
-        Iterable[Union[CoercibleToAssetKey, AssetsDefinition, SourceAsset]]
+        Iterable[Union[AssetDep, CoercibleToAssetKey, AssetsDefinition, SourceAsset]]
     ] = None
     if deps is not None:
         for dep in deps:
@@ -1229,6 +1249,9 @@ def _type_check_deps_and_non_argument_deps(
                     )
             elif isinstance(dep, SourceAsset):
                 # no additional type checking needed for SourceAssets
+                continue
+            elif isinstance(dep, AssetDep):
+                # no additional type checking needed for AssetDeps
                 continue
             else:
                 # confirm that dep is coercible to AssetKey
@@ -1249,6 +1272,30 @@ def _type_check_deps_and_non_argument_deps(
         upstream_asset_deps = list(non_argument_deps)
 
     return upstream_asset_deps
+
+
+def _make_asset_deps(
+    deps=Optional[Iterable[Union[AssetDep, CoercibleToAssetKey, AssetsDefinition, SourceAsset]]]
+) -> Iterable[AssetDep]:
+    dep_set = {}
+    if deps:
+        for dep in deps:
+            if not isinstance(dep, AssetDep):
+                asset_dep = AssetDep(dep)
+            else:
+                asset_dep = dep
+
+            # we cannot do deduplication via a set because MultiPartitionMappings have an internal
+            # dictionary that cannot be hashed. Instead deduplicate by making a dictionary and checking
+            # for existing keys.
+            if asset_dep.asset_key in dep_set.keys():
+                raise DagsterInvariantViolationError(
+                    f"Cannot set a dependency on asset {asset_dep.asset_key} more than once per"
+                    " asset."
+                )
+            dep_set[asset_dep.asset_key] = asset_dep
+
+    return list(dep_set.values())
 
 
 def _make_asset_keys(

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -855,7 +855,7 @@ def build_asset_ins(
     deps: Optional[Set[AssetKey]],
 ) -> Mapping[AssetKey, Tuple[str, In]]:
     """Creates a mapping from AssetKey to (name of input, In object)."""
-    deps = check.opt_set_param(deps, "deps", AssetKey)
+    deps = check.opt_iterable_param(deps, "deps", AssetDep) or []
 
     new_input_args = get_function_params_without_context_or_config_or_resources(fn)
 
@@ -900,14 +900,14 @@ def build_asset_ins(
             In(metadata=metadata, input_manager_key=input_manager_key, dagster_type=dagster_type),
         )
 
-    for asset_key in deps:
-        if asset_key in ins_by_asset_key:
+    for asset_dep in deps:
+        if asset_dep.asset_key in ins_by_asset_key:
             raise DagsterInvalidDefinitionError(
-                f"deps value {asset_key} also declared as input/AssetIn"
+                f"deps value {asset_dep.asset_key} also declared as input/AssetIn"
             )
             # mypy doesn't realize that Nothing is a valid type here
-        ins_by_asset_key[asset_key] = (
-            stringify_asset_key_to_input_name(asset_key),
+        ins_by_asset_key[asset_dep.asset_key] = (
+            stringify_asset_key_to_input_name(asset_dep.asset_key),
             In(cast(type, Nothing)),
         )
 

--- a/python_modules/dagster/dagster/_core/definitions/events.py
+++ b/python_modules/dagster/dagster/_core/definitions/events.py
@@ -34,6 +34,7 @@ from .metadata import (
 from .utils import DEFAULT_OUTPUT, check_valid_name
 
 if TYPE_CHECKING:
+    from dagster._core.definitions.asset_dep import CoercibleToAssetDep
     from dagster._core.definitions.assets import AssetsDefinition
     from dagster._core.definitions.source_asset import SourceAsset
     from dagster._core.execution.context.output import OutputContext
@@ -186,6 +187,24 @@ class AssetKey(NamedTuple("_AssetKey", [("path", PublicAttr[Sequence[str]])])):
             return arg.key
         elif isinstance(arg, SourceAsset):
             return arg.key
+        else:
+            return AssetKey.from_coercible(arg)
+
+    @staticmethod
+    def from_coercible_to_asset_dep(arg: "CoercibleToAssetDep") -> "AssetKey":
+        from dagster._core.definitions.asset_dep import AssetDep
+        from dagster._core.definitions.asset_spec import AssetSpec
+        from dagster._core.definitions.assets import AssetsDefinition
+        from dagster._core.definitions.source_asset import SourceAsset
+
+        if isinstance(arg, AssetsDefinition):
+            return arg.key
+        elif isinstance(arg, SourceAsset):
+            return arg.key
+        elif isinstance(arg, AssetDep):
+            return arg.asset_key
+        elif isinstance(arg, AssetSpec):
+            return arg.asset_key
         else:
             return AssetKey.from_coercible(arg)
 

--- a/python_modules/dagster/dagster/_core/definitions/events.py
+++ b/python_modules/dagster/dagster/_core/definitions/events.py
@@ -20,7 +20,6 @@ import dagster._check as check
 import dagster._seven as seven
 from dagster._annotations import PublicAttr, experimental_param, public
 from dagster._core.definitions.data_version import DataVersion
-from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.storage.tags import MULTIDIMENSIONAL_PARTITION_PREFIX, SYSTEM_TAG_PREFIX
 from dagster._serdes import whitelist_for_serdes
 from dagster._serdes.serdes import NamedTupleSerializer
@@ -35,7 +34,6 @@ from .metadata import (
 from .utils import DEFAULT_OUTPUT, check_valid_name
 
 if TYPE_CHECKING:
-    from dagster._core.definitions.asset_dep import CoercibleToAssetDep
     from dagster._core.definitions.assets import AssetsDefinition
     from dagster._core.definitions.source_asset import SourceAsset
     from dagster._core.execution.context.output import OutputContext
@@ -191,31 +189,31 @@ class AssetKey(NamedTuple("_AssetKey", [("path", PublicAttr[Sequence[str]])])):
         else:
             return AssetKey.from_coercible(arg)
 
-    @staticmethod
-    def from_coercible_to_asset_dep(arg: "CoercibleToAssetDep") -> "AssetKey":
-        from dagster._core.definitions.asset_dep import AssetDep
-        from dagster._core.definitions.asset_spec import AssetSpec
-        from dagster._core.definitions.assets import AssetsDefinition
-        from dagster._core.definitions.source_asset import SourceAsset
+    # @staticmethod
+    # def from_coercible_to_asset_dep(arg: "CoercibleToAssetDep") -> "AssetKey":
+    #     from dagster._core.definitions.asset_dep import AssetDep
+    #     from dagster._core.definitions.asset_spec import AssetSpec
+    #     from dagster._core.definitions.assets import AssetsDefinition
+    #     from dagster._core.definitions.source_asset import SourceAsset
 
-        if isinstance(arg, AssetsDefinition):
-            if len(arg.keys) > 1:
-                # Only AssetsDefinition with a single asset can be passed
-                raise DagsterInvalidDefinitionError(
-                    "Cannot pass a multi_asset AssetsDefinition as an argument to deps."
-                    " Instead, specify dependencies on the assets created by the multi_asset"
-                    f" via AssetKeys or strings. For the multi_asset {arg.node_def.name}, the"
-                    f" available keys are: {arg.keys}."
-                )
-            return arg.key
-        elif isinstance(arg, SourceAsset):
-            return arg.key
-        elif isinstance(arg, AssetDep):
-            return arg.asset_key
-        elif isinstance(arg, AssetSpec):
-            return arg.asset_key
-        else:
-            return AssetKey.from_coercible(arg)
+    #     if isinstance(arg, AssetsDefinition):
+    #         if len(arg.keys) > 1:
+    #             # Only AssetsDefinition with a single asset can be passed
+    #             raise DagsterInvalidDefinitionError(
+    #                 "Cannot pass a multi_asset AssetsDefinition as an argument to deps."
+    #                 " Instead, specify dependencies on the assets created by the multi_asset"
+    #                 f" via AssetKeys or strings. For the multi_asset {arg.node_def.name}, the"
+    #                 f" available keys are: {arg.keys}."
+    #             )
+    #         return arg.key
+    #     elif isinstance(arg, SourceAsset):
+    #         return arg.key
+    #     elif isinstance(arg, AssetDep):
+    #         return arg.asset_key
+    #     elif isinstance(arg, AssetSpec):
+    #         return arg.asset_key
+    #     else:
+    #         return AssetKey.from_coercible(arg)
 
     def has_prefix(self, prefix: Sequence[str]) -> bool:
         return len(self.path) >= len(prefix) and self.path[: len(prefix)] == prefix

--- a/python_modules/dagster/dagster/_core/definitions/events.py
+++ b/python_modules/dagster/dagster/_core/definitions/events.py
@@ -20,6 +20,7 @@ import dagster._check as check
 import dagster._seven as seven
 from dagster._annotations import PublicAttr, experimental_param, public
 from dagster._core.definitions.data_version import DataVersion
+from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.storage.tags import MULTIDIMENSIONAL_PARTITION_PREFIX, SYSTEM_TAG_PREFIX
 from dagster._serdes import whitelist_for_serdes
 from dagster._serdes.serdes import NamedTupleSerializer
@@ -198,6 +199,14 @@ class AssetKey(NamedTuple("_AssetKey", [("path", PublicAttr[Sequence[str]])])):
         from dagster._core.definitions.source_asset import SourceAsset
 
         if isinstance(arg, AssetsDefinition):
+            if len(arg.keys) > 1:
+                # Only AssetsDefinition with a single asset can be passed
+                raise DagsterInvalidDefinitionError(
+                    "Cannot pass a multi_asset AssetsDefinition as an argument to deps."
+                    " Instead, specify dependencies on the assets created by the multi_asset"
+                    f" via AssetKeys or strings. For the multi_asset {arg.node_def.name}, the"
+                    f" available keys are: {arg.keys}."
+                )
             return arg.key
         elif isinstance(arg, SourceAsset):
             return arg.key

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_asset_partition_mappings.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_asset_partition_mappings.py
@@ -584,7 +584,12 @@ def test_partition_mapping_with_asset_deps():
 
     @asset(
         partitions_def=partitions_def,
-        deps=[AssetDep(upstream, TimeWindowPartitionMapping(start_offset=-1, end_offset=-1))],
+        deps=[
+            AssetDep(
+                upstream,
+                partition_mapping=TimeWindowPartitionMapping(start_offset=-1, end_offset=-1),
+            )
+        ],
     )
     def downstream(context: AssetExecutionContext):
         upstream_key = datetime.strptime(
@@ -675,8 +680,14 @@ def test_conflicting_mappings_with_asset_deps():
         @asset(
             partitions_def=partitions_def,
             deps=[
-                AssetDep(upstream, TimeWindowPartitionMapping(start_offset=-1, end_offset=-1)),
-                AssetDep(upstream, TimeWindowPartitionMapping(start_offset=-2, end_offset=-2)),
+                AssetDep(
+                    upstream,
+                    partition_mapping=TimeWindowPartitionMapping(start_offset=-1, end_offset=-1),
+                ),
+                AssetDep(
+                    upstream,
+                    partition_mapping=TimeWindowPartitionMapping(start_offset=-2, end_offset=-2),
+                ),
             ],
         )
         def downstream():
@@ -733,7 +744,10 @@ def test_self_dependent_partition_mapping_with_asset_deps():
     @asset(
         partitions_def=partitions_def,
         deps=[
-            AssetDep("self_dependent", TimeWindowPartitionMapping(start_offset=-1, end_offset=-1))
+            AssetDep(
+                "self_dependent",
+                partition_mapping=TimeWindowPartitionMapping(start_offset=-1, end_offset=-1),
+            )
         ],
     )
     def self_dependent(context: AssetExecutionContext):
@@ -785,7 +799,7 @@ def test_dynamic_partition_mapping_with_asset_deps():
 
     @asset(
         partitions_def=partitions_def,
-        deps=[AssetDep(upstream, SpecificPartitionsPartitionMapping(["apple"]))],
+        deps=[AssetDep(upstream, partition_mapping=SpecificPartitionsPartitionMapping(["apple"]))],
     )
     def downstream(context: AssetExecutionContext):
         assert context.asset_partition_key_for_input("upstream") == "apple"

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_asset_partition_mappings.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_asset_partition_mappings.py
@@ -10,6 +10,7 @@ from dagster import (
     AssetMaterialization,
     AssetsDefinition,
     DagsterInvalidDefinitionError,
+    DagsterInvariantViolationError,
     DailyPartitionsDefinition,
     IdentityPartitionMapping,
     IOManager,
@@ -574,6 +575,33 @@ def test_identity_partition_mapping():
 
 
 def test_partition_mapping_with_asset_deps():
+    partitions_def = DailyPartitionsDefinition(start_date="2023-08-15")
+
+    ### With @asset and deps
+    @asset(partitions_def=partitions_def)
+    def upstream():
+        return
+
+    @asset(
+        partitions_def=partitions_def,
+        deps=[AssetDep(upstream, TimeWindowPartitionMapping(start_offset=-1, end_offset=-1))],
+    )
+    def downstream(context: AssetExecutionContext):
+        upstream_key = datetime.strptime(
+            context.asset_partition_key_for_input("upstream"), "%Y-%m-%d"
+        )
+
+        current_partition_key = datetime.strptime(context.partition_key, "%Y-%m-%d")
+
+        assert current_partition_key - upstream_key == timedelta(days=1)
+
+    materialize([upstream, downstream], partition_key="2023-08-20")
+
+    assert downstream.partition_mappings == {
+        AssetKey("upstream"): TimeWindowPartitionMapping(start_offset=-1, end_offset=-1),
+    }
+
+    ### With @multi_asset and AssetSpec
     asset_1 = AssetSpec(key="asset_1")
     asset_2 = AssetSpec(key="asset_2")
 
@@ -606,15 +634,11 @@ def test_partition_mapping_with_asset_deps():
         ],
     )
 
-    @multi_asset(
-        specs=[asset_1, asset_2], partitions_def=DailyPartitionsDefinition(start_date="2023-08-15")
-    )
+    @multi_asset(specs=[asset_1, asset_2], partitions_def=partitions_def)
     def multi_asset_1():
         return
 
-    @multi_asset(
-        specs=[asset_3, asset_4], partitions_def=DailyPartitionsDefinition(start_date="2023-08-15")
-    )
+    @multi_asset(specs=[asset_3, asset_4], partitions_def=partitions_def)
     def multi_asset_2(context: AssetExecutionContext):
         asset_1_key = datetime.strptime(
             context.asset_partition_key_for_input("asset_1"), "%Y-%m-%d"
@@ -639,6 +663,26 @@ def test_partition_mapping_with_asset_deps():
 
 
 def test_conflicting_mappings_with_asset_deps():
+    partitions_def = DailyPartitionsDefinition(start_date="2023-08-15")
+
+    ### With @asset and deps
+    @asset(partitions_def=partitions_def)
+    def upstream():
+        return
+
+    with pytest.raises(DagsterInvariantViolationError, match="Cannot set a dependency on asset"):
+        # full error msg: Cannot set a dependency on asset AssetKey(['upstream']) more than once per asset
+        @asset(
+            partitions_def=partitions_def,
+            deps=[
+                AssetDep(upstream, TimeWindowPartitionMapping(start_offset=-1, end_offset=-1)),
+                AssetDep(upstream, TimeWindowPartitionMapping(start_offset=-2, end_offset=-2)),
+            ],
+        )
+        def downstream():
+            pass
+
+    ### With @multi_asset and AssetSpec
     asset_1 = AssetSpec(key="asset_1")
     asset_2 = AssetSpec(key="asset_2")
 
@@ -672,17 +716,42 @@ def test_conflicting_mappings_with_asset_deps():
         ],
     )
 
-    with pytest.raises(DagsterInvalidDefinitionError):
-
+    with pytest.raises(DagsterInvalidDefinitionError, match="Two different PartitionMappings for"):
+        # full error msg: Two different PartitionMappings for AssetKey(['asset_2']) provided for multi_asset multi_asset_2. Please use the same PartitionMapping for AssetKey(['asset_2']).
         @multi_asset(
             specs=[asset_3, asset_4],
-            partitions_def=DailyPartitionsDefinition(start_date="2023-08-15"),
+            partitions_def=partitions_def,
         )
         def multi_asset_2():
             pass
 
 
 def test_self_dependent_partition_mapping_with_asset_deps():
+    partitions_def = DailyPartitionsDefinition(start_date="2023-08-15")
+
+    ### With @asset and deps
+    @asset(
+        partitions_def=partitions_def,
+        deps=[
+            AssetDep("self_dependent", TimeWindowPartitionMapping(start_offset=-1, end_offset=-1))
+        ],
+    )
+    def self_dependent(context: AssetExecutionContext):
+        upstream_key = datetime.strptime(
+            context.asset_partition_key_for_input("self_dependent"), "%Y-%m-%d"
+        )
+
+        current_partition_key = datetime.strptime(context.partition_key, "%Y-%m-%d")
+
+        assert current_partition_key - upstream_key == timedelta(days=1)
+
+    materialize([self_dependent], partition_key="2023-08-20")
+
+    assert self_dependent.partition_mappings == {
+        AssetKey("self_dependent"): TimeWindowPartitionMapping(start_offset=-1, end_offset=-1),
+    }
+
+    ### With @multi_asset and AssetSpec
     asset_1 = AssetSpec(
         key="asset_1",
         deps=[
@@ -693,7 +762,7 @@ def test_self_dependent_partition_mapping_with_asset_deps():
         ],
     )
 
-    @multi_asset(specs=[asset_1], partitions_def=DailyPartitionsDefinition(start_date="2023-08-15"))
+    @multi_asset(specs=[asset_1], partitions_def=partitions_def)
     def the_multi_asset(context: AssetExecutionContext):
         asset_1_key = datetime.strptime(
             context.asset_partition_key_for_input("asset_1"), "%Y-%m-%d"
@@ -709,6 +778,27 @@ def test_self_dependent_partition_mapping_with_asset_deps():
 def test_dynamic_partition_mapping_with_asset_deps():
     partitions_def = DynamicPartitionsDefinition(name="fruits")
 
+    ### With @asset and deps
+    @asset(partitions_def=partitions_def)
+    def upstream():
+        return
+
+    @asset(
+        partitions_def=partitions_def,
+        deps=[AssetDep(upstream, SpecificPartitionsPartitionMapping(["apple"]))],
+    )
+    def downstream(context: AssetExecutionContext):
+        assert context.asset_partition_key_for_input("upstream") == "apple"
+        assert context.partition_key == "orange"
+
+    with instance_for_test() as instance:
+        instance.add_dynamic_partitions("fruits", ["apple"])
+        materialize([upstream], partition_key="apple", instance=instance)
+
+        instance.add_dynamic_partitions("fruits", ["orange"])
+        materialize([upstream, downstream], partition_key="orange", instance=instance)
+
+    ### With @multi_asset and AssetSpec
     asset_1 = AssetSpec(
         key="asset_1",
     )

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_multipartition_partition_mapping.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_multipartition_partition_mapping.py
@@ -785,8 +785,8 @@ def test_multi_partition_mapping_with_asset_deps():
     }
 
     ### With @multi_asset and AssetSpec
-    asset_1 = AssetSpec(asset="asset_1")
-    asset_2 = AssetSpec(asset="asset_2")
+    asset_1 = AssetSpec(key="asset_1")
+    asset_2 = AssetSpec(key="asset_2")
 
     asset_1_partition_mapping = MultiPartitionMapping(
         {

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_multipartition_partition_mapping.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_multipartition_partition_mapping.py
@@ -15,6 +15,7 @@ from dagster import (
     StaticPartitionsDefinition,
     TimeWindowPartitionMapping,
     WeeklyPartitionsDefinition,
+    asset,
     materialize,
     multi_asset,
 )
@@ -730,8 +731,62 @@ def test_error_multipartitions_mapping():
 
 
 def test_multi_partition_mapping_with_asset_deps():
-    asset_1 = AssetSpec(key="asset_1")
-    asset_2 = AssetSpec(key="asset_2")
+    partitions_def = MultiPartitionsDefinition(
+        {
+            "123": StaticPartitionsDefinition(["1", "2", "3"]),
+            "time": DailyPartitionsDefinition("2023-01-01"),
+        }
+    )
+
+    ### With @asset and deps
+    @asset(partitions_def=partitions_def)
+    def upstream():
+        return
+
+    mapping = MultiPartitionMapping(
+        {
+            "123": DimensionPartitionMapping(
+                dimension_name="123",
+                partition_mapping=IdentityPartitionMapping(),
+            ),
+            "time": DimensionPartitionMapping(
+                dimension_name="time",
+                partition_mapping=TimeWindowPartitionMapping(start_offset=-1, end_offset=-1),
+            ),
+        }
+    )
+
+    @asset(partitions_def=partitions_def, deps=[AssetDep(upstream, mapping)])
+    def downstream(context: AssetExecutionContext):
+        upstream_mp_key = context.asset_partition_key_for_input("upstream")
+        current_mp_key = context.partition_key
+
+        if isinstance(upstream_mp_key, MultiPartitionKey) and isinstance(
+            current_mp_key, MultiPartitionKey
+        ):
+            upstream_key = datetime.strptime(upstream_mp_key.keys_by_dimension["time"], "%Y-%m-%d")
+
+            current_partition_key = datetime.strptime(
+                current_mp_key.keys_by_dimension["time"], "%Y-%m-%d"
+            )
+
+            assert current_partition_key - upstream_key == timedelta(days=1)
+        else:
+            assert False, "partition keys for upstream and downstream should be MultiPartitionKeys"
+
+        return
+
+    materialize(
+        [upstream, downstream], partition_key=MultiPartitionKey({"123": "1", "time": "2023-08-05"})
+    )
+
+    assert downstream.partition_mappings == {
+        AssetKey("upstream"): mapping,
+    }
+
+    ### With @multi_asset and AssetSpec
+    asset_1 = AssetSpec(asset="asset_1")
+    asset_2 = AssetSpec(asset="asset_2")
 
     asset_1_partition_mapping = MultiPartitionMapping(
         {
@@ -783,13 +838,6 @@ def test_multi_partition_mapping_with_asset_deps():
                 partition_mapping=asset_2_partition_mapping,
             ),
         ],
-    )
-
-    partitions_def = MultiPartitionsDefinition(
-        {
-            "123": StaticPartitionsDefinition(["1", "2", "3"]),
-            "time": DailyPartitionsDefinition("2023-01-01"),
-        }
     )
 
     @multi_asset(specs=[asset_1, asset_2], partitions_def=partitions_def)

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_multipartition_partition_mapping.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_multipartition_partition_mapping.py
@@ -756,7 +756,7 @@ def test_multi_partition_mapping_with_asset_deps():
         }
     )
 
-    @asset(partitions_def=partitions_def, deps=[AssetDep(upstream, mapping)])
+    @asset(partitions_def=partitions_def, deps=[AssetDep(upstream, partition_mapping=mapping)])
     def downstream(context: AssetExecutionContext):
         upstream_mp_key = context.asset_partition_key_for_input("upstream")
         current_mp_key = context.partition_key

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_deps.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_deps.py
@@ -31,6 +31,10 @@ def test_basic_instantiation():
 
     assert AssetDep("upstream", partitions_mapping).partition_mapping == partitions_mapping
 
+    # test SourceAsset
+    the_source = SourceAsset(key="the_source")
+    assert AssetDep(the_source).asset_key == the_source.key
+
 
 def test_multi_asset_errors():
     @multi_asset(specs=[AssetSpec("asset_1"), AssetSpec("asset_2")])

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_deps.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_deps.py
@@ -10,8 +10,7 @@ from dagster import (
     materialize,
     multi_asset,
 )
-from dagster._check import CheckError
-
+from dagster._check import CheckError, ParameterCheckError
 from dagster._core.definitions.asset_dep import AssetDep
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.errors import DagsterInvalidDefinitionError
@@ -42,9 +41,8 @@ def test_instantiation_with_asset_dep():
     partition_mapping = TimeWindowPartitionMapping(start_offset=-1, end_offset=-1)
     og_dep = AssetDep("upstream", partition_mapping)
 
-    # partition_mapping is ignored if instantiated from an AssetDep
-    # TODO - decide if that is the correct behavior
-    assert AssetDep(og_dep) == AssetDep("upstream")
+    with pytest.raises(ParameterCheckError):
+        assert AssetDep(og_dep) == AssetDep("upstream")
 
 
 def test_multi_asset_errors():

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_deps.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_deps.py
@@ -10,10 +10,8 @@ from dagster import (
     materialize,
     multi_asset,
 )
-<<<<<<< HEAD
 from dagster._check import CheckError
-=======
->>>>>>> 2d50011d7a (more testing)
+
 from dagster._core.definitions.asset_dep import AssetDep
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.errors import DagsterInvalidDefinitionError
@@ -60,8 +58,6 @@ def test_multi_asset_errors():
     ):
         AssetDep(a_multi_asset)
 
-
-<<<<<<< HEAD
 def test_from_coercible():
     # basic coersion
     compare_dep = AssetDep("upstream")
@@ -100,9 +96,6 @@ def test_from_coercible():
     with pytest.raises(CheckError, match="Unexpected type for AssetKey"):
         AssetDep.from_coercible(1)
 
-
-=======
->>>>>>> 2d50011d7a (more testing)
 ### Tests for deps parameter on @asset and @multi_asset
 
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_deps.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_deps.py
@@ -55,7 +55,7 @@ def test_multi_asset_errors():
 
     with pytest.raises(
         DagsterInvalidDefinitionError,
-        match="Cannot pass a multi_asset AssetsDefinition as an argument to deps",
+        match="Cannot create an AssetDep from a multi_asset AssetsDefinition",
     ):
         AssetDep(a_multi_asset)
 
@@ -90,7 +90,7 @@ def test_from_coercible():
 
     with pytest.raises(
         DagsterInvalidDefinitionError,
-        match="Cannot pass a multi_asset AssetsDefinition as an argument to deps",
+        match="Cannot create an AssetDep from a multi_asset AssetsDefinition",
     ):
         AssetDep.from_coercible(a_multi_asset)
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_deps.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_deps.py
@@ -28,9 +28,12 @@ def test_basic_instantiation():
     assert AssetDep(upstream).asset_key == upstream.key
     assert AssetDep(AssetKey(["upstream"])).asset_key == upstream.key
 
-    partitions_mapping = TimeWindowPartitionMapping(start_offset=-1, end_offset=-1)
+    partition_mapping = TimeWindowPartitionMapping(start_offset=-1, end_offset=-1)
 
-    assert AssetDep("upstream", partitions_mapping).partition_mapping == partitions_mapping
+    assert (
+        AssetDep("upstream", partition_mapping=partition_mapping).partition_mapping
+        == partition_mapping
+    )
 
     # test SourceAsset
     the_source = SourceAsset(key="the_source")
@@ -39,7 +42,7 @@ def test_basic_instantiation():
 
 def test_instantiation_with_asset_dep():
     partition_mapping = TimeWindowPartitionMapping(start_offset=-1, end_offset=-1)
-    og_dep = AssetDep("upstream", partition_mapping)
+    og_dep = AssetDep("upstream", partition_mapping=partition_mapping)
 
     with pytest.raises(ParameterCheckError):
         assert AssetDep(og_dep) == AssetDep("upstream")
@@ -77,7 +80,7 @@ def test_from_coercible():
 
     # partition_mapping should be retained when using from_coercible
     partition_mapping = TimeWindowPartitionMapping(start_offset=-1, end_offset=-1)
-    with_partition_mapping = AssetDep("with_partition_mapping", partition_mapping)
+    with_partition_mapping = AssetDep("with_partition_mapping", partition_mapping=partition_mapping)
     assert AssetDep.from_coercible(with_partition_mapping) == with_partition_mapping
 
     # multi_assets cannot be coerced by Definition

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_deps.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_deps.py
@@ -10,7 +10,7 @@ from dagster import (
     materialize,
     multi_asset,
 )
-from dagster._check import CheckError, ParameterCheckError
+from dagster._check import ParameterCheckError
 from dagster._core.definitions.asset_dep import AssetDep
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.errors import DagsterInvalidDefinitionError
@@ -56,8 +56,9 @@ def test_multi_asset_errors():
     ):
         AssetDep(a_multi_asset)
 
+
 def test_from_coercible():
-    # basic coersion
+    # basic coercion
     compare_dep = AssetDep("upstream")
 
     @asset
@@ -69,7 +70,7 @@ def test_from_coercible():
     assert AssetDep.from_coercible(AssetKey(["upstream"])) == compare_dep
     assert AssetDep.from_coercible(compare_dep) == compare_dep
 
-    # SourceAsset coersion
+    # SourceAsset coercion
     the_source = SourceAsset(key="the_source")
     source_compare_dep = AssetDep(the_source)
     assert AssetDep.from_coercible(the_source) == source_compare_dep
@@ -91,8 +92,10 @@ def test_from_coercible():
         AssetDep.from_coercible(a_multi_asset)
 
     # Test bad type
-    with pytest.raises(CheckError, match="Unexpected type for AssetKey"):
+    with pytest.raises(ParameterCheckError, match='Param "asset" is not one of'):
+        # full error msg: Param "asset" is not one of ['AssetKey', 'AssetSpec', 'AssetsDefinition', 'SourceAsset', 'str']. Got 1 which is type <class 'int'>.
         AssetDep.from_coercible(1)
+
 
 ### Tests for deps parameter on @asset and @multi_asset
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_deps.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_deps.py
@@ -10,7 +10,10 @@ from dagster import (
     materialize,
     multi_asset,
 )
+<<<<<<< HEAD
 from dagster._check import CheckError
+=======
+>>>>>>> 2d50011d7a (more testing)
 from dagster._core.definitions.asset_dep import AssetDep
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.errors import DagsterInvalidDefinitionError
@@ -58,6 +61,7 @@ def test_multi_asset_errors():
         AssetDep(a_multi_asset)
 
 
+<<<<<<< HEAD
 def test_from_coercible():
     # basic coersion
     compare_dep = AssetDep("upstream")
@@ -97,6 +101,8 @@ def test_from_coercible():
         AssetDep.from_coercible(1)
 
 
+=======
+>>>>>>> 2d50011d7a (more testing)
 ### Tests for deps parameter on @asset and @multi_asset
 
 

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_load_from_instance.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_load_from_instance.py
@@ -288,7 +288,8 @@ def test_load_from_instance_with_downstream_asset_errors():
         match=(
             "Cannot pass an instance of type <class"
             " 'dagster_airbyte.asset_defs.AirbyteInstanceCacheableAssetsDefinition'> to deps"
-            " parameter of @asset. Instead, pass AssetsDefinitions or AssetKeys."
+            " parameter of @asset. Instead, pass AssetDeps, AssetsDefinitions, SourceAssets, or"
+            " AssetKeys."
         ),
     ):
 


### PR DESCRIPTION
## Summary & Motivation
Expands the type signature of `@asset` `deps` to take `AssetDep`. this allows `PartitionMappings` to be specified for `deps`. 

This PR now also consolidates the Union type accepted by `deps`. For a split out version of that work, see the stacked PR

## How I Tested These Changes
