### PR TITLE
[ui] Front-end for launching asset checks

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/SidebarAssetInfo.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/SidebarAssetInfo.tsx
@@ -263,6 +263,7 @@ const SIDEBAR_ASSET_FRAGMENT = gql`
       }
     }
     opVersion
+    jobNames
     repository {
       id
       name

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__stories__/SidebarAssetInfo.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__stories__/SidebarAssetInfo.stories.tsx
@@ -69,6 +69,7 @@ const buildSidebarQueryMock = (
         description: null,
         configField: null,
         metadataEntries: [],
+        jobNames: ['test_job'],
         autoMaterializePolicy: null,
         freshnessPolicy: null,
         partitionDefinition: null,

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/types/SidebarAssetInfo.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/types/SidebarAssetInfo.types.ts
@@ -7,6 +7,7 @@ export type SidebarAssetFragment = {
   id: string;
   description: string | null;
   opVersion: string | null;
+  jobNames: Array<string>;
   metadataEntries: Array<
     | {
         __typename: 'AssetMetadataEntry';
@@ -15551,6 +15552,7 @@ export type SidebarAssetQuery = {
         id: string;
         description: string | null;
         opVersion: string | null;
+        jobNames: Array<string>;
         metadataEntries: Array<
           | {
               __typename: 'AssetMetadataEntry';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetSidebarActivitySummary.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetSidebarActivitySummary.tsx
@@ -1,11 +1,10 @@
-import {Body, Box, Button, Colors, Icon, Spinner, Table} from '@dagster-io/ui-components';
+import {Body, Box, Colors, Icon, Spinner, Table} from '@dagster-io/ui-components';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
 
 import {LiveDataForNode} from '../asset-graph/Utils';
 import {SidebarAssetFragment} from '../asset-graph/types/SidebarAssetInfo.types';
 import {SidebarSection} from '../pipelines/SidebarComponents';
-import {buildRepoAddress} from '../workspace/buildRepoAddress';
 
 import {AssetEventSystemTags} from './AssetEventSystemTags';
 import {AssetMaterializationGraphs} from './AssetMaterializationGraphs';
@@ -18,7 +17,7 @@ import {FailedRunSinceMaterializationBanner} from './FailedRunSinceMaterializati
 import {LatestMaterializationMetadata} from './LastMaterializationMetadata';
 import {OverdueTag, freshnessPolicyDescription} from './OverdueTag';
 import {AssetCheckStatusTag} from './asset-checks/AssetCheckStatusTag';
-import {EvaluateChecksButton} from './asset-checks/EvaluateChecksButton';
+import {ExexcuteChecksButton} from './asset-checks/ExecuteChecksButton';
 import {assetDetailsPathForKey} from './assetDetailsPathForKey';
 import {useGroupedEvents} from './groupByPartition';
 import {useRecentAssetEvents} from './useRecentAssetEvents';
@@ -171,7 +170,7 @@ export const AssetSidebarActivitySummary: React.FC<Props> = ({
       {liveData && liveData.assetChecks.length > 0 && (
         <SidebarSection title="Checks">
           <Box padding={{horizontal: 24, vertical: 12}} flex={{gap: 12, alignItems: 'center'}}>
-            <EvaluateChecksButton assetNode={asset} checks={liveData.assetChecks} />
+            <ExexcuteChecksButton assetNode={asset} checks={liveData.assetChecks} />
             <Link to={assetDetailsPathForKey(asset.assetKey, {view: 'checks'})}>
               View all check details
             </Link>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetSidebarActivitySummary.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetSidebarActivitySummary.tsx
@@ -1,10 +1,11 @@
-import {Body, Box, Colors, Icon, Spinner, Table} from '@dagster-io/ui-components';
+import {Body, Box, Button, Colors, Icon, Spinner, Table} from '@dagster-io/ui-components';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
 
 import {LiveDataForNode} from '../asset-graph/Utils';
 import {SidebarAssetFragment} from '../asset-graph/types/SidebarAssetInfo.types';
 import {SidebarSection} from '../pipelines/SidebarComponents';
+import {buildRepoAddress} from '../workspace/buildRepoAddress';
 
 import {AssetEventSystemTags} from './AssetEventSystemTags';
 import {AssetMaterializationGraphs} from './AssetMaterializationGraphs';
@@ -17,6 +18,7 @@ import {FailedRunSinceMaterializationBanner} from './FailedRunSinceMaterializati
 import {LatestMaterializationMetadata} from './LastMaterializationMetadata';
 import {OverdueTag, freshnessPolicyDescription} from './OverdueTag';
 import {AssetCheckStatusTag} from './asset-checks/AssetCheckStatusTag';
+import {EvaluateChecksButton} from './asset-checks/EvaluateChecksButton';
 import {assetDetailsPathForKey} from './assetDetailsPathForKey';
 import {useGroupedEvents} from './groupByPartition';
 import {useRecentAssetEvents} from './useRecentAssetEvents';
@@ -168,7 +170,8 @@ export const AssetSidebarActivitySummary: React.FC<Props> = ({
       </SidebarSection>
       {liveData && liveData.assetChecks.length > 0 && (
         <SidebarSection title="Checks">
-          <Box padding={{horizontal: 24, vertical: 12}}>
+          <Box padding={{horizontal: 24, vertical: 12}} flex={{gap: 12, alignItems: 'center'}}>
+            <EvaluateChecksButton assetNode={asset} checks={liveData.assetChecks} />
             <Link to={assetDetailsPathForKey(asset.assetKey, {view: 'checks'})}>
               View all check details
             </Link>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetChecks.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetChecks.tsx
@@ -17,7 +17,7 @@ import {
   MigrationRequired,
   NoChecks,
 } from './AssetCheckDetailModal';
-import {EvaluateChecksButton} from './EvaluateChecksButton';
+import {ExexcuteChecksButton} from './ExecuteChecksButton';
 import {VirtualizedAssetCheckTable} from './VirtualizedAssetCheckTable';
 import {AssetChecksQuery, AssetChecksQueryVariables} from './types/AssetChecks.types';
 
@@ -44,15 +44,15 @@ export const AssetChecks = ({
     }
     const assetNode = data.assetNodeOrError;
     const result = data.assetChecksOrError!;
-    if (assetNode?.__typename !== 'AssetNode') {
-      return <span />;
-    }
     if (result.__typename === 'AssetCheckNeedsMigrationError') {
       return <MigrationRequired />;
     }
     const checks = result.checks;
     if (!checks.length) {
       return <NoChecks />;
+    }
+    if (assetNode?.__typename !== 'AssetNode') {
+      return <span />;
     }
     return <VirtualizedAssetCheckTable assetNode={assetNode} rows={checks} />;
   }
@@ -63,7 +63,7 @@ export const AssetChecks = ({
     if (checksOrError?.__typename !== 'AssetChecks' || assetNode?.__typename !== 'AssetNode') {
       return <span />;
     }
-    return <EvaluateChecksButton assetNode={assetNode} checks={checksOrError.checks} />;
+    return <ExexcuteChecksButton assetNode={assetNode} checks={checksOrError.checks} />;
   }
 
   const {AssetChecksBanner} = useContext(AssetFeatureContext);

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetChecks.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetChecks.tsx
@@ -17,6 +17,7 @@ import {
   MigrationRequired,
   NoChecks,
 } from './AssetCheckDetailModal';
+import {EvaluateChecksButton} from './EvaluateChecksButton';
 import {VirtualizedAssetCheckTable} from './VirtualizedAssetCheckTable';
 import {AssetChecksQuery, AssetChecksQueryVariables} from './types/AssetChecks.types';
 
@@ -28,9 +29,7 @@ export const AssetChecks = ({
   lastMaterializationTimestamp: string | undefined;
 }) => {
   const queryResult = useQuery<AssetChecksQuery, AssetChecksQueryVariables>(ASSET_CHECKS_QUERY, {
-    variables: {
-      assetKey,
-    },
+    variables: {assetKey},
   });
   const {data} = queryResult;
   useQueryRefreshAtInterval(queryResult, FIFTEEN_SECONDS);
@@ -38,11 +37,16 @@ export const AssetChecks = ({
   const [openCheck, setOpenCheck] = useQueryPersistedState<string | undefined>({
     queryKey: 'checkDetail',
   });
+
   function content() {
     if (!data) {
       return <LoadingSpinner purpose="page" />;
     }
+    const assetNode = data.assetNodeOrError;
     const result = data.assetChecksOrError!;
+    if (assetNode?.__typename !== 'AssetNode') {
+      return <span />;
+    }
     if (result.__typename === 'AssetCheckNeedsMigrationError') {
       return <MigrationRequired />;
     }
@@ -50,7 +54,16 @@ export const AssetChecks = ({
     if (!checks.length) {
       return <NoChecks />;
     }
-    return <VirtualizedAssetCheckTable assetKey={assetKey} rows={checks} />;
+    return <VirtualizedAssetCheckTable assetNode={assetNode} rows={checks} />;
+  }
+
+  function executeAllButton() {
+    const assetNode = data?.assetNodeOrError;
+    const checksOrError = data?.assetChecksOrError;
+    if (checksOrError?.__typename !== 'AssetChecks' || assetNode?.__typename !== 'AssetNode') {
+      return <span />;
+    }
+    return <EvaluateChecksButton assetNode={assetNode} checks={checksOrError.checks} />;
   }
 
   const {AssetChecksBanner} = useContext(AssetFeatureContext);
@@ -93,17 +106,7 @@ export const AssetChecks = ({
             <Tag icon="materialization">None </Tag>
           )}
         </Box>
-        {/* TODO: Enable once the mutations are ready */}
-        {/* {data && 'checks' in data.assetChecksOrError! && data.assetChecksOrError.checks.length ? (
-          <Button
-            icon={<Icon name="run" />}
-            onClick={() => {
-              //TODO
-            }}
-          >
-            Execute all checks
-          </Button>
-        ) : null} */}
+        {executeAllButton()}
       </Box>
       {content()}
     </div>
@@ -112,6 +115,23 @@ export const AssetChecks = ({
 
 export const ASSET_CHECKS_QUERY = gql`
   query AssetChecksQuery($assetKey: AssetKeyInput!) {
+    assetNodeOrError(assetKey: $assetKey) {
+      ... on AssetNode {
+        id
+        jobNames
+        assetKey {
+          path
+        }
+        repository {
+          id
+          name
+          location {
+            id
+            name
+          }
+        }
+      }
+    }
     assetChecksOrError(assetKey: $assetKey) {
       ... on AssetCheckNeedsMigrationError {
         message

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/EvaluateChecksButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/EvaluateChecksButton.tsx
@@ -1,0 +1,86 @@
+import {Button, Icon, Spinner, Tooltip} from '@dagster-io/ui-components';
+import React, {useState} from 'react';
+
+import {usePermissionsForLocation} from '../../app/Permissions';
+import {AssetKeyInput} from '../../graphql/types';
+import {useLaunchPadHooks} from '../../launchpad/LaunchpadHooksContext';
+
+export type EvaluateChecksAssetNode = {
+  assetKey: AssetKeyInput;
+  repository: {name: string; location: {name: string}};
+  jobNames: string[];
+};
+
+export const EvaluateChecksButton = ({
+  assetNode,
+  checks,
+  label = `Evaluate all`,
+  icon = true,
+}: {
+  assetNode: EvaluateChecksAssetNode;
+  checks: {name: string}[];
+  label?: string;
+  icon?: boolean;
+}) => {
+  const {assetKey, jobNames, repository} = assetNode;
+  const [launching, setLaunching] = useState(false);
+  const {permissions, disabledReasons} = usePermissionsForLocation(repository.location.name);
+
+  const {useLaunchWithTelemetry} = useLaunchPadHooks();
+  const launchWithTelemetry = useLaunchWithTelemetry();
+
+  const iconEl = launching ? (
+    <Spinner purpose="caption-text" />
+  ) : icon ? (
+    <Icon name="execute" />
+  ) : null;
+
+  if (!permissions.canLaunchPipelineExecution) {
+    return (
+      <Tooltip content={disabledReasons.canLaunchPipelineExecution}>
+        <Button icon={iconEl} disabled>
+          {label}
+        </Button>
+      </Tooltip>
+    );
+  }
+
+  const jobName = jobNames[0];
+  if (!jobName) {
+    return (
+      <Tooltip content="No jobs were found to execute the selected checks">
+        <Button icon={iconEl} disabled>
+          {label}
+        </Button>
+      </Tooltip>
+    );
+  }
+
+  const onClick = async () => {
+    const params = {
+      executionParams: {
+        mode: 'default',
+        executionMetadata: {},
+        runConfigData: '{}',
+        selector: {
+          repositoryLocationName: repository.location.name,
+          repositoryName: repository.name,
+          jobName,
+          assetCheckSelection: checks.map((c) => ({
+            assetKey: {path: assetKey.path},
+            name: c.name,
+          })),
+        },
+      },
+    };
+    setLaunching(true);
+    await launchWithTelemetry(params, 'toast');
+    setLaunching(false);
+  };
+
+  return (
+    <Button disabled={launching} icon={iconEl} onClick={onClick}>
+      {label}
+    </Button>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/ExecuteChecksButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/ExecuteChecksButton.tsx
@@ -11,10 +11,10 @@ export type EvaluateChecksAssetNode = {
   jobNames: string[];
 };
 
-export const EvaluateChecksButton = ({
+export const ExexcuteChecksButton = ({
   assetNode,
   checks,
-  label = `Evaluate all`,
+  label = `Execute all`,
   icon = true,
 }: {
   assetNode: EvaluateChecksAssetNode;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/VirtualizedAssetCheckTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/VirtualizedAssetCheckTable.tsx
@@ -11,7 +11,7 @@ import {assetDetailsPathForKey} from '../assetDetailsPathForKey';
 
 import {MetadataCell} from './AssetCheckDetailModal';
 import {AssetCheckStatusTag} from './AssetCheckStatusTag';
-import {EvaluateChecksAssetNode, EvaluateChecksButton} from './EvaluateChecksButton';
+import {EvaluateChecksAssetNode, ExexcuteChecksButton} from './ExecuteChecksButton';
 import {AssetChecksQuery} from './types/AssetChecks.types';
 
 type Check = Extract<
@@ -109,10 +109,10 @@ export const VirtualizedAssetCheckRow = ({assetNode, height, start, row}: AssetC
         </RowCell>
         <RowCell>
           <Box flex={{justifyContent: 'flex-end'}}>
-            <EvaluateChecksButton
+            <ExexcuteChecksButton
               assetNode={assetNode}
               checks={[row]}
-              label="Evaluate"
+              label="Execute"
               icon={false}
             />
           </Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/VirtualizedAssetCheckTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/VirtualizedAssetCheckTable.tsx
@@ -4,7 +4,6 @@ import * as React from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components';
 
-import {AssetKeyInput} from '../../graphql/types';
 import {TimestampDisplay} from '../../schedules/TimestampDisplay';
 import {testId} from '../../testing/testId';
 import {HeaderCell, Row, RowCell, Container, Inner} from '../../ui/VirtualizedTable';
@@ -12,6 +11,7 @@ import {assetDetailsPathForKey} from '../assetDetailsPathForKey';
 
 import {MetadataCell} from './AssetCheckDetailModal';
 import {AssetCheckStatusTag} from './AssetCheckStatusTag';
+import {EvaluateChecksAssetNode, EvaluateChecksButton} from './EvaluateChecksButton';
 import {AssetChecksQuery} from './types/AssetChecks.types';
 
 type Check = Extract<
@@ -20,11 +20,11 @@ type Check = Extract<
 >['checks'][0];
 
 type Props = {
-  assetKey: AssetKeyInput;
+  assetNode: EvaluateChecksAssetNode;
   rows: Check[];
 };
 
-export const VirtualizedAssetCheckTable: React.FC<Props> = ({assetKey, rows}: Props) => {
+export const VirtualizedAssetCheckTable: React.FC<Props> = ({assetNode, rows}: Props) => {
   const parentRef = React.useRef<HTMLDivElement | null>(null);
   const count = rows.length;
 
@@ -47,7 +47,7 @@ export const VirtualizedAssetCheckTable: React.FC<Props> = ({assetKey, rows}: Pr
             const row: Check = rows[index]!;
             return (
               <VirtualizedAssetCheckRow
-                assetKey={assetKey}
+                assetNode={assetNode}
                 key={key}
                 height={size}
                 start={start}
@@ -61,16 +61,16 @@ export const VirtualizedAssetCheckTable: React.FC<Props> = ({assetKey, rows}: Pr
   );
 };
 
-const TEMPLATE_COLUMNS = '2fr 150px 1fr 1fr';
+const TEMPLATE_COLUMNS = '2fr 150px 1fr 1fr 140px';
 
 interface AssetCheckRowProps {
-  assetKey: AssetKeyInput;
+  assetNode: EvaluateChecksAssetNode;
   height: number;
   start: number;
   row: Check;
 }
 
-export const VirtualizedAssetCheckRow = ({assetKey, height, start, row}: AssetCheckRowProps) => {
+export const VirtualizedAssetCheckRow = ({assetNode, height, start, row}: AssetCheckRowProps) => {
   const execution = row.executionForLatestMaterialization;
   const timestamp = execution?.evaluation?.timestamp;
 
@@ -80,7 +80,7 @@ export const VirtualizedAssetCheckRow = ({assetKey, height, start, row}: AssetCh
         <RowCell style={{flexDirection: 'row', alignItems: 'center'}}>
           <Box flex={{direction: 'column', gap: 4}}>
             <Link
-              to={assetDetailsPathForKey(assetKey, {
+              to={assetDetailsPathForKey(assetNode.assetKey, {
                 view: 'checks',
                 checkDetail: row.name,
               })}
@@ -106,6 +106,16 @@ export const VirtualizedAssetCheckRow = ({assetKey, height, start, row}: AssetCh
         </RowCell>
         <RowCell>
           <MetadataCell metadataEntries={execution?.evaluation?.metadataEntries} />
+        </RowCell>
+        <RowCell>
+          <Box flex={{justifyContent: 'flex-end'}}>
+            <EvaluateChecksButton
+              assetNode={assetNode}
+              checks={[row]}
+              label="Evaluate"
+              icon={false}
+            />
+          </Box>
         </RowCell>
       </RowGrid>
     </Row>
@@ -135,6 +145,7 @@ export const VirtualizedAssetCheckHeader = () => {
       <HeaderCell>Status</HeaderCell>
       <HeaderCell>Evaluation timestamp</HeaderCell>
       <HeaderCell>Evaluation metadata</HeaderCell>
+      <HeaderCell>Actions</HeaderCell>
     </Box>
   );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/__stories__/AssetChecks.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/__stories__/AssetChecks.stories.tsx
@@ -3,7 +3,12 @@ import {Meta} from '@storybook/react';
 import * as React from 'react';
 import {MemoryRouter} from 'react-router-dom';
 
-import {buildAssetCheckNeedsMigrationError, buildAssetChecks} from '../../../graphql/types';
+import {
+  buildAssetCheckNeedsMigrationError,
+  buildAssetChecks,
+  buildAssetKey,
+  buildAssetNode,
+} from '../../../graphql/types';
 import {AssetFeatureProvider} from '../../AssetFeatureContext';
 import {buildQueryMock} from '../../AutoMaterializePolicyPage/__fixtures__/AutoMaterializePolicyPage.fixtures';
 import {ASSET_CHECK_DETAILS_QUERY} from '../AssetCheckDetailModal';
@@ -23,7 +28,6 @@ import {AssetChecksQuery, AssetChecksQueryVariables} from '../types/AssetChecks.
 
 // eslint-disable-next-line import/no-default-export
 export default {
-  title: 'AssetChecks',
   component: AssetChecks,
 } as Meta;
 
@@ -51,6 +55,9 @@ export const MigrationRequired = () => {
           variables: {assetKey: testAssetKey},
           data: {
             assetChecksOrError: buildAssetCheckNeedsMigrationError(),
+            assetNodeOrError: buildAssetNode({
+              assetKey: buildAssetKey(testAssetKey),
+            }),
           },
         }),
       ]}
@@ -69,6 +76,9 @@ export const NoChecks = () => {
             assetChecksOrError: buildAssetChecks({
               checks: [],
             }) as any,
+            assetNodeOrError: buildAssetNode({
+              assetKey: buildAssetKey(testAssetKey),
+            }),
           },
         }),
       ]}
@@ -94,6 +104,9 @@ export const Default = () => {
                 TestAssetCheck,
               ],
             }) as any,
+            assetNodeOrError: buildAssetNode({
+              assetKey: buildAssetKey(testAssetKey),
+            }),
           },
         }),
         buildQueryMock<AssetCheckDetailsQuery, AssetCheckDetailsQueryVariables>({

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/types/AssetChecks.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/types/AssetChecks.types.ts
@@ -8,6 +8,20 @@ export type AssetChecksQueryVariables = Types.Exact<{
 
 export type AssetChecksQuery = {
   __typename: 'Query';
+  assetNodeOrError:
+    | {
+        __typename: 'AssetNode';
+        id: string;
+        jobNames: Array<string>;
+        assetKey: {__typename: 'AssetKey'; path: Array<string>};
+        repository: {
+          __typename: 'Repository';
+          id: string;
+          name: string;
+          location: {__typename: 'RepositoryLocation'; id: string; name: string};
+        };
+      }
+    | {__typename: 'AssetNotFoundError'};
   assetChecksOrError:
     | {__typename: 'AssetCheckNeedsMigrationError'; message: string}
     | {


### PR DESCRIPTION
## Summary & Motivation

This PR adds the "Evaluate checks" button to the right sidebar of the asset DAG and to the asset checks page. On the asset checks page, you can invoke them one by one or all together.

This obeys the `canLaunchPipelineExecution` permission - without it, the button is grayed out with a tooltip explianing why.

Clicking the button gives a loading state with a spinner (similar to "Materialize") and then you see the "Run launched" banner. Thankfully this can use the same hook we use for other launch mutations and triggers a live update to pull in the new states and stuff! 

<img width="1412" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/0ad52c8d-7525-448e-a4b4-3de15d51472c">

<img width="1341" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/0dce69a7-f3ea-4dcb-979c-3c90a28e2b7c">

## How I Tested These Changes

I tested this manually with the `asset_checks` toys repo. Will write a test or two for this as well.