### PR TITLE
[RFC] CoercibleToAssetDep

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_dep.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_dep.py
@@ -13,6 +13,10 @@ from .events import (
     CoercibleToAssetKey,
 )
 
+CoercibleToAssetDep = Union[
+    CoercibleToAssetKey, AssetSpec, AssetsDefinition, SourceAsset, "AssetDep"
+]
+
 
 @experimental
 class AssetDep(
@@ -50,23 +54,19 @@ class AssetDep(
 
     def __new__(
         cls,
-        asset: Union[CoercibleToAssetKey, AssetSpec, AssetsDefinition, SourceAsset],
+        asset: CoercibleToAssetDep,
         partition_mapping: Optional[PartitionMapping] = None,
     ):
-        if isinstance(asset, AssetSpec):
-            asset_key = asset.asset_key
-        elif isinstance(asset, AssetsDefinition):
+        if isinstance(asset, AssetsDefinition) and len(asset.keys) > 1:
             # Only AssetsDefinition with a single asset can be passed
-            if len(asset.keys) > 1:
-                raise DagsterInvalidDefinitionError(
-                    "Cannot pass a multi_asset AssetsDefinition as an argument to deps."
-                    " Instead, specify dependencies on the assets created by the multi_asset"
-                    f" via AssetKeys or strings. For the multi_asset {asset.node_def.name}, the"
-                    f" available keys are: {asset.keys}."
-                )
-            asset_key = AssetKey.from_coercible_or_definition(asset)
-        else:
-            asset_key = AssetKey.from_coercible_or_definition(asset)
+            raise DagsterInvalidDefinitionError(
+                "Cannot pass a multi_asset AssetsDefinition as an argument to deps."
+                " Instead, specify dependencies on the assets created by the multi_asset"
+                f" via AssetKeys or strings. For the multi_asset {asset.node_def.name}, the"
+                f" available keys are: {asset.keys}."
+            )
+
+        asset_key = AssetKey.from_coercible_to_asset_dep(asset)
 
         return super().__new__(
             cls,
@@ -77,3 +77,17 @@ class AssetDep(
                 PartitionMapping,
             ),
         )
+
+    @staticmethod
+    def from_coercible(arg: "CoercibleToAssetDep"):
+        if isinstance(arg, AssetsDefinition) and len(arg.keys) > 1:
+            # Only AssetsDefinition with a single asset can be passed
+            raise DagsterInvalidDefinitionError(
+                "Cannot pass a multi_asset AssetsDefinition as an argument to deps."
+                " Instead, specify dependencies on the assets created by the multi_asset"
+                f" via AssetKeys or strings. For the multi_asset {arg.node_def.name}, the"
+                f" available keys are: {arg.keys}."
+            )
+        if isinstance(arg, AssetDep):
+            return arg
+        return AssetDep(asset=arg)

--- a/python_modules/dagster/dagster/_core/definitions/asset_dep.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_dep.py
@@ -89,5 +89,6 @@ class AssetDep(
                 f" available keys are: {arg.keys}."
             )
         if isinstance(arg, AssetDep):
+            # we need to retain the partition_mapping, so return the original object
             return arg
         return AssetDep(asset=arg)

--- a/python_modules/dagster/dagster/_core/definitions/asset_dep.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_dep.py
@@ -80,14 +80,6 @@ class AssetDep(
 
     @staticmethod
     def from_coercible(arg: "CoercibleToAssetDep"):
-        if isinstance(arg, AssetsDefinition) and len(arg.keys) > 1:
-            # Only AssetsDefinition with a single asset can be passed
-            raise DagsterInvalidDefinitionError(
-                "Cannot pass a multi_asset AssetsDefinition as an argument to deps."
-                " Instead, specify dependencies on the assets created by the multi_asset"
-                f" via AssetKeys or strings. For the multi_asset {arg.node_def.name}, the"
-                f" available keys are: {arg.keys}."
-            )
         if isinstance(arg, AssetDep):
             # we need to retain the partition_mapping, so return the original object
             return arg

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -1256,18 +1256,20 @@ def _make_asset_deps(deps: Optional[Iterable[CoercibleToAssetDep]]) -> Optional[
     if deps is None:
         return None
 
-    dep_dict = {}
-    for dep in deps:
-        asset_dep = AssetDep.from_coercible(dep)
+    with disable_dagster_warnings():
+        dep_dict = {}
+        for dep in deps:
+            asset_dep = AssetDep.from_coercible(dep)
 
-        # we cannot do deduplication via a set because MultiPartitionMappings have an internal
-        # dictionary that cannot be hashed. Instead deduplicate by making a dictionary and checking
-        # for existing keys.
-        if asset_dep.asset_key in dep_dict.keys():
-            raise DagsterInvariantViolationError(
-                f"Cannot set a dependency on asset {asset_dep.asset_key} more than once per asset."
-            )
-        dep_dict[asset_dep.asset_key] = asset_dep
+            # we cannot do deduplication via a set because MultiPartitionMappings have an internal
+            # dictionary that cannot be hashed. Instead deduplicate by making a dictionary and checking
+            # for existing keys.
+            if asset_dep.asset_key in dep_dict.keys():
+                raise DagsterInvariantViolationError(
+                    f"Cannot set a dependency on asset {asset_dep.asset_key} more than once per"
+                    " asset."
+                )
+            dep_dict[asset_dep.asset_key] = asset_dep
 
     return list(dep_dict.values())
 

--- a/python_modules/dagster/dagster/_core/definitions/events.py
+++ b/python_modules/dagster/dagster/_core/definitions/events.py
@@ -34,6 +34,7 @@ from .metadata import (
 from .utils import DEFAULT_OUTPUT, check_valid_name
 
 if TYPE_CHECKING:
+    from dagster._core.definitions.asset_dep import CoercibleToAssetDep
     from dagster._core.definitions.assets import AssetsDefinition
     from dagster._core.definitions.source_asset import SourceAsset
     from dagster._core.execution.context.output import OutputContext
@@ -186,6 +187,24 @@ class AssetKey(NamedTuple("_AssetKey", [("path", PublicAttr[Sequence[str]])])):
             return arg.key
         elif isinstance(arg, SourceAsset):
             return arg.key
+        else:
+            return AssetKey.from_coercible(arg)
+
+    @staticmethod
+    def from_coercible_to_asset_dep(arg: "CoercibleToAssetDep") -> "AssetKey":
+        from dagster._core.definitions.asset_dep import AssetDep
+        from dagster._core.definitions.asset_spec import AssetSpec
+        from dagster._core.definitions.assets import AssetsDefinition
+        from dagster._core.definitions.source_asset import SourceAsset
+
+        if isinstance(arg, AssetsDefinition):
+            return arg.key
+        elif isinstance(arg, SourceAsset):
+            return arg.key
+        elif isinstance(arg, AssetDep):
+            return arg.asset_key
+        elif isinstance(arg, AssetSpec):
+            return arg.asset_key
         else:
             return AssetKey.from_coercible(arg)
 


### PR DESCRIPTION
## Summary & Motivation

While implementing `AssetDep` in https://github.com/dagster-io/dagster/pull/16207, we discussed the need for a type alias to encompass `Union[CoercibleToAssetKey, AssetSpec, AssetsDefinition, SourceAsset, AssetDep]` (ie all types that can be passed to the `deps` parameter of `AssetSpec` and `@asset` - see in https://github.com/dagster-io/dagster/pull/16426) 

This RFC introduces `CoercibleToAssetDep` to represent this union of types. It also introduces:
* `AssetDep.from_coercible`
* `AssetKey.from_coercible_to_asset_dep` 

The PR also updates various code sites to use the `coercible` methods and reduce duplication of code 


## How I Tested These Changes
