### PR TITLE
[ui] Show one asset run tag or “4 assets”, hover action for lineage

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsGroupsGlobalGraphRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsGroupsGlobalGraphRoot.tsx
@@ -4,43 +4,25 @@ import * as React from 'react';
 import {useHistory, useParams} from 'react-router-dom';
 
 import {AssetGraphExplorer} from '../asset-graph/AssetGraphExplorer';
-import {tokenForAssetKey} from '../asset-graph/Utils';
 import {AssetGraphFetchScope} from '../asset-graph/useAssetGraphData';
 import {AssetLocation} from '../asset-graph/useFindAssetLocation';
-import {AssetGroupSelector, AssetKeyInput} from '../graphql/types';
+import {AssetGroupSelector} from '../graphql/types';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
 import {RepoFilterButton} from '../instance/RepoFilterButton';
-import {
-  ExplorerPath,
-  explorerPathFromString,
-  explorerPathToString,
-} from '../pipelines/PipelinePathUtils';
+import {ExplorerPath} from '../pipelines/PipelinePathUtils';
 import {ReloadAllButton} from '../workspace/ReloadAllButton';
 import {WorkspaceContext} from '../workspace/WorkspaceContext';
 
 import {AssetGroupSuggest, buildAssetGroupSelector} from './AssetGroupSuggest';
 import {assetDetailsPathForKey} from './assetDetailsPathForKey';
