### PR TITLE
[ruff] 0.0.277 -> 0.0.289

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -135,9 +135,7 @@ def network_buildkite_container(network_name: str) -> List[str]:
         r'export CONTAINER_NAME=`docker ps --filter "id=\${CONTAINER_ID}" --format "{{.Names}}"`',
         # then, we dynamically bind this container into the user-defined bridge
         # network to make the target containers visible...
-        "docker network connect {network_name} \\${{CONTAINER_NAME}}".format(
-            network_name=network_name
-        ),
+        f"docker network connect {network_name} \\${{CONTAINER_NAME}}",
     ]
 
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,6 @@ repos:
       name: black-jupyter [docs-snippets]
       files: "^examples/docs_snippets/.*.py"
 - repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: v0.0.277
+  rev: v0.0.289
   hooks:
     - id: ruff

--- a/docs/content/guides/dagster/ml-pipeline.mdx
+++ b/docs/content/guides/dagster/ml-pipeline.mdx
@@ -89,7 +89,6 @@ from dagster import multi_asset, AssetOut
 
 @multi_asset(outs={"training_data": AssetOut(), "test_data": AssetOut()})
 def training_test_data(hackernews_stories):
-    hackernews_stories = hackernews_stories
     X = hackernews_stories.title
     y = hackernews_stories.descendants
     # Split the dataset to reserve 20% of records as the test set

--- a/examples/docs_snippets/docs_snippets/guides/dagster/ml_pipelines/ml_pipeline.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/ml_pipelines/ml_pipeline.py
@@ -39,7 +39,6 @@ from dagster import multi_asset, AssetOut
 
 @multi_asset(outs={"training_data": AssetOut(), "test_data": AssetOut()})
 def training_test_data(hackernews_stories):
-    hackernews_stories = hackernews_stories
     X = hackernews_stories.title
     y = hackernews_stories.descendants
     # Split the dataset to reserve 20% of records as the test set

