### PR TITLE
Add schedules, sensors, observable source assets to resource usage page

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -2030,6 +2030,8 @@ type ResourceDetails {
   resourceType: String!
   assetKeysUsing: [AssetKey!]!
   jobsOpsUsing: [JobWithOps!]!
+  schedulesUsing: [String!]!
+  sensorsUsing: [String!]!
 }
 
 type ConfiguredValue {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -3196,6 +3196,8 @@ export type ResourceDetails = {
   nestedResources: Array<NestedResourceEntry>;
   parentResources: Array<NestedResourceEntry>;
   resourceType: Scalars['String'];
+  schedulesUsing: Array<Scalars['String']>;
+  sensorsUsing: Array<Scalars['String']>;
 };
 
 export type ResourceDetailsList = {
@@ -10269,6 +10271,10 @@ export const buildResourceDetails = (
       overrides && overrides.hasOwnProperty('parentResources') ? overrides.parentResources! : [],
     resourceType:
       overrides && overrides.hasOwnProperty('resourceType') ? overrides.resourceType! : 'sed',
+    schedulesUsing:
+      overrides && overrides.hasOwnProperty('schedulesUsing') ? overrides.schedulesUsing! : [],
+    sensorsUsing:
+      overrides && overrides.hasOwnProperty('sensorsUsing') ? overrides.sensorsUsing! : [],
   };
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/types/OverviewResourcesRoot.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/types/OverviewResourcesRoot.types.ts
@@ -47,6 +47,8 @@ export type OverviewResourcesQuery = {
                     name: string;
                     description: string | null;
                     resourceType: string;
+                    schedulesUsing: Array<string>;
+                    sensorsUsing: Array<string>;
                     parentResources: Array<{__typename: 'NestedResourceEntry'; name: string}>;
                     assetKeysUsing: Array<{__typename: 'AssetKey'; path: Array<string>}>;
                     jobsOpsUsing: Array<{

--- a/js_modules/dagster-ui/packages/ui-core/src/resources/ResourceRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/resources/ResourceRoot.tsx
@@ -511,7 +511,7 @@ const ResourceUses: React.FC<{
       ]
         .filter(({objects}) => objects.length > 0)
         .map(({name, objects, icon}) => (
-          <Box key={name}>
+          <div key={name}>
             <SectionHeader>
               <Subheading>{name}</Subheading>
             </SectionHeader>
@@ -552,7 +552,7 @@ const ResourceUses: React.FC<{
                 })}
               </tbody>
             </Table>
-          </Box>
+          </div>
         ))}
     </>
   );

--- a/js_modules/dagster-ui/packages/ui-core/src/resources/ResourceRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/resources/ResourceRoot.tsx
@@ -107,7 +107,9 @@ export const ResourceRoot: React.FC<Props> = (props) => {
     queryResult.data?.topLevelResourceDetailsOrError.__typename === 'ResourceDetails'
       ? queryResult.data.topLevelResourceDetailsOrError.parentResources.length +
         queryResult.data.topLevelResourceDetailsOrError.assetKeysUsing.length +
-        queryResult.data.topLevelResourceDetailsOrError.jobsOpsUsing.length
+        queryResult.data.topLevelResourceDetailsOrError.jobsOpsUsing.length +
+        queryResult.data.topLevelResourceDetailsOrError.schedulesUsing.length +
+        queryResult.data.topLevelResourceDetailsOrError.sensorsUsing.length
       : 0;
 
   const tab = useRouteMatch<{tab?: string}>(['/locations/:repoPath/resources/:name/:tab?'])?.params
@@ -494,6 +496,56 @@ const ResourceUses: React.FC<{
           </Table>
         </Box>
       )}
