### PR TITLE
Fix make dev_install error on dagster-hex

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,8 +69,9 @@ graphql:
 
 sanity_check:
 #NOTE:  fails on nonPOSIX-compliant shells (e.g. CMD, powershell)
+#NOTE:  dagster-hex is an external package
 	@echo Checking for prod installs - if any are listed below reinstall with 'pip -e'
-	@! (pip list --exclude-editable | grep -e dagster -e dagster-webserver)
+	@! (pip list --exclude-editable | grep -e dagster | grep -v dagster-hex)
 
 rebuild_ui: sanity_check
 	cd js_modules/dagster-ui/; yarn install && yarn build


### PR DESCRIPTION
We added external dep dagster-hex as a dependency in oss, so `make dev_install` was failing with

```
Checking for prod installs - if any are listed below reinstall with pip -e
dagster-hex                       0.1.3
```