--- a/examples/docs_snippets/docs_snippets/intro_tutorial/basics/testing/custom_types_test.py
+++ b/examples/docs_snippets/docs_snippets/intro_tutorial/basics/testing/custom_types_test.py
@@ -17,9 +17,7 @@ from dagster import (
 def less_simple_data_frame_type_check(_, value):
     if not isinstance(value, list):
         raise Failure(
-            "LessSimpleDataFrame should be a list of dicts, got {type_}".format(
-                type_=type(value)
-            )
+            f"LessSimpleDataFrame should be a list of dicts, got {type(value)}"
         )
 
     fields = [field for field in value[0].keys()]
@@ -35,9 +33,7 @@ def less_simple_data_frame_type_check(_, value):
         if fields != row_fields:
             raise Failure(
                 "Rows in LessSimpleDataFrame should have the same fields, "
-                "got {actual} for row {idx}, expected {expected}".format(
-                    actual=row_fields, idx=(i + 1), expected=fields
-                )
+                f"got {row_fields} for row {i + 1}, expected {fields}"
             )
     return True
 

--- a/examples/project_fully_featured/project_fully_featured/resources/hn_resource.py
+++ b/examples/project_fully_featured/project_fully_featured/resources/hn_resource.py
@@ -54,7 +54,7 @@ class HNSnapshotClient(HNClient):
         return int(list(self.load_items().keys())[-1])
 
     def min_item_id(self) -> int:
-        return int(list(self.load_items().keys())[0])
+        return int(next(iter(self.load_items().keys())))
 
 
 class HNAPISubsampleClient(HNClient):

--- a/examples/with_wandb/with_wandb/assets/example/train.py
+++ b/examples/with_wandb/with_wandb/assets/example/train.py
@@ -191,9 +191,7 @@ def main():
                 wandb.log(metrics)
 
                 # Print Loss
-                print(
-                    "Iteration: {0} Loss: {1:.2f} Accuracy: {2:.2f}".format(count, loss, accuracy)
-                )
+                print(f"Iteration: {count} Loss: {loss:.2f} Accuracy: {accuracy:.2f}")
     torch.save(model.state_dict(), os.path.join(wandb.run.dir, "model.pt"))
 
 

--- a/helm/dagster/schema/schema/charts/utils/utils.py
+++ b/helm/dagster/schema/schema/charts/utils/utils.py
@@ -33,7 +33,7 @@ class BaseModel(PydanticBaseModel):
         def schema_extra(schema, model):
             for prop, value in schema.get("properties", {}).items():
                 # retrieve right field from alias or name
-                field = [x for x in model.__fields__.values() if x.alias == prop][0]
+                field = next(x for x in model.__fields__.values() if x.alias == prop)
                 if field.allow_none:
                     # only one type e.g. {'type': 'integer'}
                     if "type" in value:

--- a/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/cluster.py
+++ b/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/cluster.py
@@ -171,9 +171,7 @@ def helm_postgres_url_for_k8s_run_launcher(system_namespace_for_k8s_run_launcher
     with local_port_forward_postgres(
         namespace=system_namespace_for_k8s_run_launcher
     ) as local_forward_port:
-        postgres_url = "postgresql://test:test@localhost:{local_forward_port}/test".format(
-            local_forward_port=local_forward_port
-        )
+        postgres_url = f"postgresql://test:test@localhost:{local_forward_port}/test"
         print("Local Postgres forwarding URL: ", postgres_url)
         yield postgres_url
 
@@ -185,9 +183,7 @@ def helm_postgres_url_for_user_deployments_subchart_disabled(
     with local_port_forward_postgres(
         namespace=helm_namespace_for_user_deployments_subchart_disabled
     ) as local_forward_port:
-        postgres_url = "postgresql://test:test@localhost:{local_forward_port}/test".format(
-            local_forward_port=local_forward_port
-        )
+        postgres_url = f"postgresql://test:test@localhost:{local_forward_port}/test"
         print("Local Postgres forwarding URL: ", postgres_url)
         yield postgres_url
 
@@ -215,9 +211,7 @@ def dagster_instance_for_user_deployments_subchart_disabled(
 @pytest.fixture(scope="session")
 def helm_postgres_url_for_daemon(helm_namespace_for_daemon):
     with local_port_forward_postgres(namespace=helm_namespace_for_daemon) as local_forward_port:
-        postgres_url = "postgresql://test:test@localhost:{local_forward_port}/test".format(
-            local_forward_port=local_forward_port
-        )
+        postgres_url = f"postgresql://test:test@localhost:{local_forward_port}/test"
         print("Local Postgres forwarding URL: ", postgres_url)
         yield postgres_url
 
@@ -268,9 +262,7 @@ def dagster_instance_for_k8s_run_launcher(
 @pytest.fixture(scope="session")
 def helm_postgres_url(helm_namespace):
     with local_port_forward_postgres(namespace=helm_namespace) as local_forward_port:
-        postgres_url = "postgresql://test:test@localhost:{local_forward_port}/test".format(
-            local_forward_port=local_forward_port
-        )
+        postgres_url = f"postgresql://test:test@localhost:{local_forward_port}/test"
         print("Local Postgres forwarding URL: ", postgres_url)
         yield postgres_url
 

--- a/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/helm.py
+++ b/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/helm.py
@@ -616,9 +616,7 @@ def _helm_chart_helper(
             else:
                 assert (
                     len(pod_names) == 0
-                ), "celery-worker pods {pod_names} exists when celery is not enabled.".format(
-                    pod_names=pod_names
-                )
+                ), f"celery-worker pods {pod_names} exists when celery is not enabled."
 
         dagster_user_deployments_values = helm_config.get("dagster-user-deployments", {})
         if (

--- a/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/kind.py
+++ b/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/kind.py
@@ -45,11 +45,7 @@ def create_kind_cluster(cluster_name, should_cleanup=True):
     check.bool_param(should_cleanup, "should_cleanup")
 
     try:
-        print(
-            "--- \033[32m:k8s: Running kind cluster setup for cluster {cluster_name}\033[0m".format(
-                cluster_name=cluster_name
-            )
-        )
+        print(f"--- \033[32m:k8s: Running kind cluster setup for cluster {cluster_name}\033[0m")
 
         p = subprocess.Popen(
             ["kind", "create", "cluster", "--name", cluster_name],
@@ -119,10 +115,7 @@ def kind_sync_dockerconfig():
 
         # copy the config to where kubelet will look
         cmd = os.path.expandvars(
-            "{docker_exe} cp $HOME/.docker/config.json "
-            "{node_name}:/var/lib/kubelet/config.json".format(
-                docker_exe=docker_exe, node_name=node_name
-            )
+            f"{docker_exe} cp $HOME/.docker/config.json {node_name}:/var/lib/kubelet/config.json"
         )
         print("Running cmd: %s" % cmd)
         check_output(cmd, shell=True)
@@ -191,11 +184,7 @@ def kind_cluster(cluster_name=None, should_cleanup=False, kind_ready_timeout=60.
 
 
 def cluster_info_dump():
-    print(
-        "Writing out cluster info to {output_directory}".format(
-            output_directory=CLUSTER_INFO_DUMP_DIR
-        )
-    )
+    print(f"Writing out cluster info to {CLUSTER_INFO_DUMP_DIR}")
 
     p = subprocess.Popen(
         [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -253,7 +253,7 @@ select = [
 ]
 
 # Fail if Ruff is not running this version.
-required-version = "0.0.277"
+required-version = "0.0.289"
 
 [tool.ruff.flake8-builtins]
 

--- a/python_modules/automation/automation/git.py
+++ b/python_modules/automation/automation/git.py
@@ -10,11 +10,7 @@ def git_check_status() -> None:
     changes = subprocess.check_output(["git", "status", "--porcelain"]).decode("utf-8").strip()
 
     if changes != "":
-        raise Exception(
-            "Bailing: Cannot publish with changes present in git repo:\n{changes}".format(
-                changes=changes
-            )
-        )
+        raise Exception(f"Bailing: Cannot publish with changes present in git repo:\n{changes}")
 
 
 def git_user() -> str:
@@ -41,8 +37,7 @@ def git_push(tag: Optional[str] = None, dry_run: bool = True, cwd: Optional[str]
                 [
                     "git",
                     "push",
-                    "https://{github_username}:{github_token}@github.com/dagster-io/dagster.git"
-                    .format(github_username=github_username, github_token=github_token),
+                    f"https://{github_username}:{github_token}@github.com/dagster-io/dagster.git",
                     tag,
                 ],
                 dry_run=dry_run,
@@ -52,9 +47,7 @@ def git_push(tag: Optional[str] = None, dry_run: bool = True, cwd: Optional[str]
             [
                 "git",
                 "push",
-                "https://{github_username}:{github_token}@github.com/dagster-io/dagster.git".format(
-                    github_username=github_username, github_token=github_token
-                ),
+                f"https://{github_username}:{github_token}@github.com/dagster-io/dagster.git",
             ],
             dry_run=dry_run,
             cwd=cwd,
@@ -127,7 +120,7 @@ def set_git_tag(tag: str, signed: bool = False, dry_run: bool = True) -> str:
             raise Exception(
                 "Bailing: cannot sign tag. You may find "
                 "https://stackoverflow.com/q/39494631/324449 helpful. Original error "
-                "output:\n{output}".format(output=str(exc_info.output))
+                f"output:\n{str(exc_info.output)}"
             )
 
         match = re.search(

--- a/python_modules/automation/automation/git.py
+++ b/python_modules/automation/automation/git.py
@@ -120,7 +120,7 @@ def set_git_tag(tag: str, signed: bool = False, dry_run: bool = True) -> str:
             raise Exception(
                 "Bailing: cannot sign tag. You may find "
                 "https://stackoverflow.com/q/39494631/324449 helpful. Original error "
-                f"output:\n{str(exc_info.output)}"
+                f"output:\n{exc_info.output}"
             )
 
         match = re.search(

--- a/python_modules/automation/automation/parse_spark_configs.py
+++ b/python_modules/automation/automation/parse_spark_configs.py
@@ -271,9 +271,7 @@ def serialize(result: SparkConfigNode) -> bytes:
 @click.command()
 def run() -> None:
     r = requests.get(
-        "https://raw.githubusercontent.com/apache/spark/{}/docs/configuration.md".format(
-            SPARK_VERSION
-        )
+        f"https://raw.githubusercontent.com/apache/spark/{SPARK_VERSION}/docs/configuration.md"
     )
 
     result = extract(r.text)

--- a/python_modules/automation/automation/parse_spark_configs.py
+++ b/python_modules/automation/automation/parse_spark_configs.py
@@ -227,7 +227,7 @@ def extract(spark_docs_markdown_text: str) -> SparkConfigNode:
 
     spark_configs = []
     for name, table in tables:
-        parsed_table = list(ptr.HtmlTableTextLoader(table).load())[0]
+        parsed_table = next(iter(ptr.HtmlTableTextLoader(table).load()))
         df = parsed_table.as_dataframe()
         for _, row in df.iterrows():
             s = SparkConfig(row["Property Name"], row["Default"], name + ": " + row["Meaning"])

--- a/python_modules/automation/automation_tests/test_repo.py
+++ b/python_modules/automation/automation_tests/test_repo.py
@@ -13,7 +13,7 @@ def test_all_libraries_register() -> None:
     for library in os.listdir(library_dir):
         if library.endswith("CONTRIBUTING.md"):
             continue
-        result = subprocess.run(["grep", register_call, (library_dir / library), "-r"])
+        result = subprocess.run(["grep", register_call, (library_dir / library), "-r"], check=False)
         assert (
             result.returncode == 0
         ), f"Dagster library {library} is missing call to {register_call}."

--- a/python_modules/dagster-ext/dagster_ext/__init__.py
+++ b/python_modules/dagster-ext/dagster_ext/__init__.py
@@ -662,7 +662,7 @@ class ExtContext:
             self._data["provenance_by_asset_key"], "provenance"
         )
         _assert_single_asset(self._data, "provenance")
-        return list(provenance_by_asset_key.values())[0]
+        return next(iter(provenance_by_asset_key.values()))
 
     @property
     def provenance_by_asset_key(self) -> Mapping[str, Optional[ExtDataProvenance]]:
@@ -677,7 +677,7 @@ class ExtContext:
             self._data["code_version_by_asset_key"], "code_version"
         )
         _assert_single_asset(self._data, "code_version")
-        return list(code_version_by_asset_key.values())[0]
+        return next(iter(code_version_by_asset_key.values()))
 
     @property
     def code_version_by_asset_key(self) -> Mapping[str, Optional[str]]:

--- a/python_modules/dagster-ext/dagster_ext_tests/test_external_execution.py
+++ b/python_modules/dagster-ext/dagster_ext_tests/test_external_execution.py
@@ -312,7 +312,7 @@ def test_ext_no_client(external_script):
             ExtTempFileMessageReader(),
             extras=extras,
         ) as ext_context:
-            subprocess.run(cmd, env=ext_context.get_external_process_env_vars())
+            subprocess.run(cmd, env=ext_context.get_external_process_env_vars(), check=False)
 
     with instance_for_test() as instance:
         materialize(

--- a/python_modules/dagster-graphql/dagster_graphql/cli.py
+++ b/python_modules/dagster-graphql/dagster_graphql/cli.py
@@ -127,17 +127,15 @@ PREDEFINED_QUERIES = {
     name="ui",
     help=(
         "Run a GraphQL query against the dagster interface to a specified repository or"
-        " pipeline/job.\n\n{warning}".format(warning=WORKSPACE_TARGET_WARNING)
+        f" pipeline/job.\n\n{WORKSPACE_TARGET_WARNING}"
     )
-    + (
-        "\n\nExamples:"
-        "\n\n1. dagster-graphql"
-        "\n\n2. dagster-graphql -y path/to/{default_filename}"
-        "\n\n3. dagster-graphql -f path/to/file.py -a define_repo"
-        "\n\n4. dagster-graphql -m some_module -a define_repo"
-        "\n\n5. dagster-graphql -f path/to/file.py -a define_pipeline"
-        "\n\n6. dagster-graphql -m some_module -a define_pipeline"
-    ).format(default_filename=DEFAULT_WORKSPACE_YAML_FILENAME),
+    + "\n\nExamples:"
+    "\n\n1. dagster-graphql"
+    f"\n\n2. dagster-graphql -y path/to/{DEFAULT_WORKSPACE_YAML_FILENAME}"
+    "\n\n3. dagster-graphql -f path/to/file.py -a define_repo"
+    "\n\n4. dagster-graphql -m some_module -a define_repo"
+    "\n\n5. dagster-graphql -f path/to/file.py -a define_pipeline"
+    "\n\n6. dagster-graphql -m some_module -a define_pipeline",
 )
 @click.version_option(version=__version__)
 @click.option(

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/mode.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/mode.py
@@ -26,9 +26,7 @@ class GrapheneMode(graphene.ObjectType):
         self._job_snapshot_id = pipeline_snapshot_id
 
     def resolve_id(self, _graphene_info: ResolveInfo):
-        return "{pipeline}-{mode}".format(
-            pipeline=self._job_snapshot_id, mode=self._mode_def_snap.name
-        )
+        return f"{self._job_snapshot_id}-{self._mode_def_snap.name}"
 
     def resolve_name(self, _graphene_info: ResolveInfo):
         return self._mode_def_snap.name

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_checks.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_checks.py
@@ -673,7 +673,7 @@ class TestAssetChecks(ExecutingGraphQLContextTestMatrix):
                 }
             },
         )
-        print(result.data)  # ruff: noqa: T201
+        print(result.data)  # noqa: T201
         assert result.data["launchPipelineExecution"]["__typename"] == "LaunchRunSuccess"
 
         run_id = result.data["launchPipelineExecution"]["run"]["runId"]
@@ -690,7 +690,7 @@ class TestAssetChecks(ExecutingGraphQLContextTestMatrix):
         run = poll_for_finished_run(graphql_context.instance, run_id)
 
         logs = graphql_context.instance.all_logs(run_id)
-        print(logs)  # ruff: noqa: T201
+        print(logs)  # noqa: T201
         assert run.is_success
 
         checks = [
@@ -726,7 +726,7 @@ class TestAssetChecks(ExecutingGraphQLContextTestMatrix):
                 }
             },
         )
-        print(result.data)  # ruff: noqa: T201
+        print(result.data)  # noqa: T201
         assert result.data["launchPipelineExecution"]["__typename"] == "LaunchRunSuccess"
 
         run_id = result.data["launchPipelineExecution"]["run"]["runId"]
@@ -745,7 +745,7 @@ class TestAssetChecks(ExecutingGraphQLContextTestMatrix):
         run = poll_for_finished_run(graphql_context.instance, run_id)
 
         logs = graphql_context.instance.all_logs(run_id)
-        print(logs)  # ruff: noqa: T201
+        print(logs)  # noqa: T201
         assert run.is_success
 
         check_evaluations = [
@@ -777,7 +777,7 @@ class TestAssetChecks(ExecutingGraphQLContextTestMatrix):
                 }
             },
         )
-        print(result.data)  # ruff: noqa: T201
+        print(result.data)  # noqa: T201
         assert result.data["launchPipelineExecution"]["__typename"] == "LaunchRunSuccess"
 
         run_id = result.data["launchPipelineExecution"]["run"]["runId"]
@@ -794,7 +794,7 @@ class TestAssetChecks(ExecutingGraphQLContextTestMatrix):
         run = poll_for_finished_run(graphql_context.instance, run_id)
 
         logs = graphql_context.instance.all_logs(run_id)
-        print(logs)  # ruff: noqa: T201
+        print(logs)  # noqa: T201
         assert run.is_success
 
         check_evaluations = [
@@ -832,7 +832,7 @@ class TestAssetChecks(ExecutingGraphQLContextTestMatrix):
                 }
             },
         )
-        print(result.data)  # ruff: noqa: T201
+        print(result.data)  # noqa: T201
         assert result.data["launchPipelineExecution"]["__typename"] == "InvalidSubsetError"
         assert (
             result.data["launchPipelineExecution"]["message"]

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
@@ -2406,11 +2406,11 @@ class TestCrossRepoAssetDependedBy(AllRepositoryGraphQLContextTestMatrix):
             CROSS_REPO_ASSET_GRAPH,
         )
         asset_nodes = result.data["assetNodes"]
-        derived_asset = [
+        derived_asset = next(
             node
             for node in asset_nodes
             if node["id"] == 'cross_asset_repos.upstream_assets_repository.["derived_asset"]'
-        ][0]
+        )
         dependent_asset_keys = [
             {"path": ["downstream_asset1"]},
             {"path": ["downstream_asset2"]},
@@ -2427,9 +2427,9 @@ class TestCrossRepoAssetDependedBy(AllRepositoryGraphQLContextTestMatrix):
             CROSS_REPO_ASSET_GRAPH,
         )
         asset_nodes = result.data["assetNodes"]
-        always_source_asset = [node for node in asset_nodes if "always_source_asset" in node["id"]][
-            0
-        ]
+        always_source_asset = next(
+            node for node in asset_nodes if "always_source_asset" in node["id"]
+        )
         dependent_asset_keys = [
             {"path": ["downstream_asset1"]},
             {"path": ["downstream_asset2"]},

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_context.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_context.py
@@ -64,7 +64,7 @@ def test_reload_on_process_context():
 
             # Save the repository name
             code_location = request_context.code_locations[0]
-            repo = list(code_location.get_repositories().values())[0]
+            repo = next(iter(code_location.get_repositories().values()))
             repo_name = repo.name
 
             # Reload the location and save the new repository name
@@ -73,7 +73,7 @@ def test_reload_on_process_context():
             new_request_context = process_context.create_request_context()
 
             code_location = new_request_context.code_locations[0]
-            repo = list(code_location.get_repositories().values())[0]
+            repo = next(iter(code_location.get_repositories().values()))
             new_repo_name = repo.name
 
             # Check that the repository has changed
@@ -90,7 +90,7 @@ def test_reload_on_request_context():
 
             # Save the repository name
             code_location = request_context.code_locations[0]
-            repo = list(code_location.get_repositories().values())[0]
+            repo = next(iter(code_location.get_repositories().values()))
             repo_name = repo.name
 
             # Reload the location and save the new repository name
@@ -98,7 +98,7 @@ def test_reload_on_request_context():
 
             new_request_context = process_context.create_request_context()
             code_location = new_request_context.code_locations[0]
-            repo = list(code_location.get_repositories().values())[0]
+            repo = next(iter(code_location.get_repositories().values()))
             new_repo_name = repo.name
 
             # Check that the repository has changed
@@ -107,7 +107,7 @@ def test_reload_on_request_context():
             # Check that the repository name is still the same on the old request context,
             # confirming that the old repository location is still running
             code_location = request_context.code_locations[0]
-            repo = list(code_location.get_repositories().values())[0]
+            repo = next(iter(code_location.get_repositories().values()))
             assert repo_name == repo.name
 
 
@@ -123,14 +123,14 @@ def test_reload_on_request_context_2():
 
             # Save the repository name
             code_location = request_context.code_locations[0]
-            repo = list(code_location.get_repositories().values())[0]
+            repo = next(iter(code_location.get_repositories().values()))
             repo_name = repo.name
 
             # Reload the location from the request context
             new_request_context = request_context.reload_code_location(code_location.name)
 
             code_location = new_request_context.code_locations[0]
-            repo = list(code_location.get_repositories().values())[0]
+            repo = next(iter(code_location.get_repositories().values()))
             new_repo_name = repo.name
 
             # Check that the repository has changed
@@ -139,7 +139,7 @@ def test_reload_on_request_context_2():
             # Check that the repository name is still the same on the old request context,
             # confirming that the old repository location is still running
             code_location = request_context.code_locations[0]
-            repo = list(code_location.get_repositories().values())[0]
+            repo = next(iter(code_location.get_repositories().values()))
             assert repo_name == repo.name
 
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_expectations.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_expectations.py
@@ -11,9 +11,7 @@ from .utils import sync_execute_get_events
 def get_expectation_results(logs, op_name: str):
     def _f():
         for log in logs:
-            if log["__typename"] == "StepExpectationResultEvent" and log["stepKey"] == "{}".format(
-                op_name
-            ):
+            if log["__typename"] == "StepExpectationResultEvent" and log["stepKey"] == f"{op_name}":
                 yield log
 
     return list(_f())

--- a/python_modules/dagster-test/dagster_test/fixtures/docker_compose.py
+++ b/python_modules/dagster-test/dagster_test/fixtures/docker_compose.py
@@ -128,37 +128,17 @@ def connect_container_to_network(container, network):
     # trying to connect a container to a network that it's already connected to
     try:
         subprocess.check_call(["docker", "network", "connect", network, container])
-        logging.info(
-            "Connected {container} to network {network}.".format(
-                container=container,
-                network=network,
-            )
-        )
+        logging.info(f"Connected {container} to network {network}.")
     except subprocess.CalledProcessError:
-        logging.warning(
-            "Unable to connect {container} to network {network}.".format(
-                container=container,
-                network=network,
-            )
-        )
+        logging.warning(f"Unable to connect {container} to network {network}.")
 
 
 def disconnect_container_from_network(container, network):
     try:
         subprocess.check_call(["docker", "network", "disconnect", network, container])
-        logging.info(
-            "Disconnected {container} from network {network}.".format(
-                container=container,
-                network=network,
-            )
-        )
+        logging.info(f"Disconnected {container} from network {network}.")
     except subprocess.CalledProcessError:
-        logging.warning(
-            "Unable to disconnect {container} from network {network}.".format(
-                container=container,
-                network=network,
-            )
-        )
+        logging.warning(f"Unable to disconnect {container} from network {network}.")
 
 
 def hostnames(network):

--- a/python_modules/dagster-test/dagster_test/test_project/__init__.py
+++ b/python_modules/dagster-test/dagster_test/test_project/__init__.py
@@ -348,8 +348,6 @@ def get_test_project_docker_image():
             majmin=majmin, image_version="latest"
         )
 
-    final_docker_image = "{repository}/{image_name}:{tag}".format(
-        repository=docker_repository, image_name=image_name, tag=docker_image_tag
-    )
+    final_docker_image = f"{docker_repository}/{image_name}:{docker_image_tag}"
     print("Using Docker image: %s" % final_docker_image)  # noqa: T201
     return final_docker_image

--- a/python_modules/dagster-test/dagster_test/toys/many_events.py
+++ b/python_modules/dagster-test/dagster_test/toys/many_events.py
@@ -35,9 +35,7 @@ def create_raw_file_op(name):
 
     @op(
         name=name,
-        description="Inject raw file for input to table {} and do expectation on output".format(
-            name
-        ),
+        description=f"Inject raw file for input to table {name} and do expectation on output",
     )
     def raw_file_op(_context):
         yield AssetMaterialization(

--- a/python_modules/dagster-webserver/dagster_webserver/cli.py
+++ b/python_modules/dagster-webserver/dagster_webserver/cli.py
@@ -248,9 +248,7 @@ def host_dagster_ui_with_workspace_process_context(
             port = DEFAULT_WEBSERVER_PORT
 
     logger.info(
-        "Serving dagster-webserver on http://{host}:{port}{path_prefix} in process {pid}".format(
-            host=host, port=port, path_prefix=path_prefix, pid=os.getpid()
-        )
+        f"Serving dagster-webserver on http://{host}:{port}{path_prefix} in process {os.getpid()}"
     )
     log_action(workspace_process_context.instance, START_DAGSTER_WEBSERVER)
     with uploading_logging_thread():

--- a/python_modules/dagster/dagster/_cli/api.py
+++ b/python_modules/dagster/dagster/_cli/api.py
@@ -272,8 +272,8 @@ def verify_step(instance, dagster_run, retry_state, step_keys_to_execute):
             # If this is the first attempt, there shouldn't be any step stats for this
             # event yet.
             instance.report_engine_event(
-                "Attempted to run {step_key} again even though it was already started. "
-                "Exiting to prevent re-running the step.".format(step_key=step_key),
+                f"Attempted to run {step_key} again even though it was already started. "
+                "Exiting to prevent re-running the step.",
                 dagster_run,
             )
             return False
@@ -283,18 +283,16 @@ def verify_step(instance, dagster_run, retry_state, step_keys_to_execute):
 
             if step_stat_for_key.attempts != current_attempt - 1:
                 instance.report_engine_event(
-                    "Attempted to run retry attempt {current_attempt} for step {step_key} again "
+                    f"Attempted to run retry attempt {current_attempt} for step {step_key} again "
                     "even though it was already started. Exiting to prevent re-running "
-                    "the step.".format(current_attempt=current_attempt, step_key=step_key),
+                    "the step.",
                     dagster_run,
                 )
                 return False
         elif current_attempt > 1 and not step_stat_for_key:
             instance.report_engine_event(
-                "Attempting to retry attempt {current_attempt} for step {step_key} "
-                "but there is no record of the original attempt".format(
-                    current_attempt=current_attempt, step_key=step_key
-                ),
+                f"Attempting to retry attempt {current_attempt} for step {step_key} "
+                "but there is no record of the original attempt",
                 dagster_run,
             )
             return False

--- a/python_modules/dagster/dagster/_cli/debug.py
+++ b/python_modules/dagster/dagster/_cli/debug.py
@@ -54,9 +54,7 @@ def export_command(run_id, output_file):
         run = instance.get_run_by_id(run_id)
         if run is None:
             raise click.UsageError(
-                "Could not find run with run_id '{}'.\n{}".format(
-                    run_id, _recent_failed_runs_text(instance)
-                )
+                f"Could not find run with run_id '{run_id}'.\n{_recent_failed_runs_text(instance)}"
             )
 
         export_run(instance, run, output_file)

--- a/python_modules/dagster/dagster/_cli/job.py
+++ b/python_modules/dagster/dagster/_cli/job.py
@@ -117,11 +117,11 @@ def execute_list_command(cli_args, print_fn):
 def get_job_in_same_python_env_instructions(command_name):
     return (
         "This commands targets a job. The job can be specified in a number of ways:\n\n1. dagster"
-        " job {command_name} -f /path/to/file.py -a define_some_job\n\n2. dagster job"
-        " {command_name} -m a_module.submodule -a define_some_job\n\n3. dagster job {command_name}"
-        " -f /path/to/file.py -a define_some_repo -j <<job_name>>\n\n4. dagster job {command_name}"
+        f" job {command_name} -f /path/to/file.py -a define_some_job\n\n2. dagster job"
+        f" {command_name} -m a_module.submodule -a define_some_job\n\n3. dagster job {command_name}"
+        f" -f /path/to/file.py -a define_some_repo -j <<job_name>>\n\n4. dagster job {command_name}"
         " -m a_module.submodule -a define_some_repo -j <<job_name>>"
-    ).format(command_name=command_name)
+    )
 
 
 def get_job_instructions(command_name):
@@ -284,10 +284,7 @@ def add_step_to_table(memoized_plan):
     for step_output_handle, version in memoized_plan.step_output_versions.items():
         table.append(
             [
-                "{key}.{output}".format(
-                    key=step_output_handle.step_key,
-                    output=step_output_handle.output_name,
-                ),
+                f"{step_output_handle.step_key}.{step_output_handle.output_name}",
                 version,
                 (
                     "stored"

--- a/python_modules/dagster/dagster/_cli/schedule.py
+++ b/python_modules/dagster/dagster/_cli/schedule.py
@@ -223,7 +223,7 @@ def extract_schedule_name(schedule_name: Optional[Union[str, Sequence[str]]]) ->
         if len(schedule_name) == 1:
             return schedule_name[0]
         else:
-            check.failed(f"Can only handle zero or one schedule args. Got {repr(schedule_name)}")
+            check.failed(f"Can only handle zero or one schedule args. Got {schedule_name!r}")
     return None
 
 

--- a/python_modules/dagster/dagster/_cli/schedule.py
+++ b/python_modules/dagster/dagster/_cli/schedule.py
@@ -92,9 +92,7 @@ def print_changes(external_repository, instance, print_fn=print, preview=False):
 
         print_fn(
             click.style(
-                "  ~ {name} (update) [{id}]".format(
-                    name=external_schedule.name, id=schedule_origin_id
-                ),
+                f"  ~ {external_schedule.name} (update) [{schedule_origin_id}]",
                 fg="yellow",
             )
         )
@@ -225,11 +223,7 @@ def extract_schedule_name(schedule_name: Optional[Union[str, Sequence[str]]]) ->
         if len(schedule_name) == 1:
             return schedule_name[0]
         else:
-            check.failed(
-                "Can only handle zero or one schedule args. Got {schedule_name}".format(
-                    schedule_name=repr(schedule_name)
-                )
-            )
+            check.failed(f"Can only handle zero or one schedule args. Got {repr(schedule_name)}")
     return None
 
 
@@ -264,11 +258,7 @@ def execute_start_command(schedule_name, all_flag, cli_args, print_fn):
                     except DagsterInvariantViolationError as ex:
                         raise click.UsageError(ex)
 
-                print_fn(
-                    "Started all schedules for repository {repository_name}".format(
-                        repository_name=repository_name
-                    )
-                )
+                print_fn(f"Started all schedules for repository {repository_name}")
             else:
                 try:
                     instance.start_schedule(external_repo.get_external_schedule(schedule_name))
@@ -415,11 +405,7 @@ def execute_restart_command(schedule_name, all_running_flag, cli_args, print_fn)
                         except DagsterInvariantViolationError as ex:
                             raise click.UsageError(ex)
 
-                print_fn(
-                    "Restarted all running schedules for repository {name}".format(
-                        name=repository_name
-                    )
-                )
+                print_fn(f"Restarted all running schedules for repository {repository_name}")
             else:
                 external_schedule = external_repo.get_external_schedule(schedule_name)
                 schedule_state = instance.get_instigator_state(

--- a/python_modules/dagster/dagster/_cli/sensor.py
+++ b/python_modules/dagster/dagster/_cli/sensor.py
@@ -63,9 +63,7 @@ def print_changes(external_repository, instance, print_fn=print, preview=False):
     for sensor_origin_id in added_sensors:
         print_fn(
             click.style(
-                "  + {name} (add) [{id}]".format(
-                    name=external_sensors_dict[sensor_origin_id].name, id=sensor_origin_id
-                ),
+                f"  + {external_sensors_dict[sensor_origin_id].name} (add) [{sensor_origin_id}]",
                 fg="green",
             )
         )
@@ -73,9 +71,7 @@ def print_changes(external_repository, instance, print_fn=print, preview=False):
     for sensor_origin_id in removed_sensors:
         print_fn(
             click.style(
-                "  + {name} (delete) [{id}]".format(
-                    name=external_sensors_dict[sensor_origin_id].name, id=sensor_origin_id
-                ),
+                f"  + {external_sensors_dict[sensor_origin_id].name} (delete) [{sensor_origin_id}]",
                 fg="red",
             )
         )
@@ -199,11 +195,7 @@ def execute_start_command(sensor_name, all_flag, cli_args, print_fn):
                 try:
                     for external_sensor in external_repo.get_external_sensors():
                         instance.start_sensor(external_sensor)
-                    print_fn(
-                        "Started all sensors for repository {repository_name}".format(
-                            repository_name=repository_name
-                        )
-                    )
+                    print_fn(f"Started all sensors for repository {repository_name}")
                 except DagsterInvariantViolationError as ex:
                     raise click.UsageError(ex)
             else:
@@ -312,11 +304,7 @@ def execute_preview_command(
                             )
                         )
                     else:
-                        print_fn(
-                            "Sensor returned false for {sensor_name}, skipping".format(
-                                sensor_name=external_sensor.name
-                            )
-                        )
+                        print_fn(f"Sensor returned false for {external_sensor.name}, skipping")
                 else:
                     print_fn(
                         "Sensor returning run requests for {num} run(s):\n\n{run_requests}".format(

--- a/python_modules/dagster/dagster/_cli/workspace/cli_target.py
+++ b/python_modules/dagster/dagster/_cli/workspace/cli_target.py
@@ -697,21 +697,14 @@ def get_code_location_from_workspace(
             raise click.UsageError("No locations found in workspace")
         elif provided_location_name is None:
             raise click.UsageError(
-                (
-                    "Must provide --location as there are multiple locations "
-                    "available. Options are: {}"
-                ).format(_sorted_quoted(workspace.code_location_names))
+                "Must provide --location as there are multiple locations "
+                f"available. Options are: {_sorted_quoted(workspace.code_location_names)}"
             )
 
     if provided_location_name not in workspace.code_location_names:
         raise click.UsageError(
-            (
-                'Location "{provided_location_name}" not found in workspace. '
-                "Found {found_names} instead."
-            ).format(
-                provided_location_name=provided_location_name,
-                found_names=_sorted_quoted(workspace.code_location_names),
-            )
+            f'Location "{provided_location_name}" not found in workspace. '
+            f"Found {_sorted_quoted(workspace.code_location_names)} instead."
         )
 
     if workspace.has_code_location_error(provided_location_name):
@@ -740,22 +733,14 @@ def get_external_repository_from_code_location(
 
     if provided_repo_name is None:
         raise click.UsageError(
-            (
-                "Must provide --repository as there is more than one repository "
-                "in {location}. Options are: {repos}."
-            ).format(location=code_location.name, repos=_sorted_quoted(repo_dict.keys()))
+            "Must provide --repository as there is more than one repository "
+            f"in {code_location.name}. Options are: {_sorted_quoted(repo_dict.keys())}."
         )
 
     if not code_location.has_repository(provided_repo_name):
         raise click.UsageError(
-            (
-                'Repository "{provided_repo_name}" not found in location "{location_name}". '
-                "Found {found_names} instead."
-            ).format(
-                provided_repo_name=provided_repo_name,
-                location_name=code_location.name,
-                found_names=_sorted_quoted(repo_dict.keys()),
-            )
+            f'Repository "{provided_repo_name}" not found in location "{code_location.name}". '
+            f"Found {_sorted_quoted(repo_dict.keys())} instead."
         )
 
     return code_location.get_repository(provided_repo_name)

--- a/python_modules/dagster/dagster/_config/config_type.py
+++ b/python_modules/dagster/dagster/_config/config_type.py
@@ -320,11 +320,7 @@ class Enum(ConfigType):
             if ev.config_value == value:
                 return ev.python_value
 
-        check.failed(
-            (
-                "Should never reach this. config_value should be pre-validated. Got {config_value}"
-            ).format(config_value=value)
-        )
+        check.failed(f"Should never reach this. config_value should be pre-validated. Got {value}")
 
     @classmethod
     def from_python_enum(cls, enum, name=None):

--- a/python_modules/dagster/dagster/_config/errors.py
+++ b/python_modules/dagster/dagster/_config/errors.py
@@ -445,9 +445,7 @@ def create_selector_type_error(context: ContextData, config_value: object) -> Ev
     return EvaluationError(
         stack=context.stack,
         reason=DagsterEvaluationErrorReason.RUNTIME_TYPE_MISMATCH,
-        message="Value for selector type {path_msg} must be a dict".format(
-            path_msg=get_friendly_path_msg(context.stack)
-        ),
+        message=f"Value for selector type {get_friendly_path_msg(context.stack)} must be a dict",
         error_data=RuntimeMismatchErrorData(
             config_type_snap=context.config_type_snap, value_rep=repr(config_value)
         ),

--- a/python_modules/dagster/dagster/_config/field.py
+++ b/python_modules/dagster/dagster/_config/field.py
@@ -63,19 +63,19 @@ def resolve_to_config_type(obj: object) -> Union[ConfigType, bool]:
             if not isinstance(key, str):
                 if not key_type:
                     raise DagsterInvalidDefinitionError(
-                        f"Invalid key in map specification: {repr(key)} in map {obj}"
+                        f"Invalid key in map specification: {key!r} in map {obj}"
                     )
 
                 if not key_type.kind == ConfigTypeKind.SCALAR:  # type: ignore
                     raise DagsterInvalidDefinitionError(
-                        f"Non-scalar key in map specification: {repr(key)} in map {obj}"
+                        f"Non-scalar key in map specification: {key!r} in map {obj}"
                     )
 
                 inner_type = resolve_to_config_type(obj[key])
 
                 if not inner_type:
                     raise DagsterInvalidDefinitionError(
-                        f"Invalid value in map specification: {repr(obj[str])} in map {obj}"
+                        f"Invalid value in map specification: {obj[str]!r} in map {obj}"
                     )
                 return Map(key_type, inner_type)
         return convert_fields_to_dict_type(obj)
@@ -88,7 +88,7 @@ def resolve_to_config_type(obj: object) -> Union[ConfigType, bool]:
 
         if not inner_type:
             raise DagsterInvalidDefinitionError(
-                f"Invalid member of array specification: {repr(obj[0])} in list {obj}"
+                f"Invalid member of array specification: {obj[0]!r} in list {obj}"
             )
         return Array(inner_type)
 
@@ -123,7 +123,7 @@ def resolve_to_config_type(obj: object) -> Union[ConfigType, bool]:
 
     if isinstance(obj, type) and is_subclass(obj, DagsterType):
         raise DagsterInvalidDefinitionError(
-            f"You have passed a DagsterType class {repr(obj)} to the config system. "
+            f"You have passed a DagsterType class {obj!r} to the config system. "
             "The DagsterType and config schema systems are separate. "
             f"Valid config values are:\n{VALID_CONFIG_DESC}"
         )
@@ -161,7 +161,7 @@ def resolve_to_config_type(obj: object) -> Union[ConfigType, bool]:
     if isinstance(obj, DagsterType):
         raise DagsterInvalidDefinitionError(
             f"You have passed an instance of DagsterType {obj.display_name} to the config "
-            f"system (Repr of type: {repr(obj)}). "
+            f"system (Repr of type: {obj!r}). "
             "The DagsterType and config schema systems are separate. "
             f"Valid config values are:\n{VALID_CONFIG_DESC}",
         )
@@ -256,7 +256,7 @@ class Field:
         config_type = resolve_to_config_type(config)
         if not config_type:
             raise DagsterInvalidDefinitionError(
-                f"Attempted to pass {repr(config)} to a Field that expects a valid "
+                f"Attempted to pass {config!r} to a Field that expects a valid "
                 "dagster type usable in config (e.g. Dict, Int, String et al)."
             )
         return config_type

--- a/python_modules/dagster/dagster/_config/field.py
+++ b/python_modules/dagster/dagster/_config/field.py
@@ -58,7 +58,7 @@ def resolve_to_config_type(obj: object) -> Union[ConfigType, bool]:
         # Dicts of the special form {type: value} are treated as Maps
         # mapping from the type to value type, otherwise treat as dict type
         if len(obj) == 1:
-            key = list(obj.keys())[0]
+            key = next(iter(obj.keys()))
             key_type = resolve_to_config_type(key)
             if not isinstance(key, str):
                 if not key_type:

--- a/python_modules/dagster/dagster/_config/field.py
+++ b/python_modules/dagster/dagster/_config/field.py
@@ -63,25 +63,19 @@ def resolve_to_config_type(obj: object) -> Union[ConfigType, bool]:
             if not isinstance(key, str):
                 if not key_type:
                     raise DagsterInvalidDefinitionError(
-                        "Invalid key in map specification: {key} in map {collection}".format(
-                            key=repr(key), collection=obj
-                        )
+                        f"Invalid key in map specification: {repr(key)} in map {obj}"
                     )
 
                 if not key_type.kind == ConfigTypeKind.SCALAR:  # type: ignore
                     raise DagsterInvalidDefinitionError(
-                        "Non-scalar key in map specification: {key} in map {collection}".format(
-                            key=repr(key), collection=obj
-                        )
+                        f"Non-scalar key in map specification: {repr(key)} in map {obj}"
                     )
 
                 inner_type = resolve_to_config_type(obj[key])
 
                 if not inner_type:
                     raise DagsterInvalidDefinitionError(
-                        "Invalid value in map specification: {value} in map {collection}".format(
-                            value=repr(obj[str]), collection=obj
-                        )
+                        f"Invalid value in map specification: {repr(obj[str])} in map {obj}"
                     )
                 return Map(key_type, inner_type)
         return convert_fields_to_dict_type(obj)
@@ -94,9 +88,7 @@ def resolve_to_config_type(obj: object) -> Union[ConfigType, bool]:
 
         if not inner_type:
             raise DagsterInvalidDefinitionError(
-                "Invalid member of array specification: {value} in list {the_list}".format(
-                    value=repr(obj[0]), the_list=obj
-                )
+                f"Invalid member of array specification: {repr(obj[0])} in list {obj}"
             )
         return Array(inner_type)
 
@@ -131,12 +123,9 @@ def resolve_to_config_type(obj: object) -> Union[ConfigType, bool]:
 
     if isinstance(obj, type) and is_subclass(obj, DagsterType):
         raise DagsterInvalidDefinitionError(
-            "You have passed a DagsterType class {dagster_type} to the config system. "
+            f"You have passed a DagsterType class {repr(obj)} to the config system. "
             "The DagsterType and config schema systems are separate. "
-            "Valid config values are:\n{desc}".format(
-                dagster_type=repr(obj),
-                desc=VALID_CONFIG_DESC,
-            )
+            f"Valid config values are:\n{VALID_CONFIG_DESC}"
         )
 
     if is_closed_python_optional_type(obj):
@@ -148,12 +137,10 @@ def resolve_to_config_type(obj: object) -> Union[ConfigType, bool]:
 
     if is_typing_type(obj):
         raise DagsterInvalidDefinitionError(
-            (
-                "You have passed in {dagster_type} to the config system. Types from "
-                "the typing module in python are not allowed in the config system. "
-                "You must use types that are imported from dagster or primitive types "
-                "such as bool, int, etc."
-            ).format(dagster_type=obj)
+            f"You have passed in {obj} to the config system. Types from "
+            "the typing module in python are not allowed in the config system. "
+            "You must use types that are imported from dagster or primitive types "
+            "such as bool, int, etc."
         )
 
     if obj is List or isinstance(obj, ListType):
@@ -173,16 +160,10 @@ def resolve_to_config_type(obj: object) -> Union[ConfigType, bool]:
 
     if isinstance(obj, DagsterType):
         raise DagsterInvalidDefinitionError(
-            (
-                "You have passed an instance of DagsterType {type_name} to the config "
-                "system (Repr of type: {dagster_type}). "
-                "The DagsterType and config schema systems are separate. "
-                "Valid config values are:\n{desc}"
-            ).format(
-                type_name=obj.display_name,
-                dagster_type=repr(obj),
-                desc=VALID_CONFIG_DESC,
-            ),
+            f"You have passed an instance of DagsterType {obj.display_name} to the config "
+            f"system (Repr of type: {repr(obj)}). "
+            "The DagsterType and config schema systems are separate. "
+            f"Valid config values are:\n{VALID_CONFIG_DESC}",
         )
 
     # This means that this is an error and we are return False to a callsite
@@ -275,10 +256,8 @@ class Field:
         config_type = resolve_to_config_type(config)
         if not config_type:
             raise DagsterInvalidDefinitionError(
-                (
-                    "Attempted to pass {value_repr} to a Field that expects a valid "
-                    "dagster type usable in config (e.g. Dict, Int, String et al)."
-                ).format(value_repr=repr(config))
+                f"Attempted to pass {repr(config)} to a Field that expects a valid "
+                "dagster type usable in config (e.g. Dict, Int, String et al)."
             )
         return config_type
 

--- a/python_modules/dagster/dagster/_config/field_utils.py
+++ b/python_modules/dagster/dagster/_config/field_utils.py
@@ -395,7 +395,7 @@ def expand_map(original_root: object, the_dict: Mapping[object, object], stack: 
             original_root, the_dict, stack, "Map dict must be of length 1"
         )
 
-    key = list(the_dict.keys())[0]
+    key = next(iter(the_dict.keys()))
     key_type = _convert_potential_type(original_root, key, stack)
     if not key_type or not key_type.kind == ConfigTypeKind.SCALAR:
         raise DagsterInvalidConfigDefinitionError(
@@ -428,7 +428,7 @@ def _convert_potential_type(original_root: object, potential_type, stack: List[s
     if isinstance(potential_type, Mapping):
         # A dictionary, containing a single key which is a type (int, str, etc) and not a string is interpreted as a Map
         if len(potential_type) == 1:
-            key = list(potential_type.keys())[0]
+            key = next(iter(potential_type.keys()))
             if not isinstance(key, str) and _convert_potential_type(original_root, key, stack):
                 return expand_map(original_root, potential_type, stack)
 

--- a/python_modules/dagster/dagster/_config/pythonic_config/typing_utils.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/typing_utils.py
@@ -31,25 +31,23 @@ class LateBoundTypesForResourceTypeChecking:
 
     @staticmethod
     def get_resource_rep_type() -> Type:
-        return LateBoundTypesForResourceTypeChecking._ResourceDep  # noqa: SLF001
+        return LateBoundTypesForResourceTypeChecking._ResourceDep
 
     @staticmethod
     def get_resource_type() -> Type:
-        return LateBoundTypesForResourceTypeChecking._Resource  # noqa: SLF001
+        return LateBoundTypesForResourceTypeChecking._Resource
 
     @staticmethod
     def get_partial_resource_type(base: Type) -> Type:
-        return LateBoundTypesForResourceTypeChecking._PartialResource[base]  # noqa: SLF001
+        return LateBoundTypesForResourceTypeChecking._PartialResource[base]
 
     @staticmethod
     def set_actual_types_for_type_checking(
         resource_dep_type: Type, resource_type: Type, partial_resource_type: Type
     ) -> None:
-        LateBoundTypesForResourceTypeChecking._ResourceDep = resource_dep_type  # noqa: SLF001
-        LateBoundTypesForResourceTypeChecking._Resource = resource_type  # noqa: SLF001
-        LateBoundTypesForResourceTypeChecking._PartialResource = (  # noqa: SLF001
-            partial_resource_type
-        )
+        LateBoundTypesForResourceTypeChecking._ResourceDep = resource_dep_type
+        LateBoundTypesForResourceTypeChecking._Resource = resource_type
+        LateBoundTypesForResourceTypeChecking._PartialResource = partial_resource_type
 
 
 @dataclass_transform(kw_only_default=True, field_specifiers=(Field,))

--- a/python_modules/dagster/dagster/_config/source.py
+++ b/python_modules/dagster/dagster/_config/source.py
@@ -35,7 +35,7 @@ class StringSourceType(ScalarUnion):
         if not isinstance(value, dict):
             return value
 
-        key, cfg = list(value.items())[0]
+        key, cfg = next(iter(value.items()))
         check.invariant(key == "env", "Only valid key is env")
         return str(_ensure_env_variable(cfg))
 
@@ -56,7 +56,7 @@ class IntSourceType(ScalarUnion):
 
         check.invariant(len(value) == 1, "Selector should have one entry")
 
-        key, cfg = list(value.items())[0]
+        key, cfg = next(iter(value.items()))
         check.invariant(key == "env", "Only valid key is env")
         value = _ensure_env_variable(cfg)
         try:
@@ -83,7 +83,7 @@ class BoolSourceType(ScalarUnion):
 
         check.invariant(len(value) == 1, "Selector should have one entry")
 
-        key, cfg = list(value.items())[0]
+        key, cfg = next(iter(value.items()))
         check.invariant(key == "env", "Only valid key is env")
         value = _ensure_env_variable(cfg)
         try:

--- a/python_modules/dagster/dagster/_config/source.py
+++ b/python_modules/dagster/dagster/_config/source.py
@@ -14,11 +14,9 @@ def _ensure_env_variable(var):
     value = os.getenv(var)
     if value is None:
         raise PostProcessingError(
-            (
-                'You have attempted to fetch the environment variable "{var}" '
-                "which is not set. In order for this execution to succeed it "
-                "must be set in this environment."
-            ).format(var=var)
+            f'You have attempted to fetch the environment variable "{var}" '
+            "which is not set. In order for this execution to succeed it "
+            "must be set in this environment."
         )
     return value
 
@@ -65,9 +63,7 @@ class IntSourceType(ScalarUnion):
             return int(value)
         except ValueError as e:
             raise PostProcessingError(
-                (
-                    'Value "{value}" stored in env variable "{var}" cannot be coerced into an int.'
-                ).format(value=value, var=cfg)
+                f'Value "{value}" stored in env variable "{cfg}" cannot be coerced into an int.'
             ) from e
 
 

--- a/python_modules/dagster/dagster/_core/code_pointer.py
+++ b/python_modules/dagster/dagster/_core/code_pointer.py
@@ -179,11 +179,9 @@ class FileCodePointer(
 
     def describe(self) -> str:
         if self.working_directory:
-            return "{self.python_file}::{self.fn_name} -- [dir {self.working_directory}]".format(
-                self=self
-            )
+            return f"{self.python_file}::{self.fn_name} -- [dir {self.working_directory}]"
         else:
-            return "{self.python_file}::{self.fn_name}".format(self=self)
+            return f"{self.python_file}::{self.fn_name}"
 
 
 def _load_target_from_module(module: ModuleType, fn_name: str, error_suffix: str) -> object:
@@ -227,7 +225,7 @@ class ModuleCodePointer(
         )
 
     def describe(self) -> str:
-        return "from {self.module} import {self.fn_name}".format(self=self)
+        return f"from {self.module} import {self.fn_name}"
 
 
 @whitelist_for_serdes
@@ -253,7 +251,7 @@ class PackageCodePointer(
         )
 
     def describe(self) -> str:
-        return "from {self.module} import {self.attribute}".format(self=self)
+        return f"from {self.module} import {self.attribute}"
 
 
 def get_python_file_from_target(target: object) -> Optional[str]:
@@ -294,9 +292,7 @@ class CustomPointer(
             check.invariant(isinstance(reconstructable_kwarg[0], str), "Bad kwarg key")
             check.invariant(
                 len(reconstructable_kwarg) == 2,
-                "Bad kwarg of length {length}, should be 2".format(
-                    length=len(reconstructable_kwarg)
-                ),
+                f"Bad kwarg of length {len(reconstructable_kwarg)}, should be 2",
             )
 
         return super(CustomPointer, cls).__new__(

--- a/python_modules/dagster/dagster/_core/definitions/composition.py
+++ b/python_modules/dagster/dagster/_core/definitions/composition.py
@@ -246,9 +246,7 @@ class InProgressCompositionContext:
             self._pending_invocations.pop(node_name, None)
             if self._collisions.get(node_name):
                 self._collisions[node_name] += 1
-                node_name = "{node_name}_{n}".format(
-                    node_name=node_name, n=self._collisions[node_name]
-                )
+                node_name = f"{node_name}_{self._collisions[node_name]}"
             else:
                 self._collisions[node_name] = 1
         else:
@@ -314,9 +312,7 @@ class CompleteCompositionContext(NamedTuple):
             def_name = invocation.node_def.name
             if def_name in node_def_dict and node_def_dict[def_name] is not invocation.node_def:
                 raise DagsterInvalidDefinitionError(
-                    'Detected conflicting node definitions with the same name "{name}"'.format(
-                        name=def_name
-                    )
+                    f'Detected conflicting node definitions with the same name "{def_name}"'
                 )
             node_def_dict[def_name] = invocation.node_def
 
@@ -1045,7 +1041,7 @@ def do_composition(
     check.invariant(
         context.name == graph_name,
         "Composition context stack desync: received context for "
-        '"{context.name}" expected "{graph_name}"'.format(context=context, graph_name=graph_name),
+        f'"{context.name}" expected "{graph_name}"',
     )
 
     # line up mappings in definition order
@@ -1057,12 +1053,8 @@ def do_composition(
 
         if len(mappings) == 0:
             raise DagsterInvalidDefinitionError(
-                "{decorator_name} '{graph_name}' has unmapped input '{input_name}'. "
-                "Remove it or pass it to the appropriate op/graph invocation.".format(
-                    decorator_name=decorator_name,
-                    graph_name=graph_name,
-                    input_name=defn.name,
-                )
+                f"{decorator_name} '{graph_name}' has unmapped input '{defn.name}'. "
+                "Remove it or pass it to the appropriate op/graph invocation."
             )
 
         input_mappings += mappings
@@ -1080,10 +1072,8 @@ def do_composition(
                 continue
 
             raise DagsterInvalidDefinitionError(
-                "{decorator_name} '{graph_name}' has unmapped output '{output_name}'. "
-                "Remove it or return a value from the appropriate op/graph invocation.".format(
-                    decorator_name=decorator_name, graph_name=graph_name, output_name=defn.name
-                )
+                f"{decorator_name} '{graph_name}' has unmapped output '{defn.name}'. "
+                "Remove it or return a value from the appropriate op/graph invocation."
             )
         output_mappings.append(mapping)
 

--- a/python_modules/dagster/dagster/_core/definitions/decorators/hook_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/hook_decorator.py
@@ -28,12 +28,10 @@ def _validate_hook_fn_params(fn, expected_positionals):
     missing_positional = validate_expected_params(params, expected_positionals)
     if missing_positional:
         raise DagsterInvalidDefinitionError(
-            "'{hook_name}' decorated function does not have required positional "
-            "parameter '{missing_param}'. Hook functions should only have keyword arguments "
+            f"'{fn.__name__}' decorated function does not have required positional "
+            f"parameter '{missing_positional}'. Hook functions should only have keyword arguments "
             "that match input names and a first positional parameter named 'context' and "
-            "a second positional parameter named 'event_list'.".format(
-                hook_name=fn.__name__, missing_param=missing_positional
-            )
+            "a second positional parameter named 'event_list'."
         )
 
 

--- a/python_modules/dagster/dagster/_core/definitions/decorators/sensor_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/sensor_decorator.py
@@ -181,11 +181,9 @@ def asset_sensor(
 
             elif result is not None:
                 raise DagsterInvariantViolationError(
-                    (
-                        "Error in sensor {sensor_name}: Sensor unexpectedly returned output "
-                        "{result} of type {type_}.  Should only return SkipReason or "
-                        "RunRequest objects."
-                    ).format(sensor_name=sensor_name, result=result, type_=type(result))
+                    f"Error in sensor {sensor_name}: Sensor unexpectedly returned output "
+                    f"{result} of type {type(result)}.  Should only return SkipReason or "
+                    "RunRequest objects."
                 )
 
         # Preserve any resource arguments from the underlying function, for when we inspect the

--- a/python_modules/dagster/dagster/_core/definitions/dependency.py
+++ b/python_modules/dagster/dagster/_core/definitions/dependency.py
@@ -987,7 +987,7 @@ class DependencyStructure:
             raise DagsterInvalidDefinitionError(
                 f"{node_input.node.describe_node()} cannot be both downstream of dynamic output "
                 f"{node_output.describe()} and collect over dynamic output "
-                f"{list(self._collect_index[node_input.node_name])[0].describe()}."
+                f"{next(iter(self._collect_index[node_input.node_name])).describe()}."
             )
 
         if self._dynamic_fan_out_index.get(node_input.node_name) is None:

--- a/python_modules/dagster/dagster/_core/definitions/dependency.py
+++ b/python_modules/dagster/dagster/_core/definitions/dependency.py
@@ -418,9 +418,7 @@ class NodeHandle(NamedTuple("_NodeHandle", [("name", str), ("parent", Optional["
         check.inst_param(ancestor, "ancestor", NodeHandle)
         check.invariant(
             self.is_or_descends_from(ancestor),
-            "Handle {handle} does not descend from {ancestor}".format(
-                handle=self.to_string(), ancestor=ancestor.to_string()
-            ),
+            f"Handle {self.to_string()} does not descend from {ancestor.to_string()}",
         )
 
         return NodeHandle.from_path(self.path[len(ancestor.path) :])
@@ -852,9 +850,7 @@ def _create_handle_dict(
                         handles.append(inner_dep)
                     else:
                         check.failed(
-                            "Unexpected MultiDependencyDefinition dependencies type {}".format(
-                                inner_dep
-                            )
+                            f"Unexpected MultiDependencyDefinition dependencies type {inner_dep}"
                         )
 
                 handle_dict[from_node.get_input(input_name)] = (DependencyType.FAN_IN, handles)

--- a/python_modules/dagster/dagster/_core/definitions/executor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/executor_definition.py
@@ -332,7 +332,7 @@ def _core_multiprocess_executor_creation(config: ExecutorConfig) -> "Multiproces
     start_cfg: Dict[str, object] = {}
     start_selector = check.opt_dict_elem(config, "start_method")
     if start_selector:
-        start_method, start_cfg = list(start_selector.items())[0]
+        start_method, start_cfg = next(iter(start_selector.items()))
 
     return MultiprocessExecutor(
         max_concurrent=check.opt_int_elem(config, "max_concurrent"),

--- a/python_modules/dagster/dagster/_core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/graph_definition.py
@@ -535,8 +535,8 @@ class GraphDefinition(NodeDefinition):
         if not self.has_config_mapping:
             raise DagsterInvalidDefinitionError(
                 "Only graphs utilizing config mapping can be pre-configured. The graph "
-                '"{graph_name}" does not have a config mapping, and thus has nothing to be '
-                "configured.".format(graph_name=self.name)
+                f'"{self.name}" does not have a config mapping, and thus has nothing to be '
+                "configured."
             )
         config_mapping = cast(ConfigMapping, self.config_mapping)
         return self.copy(
@@ -1022,20 +1022,13 @@ def _validate_out_mappings(
             target_node = node_dict.get(mapping.maps_from.node_name)
             if target_node is None:
                 raise DagsterInvalidDefinitionError(
-                    "In {class_name} '{name}' output mapping references node "
-                    "'{node_name}' which it does not contain.".format(
-                        name=name, node_name=mapping.maps_from.node_name, class_name=class_name
-                    )
+                    f"In {class_name} '{name}' output mapping references node "
+                    f"'{mapping.maps_from.node_name}' which it does not contain."
                 )
             if not target_node.has_output(mapping.maps_from.output_name):
                 raise DagsterInvalidDefinitionError(
-                    "In {class_name} {name} output mapping from {described_node} "
-                    "which contains no output named '{mapping.maps_from.output_name}'".format(
-                        described_node=target_node.describe_node(),
-                        name=name,
-                        mapping=mapping,
-                        class_name=class_name,
-                    )
+                    f"In {class_name} {name} output mapping from {target_node.describe_node()} "
+                    f"which contains no output named '{mapping.maps_from.output_name}'"
                 )
 
             target_output = target_node.output_def_named(mapping.maps_from.output_name)
@@ -1049,29 +1042,22 @@ def _validate_out_mappings(
                 and class_name != "GraphDefinition"
             ):
                 raise DagsterInvalidDefinitionError(
-                    "In {class_name} '{name}' output '{mapping.graph_output_name}' of type"
-                    " {mapping.dagster_type.display_name} maps from"
-                    " {mapping.maps_from.node_name}.{mapping.maps_from.output_name} of different"
-                    " type {target_output.dagster_type.display_name}. OutputMapping source and"
-                    " destination must have the same type.".format(
-                        class_name=class_name,
-                        mapping=mapping,
-                        name=name,
-                        target_output=target_output,
-                    )
+                    f"In {class_name} '{name}' output '{mapping.graph_output_name}' of type"
+                    f" {mapping.dagster_type.display_name} maps from"
+                    f" {mapping.maps_from.node_name}.{mapping.maps_from.output_name} of different"
+                    f" type {target_output.dagster_type.display_name}. OutputMapping source and"
+                    " destination must have the same type."
                 )
 
         elif isinstance(mapping, OutputDefinition):
             raise DagsterInvalidDefinitionError(
-                "You passed an OutputDefinition named '{output_name}' directly "
+                f"You passed an OutputDefinition named '{mapping.name}' directly "
                 "in to output_mappings. Return an OutputMapping by calling "
-                "mapping_from on the OutputDefinition.".format(output_name=mapping.name)
+                "mapping_from on the OutputDefinition."
             )
         else:
             raise DagsterInvalidDefinitionError(
-                "Received unexpected type '{type}' in output_mappings. "
-                "Provide an OutputMapping using OutputDefinition(...).mapping_from(...)".format(
-                    type=type(mapping)
-                )
+                f"Received unexpected type '{type(mapping)}' in output_mappings. "
+                "Provide an OutputMapping using OutputDefinition(...).mapping_from(...)"
             )
     return output_mappings, output_defs

--- a/python_modules/dagster/dagster/_core/definitions/input.py
+++ b/python_modules/dagster/dagster/_core/definitions/input.py
@@ -52,16 +52,9 @@ def _check_default_value(input_name: str, dagster_type: DagsterType, default_val
             type_check = dagster_type.type_check_scalar_value(default_value)
             if not type_check.success:
                 raise DagsterInvalidDefinitionError(
-                    (
-                        "Type check failed for the default_value of InputDefinition "
-                        "{input_name} of type {dagster_type}. "
-                        "Received value {value} of type {type}"
-                    ).format(
-                        input_name=input_name,
-                        dagster_type=dagster_type.display_name,
-                        value=default_value,
-                        type=type(default_value),
-                    ),
+                    "Type check failed for the default_value of InputDefinition "
+                    f"{input_name} of type {dagster_type.display_name}. "
+                    f"Received value {default_value} of type {type(default_value)}",
                 )
 
     return default_value

--- a/python_modules/dagster/dagster/_core/definitions/op_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_definition.py
@@ -471,7 +471,7 @@ def _resolve_output_defs_from_outs(
     # If only a single entry has been provided to the out dict, then slurp the
     # annotation into the entry.
     if len(outs) == 1:
-        name = list(outs.keys())[0]
+        name = next(iter(outs.keys()))
         only_out = outs[name]
         return [only_out.to_definition(annotation, name, description, default_code_version)]
 

--- a/python_modules/dagster/dagster/_core/definitions/reconstruct.py
+++ b/python_modules/dagster/dagster/_core/definitions/reconstruct.py
@@ -289,9 +289,7 @@ class ReconstructableJob(
         )
 
     def describe(self) -> str:
-        return '"{name}" in repository ({repo})'.format(
-            repo=self.repository.pointer.describe, name=self.job_name
-        )
+        return f'"{self.job_name}" in repository ({self.repository.pointer.describe})'
 
     @staticmethod
     def for_file(python_file: str, fn_name: str) -> "ReconstructableJob":
@@ -311,9 +309,7 @@ class ReconstructableJob(
         inst = unpack_value(val)
         check.invariant(
             isinstance(inst, ReconstructableJob),
-            "Deserialized object is not instance of ReconstructableJob, got {type}".format(
-                type=type(inst)
-            ),
+            f"Deserialized object is not instance of ReconstructableJob, got {type(inst)}",
         )
         return inst  # type: ignore  # (illegible runtime check)
 
@@ -408,7 +404,7 @@ def reconstructable(target: Callable[..., "JobDefinition"]) -> ReconstructableJo
             )
         raise DagsterInvariantViolationError(
             "Reconstructable target should be a function or definition produced "
-            "by a decorated function, got {type}.".format(type=type(target)),
+            f"by a decorated function, got {type(target)}.",
         )
 
     if seven.is_lambda(target):
@@ -420,12 +416,10 @@ def reconstructable(target: Callable[..., "JobDefinition"]) -> ReconstructableJo
 
     if seven.qualname_differs(target):
         raise DagsterInvariantViolationError(
-            'Reconstructable target "{target.__name__}" has a different '
-            '__qualname__ "{target.__qualname__}" indicating it is not '
+            f'Reconstructable target "{target.__name__}" has a different '
+            f'__qualname__ "{target.__qualname__}" indicating it is not '
             "defined at module scope. Use a function or decorated function "
-            "defined at module scope instead, or use build_reconstructable_job.".format(
-                target=target
-            )
+            "defined at module scope instead, or use build_reconstructable_job."
         )
 
     try:
@@ -659,10 +653,8 @@ def def_from_pointer(
 
     if seven.get_arg_names(target):
         raise DagsterInvariantViolationError(
-            "Error invoking function at {target} with no arguments. "
-            "Reconstructable target must be callable with no arguments".format(
-                target=pointer.describe()
-            )
+            f"Error invoking function at {pointer.describe()} with no arguments. "
+            "Reconstructable target must be callable with no arguments"
         )
 
     return _check_is_loadable(target())
@@ -749,8 +741,8 @@ def repository_def_from_pointer(
     repo_def = repository_def_from_target_def(target, repository_load_data)
     if not repo_def:
         raise DagsterInvariantViolationError(
-            "CodePointer ({str}) must resolve to a "
+            f"CodePointer ({pointer.describe()}) must resolve to a "
             "RepositoryDefinition, JobDefinition, or JobDefinition. "
-            "Received a {type}".format(str=pointer.describe(), type=type(target))
+            f"Received a {type(target)}"
         )
     return repo_def

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/caching_index.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/caching_index.py
@@ -38,13 +38,8 @@ class CacheingDefinitionIndex(Generic[T_RepositoryLevelDefinition]):
         for key, definition in definitions.items():
             check.invariant(
                 isinstance(definition, definition_class) or callable(definition),
-                "Bad definition for {definition_kind} {key}: must be {definition_class_name} or "
-                "callable, got {type_}".format(
-                    definition_kind=definition_kind,
-                    key=key,
-                    definition_class_name=definition_class_name,
-                    type_=type(definition),
-                ),
+                f"Bad definition for {definition_kind} {key}: must be {definition_class_name} or "
+                f"callable, got {type(definition)}",
             )
 
         self._definition_class: Type[T_RepositoryLevelDefinition] = definition_class
@@ -143,22 +138,12 @@ class CacheingDefinitionIndex(Generic[T_RepositoryLevelDefinition]):
     ):
         check.invariant(
             isinstance(definition, self._definition_class),
-            "Bad constructor for {definition_kind} {definition_name}: must return "
-            "{definition_class_name}, got value of type {type_}".format(
-                definition_kind=self._definition_kind,
-                definition_name=definition_dict_key,
-                definition_class_name=self._definition_class_name,
-                type_=type(definition),
-            ),
+            f"Bad constructor for {self._definition_kind} {definition_dict_key}: must return "
+            f"{self._definition_class_name}, got value of type {type(definition)}",
         )
         check.invariant(
             definition.name == definition_dict_key,
-            "Bad constructor for {definition_kind} '{definition_name}': name in "
-            "{definition_class_name} does not match: got '{definition_def_name}'".format(
-                definition_kind=self._definition_kind,
-                definition_name=definition_dict_key,
-                definition_class_name=self._definition_class_name,
-                definition_def_name=definition.name,
-            ),
+            f"Bad constructor for {self._definition_kind} '{definition_dict_key}': name in "
+            f"{self._definition_class_name} does not match: got '{definition.name}'",
         )
         self._definition_cache[definition_dict_key] = self._validation_fn(definition)

--- a/python_modules/dagster/dagster/_core/definitions/run_config.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_config.py
@@ -574,10 +574,8 @@ def construct_config_type_dictionary(
         if name and name in type_dict_by_name:
             if type(config_type) is not type(type_dict_by_name[name]):
                 raise DagsterInvalidDefinitionError(
-                    (
-                        "Type names must be unique. You have constructed two different "
-                        'instances of types with the same name "{name}".'
-                    ).format(name=name)
+                    "Type names must be unique. You have constructed two different "
+                    f'instances of types with the same name "{name}".'
                 )
         elif name:
             type_dict_by_name[name] = config_type

--- a/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
@@ -652,11 +652,7 @@ class ScheduleDefinition(IHasInternalInit):
                     ),
                 ):
                     if not self._should_execute(context):
-                        yield SkipReason(
-                            "should_execute function for {schedule_name} returned false.".format(
-                                schedule_name=name
-                            )
-                        )
+                        yield SkipReason(f"should_execute function for {name} returned false.")
                         return
 
                 with user_code_error_boundary(

--- a/python_modules/dagster/dagster/_core/definitions/utils.py
+++ b/python_modules/dagster/dagster/_core/definitions/utils.py
@@ -113,10 +113,8 @@ def validate_tags(
 
             if not valid:
                 raise DagsterInvalidDefinitionError(
-                    'Invalid value for tag "{key}", {err_reason}. Tag values must be strings '
-                    "or meet the constraint that json.loads(json.dumps(value)) == value.".format(
-                        key=key, err_reason=err_reason
-                    )
+                    f'Invalid value for tag "{key}", {err_reason}. Tag values must be strings '
+                    "or meet the constraint that json.loads(json.dumps(value)) == value."
                 )
 
             valid_tags[key] = str_val  # type: ignore  # (possible none)
@@ -159,9 +157,7 @@ def config_from_files(config_files: Sequence[str]) -> Mapping[str, Any]:
         globbed_files = glob(file_glob)
         if not globbed_files:
             raise DagsterInvariantViolationError(
-                'File or glob pattern "{file_glob}" for "config_files" produced no results.'.format(
-                    file_glob=file_glob
-                )
+                f'File or glob pattern "{file_glob}" for "config_files" produced no results.'
             )
 
         filenames += [os.path.realpath(globbed_file) for globbed_file in globbed_files]

--- a/python_modules/dagster/dagster/_core/errors.py
+++ b/python_modules/dagster/dagster/_core/errors.py
@@ -392,9 +392,9 @@ class DagsterUnknownResourceError(DagsterError, AttributeError):
     def __init__(self, resource_name, *args, **kwargs):
         self.resource_name = check.str_param(resource_name, "resource_name")
         msg = (
-            "Unknown resource `{resource_name}`. Specify `{resource_name}` as a required resource "
+            f"Unknown resource `{resource_name}`. Specify `{resource_name}` as a required resource "
             "on the compute / config function that accessed it."
-        ).format(resource_name=resource_name)
+        )
         super(DagsterUnknownResourceError, self).__init__(msg, *args, **kwargs)
 
 
@@ -421,9 +421,7 @@ class DagsterInvalidConfigError(DagsterError):
 
         for i_error, error in enumerate(self.errors):
             error_messages.append(error.message)
-            error_msg += "\n    Error {i_error}: {error_message}".format(
-                i_error=i_error + 1, error_message=error.message
-            )
+            error_msg += f"\n    Error {i_error + 1}: {error.message}"
 
         self.message = error_msg
         self.error_messages = error_messages

--- a/python_modules/dagster/dagster/_core/events/__init__.py
+++ b/python_modules/dagster/dagster/_core/events/__init__.py
@@ -896,9 +896,7 @@ class DagsterEvent(
         return DagsterEvent.from_step(
             event_type=DagsterEventType.STEP_START,
             step_context=step_context,
-            message='Started execution of step "{step_key}".'.format(
-                step_key=step_context.step.key
-            ),
+            message=f'Started execution of step "{step_context.step.key}".',
         )
 
     @staticmethod
@@ -930,9 +928,7 @@ class DagsterEvent(
         return DagsterEvent.from_step(
             event_type=DagsterEventType.STEP_SKIPPED,
             step_context=step_context,
-            message='Skipped execution of step "{step_key}".'.format(
-                step_key=step_context.step.key
-            ),
+            message=f'Skipped execution of step "{step_context.step.key}".',
         )
 
     @staticmethod
@@ -1203,17 +1199,13 @@ class DagsterEvent(
         step_context: IStepContext, object_store_operation_result: "ObjectStoreOperation"
     ) -> "DagsterEvent":
         object_store_name = (
-            "{object_store_name} ".format(
-                object_store_name=object_store_operation_result.object_store_name
-            )
+            f"{object_store_operation_result.object_store_name} "
             if object_store_operation_result.object_store_name
             else ""
         )
 
         serialization_strategy_modifier = (
-            " using {serialization_strategy_name}".format(
-                serialization_strategy_name=object_store_operation_result.serialization_strategy_name
-            )
+            f" using {object_store_operation_result.serialization_strategy_name}"
             if object_store_operation_result.serialization_strategy_name
             else ""
         )
@@ -1225,24 +1217,16 @@ class DagsterEvent(
             == ObjectStoreOperationType.SET_OBJECT
         ):
             message = (
-                "Stored intermediate object for output {value_name} in "
-                "{object_store_name}object store{serialization_strategy_modifier}."
-            ).format(
-                value_name=value_name,
-                object_store_name=object_store_name,
-                serialization_strategy_modifier=serialization_strategy_modifier,
+                f"Stored intermediate object for output {value_name} in "
+                f"{object_store_name}object store{serialization_strategy_modifier}."
             )
         elif (
             ObjectStoreOperationType(object_store_operation_result.op)
             == ObjectStoreOperationType.GET_OBJECT
         ):
             message = (
-                "Retrieved intermediate object for input {value_name} in "
-                "{object_store_name}object store{serialization_strategy_modifier}."
-            ).format(
-                value_name=value_name,
-                object_store_name=object_store_name,
-                serialization_strategy_modifier=serialization_strategy_modifier,
+                f"Retrieved intermediate object for input {value_name} in "
+                f"{object_store_name}object store{serialization_strategy_modifier}."
             )
         elif (
             ObjectStoreOperationType(object_store_operation_result.op)
@@ -1383,9 +1367,9 @@ class DagsterEvent(
             step_kind_value=step_context.step.kind.value,
             logging_tags=step_context.event_tags,
             message=(
-                'Skipped the execution of hook "{hook_name}". It did not meet its triggering '
-                'condition during the execution of "{solid_name}".'
-            ).format(hook_name=hook_def.name, solid_name=step_context.op.name),
+                f'Skipped the execution of hook "{hook_def.name}". It did not meet its triggering '
+                f'condition during the execution of "{step_context.op.name}".'
+            ),
         )
 
         step_context.log.log_dagster_event(

--- a/python_modules/dagster/dagster/_core/execution/api.py
+++ b/python_modules/dagster/dagster/_core/execution/api.py
@@ -544,9 +544,7 @@ def _reexecute_job(
         parent_dagster_run = execute_instance.get_run_by_id(parent_run_id)
         if parent_dagster_run is None:
             check.failed(
-                "No parent run with id {parent_run_id} found in instance.".format(
-                    parent_run_id=parent_run_id
-                ),
+                f"No parent run with id {parent_run_id} found in instance.",
             )
 
         execution_plan: Optional[ExecutionPlan] = None

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -504,7 +504,7 @@ class OpExecutionContext(AbstractComputeExecutionContext):
             )
         # pass in the output name to handle the case when a multi_asset has a single AssetOut
         return self.asset_key_for_output(
-            output_name=list(self.assets_def.keys_by_output_name.keys())[0]
+            output_name=next(iter(self.assets_def.keys_by_output_name.keys()))
         )
 
     @public

--- a/python_modules/dagster/dagster/_core/execution/plan/active.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/active.py
@@ -161,14 +161,14 @@ class ActiveExecution:
         if len(self._unknown_state) > 0:
             if self._interrupted:
                 raise DagsterExecutionInterruptedError(
-                    "Execution exited with steps {step_list} in an unknown state after "
-                    "being interrupted.".format(step_list=self._unknown_state)
+                    f"Execution exited with steps {self._unknown_state} in an unknown state after "
+                    "being interrupted."
                 )
             else:
                 raise DagsterUnknownStepStateError(
-                    "Execution exited with steps {step_list} in an unknown state to this"
+                    f"Execution exited with steps {self._unknown_state} in an unknown state to this"
                     " process.\nThis was likely caused by losing communication with the process"
-                    " performing step execution.".format(step_list=self._unknown_state)
+                    " performing step execution."
                 )
 
     def _pending_state_str(self) -> str:
@@ -495,9 +495,7 @@ class ActiveExecution:
     def _mark_complete(self, step_key: str) -> None:
         check.invariant(
             step_key in self._in_flight,
-            "Attempted to mark step {} as complete that was not known to be in flight".format(
-                step_key
-            ),
+            f"Attempted to mark step {step_key} as complete that was not known to be in flight",
         )
         self._in_flight.remove(step_key)
 

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
@@ -492,11 +492,7 @@ def core_dagster_event_sequence_for_step(
             elif isinstance(user_event, ExpectationResult):
                 yield DagsterEvent.step_expectation_result(step_context, user_event)
             else:
-                check.failed(
-                    "Unexpected event {event}, should have been caught earlier".format(
-                        event=user_event
-                    )
-                )
+                check.failed(f"Unexpected event {user_event}, should have been caught earlier")
 
     yield DagsterEvent.step_success_event(
         step_context, StepSuccessData(duration_ms=timer_result.millis)

--- a/python_modules/dagster/dagster/_core/execution/plan/external_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/external_step.py
@@ -95,10 +95,7 @@ def _module_in_package_dir(file_path: str, package_dir: str) -> str:
     abs_package_dir = os.path.abspath(package_dir)
     check.invariant(
         os.path.commonprefix([abs_path, abs_package_dir]) == abs_package_dir,
-        "File {abs_path} is not underneath package dir {abs_package_dir}".format(
-            abs_path=abs_path,
-            abs_package_dir=abs_package_dir,
-        ),
+        f"File {abs_path} is not underneath package dir {abs_package_dir}",
     )
 
     relative_path = os.path.relpath(abs_path, abs_package_dir)

--- a/python_modules/dagster/dagster/_core/execution/plan/plan.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/plan.py
@@ -412,13 +412,8 @@ class _PlanBuilder:
 
         # Otherwise we throw an error.
         raise DagsterInvariantViolationError(
-            (
-                "In top-level graph of {described_target}, input {input_name} "
-                "must get a value from the inputs section of its configuration."
-            ).format(
-                described_target=self.job_def.describe_target(),
-                input_name=input_name,
-            )
+            f"In top-level graph of {self.job_def.describe_target()}, input {input_name} "
+            "must get a value from the inputs section of its configuration."
         )
 
 
@@ -537,15 +532,9 @@ def get_step_input_source(
 
     # Otherwise we throw an error.
     raise DagsterInvariantViolationError(
-        (
-            "In {described_target} {described_node}, input {input_name} "
-            "must get a value either (a) from a dependency or (b) from the "
-            "inputs section of its configuration."
-        ).format(
-            described_target=job_def.describe_target(),
-            described_node=node.describe_node(),
-            input_name=input_name,
-        )
+        f"In {job_def.describe_target()} {node.describe_node()}, input {input_name} "
+        "must get a value either (a) from a dependency or (b) from the "
+        "inputs section of its configuration."
     )
 
 

--- a/python_modules/dagster/dagster/_core/execution/plan/step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/step.py
@@ -308,7 +308,7 @@ class UnresolvedMappedExecutionStep(
         # this function will be removed in moving to supporting being downstream of multiple dynamic outputs
         keys = self.resolved_by_step_keys
         check.invariant(len(keys) == 1, "Unresolved step expects one and only one dynamic step key")
-        return list(keys)[0]
+        return next(iter(keys))
 
     @property
     def resolved_by_output_name(self) -> str:
@@ -322,7 +322,7 @@ class UnresolvedMappedExecutionStep(
             len(keys) == 1, "Unresolved step expects one and only one dynamic output name"
         )
 
-        return list(keys)[0]
+        return next(iter(keys))
 
     @property
     def resolved_by_step_keys(self) -> FrozenSet[str]:

--- a/python_modules/dagster/dagster/_core/execution/resources_init.py
+++ b/python_modules/dagster/dagster/_core/execution/resources_init.py
@@ -89,9 +89,7 @@ def ensure_resource_deps_satisfiable(resource_deps: Mapping[str, AbstractSet[str
         for reqd_resource_key in resource_deps[resource_key]:
             if reqd_resource_key in path:
                 raise DagsterInvariantViolationError(
-                    'Resource key "{key}" transitively depends on itself.'.format(
-                        key=reqd_resource_key
-                    )
+                    f'Resource key "{reqd_resource_key}" transitively depends on itself.'
                 )
             if reqd_resource_key not in resource_deps:
                 raise DagsterInvariantViolationError(
@@ -312,9 +310,7 @@ def single_resource_event_generator(
     context: InitResourceContext, resource_name: str, resource_def: ResourceDefinition
 ) -> Generator[InitializedResource, None, None]:
     try:
-        msg_fn = lambda: "Error executing resource_fn on ResourceDefinition {name}".format(
-            name=resource_name
-        )
+        msg_fn = lambda: f"Error executing resource_fn on ResourceDefinition {resource_name}"
         with user_code_error_boundary(
             DagsterResourceFunctionError, msg_fn, log_manager=context.log
         ):

--- a/python_modules/dagster/dagster/_core/executor/multiprocess.py
+++ b/python_modules/dagster/dagster/_core/executor/multiprocess.py
@@ -178,9 +178,7 @@ class MultiprocessExecutor(Executor):
 
         yield DagsterEvent.engine_event(
             plan_context,
-            "Executing steps using multiprocess executor: parent process (pid: {pid})".format(
-                pid=os.getpid()
-            ),
+            f"Executing steps using multiprocess executor: parent process (pid: {os.getpid()})",
             event_specific_data=EngineEventData.multiprocess(
                 os.getpid(), step_keys_to_execute=execution_plan.step_keys_to_execute
             ),

--- a/python_modules/dagster/dagster/_core/host_representation/code_location.py
+++ b/python_modules/dagster/dagster/_core/host_representation/code_location.py
@@ -362,8 +362,8 @@ class InProcessCodeLocation(CodeLocation):
         check.inst_param(selector, "selector", JobSubsetSelector)
         check.invariant(
             selector.location_name == self.name,
-            "PipelineSelector location_name mismatch, got {selector.location_name} expected"
-            " {self.name}".format(self=self, selector=selector),
+            f"PipelineSelector location_name mismatch, got {selector.location_name} expected"
+            f" {self.name}",
         )
 
         from dagster._grpc.impl import get_external_pipeline_subset_result
@@ -766,8 +766,8 @@ class GrpcServerCodeLocation(CodeLocation):
         check.inst_param(selector, "selector", JobSubsetSelector)
         check.invariant(
             selector.location_name == self.name,
-            "PipelineSelector location_name mismatch, got {selector.location_name} expected"
-            " {self.name}".format(self=self, selector=selector),
+            f"PipelineSelector location_name mismatch, got {selector.location_name} expected"
+            f" {self.name}",
         )
 
         external_repository = self.get_repository(selector.repository_name)

--- a/python_modules/dagster/dagster/_core/host_representation/external.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external.py
@@ -763,7 +763,7 @@ class ExternalSensor:
 
     def _get_single_target(self) -> Optional[ExternalTargetData]:
         if self._external_sensor_data.target_dict:
-            return list(self._external_sensor_data.target_dict.values())[0]
+            return next(iter(self._external_sensor_data.target_dict.values()))
         else:
             return None
 

--- a/python_modules/dagster/dagster/_core/host_representation/origin.py
+++ b/python_modules/dagster/dagster/_core/host_representation/origin.py
@@ -50,9 +50,7 @@ def _assign_grpc_location_name(port, socket, host):
     check.opt_str_param(socket, "socket")
     check.str_param(host, "host")
     check.invariant(port or socket)
-    return "grpc:{host}:{socket_or_port}".format(
-        host=host, socket_or_port=(socket if socket else port)
-    )
+    return f"grpc:{host}:{socket if socket else port}"
 
 
 def _assign_loadable_target_origin_name(loadable_target_origin: LoadableTargetOrigin) -> str:
@@ -69,9 +67,7 @@ def _assign_loadable_target_origin_name(loadable_target_origin: LoadableTargetOr
     )
 
     return (
-        "{file_or_module}:{attribute}".format(
-            file_or_module=file_or_module, attribute=loadable_target_origin.attribute
-        )
+        f"{file_or_module}:{loadable_target_origin.attribute}"
         if loadable_target_origin.attribute
         else file_or_module
     )

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -1252,14 +1252,9 @@ class DagsterInstance(DynamicPartitionsStore):
 
         check.invariant(
             execution_plan_snapshot.job_snapshot_id == job_snapshot_id,
-            (
-                "Snapshot mismatch: Snapshot ID in execution plan snapshot is "
-                '"{ep_pipeline_snapshot_id}" and snapshot_id created in memory is '
-                '"{job_snapshot_id}"'
-            ).format(
-                ep_pipeline_snapshot_id=execution_plan_snapshot.job_snapshot_id,
-                job_snapshot_id=job_snapshot_id,
-            ),
+            "Snapshot mismatch: Snapshot ID in execution plan snapshot is "
+            f'"{execution_plan_snapshot.job_snapshot_id}" and snapshot_id created in memory is '
+            f'"{job_snapshot_id}"',
         )
 
         execution_plan_snapshot_id = create_execution_plan_snapshot_id(execution_plan_snapshot)

--- a/python_modules/dagster/dagster/_core/launcher/default_run_launcher.py
+++ b/python_modules/dagster/dagster/_core/launcher/default_run_launcher.py
@@ -210,9 +210,7 @@ class DefaultRunLauncher(RunLauncher, ConfigurableClass):
                 return
 
             if total_time >= timeout:
-                raise Exception(
-                    f"Timed out waiting for these runs to finish: {repr(active_run_ids)}"
-                )
+                raise Exception(f"Timed out waiting for these runs to finish: {active_run_ids!r}")
 
             total_time += interval
             time.sleep(interval)

--- a/python_modules/dagster/dagster/_core/launcher/default_run_launcher.py
+++ b/python_modules/dagster/dagster/_core/launcher/default_run_launcher.py
@@ -211,9 +211,7 @@ class DefaultRunLauncher(RunLauncher, ConfigurableClass):
 
             if total_time >= timeout:
                 raise Exception(
-                    "Timed out waiting for these runs to finish: {active_run_ids}".format(
-                        active_run_ids=repr(active_run_ids)
-                    )
+                    f"Timed out waiting for these runs to finish: {repr(active_run_ids)}"
                 )
 
             total_time += interval

--- a/python_modules/dagster/dagster/_core/selector/subset_selector.py
+++ b/python_modules/dagster/dagster/_core/selector/subset_selector.py
@@ -456,9 +456,7 @@ def parse_step_selection(
         subset = clause_to_subset(graph, clause, lambda x: x)
         if len(subset) == 0:
             raise DagsterInvalidSubsetError(
-                "No qualified steps to execute found for step_selection={requested}".format(
-                    requested=step_selection
-                ),
+                f"No qualified steps to execute found for step_selection={step_selection}",
             )
         steps_set.update(subset)
 

--- a/python_modules/dagster/dagster/_core/snap/dep_snapshot.py
+++ b/python_modules/dagster/dagster/_core/snap/dep_snapshot.py
@@ -144,12 +144,7 @@ class DependencyStructureIndex:
             if input_dep_snap.input_name == input_name:
                 return input_dep_snap.upstream_output_snaps
 
-        check.failed(
-            "Input {input_name} not found for node {node_name}".format(
-                input_name=input_name,
-                node_name=node_name,
-            )
-        )
+        check.failed(f"Input {input_name} not found for node {node_name}")
 
     def get_upstream_output(self, node_name: str, input_name: str) -> "OutputHandleSnap":
         check.str_param(node_name, "node_name")

--- a/python_modules/dagster/dagster/_core/storage/migration/utils.py
+++ b/python_modules/dagster/dagster/_core/storage/migration/utils.py
@@ -49,7 +49,7 @@ def upgrading_instance(instance: DagsterInstance) -> Iterator[None]:
     global _UPGRADING_INSTANCE  # noqa: PLW0603
     check.invariant(_UPGRADING_INSTANCE is None, "update already in progress")
     try:
-        _UPGRADING_INSTANCE = instance  # noqa: PLW0603
+        _UPGRADING_INSTANCE = instance
         yield
     finally:
         _UPGRADING_INSTANCE = None

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -126,9 +126,7 @@ class SqlRunStorage(RunStorage):
 
         if dagster_run.job_snapshot_id and not self.has_job_snapshot(dagster_run.job_snapshot_id):
             raise DagsterSnapshotDoesNotExist(
-                "Snapshot {ss_id} does not exist in run storage".format(
-                    ss_id=dagster_run.job_snapshot_id
-                )
+                f"Snapshot {dagster_run.job_snapshot_id} does not exist in run storage"
             )
 
         has_tags = dagster_run.tags and len(dagster_run.tags) > 0

--- a/python_modules/dagster/dagster/_core/storage/schedules/sql_schedule_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/schedules/sql_schedule_storage.py
@@ -196,9 +196,7 @@ class SqlScheduleStorage(ScheduleStorage):
         check.inst_param(state, "state", InstigatorState)
         if not self.get_instigator_state(state.instigator_origin_id, state.selector_id):
             raise DagsterInvariantViolationError(
-                "InstigatorState {id} is not present in storage".format(
-                    id=state.instigator_origin_id
-                )
+                f"InstigatorState {state.instigator_origin_id} is not present in storage"
             )
 
         values = {

--- a/python_modules/dagster/dagster/_core/storage/tags.py
+++ b/python_modules/dagster/dagster/_core/storage/tags.py
@@ -21,9 +21,7 @@ get_multidimensional_partition_tag = (
 )
 get_dimension_from_partition_tag = lambda tag: tag[len(MULTIDIMENSIONAL_PARTITION_PREFIX) :]
 
-ASSET_PARTITION_RANGE_START_TAG = "{prefix}asset_partition_range_start".format(
-    prefix=SYSTEM_TAG_PREFIX
-)
+ASSET_PARTITION_RANGE_START_TAG = f"{SYSTEM_TAG_PREFIX}asset_partition_range_start"
 
 ASSET_PARTITION_RANGE_END_TAG = f"{SYSTEM_TAG_PREFIX}asset_partition_range_end"
 

--- a/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
@@ -407,10 +407,10 @@ class UPathIOManager(MemoizableIOManager):
             elif len(asset_partition_keys) == 1:
                 paths = self._get_paths_for_partitions(context)
                 check.invariant(len(paths) == 1, f"Expected 1 path, but got {len(paths)}")
-                path = list(paths.values())[0]
+                path = next(iter(paths.values()))
                 backcompat_paths = self._get_multipartition_backcompat_paths(context)
                 backcompat_path = (
-                    None if not backcompat_paths else list(backcompat_paths.values())[0]
+                    None if not backcompat_paths else next(iter(backcompat_paths.values()))
                 )
 
                 return self._load_single_input(path, context, backcompat_path)
@@ -445,7 +445,7 @@ class UPathIOManager(MemoizableIOManager):
                 " backfill with the 'multiple runs' option.",
             )
 
-            path = list(paths.values())[0]
+            path = next(iter(paths.values()))
         else:
             path = self._get_path(context)
         self.make_directory(path.parent)

--- a/python_modules/dagster/dagster/_core/system_config/objects.py
+++ b/python_modules/dagster/dagster/_core/system_config/objects.py
@@ -332,10 +332,8 @@ def config_map_objects(
     check.inst(
         obj_def,
         def_type,
-        (
-            "Could not find a {def_type} definition on the selected mode that matches the "
-            '{def_type} "{obj_name}" given in run config'
-        ).format(def_type=def_type, obj_name=obj_name),
+        f"Could not find a {def_type} definition on the selected mode that matches the "
+        f'{def_type} "{obj_name}" given in run config',
     )
     obj_def = cast(ConfigurableDefinition, obj_def)
 

--- a/python_modules/dagster/dagster/_core/telemetry.py
+++ b/python_modules/dagster/dagster/_core/telemetry.py
@@ -347,9 +347,7 @@ def _check_telemetry_instance_param(
             args[instance_index],  # type: ignore
             "instance",
             DagsterInstance,
-            "'instance' argument at position {position} must be a DagsterInstance".format(
-                position=instance_index
-            ),
+            f"'instance' argument at position {instance_index} must be a DagsterInstance",
         )
 
 

--- a/python_modules/dagster/dagster/_core/types/builtin_config_schemas.py
+++ b/python_modules/dagster/dagster/_core/types/builtin_config_schemas.py
@@ -31,7 +31,7 @@ def define_typed_input_schema_dict(value_config_type):
 
 
 def load_type_input_schema_dict(value):
-    file_type, file_options = list(value.items())[0]
+    file_type, file_options = next(iter(value.items()))
     if file_type == "value":
         return file_options
     elif file_type == "json":

--- a/python_modules/dagster/dagster/_core/types/dagster_type.py
+++ b/python_modules/dagster/dagster/_core/types/dagster_type.py
@@ -172,11 +172,9 @@ class DagsterType(RequiresResources):
 
         if not isinstance(retval, (bool, TypeCheck)):
             raise DagsterInvariantViolationError(
-                (
-                    "You have returned {retval} of type {retval_type} from the type "
-                    'check function of type "{type_key}". Return value must be instance '
-                    "of TypeCheck or a bool."
-                ).format(retval=repr(retval), retval_type=type(retval), type_key=self.key)
+                f"You have returned {repr(retval)} of type {type(retval)} from the type "
+                f'check function of type "{self.key}". Return value must be instance '
+                "of TypeCheck or a bool."
             )
 
         return TypeCheck(success=retval) if isinstance(retval, bool) else retval
@@ -299,17 +297,13 @@ def _validate_type_check_fn(fn: t.Callable, name: t.Optional[str]) -> bool:
         }
         if args[0] not in possible_names:
             DagsterInvalidDefinitionError(
-                'type_check function on type "{name}" must have first '
-                'argument named "context" (or _, _context, context_).'.format(
-                    name=name,
-                )
+                f'type_check function on type "{name}" must have first '
+                'argument named "context" (or _, _context, context_).'
             )
         return True
 
     raise DagsterInvalidDefinitionError(
-        'type_check_fn argument on type "{name}" must take 2 arguments, received {count}.'.format(
-            name=name, count=len(args)
-        )
+        f'type_check_fn argument on type "{name}" must take 2 arguments, received {len(args)}.'
     )
 
 

--- a/python_modules/dagster/dagster/_core/types/dagster_type.py
+++ b/python_modules/dagster/dagster/_core/types/dagster_type.py
@@ -172,7 +172,7 @@ class DagsterType(RequiresResources):
 
         if not isinstance(retval, (bool, TypeCheck)):
             raise DagsterInvariantViolationError(
-                f"You have returned {repr(retval)} of type {type(retval)} from the type "
+                f"You have returned {retval!r} of type {type(retval)} from the type "
                 f'check function of type "{self.key}". Return value must be instance '
                 "of TypeCheck or a bool."
             )

--- a/python_modules/dagster/dagster/_core/types/python_dict.py
+++ b/python_modules/dagster/dagster/_core/types/python_dict.py
@@ -86,9 +86,7 @@ class _TypedPythonDict(DagsterType):
         if not isinstance(value, dict):
             return TypeCheck(
                 success=False,
-                description="Value should be a dict, got a {value_type}".format(
-                    value_type=type(value)
-                ),
+                description=f"Value should be a dict, got a {type(value)}",
             )
 
         for key, value in value.items():
@@ -103,9 +101,7 @@ class _TypedPythonDict(DagsterType):
 
     @property
     def display_name(self):
-        return "Dict[{key},{value}]".format(
-            key=self.key_type.display_name, value=self.value_type.display_name
-        )
+        return f"Dict[{self.key_type.display_name},{self.value_type.display_name}]"
 
     @property
     def inner_types(self):

--- a/python_modules/dagster/dagster/_core/types/python_set.py
+++ b/python_modules/dagster/dagster/_core/types/python_set.py
@@ -48,9 +48,7 @@ class _TypedPythonSet(DagsterType):
         if not isinstance(value, set):
             return TypeCheck(
                 success=False,
-                description="Value should be a set, got a{value_type}".format(
-                    value_type=type(value)
-                ),
+                description=f"Value should be a set, got a{type(value)}",
             )
 
         for item in value:

--- a/python_modules/dagster/dagster/_core/types/python_tuple.py
+++ b/python_modules/dagster/dagster/_core/types/python_tuple.py
@@ -46,9 +46,7 @@ class _TypedPythonTuple(DagsterType):
         if not isinstance(value, tuple):
             return TypeCheck(
                 success=False,
-                description="Value should be a tuple, got a {value_type}".format(
-                    value_type=type(value)
-                ),
+                description=f"Value should be a tuple, got a {type(value)}",
             )
 
         if len(value) != len(self.dagster_types):

--- a/python_modules/dagster/dagster/_core/utility_ops.py
+++ b/python_modules/dagster/dagster/_core/utility_ops.py
@@ -16,7 +16,7 @@ def _compute_fn(
     seen = set()
     for row in inputs.values():
         for item in row:
-            key = list(item.keys())[0]
+            key = next(iter(item.keys()))
             if key not in seen:
                 seen.add(key)
                 passed_rows.append(item)

--- a/python_modules/dagster/dagster/_core/workspace/config_schema.py
+++ b/python_modules/dagster/dagster/_core/workspace/config_schema.py
@@ -32,9 +32,7 @@ def ensure_workspace_config(
     validation_result = process_workspace_config(workspace_config)
     if not validation_result.success:
         raise DagsterInvalidConfigError(
-            "Errors while loading workspace config from {yaml_path}.".format(
-                yaml_path=os.path.abspath(yaml_path)
-            ),
+            f"Errors while loading workspace config from {os.path.abspath(yaml_path)}.",
             validation_result.errors,
             workspace_config,
         )

--- a/python_modules/dagster/dagster/_core/workspace/context.py
+++ b/python_modules/dagster/dagster/_core/workspace/context.py
@@ -607,11 +607,7 @@ class WorkspaceProcessContext(IWorkspaceProcessContext):
 
         except Exception:
             error = serializable_error_info_from_exc_info(sys.exc_info())
-            warnings.warn(
-                "Error loading repository location {location_name}:{error_string}".format(
-                    location_name=location_name, error_string=error.to_string()
-                )
-            )
+            warnings.warn(f"Error loading repository location {location_name}:{error.to_string()}")
 
         return CodeLocationEntry(
             origin=origin,

--- a/python_modules/dagster/dagster/_daemon/auto_run_reexecution/event_log_consumer.py
+++ b/python_modules/dagster/dagster/_daemon/auto_run_reexecution/event_log_consumer.py
@@ -86,9 +86,7 @@ class EventLogConsumerDaemon(IntervalDaemon):
                     yield from fn(workspace_process_context, run_records)
                 except Exception:
                     self._logger.exception(
-                        "Error calling event event log consumer handler: {handler_fn}".format(
-                            handler_fn=fn.__name__,
-                        )
+                        f"Error calling event event log consumer handler: {fn.__name__}"
                     )
 
         # persist cursors now that we've processed all the events through the handlers
@@ -186,9 +184,7 @@ def get_new_cursor(
 
     check.invariant(
         max_new_event_id > persisted_cursor,
-        "The new cursor {} should be greater than the previous {}".format(
-            max_new_event_id, persisted_cursor
-        ),
+        f"The new cursor {max_new_event_id} should be greater than the previous {persisted_cursor}",
     )
 
     num_new_events = len(new_event_ids)

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -630,11 +630,7 @@ def _submit_run_request(
     try:
         logger.info(f"Launching run for {external_sensor.name}")
         instance.submit_run(run.run_id, workspace_process_context.create_request_context())
-        logger.info(
-            "Completed launch of run {run_id} for {sensor_name}".format(
-                run_id=run.run_id, sensor_name=external_sensor.name
-            )
-        )
+        logger.info(f"Completed launch of run {run.run_id} for {external_sensor.name}")
     except Exception:
         error_info = serializable_error_info_from_exc_info(sys.exc_info())
         logger.error(f"Run {run.run_id} created successfully but failed to launch: {error_info}")

--- a/python_modules/dagster/dagster/_grpc/impl.py
+++ b/python_modules/dagster/dagster/_grpc/impl.py
@@ -205,9 +205,7 @@ def _run_in_subprocess(
         serializable_error_info = serializable_error_info_from_exc_info(sys.exc_info())
         event = IPCErrorMessage(
             serializable_error_info=serializable_error_info,
-            message="Error during RPC setup for executing run: {message}".format(
-                message=serializable_error_info.message
-            ),
+            message=f"Error during RPC setup for executing run: {serializable_error_info.message}",
         )
         subprocess_status_handler(event)
         subprocess_status_handler(RunInSubprocessComplete())
@@ -321,8 +319,7 @@ def get_external_schedule_execution(
             with user_code_error_boundary(
                 ScheduleExecutionError,
                 lambda: (
-                    "Error occurred during the execution function for schedule {schedule_name}"
-                    .format(schedule_name=schedule_def.name)
+                    f"Error occurred during the execution function for schedule {schedule_def.name}"
                 ),
             ):
                 return schedule_def.evaluate_tick(schedule_context)

--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -871,11 +871,8 @@ class DagsterApiServer(DagsterApiServicer):
                     # subprocess died unexpectedly
                     success = False
                     message = (
-                        "GRPC server: Subprocess for {run_id} terminated unexpectedly with "
-                        "exit code {exit_code}".format(
-                            run_id=run_id,
-                            exit_code=execution_process.exitcode,
-                        )
+                        f"GRPC server: Subprocess for {run_id} terminated unexpectedly with "
+                        f"exit code {execution_process.exitcode}"
                     )
                     serializable_error_info = serializable_error_info_from_exc_info(sys.exc_info())
             else:

--- a/python_modules/dagster/dagster/_serdes/ipc.py
+++ b/python_modules/dagster/dagster/_serdes/ipc.py
@@ -144,9 +144,7 @@ def _poll_process(ipc_process: "Optional[Popen[bytes]]") -> None:
         return
     if ipc_process.poll() is not None:
         raise DagsterIPCProtocolError(
-            "Process exited with return code {return_code} while waiting for events".format(
-                return_code=ipc_process.returncode
-            )
+            f"Process exited with return code {ipc_process.returncode} while waiting for events"
         )
 
 
@@ -163,9 +161,7 @@ def ipc_read_event_stream(
 
     if not os.path.exists(file_path):
         raise DagsterIPCProtocolError(
-            "Timeout: read stream has not received any data in {timeout} seconds".format(
-                timeout=timeout
-            )
+            f"Timeout: read stream has not received any data in {timeout} seconds"
         )
 
     with open(os.path.abspath(file_path), "r", encoding="utf8") as file_pointer:
@@ -179,8 +175,8 @@ def ipc_read_event_stream(
         # Process start message
         if not isinstance(message, IPCStartMessage):
             raise DagsterIPCProtocolError(
-                "Attempted to read stream at file {file_path}, but first message was not an "
-                "IPCStartMessage".format(file_path=file_path)
+                f"Attempted to read stream at file {file_path}, but first message was not an "
+                "IPCStartMessage"
             )
 
         message = _process_line(file_pointer)

--- a/python_modules/dagster/dagster/_serdes/serdes.py
+++ b/python_modules/dagster/dagster/_serdes/serdes.py
@@ -955,8 +955,8 @@ def _check_serdes_tuple_class_invariants(klass: Type[NamedTuple]) -> None:
                 "in the named tuple that are not present as parameters to the "
                 "to the __new__ method. In order for "
                 "both serdes serialization and pickling to work, "
-                "these must match. Missing: {missing_fields}"
-            ).format(missing_fields=repr(list(klass._fields[index:])))
+                f"these must match. Missing: {repr(list(klass._fields[index:]))}"
+            )
 
             raise SerdesUsageError(_with_header(error_msg))
 
@@ -964,9 +964,9 @@ def _check_serdes_tuple_class_invariants(klass: Type[NamedTuple]) -> None:
         if value_param.name != field:
             error_msg = (
                 "Params to __new__ must match the order of field declaration in the namedtuple. "
-                'Declared field number {one_based_index} in the namedtuple is "{field_name}". '
-                'Parameter {one_based_index} in __new__ method is "{param_name}".'
-            ).format(one_based_index=index + 1, field_name=field, param_name=value_param.name)
+                f'Declared field number {index + 1} in the namedtuple is "{field}". '
+                f'Parameter {index + 1} in __new__ method is "{value_param.name}".'
+            )
             raise SerdesUsageError(_with_header(error_msg))
 
     if len(value_params) > len(klass._fields):

--- a/python_modules/dagster/dagster/_serdes/serdes.py
+++ b/python_modules/dagster/dagster/_serdes/serdes.py
@@ -372,7 +372,7 @@ class UnpackContext:
             for inner in obj:
                 self.clear_ignored_unknown_values(inner)
         elif isinstance(obj, dict):
-            for k, v in obj.items():
+            for v in obj.values():
                 self.clear_ignored_unknown_values(v)
 
         return obj

--- a/python_modules/dagster/dagster/_serdes/serdes.py
+++ b/python_modules/dagster/dagster/_serdes/serdes.py
@@ -955,7 +955,7 @@ def _check_serdes_tuple_class_invariants(klass: Type[NamedTuple]) -> None:
                 "in the named tuple that are not present as parameters to the "
                 "to the __new__ method. In order for "
                 "both serdes serialization and pickling to work, "
-                f"these must match. Missing: {repr(list(klass._fields[index:]))}"
+                f"these must match. Missing: {list(klass._fields[index:])!r}"
             )
 
             raise SerdesUsageError(_with_header(error_msg))

--- a/python_modules/dagster/dagster/_seven/__init__.py
+++ b/python_modules/dagster/dagster/_seven/__init__.py
@@ -33,8 +33,7 @@ def import_module_from_path(module_name: str, path_to_file: str) -> ModuleType:
     spec = importlib.util.spec_from_file_location(module_name, path_to_file)
     if spec is None:
         raise Exception(
-            "Can not import module {module_name} from path {path_to_file}, unable to load spec."
-            .format(module_name=module_name, path_to_file=path_to_file)
+            f"Can not import module {module_name} from path {path_to_file}, unable to load spec."
         )
 
     if sys.modules.get(spec.name) and spec.origin:

--- a/python_modules/dagster/dagster/_utils/__init__.py
+++ b/python_modules/dagster/dagster/_utils/__init__.py
@@ -182,7 +182,7 @@ def camelcase(string: str) -> str:
 def ensure_single_item(ddict: Mapping[T, U]) -> Tuple[T, U]:
     check.mapping_param(ddict, "ddict")
     check.param_invariant(len(ddict) == 1, "ddict", "Expected dict with single item")
-    return list(ddict.items())[0]
+    return next(iter(ddict.items()))
 
 
 @contextlib.contextmanager

--- a/python_modules/dagster/dagster/_utils/dagster_type.py
+++ b/python_modules/dagster/dagster/_utils/dagster_type.py
@@ -33,10 +33,8 @@ def check_dagster_type(dagster_type: Any, value: Any) -> TypeCheck:
     """
     if is_typing_type(dagster_type):
         raise DagsterInvariantViolationError(
-            (
-                "Must pass in a type from dagster module. You passed {dagster_type} "
-                "which is part of python's typing module."
-            ).format(dagster_type=dagster_type)
+            f"Must pass in a type from dagster module. You passed {dagster_type} "
+            "which is part of python's typing module."
         )
 
     dagster_type = resolve_dagster_type(dagster_type)

--- a/python_modules/dagster/dagster/_utils/error.py
+++ b/python_modules/dagster/dagster/_utils/error.py
@@ -54,9 +54,7 @@ class SerializableErrorInfo(
             else ""
         )
 
-        return "{err.message}{stack}{cause}{context}".format(
-            err=self, stack=stack_str, cause=cause_str, context=context_str
-        )
+        return f"{self.message}{stack_str}{cause_str}{context_str}"
 
     def to_exception_message_only(self) -> "SerializableErrorInfo":
         """Return a new SerializableErrorInfo with only the message and cause set.

--- a/python_modules/dagster/dagster/_utils/test/__init__.py
+++ b/python_modules/dagster/dagster/_utils/test/__init__.py
@@ -113,18 +113,14 @@ def build_job_with_input_stubs(
     for node_name, input_dict in inputs.items():
         if not job_def.has_node_named(node_name):
             raise DagsterInvariantViolationError(
-                (
-                    "You are injecting an input value for node {node_name} "
-                    "into pipeline {job_name} but that node was not found"
-                ).format(node_name=node_name, job_name=job_def.name)
+                f"You are injecting an input value for node {node_name} "
+                f"into pipeline {job_def.name} but that node was not found"
             )
 
         node = job_def.get_node_named(node_name)
         for input_name, input_value in input_dict.items():
             stub_node_def = create_stub_op(
-                "__stub_{node_name}_{input_name}".format(
-                    node_name=node_name, input_name=input_name
-                ),
+                f"__stub_{node_name}_{input_name}",
                 input_value,
             )
             stub_node_defs.append(stub_node_def)

--- a/python_modules/dagster/dagster/_utils/warnings.py
+++ b/python_modules/dagster/dagster/_utils/warnings.py
@@ -46,11 +46,7 @@ def normalize_renamed_param(
     check.str_param(old_arg, "old_arg")
     check.opt_callable_param(coerce_old_to_new, "coerce_old_to_new")
     if new_val is not None and old_val is not None:
-        check.failed(
-            'Do not use deprecated "{old_arg}" now that you are using "{new_arg}".'.format(
-                old_arg=old_arg, new_arg=new_arg
-            )
-        )
+        check.failed(f'Do not use deprecated "{old_arg}" now that you are using "{new_arg}".')
     elif old_val is not None:
         return coerce_old_to_new(old_val) if coerce_old_to_new else old_val
     else:

--- a/python_modules/dagster/dagster/_utils/yaml_utils.py
+++ b/python_modules/dagster/dagster/_utils/yaml_utils.py
@@ -98,10 +98,8 @@ def merge_yamls(
             merged = deep_merge_dicts(merged, yaml_dict)
         else:
             check.failed(
-                (
-                    "Expected YAML from file {yaml_file} to parse to dictionary, "
-                    'instead got: "{yaml_dict}"'
-                ).format(yaml_file=yaml_file, yaml_dict=yaml_dict)
+                f"Expected YAML from file {yaml_file} to parse to dictionary, "
+                f'instead got: "{yaml_dict}"'
             )
     return merged
 

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_launch_run.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_launch_run.py
@@ -140,9 +140,7 @@ def test_launch_unloadable_run_grpc():
 
                 assert not res.success
                 assert (
-                    "gRPC server could not load run {run_id} in order to execute it. "
-                    "Make sure that the gRPC server has access to your run storage.".format(
-                        run_id=run_id
-                    )
+                    f"gRPC server could not load run {run_id} in order to execute it. "
+                    "Make sure that the gRPC server has access to your run storage."
                     in res.serializable_error_info.message
                 )

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -578,10 +578,10 @@ def test_multiple_assets_io_manager_defs():
 
     assert num_times[0] == 2
 
-    the_asset_key = [key for key in io_manager_inst.values.keys() if key[1] == "the_asset"][0]
+    the_asset_key = next(key for key in io_manager_inst.values.keys() if key[1] == "the_asset")
     assert io_manager_inst.values[the_asset_key] == 5
 
-    other_asset_key = [key for key in io_manager_inst.values.keys() if key[1] == "other_asset"][0]
+    other_asset_key = next(key for key in io_manager_inst.values.keys() if key[1] == "other_asset")
     assert io_manager_inst.values[other_asset_key] == 6
 
 
@@ -598,7 +598,7 @@ def test_asset_with_io_manager_key_only():
 
     materialize([the_asset], resources={"the_key": the_io_manager})
 
-    assert list(io_manager_inst.values.values())[0] == 5
+    assert next(iter(io_manager_inst.values.values())) == 5
 
 
 def test_asset_both_io_manager_args_provided():

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_external_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_external_asset_graph.py
@@ -244,9 +244,9 @@ def test_get_implicit_job_name_for_assets():
 
     partitioned_defs_workspace = make_context(["partitioned_defs"])
     asset_graph = ExternalAssetGraph.from_workspace(partitioned_defs_workspace)
-    external_repo = list(partitioned_defs_workspace.code_locations[0].get_repositories().values())[
-        0
-    ]
+    external_repo = next(
+        iter(partitioned_defs_workspace.code_locations[0].get_repositories().values())
+    )
     assert (
         asset_graph.get_implicit_job_name_for_assets(
             [downstream_of_partitioned_source.key], external_repo=external_repo

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_cli_commands.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_cli_commands.py
@@ -892,16 +892,9 @@ def runner_job_execute(runner, cli_args):
     if result.exit_code != 0:
         # CliRunner captures stdout so printing it out here
         raise Exception(
-            (
-                "dagster job execute commands with cli_args {cli_args} "
-                'returned exit_code {exit_code} with stdout:\n"{stdout}" and '
-                '\nresult as string: "{result}"'
-            ).format(
-                cli_args=cli_args,
-                exit_code=result.exit_code,
-                stdout=result.stdout,
-                result=result,
-            )
+            f"dagster job execute commands with cli_args {cli_args} "
+            f'returned exit_code {result.exit_code} with stdout:\n"{result.stdout}" and '
+            f'\nresult as string: "{result}"'
         )
     return result
 

--- a/python_modules/dagster/dagster_tests/cli_tests/test_api_commands.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/test_api_commands.py
@@ -20,18 +20,10 @@ def runner_execute_run(runner, cli_args):
     if result.exit_code != 0:
         # CliRunner captures stdout so printing it out here
         raise Exception(
-            (
-                "dagster runner_execute_run commands with cli_args {cli_args} "
-                'returned exit_code {exit_code} with stdout:\n"{stdout}"'
-                '\n exception: "\n{exception}"'
-                '\n and result as string: "{result}"'
-            ).format(
-                cli_args=cli_args,
-                exit_code=result.exit_code,
-                stdout=result.stdout,
-                exception=result.exception,
-                result=result,
-            )
+            f"dagster runner_execute_run commands with cli_args {cli_args} "
+            f'returned exit_code {result.exit_code} with stdout:\n"{result.stdout}"'
+            f'\n exception: "\n{result.exception}"'
+            f'\n and result as string: "{result}"'
         )
     return result
 
@@ -289,18 +281,10 @@ def runner_execute_step(runner, cli_args, env=None):
     if result.exit_code != 0:
         # CliRunner captures stdout so printing it out here
         raise Exception(
-            (
-                "dagster runner_execute_step commands with cli_args {cli_args} "
-                'returned exit_code {exit_code} with stdout:\n"{stdout}"'
-                '\n exception: "\n{exception}"'
-                '\n and result as string: "{result}"'
-            ).format(
-                cli_args=cli_args,
-                exit_code=result.exit_code,
-                stdout=result.stdout,
-                exception=result.exception,
-                result=result,
-            )
+            f"dagster runner_execute_step commands with cli_args {cli_args} "
+            f'returned exit_code {result.exit_code} with stdout:\n"{result.stdout}"'
+            f'\n exception: "\n{result.exception}"'
+            f'\n and result as string: "{result}"'
         )
     return result
 

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/multi_location/test_multi_location_workspace.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/multi_location/test_multi_location_workspace.py
@@ -94,7 +94,7 @@ def test_multi_file_extend_and_override_workspace(instance):
 
 
 def _get_multi_location_workspace_yaml(executable):
-    return """
+    return f"""
 load_from:
     - python_file:
         executable_path: {executable}
@@ -128,7 +128,7 @@ load_from:
         attribute: named_hello_world_repository
         location_name: named_loaded_from_file_attribute
 
-    """.format(executable=executable)
+    """
 
 
 @pytest.mark.parametrize(

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/test_grpc_server_workspace.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/test_grpc_server_workspace.py
@@ -135,7 +135,7 @@ load_from:
             # fake out as if it were loaded by a yaml file in this directory
             file_relative_path(__file__, "not_a_real.yaml"),
         )
-        origin = list(origins.values())[0]
+        origin = next(iter(origins.values()))
         assert origin.use_ssl
 
         # Actually connecting to the server will fail since it's expecting SSL

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/test_grpc_server_workspace.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/test_grpc_server_workspace.py
@@ -30,15 +30,15 @@ def test_grpc_socket_workspace(instance):
             second_server = second_server_process.create_client()
             first_socket = first_server.socket
             second_socket = second_server.socket
-            workspace_yaml = """
+            workspace_yaml = f"""
 load_from:
 - grpc_server:
     host: localhost
-    socket: {socket_one}
+    socket: {first_socket}
 - grpc_server:
-    socket: {socket_two}
+    socket: {second_socket}
     location_name: 'local_port_default_host'
-                """.format(socket_one=first_socket, socket_two=second_socket)
+                """
 
             origins = location_origins_from_config(
                 yaml.safe_load(workspace_yaml),
@@ -158,15 +158,15 @@ def test_grpc_server_workspace(instance):
             second_server = second_server_process.create_client()
             first_port = first_server.port
             second_port = second_server.port
-            workspace_yaml = """
+            workspace_yaml = f"""
 load_from:
 - grpc_server:
     host: localhost
-    port: {port_one}
+    port: {first_port}
 - grpc_server:
-    port: {port_two}
+    port: {second_port}
     location_name: 'local_port_default_host'
-                """.format(port_one=first_port, port_two=second_port)
+                """
 
             origins = location_origins_from_config(
                 yaml.safe_load(workspace_yaml),

--- a/python_modules/dagster/dagster_tests/core_tests/config_types_tests/evaluator_tests/test_evaluator.py
+++ b/python_modules/dagster/dagster_tests/core_tests/config_types_tests/evaluator_tests/test_evaluator.py
@@ -194,11 +194,11 @@ def test_nested_missing_and_not_defined():
     assert not result.success
     assert len(result.errors) == 2
 
-    fields_error = [
+    fields_error = next(
         error
         for error in result.errors
         if error.reason == DagsterEvaluationErrorReason.MISSING_REQUIRED_FIELDS
-    ][0]
+    )
 
     assert fields_error.reason == DagsterEvaluationErrorReason.MISSING_REQUIRED_FIELDS
     assert fields_error.error_data.field_names == ["bool_field", "string_field"]

--- a/python_modules/dagster/dagster_tests/core_tests/config_types_tests/evaluator_tests/test_validate.py
+++ b/python_modules/dagster/dagster_tests/core_tests/config_types_tests/evaluator_tests/test_validate.py
@@ -156,11 +156,11 @@ def test_nested_missing_and_not_defined():
     assert not result.success
     assert len(result.errors) == 2
 
-    fields_error = [
+    fields_error = next(
         error
         for error in result.errors
         if error.reason == DagsterEvaluationErrorReason.MISSING_REQUIRED_FIELDS
-    ][0]
+    )
 
     assert fields_error.reason == DagsterEvaluationErrorReason.MISSING_REQUIRED_FIELDS
     assert fields_error.error_data.field_names == ["bool_field", "string_field"]

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_with_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_with_resources.py
@@ -56,7 +56,7 @@ def test_assets_direct():
     assert transformed_asset.node_def.output_defs[0].io_manager_key == "io_manager"
 
     assert build_assets_job("the_job", [transformed_asset]).execute_in_process().success
-    assert list(in_mem.values.values())[0] == 5
+    assert next(iter(in_mem.values.values())) == 5
 
 
 def test_asset_requires_io_manager_key():
@@ -77,7 +77,7 @@ def test_asset_requires_io_manager_key():
     assert isinstance(transformed_asset, AssetsDefinition)
 
     assert build_assets_job("the_job", [transformed_asset]).execute_in_process().success
-    assert list(in_mem.values.values())[0] == 5
+    assert next(iter(in_mem.values.values())) == 5
 
 
 def test_assets_direct_resource_conflicts():

--- a/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_types.py
+++ b/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_types.py
@@ -394,9 +394,7 @@ def define_custom_dict(name, permitted_key_names):
         if not isinstance(value, dict):
             return TypeCheck(
                 False,
-                description="Value {value} should be of type {type_name}.".format(
-                    value=value, type_name=name
-                ),
+                description=f"Value {value} should be of type {name}.",
             )
         for key in value:
             if key not in permitted_key_names:

--- a/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_types.py
+++ b/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_types.py
@@ -137,13 +137,13 @@ def execute_no_throw(job_def):
 
 def _type_check_data_for_input(result, op_name, input_name):
     events_for_op = result.events_for_node(op_name)
-    step_input_event = [
+    step_input_event = next(
         event
         for event in events_for_op
         if event.event_type == DagsterEventType.STEP_INPUT
         and event.step_handle.to_key() == op_name
         and event.event_specific_data.input_name == input_name
-    ][0]
+    )
     return step_input_event.event_specific_data.type_check_data
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/selector_tests/test_execute.py
+++ b/python_modules/dagster/dagster_tests/core_tests/selector_tests/test_execute.py
@@ -133,11 +133,7 @@ def test_execute_job_with_op_selection_invalid():
     with instance_for_test() as instance:
         with pytest.raises(
             DagsterInvalidSubsetError,
-            match=re.escape(
-                "No qualified ops to execute found for op_selection={input}".format(
-                    input=invalid_input
-                )
-            ),
+            match=re.escape(f"No qualified ops to execute found for op_selection={invalid_input}"),
         ):
             execute_job(reconstructable(foo_job), op_selection=invalid_input, instance=instance)
 

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_active_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_active_data.py
@@ -91,7 +91,7 @@ def test_external_repo_shared_index(snapshot_mock):
 
             def _fetch_snap_id():
                 location = workspace.code_locations[0]
-                ex_repo = list(location.get_repositories().values())[0]
+                ex_repo = next(iter(location.get_repositories().values()))
                 return ex_repo.get_all_external_jobs()[0].identifying_job_snapshot_id
 
             _fetch_snap_id()
@@ -113,7 +113,7 @@ def test_external_repo_shared_index_threaded(snapshot_mock):
 
             def _fetch_snap_id():
                 location = workspace.code_locations[0]
-                ex_repo = list(location.get_repositories().values())[0]
+                ex_repo = next(iter(location.get_repositories().values()))
                 return ex_repo.get_all_external_jobs()[0].identifying_job_snapshot_id
 
             with ThreadPoolExecutor() as executor:

--- a/python_modules/dagster/dagster_tests/core_tests/test_data_time.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_data_time.py
@@ -197,16 +197,18 @@ def _get_record(instance):
         instance=instance,
     )
     assert result.success
-    return list(
-        instance.get_event_records(
-            EventRecordsFilter(
-                event_type=DagsterEventType.ASSET_MATERIALIZATION,
-                asset_key=AssetKey("unpartitioned_asset"),
-            ),
-            ascending=False,
-            limit=1,
+    return next(
+        iter(
+            instance.get_event_records(
+                EventRecordsFilter(
+                    event_type=DagsterEventType.ASSET_MATERIALIZATION,
+                    asset_key=AssetKey("unpartitioned_asset"),
+                ),
+                ascending=False,
+                limit=1,
+            )
         )
-    )[0]
+    )
 
 
 class PartitionedDataTimeScenario(NamedTuple):

--- a/python_modules/dagster/dagster_tests/core_tests/test_job_execution.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_job_execution.py
@@ -52,7 +52,7 @@ from dagster._core.workspace.load import location_origin_from_python_file
 
 def _default_passthrough_compute_fn(*args, **kwargs):
     check.invariant(not args, "There should be no positional args")
-    return list(kwargs.values())[0]
+    return next(iter(kwargs.values()))
 
 
 def create_dep_input_fn(name):
@@ -65,7 +65,7 @@ def make_compute_fn():
         seen = set()
         for row in inputs.values():
             for item in row:
-                key = list(item.keys())[0]
+                key = next(iter(item.keys()))
                 if key not in seen:
                     seen.add(key)
                     passed_rows.append(item)

--- a/python_modules/dagster/dagster_tests/core_tests/test_op_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_op_invocation.py
@@ -545,7 +545,7 @@ def test_optional_output_yielded():
     def op_multiple_outputs_not_sent():
         yield Output(2, output_name="2")
 
-    assert list(op_multiple_outputs_not_sent())[0].value == 2
+    assert next(iter(op_multiple_outputs_not_sent())).value == 2
 
 
 def test_optional_output_yielded_async():

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_pythonic_resources.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_pythonic_resources.py
@@ -114,7 +114,7 @@ is_in_cm = False
 @contextmanager
 def my_cm_resource(_) -> Iterator[str]:
     global is_in_cm  # noqa: PLW0603
-    is_in_cm = True  # noqa: PLW0603
+    is_in_cm = True
     yield "foo"
     is_in_cm = False
 

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_run_status_sensors.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_run_status_sensors.py
@@ -730,7 +730,7 @@ def test_cross_code_location_run_status_sensor(executor: Optional[ThreadPoolExec
 
             instance.submit_run(dagster_run.run_id, workspace_context.create_request_context())
             wait_for_all_runs_to_finish(instance)
-            dagster_run = list(instance.get_runs())[0]
+            dagster_run = next(iter(instance.get_runs()))
             assert dagster_run.status == DagsterRunStatus.SUCCESS
             freeze_datetime = freeze_datetime.add(seconds=60)
 
@@ -827,7 +827,7 @@ def test_cross_code_location_job_selector_on_defs_run_status_sensor(
 
             instance.submit_run(dagster_run.run_id, workspace_context.create_request_context())
             wait_for_all_runs_to_finish(instance)
-            dagster_run = list(instance.get_runs())[0]
+            dagster_run = next(iter(instance.get_runs()))
             assert dagster_run.status == DagsterRunStatus.SUCCESS
             freeze_datetime = freeze_datetime.add(seconds=60)
 
@@ -874,7 +874,7 @@ def test_cross_code_location_job_selector_on_defs_run_status_sensor(
 
             instance.submit_run(dagster_run.run_id, workspace_context.create_request_context())
             wait_for_all_runs_to_finish(instance)
-            dagster_run = list(instance.get_runs())[0]
+            dagster_run = next(iter(instance.get_runs()))
             assert dagster_run.status == DagsterRunStatus.SUCCESS
             freeze_datetime = freeze_datetime.add(seconds=60)
 

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -934,7 +934,7 @@ def test_backfill_from_failure_for_subselection(
 
     assert instance.get_runs_count() == 1
     wait_for_all_runs_to_finish(instance)
-    run = list(instance.get_runs())[0]
+    run = next(iter(instance.get_runs()))
     assert run.status == DagsterRunStatus.FAILURE
 
     external_partition_set = external_repo.get_external_partition_set(
@@ -956,7 +956,7 @@ def test_backfill_from_failure_for_subselection(
 
     list(execute_backfill_iteration(workspace_context, get_default_daemon_logger("BackfillDaemon")))
     assert instance.get_runs_count() == 2
-    child_run = list(instance.get_runs(limit=1))[0]
+    child_run = next(iter(instance.get_runs(limit=1)))
     assert child_run.resolved_op_selection == run.resolved_op_selection
     assert child_run.op_selection == run.op_selection
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_op.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_op.py
@@ -778,7 +778,7 @@ def test_type_annotations_with_generator():
     def my_op_yields_output() -> Generator[Output, None, None]:
         yield Output(5)
 
-    assert list(my_op_yields_output())[0].value == 5
+    assert next(iter(my_op_yields_output())).value == 5
     result = execute_op_in_graph(my_op_yields_output)
     assert result.output_for_node("my_op_yields_output") == 5
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_composition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_composition.py
@@ -817,7 +817,7 @@ def test_tags():
         emit.tag({"invoke": "2"})()
 
     plan = create_execution_plan(tag)
-    step = list(plan.step_dict.values())[0]
+    step = next(iter(plan.step_dict.values()))
     assert step.tags == {"def": "1", "invoke": "2"}
 
 
@@ -844,7 +844,7 @@ def test_tag_subset():
         emit.tag({"invoke": "2"})()
 
     plan = create_execution_plan(tag.get_subset(op_selection=["emit"]))
-    step = list(plan.step_dict.values())[0]
+    step = next(iter(plan.step_dict.values()))
     assert step.tags == {"def": "1", "invoke": "2"}
 
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
@@ -1550,9 +1550,13 @@ def test_build_multi_asset_sensor_context_asset_selection_set_to_latest_material
 
     with instance_for_test() as instance:
         result = materialize([my_asset], instance=instance)
-        records = list(
-            instance.get_event_records(EventRecordsFilter(DagsterEventType.ASSET_MATERIALIZATION))
-        )[0]
+        records = next(
+            iter(
+                instance.get_event_records(
+                    EventRecordsFilter(DagsterEventType.ASSET_MATERIALIZATION)
+                )
+            )
+        )
         assert records.event_log_entry.run_id == result.run_id
 
         ctx = build_multi_asset_sensor_context(
@@ -1595,9 +1599,13 @@ def test_build_multi_asset_sensor_context_set_to_latest_materializations():
 
     with instance_for_test() as instance:
         result = materialize([my_asset], instance=instance)
-        records = list(
-            instance.get_event_records(EventRecordsFilter(DagsterEventType.ASSET_MATERIALIZATION))
-        )[0]
+        records = next(
+            iter(
+                instance.get_event_records(
+                    EventRecordsFilter(DagsterEventType.ASSET_MATERIALIZATION)
+                )
+            )
+        )
         assert records.event_log_entry.run_id == result.run_id
 
         ctx = build_multi_asset_sensor_context(

--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_child_process_executor.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_child_process_executor.py
@@ -35,7 +35,7 @@ class ThrowAnErrorCommand(ChildProcessCommand):
 class CrashyCommand(ChildProcessCommand):
     def execute(self):
         # access inner API to simulate hard crash
-        os._exit(1)  # noqa: SLF001
+        os._exit(1)
 
 
 class SegfaultCommand(ChildProcessCommand):

--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_multiprocessing.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_multiprocessing.py
@@ -397,7 +397,7 @@ def sys_exit(context):
     context.log.info("Informational message")
     print("Crashy output to stdout")  # noqa: T201
     sys.stdout.flush()
-    os._exit(1)  # noqa: SLF001
+    os._exit(1)
 
 
 @job

--- a/python_modules/dagster/dagster_tests/execution_tests/test_api_iterators.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_api_iterators.py
@@ -291,10 +291,8 @@ def test_execute_run_bad_state():
 
         with pytest.raises(
             check.CheckError,
-            match=r"Run basic_resource_pipeline \({}\) in state"
-            r" DagsterRunStatus.SUCCESS, expected NOT_STARTED or STARTING".format(
-                dagster_run.run_id
-            ),
+            match=rf"Run basic_resource_pipeline \({dagster_run.run_id}\) in state"
+            r" DagsterRunStatus.SUCCESS, expected NOT_STARTED or STARTING",
         ):
             execute_run(InMemoryJob(job_def), dagster_run, instance=instance)
 

--- a/python_modules/dagster/dagster_tests/execution_tests/test_markers.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_markers.py
@@ -31,16 +31,10 @@ def test_multiproc_markers():
                 dagster_event = event.dagster_event
                 if dagster_event and dagster_event.event_type in MARKER_EVENTS:
                     if dagster_event.engine_event_data.marker_start:
-                        key = "{step}.{marker}".format(
-                            step=event.step_key,
-                            marker=dagster_event.engine_event_data.marker_start,
-                        )
+                        key = f"{event.step_key}.{dagster_event.engine_event_data.marker_start}"
                         start_markers[key] = event.timestamp
                     if dagster_event.engine_event_data.marker_end:
-                        key = "{step}.{marker}".format(
-                            step=event.step_key,
-                            marker=dagster_event.engine_event_data.marker_end,
-                        )
+                        key = f"{event.step_key}.{dagster_event.engine_event_data.marker_end}"
                         end_markers[key] = event.timestamp
 
             seen = set()

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_persistent.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_persistent.py
@@ -75,7 +75,7 @@ def test_load_grpc_server(entrypoint):
         subprocess.check_call(["dagster", "api", "grpc-health-check", "--port", str(port)])
 
         ssl_result = subprocess.run(
-            ["dagster", "api", "grpc-health-check", "--port", str(port), "--use-ssl"]
+            ["dagster", "api", "grpc-health-check", "--port", str(port), "--use-ssl"], check=False
         )
         assert ssl_result.returncode == 1
 

--- a/python_modules/dagster/dagster_tests/general_tests/test_serdes.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_serdes.py
@@ -162,8 +162,6 @@ def test_serdes_enum_backcompat():
         def unpack(self, value):
             if value == "FOO":
                 value = "FOO_FOO"
-            else:
-                value = value
 
             return super().unpack(value)
 

--- a/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_yaml.py
+++ b/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_yaml.py
@@ -100,9 +100,7 @@ final: "result"
     }
 
     string_yaml = "this is a valid YAML string but not a dictionary"
-    expected = 'Expected YAML dictionary, instead got: "{string_yaml}"'.format(
-        string_yaml=string_yaml
-    )
+    expected = f'Expected YAML dictionary, instead got: "{string_yaml}"'
 
     with pytest.raises(check.CheckError, match=expected):
         merge_yaml_strings([a, string_yaml])

--- a/python_modules/dagster/dagster_tests/general_tests/utils_tests/utils.py
+++ b/python_modules/dagster/dagster_tests/general_tests/utils_tests/utils.py
@@ -8,6 +8,4 @@ def assert_no_warnings():
     # https://stackoverflow.com/questions/45671803/how-to-use-pytest-to-assert-no-warning-is-raised
     with pytest.warns(None) as record:
         yield
-    assert len(record) == 0, "Unexpected warnings: {warnings}".format(
-        warnings=[str(record[i]) for i in range(len(record))]
-    )
+    assert len(record) == 0, f"Unexpected warnings: {[str(record[i]) for i in range(len(record))]}"

--- a/python_modules/dagster/dagster_tests/launcher_tests/test_default_run_launcher.py
+++ b/python_modules/dagster/dagster_tests/launcher_tests/test_default_run_launcher.py
@@ -48,7 +48,7 @@ def noop_job():
 
 @op
 def crashy_op(_):
-    os._exit(1)  # noqa: SLF001
+    os._exit(1)
 
 
 @job

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_pythonic_resources.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_pythonic_resources.py
@@ -192,7 +192,7 @@ def test_resources(
         assert len(ticks) == 1
 
         assert instance.get_runs_count() == 1
-        run = list(instance.get_runs())[0]
+        run = next(iter(instance.get_runs()))
         assert ticks[0].run_keys == ["foo"]
 
         expected_datetime = create_pendulum_time(year=2019, month=2, day=28)

--- a/python_modules/dagster/dagster_tests/storage_tests/test_asset_events.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_asset_events.py
@@ -73,9 +73,9 @@ def test_io_manager_add_input_metadata():
     )
 
     # confirm loaded_input event contains metadata
-    loaded_input_event = [
+    loaded_input_event = next(
         event for event in result.all_events if event.event_type_value == "LOADED_INPUT"
-    ][0]
+    )
     assert loaded_input_event
     loaded_input_event_metadata = loaded_input_event.event_specific_data.metadata
     assert len(loaded_input_event_metadata) == 2
@@ -99,9 +99,9 @@ def test_input_manager_add_input_metadata():
         my_op()
 
     result = my_job.execute_in_process()
-    loaded_input_event = [
+    loaded_input_event = next(
         event for event in result.all_events if event.event_type_value == "LOADED_INPUT"
-    ][0]
+    )
     metadata = loaded_input_event.event_specific_data.metadata
     assert len(metadata) == 2
     assert "foo" in metadata

--- a/python_modules/dagster/dagster_tests/storage_tests/test_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_io_manager.py
@@ -683,9 +683,9 @@ def test_error_boundary_with_gen():
         basic_op()
 
     result = single_op_job.execute_in_process(raise_on_error=False)
-    step_failure = [
+    step_failure = next(
         event for event in result.all_events if event.event_type_value == "STEP_FAILURE"
-    ][0]
+    )
     assert step_failure.event_specific_data.error.cls_name == "DagsterExecutionHandleOutputError"
 
 
@@ -710,9 +710,9 @@ def test_handle_output_exception_raised():
         basic_op()
 
     result = single_op_job.execute_in_process(raise_on_error=False)
-    step_failure = [
+    step_failure = next(
         event for event in result.all_node_events if event.event_type_value == "STEP_FAILURE"
-    ][0]
+    )
     assert step_failure.event_specific_data.error.cls_name == "DagsterExecutionHandleOutputError"
 
 
@@ -916,9 +916,9 @@ def test_context_logging_metadata_add_output_metadata_called_twice():
     materialization = result.asset_materializations_for_node("asset1")[0]
     assert set(materialization.metadata.keys()) == {"foo", "bar"}
 
-    handled_output_event = [
+    handled_output_event = next(
         event for event in result.all_node_events if event.event_type_value == "HANDLED_OUTPUT"
-    ][0]
+    )
     assert set(handled_output_event.event_specific_data.metadata.keys()) == {
         "foo",
         "bar",

--- a/python_modules/dagster/dagster_tests/storage_tests/test_io_managers_pythonic_config.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_io_managers_pythonic_config.py
@@ -500,7 +500,7 @@ def test_telemetry_custom_io_manager():
         def load_input(self, context):
             return 1
 
-    assert not MyIOManager._is_dagster_maintained()
+    assert not MyIOManager._is_dagster_maintained()  # noqa: SLF001
 
 
 def test_telemetry_dagster_io_manager():

--- a/python_modules/dagster/dagster_tests/storage_tests/test_local_instance.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_local_instance.py
@@ -156,7 +156,7 @@ def test_get_run_by_id():
             global MOCK_HAS_RUN_CALLED  # noqa: PLW0603
             if not self._run_storage.has_run(run_id) and not MOCK_HAS_RUN_CALLED:
                 self._run_storage.add_run(DagsterRun(job_name="foo_job", run_id=run_id))
-                MOCK_HAS_RUN_CALLED = True  # noqa: PLW0603
+                MOCK_HAS_RUN_CALLED = True
                 return False
             elif self._run_storage.has_run(run_id) and MOCK_HAS_RUN_CALLED:
                 MOCK_HAS_RUN_CALLED = False

--- a/python_modules/dagster/dagster_tests/storage_tests/test_upath_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_upath_io_manager.py
@@ -488,9 +488,9 @@ def test_upath_io_manager_custom_metadata(tmp_path: Path, json_data: Any):
         [my_asset],
         resources={"io_manager": manager},
     )
-    handled_output_data = list(filter(lambda evt: evt.is_handled_output, result.all_node_events))[
-        0
-    ].event_specific_data
+    handled_output_data = next(
+        iter(filter(lambda evt: evt.is_handled_output, result.all_node_events))
+    ).event_specific_data
     assert isinstance(handled_output_data, HandledOutputData)
     assert handled_output_data.metadata["length"] == MetadataValue.int(get_length(json_data))
 

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -639,25 +639,25 @@ class TestEventLogStorage:
         step_stats = storage.get_step_stats_for_run(test_run_id)
         assert len(step_stats) == 4
 
-        a_stats = [stats for stats in step_stats if stats.step_key == "A"][0]
+        a_stats = next(stats for stats in step_stats if stats.step_key == "A")
         assert a_stats.step_key == "A"
         assert a_stats.status.value == "SUCCESS"
         assert a_stats.end_time - a_stats.start_time == 100
         assert len(a_stats.attempts_list) == 1
 
-        b_stats = [stats for stats in step_stats if stats.step_key == "B"][0]
+        b_stats = next(stats for stats in step_stats if stats.step_key == "B")
         assert b_stats.step_key == "B"
         assert b_stats.status.value == "FAILURE"
         assert b_stats.end_time - b_stats.start_time == 50
         assert len(b_stats.attempts_list) == 1
 
-        c_stats = [stats for stats in step_stats if stats.step_key == "C"][0]
+        c_stats = next(stats for stats in step_stats if stats.step_key == "C")
         assert c_stats.step_key == "C"
         assert c_stats.status.value == "SKIPPED"
         assert c_stats.end_time - c_stats.start_time == 25
         assert len(c_stats.attempts_list) == 1
 
-        d_stats = [stats for stats in step_stats if stats.step_key == "D"][0]
+        d_stats = next(stats for stats in step_stats if stats.step_key == "D")
         assert d_stats.step_key == "D"
         assert d_stats.status.value == "SUCCESS"
         assert d_stats.end_time - d_stats.start_time == 150
@@ -2711,9 +2711,9 @@ class TestEventLogStorage:
                 assert len(records) == 1
                 asset_entry = records[0].asset_entry
                 assert asset_entry.asset_key == my_asset_key
-                materialize_event = [
+                materialize_event = next(
                     event for event in result.all_events if event.is_step_materialization
-                ][0]
+                )
                 assert asset_entry.last_materialization.dagster_event == materialize_event
                 assert asset_entry.last_run_id == result.run_id
                 assert asset_entry.asset_details is None
@@ -2750,9 +2750,9 @@ class TestEventLogStorage:
                     )  # order by asset key
                     asset_entry = records[0].asset_entry
                     assert asset_entry.asset_key == my_asset_key
-                    materialize_event = [
+                    materialize_event = next(
                         event for event in result.all_events if event.is_step_materialization
-                    ][0]
+                    )
                     assert asset_entry.last_materialization.dagster_event == materialize_event
                     assert asset_entry.last_run_id == result.run_id
                     assert isinstance(asset_entry.asset_details, AssetDetails)
@@ -3391,11 +3391,11 @@ class TestEventLogStorage:
                 materialization = (
                     record.event_log_entry.dagster_event.step_materialization_data.materialization
                 )
-                date_dimension = [
+                date_dimension = next(
                     dimension
                     for dimension in materialization.partition.dimension_keys
                     if dimension.dimension_name == "date"
-                ][0]
+                )
                 assert date_dimension.partition_key == "2022-10-13"
 
     def test_event_records_filter_tags_requires_asset_key(self, storage):

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -157,7 +157,7 @@ setup(
             "types-toml",  # version will be resolved against toml
         ],
         "ruff": [
-            "ruff==0.0.277",
+            "ruff==0.0.289",
         ],
     },
     entry_points={

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
@@ -755,9 +755,7 @@ class AirbyteYAMLCacheableAssetsDefinition(AirbyteCoreCacheableAssetsDefinition)
                 ]
                 check.invariant(
                     len(state_files) > 0,
-                    "No state files found for connection {} in {}".format(
-                        connection_name, connection_dir
-                    ),
+                    f"No state files found for connection {connection_name} in {connection_dir}",
                 )
                 check.invariant(
                     len(state_files) <= 1,

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/resources/airflow_db.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/resources/airflow_db.py
@@ -44,17 +44,12 @@ class AirflowDatabase:
             )
         except ValueError:
             raise DagsterInvariantViolationError(
-                'Could not parse execution_date "{execution_date_str}". Please use datetime'
-                " format compatible with  dateutil.parser.parse.".format(
-                    execution_date_str=execution_date_str,
-                )
+                f'Could not parse execution_date "{execution_date_str}". Please use datetime'
+                " format compatible with  dateutil.parser.parse."
             )
         except OverflowError:
             raise DagsterInvariantViolationError(
-                'Date "{execution_date_str}" exceeds the largest valid C integer on the system.'
-                .format(
-                    execution_date_str=execution_date_str,
-                )
+                f'Date "{execution_date_str}" exceeds the largest valid C integer on the system.'
             )
         return execution_date
 
@@ -75,11 +70,8 @@ class AirflowDatabase:
             execution_date = self._parse_execution_date_for_asset(dag, run_tags)
         else:
             raise DagsterInvariantViolationError(
-                'Could not find "{AIRFLOW_EXECUTION_DATE_STR}" in tags "{tags}". Please '
-                'add "{AIRFLOW_EXECUTION_DATE_STR}" to tags before executing'.format(
-                    AIRFLOW_EXECUTION_DATE_STR=AIRFLOW_EXECUTION_DATE_STR,
-                    tags=run_tags,
-                )
+                f'Could not find "{AIRFLOW_EXECUTION_DATE_STR}" in tags "{run_tags}". Please '
+                f'add "{AIRFLOW_EXECUTION_DATE_STR}" to tags before executing'
             )
         dagrun = dag.get_dagrun(execution_date=execution_date)
         if not dagrun:

--- a/python_modules/libraries/dagster-aws/dagster_aws/cloudwatch/loggers.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/cloudwatch/loggers.py
@@ -76,7 +76,7 @@ class CloudwatchLogsHandler(logging.Handler):
         if not log_group_exists:
             raise Exception(
                 "Failed to initialize Cloudwatch logger: Could not find log group with name "
-                "{log_group_name}".format(log_group_name=self.log_group_name)
+                f"{self.log_group_name}"
             )
 
     def check_log_stream(self):
@@ -105,7 +105,7 @@ class CloudwatchLogsHandler(logging.Handler):
         if not log_stream_exists:
             raise Exception(
                 "Failed to initialize Cloudwatch logger: Could not find log stream with name "
-                "{log_stream_name}".format(log_stream_name=self.log_stream_name)
+                f"{self.log_stream_name}"
             )
 
     def log_error(self, record, exc):
@@ -151,15 +151,11 @@ class CloudwatchLogsHandler(logging.Handler):
         except self.client.exceptions.DataAlreadyAcceptedException:
             logging.error(f"Cloudwatch logger: log events already accepted: {res}")
         except self.client.exceptions.InvalidParameterException:
-            logging.error(
-                "Cloudwatch logger: Invalid parameter exception while logging: {res}".format(
-                    res=res
-                )
-            )
+            logging.error(f"Cloudwatch logger: Invalid parameter exception while logging: {res}")
         except self.client.exceptions.ResourceNotFoundException:
             logging.error(
                 "Cloudwatch logger: Resource not found. Check that the log stream or log group "
-                "was not deleted: {res}".format(res=res)
+                f"was not deleted: {res}"
             )
         except self.client.exceptions.ServiceUnavailableException:
             if not retry:
@@ -172,7 +168,7 @@ class CloudwatchLogsHandler(logging.Handler):
             else:
                 logging.error(
                     "Cloudwatch logger: Unrecognized client. Check your AWS access key id and "
-                    "secret key: {res}".format(res=res)
+                    f"secret key: {res}"
                 )
 
 

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -770,11 +770,7 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
                         container_name=self._get_container_name(container_context),
                     )
                 except:
-                    logging.exception(
-                        "Error trying to get logs for failed task {task_arn}".format(
-                            task_arn=tags.arn,
-                        )
-                    )
+                    logging.exception(f"Error trying to get logs for failed task {tags.arn}")
 
                 if logs:
                     failure_text.append("Run worker logs:\n" + "\n".join(logs))

--- a/python_modules/libraries/dagster-aws/dagster_aws/emr/emr.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/emr/emr.py
@@ -113,11 +113,7 @@ class EmrJobRunner:
             if cluster["Name"] == cluster_name:
                 return cluster["Id"]
 
-        raise EmrError(
-            "cluster {cluster_name} not found in region {region}".format(
-                cluster_name=cluster_name, region=self.region
-            )
-        )
+        raise EmrError(f"cluster {cluster_name} not found in region {self.region}")
 
     @staticmethod
     def construct_step_dict_for_command(step_name, command, action_on_failure="CONTINUE"):
@@ -372,9 +368,7 @@ class EmrJobRunner:
 
         log_bucket, log_key_prefix = self.log_location_for_cluster(cluster_id)
 
-        prefix = "{log_key_prefix}{cluster_id}/steps/{step_id}".format(
-            log_key_prefix=log_key_prefix, cluster_id=cluster_id, step_id=step_id
-        )
+        prefix = f"{log_key_prefix}{cluster_id}/steps/{step_id}"
         stdout_log = self.wait_for_log(log, log_bucket, f"{prefix}/stdout.gz")
         stderr_log = self.wait_for_log(log, log_bucket, f"{prefix}/stderr.gz")
         return stdout_log, stderr_log
@@ -400,11 +394,7 @@ class EmrJobRunner:
         check.int_param(waiter_delay, "waiter_delay")
         check.int_param(waiter_max_attempts, "waiter_max_attempts")
 
-        log.info(
-            "Attempting to get log: s3://{log_bucket}/{log_key}".format(
-                log_bucket=log_bucket, log_key=log_key
-            )
-        )
+        log.info(f"Attempting to get log: s3://{log_bucket}/{log_key}")
 
         s3 = _wrap_aws_client(boto3.client("s3"), min_backoff=self.check_cluster_every)
         waiter = s3.get_waiter("object_exists")

--- a/python_modules/libraries/dagster-aws/dagster_aws/emr/pyspark_step_launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/emr/pyspark_step_launcher.py
@@ -288,11 +288,7 @@ class EmrPySparkStepLauncher(StepLauncher):
             def _upload_file_to_s3(local_path, s3_filename):
                 key = self._artifact_s3_key(run_id, step_key, s3_filename)
                 s3_uri = self._artifact_s3_uri(run_id, step_key, s3_filename)
-                log.debug(
-                    "Uploading file {local_path} to {s3_uri}".format(
-                        local_path=local_path, s3_uri=s3_uri
-                    )
-                )
+                log.debug(f"Uploading file {local_path} to {s3_uri}")
                 s3.upload_file(Filename=local_path, Bucket=self.staging_bucket, Key=key)
 
             # Upload main file.

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/utils.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/utils.py
@@ -18,12 +18,7 @@ class S3Callback:
         self._seen_so_far += bytes_amount
         percentage = (self._seen_so_far / self._size) * 100
         self._logger(
-            "Download of {bucket}/{key} to {target_path}: {percentage}% complete".format(
-                bucket=self._bucket,
-                key=self._key,
-                target_path=self._filename,
-                percentage=percentage,
-            )
+            f"Download of {self._bucket}/{self._key} to {self._filename}: {percentage}% complete"
         )
 
 

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
@@ -47,7 +47,7 @@ def test_default_launcher(
     # A new task definition is created
     task_definitions = ecs.list_task_definitions()["taskDefinitionArns"]
     assert len(task_definitions) == len(initial_task_definitions) + 1
-    task_definition_arn = list(set(task_definitions).difference(initial_task_definitions))[0]
+    task_definition_arn = next(iter(set(task_definitions).difference(initial_task_definitions)))
     task_definition = ecs.describe_task_definition(taskDefinition=task_definition_arn)
     task_definition = task_definition["taskDefinition"]
 
@@ -69,7 +69,7 @@ def test_default_launcher(
     tasks = ecs.list_tasks()["taskArns"]
 
     assert len(tasks) == len(initial_tasks) + 1
-    task_arn = list(set(tasks).difference(initial_tasks))[0]
+    task_arn = next(iter(set(tasks).difference(initial_tasks)))
     task = ecs.describe_tasks(tasks=[task_arn])["tasks"][0]
     assert subnet.id in str(task)
     assert task["taskDefinitionArn"] == task_definition["taskDefinitionArn"]
@@ -134,7 +134,7 @@ def test_launcher_fargate_spot(
     # A new task definition is still created
     task_definitions = ecs.list_task_definitions()["taskDefinitionArns"]
     assert len(task_definitions) == len(initial_task_definitions) + 1
-    task_definition_arn = list(set(task_definitions).difference(initial_task_definitions))[0]
+    task_definition_arn = next(iter(set(task_definitions).difference(initial_task_definitions)))
     task_definition = ecs.describe_task_definition(taskDefinition=task_definition_arn)
     task_definition = task_definition["taskDefinition"]
 
@@ -142,7 +142,7 @@ def test_launcher_fargate_spot(
     tasks = ecs.list_tasks()["taskArns"]
 
     assert len(tasks) == len(initial_tasks) + 1
-    task_arn = list(set(tasks).difference(initial_tasks))[0]
+    task_arn = next(iter(set(tasks).difference(initial_tasks)))
     task = ecs.describe_tasks(tasks=[task_arn])["tasks"][0]
 
     assert task["capacityProviderName"] == "FARGATE_SPOT"
@@ -172,7 +172,7 @@ def test_launcher_fargate_spot(
     # A new task definition is still created
     task_definitions = ecs.list_task_definitions()["taskDefinitionArns"]
     assert len(task_definitions) == len(initial_task_definitions) + 1
-    task_definition_arn = list(set(task_definitions).difference(initial_task_definitions))[0]
+    task_definition_arn = next(iter(set(task_definitions).difference(initial_task_definitions)))
     task_definition = ecs.describe_task_definition(taskDefinition=task_definition_arn)
     task_definition = task_definition["taskDefinition"]
 
@@ -180,7 +180,7 @@ def test_launcher_fargate_spot(
     second_tasks = ecs.list_tasks()["taskArns"]
 
     assert len(second_tasks) == len(tasks) + 1
-    task_arn = list(set(second_tasks).difference(tasks))[0]
+    task_arn = next(iter(set(second_tasks).difference(tasks)))
     task = ecs.describe_tasks(tasks=[task_arn])["tasks"][0]
 
     assert task["capacityProviderName"] == "CUSTOM"
@@ -216,7 +216,7 @@ def test_launcher_dont_use_current_task(
     # A new task definition is still created
     task_definitions = ecs.list_task_definitions()["taskDefinitionArns"]
     assert len(task_definitions) == len(initial_task_definitions) + 1
-    task_definition_arn = list(set(task_definitions).difference(initial_task_definitions))[0]
+    task_definition_arn = next(iter(set(task_definitions).difference(initial_task_definitions)))
     task_definition = ecs.describe_task_definition(taskDefinition=task_definition_arn)
     task_definition = task_definition["taskDefinition"]
 
@@ -239,7 +239,7 @@ def test_launcher_dont_use_current_task(
     tasks = ecs.list_tasks(cluster=cluster)["taskArns"]
 
     assert len(tasks) == len(initial_tasks) + 1
-    task_arn = list(set(tasks).difference(initial_tasks))[0]
+    task_arn = next(iter(set(tasks).difference(initial_tasks)))
     task = ecs.describe_tasks(cluster=cluster, tasks=[task_arn])["tasks"][0]
     assert subnet.id in str(task)
     assert task["taskDefinitionArn"] == task_definition["taskDefinitionArn"]
@@ -571,7 +571,7 @@ def test_default_task_definition_resources(ecs, instance_cm, run, workspace, job
         instance.launch_run(run.run_id, workspace)
 
         tasks = ecs.list_tasks()["taskArns"]
-        task_arn = list(set(tasks).difference(initial_tasks))[0]
+        task_arn = next(iter(set(tasks).difference(initial_tasks)))
 
         task = ecs.describe_tasks(tasks=[task_arn])["tasks"][0]
 
@@ -605,7 +605,7 @@ def test_default_task_definition_resources(ecs, instance_cm, run, workspace, job
         instance.launch_run(run.run_id, workspace)
 
         tasks = ecs.list_tasks()["taskArns"]
-        task_arn = list(set(tasks).difference(initial_tasks))[0]
+        task_arn = next(iter(set(tasks).difference(initial_tasks)))
 
         task = ecs.describe_tasks(tasks=[task_arn])["tasks"][0]
 
@@ -639,7 +639,7 @@ def test_default_task_definition_resources(ecs, instance_cm, run, workspace, job
         instance.launch_run(run.run_id, workspace)
 
         tasks = ecs.list_tasks()["taskArns"]
-        task_arn = list(set(tasks).difference(initial_tasks))[0]
+        task_arn = next(iter(set(tasks).difference(initial_tasks)))
 
         task = ecs.describe_tasks(tasks=[task_arn])["tasks"][0]
 
@@ -723,7 +723,7 @@ def test_launching_with_task_definition_dict(ecs, instance_cm, run, workspace, j
         # A new task is launched
         tasks = ecs.list_tasks()["taskArns"]
         assert len(tasks) == len(initial_tasks) + 1
-        task_arn = list(set(tasks).difference(initial_tasks))[0]
+        task_arn = next(iter(set(tasks).difference(initial_tasks)))
         task = ecs.describe_tasks(tasks=[task_arn])["tasks"][0]
         task_definition_arn = task["taskDefinitionArn"]
 
@@ -819,7 +819,7 @@ def test_launching_custom_task_definition(ecs, instance_cm, run, workspace, job,
         # A new task is launched
         tasks = ecs.list_tasks()["taskArns"]
         assert len(tasks) == len(initial_tasks) + 1
-        task_arn = list(set(tasks).difference(initial_tasks))[0]
+        task_arn = next(iter(set(tasks).difference(initial_tasks)))
         task = ecs.describe_tasks(tasks=[task_arn])["tasks"][0]
         assert task["taskDefinitionArn"] == task_definition["taskDefinitionArn"]
 
@@ -878,7 +878,7 @@ def test_public_ip_assignment(ecs, ec2, instance, workspace, run, assign_public_
     instance.launch_run(run.run_id, workspace)
 
     tasks = ecs.list_tasks()["taskArns"]
-    task_arn = list(set(tasks).difference(initial_tasks))[0]
+    task_arn = next(iter(set(tasks).difference(initial_tasks)))
     task = ecs.describe_tasks(tasks=[task_arn])["tasks"][0]
     attachment = task.get("attachments")[0]
     details = dict([(detail.get("name"), detail.get("value")) for detail in attachment["details"]])
@@ -907,7 +907,7 @@ def test_launcher_run_resources(
     instance.launch_run(run.run_id, workspace)
 
     tasks = ecs.list_tasks()["taskArns"]
-    task_arn = list(set(tasks).difference(existing_tasks))[0]
+    task_arn = next(iter(set(tasks).difference(existing_tasks)))
     task = ecs.describe_tasks(tasks=[task_arn])["tasks"][0]
 
     assert task.get("overrides").get("memory") == "2048"
@@ -940,7 +940,7 @@ def test_launch_run_with_container_context(
     launch_run_with_container_context(instance)
 
     tasks = ecs.list_tasks()["taskArns"]
-    task_arn = list(set(tasks).difference(existing_tasks))[0]
+    task_arn = next(iter(set(tasks).difference(existing_tasks)))
     task = ecs.describe_tasks(tasks=[task_arn])["tasks"][0]
 
     assert any(tag == {"key": "HAS_VALUE", "value": "SEE"} for tag in task["tags"])
@@ -1001,7 +1001,7 @@ def test_memory_and_cpu(ecs, instance, workspace, run, task_definition):
     instance.launch_run(run.run_id, workspace)
 
     tasks = ecs.list_tasks()["taskArns"]
-    task_arn = list(set(tasks).difference(initial_tasks))[0]
+    task_arn = next(iter(set(tasks).difference(initial_tasks)))
     task = ecs.describe_tasks(tasks=[task_arn])["tasks"][0]
 
     assert task.get("memory") == task_definition.get("memory")
@@ -1016,7 +1016,7 @@ def test_memory_and_cpu(ecs, instance, workspace, run, task_definition):
     instance.launch_run(run.run_id, workspace)
 
     tasks = ecs.list_tasks()["taskArns"]
-    task_arn = list(set(tasks).difference(existing_tasks))[0]
+    task_arn = next(iter(set(tasks).difference(existing_tasks)))
     task = ecs.describe_tasks(tasks=[task_arn])["tasks"][0]
 
     assert task.get("memory") == task_definition.get("memory")
@@ -1035,7 +1035,7 @@ def test_memory_and_cpu(ecs, instance, workspace, run, task_definition):
     instance.launch_run(run.run_id, workspace)
 
     tasks = ecs.list_tasks()["taskArns"]
-    task_arn = list(set(tasks).difference(existing_tasks))[0]
+    task_arn = next(iter(set(tasks).difference(existing_tasks)))
     task = ecs.describe_tasks(tasks=[task_arn])["tasks"][0]
 
     assert task.get("memory") == task_definition.get("memory")
@@ -1078,7 +1078,7 @@ def test_status(
     # our internal task data structure - maybe a dict of dicts
     # using cluster and arn as keys - instead of a dict of lists?
     task_arn = instance.get_run_by_id(run.run_id).tags["ecs/task_arn"]
-    task = [task for task in ecs.storage.tasks["default"] if task["taskArn"] == task_arn][0]
+    task = next(task for task in ecs.storage.tasks["default"] if task["taskArn"] == task_arn)
 
     task_id = task_arn.split("/")[-1]
 
@@ -1153,7 +1153,7 @@ def test_status(
     )
     instance.run_launcher.launch_run(LaunchRunContext(dagster_run=starting_run, workspace=None))
     task_arn = instance.get_run_by_id(starting_run.run_id).tags["ecs/task_arn"]
-    task = [task for task in ecs.storage.tasks["default"] if task["taskArn"] == task_arn][0]
+    task = next(task for task in ecs.storage.tasks["default"] if task["taskArn"] == task_arn)
     task["lastStatus"] = "STOPPED"
     task["stoppedReason"] = "Timeout waiting for network interface provisioning to complete."
 
@@ -1206,7 +1206,7 @@ def test_custom_launcher(
     custom_instance.launch_run(custom_run.run_id, custom_workspace)
 
     tasks = ecs.list_tasks()["taskArns"]
-    task_arn = list(set(tasks).difference(initial_tasks))[0]
+    task_arn = next(iter(set(tasks).difference(initial_tasks)))
 
     # And we log
     events = custom_instance.event_log_storage.get_logs_for_run(custom_run.run_id)

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_secrets.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_secrets.py
@@ -30,7 +30,7 @@ def test_secrets(
     # A new task definition is created
     task_definitions = ecs.list_task_definitions()["taskDefinitionArns"]
     assert len(task_definitions) == len(initial_task_definitions) + 1
-    task_definition_arn = list(set(task_definitions).difference(initial_task_definitions))[0]
+    task_definition_arn = next(iter(set(task_definitions).difference(initial_task_definitions)))
     task_definition = ecs.describe_task_definition(taskDefinition=task_definition_arn)
     task_definition = task_definition["taskDefinition"]
 
@@ -63,7 +63,7 @@ def test_environment(
     # A new task definition is created
     task_definitions = ecs.list_task_definitions()["taskDefinitionArns"]
     assert len(task_definitions) == len(initial_task_definitions) + 1
-    task_definition_arn = list(set(task_definitions).difference(initial_task_definitions))[0]
+    task_definition_arn = next(iter(set(task_definitions).difference(initial_task_definitions)))
     task_definition = ecs.describe_task_definition(taskDefinition=task_definition_arn)
     task_definition = task_definition["taskDefinition"]
 
@@ -93,7 +93,7 @@ def test_environment_missing_env_var_value(
     # A new task definition is created
     task_definitions = ecs.list_task_definitions()["taskDefinitionArns"]
     assert len(task_definitions) == len(initial_task_definitions) + 1
-    task_definition_arn = list(set(task_definitions).difference(initial_task_definitions))[0]
+    task_definition_arn = next(iter(set(task_definitions).difference(initial_task_definitions)))
     task_definition = ecs.describe_task_definition(taskDefinition=task_definition_arn)
     task_definition = task_definition["taskDefinition"]
 
@@ -122,7 +122,7 @@ def test_secrets_with_container_context(
     # A new task definition is created
     task_definitions = ecs.list_task_definitions()["taskDefinitionArns"]
     assert len(task_definitions) == len(initial_task_definitions) + 1
-    task_definition_arn = list(set(task_definitions).difference(initial_task_definitions))[0]
+    task_definition_arn = next(iter(set(task_definitions).difference(initial_task_definitions)))
     task_definition = ecs.describe_task_definition(taskDefinition=task_definition_arn)
     task_definition = task_definition["taskDefinition"]
 
@@ -156,7 +156,7 @@ def test_environment_with_container_context(
     # A new task definition is created
     task_definitions = ecs.list_task_definitions()["taskDefinitionArns"]
     assert len(task_definitions) == len(initial_task_definitions) + 1
-    task_definition_arn = list(set(task_definitions).difference(initial_task_definitions))[0]
+    task_definition_arn = next(iter(set(task_definitions).difference(initial_task_definitions)))
     task_definition = ecs.describe_task_definition(taskDefinition=task_definition_arn)
     task_definition = task_definition["taskDefinition"]
 
@@ -190,7 +190,7 @@ def test_secrets_backcompat(
     # A new task definition is created
     task_definitions = ecs.list_task_definitions()["taskDefinitionArns"]
     assert len(task_definitions) == len(initial_task_definitions) + 1
-    task_definition_arn = list(set(task_definitions).difference(initial_task_definitions))[0]
+    task_definition_arn = next(iter(set(task_definitions).difference(initial_task_definitions)))
     task_definition = ecs.describe_task_definition(taskDefinition=task_definition_arn)
     task_definition = task_definition["taskDefinition"]
 
@@ -224,7 +224,7 @@ def test_empty_secrets(
     # A new task definition is created
     task_definitions = ecs.list_task_definitions()["taskDefinitionArns"]
     assert len(task_definitions) == len(initial_task_definitions) + 1
-    task_definition_arn = list(set(task_definitions).difference(initial_task_definitions))[0]
+    task_definition_arn = next(iter(set(task_definitions).difference(initial_task_definitions)))
     task_definition = ecs.describe_task_definition(taskDefinition=task_definition_arn)
     task_definition = task_definition["taskDefinition"]
 

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_sidecars.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_sidecars.py
@@ -6,7 +6,7 @@ def test_default(ecs, instance, launch_run):
     # A new task definition is created
     task_definitions = ecs.list_task_definitions()["taskDefinitionArns"]
     assert len(task_definitions) == len(initial_task_definitions) + 1
-    task_definition_arn = list(set(task_definitions).difference(initial_task_definitions))[0]
+    task_definition_arn = next(iter(set(task_definitions).difference(initial_task_definitions)))
     task_definition = ecs.describe_task_definition(taskDefinition=task_definition_arn)
     container_definitions = task_definition["taskDefinition"]["containerDefinitions"]
 
@@ -23,7 +23,7 @@ def test_include_sidecars_with_depends_on(ecs, instance_cm, launch_run, task_def
         # A new task definition is created
         task_definitions = ecs.list_task_definitions()["taskDefinitionArns"]
         assert len(task_definitions) == len(initial_task_definitions) + 1
-        task_definition_arn = list(set(task_definitions).difference(initial_task_definitions))[0]
+        task_definition_arn = next(iter(set(task_definitions).difference(initial_task_definitions)))
         task_definition = ecs.describe_task_definition(taskDefinition=task_definition_arn)
         container_definitions = task_definition["taskDefinition"]["containerDefinitions"]
 

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/stubbed_ecs.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/stubbed_ecs.py
@@ -538,9 +538,9 @@ class StubbedEcs:
 
     def _long_arn_enabled(self):
         settings = self.list_account_settings(effectiveSettings=True)["settings"]
-        task_arn_format_setting = [
+        task_arn_format_setting = next(
             setting for setting in settings if setting["name"] == "taskLongArnFormat"
-        ][0]
+        )
         return task_arn_format_setting["value"] != "disabled"
 
     def _valid_cpu_and_memory(self, cpu, memory):

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/test_stubbed_ecs.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/test_stubbed_ecs.py
@@ -75,9 +75,9 @@ def test_list_account_settings(ecs):
     settings = ecs.list_account_settings(effectiveSettings=True)["settings"]
     assert settings
 
-    task_arn_format_setting = [
+    task_arn_format_setting = next(
         setting for setting in settings if setting["name"] == "taskLongArnFormat"
-    ][0]
+    )
     assert task_arn_format_setting["value"] == "enabled"
 
 
@@ -181,9 +181,9 @@ def test_put_account_setting(ecs):
     settings = ecs.list_account_settings(effectiveSettings=True)["settings"]
     assert settings
 
-    task_arn_format_setting = [
+    task_arn_format_setting = next(
         setting for setting in settings if setting["name"] == "taskLongArnFormat"
-    ][0]
+    )
     assert task_arn_format_setting["value"] == "disabled"
 
 

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/redshift_tests/test_resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/redshift_tests/test_resources.py
@@ -241,9 +241,7 @@ def test_live_redshift(s3_bucket):
             cursor.execute(REDSHIFT_FAILED_LOAD_QUERY)
             res = cursor.fetchall()
             assert res[0][1] == "Char length exceeds DDL length"
-            assert res[0][2] == "s3://{s3_bucket}/{file_key}".format(
-                s3_bucket=s3_bucket, file_key=file_key
-            )
+            assert res[0][2] == f"s3://{s3_bucket}/{file_key}"
             assert res[0][3] == 7
             assert res[0][4].strip() == "52|PNC Arena|Raleigh|NC  ,25   |0"
             assert res[0][5].strip() == "NC  ,25"

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_compute_log_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_compute_log_manager.py
@@ -102,15 +102,15 @@ def test_compute_log_manager(mock_s3_bucket):
 def test_compute_log_manager_from_config(mock_s3_bucket):
     s3_prefix = "foobar"
 
-    dagster_yaml = """
+    dagster_yaml = f"""
 compute_logs:
   module: dagster_aws.s3.compute_log_manager
   class: S3ComputeLogManager
   config:
-    bucket: "{s3_bucket}"
+    bucket: "{mock_s3_bucket.name}"
     local_dir: "/tmp/cool"
     prefix: "{s3_prefix}"
-""".format(s3_bucket=mock_s3_bucket.name, s3_prefix=s3_prefix)
+"""
 
     with tempfile.TemporaryDirectory() as tempdir:
         with open(os.path.join(tempdir, "dagster.yaml"), "wb") as f:

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_s3_file_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_s3_file_manager.py
@@ -79,7 +79,7 @@ def test_depends_on_s3_resource_file_manager(mock_s3_bucket):
 
     assert len(keys_in_bucket) == 1
 
-    file_key = list(keys_in_bucket)[0]
+    file_key = next(iter(keys_in_bucket))
     comps = file_key.split("/")
 
     assert "/".join(comps[:-1]) == "some-prefix"
@@ -126,7 +126,7 @@ def test_depends_on_s3_resource_file_manager_pythonic(mock_s3_bucket) -> None:
 
     assert len(keys_in_bucket) == 1
 
-    file_key = list(keys_in_bucket)[0]
+    file_key = next(iter(keys_in_bucket))
     comps = file_key.split("/")
 
     assert "/".join(comps[:-1]) == "some-prefix"

--- a/python_modules/libraries/dagster-azure/dagster_azure/adls2/file_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/adls2/file_manager.py
@@ -42,11 +42,7 @@ class ADLS2FileHandle(FileHandle):
     @property
     def adls2_path(self):
         """str: The file's ADLS2 URL."""
-        return "adfss://{file_system}@{account}.dfs.core.windows.net/{key}".format(
-            file_system=self.file_system,
-            account=self.account,
-            key=self.key,
-        )
+        return f"adfss://{self.file_system}@{self.account}.dfs.core.windows.net/{self.key}"
 
 
 class ADLS2FileManager(FileManager):

--- a/python_modules/libraries/dagster-azure/dagster_azure_tests/adls2_tests/test_adls2_file_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure_tests/adls2_tests/test_adls2_file_manager.py
@@ -133,7 +133,7 @@ def test_depends_on_adls2_resource_file_manager(storage_account, file_system):
 
     assert len(keys_in_bucket) == 1
 
-    file_key = list(keys_in_bucket)[0]
+    file_key = next(iter(keys_in_bucket))
     comps = file_key.split("/")
 
     assert "/".join(comps[:-1]) == "some-prefix"

--- a/python_modules/libraries/dagster-azure/dagster_azure_tests/adls2_tests/test_adls2_file_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure_tests/adls2_tests/test_adls2_file_manager.py
@@ -85,9 +85,7 @@ def test_adls2_file_manager_read(storage_account, file_system):
 
 
 def create_adls2_key(run_id, step_key, output_name):
-    return "dagster/storage/{run_id}/intermediates/{step_key}/{output_name}".format(
-        run_id=run_id, step_key=step_key, output_name=output_name
-    )
+    return f"dagster/storage/{run_id}/intermediates/{step_key}/{output_name}"
 
 
 def test_depends_on_adls2_resource_file_manager(storage_account, file_system):

--- a/python_modules/libraries/dagster-azure/dagster_azure_tests/blob_tests/test_compute_log_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure_tests/blob_tests/test_compute_log_manager.py
@@ -127,7 +127,7 @@ def test_compute_log_manager(
 def test_compute_log_manager_from_config(storage_account, container, credential):
     prefix = "foobar"
 
-    dagster_yaml = """
+    dagster_yaml = f"""
 compute_logs:
   module: dagster_azure.blob.compute_log_manager
   class: AzureBlobComputeLogManager
@@ -137,9 +137,7 @@ compute_logs:
     secret_key: {credential}
     local_dir: "/tmp/cool"
     prefix: "{prefix}"
-""".format(
-        storage_account=storage_account, container=container, credential=credential, prefix=prefix
-    )
+"""
 
     with tempfile.TemporaryDirectory() as tempdir:
         with open(os.path.join(tempdir, "dagster.yaml"), "wb") as f:
@@ -343,7 +341,7 @@ def test_compute_log_manager_default_azure_credential(
 def test_compute_log_manager_from_config_default_azure_credential(storage_account, container):
     prefix = "foobar"
 
-    dagster_yaml = """
+    dagster_yaml = f"""
 compute_logs:
   module: dagster_azure.blob.compute_log_manager
   class: AzureBlobComputeLogManager
@@ -354,7 +352,7 @@ compute_logs:
     prefix: "{prefix}"
     default_azure_credential:
       exclude_environment_credentials: true
-""".format(storage_account=storage_account, container=container, prefix=prefix)
+"""
 
     with tempfile.TemporaryDirectory() as tempdir:
         with open(os.path.join(tempdir, "dagster.yaml"), "wb") as f:

--- a/python_modules/libraries/dagster-celery/dagster_celery/core_execution_loop.py
+++ b/python_modules/libraries/dagster-celery/dagster_celery/core_execution_loop.py
@@ -83,9 +83,7 @@ def core_celery_execution_loop(job_context, execution_plan, step_execution_fn):
                         step = active_execution.get_step_by_key(step_key)
                         yield DagsterEvent.engine_event(
                             job_context.for_step(step),
-                            'celery task for running step "{step_key}" was revoked.'.format(
-                                step_key=step_key,
-                            ),
+                            f'celery task for running step "{step_key}" was revoked.',
                             EngineEventData(marker_end=DELEGATE_MARKER),
                         )
                     except Exception:
@@ -125,9 +123,7 @@ def core_celery_execution_loop(job_context, execution_plan, step_execution_fn):
                     queue = step.tags.get(DAGSTER_CELERY_QUEUE_TAG, task_default_queue)
                     yield DagsterEvent.engine_event(
                         job_context.for_step(step),
-                        'Submitting celery task for step "{step_key}" to queue "{queue}".'.format(
-                            step_key=step.key, queue=queue
-                        ),
+                        f'Submitting celery task for step "{step.key}" to queue "{queue}".',
                         EngineEventData(marker_start=DELEGATE_MARKER),
                     )
 

--- a/python_modules/libraries/dagster-celery/dagster_celery_tests/test_execute.py
+++ b/python_modules/libraries/dagster-celery/dagster_celery_tests/test_execute.py
@@ -138,16 +138,10 @@ def test_execute_eagerly_on_celery(instance: DagsterInstance):
             dagster_event = event.dagster_event
             if dagster_event and dagster_event.is_engine_event:
                 if dagster_event.engine_event_data.marker_start:
-                    key = "{step}.{marker}".format(
-                        step=event.step_key,
-                        marker=dagster_event.engine_event_data.marker_start,
-                    )
+                    key = f"{event.step_key}.{dagster_event.engine_event_data.marker_start}"
                     start_markers[key] = event.timestamp
                 if dagster_event.engine_event_data.marker_end:
-                    key = "{step}.{marker}".format(
-                        step=event.step_key,
-                        marker=dagster_event.engine_event_data.marker_end,
-                    )
+                    key = f"{event.step_key}.{dagster_event.engine_event_data.marker_end}"
                     end_markers[key] = event.timestamp
 
         seen = set()

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -183,7 +183,7 @@ def get_asset_key_for_source(dbt_assets: Sequence[AssetsDefinition], source_name
             " source."
         )
 
-    return list(asset_keys_by_output_name.values())[0]
+    return next(iter(asset_keys_by_output_name.values()))
 
 
 def build_dbt_asset_selection(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resources_v2.py
@@ -80,7 +80,7 @@ def test_dbt_cli_subprocess_cleanup(caplog: pytest.LogCaptureFixture) -> None:
 
     assert dbt_cli_invocation_1.process.returncode is None
 
-    atexit._run_exitfuncs()  # ruff: noqa: SLF001
+    atexit._run_exitfuncs()  # noqa: SLF001
 
     assert "Terminating the execution of dbt command." in caplog.text
     assert not dbt_cli_invocation_1.is_successful()
@@ -90,7 +90,7 @@ def test_dbt_cli_subprocess_cleanup(caplog: pytest.LogCaptureFixture) -> None:
 
     dbt_cli_invocation_2 = dbt.cli(["run"]).wait()
 
-    atexit._run_exitfuncs()  # ruff: noqa: SLF001
+    atexit._run_exitfuncs()  # noqa: SLF001
 
     assert "Terminating the execution of dbt command." not in caplog.text
     assert dbt_cli_invocation_2.is_successful()

--- a/python_modules/libraries/dagster-docker/dagster_docker/docker_run_launcher.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/docker_run_launcher.py
@@ -130,12 +130,7 @@ class DockerRunLauncher(RunLauncher, ConfigurableClass):
                 network.connect(container)
 
         self._instance.report_engine_event(
-            message=(
-                "Launching run in a new container {container_id} with image {docker_image}".format(
-                    container_id=container.id,
-                    docker_image=docker_image,
-                )
-            ),
+            message=f"Launching run in a new container {container.id} with image {docker_image}",
             dagster_run=run,
             cls=self.__class__,
         )

--- a/python_modules/libraries/dagster-docker/dagster_docker/ops/docker_container_op.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/ops/docker_container_op.py
@@ -44,7 +44,6 @@ def _get_client(docker_container_context: DockerContainerContext):
 def _get_container_name(run_id, op_name, retry_number):
     container_name = hash_str(run_id + op_name)
 
-    retry_number = retry_number
     if retry_number > 0:
         container_name = f"{container_name}-{retry_number}"
 

--- a/python_modules/libraries/dagster-docker/dagster_docker/utils.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/utils.py
@@ -55,8 +55,4 @@ def validate_docker_image(docker_image):
         # validate that the docker image name is valid
         reference.Reference.parse(docker_image)
     except Exception as e:
-        raise Exception(
-            "Docker image name {docker_image} is not correctly formatted".format(
-                docker_image=docker_image
-            )
-        ) from e
+        raise Exception(f"Docker image name {docker_image} is not correctly formatted") from e

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
@@ -119,7 +119,7 @@ def _build_fivetran_assets(
 
         else:
             if unmaterialized_asset_keys:
-                asset_key = list(unmaterialized_asset_keys)[0]
+                asset_key = next(iter(unmaterialized_asset_keys))
                 output_name = "_".join(asset_key.path)
                 raise DagsterStepOutputNotFoundError(
                     f"Core compute for {context.op_def.name} did not return an output for"

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_asset_defs.py
@@ -41,7 +41,7 @@ def test_fivetran_group_label(group_name, expected_group_name):
     )
     group_names = set(ft_assets[0].group_names_by_key.values())
     assert len(group_names) == 1
-    assert list(group_names)[0] == expected_group_name
+    assert next(iter(group_names)) == expected_group_name
 
 
 @pytest.mark.parametrize("schema_prefix", ["", "the_prefix"])

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/dataproc/resources.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/dataproc/resources.py
@@ -74,7 +74,7 @@ class DataprocClient:
             cluster = self.get_cluster()
             return cluster["status"]["state"] in {"RUNNING", "UPDATING"}
 
-        done = DataprocClient._iter_and_sleep_until_ready(iter_fn)  # noqa: SLF001
+        done = DataprocClient._iter_and_sleep_until_ready(iter_fn)
         if not done:
             cluster = self.get_cluster()
             raise DataprocError(
@@ -118,9 +118,7 @@ class DataprocClient:
 
             return False
 
-        done = DataprocClient._iter_and_sleep_until_ready(  # noqa: SLF001
-            iter_fn, max_wait_time_sec=wait_timeout
-        )
+        done = DataprocClient._iter_and_sleep_until_ready(iter_fn, max_wait_time_sec=wait_timeout)
         if not done:
             job = self.get_job(job_id)
             raise DataprocError("Job run timed out: %s" % str(job["status"]))

--- a/python_modules/libraries/dagster-gcp/dagster_gcp_tests/dataproc_tests/test_resources.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp_tests/dataproc_tests/test_resources.py
@@ -18,9 +18,7 @@ PROJECT_ID = os.getenv("GCP_PROJECT_ID", "default_project")
 CLUSTER_NAME = "test-%s" % uuid.uuid4().hex
 REGION = "us-west1"
 
-DATAPROC_BASE_URI = "https://dataproc.googleapis.com/v1/projects/{project}/regions/{region}".format(
-    project=PROJECT_ID, region=REGION
-)
+DATAPROC_BASE_URI = f"https://dataproc.googleapis.com/v1/projects/{PROJECT_ID}/regions/{REGION}"
 DATAPROC_CLUSTERS_URI = f"{DATAPROC_BASE_URI}/clusters"
 DATAPROC_JOBS_URI = f"{DATAPROC_BASE_URI}/jobs"
 DATAPROC_SCHEMA_URI = "https://www.googleapis.com/discovery/v1/apis/dataproc/v1/rest"

--- a/python_modules/libraries/dagster-gcp/dagster_gcp_tests/gcs_tests/test_compute_log_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp_tests/gcs_tests/test_compute_log_manager.py
@@ -212,15 +212,15 @@ def test_compute_log_manager_with_envvar(gcs_bucket):
 def test_compute_log_manager_from_config(gcs_bucket):
     gcs_prefix = "foobar"
 
-    dagster_yaml = """
+    dagster_yaml = f"""
 compute_logs:
   module: dagster_gcp.gcs.compute_log_manager
   class: GCSComputeLogManager
   config:
-    bucket: "{bucket}"
+    bucket: "{gcs_bucket}"
     local_dir: "/tmp/cool"
-    prefix: "{prefix}"
-""".format(bucket=gcs_bucket, prefix=gcs_prefix)
+    prefix: "{gcs_prefix}"
+"""
 
     with tempfile.TemporaryDirectory() as tempdir:
         with open(os.path.join(tempdir, "dagster.yaml"), "wb") as f:

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
@@ -261,8 +261,8 @@ class DagsterKubernetesClient:
                 if jobs.items:
                     check.invariant(
                         len(jobs.items) == 1,
-                        'There should only be one k8s job with name "{}", but got multiple'
-                        ' jobs:" {}'.format(job_name, jobs.items),
+                        f'There should only be one k8s job with name "{job_name}", but got multiple'
+                        f' jobs:" {jobs.items}',
                     )
                     return jobs.items[0]
                 else:
@@ -292,9 +292,7 @@ class DagsterKubernetesClient:
         while True:
             if wait_timeout and (self.timer() - start > wait_timeout):
                 raise DagsterK8sTimeoutError(
-                    "Timed out while waiting for job {job_name} to have pods".format(
-                        job_name=job_name
-                    )
+                    f"Timed out while waiting for job {job_name} to have pods"
                 )
 
             pod_list = k8s_api_retry(_get_pods, max_retries=3, timeout=wait_time_between_attempts)
@@ -377,9 +375,7 @@ class DagsterKubernetesClient:
         while True:
             if wait_timeout and (self.timer() - start_time > wait_timeout):
                 raise DagsterK8sTimeoutError(
-                    "Timed out while waiting for job {job_name} to complete".format(
-                        job_name=job_name
-                    )
+                    f"Timed out while waiting for job {job_name} to complete"
                 )
 
             # Reads the status of the specified job. Returns a V1Job object that
@@ -397,10 +393,8 @@ class DagsterKubernetesClient:
             # status.failed represents the number of pods which reached phase Failed.
             if status.failed and status.failed > 0:
                 raise DagsterK8sError(
-                    "Encountered failed job pods for job {job_name} with status: {status}, "
-                    "in namespace {namespace}".format(
-                        job_name=job_name, status=status, namespace=namespace
-                    )
+                    f"Encountered failed job pods for job {job_name} with status: {status}, "
+                    f"in namespace {namespace}"
                 )
 
             if instance and run_id:

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
@@ -376,9 +376,7 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
             full_msg = "\n".join(pod_debug_info)
         except Exception:
             logging.exception(
-                "Error trying to get debug information for failed k8s job {job_name}".format(
-                    job_name=job_name
-                )
+                f"Error trying to get debug information for failed k8s job {job_name}"
             )
         if pod_names:
             full_msg = (

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_resource_tags.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_resource_tags.py
@@ -106,7 +106,7 @@ def test_tags_to_plan():
         )()
 
     plan = create_execution_plan(k8s_ready)
-    step = list(plan.step_dict.values())[0]
+    step = next(iter(plan.step_dict.values()))
 
     user_defined_k8s_config = get_user_defined_k8s_config(step.tags)
 

--- a/python_modules/libraries/dagster-msteams/dagster_msteams/hooks.py
+++ b/python_modules/libraries/dagster-msteams/dagster_msteams/hooks.py
@@ -72,10 +72,7 @@ def teams_on_failure(
     def _hook(context: HookContext):
         text = message_fn(context)
         if webserver_base_url:
-            text += "<a href='{base_url}/runs/{run_id}'>View in Dagster UI</a>".format(
-                base_url=webserver_base_url,
-                run_id=context.run_id,
-            )
+            text += f"<a href='{webserver_base_url}/runs/{context.run_id}'>View in Dagster UI</a>"
         card = Card()
         card.add_attachment(text_message=text)
         context.resources.msteams.post_message(payload=card.payload)
@@ -132,10 +129,7 @@ def teams_on_success(
     def _hook(context: HookContext):
         text = message_fn(context)
         if webserver_base_url:
-            text += "<a href='{base_url}/runs/{run_id}'>View in webserver</a>".format(
-                base_url=webserver_base_url,
-                run_id=context.run_id,
-            )
+            text += f"<a href='{webserver_base_url}/runs/{context.run_id}'>View in webserver</a>"
         card = Card()
         card.add_attachment(text_message=text)
         context.resources.msteams.post_message(payload=card.payload)

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/utils.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/utils.py
@@ -58,13 +58,7 @@ def mysql_url_from_config(config_value: MySqlStorageConfig) -> str:
 def get_conn_string(
     username: str, password: str, hostname: str, db_name: str, port: Union[int, str] = "3306"
 ) -> str:
-    return "mysql+mysqlconnector://{username}:{password}@{hostname}:{port}/{db_name}".format(
-        username=username,
-        password=urlquote(password),
-        hostname=hostname,
-        db_name=db_name,
-        port=port,
-    )
+    return f"mysql+mysqlconnector://{username}:{urlquote(password)}@{hostname}:{port}/{db_name}"
 
 
 def parse_mysql_version(version: str) -> Tuple[int, ...]:

--- a/python_modules/libraries/dagster-mysql/dagster_mysql_tests/test_event_log.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql_tests/test_event_log.py
@@ -88,15 +88,15 @@ class TestMySQLEventLogStorage(TestEventLogStorage):
             parse_result.port
         )  # can be different, based on the backcompat mysql version or latest mysql version
 
-        url_cfg = """
+        url_cfg = f"""
         event_log_storage:
             module: dagster_mysql.event_log
             class: MySQLEventLogStorage
             config:
                 mysql_url: mysql+mysqlconnector://test:test@{hostname}:{port}/test
-        """.format(hostname=hostname, port=port)
+        """
 
-        explicit_cfg = """
+        explicit_cfg = f"""
         event_log_storage:
             module: dagster_mysql.event_log
             class: MySQLEventLogStorage
@@ -107,7 +107,7 @@ class TestMySQLEventLogStorage(TestEventLogStorage):
                     hostname: {hostname}
                     port: {port}
                     db_name: test
-        """.format(hostname=hostname, port=port)
+        """
 
         with instance_for_test(overrides=yaml.safe_load(url_cfg)) as from_url_instance:
             from_url = from_url_instance._event_storage  # noqa: SLF001

--- a/python_modules/libraries/dagster-mysql/dagster_mysql_tests/test_instance.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql_tests/test_instance.py
@@ -15,7 +15,7 @@ from sqlalchemy.pool import NullPool
 
 
 def full_mysql_config(hostname, port):
-    return """
+    return f"""
       run_storage:
         module: dagster_mysql.run_storage
         class: MySQLRunStorage
@@ -48,7 +48,7 @@ def full_mysql_config(hostname, port):
               hostname: {hostname}
               port: {port}
               db_name: test
-    """.format(hostname=hostname, port=port)
+    """
 
 
 def unified_mysql_config(hostname, port):

--- a/python_modules/libraries/dagster-mysql/dagster_mysql_tests/test_run_storage.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql_tests/test_run_storage.py
@@ -25,18 +25,15 @@ class TestMySQLRunStorage(TestRunStorage):
             parse_result.port
         )  # can be different, based on the backcompat mysql version or latest mysql version
 
-        url_cfg = """
+        url_cfg = f"""
           run_storage:
             module: dagster_mysql.run_storage
             class: MySQLRunStorage
             config:
               mysql_url: mysql+mysqlconnector://test:test@{hostname}:{port}/test
-        """.format(
-            hostname=hostname,
-            port=port,
-        )
+        """
 
-        explicit_cfg = """
+        explicit_cfg = f"""
           run_storage:
             module: dagster_mysql.run_storage
             class: MySQLRunStorage
@@ -47,13 +44,10 @@ class TestMySQLRunStorage(TestRunStorage):
                 hostname: {hostname}
                 db_name: test
                 port: {port}
-        """.format(
-            hostname=hostname,
-            port=port,
-        )
+        """
 
         with environ({"TEST_MYSQL_PASSWORD": "test"}):
-            env_cfg = """
+            env_cfg = f"""
             run_storage:
               module: dagster_mysql.run_storage
               class: MySQLRunStorage
@@ -65,7 +59,7 @@ class TestMySQLRunStorage(TestRunStorage):
                   hostname: {hostname}
                   db_name: test
                   port: {port}
-            """.format(hostname=hostname, port=port)
+            """
 
             with instance_for_test(overrides=yaml.safe_load(url_cfg)) as from_url_instance:
                 with instance_for_test(

--- a/python_modules/libraries/dagster-pagerduty/dagster_pagerduty/hooks.py
+++ b/python_modules/libraries/dagster-pagerduty/dagster_pagerduty/hooks.py
@@ -77,11 +77,7 @@ def pagerduty_on_failure(
     def _hook(context: HookContext):
         custom_details = {}
         if webserver_base_url:
-            custom_details = {
-                "webserver url": "{base_url}/runs/{run_id}".format(
-                    base_url=webserver_base_url, run_id=context.run_id
-                )
-            }
+            custom_details = {"webserver url": f"{webserver_base_url}/runs/{context.run_id}"}
         context.resources.pagerduty.EventV2_create(
             summary=summary_fn(context),
             source=_source_fn(context),

--- a/python_modules/libraries/dagster-pandas/dagster_pandas/constraints.py
+++ b/python_modules/libraries/dagster-pandas/dagster_pandas/constraints.py
@@ -83,9 +83,7 @@ class DataFrameConstraintViolationException(ConstraintViolationException):
 
     def __init__(self, constraint_name, constraint_description):
         super(DataFrameConstraintViolationException, self).__init__(
-            "Violated {constraint_name} - {constraint_description}".format(
-                constraint_name=constraint_name, constraint_description=constraint_description
-            )
+            f"Violated {constraint_name} - {constraint_description}"
         )
 
 
@@ -203,9 +201,7 @@ class ConstraintWithMetadata:
             )
         return DagsterType(
             name=self.name,
-            description="A Pandas DataFrame with the following validation: {}".format(
-                self.description
-            ),
+            description=f"A Pandas DataFrame with the following validation: {self.description}",
             type_check_fn=lambda x: self.validate(x, *args),
             **kwargs,
         )
@@ -367,9 +363,7 @@ class RowCountConstraint(DataFrameConstraint):
         self.error_tolerance = abs(check.int_param(error_tolerance, "error_tolerance"))
         if self.error_tolerance > self.num_allowed_rows:
             raise ValueError("Tolerance can't be greater than the number of rows you expect.")
-        description = "Dataframe must have {} +- {} rows.".format(
-            self.num_allowed_rows, self.error_tolerance
-        )
+        description = f"Dataframe must have {self.num_allowed_rows} +- {self.error_tolerance} rows."
         super(RowCountConstraint, self).__init__(
             error_description=description, markdown_description=description
         )
@@ -749,9 +743,7 @@ def column_range_validation_factory(minim=None, maxim=None, ignore_missing_vals=
             return True, {}
         return (isinstance(x, (type(minim), type(maxim)))) and (x <= maxim) and (x >= minim), {}
 
-    in_range_validation_fn.__doc__ = "checks whether values are between {} and {}".format(
-        minim, maxim
-    )
+    in_range_validation_fn.__doc__ = f"checks whether values are between {minim} and {maxim}"
     if ignore_missing_vals:
         in_range_validation_fn.__doc__ += ", ignoring nulls"
 
@@ -856,9 +848,7 @@ def dtype_in_set_validation_factory(datatypes, ignore_missing_vals=False):
             return True, {}
         return isinstance(x, datatypes), {}
 
-    dtype_in_set_validation_fn.__doc__ = "checks whether values are this type/types: {}".format(
-        datatypes
-    )
+    dtype_in_set_validation_fn.__doc__ = f"checks whether values are this type/types: {datatypes}"
     if ignore_missing_vals:
         dtype_in_set_validation_fn.__doc__ += ", ignoring nulls"
 
@@ -942,9 +932,7 @@ class ColumnDTypeInSetConstraint(ColumnConstraint):
 
     def __init__(self, expected_dtype_set):
         self.expected_dtype_set = check.set_param(expected_dtype_set, "expected_dtype_set")
-        description = "Column dtype must be in the following set {}.".format(
-            self.expected_dtype_set
-        )
+        description = f"Column dtype must be in the following set {self.expected_dtype_set}."
         super(ColumnDTypeInSetConstraint, self).__init__(
             error_description=description, markdown_description=description
         )
@@ -955,9 +943,7 @@ class ColumnDTypeInSetConstraint(ColumnConstraint):
             raise ColumnConstraintViolationException(
                 constraint_name=self.name,
                 constraint_description=(
-                    "{base_error_message}. DTypes received: {received_dtypes}".format(
-                        base_error_message=self.error_description, received_dtypes=received_dtypes
-                    )
+                    f"{self.error_description}. DTypes received: {received_dtypes}"
                 ),
                 column_name=column_name,
             )

--- a/python_modules/libraries/dagster-pandas/dagster_pandas/data_frame.py
+++ b/python_modules/libraries/dagster-pandas/dagster_pandas/data_frame.py
@@ -42,7 +42,7 @@ CONSTRAINT_BLACKLIST = {ColumnDTypeFnConstraint, ColumnDTypeInSetConstraint}
     )
 )
 def dataframe_loader(_context, config):
-    file_type, file_options = list(config.items())[0]
+    file_type, file_options = next(iter(config.items()))
 
     if file_type == "csv":
         path = file_options["path"]

--- a/python_modules/libraries/dagster-pandas/dagster_pandas/data_frame.py
+++ b/python_modules/libraries/dagster-pandas/dagster_pandas/data_frame.py
@@ -83,9 +83,7 @@ DataFrame = DagsterType(
 
 def _construct_constraint_list(constraints):
     def add_bullet(constraint_list, constraint_description):
-        return constraint_list + "+ {constraint_description}\n".format(
-            constraint_description=constraint_description
-        )
+        return constraint_list + f"+ {constraint_description}\n"
 
     constraint_list = ""
     for constraint in constraints:
@@ -99,13 +97,9 @@ def _build_column_header(column_name, constraints):
     for constraint in constraints:
         if isinstance(constraint, ColumnDTypeInSetConstraint):
             dtypes_tuple = tuple(constraint.expected_dtype_set)
-            return header + ": `{expected_dtypes}`".format(
-                expected_dtypes=dtypes_tuple if len(dtypes_tuple) > 1 else dtypes_tuple[0]
-            )
+            return header + f": `{dtypes_tuple if len(dtypes_tuple) > 1 else dtypes_tuple[0]}`"
         elif isinstance(constraint, ColumnDTypeFnConstraint):
-            return header + ": Validator `{expected_dtype_fn}`".format(
-                expected_dtype_fn=constraint.type_fn.__name__
-            )
+            return header + f": Validator `{constraint.type_fn.__name__}`"
     return header
 
 
@@ -180,8 +174,8 @@ def create_dagster_pandas_dataframe_type(
         if not isinstance(value, pd.DataFrame):
             return TypeCheck(
                 success=False,
-                description="Must be a pandas.DataFrame. Got value of type. {type_name}".format(
-                    type_name=type(value).__name__
+                description=(
+                    f"Must be a pandas.DataFrame. Got value of type. {type(value).__name__}"
                 ),
             )
 
@@ -243,8 +237,8 @@ def create_structured_dataframe_type(
         if not isinstance(value, pd.DataFrame):
             return TypeCheck(
                 success=False,
-                description="Must be a pandas.DataFrame. Got value of type. {type_name}".format(
-                    type_name=type(value).__name__
+                description=(
+                    f"Must be a pandas.DataFrame. Got value of type. {type(value).__name__}"
                 ),
             )
         individual_result_dict = {}

--- a/python_modules/libraries/dagster-pandas/dagster_pandas/validation.py
+++ b/python_modules/libraries/dagster-pandas/dagster_pandas/validation.py
@@ -65,10 +65,7 @@ class PandasColumn:
             # Ignore validation if column is missing from dataframe and is not required
             if self.is_required:
                 raise ConstraintViolationException(
-                    "Required column {column_name} not in dataframe with columns"
-                    " {dataframe_columns}".format(
-                        column_name=self.name, dataframe_columns=dataframe.columns
-                    )
+                    f"Required column {self.name} not in dataframe with columns {dataframe.columns}"
                 )
         else:
             for constraint in self.constraints:

--- a/python_modules/libraries/dagster-pandas/dagster_pandas_tests/test_data_frame.py
+++ b/python_modules/libraries/dagster-pandas/dagster_pandas_tests/test_data_frame.py
@@ -204,7 +204,7 @@ def test_custom_dagster_dataframe_parametrizable_input():
         )
     )
     def silly_loader(_, config):
-        which_door = list(config.keys())[0]
+        which_door = next(iter(config.keys()))
         if which_door == "door_a":
             return DataFrame({"foo": ["goat"]})
         elif which_door == "door_b":

--- a/python_modules/libraries/dagster-pandas/dagster_pandas_tests/test_pandas_ops.py
+++ b/python_modules/libraries/dagster-pandas/dagster_pandas_tests/test_pandas_ops.py
@@ -20,7 +20,7 @@ def get_op_result_value(op_inst):
         node_defs=[load_num_csv_op("load_csv"), op_inst],
         dependencies={
             op_inst.name: {
-                list(op_inst.input_dict.values())[0].name: DependencyDefinition("load_csv")
+                next(iter(op_inst.input_dict.values())).name: DependencyDefinition("load_csv")
             }
         },
         input_mappings=None,

--- a/python_modules/libraries/dagster-pandas/dagster_pandas_tests/test_structured_df_types.py
+++ b/python_modules/libraries/dagster-pandas/dagster_pandas_tests/test_structured_df_types.py
@@ -89,7 +89,7 @@ def test_failing_type_eval_column():
         return create_dataframe()
 
     result = basic_graph.execute_in_process(raise_on_error=False)
-    output = [item for item in result.all_node_events if item.is_successful_output][0]
+    output = next(item for item in result.all_node_events if item.is_successful_output)
     output_data = output.event_specific_data.type_check_data
     output_metadata = output_data.metadata
     assert len(output_metadata) == 1
@@ -131,7 +131,7 @@ def test_failing_type_eval_aggregate():
         return create_dataframe()
 
     result = basic_graph.execute_in_process(raise_on_error=False)
-    output = [item for item in result.all_node_events if item.is_successful_output][0]
+    output = next(item for item in result.all_node_events if item.is_successful_output)
     output_data = output.event_specific_data.type_check_data
     output_metadata = output_data.metadata
     assert len(output_metadata) == 1
@@ -164,7 +164,7 @@ def test_failing_type_eval_dataframe():
         return create_dataframe()
 
     result = basic_graph.execute_in_process(raise_on_error=False)
-    output = [item for item in result.all_node_events if item.is_successful_output][0]
+    output = next(item for item in result.all_node_events if item.is_successful_output)
     output_data = output.event_specific_data.type_check_data
     output_metadata = output_data.metadata
     assert len(output_metadata) == 1
@@ -193,7 +193,7 @@ def test_failing_type_eval_multi_error():
         return create_dataframe()
 
     result = basic_graph.execute_in_process(raise_on_error=False)
-    output = [item for item in result.all_node_events if item.is_successful_output][0]
+    output = next(item for item in result.all_node_events if item.is_successful_output)
     output_data = output.event_specific_data.type_check_data
     output_metadata = output_data.metadata
     assert len(output_metadata) == 3

--- a/python_modules/libraries/dagster-papertrail/dagster_papertrail_tests/test_loggers.py
+++ b/python_modules/libraries/dagster-papertrail/dagster_papertrail_tests/test_loggers.py
@@ -40,6 +40,4 @@ def test_papertrail_logger():
     assert log_record.name == "do_logs"
     assert log_record.levelname == "INFO"
 
-    assert log_record.msg == "do_logs - {run_id} - hello_logs - Hello, world!".format(
-        run_id=result.run_id
-    )
+    assert log_record.msg == f"do_logs - {result.run_id} - hello_logs - Hello, world!"

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_event_log.py
@@ -82,15 +82,15 @@ class TestPostgresEventLogStorage(TestEventLogStorage):
         assert [int(evt.message) for evt in watched_2] == [4, 5]
 
     def test_load_from_config(self, hostname):
-        url_cfg = """
+        url_cfg = f"""
         event_log_storage:
             module: dagster_postgres.event_log
             class: PostgresEventLogStorage
             config:
                 postgres_url: postgresql://test:test@{hostname}:5432/test
-        """.format(hostname=hostname)
+        """
 
-        explicit_cfg = """
+        explicit_cfg = f"""
         event_log_storage:
             module: dagster_postgres.event_log
             class: PostgresEventLogStorage
@@ -100,7 +100,7 @@ class TestPostgresEventLogStorage(TestEventLogStorage):
                     password: test
                     hostname: {hostname}
                     db_name: test
-        """.format(hostname=hostname)
+        """
 
         with instance_for_test(overrides=yaml.safe_load(url_cfg)) as from_url_instance:
             from_url = from_url_instance._event_storage  # noqa: SLF001

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_instance.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_instance.py
@@ -12,7 +12,7 @@ from dagster_postgres.utils import get_conn, get_conn_string
 
 
 def full_pg_config(hostname):
-    return """
+    return f"""
       run_storage:
         module: dagster_postgres.run_storage
         class: PostgresRunStorage
@@ -42,7 +42,7 @@ def full_pg_config(hostname):
               password: test
               hostname: {hostname}
               db_name: test
-    """.format(hostname=hostname)
+    """
 
 
 def unified_pg_config(hostname):
@@ -59,7 +59,7 @@ def unified_pg_config(hostname):
 
 
 def skip_autocreate_pg_config(hostname):
-    return """
+    return f"""
       run_storage:
         module: dagster_postgres.run_storage
         class: PostgresRunStorage
@@ -92,11 +92,11 @@ def skip_autocreate_pg_config(hostname):
               password: test
               hostname: {hostname}
               db_name: test
-    """.format(hostname=hostname)
+    """
 
 
 def params_specified_pg_config(hostname):
-    return """
+    return f"""
       run_storage:
         module: dagster_postgres.run_storage
         class: PostgresRunStorage
@@ -141,7 +141,7 @@ def params_specified_pg_config(hostname):
                 connect_timeout: 10
                 application_name: myapp
                 options: -c synchronous_commit=off
-    """.format(hostname=hostname)
+    """
 
 
 def schema_specified_pg_config(hostname):

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_run_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_run_storage.py
@@ -15,15 +15,15 @@ class TestPostgresRunStorage(TestRunStorage):
         return storage
 
     def test_load_from_config(self, hostname):
-        url_cfg = """
+        url_cfg = f"""
           run_storage:
             module: dagster_postgres.run_storage
             class: PostgresRunStorage
             config:
               postgres_url: postgresql://test:test@{hostname}:5432/test
-        """.format(hostname=hostname)
+        """
 
-        explicit_cfg = """
+        explicit_cfg = f"""
           run_storage:
             module: dagster_postgres.run_storage
             class: PostgresRunStorage
@@ -33,10 +33,10 @@ class TestPostgresRunStorage(TestRunStorage):
                 password: test
                 hostname: {hostname}
                 db_name: test
-        """.format(hostname=hostname)
+        """
 
         with environ({"TEST_PG_PASSWORD": "test"}):
-            env_cfg = """
+            env_cfg = f"""
             run_storage:
               module: dagster_postgres.run_storage
               class: PostgresRunStorage
@@ -47,7 +47,7 @@ class TestPostgresRunStorage(TestRunStorage):
                     env: TEST_PG_PASSWORD
                   hostname: {hostname}
                   db_name: test
-            """.format(hostname=hostname)
+            """
 
             with instance_for_test(overrides=yaml.safe_load(url_cfg)) as from_url_instance:
                 with instance_for_test(

--- a/python_modules/libraries/dagster-pyspark/dagster_pyspark/types.py
+++ b/python_modules/libraries/dagster-pyspark/dagster_pyspark/types.py
@@ -670,7 +670,7 @@ WriteCompressionParquetOptions = Enum(
 )
 def dataframe_loader(_context, config):
     spark_read = _context.resources.pyspark.spark_session.read
-    file_type, file_options = list(config.items())[0]
+    file_type, file_options = next(iter(config.items()))
     path = file_options.get("path")
 
     if file_type == "csv":

--- a/python_modules/libraries/dagster-shell/dagster_shell/ops.py
+++ b/python_modules/libraries/dagster-shell/dagster_shell/ops.py
@@ -157,11 +157,7 @@ def create_shell_command_op(
         )
 
         if return_code:
-            raise Failure(
-                description="Shell command execution failed with output: {output}".format(
-                    output=output
-                )
-            )
+            raise Failure(description=f"Shell command execution failed with output: {output}")
 
         return output
 
@@ -237,11 +233,7 @@ def create_shell_script_op(
         )
 
         if return_code:
-            raise Failure(
-                description="Shell command execution failed with output: {output}".format(
-                    output=output
-                )
-            )
+            raise Failure(description=f"Shell command execution failed with output: {output}")
 
         return output
 

--- a/python_modules/libraries/dagster-shell/dagster_shell/utils.py
+++ b/python_modules/libraries/dagster-shell/dagster_shell/utils.py
@@ -99,7 +99,7 @@ def execute_script_file(
             stderr=stderr_pipe,
             cwd=cwd,
             env=env,
-            preexec_fn=pre_exec,
+            preexec_fn=pre_exec,  # noqa: PLW1509
             encoding="UTF-8",
         )
 

--- a/python_modules/libraries/dagster-slack/dagster_slack/hooks.py
+++ b/python_modules/libraries/dagster-slack/dagster_slack/hooks.py
@@ -7,12 +7,7 @@ from dagster._utils.warnings import normalize_renamed_param
 
 
 def _default_status_message(context: HookContext, status: str) -> str:
-    return "Op {op_name} on job {job_name} {status}!\nRun ID: {run_id}".format(
-        op_name=context.op.name,
-        job_name=context.job_name,
-        run_id=context.run_id,
-        status=status,
-    )
+    return f"Op {context.op.name} on job {context.job_name} {status}!\nRun ID: {context.run_id}"
 
 
 def _default_failure_message(context: HookContext) -> str:
@@ -75,9 +70,7 @@ def slack_on_failure(
     def _hook(context: HookContext):
         text = message_fn(context)
         if webserver_base_url:
-            text += "\n<{base_url}/runs/{run_id}|View in Dagster UI>".format(
-                base_url=webserver_base_url, run_id=context.run_id
-            )
+            text += f"\n<{webserver_base_url}/runs/{context.run_id}|View in Dagster UI>"
 
         context.resources.slack.chat_postMessage(channel=channel, text=text)
 
@@ -136,9 +129,7 @@ def slack_on_success(
     def _hook(context: HookContext):
         text = message_fn(context)
         if webserver_base_url:
-            text += "\n<{base_url}/runs/{run_id}|View in Dagster UI>".format(
-                base_url=webserver_base_url, run_id=context.run_id
-            )
+            text += f"\n<{webserver_base_url}/runs/{context.run_id}|View in Dagster UI>"
 
         context.resources.slack.chat_postMessage(channel=channel, text=text)
 

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
@@ -660,8 +660,7 @@ class SnowflakeConnection:
             f"CREATE OR REPLACE TABLE {table} ( data VARIANT DEFAULT NULL);",
             "CREATE OR REPLACE FILE FORMAT parquet_format TYPE = 'parquet';",
             f"PUT {src} @%{table};",
-            "COPY INTO {table} FROM @%{table} FILE_FORMAT = (FORMAT_NAME = 'parquet_format');"
-            .format(table=table),
+            f"COPY INTO {table} FROM @%{table} FILE_FORMAT = (FORMAT_NAME = 'parquet_format');",
         ]
 
         self.execute_queries(sql_queries)

--- a/python_modules/libraries/dagster-spark/dagster_spark/resources.py
+++ b/python_modules/libraries/dagster-spark/dagster_spark/resources.py
@@ -40,8 +40,8 @@ class SparkResource:
 
         if not os.path.exists(application_jar):
             raise SparkOpError(
-                "Application jar {} does not exist. A valid jar must be "
-                "built before running this op.".format(application_jar)
+                f"Application jar {application_jar} does not exist. A valid jar must be "
+                "built before running this op."
             )
 
         spark_shell_cmd = construct_spark_shell_command(

--- a/python_modules/libraries/dagster-ssh/dagster_ssh/resources.py
+++ b/python_modules/libraries/dagster-ssh/dagster_ssh/resources.py
@@ -181,9 +181,7 @@ class SSHResource:
             # Create intermediate directories if they don't exist
             mkdir_p(local_folder)
 
-            self.log.info(
-                "Starting to transfer from {0} to {1}".format(remote_filepath, local_filepath)
-            )
+            self.log.info(f"Starting to transfer from {remote_filepath} to {local_filepath}")
 
             sftp_client.get(remote_filepath, local_filepath)
 
@@ -195,9 +193,7 @@ class SSHResource:
         check.str_param(local_filepath, "local_filepath")
         conn = self.get_connection()
         with conn.open_sftp() as sftp_client:
-            self.log.info(
-                "Starting to transfer file from {0} to {1}".format(local_filepath, remote_filepath)
-            )
+            self.log.info(f"Starting to transfer file from {local_filepath} to {remote_filepath}")
 
             sftp_client.put(local_filepath, remote_filepath, confirm=confirm)
 

--- a/python_modules/libraries/dagster-wandb/dagster_wandb/io_manager.py
+++ b/python_modules/libraries/dagster-wandb/dagster_wandb/io_manager.py
@@ -479,7 +479,7 @@ class ArtifactsIOManager(IOManager):
 
                 if len(output) == 1:
                     # If there's only one partition, return the value directly
-                    return list(output.values())[0]
+                    return next(iter(output.values()))
 
                 return output
 

--- a/python_modules/libraries/dagstermill/dagstermill/cli.py
+++ b/python_modules/libraries/dagstermill/dagstermill/cli.py
@@ -110,11 +110,9 @@ def execute_create_notebook(notebook: str, force_overwrite: bool, kernel: str):
 
     if not force_overwrite and safe_isfile(notebook_path):
         click.confirm(
-            (
-                "Warning, {notebook_path} already exists and continuing "
-                "will overwrite the existing notebook. "
-                "Are you sure you want to continue?"
-            ).format(notebook_path=notebook_path),
+            f"Warning, {notebook_path} already exists and continuing "
+            "will overwrite the existing notebook. "
+            "Are you sure you want to continue?",
             abort=True,
         )
 

--- a/python_modules/libraries/dagstermill/dagstermill_tests/test_assets.py
+++ b/python_modules/libraries/dagstermill/dagstermill_tests/test_assets.py
@@ -13,7 +13,7 @@ from dagstermill.examples.repository import custom_io_mgr_key_asset
 
 
 def get_path(materialization_event):
-    for key, value in materialization_event.event_specific_data.materialization.metadata.items():
+    for value in materialization_event.event_specific_data.materialization.metadata.values():
         if isinstance(value, (NotebookMetadataValue, PathMetadataValue)):
             return value.path
 

--- a/python_modules/libraries/dagstermill/dagstermill_tests/test_ops.py
+++ b/python_modules/libraries/dagstermill/dagstermill_tests/test_ops.py
@@ -338,16 +338,14 @@ def test_hello_world_reexecution():
 
         with tempfile.NamedTemporaryFile("w+", suffix=".py") as reexecution_notebook_file:
             reexecution_notebook_file.write(
-                (
-                    "from dagster import job\n"
-                    "from dagstermill.factory import define_dagstermill_op\n\n\n"
-                    "reexecution_op = define_dagstermill_op(\n"
-                    "    'hello_world_reexecution', '{output_notebook_path}'\n"
-                    ")\n\n"
-                    "@job\n"
-                    "def reexecution_job():\n"
-                    "    reexecution_op()\n"
-                ).format(output_notebook_path=output_notebook_path)
+                "from dagster import job\n"
+                "from dagstermill.factory import define_dagstermill_op\n\n\n"
+                "reexecution_op = define_dagstermill_op(\n"
+                f"    'hello_world_reexecution', '{output_notebook_path}'\n"
+                ")\n\n"
+                "@job\n"
+                "def reexecution_job():\n"
+                "    reexecution_op()\n"
             )
             reexecution_notebook_file.flush()
 

--- a/python_modules/libraries/dagstermill/dagstermill_tests/test_ops.py
+++ b/python_modules/libraries/dagstermill/dagstermill_tests/test_ops.py
@@ -333,7 +333,7 @@ def test_hello_world_reexecution():
         assert result.success
 
         output_notebook_path = get_path(
-            [x for x in result.all_events if x.event_type_value == "ASSET_MATERIALIZATION"][0]
+            next(x for x in result.all_events if x.event_type_value == "ASSET_MATERIALIZATION")
         )
 
         with tempfile.NamedTemporaryFile("w+", suffix=".py") as reexecution_notebook_file:

--- a/scripts/run-pyright.py
+++ b/scripts/run-pyright.py
@@ -348,7 +348,7 @@ def run_pyright(
         shell_cmd = " \\\n".join([base_pyright_cmd, *[f"    {p}" for p in paths or []]])
         print(f"Running pyright for environment `{env}`...")
         print(f"  {shell_cmd}")
-        result = subprocess.run(shell_cmd, capture_output=True, shell=True, text=True)
+        result = subprocess.run(shell_cmd, capture_output=True, shell=True, text=True, check=True)
         try:
             json_result = json.loads(result.stdout)
         except json.JSONDecodeError:


### PR DESCRIPTION
## Summary & Motivation

Bump ruff version from 0.0.277 -> 0.0.288 and fix newly raised issues. Each violated rule has all of its fixes in 1 commit. Rules:

- UP032 (existing rule): Auto-converts `.format` to f-string in most cases. This rule became more aggressive and converted many more instances.
- RUF015 (new rule): Prefer an iterator over list conversion when performing one-off access to first iterable element.
- RUF100 (existing rule): No unnecessary noqa comments. Several were removed due to bugfixes in other rules.
- RUF010 (existing rule): Use conversion flags in f-strings. Behavior changed to convert use of `repr()` to `!r` flag.
- PLW0127 (new rule): No redundant assignment, e.g. `x = x`.
- SLF001 (existing rule): No private attr access. Bugfix allows accessing class private attr inside an instance.
- PLW1510 (new rule): Always pass explicit `check=` kwarg when calling `subprocess.run()`.
- PERF102 (existing rule): When using only values of a dict, use `values()` instead of `items()`.
- PLW1509 (new rule): `preexec_fn` is unsafe for subprocess.run.

## How I Tested These Changes

Existing test suite.