+      {[
+        {name: 'Schedules', objects: resourceDetails.schedulesUsing, icon: 'schedules'},
+        {name: 'Sensors', objects: resourceDetails.sensorsUsing, icon: 'sensors'},
+      ].map(
+        ({name, objects, icon}) =>
+          objects.length > 0 && (
+            <Box>
+              <SectionHeader>
+                <Subheading>{name}</Subheading>
+              </SectionHeader>
+              <Table>
+                <thead>
+                  <tr>
+                    <th>Name</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {resourceDetails.sensorsUsing.map((sensorName) => {
+                    return (
+                      <tr key={sensorName}>
+                        <td>
+                          <Box
+                            flex={{
+                              direction: 'row',
+                              alignItems: 'center',
+                              display: 'inline-flex',
+                              gap: 8,
+                            }}
+                            style={{maxWidth: '100%'}}
+                          >
+                            <Icon name={icon} color={Colors.Gray400} />
+
+                            <Link
+                              to={workspacePathFromAddress(
+                                repoAddress,
+                                `/${name.toLowerCase()}/${sensorName}`,
+                              )}
+                            >
+                              <MiddleTruncate text={sensorName} />
+                            </Link>
+                          </Box>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </Table>
+            </Box>
+          ),
+      )}
     </>
   );
 };
@@ -576,6 +628,8 @@ const RESOURCE_DETAILS_FRAGMENT = gql`
     assetKeysUsing {
       path
     }
+    schedulesUsing
+    sensorsUsing
     jobsOpsUsing {
       job {
         id

--- a/js_modules/dagster-ui/packages/ui-core/src/resources/ResourceRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/resources/ResourceRoot.tsx
@@ -252,12 +252,13 @@ const ResourceConfig: React.FC<{
                 const resourceEntry =
                   resource.type === 'TOP_LEVEL' && resource.resource ? (
                     <ResourceEntry
+                      key={resource.name}
                       url={workspacePathFromAddress(repoAddress, `/resources/${resource.name}`)}
                       name={resourceDisplayName(resource.resource) || ''}
                       description={resource.resource.description || undefined}
                     />
                   ) : (
-                    <ResourceEntry name={resource.name} />
+                    <ResourceEntry key={resource.name} name={resource.name} />
                   );
 
                 return (
@@ -497,55 +498,62 @@ const ResourceUses: React.FC<{
         </Box>
       )}
       {[
-        {name: 'Schedules', objects: resourceDetails.schedulesUsing, icon: 'schedules'},
-        {name: 'Sensors', objects: resourceDetails.sensorsUsing, icon: 'sensors'},
-      ].map(
-        ({name, objects, icon}) =>
-          objects.length > 0 && (
-            <Box>
-              <SectionHeader>
-                <Subheading>{name}</Subheading>
-              </SectionHeader>
-              <Table>
-                <thead>
-                  <tr>
-                    <th>Name</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {resourceDetails.sensorsUsing.map((sensorName) => {
-                    return (
-                      <tr key={sensorName}>
-                        <td>
-                          <Box
-                            flex={{
-                              direction: 'row',
-                              alignItems: 'center',
-                              display: 'inline-flex',
-                              gap: 8,
-                            }}
-                            style={{maxWidth: '100%'}}
-                          >
-                            <Icon name={icon} color={Colors.Gray400} />
+        {
+          name: 'Schedules',
+          objects: resourceDetails.schedulesUsing,
+          icon: <Icon name="schedule" color={Colors.Gray400} />,
+        },
+        {
+          name: 'Sensors',
+          objects: resourceDetails.sensorsUsing,
+          icon: <Icon name="sensors" color={Colors.Gray400} />,
+        },
+      ]
+        .filter(({objects}) => objects.length > 0)
+        .map(({name, objects, icon}) => (
+          <Box key={name}>
+            <SectionHeader>
+              <Subheading>{name}</Subheading>
+            </SectionHeader>
+            <Table>
+              <thead>
+                <tr>
+                  <th>Name</th>
+                </tr>
+              </thead>
+              <tbody>
+                {objects.map((itemName) => {
+                  return (
+                    <tr key={name + ':' + itemName}>
+                      <td>
+                        <Box
+                          flex={{
+                            direction: 'row',
+                            alignItems: 'center',
+                            display: 'inline-flex',
+                            gap: 8,
+                          }}
+                          style={{maxWidth: '100%'}}
+                        >
+                          {icon}
 
-                            <Link
-                              to={workspacePathFromAddress(
-                                repoAddress,
-                                `/${name.toLowerCase()}/${sensorName}`,
-                              )}
-                            >
-                              <MiddleTruncate text={sensorName} />
-                            </Link>
-                          </Box>
-                        </td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </Table>
-            </Box>
-          ),
-      )}
+                          <Link
+                            to={workspacePathFromAddress(
+                              repoAddress,
+                              `/${name.toLowerCase()}/${itemName}`,
+                            )}
+                          >
+                            <MiddleTruncate text={itemName} />
+                          </Link>
+                        </Box>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </Table>
+          </Box>
+        ))}
     </>
   );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/resources/VirtualizedResourceRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/resources/VirtualizedResourceRow.tsx
@@ -29,9 +29,16 @@ export const VirtualizedResourceRow = (props: ResourceRowProps) => {
     parentResources,
     jobsOpsUsing,
     assetKeysUsing,
+    schedulesUsing,
+    sensorsUsing,
   } = props;
   const resourceTypeSuccinct = succinctType(resourceType);
-  const uses = parentResources.length + jobsOpsUsing.length + assetKeysUsing.length;
+  const uses =
+    parentResources.length +
+    jobsOpsUsing.length +
+    assetKeysUsing.length +
+    schedulesUsing.length +
+    sensorsUsing.length;
 
   return (
     <Row $height={height} $start={start}>

--- a/js_modules/dagster-ui/packages/ui-core/src/resources/WorkspaceResourcesRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/resources/WorkspaceResourcesRoot.tsx
@@ -140,6 +140,8 @@ export const RESOURCE_ENTRY_FRAGMENT = gql`
         id
       }
     }
