### PR TITLE
Remove check name query in run link

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetCheckStatusTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetCheckStatusTag.tsx
@@ -1,5 +1,4 @@
 import {BaseTag, Box, Colors, Icon, Spinner, Tag} from '@dagster-io/ui-components';
-import qs from 'qs';
 import * as React from 'react';
 
 import {assertUnreachable} from '../../app/Util';
@@ -7,7 +6,6 @@ import {AssetCheckExecutionResolvedStatus, AssetCheckSeverity} from '../../graph
 import {TagActionsPopover} from '../../ui/TagActions';
 
 export const AssetCheckStatusTag = ({
-  check,
   execution,
 }: {
   check: {
@@ -85,7 +83,7 @@ export const AssetCheckStatusTag = ({
       actions={[
         {
           label: 'View in run logs',
-          to: `/runs/${runId}?${qs.stringify({logs: check.name})}`,
+          to: `/runs/${runId})}`,
         },
       ]}
     >


### PR DESCRIPTION
If the check is computed in a step with a name other than the check name, the current link filters out all logs. I think we should add this back once we surface the check's step name