### PR TITLE
Show asset checks if they were in the same run as a materialization

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_checks.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_checks.py
@@ -122,7 +122,9 @@ def _execution_targets_latest_materialization(
         # asset hasn't been materialized yet, so no reason to hide the check
         return True
 
-    # if the check is executed in the same run as the materialization, then show it
+    # If the check is executed in the same run as the materialization, then show it.
+    # This is a workaround to support the 'stage then promote' graph asset pattern,
+    # where checks happen before a materialization.
     latest_materialization_run_id = latest_materialization.event_log_entry.run_id
     if latest_materialization_run_id == execution.run_id:
         return True

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_checks.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_checks.py
@@ -122,6 +122,11 @@ def _execution_targets_latest_materialization(
         # asset hasn't been materialized yet, so no reason to hide the check
         return True
 
+    # if the check is executed in the same run as the materialization, then show it
+    latest_materialization_run_id = latest_materialization.event_log_entry.run_id
+    if latest_materialization_run_id == execution.run_id:
+        return True
+
     if resolved_status in [
         AssetCheckExecutionResolvedStatus.SUCCEEDED,
         AssetCheckExecutionResolvedStatus.FAILED,
@@ -146,11 +151,6 @@ def _execution_targets_latest_materialization(
         AssetCheckExecutionResolvedStatus.EXECUTION_FAILED,
         AssetCheckExecutionResolvedStatus.SKIPPED,
     ]:
-        # if the check is executed in the same run as the materialization, then show it
-        latest_materialization_run_id = latest_materialization.event_log_entry.run_id
-        if latest_materialization_run_id == execution.run_id:
-            return True
-
         # As a last ditch effort, check if the check's run was launched after the materialization's
         latest_materialization_run_record = instance.get_run_record_by_id(
             latest_materialization_run_id

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_checks.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_checks.py
@@ -404,6 +404,8 @@ class TestAssetChecks(ExecutingGraphQLContextTestMatrix):
                 }
             }, "new materialization should clear latest execution"
             records = instance.get_asset_records([AssetKey(["asset_1"])])
+            assert records
+            assert records[0].asset_entry.last_materialization_record
             return records[0].asset_entry.last_materialization_record
 
         # no materialization, surface latest execution

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_checks.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_checks.py
@@ -403,7 +403,8 @@ class TestAssetChecks(ExecutingGraphQLContextTestMatrix):
                     "checks": [{"name": "my_check", "executionForLatestMaterialization": None}],
                 }
             }, "new materialization should clear latest execution"
-            return instance.get_records_for_run(run.run_id).records[0]
+            records = instance.get_asset_records([AssetKey(["asset_1"])])
+            return records[0].asset_entry.last_materialization_record
 
         # no materialization, surface latest execution
         run = create_run_for_test(instance)
@@ -507,4 +508,65 @@ class TestAssetChecks(ExecutingGraphQLContextTestMatrix):
             }
         }
 
-        new_materialization()
+        materialization_record = new_materialization()
+
+        # run the checks, then materialize. The checks still apply because they're in the same run
+        run = create_run_for_test(instance)
+        instance.event_log_storage.store_event(
+            _planned_event(
+                run.run_id,
+                AssetCheckEvaluationPlanned(asset_key=AssetKey(["asset_1"]), check_name="my_check"),
+            )
+        )
+        instance.event_log_storage.store_event(
+            _evaluation_event(
+                run.run_id,
+                AssetCheckEvaluation(
+                    asset_key=AssetKey(["asset_1"]),
+                    check_name="my_check",
+                    success=True,
+                    metadata={},
+                    target_materialization_data=AssetCheckEvaluationTargetMaterializationData(
+                        storage_id=materialization_record.storage_id,
+                        run_id=materialization_record.event_log_entry.run_id,
+                        timestamp=materialization_record.event_log_entry.timestamp,
+                    ),
+                    severity=AssetCheckSeverity.ERROR,
+                ),
+            )
+        )
+        res = execute_dagster_graphql(
+            graphql_context, GET_LATEST_EXECUTION, variables={"assetKey": {"path": ["asset_1"]}}
+        )
+        assert res.data == {
+            "assetChecksOrError": {
+                "checks": [
+                    {
+                        "name": "my_check",
+                        "executionForLatestMaterialization": {
+                            "runId": run.run_id,
+                            "status": "SUCCEEDED",
+                        },
+                    }
+                ],
+            }
+        }
+        instance.event_log_storage.store_event(
+            _materialization_event(run.run_id, AssetKey(["asset_1"]))
+        )
+        res = execute_dagster_graphql(
+            graphql_context, GET_LATEST_EXECUTION, variables={"assetKey": {"path": ["asset_1"]}}
+        )
+        assert res.data == {
+            "assetChecksOrError": {
+                "checks": [
+                    {
+                        "name": "my_check",
+                        "executionForLatestMaterialization": {
+                            "runId": run.run_id,
+                            "status": "SUCCEEDED",
+                        },
+                    }
+                ],
+            }
+        }


### PR DESCRIPTION
Previously, we hid checks if they returned a result before the latest materialization. This means we hide them with the asset promotion pattern. This diff shows the check as long as it was evaluated in the same run as the eventual materialization.

I suspect we'll need to iterate here. E.g. if I run the promotion step and not the check, i'll still hide the check. We might end up with a flag on checks to indicate that they apply to future materializations. I think if we ship this simple change, it will let users get far enough to give us feedback about how they want check status shown in the various states with this pattern.

Tests:
- unit
- using the toys graph asset example