+    schedulesUsing
+    sensorsUsing
   }
 `;
 

--- a/js_modules/dagster-ui/packages/ui-core/src/resources/types/ResourceRoot.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/resources/types/ResourceRoot.types.ts
@@ -6,6 +6,8 @@ export type ResourceDetailsFragment = {
   __typename: 'ResourceDetails';
   name: string;
   description: string | null;
+  schedulesUsing: Array<string>;
+  sensorsUsing: Array<string>;
   resourceType: string;
   configFields: Array<{
     __typename: 'ConfigTypeField';
@@ -75,6 +77,8 @@ export type ResourceRootQuery = {
         __typename: 'ResourceDetails';
         name: string;
         description: string | null;
+        schedulesUsing: Array<string>;
+        sensorsUsing: Array<string>;
         resourceType: string;
         configFields: Array<{
           __typename: 'ConfigTypeField';

--- a/js_modules/dagster-ui/packages/ui-core/src/resources/types/WorkspaceResourcesRoot.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/resources/types/WorkspaceResourcesRoot.types.ts
@@ -7,6 +7,8 @@ export type ResourceEntryFragment = {
   name: string;
   description: string | null;
   resourceType: string;
+  schedulesUsing: Array<string>;
+  sensorsUsing: Array<string>;
   parentResources: Array<{__typename: 'NestedResourceEntry'; name: string}>;
   assetKeysUsing: Array<{__typename: 'AssetKey'; path: Array<string>}>;
   jobsOpsUsing: Array<{__typename: 'JobWithOps'; job: {__typename: 'Job'; id: string}}>;
@@ -38,6 +40,8 @@ export type WorkspaceResourcesQuery = {
           name: string;
           description: string | null;
           resourceType: string;
+          schedulesUsing: Array<string>;
+          sensorsUsing: Array<string>;
           parentResources: Array<{__typename: 'NestedResourceEntry'; name: string}>;
           assetKeysUsing: Array<{__typename: 'AssetKey'; path: Array<string>}>;
           jobsOpsUsing: Array<{__typename: 'JobWithOps'; job: {__typename: 'Job'; id: string}}>;

--- a/python_modules/dagster-graphql/dagster_graphql/schema/resources.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/resources.py
@@ -101,6 +101,8 @@ class GrapheneResourceDetails(graphene.ObjectType):
     resourceType = graphene.NonNull(graphene.String)
     assetKeysUsing = graphene.Field(non_null_list(GrapheneAssetKey))
     jobsOpsUsing = graphene.Field(non_null_list(GrapheneJobAndSpecificOps))
+    schedulesUsing = graphene.Field(non_null_list(graphene.String))
+    sensorsUsing = graphene.Field(non_null_list(graphene.String))
 
     class Meta:
         name = "ResourceDetails"
@@ -128,6 +130,8 @@ class GrapheneResourceDetails(graphene.ObjectType):
         self.resourceType = external_resource.resource_type
         self._asset_keys_using = external_resource.asset_keys_using
         self._job_ops_using = external_resource.job_ops_using
+        self._schedules_using = external_resource.schedules_using
+        self._sensors_using = external_resource.sensors_using
 
     def resolve_configFields(self, _graphene_info):
         return [
@@ -206,6 +210,12 @@ class GrapheneResourceDetails(graphene.ObjectType):
         repo = context.get_code_location(self._location_name).get_repository(self._repository_name)
 
         return [self._construct_job_and_specific_ops(repo, entry) for entry in self._job_ops_using]
+
+    def resolve_schedulesUsing(self, _graphene_info) -> List[str]:
+        return self._schedules_using
+
+    def resolve_sensorsUsing(self, _graphene_info) -> List[str]:
+        return self._sensors_using
 
 
 class GrapheneResourceDetailsOrError(graphene.Union):

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_top_level_resources.ambr
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_top_level_resources.ambr
@@ -91,12 +91,10 @@
       'jobsOpsUsing': list([
         dict({
           'job': dict({
-            'id': 'bd6544ee6fcf652cbbea285bca66881ec6d3b60f',
             'name': 'my_asset_job',
           }),
           'opsUsing': list([
             dict({
-              'handleID': 'my_asset',
               'solid': dict({
                 'name': 'my_asset',
               }),

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_top_level_resources.ambr
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_top_level_resources.ambr
@@ -72,6 +72,49 @@
     }),
   })
 # ---
+# name: test_fetch_top_level_resource_uses[0]
+  dict({
+    'topLevelResourceDetailsOrError': dict({
+      '__typename': 'ResourceDetails',
+      'assetKeysUsing': list([
+        dict({
+          'path': list([
+            'my_asset',
+          ]),
+        }),
+        dict({
+          'path': list([
+            'my_observable_source_asset',
+          ]),
+        }),
+      ]),
+      'jobsOpsUsing': list([
+        dict({
+          'job': dict({
+            'id': 'bd6544ee6fcf652cbbea285bca66881ec6d3b60f',
+            'name': 'my_asset_job',
+          }),
+          'opsUsing': list([
+            dict({
+              'handleID': 'my_asset',
+              'solid': dict({
+                'name': 'my_asset',
+              }),
+            }),
+          ]),
+        }),
+      ]),
+      'name': 'my_resource',
+      'schedulesUsing': list([
+        'my_schedule',
+      ]),
+      'sensorsUsing': list([
+        'my_sensor',
+        'my_sensor_two',
+      ]),
+    }),
+  })
+# ---
 # name: test_fetch_top_level_resources[0]
   dict({
     'allTopLevelResourceDetailsOrError': dict({

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo_definitions.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo_definitions.py
@@ -5,16 +5,16 @@ from dagster import (
     Definitions,
     _check as check,
     asset,
+    define_asset_job,
+    observable_source_asset,
+    schedule,
+    sensor,
 )
 from dagster._config.field_utils import EnvVar
 from dagster._config.pythonic_config import ConfigurableResource
+from dagster._core.definitions.asset_selection import AssetSelection
 from dagster._core.test_utils import environ
 from dagster_graphql.test.utils import define_out_of_process_context
-
-
-@asset
-def my_asset():
-    pass
 
 
 class MyResource(ConfigurableResource):
@@ -22,6 +22,34 @@ class MyResource(ConfigurableResource):
 
     a_string: str = "baz"
     an_unset_string: str = "defaulted"
+
+
+@asset
+def my_asset(my_resource: MyResource):
+    pass
+
+
+@observable_source_asset
+def my_observable_source_asset(my_resource: MyResource):
+    pass
+
+
+@sensor(asset_selection=AssetSelection.all())
+def my_sensor(my_resource: MyResource):
+    pass
+
+
+@sensor(asset_selection=AssetSelection.all())
+def my_sensor_two(my_resource: MyResource):
+    pass
+
+
+my_asset_job = define_asset_job(name="my_asset_job", selection=AssetSelection.assets(my_asset))
+
+
+@schedule(job_name="my_asset_job", cron_schedule="* * * * *")
+def my_schedule(my_resource: MyResource):
+    pass
 
 
 class MyInnerResource(ConfigurableResource):
@@ -34,7 +62,7 @@ class MyOuterResource(ConfigurableResource):
 
 with environ({"MY_STRING": "bar", "MY_OTHER_STRING": "foo"}):
     defs = Definitions(
-        assets=[my_asset],
+        assets=[my_asset, my_observable_source_asset],
         resources={
             "foo": "a_string",
             "my_resource": MyResource(
@@ -48,6 +76,9 @@ with environ({"MY_STRING": "bar", "MY_OTHER_STRING": "foo"}):
                 inner=MyInnerResource(a_str="wrapped"),
             ),
         },
+        jobs=[my_asset_job],
+        sensors=[my_sensor, my_sensor_two],
+        schedules=[my_schedule],
     )
 
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_top_level_resources.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_top_level_resources.py
@@ -163,11 +163,9 @@ query ResourceDetailsQuery($selector: ResourceSelector!) {
 
             jobsOpsUsing {
                 job {
-                    id
                     name
                 }
                 opsUsing {
-                    handleID
                     solid {
                         name
                     }

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_top_level_resources.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_top_level_resources.py
@@ -149,3 +149,68 @@ def test_fetch_top_level_resource_env_var(definitions_graphql_context, snapshot)
     ]
 
     snapshot.assert_match(result.data)
+
+
+TOP_LEVEL_RESOURCE_USES_QUERY = """
+query ResourceDetailsQuery($selector: ResourceSelector!) {
+    topLevelResourceDetailsOrError(resourceSelector: $selector) {
+        __typename
+        ... on ResourceDetails {
+            name
+
+            schedulesUsing
+            sensorsUsing
+
+            jobsOpsUsing {
+                job {
+                    id
+                    name
+                }
+                opsUsing {
+                    handleID
+                    solid {
+                        name
+                    }
+                }
+            }
+
+            assetKeysUsing {
+                path
+            }
+        }
+    }
+}
+"""
+
+
+def test_fetch_top_level_resource_uses(definitions_graphql_context, snapshot) -> None:
+    selector = infer_resource_selector(definitions_graphql_context, name="my_resource")
+    result = execute_dagster_graphql(
+        definitions_graphql_context,
+        TOP_LEVEL_RESOURCE_USES_QUERY,
+        {"selector": selector},
+    )
+
+    assert not result.errors
+    assert result.data
+    assert result.data["topLevelResourceDetailsOrError"]
+    my_resource = result.data["topLevelResourceDetailsOrError"]
+
+    assert my_resource["name"] == "my_resource"
+
+    assert my_resource["schedulesUsing"] == ["my_schedule"]
+    assert my_resource["sensorsUsing"] == ["my_sensor", "my_sensor_two"]
+
+    jobs = my_resource["jobsOpsUsing"]
+    assert len(jobs) == 1
+    assert jobs[0]["job"]["name"] == "my_asset_job"
+    assert len(jobs[0]["opsUsing"]) == 1
+    assert jobs[0]["opsUsing"][0]["solid"]["name"] == "my_asset"
+
+    assets = my_resource["assetKeysUsing"]
+    assert len(assets) == 2
+    paths = [asset["path"] for asset in assets]
+    assert ["my_asset"] in paths
+    assert ["my_observable_source_asset"] in paths
+
+    snapshot.assert_match(result.data)

--- a/python_modules/dagster/dagster/_core/host_representation/external.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external.py
@@ -592,6 +592,14 @@ class ExternalResource:
         return self._external_resource_data.job_ops_using
 
     @property
+    def schedules_using(self) -> List[str]:
+        return self._external_resource_data.schedules_using
+
+    @property
+    def sensors_using(self) -> List[str]:
+        return self._external_resource_data.sensors_using
+
+    @property
     def is_dagster_maintained(self) -> bool:
         return self._external_resource_data.dagster_maintained
 

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_repository_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_repository_snap.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from typing import Dict, List, cast
 
 from dagster import (
     AssetCheckSpec,
@@ -10,6 +10,8 @@ from dagster import (
     op,
     repository,
     resource,
+    schedule,
+    sensor,
 )
 from dagster._config.field_utils import EnvVar
 from dagster._config.pythonic_config import Config, ConfigurableResource
@@ -27,6 +29,7 @@ from dagster._core.host_representation import (
     external_repository_data_from_def,
 )
 from dagster._core.host_representation.external_data import (
+    ExternalResourceData,
     NestedResource,
     NestedResourceType,
     ResourceJobUsageEntry,
@@ -683,3 +686,69 @@ def test_asset_check_multiple_jobs():
     assert len(external_repo_data.external_asset_checks) == 2
     assert external_repo_data.external_asset_checks[0].name == "my_asset_check"
     assert external_repo_data.external_asset_checks[1].name == "my_other_asset_check"
+
+
+def test_repository_snap_definitions_resources_schedule_sensor_usage():
+    class MyResource(ConfigurableResource):
+        a_str: str
+
+    @op
+    def my_op() -> None:
+        pass
+
+    @job
+    def my_job() -> None:
+        my_op()
+
+    @sensor(job=my_job)
+    def my_sensor(foo: MyResource):
+        pass
+
+    @sensor(job=my_job)
+    def my_sensor_two(foo: MyResource, bar: MyResource):
+        pass
+
+    @schedule(job=my_job, cron_schedule="* * * * *")
+    def my_schedule(foo: MyResource):
+        pass
+
+    @schedule(job=my_job, cron_schedule="* * * * *")
+    def my_schedule_two(foo: MyResource, baz: MyResource):
+        pass
+
+    defs = Definitions(
+        resources={
+            "foo": MyResource(a_str="foo"),
+            "bar": MyResource(a_str="bar"),
+            "baz": MyResource(a_str="baz"),
+        },
+        sensors=[my_sensor, my_sensor_two],
+        schedules=[my_schedule, my_schedule_two],
+    )
+
+    repo = resolve_pending_repo_if_required(defs)
+    external_repo_data = external_repository_data_from_def(repo)
+    assert external_repo_data.external_resource_data
+
+    assert len(external_repo_data.external_resource_data) == 3
+
+    foo = [data for data in external_repo_data.external_resource_data if data.name == "foo"]
+    assert len(foo) == 1
+
+    assert set(cast(ExternalResourceData, foo[0]).schedules_using) == {
+        "my_schedule",
+        "my_schedule_two",
+    }
+    assert set(cast(ExternalResourceData, foo[0]).sensors_using) == {"my_sensor", "my_sensor_two"}
+
+    bar = [data for data in external_repo_data.external_resource_data if data.name == "bar"]
+    assert len(bar) == 1
+
+    assert set(cast(ExternalResourceData, bar[0]).schedules_using) == set()
+    assert set(cast(ExternalResourceData, bar[0]).sensors_using) == {"my_sensor_two"}
+
+    baz = [data for data in external_repo_data.external_resource_data if data.name == "baz"]
+    assert len(baz) == 1
+
+    assert set(cast(ExternalResourceData, baz[0]).schedules_using) == set({"my_schedule_two"})
+    assert set(cast(ExternalResourceData, baz[0]).sensors_using) == set()


### PR DESCRIPTION
## Summary

Adds two new sections to the resource "Uses" page, to showcase schedules and sensors which utilize a resource. Also includes these in the uses count.

Additionally, adds observable source assets whose observation function uses a resource to the list, since these weren't previously counted.

![Screenshot 2023-09-13 at 9 48 23 AM](https://github.com/dagster-io/dagster/assets/10215173/aa6e693b-fb76-4074-8e4a-12cc3fae21cb)


## Test Plan

Add tests for GQL layer, snapshot layer