### PR TITLE
Materialize assets without running checks

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
@@ -164,7 +164,7 @@ def pipeline_selector_from_graphql(data: Mapping[str, Any]) -> JobSubsetSelector
                 AssetCheckHandle.from_graphql_input(asset_check)
                 for asset_check in asset_check_selection
             ]
-            if asset_check_selection
+            if asset_check_selection is not None
             else None
         ),
     )

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_checks.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_checks.py
@@ -840,3 +840,43 @@ class TestAssetChecks(ExecutingGraphQLContextTestMatrix):
             " asset_check_selection argument AssetCheckHandle(asset_key=AssetKey(['asset_1']),"
             " name='non-existent-check') do not exist in parent asset group or job.\n"
         )
+
+    def test_launch_subset_asset_no_check(self, graphql_context: WorkspaceRequestContext):
+        selector = infer_job_or_pipeline_selector(
+            graphql_context,
+            "asset_check_job",
+            asset_selection=[{"path": ["asset_1"]}],
+            asset_check_selection=[],
+        )
+        result = execute_dagster_graphql(
+            graphql_context,
+            LAUNCH_PIPELINE_EXECUTION_MUTATION,
+            variables={
+                "executionParams": {
+                    "selector": selector,
+                    "mode": "default",
+                    "stepKeys": None,
+                }
+            },
+        )
+        print(result.data)  # noqa: T201
+        assert result.data["launchPipelineExecution"]["__typename"] == "LaunchRunSuccess"
+
+        run_id = result.data["launchPipelineExecution"]["run"]["runId"]
+        run = poll_for_finished_run(graphql_context.instance, run_id)
+
+        logs = graphql_context.instance.all_logs(run_id)
+        print(logs)  # noqa: T201
+        assert run.is_success
+
+        for log in logs:
+            if log.dagster_event:
+                assert log.dagster_event.event_type != DagsterEventType.ASSET_CHECK_EVALUATION.value
+
+        materializations = [
+            log
+            for log in logs
+            if log.dagster_event
+            and log.dagster_event.event_type == DagsterEventType.ASSET_MATERIALIZATION
+        ]
+        assert len(materializations) == 1

--- a/python_modules/dagster/dagster/_core/definitions/selector.py
+++ b/python_modules/dagster/dagster/_core/definitions/selector.py
@@ -34,7 +34,9 @@ class JobSubsetSelector(
         asset_check_selection: Optional[Iterable[AssetCheckHandle]] = None,
     ):
         asset_selection = set(asset_selection) if asset_selection else None
-        asset_check_selection = set(asset_check_selection) if asset_check_selection else None
+        asset_check_selection = (
+            set(asset_check_selection) if asset_check_selection is not None else None
+        )
         return super(JobSubsetSelector, cls).__new__(
             cls,
             location_name=check.str_param(location_name, "location_name"),

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -1434,7 +1434,9 @@ class DagsterInstance(DynamicPartitionsStore):
         # We are asserting that invariant here to maintain that behavior.
         #
         # Finally, asset_check_selection can be passed along with asset_selection. It
-        # is mutually exclusive with op_selection and resolved_op_selection.
+        # is mutually exclusive with op_selection and resolved_op_selection. A `None`
+        # value will include any asset checks that target selected assets. An empty set
+        # will include no asset checks.
 
         check.opt_set_param(resolved_op_selection, "resolved_op_selection", of_type=str)
         check.opt_sequence_param(op_selection, "op_selection", of_type=str)


### PR DESCRIPTION
Addendum to https://github.com/dagster-io/dagster/commit/e6ed0786ad5740a67f0c20b67effe3a5cb684417.

Remove two places where we turned `asset_check_selection` from `[]` to `None`. This lets us pass `asset_selection=[whatever]` and `asset_check_selection=[]` to only materialize the assets and not run checks. `asset_selection=[whatever]` and `asset_check_selection=None` will do both.

This is somewhere that having a combined object might let us be more explicit instead of using these two values. But I think as long as we have a test cases for entrypoints we add, we'll catch if they get messed up