### PR TITLE
[ui] Add an “Experimental” banner to auto-materialize policies

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AssetAutomaterializePolicyPage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AssetAutomaterializePolicyPage.tsx
@@ -4,8 +4,10 @@ import styled from 'styled-components';
 
 import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../../app/QueryRefresh';
 import {useQueryPersistedState} from '../../hooks/useQueryPersistedState';
+import {AssetChecksBanner} from '../asset-checks/AssetChecksBanner';
 import {AssetKey} from '../types';
 
+import {AutoMaterializeExperimentalBanner} from './AutoMaterializeExperimentalBanner';
 import {AutomaterializeLeftPanel} from './AutomaterializeLeftPanel';
 import {AutomaterializeMiddlePanel} from './AutomaterializeMiddlePanel';
 import {AutomaterializeRightPanel} from './AutomaterializeRightPanel';
@@ -78,46 +80,54 @@ export const AssetAutomaterializePolicyPage = ({
   return (
     <AutomaterializePage
       style={{flex: 1, minHeight: 0, color: Colors.Gray700, overflow: 'hidden'}}
-      flex={{direction: 'row'}}
+      flex={{direction: 'column'}}
     >
-      <Box flex={{direction: 'column', grow: 1}}>
-        <Box
-          flex={{alignItems: 'center'}}
-          padding={{vertical: 16, horizontal: 24}}
-          border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
-        >
-          <Subheading>Evaluation history</Subheading>
-        </Box>
-        <Box flex={{direction: 'row'}} style={{flex: 1, minHeight: 0}}>
-          <Box
-            border={{side: 'right', color: Colors.KeylineGray, width: 1}}
-            flex={{grow: 0, direction: 'column'}}
-            style={{flex: '0 0 296px'}}
-          >
-            <AutomaterializeLeftPanel
-              assetHasDefinedPartitions={assetHasDefinedPartitions}
-              evaluations={evaluations}
-              evaluationsIncludingEmpty={evaluationsIncludingEmpty}
-              paginationProps={paginationProps}
-              onSelectEvaluation={(evaluation) => {
-                setSelectedEvaluationId(evaluation.evaluationId);
-              }}
-              selectedEvaluation={selectedEvaluation}
-            />
-          </Box>
-          <Box flex={{grow: 1}} style={{minHeight: 0, overflowY: 'auto'}}>
-            <AutomaterializeMiddlePanel
-              assetKey={assetKey}
-              assetHasDefinedPartitions={assetHasDefinedPartitions}
-              // Use the evaluation ID of the current evaluation object, if any. Otherwise
-              // fall back to the evaluation ID from the query parameter, if any.
-              selectedEvaluationId={selectedEvaluation?.evaluationId || selectedEvaluationId}
-            />
-          </Box>
-        </Box>
+      <Box
+        padding={{horizontal: 24, vertical: 12}}
+        border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+      >
+        <AutoMaterializeExperimentalBanner />
       </Box>
-      <Box border={{side: 'left', color: Colors.KeylineGray, width: 1}}>
-        <AutomaterializeRightPanel assetKey={assetKey} />
+      <Box flex={{direction: 'row'}}>
+        <Box flex={{direction: 'column', grow: 1}}>
+          <Box
+            flex={{alignItems: 'center'}}
+            padding={{vertical: 16, horizontal: 24}}
+            border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+          >
+            <Subheading>Evaluation history</Subheading>
+          </Box>
+          <Box flex={{direction: 'row'}} style={{flex: 1, minHeight: 0}}>
+            <Box
+              border={{side: 'right', color: Colors.KeylineGray, width: 1}}
+              flex={{grow: 0, direction: 'column'}}
+              style={{flex: '0 0 296px'}}
+            >
+              <AutomaterializeLeftPanel
+                assetHasDefinedPartitions={assetHasDefinedPartitions}
+                evaluations={evaluations}
+                evaluationsIncludingEmpty={evaluationsIncludingEmpty}
+                paginationProps={paginationProps}
+                onSelectEvaluation={(evaluation) => {
+                  setSelectedEvaluationId(evaluation.evaluationId);
+                }}
+                selectedEvaluation={selectedEvaluation}
+              />
+            </Box>
+            <Box flex={{grow: 1}} style={{minHeight: 0, overflowY: 'auto'}}>
+              <AutomaterializeMiddlePanel
+                assetKey={assetKey}
+                assetHasDefinedPartitions={assetHasDefinedPartitions}
+                // Use the evaluation ID of the current evaluation object, if any. Otherwise
+                // fall back to the evaluation ID from the query parameter, if any.
+                selectedEvaluationId={selectedEvaluation?.evaluationId || selectedEvaluationId}
+              />
+            </Box>
+          </Box>
+        </Box>
+        <Box border={{side: 'left', color: Colors.KeylineGray, width: 1}}>
+          <AutomaterializeRightPanel assetKey={assetKey} />
+        </Box>
       </Box>
     </AutomaterializePage>
   );

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AssetAutomaterializePolicyPage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AssetAutomaterializePolicyPage.tsx
@@ -4,7 +4,6 @@ import styled from 'styled-components';
 
 import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../../app/QueryRefresh';
 import {useQueryPersistedState} from '../../hooks/useQueryPersistedState';
-import {AssetChecksBanner} from '../asset-checks/AssetChecksBanner';
 import {AssetKey} from '../types';
 
 import {AutoMaterializeExperimentalBanner} from './AutoMaterializeExperimentalBanner';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutoMaterializeExperimentalBanner.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutoMaterializeExperimentalBanner.tsx
@@ -1,0 +1,51 @@
+import {Alert, Box, Colors, Icon, Popover, Tag} from '@dagster-io/ui-components';
+import React from 'react';
+import styled from 'styled-components';
+
+const AutoMaterializeExperimentalText = (
+  <span>
+    You can learn more about this new feature and provide feedback{' '}
+    <a href="https://docs.dagster.io/concepts/assets/asset-auto-execution#auto-materializing-assets-">
+      here
+    </a>
+    .
+  </span>
+);
+
+export const AutoMaterializeExperimentalBanner = () => {
+  return (
+    <Alert
+      intent="info"
+      title="Auto-materialize policies are experimental"
+      icon={<Icon name="info" color={Colors.Blue700} />}
+      description={AutoMaterializeExperimentalText}
+    />
+  );
+};
+
+export const AutoMaterializeExperimentalTag = () => {
+  return (
+    <Popover
+      content={<Container>{AutoMaterializeExperimentalText}</Container>}
+      hoverOpenDelay={100}
+      hoverCloseDelay={100}
+      placement="top"
+      interactionKind="hover"
+    >
+      <Tag intent="primary">Experimental</Tag>
+    </Popover>
+  );
+};
+
+const Container = styled(Box)`
+  border-radius: 8px;
+  overflow: hidden;
+  background: ${Colors.Dark};
+  padding: 8px 12px;
+  color: ${Colors.Gray100};
+
+  & a {
+    color: ${Colors.White};
+    text-decoration: underline;
+  }
+`;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutoMaterializeExperimentalBanner.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutoMaterializeExperimentalBanner.tsx
@@ -1,16 +1,8 @@
-import {Alert, Box, Colors, Icon, Popover, Tag} from '@dagster-io/ui-components';
+import {Alert, Colors, Icon, Tag, Tooltip} from '@dagster-io/ui-components';
 import React from 'react';
-import styled from 'styled-components';
 
-const AutoMaterializeExperimentalText = (
-  <span>
-    You can learn more about this new feature and provide feedback{' '}
-    <a href="https://docs.dagster.io/concepts/assets/asset-auto-execution#auto-materializing-assets-">
-      here
-    </a>
-    .
-  </span>
-);
+const LearnMoreLink =
+  'https://docs.dagster.io/concepts/assets/asset-auto-execution#auto-materializing-assets-';
 
 export const AutoMaterializeExperimentalBanner = () => {
   return (
@@ -18,34 +10,25 @@ export const AutoMaterializeExperimentalBanner = () => {
       intent="info"
       title="Auto-materialize policies are experimental"
       icon={<Icon name="info" color={Colors.Blue700} />}
-      description={AutoMaterializeExperimentalText}
+      description={
+        <span>
+          You can learn more about this new feature and provide feedback{' '}
+          <a target="_blank" href={LearnMoreLink} rel="noreferrer">
+            here
+          </a>
+          .
+        </span>
+      }
     />
   );
 };
 
 export const AutoMaterializeExperimentalTag = () => {
   return (
-    <Popover
-      content={<Container>{AutoMaterializeExperimentalText}</Container>}
-      hoverOpenDelay={100}
-      hoverCloseDelay={100}
-      placement="top"
-      interactionKind="hover"
-    >
-      <Tag intent="primary">Experimental</Tag>
-    </Popover>
+    <Tooltip content="Click to learn more about this new feature and provide feedback">
+      <a target="_blank" href={LearnMoreLink} rel="noreferrer">
+        <Tag intent="primary">Experimental</Tag>
+      </a>
+    </Tooltip>
   );
 };
-
-const Container = styled(Box)`
-  border-radius: 8px;
-  overflow: hidden;
-  background: ${Colors.Dark};
-  padding: 8px 12px;
-  color: ${Colors.Gray100};
-
-  & a {
-    color: ${Colors.White};
-    text-decoration: underline;
-  }
-`;

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/DaemonList.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/DaemonList.tsx
@@ -6,6 +6,7 @@ import {useConfirmation} from '../app/CustomConfirmationProvider';
 import {useUnscopedPermissions} from '../app/Permissions';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {Timestamp} from '../app/time/Timestamp';
+import {AutoMaterializeExperimentalTag} from '../assets/AutoMaterializePolicyPage/AutoMaterializeExperimentalBanner';
 import {useAutomaterializeDaemonStatus} from '../assets/AutomaterializeDaemonStatusTag';
 import {TimeFromNow} from '../ui/TimeFromNow';
 
@@ -66,7 +67,10 @@ export const DaemonList: React.FC<Props> = ({daemonStatuses, showTimestampColumn
           <tr>
             <td>
               <Box flex={{direction: 'row', justifyContent: 'space-between'}}>
-                Auto-materializing
+                <Box flex={{gap: 8, alignItems: 'center'}}>
+                  Auto-materializing
+                  <AutoMaterializeExperimentalTag />
+                </Box>
                 {automaterialize.loading ? (
                   <Spinner purpose="body-text" />
                 ) : (


### PR DESCRIPTION
## Summary & Motivation

The first notice is on the daemons page - the link goes to https://docs.dagster.io/concepts/assets/asset-auto-execution#auto-materializing-assets-, and the tag appearance was sort of inspired by the "Experimental" tag that also appears on that doc page.

<img width="614" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/74da99b0-13bf-426c-810f-3237ff6ac9ff">

The second notice is on the asset details tab. It looks the same / shares placement with the "Asset Checks" tab's identical experimental banner.

<img width="1728" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/d4d8284f-343e-4306-bf79-5295a9bd81e6">

## How I Tested These Changes

Just viewed these two pages 🙏 