### PR TITLE
remove urllib3 pins

### DIFF
--- a/.buildkite/dagster-buildkite/setup.py
+++ b/.buildkite/dagster-buildkite/setup.py
@@ -22,9 +22,6 @@ setup(
         "requests",
         "typing_extensions>=4.2",
         "pathspec",
-        # Need this until we have OpenSSL 1.1.1+ available in BK base image
-        # Context: https://github.com/psf/requests/issues/6432
-        "urllib3<2",
     ],
     entry_points={
         "console_scripts": [

--- a/integration_tests/test_suites/backcompat-test-suite/webserver_service/pins.txt
+++ b/integration_tests/test_suites/backcompat-test-suite/webserver_service/pins.txt
@@ -13,6 +13,3 @@ grpcio<1.48.1; python_version < '3.10'
 
 # Added sqlalchemy pins in later versions
 sqlalchemy<2.0.0
-
-# https://github.com/dagster-io/dagster/pull/14089
-urllib3<2.0.0


### PR DESCRIPTION
## Summary & Motivation

Remove more urllib3 pins, no longer needed-- we know this because tests now pass.

## How I Tested These Changes

Existng test suite