### PR TITLE
[1/n] Asset graph sidebar

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/components/MiddleTruncate.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/MiddleTruncate.tsx
@@ -68,8 +68,6 @@ const MeasureWidth = styled.div`
   height: 0;
   overflow: hidden;
   white-space: nowrap;
-  user-select: none;
-  visibility: hidden;
 `;
 
 const Container = styled.div`

--- a/js_modules/dagster-ui/packages/ui-components/src/components/MiddleTruncate.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/MiddleTruncate.tsx
@@ -68,6 +68,8 @@ const MeasureWidth = styled.div`
   height: 0;
   overflow: hidden;
   white-space: nowrap;
+  user-select: none;
+  visibility: hidden;
 `;
 
 const Container = styled.div`

--- a/js_modules/dagster-ui/packages/ui-components/src/components/TextInput.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/TextInput.tsx
@@ -56,7 +56,7 @@ export const TextInputContainerStyles = css`
   position: relative;
 `;
 
-export const TextInputContainer = styled.div<{$disabled: boolean}>`
+export const TextInputContainer = styled.div<{$disabled?: boolean}>`
   ${TextInputContainerStyles}
 
   > ${IconWrapper}:first-child {

--- a/js_modules/dagster-ui/packages/ui-components/src/index.ts
+++ b/js_modules/dagster-ui/packages/ui-components/src/index.ts
@@ -50,6 +50,7 @@ export * from './components/styles';
 export * from './components/useSuggestionsForString';
 export * from './components/ErrorBoundary';
 export * from './components/useViewport';
+export * from './components/UnstyledButton';
 export * from './components/StyledRawCodeMirror';
 
 // Global font styles, exported as styled-component components to render in

--- a/js_modules/dagster-ui/packages/ui-core/src/app/Flags.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/Flags.tsx
@@ -14,6 +14,7 @@ export const FeatureFlag = {
   flagSidebarResources: 'flagSidebarResources' as const,
   flagHorizontalDAGs: 'flagHorizontalDAGs' as const,
   flagDisableAutoLoadDefaults: 'flagDisableAutoLoadDefaults' as const,
+  flagDAGSidebar: 'flagDAGSidebar' as const,
 };
 export type FeatureFlagType = keyof typeof FeatureFlag;
 

--- a/js_modules/dagster-ui/packages/ui-core/src/app/UserSettingsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/UserSettingsDialog.tsx
@@ -21,7 +21,7 @@ import {TimezoneSelect} from './time/TimezoneSelect';
 import {automaticLabel} from './time/browserTimezone';
 
 type OnCloseFn = (event: React.SyntheticEvent<HTMLElement>) => void;
-type VisibleFlag = {key: string; flagType: FeatureFlagType};
+type VisibleFlag = {key: string; label?: React.ReactNode; flagType: FeatureFlagType};
 
 interface DialogProps {
   isOpen: boolean;
@@ -44,7 +44,7 @@ export const UserSettingsDialog: React.FC<DialogProps> = ({isOpen, onClose, visi
 
 interface DialogContentProps {
   onClose: OnCloseFn;
-  visibleFlags: {key: string; flagType: FeatureFlagType}[];
+  visibleFlags: {key: string; label?: React.ReactNode; flagType: FeatureFlagType}[];
 }
 
 /**
@@ -139,8 +139,9 @@ const UserSettingsDialogContent: React.FC<DialogContentProps> = ({onClose, visib
             <Subheading>Experimental features</Subheading>
           </Box>
           <MetadataTable
-            rows={visibleFlags.map(({key, flagType}) => ({
+            rows={visibleFlags.map(({key, label, flagType}) => ({
               key,
+              label,
               value: (
                 <Checkbox
                   format="switch"

--- a/js_modules/dagster-ui/packages/ui-core/src/app/getVisibleFeatureFlagRows.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/getVisibleFeatureFlagRows.tsx
@@ -1,3 +1,6 @@
+import {Box} from '@dagster-io/ui-components';
+import React from 'react';
+
 import {FeatureFlag} from './Flags';
 
 /**
@@ -33,7 +36,21 @@ export const getVisibleFeatureFlagRows = () => [
     flagType: FeatureFlag.flagHorizontalDAGs,
   },
   {
-    key: 'Experimental DAG sidebar',
+    key: 'New asset lineage sidebar',
+    label: (
+      <Box flex={{direction: 'column'}}>
+        New asset lineage sidebar,
+        <div>
+          <a
+            href="https://github.com/dagster-io/dagster/discussions/16657"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Learn more
+          </a>
+        </div>
+      </Box>
+    ),
     flagType: FeatureFlag.flagDAGSidebar,
   },
 ];

--- a/js_modules/dagster-ui/packages/ui-core/src/app/getVisibleFeatureFlagRows.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/getVisibleFeatureFlagRows.tsx
@@ -32,4 +32,8 @@ export const getVisibleFeatureFlagRows = () => [
     key: 'Experimental horizontal asset DAGs',
     flagType: FeatureFlag.flagHorizontalDAGs,
   },
+  {
+    key: 'Experimental DAG sidebar',
+    flagType: FeatureFlag.flagDAGSidebar,
+  },
 ];

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -290,7 +290,7 @@ const AssetGraphExplorerWithData: React.FC<WithDataProps> = ({
         <AssetGraphExplorerSidebar
           assetGraphData={assetGraphData}
           lastSelectedNode={lastSelectedNode}
-          selectNode={selectNode}
+          selectNode={selectNodeById}
         />
       }
       second={

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -271,13 +271,19 @@ const AssetGraphExplorerWithData: React.FC<WithDataProps> = ({
       return;
     }
     const node = assetGraphData.nodes[nodeId];
-    if (node && viewportEl.current) {
+    if (node) {
       onSelectNode(e, node.assetKey, node);
-      if (layout) {
+      if (layout && viewportEl.current) {
         viewportEl.current.zoomToSVGBox(layout.nodes[nodeId]!.bounds, true);
       }
     }
   };
+  React.useEffect(() => {
+    if (layout && lastSelectedNode) {
+      selectNodeById({stopPropagation: () => {}} as any, lastSelectedNode.id);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [!!layout]);
 
   const allowGroupsOnlyZoomLevel = !!(layout && Object.keys(layout.groups).length);
 

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -220,13 +220,13 @@ const AssetGraphExplorerWithData: React.FC<WithDataProps> = ({
       );
     },
     [
-      assetGraphData,
       explorerPath,
-      findAssetLocation,
-      layout?.nodes,
       onChangeExplorerPath,
       onNavigateToSourceAssetNode,
+      findAssetLocation,
       selectedGraphNodes,
+      assetGraphData,
+      layout,
     ],
   );
 
@@ -241,7 +241,10 @@ const AssetGraphExplorerWithData: React.FC<WithDataProps> = ({
     // focus on the selected node. (If selection was specified in the URL).
     // Don't animate this change.
     if (lastSelectedNode) {
-      // viewportEl.current.zoomToSVGBox(layout.nodes[lastSelectedNode.id].bounds, false);
+      const layoutNode = layout.nodes[lastSelectedNode.id];
+      if (layoutNode) {
+        viewportEl.current.zoomToSVGBox(layoutNode.bounds, false);
+      }
       viewportEl.current.focus();
     } else {
       viewportEl.current.autocenter(false);
@@ -281,13 +284,6 @@ const AssetGraphExplorerWithData: React.FC<WithDataProps> = ({
     },
     [assetGraphData.nodes, layout, onSelectNode],
   );
-
-  React.useEffect(() => {
-    if (layout && lastSelectedNode) {
-      selectNodeById({stopPropagation: () => {}} as any, lastSelectedNode.id);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [!!layout]);
 
   const allowGroupsOnlyZoomLevel = !!(layout && Object.keys(layout.groups).length);
 

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -263,14 +263,13 @@ const AssetGraphExplorerWithData: React.FC<WithDataProps> = ({
     const layoutWithoutExternalLinks = {...layout, nodes: pickBy(layout.nodes, hasDefinition)};
 
     const nextId = closestNodeInDirection(layoutWithoutExternalLinks, lastSelectedNode.id, dir);
-    const node = nextId && assetGraphData.nodes[nextId];
-    if (node && viewportEl.current) {
-      onSelectNode(e, node.assetKey, node);
-      viewportEl.current.zoomToSVGBox(layout.nodes[nextId]!.bounds, true);
-    }
+    selectNodeById(e, nextId);
   };
 
-  const selectNode = (e: React.MouseEvent<any>, nodeId: string) => {
+  const selectNodeById = (e: React.MouseEvent<any> | React.KeyboardEvent<any>, nodeId?: string) => {
+    if (!nodeId) {
+      return;
+    }
     const node = assetGraphData.nodes[nodeId];
     if (node && viewportEl.current) {
       onSelectNode(e, node.assetKey, node);

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -220,13 +220,13 @@ const AssetGraphExplorerWithData: React.FC<WithDataProps> = ({
       );
     },
     [
+      assetGraphData,
       explorerPath,
+      findAssetLocation,
+      layout?.nodes,
       onChangeExplorerPath,
       onNavigateToSourceAssetNode,
-      findAssetLocation,
       selectedGraphNodes,
-      assetGraphData,
-      layout,
     ],
   );
 
@@ -266,18 +266,22 @@ const AssetGraphExplorerWithData: React.FC<WithDataProps> = ({
     selectNodeById(e, nextId);
   };
 
-  const selectNodeById = (e: React.MouseEvent<any> | React.KeyboardEvent<any>, nodeId?: string) => {
-    if (!nodeId) {
-      return;
-    }
-    const node = assetGraphData.nodes[nodeId];
-    if (node) {
-      onSelectNode(e, node.assetKey, node);
-      if (layout && viewportEl.current) {
-        viewportEl.current.zoomToSVGBox(layout.nodes[nodeId]!.bounds, true);
+  const selectNodeById = React.useCallback(
+    (e: React.MouseEvent<any> | React.KeyboardEvent<any>, nodeId?: string) => {
+      if (!nodeId) {
+        return;
       }
-    }
-  };
+      const node = assetGraphData.nodes[nodeId];
+      if (node) {
+        onSelectNode(e, node.assetKey, node);
+        if (layout && viewportEl.current) {
+          viewportEl.current.zoomToSVGBox(layout.nodes[nodeId]!.bounds, true);
+        }
+      }
+    },
+    [assetGraphData.nodes, layout, onSelectNode],
+  );
+
   React.useEffect(() => {
     if (layout && lastSelectedNode) {
       selectNodeById({stopPropagation: () => {}} as any, lastSelectedNode.id);
@@ -296,7 +300,12 @@ const AssetGraphExplorerWithData: React.FC<WithDataProps> = ({
         <AssetGraphExplorerSidebar
           assetGraphData={assetGraphData}
           lastSelectedNode={lastSelectedNode}
-          selectNode={selectNodeById}
+          selectNode={React.useCallback(
+            (e, nodeId) => {
+              selectNodeById(e, nodeId);
+            },
+            [selectNodeById],
+          )}
         />
       }
       second={

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -296,12 +296,7 @@ const AssetGraphExplorerWithData: React.FC<WithDataProps> = ({
         <AssetGraphExplorerSidebar
           assetGraphData={assetGraphData}
           lastSelectedNode={lastSelectedNode}
-          selectNode={React.useCallback(
-            (e, nodeId) => {
-              selectNodeById(e, nodeId);
-            },
-            [selectNodeById],
-          )}
+          selectNode={selectNodeById}
         />
       }
       second={

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -162,7 +162,6 @@ const AssetGraphExplorerWithData: React.FC<WithDataProps> = ({
       assetKey: {path: string[]},
       node: GraphNode | null,
     ) => {
-      // todo (Toggle sidebar)
       e.stopPropagation();
 
       const token = tokenForAssetKey(assetKey);

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -5,6 +5,9 @@ import {
   NonIdealState,
   SplitPanelContainer,
   ErrorBoundary,
+  Button,
+  Icon,
+  Tooltip,
 } from '@dagster-io/ui-components';
 import pickBy from 'lodash/pickBy';
 import uniq from 'lodash/uniq';
@@ -17,7 +20,7 @@ import {QueryRefreshCountdown, QueryRefreshState} from '../app/QueryRefresh';
 import {LaunchAssetExecutionButton} from '../assets/LaunchAssetExecutionButton';
 import {LaunchAssetObservationButton} from '../assets/LaunchAssetObservationButton';
 import {AssetKey} from '../assets/types';
-import {SVGViewport} from '../graph/SVGViewport';
+import {DEFAULT_MAX_ZOOM, SVGViewport} from '../graph/SVGViewport';
 import {useAssetLayout} from '../graph/asyncGraphLayout';
 import {closestNodeInDirection} from '../graph/common';
 import {
@@ -137,11 +140,12 @@ const AssetGraphExplorerWithData: React.FC<WithDataProps> = ({
   applyingEmptyDefault,
   fetchOptions,
   fetchOptionFilters,
+  allAssetKeys,
 }) => {
   const findAssetLocation = useFindAssetLocation();
   const {layout, loading, async} = useAssetLayout(assetGraphData);
   const viewportEl = React.useRef<SVGViewport>();
-  const {flagHorizontalDAGs} = useFeatureFlags();
+  const {flagHorizontalDAGs, flagDAGSidebar} = useFeatureFlags();
 
   const [highlighted, setHighlighted] = React.useState<string | null>(null);
 
@@ -287,227 +291,239 @@ const AssetGraphExplorerWithData: React.FC<WithDataProps> = ({
 
   const allowGroupsOnlyZoomLevel = !!(layout && Object.keys(layout.groups).length);
 
-  return (
+  const [showSidebar, setShowSidebar] = React.useState(true);
+
+  const explorer = (
     <SplitPanelContainer
-      identifier="explorer-wrapper"
-      firstMinSize={300}
-      firstInitialPercent={0}
+      key="explorer"
+      identifier="explorer"
+      firstInitialPercent={70}
+      firstMinSize={400}
       first={
-        <AssetGraphExplorerSidebar
-          assetGraphData={assetGraphData}
-          lastSelectedNode={lastSelectedNode}
-          selectNode={selectNodeById}
-        />
+        <ErrorBoundary region="graph">
+          {graphQueryItems.length === 0 ? (
+            <EmptyDAGNotice nodeType="asset" isGraph />
+          ) : applyingEmptyDefault ? (
+            <LargeDAGNotice nodeType="asset" anchorLeft="40px" />
+          ) : Object.keys(assetGraphData.nodes).length === 0 ? (
+            <EntirelyFilteredDAGNotice nodeType="asset" />
+          ) : undefined}
+          {loading || !layout ? (
+            <LoadingNotice async={async} nodeType="asset" />
+          ) : (
+            <SVGViewport
+              ref={(r) => (viewportEl.current = r || undefined)}
+              defaultZoom={flagHorizontalDAGs ? 'zoom-to-fit-width' : 'zoom-to-fit'}
+              interactor={SVGViewport.Interactors.PanAndZoom}
+              graphWidth={layout.width}
+              graphHeight={layout.height}
+              graphHasNoMinimumZoom={allowGroupsOnlyZoomLevel}
+              onClick={onClickBackground}
+              onArrowKeyDown={onArrowKeyDown}
+              onDoubleClick={(e) => {
+                viewportEl.current?.autocenter(true);
+                e.stopPropagation();
+              }}
+              maxZoom={DEFAULT_MAX_ZOOM}
+              maxAutocenterZoom={1.0}
+            >
+              {({scale}) => (
+                <SVGContainer width={layout.width} height={layout.height}>
+                  <AssetEdges
+                    highlighted={highlighted}
+                    edges={layout.edges}
+                    strokeWidth={allowGroupsOnlyZoomLevel ? Math.max(4, 3 / scale) : 4}
+                    baseColor={
+                      allowGroupsOnlyZoomLevel && scale < GROUPS_ONLY_SCALE
+                        ? Colors.Gray400
+                        : Colors.KeylineGray
+                    }
+                  />
+
+                  {Object.values(layout.groups)
+                    .sort((a, b) => a.id.length - b.id.length)
+                    .map((group) => (
+                      <foreignObject
+                        key={group.id}
+                        {...group.bounds}
+                        onDoubleClick={(e) => {
+                          if (!viewportEl.current) {
+                            return;
+                          }
+                          const targetScale = viewportEl.current.scaleForSVGBounds(
+                            group.bounds.width,
+                            group.bounds.height,
+                          );
+                          viewportEl.current.zoomToSVGBox(group.bounds, true, targetScale * 0.9);
+                          e.stopPropagation();
+                        }}
+                      >
+                        <AssetGroupNode group={group} scale={scale} />
+                      </foreignObject>
+                    ))}
+
+                  {Object.values(layout.nodes).map(({id, bounds}) => {
+                    const graphNode = assetGraphData.nodes[id]!;
+                    const path = JSON.parse(id);
+                    if (allowGroupsOnlyZoomLevel && scale < GROUPS_ONLY_SCALE) {
+                      return;
+                    }
+                    return (
+                      <foreignObject
+                        {...bounds}
+                        key={id}
+                        onMouseEnter={() => setHighlighted(id)}
+                        onMouseLeave={() => setHighlighted(null)}
+                        onClick={(e) => onSelectNode(e, {path}, graphNode)}
+                        onDoubleClick={(e) => {
+                          viewportEl.current?.zoomToSVGBox(bounds, true, 1.2);
+                          e.stopPropagation();
+                        }}
+                        style={{overflow: 'visible'}}
+                      >
+                        {!graphNode ? (
+                          <AssetNodeLink assetKey={{path}} />
+                        ) : scale < MINIMAL_SCALE ? (
+                          <AssetNodeMinimal
+                            definition={graphNode.definition}
+                            liveData={liveDataByNode[graphNode.id]}
+                            selected={selectedGraphNodes.includes(graphNode)}
+                          />
+                        ) : (
+                          <AssetNode
+                            definition={graphNode.definition}
+                            liveData={liveDataByNode[graphNode.id]}
+                            selected={selectedGraphNodes.includes(graphNode)}
+                          />
+                        )}
+                      </foreignObject>
+                    );
+                  })}
+                </SVGContainer>
+              )}
+            </SVGViewport>
+          )}
+          {setOptions && (
+            <OptionsOverlay>
+              <Checkbox
+                format="switch"
+                label="View as Asset Graph"
+                checked={options.preferAssetRendering}
+                onChange={() => {
+                  onChangeExplorerPath(
+                    {...explorerPath, opNames: selectedDefinitions[0]?.opNames || []},
+                    'replace',
+                  );
+                  setOptions({
+                    ...options,
+                    preferAssetRendering: !options.preferAssetRendering,
+                  });
+                }}
+              />
+            </OptionsOverlay>
+          )}
+
+          <Box style={{position: 'absolute', right: 12, top: 8}}>
+            <Box flex={{alignItems: 'center', gap: 12}}>
+              <QueryRefreshCountdown
+                refreshState={liveDataRefreshState}
+                dataDescription="materializations"
+              />
+              <LaunchAssetObservationButton
+                preferredJobName={explorerPath.pipelineName}
+                scope={
+                  selectedDefinitions.length
+                    ? {selected: selectedDefinitions.filter((a) => a.isObservable)}
+                    : {all: allDefinitionsForMaterialize.filter((a) => a.isObservable)}
+                }
+              />
+              <LaunchAssetExecutionButton
+                preferredJobName={explorerPath.pipelineName}
+                liveDataForStale={liveDataByNode}
+                scope={
+                  selectedDefinitions.length
+                    ? {selected: selectedDefinitions}
+                    : {all: allDefinitionsForMaterialize}
+                }
+              />
+            </Box>
+          </Box>
+          <QueryOverlay>
+            {showSidebar || !flagDAGSidebar ? null : (
+              <Tooltip content="Show sidebar">
+                <Button
+                  icon={<Icon name="panel_show_left" />}
+                  onClick={() => {
+                    setShowSidebar(true);
+                  }}
+                />
+              </Tooltip>
+            )}
+            {fetchOptionFilters}
+
+            <GraphQueryInput
+              width={fetchOptionFilters ? '16vw' : undefined}
+              items={graphQueryItems}
+              value={explorerPath.opsQuery}
+              placeholder="Type an asset subset…"
+              onChange={(opsQuery) => onChangeExplorerPath({...explorerPath, opsQuery}, 'replace')}
+              popoverPosition="bottom-left"
+            />
+          </QueryOverlay>
+        </ErrorBoundary>
       }
       second={
-        <SplitPanelContainer
-          identifier="explorer"
-          firstInitialPercent={70}
-          firstMinSize={400}
-          first={
-            <ErrorBoundary region="graph">
-              {graphQueryItems.length === 0 ? (
-                <EmptyDAGNotice nodeType="asset" isGraph />
-              ) : applyingEmptyDefault ? (
-                <LargeDAGNotice
-                  nodeType="asset"
-                  anchorLeft={fetchOptionFilters ? '300px' : '40px'}
+        selectedGraphNodes.length === 1 && selectedGraphNodes[0] ? (
+          <RightInfoPanel>
+            <RightInfoPanelContent>
+              <ErrorBoundary region="asset sidebar" resetErrorOnChange={[selectedGraphNodes[0].id]}>
+                <SidebarAssetInfo
+                  graphNode={selectedGraphNodes[0]}
+                  liveData={liveDataByNode[selectedGraphNodes[0].id]}
                 />
-              ) : Object.keys(assetGraphData.nodes).length === 0 ? (
-                <EntirelyFilteredDAGNotice nodeType="asset" />
-              ) : undefined}
-              {loading || !layout ? (
-                <LoadingNotice async={async} nodeType="asset" />
-              ) : (
-                <SVGViewport
-                  ref={(r) => (viewportEl.current = r || undefined)}
-                  defaultZoom={flagHorizontalDAGs ? 'zoom-to-fit-width' : 'zoom-to-fit'}
-                  interactor={SVGViewport.Interactors.PanAndZoom}
-                  graphWidth={layout.width}
-                  graphHeight={layout.height}
-                  graphHasNoMinimumZoom={allowGroupsOnlyZoomLevel}
-                  onClick={onClickBackground}
-                  onArrowKeyDown={onArrowKeyDown}
-                  onDoubleClick={(e) => {
-                    viewportEl.current?.autocenter(true);
-                    e.stopPropagation();
-                  }}
-                  maxZoom={1.2}
-                  maxAutocenterZoom={1.0}
-                >
-                  {({scale}) => (
-                    <SVGContainer width={layout.width} height={layout.height}>
-                      <AssetEdges
-                        highlighted={highlighted}
-                        edges={layout.edges}
-                        strokeWidth={allowGroupsOnlyZoomLevel ? Math.max(4, 3 / scale) : 4}
-                        baseColor={
-                          allowGroupsOnlyZoomLevel && scale < GROUPS_ONLY_SCALE
-                            ? Colors.Gray400
-                            : Colors.KeylineGray
-                        }
-                      />
-
-                      {Object.values(layout.groups)
-                        .sort((a, b) => a.id.length - b.id.length)
-                        .map((group) => (
-                          <foreignObject
-                            key={group.id}
-                            {...group.bounds}
-                            onDoubleClick={(e) => {
-                              if (!viewportEl.current) {
-                                return;
-                              }
-                              const targetScale = viewportEl.current.scaleForSVGBounds(
-                                group.bounds.width,
-                                group.bounds.height,
-                              );
-                              viewportEl.current.zoomToSVGBox(
-                                group.bounds,
-                                true,
-                                targetScale * 0.9,
-                              );
-                              e.stopPropagation();
-                            }}
-                          >
-                            <AssetGroupNode group={group} scale={scale} />
-                          </foreignObject>
-                        ))}
-
-                      {Object.values(layout.nodes).map(({id, bounds}) => {
-                        const graphNode = assetGraphData.nodes[id]!;
-                        const path = JSON.parse(id);
-                        if (allowGroupsOnlyZoomLevel && scale < GROUPS_ONLY_SCALE) {
-                          return;
-                        }
-                        return (
-                          <foreignObject
-                            {...bounds}
-                            key={id}
-                            onMouseEnter={() => setHighlighted(id)}
-                            onMouseLeave={() => setHighlighted(null)}
-                            onClick={(e) => onSelectNode(e, {path}, graphNode)}
-                            onDoubleClick={(e) => {
-                              viewportEl.current?.zoomToSVGBox(bounds, true, 1.2);
-                              e.stopPropagation();
-                            }}
-                            style={{overflow: 'visible'}}
-                          >
-                            {!graphNode ? (
-                              <AssetNodeLink assetKey={{path}} />
-                            ) : scale < MINIMAL_SCALE ? (
-                              <AssetNodeMinimal
-                                definition={graphNode.definition}
-                                liveData={liveDataByNode[graphNode.id]}
-                                selected={selectedGraphNodes.includes(graphNode)}
-                              />
-                            ) : (
-                              <AssetNode
-                                definition={graphNode.definition}
-                                liveData={liveDataByNode[graphNode.id]}
-                                selected={selectedGraphNodes.includes(graphNode)}
-                              />
-                            )}
-                          </foreignObject>
-                        );
-                      })}
-                    </SVGContainer>
-                  )}
-                </SVGViewport>
-              )}
-              {setOptions && (
-                <OptionsOverlay>
-                  <Checkbox
-                    format="switch"
-                    label="View as Asset Graph"
-                    checked={options.preferAssetRendering}
-                    onChange={() => {
-                      onChangeExplorerPath(
-                        {...explorerPath, opNames: selectedDefinitions[0]?.opNames || []},
-                        'replace',
-                      );
-                      setOptions({
-                        ...options,
-                        preferAssetRendering: !options.preferAssetRendering,
-                      });
-                    }}
-                  />
-                </OptionsOverlay>
-              )}
-
-              <Box
-                flex={{direction: 'column', alignItems: 'flex-end', gap: 8}}
-                style={{position: 'absolute', right: 12, top: 8}}
-              >
-                <Box flex={{alignItems: 'center', gap: 12}}>
-                  <QueryRefreshCountdown
-                    refreshState={liveDataRefreshState}
-                    dataDescription="materializations"
-                  />
-                  <LaunchAssetObservationButton
-                    preferredJobName={explorerPath.pipelineName}
-                    scope={
-                      selectedDefinitions.length
-                        ? {selected: selectedDefinitions.filter((a) => a.isObservable)}
-                        : {all: allDefinitionsForMaterialize.filter((a) => a.isObservable)}
-                    }
-                  />
-                  <LaunchAssetExecutionButton
-                    preferredJobName={explorerPath.pipelineName}
-                    liveDataForStale={liveDataByNode}
-                    scope={
-                      selectedDefinitions.length
-                        ? {selected: selectedDefinitions}
-                        : {all: allDefinitionsForMaterialize}
-                    }
-                  />
-                </Box>
-              </Box>
-              <QueryOverlay>
-                {fetchOptionFilters}
-
-                <GraphQueryInput
-                  width={fetchOptionFilters ? '16vw' : undefined}
-                  items={graphQueryItems}
-                  value={explorerPath.opsQuery}
-                  placeholder="Type an asset subset…"
-                  onChange={(opsQuery) =>
-                    onChangeExplorerPath({...explorerPath, opsQuery}, 'replace')
-                  }
-                  popoverPosition="bottom-left"
-                />
-              </QueryOverlay>
-            </ErrorBoundary>
-          }
-          second={
-            selectedGraphNodes.length === 1 && selectedGraphNodes[0] ? (
-              <RightInfoPanel>
-                <RightInfoPanelContent>
-                  <ErrorBoundary
-                    region="asset sidebar"
-                    resetErrorOnChange={[selectedGraphNodes[0].id]}
-                  >
-                    <SidebarAssetInfo
-                      graphNode={selectedGraphNodes[0]}
-                      liveData={liveDataByNode[selectedGraphNodes[0].id]}
-                    />
-                  </ErrorBoundary>
-                </RightInfoPanelContent>
-              </RightInfoPanel>
-            ) : fetchOptions.pipelineSelector ? (
-              <RightInfoPanel>
-                <RightInfoPanelContent>
-                  <ErrorBoundary region="asset job sidebar">
-                    <AssetGraphJobSidebar pipelineSelector={fetchOptions.pipelineSelector} />
-                  </ErrorBoundary>
-                </RightInfoPanelContent>
-              </RightInfoPanel>
-            ) : null
-          }
-        />
+              </ErrorBoundary>
+            </RightInfoPanelContent>
+          </RightInfoPanel>
+        ) : fetchOptions.pipelineSelector ? (
+          <RightInfoPanel>
+            <RightInfoPanelContent>
+              <ErrorBoundary region="asset job sidebar">
+                <AssetGraphJobSidebar pipelineSelector={fetchOptions.pipelineSelector} />
+              </ErrorBoundary>
+            </RightInfoPanelContent>
+          </RightInfoPanel>
+        ) : null
       }
     />
   );
+
+  if (showSidebar && flagDAGSidebar) {
+    return (
+      <SplitPanelContainer
+        key="explorer-wrapper"
+        identifier="explorer-wrapper"
+        firstMinSize={300}
+        firstInitialPercent={0}
+        first={
+          showSidebar ? (
+            <AssetGraphExplorerSidebar
+              allAssetKeys={allAssetKeys}
+              assetGraphData={assetGraphData}
+              lastSelectedNode={lastSelectedNode}
+              selectNode={selectNodeById}
+              explorerPath={explorerPath}
+              onChangeExplorerPath={onChangeExplorerPath}
+              hideSidebar={() => {
+                setShowSidebar(false);
+              }}
+            />
+          ) : null
+        }
+        second={explorer}
+      />
+    );
+  }
+  return explorer;
 };
 
 const SVGContainer = styled.svg`

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorerFilters.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorerFilters.tsx
@@ -1,0 +1,114 @@
+import {Box, Icon} from '@dagster-io/ui-components';
+import React from 'react';
+
+import {AssetGroupSelector} from '../graphql/types';
+import {TruncatedTextWithFullTextOnHover} from '../nav/getLeftNavItemsForOption';
+import {useFilters} from '../ui/Filters';
+import {FilterObject} from '../ui/Filters/useFilter';
+import {useStaticSetFilter} from '../ui/Filters/useStaticSetFilter';
+import {DagsterRepoOption, WorkspaceContext} from '../workspace/WorkspaceContext';
+import {buildRepoAddress, buildRepoPathForHuman} from '../workspace/buildRepoAddress';
+
+export const AssetGraphExplorerFilters = React.memo(
+  ({
+    assetGroups,
+    visibleAssetGroups,
+    setGroupFilters,
+  }:
+    | {
+        assetGroups: AssetGroupSelector[];
+        visibleAssetGroups: AssetGroupSelector[];
+        setGroupFilters: (groups: AssetGroupSelector[]) => void;
+      }
+    | {assetGroups?: null; setGroupFilters?: null; visibleAssetGroups?: null}) => {
+    const {allRepos, visibleRepos, toggleVisible} = React.useContext(WorkspaceContext);
+
+    const visibleReposSet = React.useMemo(() => new Set(visibleRepos), [visibleRepos]);
+
+    const reposFilter = useStaticSetFilter<DagsterRepoOption>({
+      name: 'Repository',
+      icon: 'repo',
+      allValues: allRepos.map((repo) => ({
+        key: repo.repository.id,
+        value: repo,
+        match: [buildRepoPathForHuman(repo.repository.name, repo.repositoryLocation.name)],
+      })),
+      menuWidth: '300px',
+      renderLabel: ({value}) => (
+        <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
+          <Icon name="repo" />
+          <TruncatedTextWithFullTextOnHover
+            text={buildRepoPathForHuman(value.repository.name, value.repositoryLocation.name)}
+          />
+        </Box>
+      ),
+      getStringValue: (value) =>
+        buildRepoPathForHuman(value.repository.name, value.repositoryLocation.name),
+      initialState: visibleReposSet,
+      onStateChanged: (values) => {
+        allRepos.forEach((repo) => {
+          if (visibleReposSet.has(repo) !== values.has(repo)) {
+            toggleVisible([buildRepoAddress(repo.repository.name, repo.repositoryLocation.name)]);
+          }
+        });
+      },
+    });
+
+    const groupsFilter = useStaticSetFilter<AssetGroupSelector>({
+      name: 'Asset Groups',
+      icon: 'asset_group',
+      allValues: (assetGroups || []).map((group) => ({
+        key: group.groupName,
+        value:
+          visibleAssetGroups?.find(
+            (visibleGroup) =>
+              visibleGroup.groupName === group.groupName &&
+              visibleGroup.repositoryName === group.repositoryName &&
+              visibleGroup.repositoryLocationName === group.repositoryLocationName,
+          ) ?? group,
+        match: [group.groupName],
+      })),
+      menuWidth: '300px',
+      renderLabel: ({value}) => (
+        <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
+          <Icon name="repo" />
+          <TruncatedTextWithFullTextOnHover
+            tooltipText={
+              value.groupName +
+              ' - ' +
+              buildRepoPathForHuman(value.repositoryName, value.repositoryLocationName)
+            }
+            text={
+              <>
+                {value.groupName}
+                <span style={{opacity: 0.5, paddingLeft: '4px'}}>
+                  {buildRepoPathForHuman(value.repositoryName, value.repositoryLocationName)}
+                </span>
+              </>
+            }
+          />
+        </Box>
+      ),
+      getStringValue: (group) => group.groupName,
+      initialState: React.useMemo(() => new Set(visibleAssetGroups ?? []), [visibleAssetGroups]),
+      onStateChanged: (values) => {
+        if (setGroupFilters) {
+          setGroupFilters(Array.from(values));
+        }
+      },
+    });
+
+    const filters: FilterObject[] = [];
+    if (allRepos.length > 1) {
+      filters.push(reposFilter);
+    }
+    if (assetGroups) {
+      filters.push(groupsFilter);
+    }
+    const {button} = useFilters({filters});
+    if (allRepos.length <= 1 && !assetGroups) {
+      return null;
+    }
+    return button;
+  },
+);

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorerSidebar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorerSidebar.tsx
@@ -258,7 +258,6 @@ export const AssetGraphExplorerSidebar = React.memo(
       assetGraphData,
       viewType,
       // eslint-disable-next-line react-hooks/exhaustive-deps
-
       lastSelectedNode &&
         renderedNodes.findIndex((node) => nodeId(lastSelectedNode) === nodeId(node)),
     ]);

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorerSidebar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorerSidebar.tsx
@@ -132,7 +132,6 @@ export const AssetGraphExplorerSidebar = ({
 
   React.useLayoutEffect(() => {
     rowVirtualizer.measure();
-    console.log('measuring');
   }, [viewport.width, viewport.height, rowVirtualizer]);
 
   return (

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorerSidebar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorerSidebar.tsx
@@ -237,9 +237,11 @@ const Node = ({
     : Object.keys(assetGraphData.downstream[node.id] ?? {});
   const elementRef = React.useRef<HTMLDivElement | null>(null);
   React.useLayoutEffect(() => {
-    if (elementRef.current) {
-      measureElement(elementRef.current);
-    }
+    setTimeout(() => {
+      if (elementRef.current) {
+        measureElement(elementRef.current);
+      }
+    }, 100);
   }, [measureElement, isOpen]);
 
   const [showDownstream, setShowDownstream] = React.useState(false);

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorerSidebar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorerSidebar.tsx
@@ -1,0 +1,260 @@
+import {Box, ButtonLink, Colors, Icon, useViewport} from '@dagster-io/ui-components';
+import {useVirtualizer} from '@tanstack/react-virtual';
+import React from 'react';
+
+import {withMiddleTruncation} from '../app/Util';
+import {Container, Inner, Row} from '../ui/VirtualizedTable';
+
+import {NameTooltipStyle} from './AssetNode';
+import {GraphData, GraphNode} from './Utils';
+
+const COLLATOR = new Intl.Collator(navigator.language, {sensitivity: 'base', numeric: true});
+
+type GroupNode = {
+  nodes: string[];
+  groupName: string | null;
+  repositoryLocationName: string;
+  repositoryName: string;
+  id: string;
+};
+
+export const AssetGraphExplorerSidebar = ({
+  assetGraphData,
+  lastSelectedNode,
+  selectNode,
+}: {
+  assetGraphData: GraphData;
+  lastSelectedNode: GraphNode;
+  selectNode: (e: React.MouseEvent<any>, nodeId: string) => void;
+}) => {
+  const [openNodes, setOpenNodes] = React.useState<Set<string>>(() => new Set());
+  const {rootGroupsWithRootNodes, nodeToGroupId} = React.useMemo(() => {
+    const nodeToGroupId: Record<string, string> = {};
+    const groups: Record<string, GroupNode> = {};
+    Object.entries(assetGraphData.nodes).forEach(([_, node]) => {
+      const groupName = node.definition.groupName;
+      const repositoryLocationName = node.definition.repository.location.name;
+      const repositoryName = node.definition.repository.name;
+      const groupId = `${groupName}@${repositoryName}@${repositoryLocationName}`;
+      groups[groupId] = groups[groupId] || {
+        nodes: [],
+        groupName,
+        repositoryLocationName,
+        repositoryName,
+        id: groupId,
+      };
+      groups[groupId]!.nodes.push(node.id);
+      nodeToGroupId[node.id] = groupId;
+    });
+    Object.entries(groups).forEach(([_, group]) => {
+      group.nodes = group.nodes
+        .filter((nodeId) => !assetGraphData.upstream[nodeId])
+        .sort((nodeA, nodeB) => COLLATOR.compare(nodeA, nodeB));
+    });
+    return {rootGroupsWithRootNodes: groups, nodeToGroupId};
+  }, [assetGraphData]);
+
+  const renderedNodes = React.useMemo(() => {
+    const queue = Object.entries(rootGroupsWithRootNodes).map(([_, {id}]) => ({level: 1, id}));
+
+    const renderedNodes: {level: number; id: string}[] = [];
+    while (queue.length) {
+      const node = queue.shift()!;
+      renderedNodes.push(node);
+      if (openNodes.has(node.id)) {
+        const groupNode = rootGroupsWithRootNodes[node.id];
+        if (groupNode) {
+          const downstream = groupNode.nodes;
+          if (downstream.length) {
+            queue.unshift(...downstream.map((id) => ({level: 2, id})));
+          }
+        } else {
+          const downstream = assetGraphData.downstream[node.id];
+          if (downstream) {
+            queue.unshift(...Object.keys(downstream).map((id) => ({level: node.level + 1, id})));
+          }
+        }
+      }
+    }
+    return renderedNodes;
+  }, [assetGraphData.downstream, openNodes, rootGroupsWithRootNodes]);
+
+  const containerRef = React.useRef<HTMLDivElement | null>(null);
+
+  const rowVirtualizer = useVirtualizer({
+    count: renderedNodes.length,
+    getScrollElement: () => containerRef.current,
+    estimateSize: () => 32,
+    overscan: 5,
+  });
+
+  const totalHeight = rowVirtualizer.getTotalSize();
+  const items = rowVirtualizer.getVirtualItems();
+
+  React.useLayoutEffect(() => {
+    requestAnimationFrame(() => {
+      rowVirtualizer.measure();
+    });
+  }, [rowVirtualizer]);
+
+  const indexOfLastSelectedNode = React.useMemo(
+    () =>
+      lastSelectedNode ? renderedNodes.findIndex((node) => node.id === lastSelectedNode.id) : -1,
+    [renderedNodes, lastSelectedNode],
+  );
+
+  React.useLayoutEffect(() => {
+    if (indexOfLastSelectedNode !== -1) {
+      rowVirtualizer.scrollToIndex(indexOfLastSelectedNode);
+    }
+  }, [indexOfLastSelectedNode, rowVirtualizer]);
+
+  React.useEffect(() => {
+    if (lastSelectedNode) {
+      setOpenNodes((nodes) => {
+        const nextOpenNodes = new Set(nodes);
+        nextOpenNodes.add(lastSelectedNode.id);
+        const upstreamQueue = Object.keys(assetGraphData.upstream[lastSelectedNode.id] ?? {});
+        while (upstreamQueue.length) {
+          const next = upstreamQueue.pop()!;
+          const nextUpstream = Object.keys(assetGraphData.upstream[next] ?? {});
+          upstreamQueue.push(...nextUpstream);
+          nextOpenNodes.add(next);
+        }
+        nextOpenNodes.add(nodeToGroupId[lastSelectedNode.id]!);
+        return nextOpenNodes;
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [lastSelectedNode, nodeToGroupId]);
+
+  const {containerProps, viewport} = useViewport();
+
+  React.useLayoutEffect(() => {
+    rowVirtualizer.measure();
+    console.log('measuring');
+  }, [viewport.width, viewport.height, rowVirtualizer]);
+
+  return (
+    <Container
+      {...containerProps}
+      ref={(el) => {
+        if (el) {
+          containerProps.ref(el);
+          containerRef.current = el;
+        }
+      }}
+    >
+      <Inner $totalHeight={totalHeight}>
+        {items.map(({index, key, size, start, measureElement}) => {
+          const node = renderedNodes[index]!;
+          return (
+            <Row
+              $height={size}
+              $start={start}
+              key={key}
+              style={{overflow: 'visible'}}
+              ref={measureElement}
+            >
+              <Node
+                isOpen={openNodes.has(node.id)}
+                assetGraphData={assetGraphData}
+                node={(assetGraphData.nodes[node.id] ?? rootGroupsWithRootNodes[node.id])!}
+                level={node.level}
+                isSelected={lastSelectedNode?.id === node.id}
+                toggleOpen={(e: React.MouseEvent) => {
+                  selectNode(e, node.id);
+                  setOpenNodes((nodes) => {
+                    const openNodes = new Set(nodes);
+                    const isOpen = openNodes.has(node.id);
+                    if (isOpen) {
+                      openNodes.delete(node.id);
+                    } else {
+                      openNodes.add(node.id);
+                    }
+                    return openNodes;
+                  });
+                }}
+                measureElement={measureElement}
+              />
+            </Row>
+          );
+        })}
+      </Inner>
+    </Container>
+  );
+};
+
+const Node = ({
+  assetGraphData,
+  node,
+  level,
+  toggleOpen,
+  isOpen,
+  measureElement,
+  isSelected,
+}: {
+  assetGraphData: GraphData;
+  node: GraphNode | GroupNode;
+  level: number;
+  toggleOpen: (e: React.MouseEvent) => void;
+  isOpen: boolean;
+  measureElement: (el: HTMLDivElement) => void;
+  isSelected: boolean;
+}) => {
+  const isGroupNode = 'groupName' in node;
+
+  const displayName = isGroupNode
+    ? `${node.groupName ?? 'default'} in ${node.repositoryName}@${node.repositoryLocationName}`
+    : node.assetKey.path[node.assetKey.path.length - 1]!;
+
+  const upstream = isGroupNode ? [] : Object.keys(assetGraphData.upstream[node.id] ?? {});
+  const downstream = isGroupNode
+    ? node.nodes
+    : Object.keys(assetGraphData.downstream[node.id] ?? {});
+  const elementRef = React.useRef<HTMLDivElement | null>(null);
+  React.useLayoutEffect(() => {
+    if (elementRef.current) {
+      measureElement(elementRef.current);
+    }
+  }, [measureElement, isOpen]);
+
+  return (
+    <Box
+      ref={elementRef}
+      onClick={toggleOpen}
+      border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+      style={{
+        ...(downstream ? {cursor: 'pointer'} : {}),
+        ...(isSelected ? {background: Colors.LightPurple} : {}),
+      }}
+      padding={{vertical: 8, left: (8 * level + (downstream.length ? 0 : 20)) as any, right: 24}}
+      flex={{direction: 'row', gap: 4, alignItems: 'center'}}
+    >
+      {downstream.length ? (
+        <Icon
+          name="arrow_drop_down"
+          style={{transform: isOpen ? 'rotate(0deg)' : 'rotate(-90deg)'}}
+        />
+      ) : null}
+      <Box
+        flex={{
+          direction: 'row',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: 12,
+          grow: 1,
+        }}
+      >
+        <div
+          data-tooltip={displayName}
+          data-tooltip-style={NameTooltipStyle}
+          style={{overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap'}}
+        >
+          {withMiddleTruncation(displayName, {maxLength: 30})}
+        </div>
+        {upstream.length > 1 ? <ButtonLink>{upstream.length}</ButtonLink> : null}
+      </Box>
+    </Box>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorerSidebar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorerSidebar.tsx
@@ -21,7 +21,6 @@ import {useVirtualizer} from '@tanstack/react-virtual';
 import React from 'react';
 import styled from 'styled-components';
 
-
 import {showSharedToaster} from '../app/DomUtils';
 import {useMaterializationAction} from '../assets/LaunchAssetExecutionButton';
 import {AssetKey} from '../assets/types';
@@ -259,7 +258,7 @@ export const AssetGraphExplorerSidebar = React.memo(
       assetGraphData,
       viewType,
       // eslint-disable-next-line react-hooks/exhaustive-deps
-      
+
       lastSelectedNode &&
         renderedNodes.findIndex((node) => nodeId(lastSelectedNode) === nodeId(node)),
     ]);
@@ -563,27 +562,6 @@ const Node = ({
                             onClick([node.assetKey], e, false);
                           }}
                         />
-                        {upstream.length || downstream.length ? <MenuDivider /> : null}
-                        {upstream.length ? (
-                          <MenuItem
-                            text="Select upstream"
-                            icon="panel_show_left"
-                            onClick={() => {
-                              // TODO: Hook up selecting the nodes
-                              showUpstreamGraph();
-                            }}
-                          />
-                        ) : null}
-                        {downstream.length ? (
-                          <MenuItem
-                            text="Select downstream"
-                            icon="panel_show_right"
-                            onClick={() => {
-                              // TODO: Hook up selecting the nodes
-                              showDownstreamGraph();
-                            }}
-                          />
-                        ) : null}
                         {upstream.length || downstream.length ? <MenuDivider /> : null}
                         {upstream.length ? (
                           <MenuItem

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode.tsx
@@ -334,7 +334,7 @@ const NameTooltipCSS: CSSObject = {
   fontSize: 16.8,
 };
 
-const NameTooltipStyle = JSON.stringify({
+export const NameTooltipStyle = JSON.stringify({
   ...NameTooltipCSS,
   background: Colors.Blue50,
   border: `1px solid ${Colors.Blue100}`,

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/Utils.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/Utils.tsx
@@ -261,3 +261,21 @@ export const itemWithAssetKey = (key: {path: string[]}) => {
   const token = tokenForAssetKey(key);
   return (asset: {assetKey: {path: string[]}}) => tokenForAssetKey(asset.assetKey) === token;
 };
+
+export function walkTreeUpwards(
+  nodeId: string,
+  graphData: GraphData,
+  callback: (nodeId: string) => void,
+) {
+  // TODO
+  console.log({nodeId, graphData, callback});
+}
+
+export function walkTreeDownwards(
+  nodeId: string,
+  graphData: GraphData,
+  callback: (nodeId: string) => void,
+) {
+  // TODO
+  console.log({nodeId, graphData, callback});
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetGroupRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetGroupRoot.tsx
@@ -65,7 +65,7 @@ export const AssetGroupRoot: React.FC<{repoAddress: RepoAddress; tab: 'lineage' 
   const onNavigateToSourceAssetNode = React.useCallback(
     (node: AssetLocation) => {
       if (node.groupName && node.repoAddress) {
-        history.replace(
+        history.push(
           workspacePathFromAddress(
             node.repoAddress,
             `/asset-groups/${node.groupName}/lineage/${node.assetKey.path

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeLineageGraph.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeLineageGraph.tsx
@@ -9,7 +9,7 @@ import {AssetGroupNode} from '../asset-graph/AssetGroupNode';
 import {AssetNodeMinimal, AssetNode} from '../asset-graph/AssetNode';
 import {AssetNodeLink} from '../asset-graph/ForeignNode';
 import {GraphData, LiveData, toGraphId} from '../asset-graph/Utils';
-import {SVGViewport} from '../graph/SVGViewport';
+import {DEFAULT_MAX_ZOOM, SVGViewport} from '../graph/SVGViewport';
 import {useAssetLayout} from '../graph/asyncGraphLayout';
 import {AssetKeyInput} from '../graphql/types';
 import {getJSONForKey} from '../hooks/useStateWithStorage';
@@ -64,8 +64,8 @@ export const AssetNodeLineageGraph: React.FC<{
         viewportEl.current?.autocenter(true);
         e.stopPropagation();
       }}
-      maxZoom={1.2}
-      maxAutocenterZoom={1.2}
+      maxZoom={DEFAULT_MAX_ZOOM}
+      maxAutocenterZoom={DEFAULT_MAX_ZOOM}
     >
       {({scale}) => (
         <SVGContainer width={layout.width} height={layout.height}>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsGroupsGlobalGraphRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsGroupsGlobalGraphRoot.tsx
@@ -4,17 +4,17 @@ import * as React from 'react';
 import {useHistory, useParams} from 'react-router-dom';
 
 import {AssetGraphExplorer} from '../asset-graph/AssetGraphExplorer';
+import {AssetGraphExplorerFilters} from '../asset-graph/AssetGraphExplorerFilters';
 import {AssetGraphFetchScope} from '../asset-graph/useAssetGraphData';
 import {AssetLocation} from '../asset-graph/useFindAssetLocation';
 import {AssetGroupSelector} from '../graphql/types';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
-import {RepoFilterButton} from '../instance/RepoFilterButton';
 import {ExplorerPath} from '../pipelines/PipelinePathUtils';
 import {ReloadAllButton} from '../workspace/ReloadAllButton';
 import {WorkspaceContext} from '../workspace/WorkspaceContext';
 
-import {AssetGroupSuggest, buildAssetGroupSelector} from './AssetGroupSuggest';
+import {buildAssetGroupSelector} from './AssetGroupSuggest';
 import {assetDetailsPathForKey} from './assetDetailsPathForKey';
 import {
   globalAssetGraphPathFromString,
@@ -27,7 +27,7 @@ interface AssetGroupRootParams {
 
 export const AssetsGroupsGlobalGraphRoot: React.FC = () => {
   const {0: path} = useParams<AssetGroupRootParams>();
-  const {allRepos, visibleRepos} = React.useContext(WorkspaceContext);
+  const {visibleRepos} = React.useContext(WorkspaceContext);
   const history = useHistory();
 
   const [filters, setFilters] = useQueryPersistedState<{groups: AssetGroupSelector[]}>({
@@ -103,14 +103,14 @@ export const AssetsGroupsGlobalGraphRoot: React.FC = () => {
       <AssetGraphExplorer
         fetchOptions={fetchOptions}
         fetchOptionFilters={
-          <>
-            {allRepos.length > 1 && <RepoFilterButton />}
-            <AssetGroupSuggest
-              assetGroups={assetGroups}
-              value={filters.groups || []}
-              onChange={(groups) => setFilters({...filters, groups})}
-            />
-          </>
+          <AssetGraphExplorerFilters
+            assetGroups={assetGroups}
+            visibleAssetGroups={React.useMemo(() => filters.groups || [], [filters.groups])}
+            setGroupFilters={React.useCallback((groups) => setFilters({...filters, groups}), [
+              filters,
+              setFilters,
+            ])}
+          />
         }
         options={{preferAssetRendering: true, explodeComposites: true}}
         explorerPath={globalAssetGraphPathFromString(path)}

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/OpGraph.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/OpGraph.tsx
@@ -8,7 +8,7 @@ import {OpNameOrPath} from '../ops/OpNameOrPath';
 import {OpEdges} from './OpEdges';
 import {OpNode, OP_NODE_DEFINITION_FRAGMENT, OP_NODE_INVOCATION_FRAGMENT} from './OpNode';
 import {ParentOpNode, SVGLabeledParentRect} from './ParentOpNode';
-import {DETAIL_ZOOM, SVGViewport, SVGViewportInteractor} from './SVGViewport';
+import {DEFAULT_MAX_ZOOM, DETAIL_ZOOM, SVGViewport, SVGViewportInteractor} from './SVGViewport';
 import {OpGraphLayout} from './asyncGraphLayout';
 import {
   Edge,
@@ -199,7 +199,7 @@ export class OpGraph extends React.Component<OpGraphProps> {
       <SVGViewport
         ref={this.viewportEl}
         key={jobName}
-        maxZoom={1.2}
+        maxZoom={DEFAULT_MAX_ZOOM}
         defaultZoom="zoom-to-fit"
         interactor={interactor || SVGViewport.Interactors.PanAndZoom}
         graphWidth={layout.width}

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/SVGViewport.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/SVGViewport.tsx
@@ -438,7 +438,7 @@ export class SVGViewport extends React.Component<SVGViewportProps, SVGViewportSt
       box.x + box.width / 2,
       box.y + box.height / 2,
       animate,
-      newScale === DEFAULT_MIN_ZOOM ? DEFAULT_MAX_ZOOM : newScale,
+      newScale === this.getMinZoom() ? this.getMaxZoom() : newScale,
     );
   }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/SVGViewport.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/SVGViewport.tsx
@@ -50,6 +50,7 @@ export const DETAIL_ZOOM = 0.75;
 const DEFAULT_ZOOM = 0.75;
 const DEFAULT_MAX_AUTOCENTER_ZOOM = 1;
 const DEFAULT_MIN_ZOOM = 0.17;
+export const DEFAULT_MAX_ZOOM = 1.2;
 
 const BUTTON_INCREMENT = 0.05;
 
@@ -433,7 +434,12 @@ export class SVGViewport extends React.Component<SVGViewportProps, SVGViewportSt
   }
 
   public zoomToSVGBox(box: IBounds, animate: boolean, newScale = this.state.scale) {
-    this.zoomToSVGCoords(box.x + box.width / 2, box.y + box.height / 2, animate, newScale);
+    this.zoomToSVGCoords(
+      box.x + box.width / 2,
+      box.y + box.height / 2,
+      animate,
+      newScale === DEFAULT_MIN_ZOOM ? DEFAULT_MAX_ZOOM : newScale,
+    );
   }
 
   public zoomToSVGCoords(x: number, y: number, animate: boolean, scale = this.state.scale) {

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/getLeftNavItemsForOption.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/getLeftNavItemsForOption.tsx
@@ -119,7 +119,7 @@ const Label = styled.div<{$hasIcon: boolean}>`
   white-space: nowrap;
 `;
 
-const LabelTooltipStyles = JSON.stringify({
+export const LabelTooltipStyles = JSON.stringify({
   background: Colors.Gray100,
   filter: `brightness(97%)`,
   color: Colors.Gray900,
@@ -140,11 +140,18 @@ const TruncatingName = styled.div`
 
 export const TruncatedTextWithFullTextOnHover = React.forwardRef(
   (
-    {text, tooltipStyle, ...rest}: {text: string; tooltipStyle?: string},
+    {
+      text,
+      tooltipStyle,
+      tooltipText,
+      ...rest
+    }:
+      | {text: string; tooltipStyle?: string; tooltipText?: null}
+      | {text: React.ReactNode; tooltipStyle?: string; tooltipText: string},
     ref: React.ForwardedRef<HTMLDivElement>,
   ) => (
     <TruncatingName
-      data-tooltip={text}
+      data-tooltip={tooltipText ?? text}
       data-tooltip-style={tooltipStyle ?? LabelTooltipStyles}
       ref={ref}
       {...rest}

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/FilterDropdown.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/FilterDropdown.tsx
@@ -250,7 +250,7 @@ export const FilterDropdown = ({filters, setIsOpen, setPortaledElements}: Filter
             <Container
               ref={parentRef}
               style={{
-                maxHeight: '500px',
+                maxHeight: `min(500px, 50vh)`,
                 overflowY: 'auto',
                 width: selectedFilter?.menuWidth || 'auto',
               }}


### PR DESCRIPTION
## Summary & Motivation

https://www.loom.com/share/647d76108782411f8ef1c9b06f55eae5

This adds a sidebar to the left of the asset graph that makes it easier to navigate the asset graph without needing to scroll around. This is useful for cases where the asset graph is very large and it's hard to see the ancestors / descendants of a particular asset.

It would be nice if we could figure out how to combine this with the existing asset graph sidebar that shows up on the right side somehow so that there's only one sidebar.

I put minimal effort into the design for now since this is just a prototype I built to demonstrate one solution to the problem of navigating large asset graphs. Looking for input as to whether we should pursue this direction or not.