+import {
+  globalAssetGraphPathFromString,
+  globalAssetGraphPathToString,
+} from './globalAssetGraphPathToString';
 
 interface AssetGroupRootParams {
   0: string;
-}
-
-const __GLOBAL__ = '__GLOBAL__';
-
-export function globalAssetGraphPathFor(path: Omit<ExplorerPath, 'pipelineName'>) {
-  const str = explorerPathToString({...path, pipelineName: __GLOBAL__}).replace(__GLOBAL__, '');
-  return `/asset-groups${str}`;
-}
-
-export function globalAssetGraphPathForAssetsAndDescendants(assetKeys: AssetKeyInput[]) {
-  // Note: the max-length of a URL in chrome is 32k characters, and Firefox is 64k characters.
-  // In a perfect world we populate ops query to "asset1*,asset2*" and then select the roots
-  // by passing opNames. If we don't have enough characters to do both, just populate the ops
-  // query. It might still be too long, but we tried.
-  const opsQuery = assetKeys.map((a) => `${tokenForAssetKey(a)}*`).join(', ');
-  const opNames = opsQuery.length > 16000 ? [] : [assetKeys.map(tokenForAssetKey).join(',')];
-  return globalAssetGraphPathFor({opNames, opsQuery});
 }
 
 export const AssetsGroupsGlobalGraphRoot: React.FC = () => {
@@ -58,7 +40,7 @@ export const AssetsGroupsGlobalGraphRoot: React.FC = () => {
   const onChangeExplorerPath = React.useCallback(
     (path: ExplorerPath, mode: 'push' | 'replace') => {
       history[mode]({
-        pathname: globalAssetGraphPathFor(path),
+        pathname: globalAssetGraphPathToString(path),
         search: history.location.search,
       });
     },
@@ -131,7 +113,7 @@ export const AssetsGroupsGlobalGraphRoot: React.FC = () => {
           </>
         }
         options={{preferAssetRendering: true, explodeComposites: true}}
-        explorerPath={explorerPathFromString(__GLOBAL__ + path || '/')}
+        explorerPath={globalAssetGraphPathFromString(path)}
         onChangeExplorerPath={onChangeExplorerPath}
         onNavigateToSourceAssetNode={onNavigateToSourceAssetNode}
       />

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/globalAssetGraphPathToString.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/globalAssetGraphPathToString.test.tsx
@@ -1,0 +1,36 @@
+import {
+  globalAssetGraphPathToString,
+  globalAssetGraphPathForAssetsAndDescendants,
+} from '../globalAssetGraphPathToString';
+
+// This file must be mocked because Jest can't handle `import.meta.url`.
+jest.mock('../../graph/asyncGraphLayout', () => ({}));
+
+describe('Global Graph URLs', () => {
+  describe('globalAssetGraphPathToString', () => {
+    it('should return a valid path given a selection and query', async () => {
+      const url = globalAssetGraphPathToString({
+        opNames: ['foo_bar'],
+        opsQuery: `foo*, bar, foo_bar++`,
+      });
+      expect(url).toEqual(`/asset-groups~foo*%2C%20bar%2C%20foo_bar%2B%2B/foo_bar`);
+    });
+  });
+
+  describe('globalAssetGraphPathForAssetsAndDescendants', () => {
+    it('should return a valid path for a single asset', async () => {
+      const url = globalAssetGraphPathForAssetsAndDescendants([{path: ['asset_0']}]);
+      expect(url).toEqual(`/asset-groups~asset_0*/asset_0`);
+    });
+
+    it('should avoid exceeding a 32k character URL', async () => {
+      const keysLarge = new Array(900).fill(0).map((_, idx) => ({path: [`asset_${idx}`]}));
+      const urlLarge = globalAssetGraphPathForAssetsAndDescendants(keysLarge);
+      expect(urlLarge.length).toEqual(24986);
+
+      const keysHuge = new Array(1500).fill(0).map((_, idx) => ({path: [`asset_${idx}`]}));
+      const urlHuge = globalAssetGraphPathForAssetsAndDescendants(keysHuge);
+      expect(urlHuge.length).toEqual(24399); // smaller because the selection is not passed
+    });
+  });
+});

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/globalAssetGraphPathToString.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/globalAssetGraphPathToString.tsx
@@ -1,0 +1,30 @@
+import {tokenForAssetKey} from '../asset-graph/Utils';
+import {AssetKeyInput} from '../graphql/types';
+import {
+  ExplorerPath,
+  explorerPathFromString,
+  explorerPathToString,
+} from '../pipelines/PipelinePathUtils';
+
+// https://stackoverflow.com/questions/417142/what-is-the-maximum-length-of-a-url-in-different-browsers
+const URL_MAX_LENGTH = 32000;
+const __GLOBAL__ = '__GLOBAL__';
+
+export function globalAssetGraphPathToString(path: Omit<ExplorerPath, 'pipelineName'>) {
+  const str = explorerPathToString({...path, pipelineName: __GLOBAL__}).replace(__GLOBAL__, '');
+  return `/asset-groups${str}`;
+}
+
+export function globalAssetGraphPathFromString(pathName: string) {
+  return explorerPathFromString(__GLOBAL__ + pathName || '/');
+}
+
+export function globalAssetGraphPathForAssetsAndDescendants(assetKeys: AssetKeyInput[]) {
+  // In a perfect world we populate ops query to "asset1*,asset2*" and then select the roots
+  // by passing opNames. If we don't have enough characters to do both, just populate the ops
+  // query. It might still be too long, but we tried.
+  const opsQuery = assetKeys.map((a) => `${tokenForAssetKey(a)}*`).join(', ');
+  const opNames =
+    opsQuery.length > URL_MAX_LENGTH / 2 ? [] : [assetKeys.map(tokenForAssetKey).join(',')];
+  return globalAssetGraphPathToString({opNames, opsQuery});
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/LatestRunTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/LatestRunTag.tsx
@@ -5,7 +5,7 @@ import {Link} from 'react-router-dom';
 
 import {useQueryRefreshAtInterval, FIFTEEN_SECONDS} from '../app/QueryRefresh';
 import {RunStatus} from '../graphql/types';
-import {timingStringForStatus} from '../runs/RunDetails';
+import {timingStringForStatus} from '../runs/RunTimingDetails';
 import {RunStatusIndicator} from '../runs/RunStatusDots';
 import {DagsterTag} from '../runs/RunTag';
 import {RunTime, RUN_TIME_FRAGMENT} from '../runs/RunUtils';

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/LatestRunTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/LatestRunTag.tsx
@@ -5,9 +5,9 @@ import {Link} from 'react-router-dom';
 
 import {useQueryRefreshAtInterval, FIFTEEN_SECONDS} from '../app/QueryRefresh';
 import {RunStatus} from '../graphql/types';
-import {timingStringForStatus} from '../runs/RunTimingDetails';
 import {RunStatusIndicator} from '../runs/RunStatusDots';
 import {DagsterTag} from '../runs/RunTag';
+import {timingStringForStatus} from '../runs/RunTimingDetails';
 import {RunTime, RUN_TIME_FRAGMENT} from '../runs/RunUtils';
 import {TimestampDisplay} from '../schedules/TimestampDisplay';
 import {repoAddressAsTag} from '../workspace/repoAddressAsString';

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/AssetKeyTagCollection.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/AssetKeyTagCollection.tsx
@@ -3,8 +3,8 @@ import * as React from 'react';
 import {Link} from 'react-router-dom';
 
 import {displayNameForAssetKey} from '../asset-graph/Utils';
-import {globalAssetGraphPathForAssetsAndDescendants} from '../assets/AssetsGroupsGlobalGraphRoot';
 import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
+import {globalAssetGraphPathForAssetsAndDescendants} from '../assets/globalAssetGraphPathToString';
 import {AssetKey} from '../assets/types';
 import {TagActionsPopover} from '../ui/TagActions';
 import {VirtualizedItemListForDialog} from '../ui/VirtualizedItemListForDialog';

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/AssetKeyTagCollection.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/AssetKeyTagCollection.tsx
@@ -1,4 +1,13 @@
-import {Box, Button, Colors, Dialog, DialogFooter, Icon, Tag} from '@dagster-io/ui-components';
+import {
+  Box,
+  Button,
+  ButtonLink,
+  Colors,
+  Dialog,
+  DialogFooter,
+  Icon,
+  Tag,
+} from '@dagster-io/ui-components';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
 
@@ -49,7 +58,7 @@ export const AssetKeyTagCollection: React.FC<{
     // parent is a flexbox.
     const assetKey = assetKeys[0]!;
     return (
-      <span style={{lineHeight: 0}}>
+      <span style={useTags ? {} : {marginBottom: -4}}>
         <TagActionsPopover
           data={{key: '', value: ''}}
           actions={[
@@ -71,10 +80,12 @@ export const AssetKeyTagCollection: React.FC<{
               {displayNameForAssetKey(assetKey)}
             </Tag>
           ) : (
-            <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
-              <Icon color={Colors.Gray400} name="asset" size={16} />
-              {displayNameForAssetKey(assetKey)}
-            </Box>
+            <Link to={assetDetailsPathForKey(assetKey)}>
+              <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
+                <Icon color={Colors.Gray400} name="asset" size={16} />
+                {displayNameForAssetKey(assetKey)}
+              </Box>
+            </Link>
           )}
         </TagActionsPopover>
       </span>
@@ -82,7 +93,7 @@ export const AssetKeyTagCollection: React.FC<{
   }
 
   return (
-    <span style={{lineHeight: 0}}>
+    <span style={useTags ? {} : {marginBottom: -4}}>
       <TagActionsPopover
         data={{key: '', value: ''}}
         actions={[
@@ -101,12 +112,14 @@ export const AssetKeyTagCollection: React.FC<{
             {assetKeys.length} assets
           </Tag>
         ) : (
-          <Box flex={{direction: 'row', gap: 8, alignItems: 'center', display: 'inline-flex'}}>
-            <Icon color={Colors.Gray400} name="asset" size={16} />
-            <Box style={{flex: 1}} flex={{wrap: 'wrap', display: 'inline-flex'}}>
-              {`${assetKeys.length} assets`}
+          <ButtonLink onClick={() => setShowMore(true)}>
+            <Box flex={{direction: 'row', gap: 8, alignItems: 'center', display: 'inline-flex'}}>
+              <Icon color={Colors.Gray400} name="asset" size={16} />
+              <Box style={{flex: 1}} flex={{wrap: 'wrap', display: 'inline-flex'}}>
+                {`${assetKeys.length} assets`}
+              </Box>
             </Box>
-          </Box>
+          </ButtonLink>
         )}
       </TagActionsPopover>
       {showMoreDialog}

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunConfigDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunConfigDialog.tsx
@@ -1,19 +1,18 @@
-import {gql, useMutation} from '@apollo/client';
+import {useMutation} from '@apollo/client';
 import {
+  Box,
   Button,
   Colors,
-  DialogFooter,
   Dialog,
+  DialogFooter,
   Group,
   Icon,
-  MenuItem,
   Menu,
-  MetadataTable,
+  MenuItem,
   Popover,
-  Tooltip,
-  Subheading,
-  Box,
   StyledRawCodeMirror,
+  Subheading,
+  Tooltip,
 } from '@dagster-io/ui-components';
 import * as React from 'react';
 import {useHistory} from 'react-router-dom';
@@ -23,14 +22,12 @@ import {AppContext} from '../app/AppContext';
 import {showSharedToaster} from '../app/DomUtils';
 import {useFeatureFlags} from '../app/Flags';
 import {useCopyToClipboard} from '../app/browser';
-import {RunStatus} from '../graphql/types';
 import {FREE_CONCURRENCY_SLOTS_FOR_RUN_MUTATION} from '../instance/InstanceConcurrency';
 import {
   FreeConcurrencySlotsForRunMutation,
   FreeConcurrencySlotsForRunMutationVariables,
 } from '../instance/types/InstanceConcurrency.types';
 import {NO_LAUNCH_PERMISSION_MESSAGE} from '../launchpad/LaunchRootExecutionButton';
-import {TimestampDisplay} from '../schedules/TimestampDisplay';
 import {AnchorButton} from '../ui/AnchorButton';
 import {workspacePathFromRunDetails, workspacePipelinePath} from '../workspace/workspacePath';
 
@@ -39,98 +36,7 @@ import {doneStatuses} from './RunStatuses';
 import {RunTags} from './RunTags';
 import {RunsQueryRefetchContext} from './RunUtils';
 import {TerminationDialog} from './TerminationDialog';
-import {TimeElapsed} from './TimeElapsed';
-import {RunDetailsFragment} from './types/RunDetails.types';
 import {RunFragment} from './types/RunFragments.types';
-
-export const timingStringForStatus = (status?: RunStatus) => {
-  switch (status) {
-    case RunStatus.QUEUED:
-      return 'Queued';
-    case RunStatus.CANCELED:
-      return 'Canceled';
-    case RunStatus.CANCELING:
-      return 'Canceling…';
-    case RunStatus.FAILURE:
-      return 'Failed';
-    case RunStatus.NOT_STARTED:
-      return 'Waiting to start…';
-    case RunStatus.STARTED:
-      return 'Started…';
-    case RunStatus.STARTING:
-      return 'Starting…';
-    case RunStatus.SUCCESS:
-      return 'Succeeded';
-    default:
-      return 'None';
-  }
-};
-
-const LoadingOrValue: React.FC<{
-  loading: boolean;
-  children: () => React.ReactNode;
-}> = ({loading, children}) =>
-  loading ? <div style={{color: Colors.Gray400}}>Loading…</div> : <div>{children()}</div>;
-
-const TIME_FORMAT = {showSeconds: true, showTimezone: false};
-
-export const RunDetails: React.FC<{
-  loading: boolean;
-  run: RunDetailsFragment | undefined;
-}> = ({loading, run}) => {
-  return (
-    <MetadataTable
-      spacing={0}
-      rows={[
-        {
-          key: 'Started',
-          value: (
-            <LoadingOrValue loading={loading}>
-              {() => {
-                if (run?.startTime) {
-                  return <TimestampDisplay timestamp={run.startTime} timeFormat={TIME_FORMAT} />;
-                }
-                return (
-                  <div style={{color: Colors.Gray400}}>{timingStringForStatus(run?.status)}</div>
-                );
-              }}
-            </LoadingOrValue>
-          ),
-        },
-        {
-          key: 'Ended',
-          value: (
-            <LoadingOrValue loading={loading}>
-              {() => {
-                if (run?.endTime) {
-                  return <TimestampDisplay timestamp={run.endTime} timeFormat={TIME_FORMAT} />;
-                }
-                return (
-                  <div style={{color: Colors.Gray400}}>{timingStringForStatus(run?.status)}</div>
-                );
-              }}
-            </LoadingOrValue>
-          ),
-        },
-        {
-          key: 'Duration',
-          value: (
-            <LoadingOrValue loading={loading}>
-              {() => {
-                if (run?.startTime) {
-                  return <TimeElapsed startUnix={run.startTime} endUnix={run.endTime} />;
-                }
-                return (
-                  <div style={{color: Colors.Gray400}}>{timingStringForStatus(run?.status)}</div>
-                );
-              }}
-            </LoadingOrValue>
-          ),
-        },
-      ]}
-    />
-  );
-};
 
 type VisibleDialog = 'config' | 'delete' | 'terminate' | 'free_slots' | null;
 
@@ -323,15 +229,5 @@ const CodeMirrorContainer = styled.div`
 
   .CodeMirror {
     height: 100%;
-  }
-`;
-
-export const RUN_DETAILS_FRAGMENT = gql`
-  fragment RunDetailsFragment on Run {
-    id
-    startTime
-    endTime
-    status
-    hasConcurrencyKeySlots
   }
 `;

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunFragments.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunFragments.tsx
@@ -3,8 +3,8 @@ import {gql} from '@apollo/client';
 import {EXECUTION_PLAN_TO_GRAPH_FRAGMENT} from '../gantt/toGraphQueryItems';
 
 import {LOGS_SCROLLING_TABLE_MESSAGE_FRAGMENT} from './LogsScrollingTable';
-import {RUN_DETAILS_FRAGMENT} from './RunDetails';
 import {RUN_METADATA_PROVIDER_MESSAGE_FRAGMENT} from './RunMetadataProvider';
+import {RUN_TIMING_FRAGMENT} from './RunTimingDetails';
 
 export const RUN_FRAGMENT = gql`
   fragment RunFragment on Run {
@@ -61,11 +61,11 @@ export const RUN_FRAGMENT = gql`
         endTime
       }
     }
-    ...RunDetailsFragment
+    ...RunTimingFragment
   }
 
   ${EXECUTION_PLAN_TO_GRAPH_FRAGMENT}
-  ${RUN_DETAILS_FRAGMENT}
+  ${RUN_TIMING_FRAGMENT}
 `;
 
 export const RUN_DAGSTER_RUN_EVENT_FRAGMENT = gql`

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunRoot.tsx
@@ -1,33 +1,24 @@
 import {gql, useQuery} from '@apollo/client';
-import {
-  Box,
-  NonIdealState,
-  PageHeader,
-  Popover,
-  Tag,
-  Heading,
-  FontFamily,
-} from '@dagster-io/ui-components';
+import {Box, FontFamily, Heading, NonIdealState, PageHeader, Tag} from '@dagster-io/ui-components';
 import * as React from 'react';
 import {useParams} from 'react-router-dom';
 
-import {formatElapsedTime} from '../app/Util';
 import {useTrackPageView} from '../app/analytics';
 import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
 import {AutomaterializeTagWithEvaluation} from '../assets/AutomaterializeTagWithEvaluation';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {PipelineReference} from '../pipelines/PipelineReference';
-import {TimestampDisplay} from '../schedules/TimestampDisplay';
 import {isThisThingAJob} from '../workspace/WorkspaceContext';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
 import {useRepositoryForRunWithParentSnapshot} from '../workspace/useRepositoryForRun';
 
 import {AssetKeyTagCollection} from './AssetKeyTagCollection';
 import {Run} from './Run';
-import {RunConfigDialog, RunDetails} from './RunDetails';
+import {RunConfigDialog} from './RunConfigDialog';
 import {RUN_PAGE_FRAGMENT} from './RunFragments';
 import {RunStatusTag} from './RunStatusTag';
 import {DagsterTag} from './RunTag';
+import {RunTimingTags} from './RunTimingTags';
 import {assetKeysForRun} from './RunUtils';
 import {RunRootQuery, RunRootQueryVariables} from './types/RunRoot.types';
 
@@ -85,80 +76,36 @@ export const RunRoot = () => {
           }
           tags={
             run ? (
-              <>
+              <Box flex={{direction: 'row', alignItems: 'flex-start', gap: 12, wrap: 'wrap'}}>
                 <RunStatusTag status={run.status} />
-                {isHiddenAssetGroupJob(run.pipelineName) ? (
-                  <AssetKeyTagCollection assetKeys={assetKeysForRun(run)} useTags />
-                ) : (
-                  <>
-                    <Tag icon="run">
-                      Run of{' '}
-                      <PipelineReference
-                        pipelineName={run?.pipelineName}
-                        pipelineHrefContext={repoAddress || 'repo-unknown'}
-                        snapshotId={snapshotID}
-                        size="small"
-                        isJob={isJob}
-                      />
-                    </Tag>
-                    <AssetKeyTagCollection assetKeys={run.assets.map((a) => a.key)} useTags />
-                  </>
-                )}
-                <Box flex={{direction: 'row', alignItems: 'flex-start', gap: 12, wrap: 'wrap'}}>
-                  {run?.startTime ? (
-                    <Popover
-                      interactionKind="hover"
-                      placement="bottom"
-                      content={
-                        <Box padding={16}>
-                          <RunDetails run={run} loading={loading} />
-                        </Box>
-                      }
-                    >
-                      <Tag icon="schedule">
-                        <TimestampDisplay
-                          timestamp={run.startTime}
-                          timeFormat={{showSeconds: true, showTimezone: false}}
-                        />
-                      </Tag>
-                    </Popover>
-                  ) : run.updateTime ? (
-                    <Tag icon="schedule">
-                      <TimestampDisplay
-                        timestamp={run.updateTime}
-                        timeFormat={{showSeconds: true, showTimezone: false}}
-                      />
-                    </Tag>
-                  ) : undefined}
-                  {run?.startTime && run?.endTime ? (
-                    <Popover
-                      interactionKind="hover"
-                      placement="bottom"
-                      content={
-                        <Box padding={16}>
-                          <RunDetails run={run} loading={loading} />
-                        </Box>
-                      }
-                    >
-                      <Tag icon="timer">
-                        <span style={{fontVariantNumeric: 'tabular-nums'}}>
-                          {run?.startTime
-                            ? formatElapsedTime(
-                                (run?.endTime * 1000 || Date.now()) - run?.startTime * 1000,
-                              )
-                            : '–'}
-                        </span>
-                      </Tag>
-                    </Popover>
-                  ) : null}
-                  {automaterializeTag && run.assetSelection?.length ? (
-                    <AutomaterializeTagWithEvaluation
-                      assetKeys={run.assetSelection}
-                      evaluationId={automaterializeTag.value}
+                {!isHiddenAssetGroupJob(run.pipelineName) ? (
+                  <Tag icon="run">
+                    Run of{' '}
+                    <PipelineReference
+                      pipelineName={run?.pipelineName}
+                      pipelineHrefContext={repoAddress || 'repo-unknown'}
+                      snapshotId={snapshotID}
+                      size="small"
+                      isJob={isJob}
                     />
-                  ) : null}
-                </Box>
-              </>
+                  </Tag>
+                ) : null}
+                <AssetKeyTagCollection
+                  useTags
+                  assetKeys={
+                    isHiddenAssetGroupJob(run.pipelineName)
+                      ? assetKeysForRun(run)
+                      : run.assets.map((a) => a.key)
+                  }
+                />
+                <RunTimingTags run={run} loading={loading} />
+                {automaterializeTag && run.assetSelection?.length ? (
+                  <AutomaterializeTagWithEvaluation
+                    assetKeys={run.assetSelection}
+                    evaluationId={automaterializeTag.value}
+                  />
+                ) : null}
+              </Box>
             ) : null
           }
           right={run ? <RunConfigDialog run={run} isJob={isJob} /> : null}

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunTimingDetails.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunTimingDetails.tsx
@@ -1,0 +1,109 @@
+import {gql} from '@apollo/client';
+import {Colors, MetadataTable} from '@dagster-io/ui-components';
+import * as React from 'react';
+
+import {RunStatus} from '../graphql/types';
+import {TimestampDisplay} from '../schedules/TimestampDisplay';
+
+import {TimeElapsed} from './TimeElapsed';
+import {RunTimingFragment} from './types/RunTimingDetails.types';
+
+export const timingStringForStatus = (status?: RunStatus) => {
+  switch (status) {
+    case RunStatus.QUEUED:
+      return 'Queued';
+    case RunStatus.CANCELED:
+      return 'Canceled';
+    case RunStatus.CANCELING:
+      return 'Canceling…';
+    case RunStatus.FAILURE:
+      return 'Failed';
+    case RunStatus.NOT_STARTED:
+      return 'Waiting to start…';
+    case RunStatus.STARTED:
+      return 'Started…';
+    case RunStatus.STARTING:
+      return 'Starting…';
+    case RunStatus.SUCCESS:
+      return 'Succeeded';
+    default:
+      return 'None';
+  }
+};
+
+const LoadingOrValue: React.FC<{
+  loading: boolean;
+  children: () => React.ReactNode;
+}> = ({loading, children}) =>
+  loading ? <div style={{color: Colors.Gray400}}>Loading…</div> : <div>{children()}</div>;
+
+const TIME_FORMAT = {showSeconds: true, showTimezone: false};
+
+export const RunTimingDetails: React.FC<{
+  loading: boolean;
+  run: RunTimingFragment | undefined;
+}> = ({loading, run}) => {
+  return (
+    <MetadataTable
+      spacing={0}
+      rows={[
+        {
+          key: 'Started',
+          value: (
+            <LoadingOrValue loading={loading}>
+              {() => {
+                if (run?.startTime) {
+                  return <TimestampDisplay timestamp={run.startTime} timeFormat={TIME_FORMAT} />;
+                }
+                return (
+                  <div style={{color: Colors.Gray400}}>{timingStringForStatus(run?.status)}</div>
+                );
+              }}
+            </LoadingOrValue>
+          ),
+        },
+        {
+          key: 'Ended',
+          value: (
+            <LoadingOrValue loading={loading}>
+              {() => {
+                if (run?.endTime) {
+                  return <TimestampDisplay timestamp={run.endTime} timeFormat={TIME_FORMAT} />;
+                }
+                return (
+                  <div style={{color: Colors.Gray400}}>{timingStringForStatus(run?.status)}</div>
+                );
+              }}
+            </LoadingOrValue>
+          ),
+        },
+        {
+          key: 'Duration',
+          value: (
+            <LoadingOrValue loading={loading}>
+              {() => {
+                if (run?.startTime) {
+                  return <TimeElapsed startUnix={run.startTime} endUnix={run.endTime} />;
+                }
+                return (
+                  <div style={{color: Colors.Gray400}}>{timingStringForStatus(run?.status)}</div>
+                );
+              }}
+            </LoadingOrValue>
+          ),
+        },
+      ]}
+    />
+  );
+};
+
+export const RUN_TIMING_FRAGMENT = gql`
+  fragment RunTimingFragment on Run {
+    id
+    startTime
+    endTime
+    updateTime
+    status
+    hasConcurrencyKeySlots
+  }
+`;

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunTimingTags.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunTimingTags.tsx
@@ -1,0 +1,59 @@
+import {Box, Popover, Tag} from '@dagster-io/ui-components';
+import * as React from 'react';
+
+import {formatElapsedTime} from '../app/Util';
+import {TimestampDisplay} from '../schedules/TimestampDisplay';
+
+import {RunTimingDetails} from './RunTimingDetails';
+import {RunTimingFragment} from './types/RunTimingDetails.types';
+
+export const RunTimingTags = ({loading, run}: {loading: boolean; run: RunTimingFragment}) => {
+  return (
+    <>
+      {run?.startTime ? (
+        <Popover
+          interactionKind="hover"
+          placement="bottom"
+          content={
+            <Box padding={16}>
+              <RunTimingDetails run={run} loading={loading} />
+            </Box>
+          }
+        >
+          <Tag icon="schedule">
+            <TimestampDisplay
+              timestamp={run.startTime}
+              timeFormat={{showSeconds: true, showTimezone: false}}
+            />
+          </Tag>
+        </Popover>
+      ) : run.updateTime ? (
+        <Tag icon="schedule">
+          <TimestampDisplay
+            timestamp={run.updateTime}
+            timeFormat={{showSeconds: true, showTimezone: false}}
+          />
+        </Tag>
+      ) : undefined}
+      {run?.startTime && run?.endTime ? (
+        <Popover
+          interactionKind="hover"
+          placement="bottom"
+          content={
+            <Box padding={16}>
+              <RunTimingDetails run={run} loading={loading} />
+            </Box>
+          }
+        >
+          <Tag icon="timer">
+            <span style={{fontVariantNumeric: 'tabular-nums'}}>
+              {run?.startTime
+                ? formatElapsedTime((run?.endTime * 1000 || Date.now()) - run?.startTime * 1000)
+                : '–'}
+            </span>
+          </Tag>
+        </Popover>
+      ) : null}
+    </>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/AssetKeyTagCollection.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/AssetKeyTagCollection.test.tsx
@@ -3,6 +3,7 @@ import faker from 'faker';
 import * as React from 'react';
 import {MemoryRouter} from 'react-router-dom';
 
+import {displayNameForAssetKey} from '../../asset-graph/Utils';
 import {AssetKeyTagCollection} from '../AssetKeyTagCollection';
 
 describe('AssetKeyTagCollection', () => {
@@ -12,33 +13,30 @@ describe('AssetKeyTagCollection', () => {
       .map((_) => ({path: [faker.random.word()]}));
   };
 
-  it('renders individual tags if <= 3', async () => {
+  it('renders individual tag if there is just one key', async () => {
+    const key = makeKeys(1)[0]!;
     render(
       <MemoryRouter>
-        <AssetKeyTagCollection assetKeys={makeKeys(3)} useTags />
+        <AssetKeyTagCollection assetKeys={[key]} useTags />
       </MemoryRouter>,
     );
 
-    const links = await screen.findAllByRole('link');
-    expect(links).toHaveLength(3);
-
-    expect(screen.queryByRole('button')).toBeNull();
+    expect(screen.queryByText('1 asset')).toBeNull();
+    expect(screen.queryByText(displayNameForAssetKey(key))).toBeDefined();
   });
 
-  it('renders single tag if > 3', async () => {
+  it('renders a "5 assets" tag if there are >1 key', async () => {
+    const keys = makeKeys(5);
     // `act` because we're asserting a null state
     await act(async () => {
       render(
         <MemoryRouter>
-          <AssetKeyTagCollection assetKeys={makeKeys(5)} useTags />
+          <AssetKeyTagCollection assetKeys={keys} useTags />
         </MemoryRouter>,
       );
     });
 
-    const links = screen.queryByRole('link');
-    expect(links).toBeNull();
-
-    const button = screen.queryByRole('button') as HTMLButtonElement;
-    expect(button.textContent).toBe('5 assets');
+    expect(screen.queryByText('5 assets')).toBeDefined();
+    expect(screen.queryByText(displayNameForAssetKey(keys[0]!))).toBeNull();
   });
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/RunTimingDetails.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/RunTimingDetails.test.tsx
@@ -3,13 +3,13 @@ import * as React from 'react';
 
 import {TimeProvider} from '../../app/time/TimeContext';
 import {RunStatus, buildRun} from '../../graphql/types';
-import {RunDetails} from '../RunDetails';
+import {RunTimingDetails} from '../RunTimingDetails';
 
 jest.mock('../../app/time/browserTimezone.ts', () => ({
   browserTimezone: () => 'America/Los_Angeles',
 }));
 
-describe('RunDetails', () => {
+describe('RunTimingDetails', () => {
   const START_TIME = 1613571870.934;
   const END_TIME = 1613571916.945;
   const FAKE_NOW = 1613571931.945; // Fifteen seconds later
@@ -37,7 +37,7 @@ describe('RunDetails', () => {
 
     render(
       <TimeProvider>
-        <RunDetails loading={false} run={run} />
+        <RunTimingDetails loading={false} run={run} />
       </TimeProvider>,
     );
 
@@ -61,7 +61,7 @@ describe('RunDetails', () => {
 
     render(
       <TimeProvider>
-        <RunDetails loading={false} run={run} />
+        <RunTimingDetails loading={false} run={run} />
       </TimeProvider>,
     );
 
@@ -81,7 +81,7 @@ describe('RunDetails', () => {
 
     render(
       <TimeProvider>
-        <RunDetails loading={false} run={run} />
+        <RunTimingDetails loading={false} run={run} />
       </TimeProvider>,
     );
 
@@ -101,7 +101,7 @@ describe('RunDetails', () => {
 
     render(
       <TimeProvider>
-        <RunDetails loading={false} run={run} />
+        <RunTimingDetails loading={false} run={run} />
       </TimeProvider>,
     );
 
@@ -121,7 +121,7 @@ describe('RunDetails', () => {
 
     render(
       <TimeProvider>
-        <RunDetails loading={false} run={run} />
+        <RunTimingDetails loading={false} run={run} />
       </TimeProvider>,
     );
 
@@ -141,7 +141,7 @@ describe('RunDetails', () => {
 
     render(
       <TimeProvider>
-        <RunDetails loading={false} run={run} />
+        <RunTimingDetails loading={false} run={run} />
       </TimeProvider>,
     );
 
@@ -161,7 +161,7 @@ describe('RunDetails', () => {
 
     render(
       <TimeProvider>
-        <RunDetails loading={false} run={run} />
+        <RunTimingDetails loading={false} run={run} />
       </TimeProvider>,
     );
 
@@ -181,7 +181,7 @@ describe('RunDetails', () => {
 
     render(
       <TimeProvider>
-        <RunDetails loading={false} run={run} />
+        <RunTimingDetails loading={false} run={run} />
       </TimeProvider>,
     );
 
@@ -201,7 +201,7 @@ describe('RunDetails', () => {
 
     render(
       <TimeProvider>
-        <RunDetails loading={false} run={run} />
+        <RunTimingDetails loading={false} run={run} />
       </TimeProvider>,
     );
 
@@ -221,7 +221,7 @@ describe('RunDetails', () => {
 
     render(
       <TimeProvider>
-        <RunDetails loading={false} run={run} />
+        <RunTimingDetails loading={false} run={run} />
       </TimeProvider>,
     );
 
@@ -241,7 +241,7 @@ describe('RunDetails', () => {
 
     render(
       <TimeProvider>
-        <RunDetails loading={false} run={run} />
+        <RunTimingDetails loading={false} run={run} />
       </TimeProvider>,
     );
 

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunTimingDetails.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunTimingDetails.types.ts
@@ -2,11 +2,12 @@
 
 import * as Types from '../../graphql/types';
 
-export type RunDetailsFragment = {
+export type RunTimingFragment = {
   __typename: 'Run';
   id: string;
   startTime: number | null;
   endTime: number | null;
+  updateTime: number | null;
   status: Types.RunStatus;
   hasConcurrencyKeySlots: boolean;
 };


### PR DESCRIPTION
## Summary & Motivation

This PR changes the asset tags that appear in the run table and on the run details page:

1) Rather than show 1-3 individual assets or a "6 assets" link in the run table or run details header, we now show either a single asset or "6 assets". This means the rendering is more compact in the 2-3 asset case since the tags are not rendered individually.

2) Instead of being directly clickable, hovering over the assets gives you the option to jump to a lineage view OR open the list of assets. For >1 asset, the downstream lineage option goes to the global asset graph with the "assetA*, assetB*" query. It's actually pretty slick.

Right now in Dagit we don't have a "default behavior" for clicking tags that have tag actions -- you have to choose an action. I could see keeping the default "link" behavior we had before though...

Before:
![image](https://github.com/dagster-io/dagster/assets/1037212/e09c7998-d92a-496f-96b4-bcdd7d48c253)
![image](https://github.com/dagster-io/dagster/assets/1037212/ea86bac2-bf6a-4c03-84b6-3c134c01db5f)
![image](https://github.com/dagster-io/dagster/assets/1037212/44c711e0-dfef-4213-acaf-deff4f70b489)

After:
![image](https://github.com/dagster-io/dagster/assets/1037212/f81a4178-c3af-437a-bcba-1db760750244)
![image](https://github.com/dagster-io/dagster/assets/1037212/845dfd0b-b1b7-438b-8d70-b9130fba9fb1)
![image](https://github.com/dagster-io/dagster/assets/1037212/836cbb21-f485-4555-b82a-dfe6303cbeec)

Also verified with multi-component asset keys:
![image](https://github.com/dagster-io/dagster/assets/1037212/882bced3-382c-4bdb-b420-93e32be2038e)
![image](https://github.com/dagster-io/dagster/assets/1037212/da6b77b9-6ff9-40ef-aced-235fb6677439)


## How I Tested These Changes

I viewed the runs list and run details for a wide range of runs.
