### PR TITLE
feat(dbt): validate `project_dir` and `profiles_dir` for `DbtCliResource`

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -50,6 +50,8 @@ from ..utils import ASSET_RESOURCE_TYPES, get_dbt_resource_props_by_dbt_unique_i
 logger = get_dagster_logger()
 
 
+DBT_PROJECT_YML_NAME = "dbt_project.yml"
+DBT_PROFILES_YML_NAME = "profiles.yml"
 PARTIAL_PARSE_FILE_NAME = "partial_parse.msgpack"
 
 
@@ -488,12 +490,65 @@ class DbtCliResource(ConfigurableResource):
         ),
     )
 
+    @classmethod
+    def _validate_absolute_path_exists(cls, path: Union[str, Path]) -> Path:
+        absolute_path = Path(path).absolute()
+        try:
+            resolved_path = absolute_path.resolve(strict=True)
+        except FileNotFoundError:
+            raise ValueError(f"The absolute path of '{path}' ('{absolute_path}') does not exist")
+
+        return resolved_path
+
+    @classmethod
+    def _validate_path_contains_file(cls, path: Path, file_name: str, error_message: str):
+        if not path.joinpath(file_name).exists():
+            raise ValueError(error_message)
+
     @validator("project_dir", "profiles_dir", pre=True)
     def convert_path_to_str(cls, v: Any) -> Any:
-        if v and isinstance(v, Path):
-            return os.fspath(v)
+        """Validate that the path is converted to a string."""
+        if isinstance(v, Path):
+            resolved_path = cls._validate_absolute_path_exists(v)
+
+            absolute_path = Path(v).absolute()
+            try:
+                resolved_path = absolute_path.resolve(strict=True)
+            except FileNotFoundError:
+                raise ValueError(f"The absolute path of '{v}' ('{absolute_path}') does not exist")
+            return os.fspath(resolved_path)
 
         return v
+
+    @validator("project_dir")
+    def validate_project_dir(cls, project_dir: str) -> str:
+        resolved_project_dir = cls._validate_absolute_path_exists(project_dir)
+
+        cls._validate_path_contains_file(
+            path=resolved_project_dir,
+            file_name=DBT_PROJECT_YML_NAME,
+            error_message=(
+                f"{resolved_project_dir} does not contain a {DBT_PROJECT_YML_NAME} file. Please"
+                " specify a valid path to a dbt project."
+            ),
+        )
+
+        return os.fspath(resolved_project_dir)
+
+    @validator("profiles_dir")
+    def validate_profiles_dir(cls, profiles_dir: str) -> str:
+        resolved_project_dir = cls._validate_absolute_path_exists(profiles_dir)
+
+        cls._validate_path_contains_file(
+            path=resolved_project_dir,
+            file_name=DBT_PROFILES_YML_NAME,
+            error_message=(
+                f"{resolved_project_dir} does not contain a {DBT_PROFILES_YML_NAME} file. Please"
+                " specify a valid path to a dbt profile directory."
+            ),
+        )
+
+        return os.fspath(resolved_project_dir)
 
     def _get_unique_target_path(self, *, context: Optional[AssetExecutionContext]) -> str:
         """Get a unique target path for the dbt CLI invocation.
@@ -696,7 +751,7 @@ class DbtCliResource(ConfigurableResource):
             profile_args += ["--target", self.target]
 
         args = ["dbt"] + self.global_config_flags + args + profile_args + selection_args
-        project_dir = Path(self.project_dir).resolve(strict=True)
+        project_dir = Path(self.project_dir)
 
         return DbtCliInvocation.run(
             args=args,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resources_v2.py
@@ -26,6 +26,7 @@ from dagster_dbt.core.resources_v2 import (
 )
 from dagster_dbt.dbt_manifest import DbtManifestParam
 from dagster_dbt.errors import DagsterDbtCliRuntimeError
+from pydantic import ValidationError
 
 from ..conftest import TEST_PROJECT_DIR
 
@@ -52,13 +53,22 @@ def test_dbt_cli(global_config_flags: List[str], command: str) -> None:
 def test_dbt_cli_manifest_argument(manifest: DbtManifestParam) -> None:
     dbt = DbtCliResource(project_dir=TEST_PROJECT_DIR)
 
-    assert dbt.cli(["run"]).is_successful()
+    assert dbt.cli(["run"], manifest=manifest).is_successful()
 
 
 def test_dbt_cli_project_dir_path() -> None:
     dbt = DbtCliResource(project_dir=Path(TEST_PROJECT_DIR))  # type: ignore
 
+    assert Path(dbt.project_dir).is_absolute()
     assert dbt.cli(["run"]).is_successful()
+
+    # project directory must exist
+    with pytest.raises(ValidationError, match="does not exist"):
+        DbtCliResource(project_dir="nonexistent")
+
+    # project directory must be a valid dbt project
+    with pytest.raises(ValidationError, match="specify a valid path to a dbt project"):
+        DbtCliResource(project_dir=f"{TEST_PROJECT_DIR}/models")
 
 
 def test_dbt_cli_failure() -> None:
@@ -73,7 +83,6 @@ def test_dbt_cli_failure() -> None:
     assert dbt_cli_invocation.target_path.joinpath("dbt.log").exists()
 
 
-# as
 def test_dbt_cli_subprocess_cleanup(caplog: pytest.LogCaptureFixture) -> None:
     dbt = DbtCliResource(project_dir=TEST_PROJECT_DIR)
     dbt_cli_invocation_1 = dbt.cli(["run"])
@@ -148,12 +157,13 @@ def test_dbt_profile_dir_configuration(profiles_dir: Union[str, Path]) -> None:
 
     assert dbt.cli(["parse"]).is_successful()
 
-    dbt = DbtCliResource(
-        project_dir=TEST_PROJECT_DIR, profiles_dir=f"{TEST_PROJECT_DIR}/nonexistent"
-    )
+    # profiles directory must exist
+    with pytest.raises(ValidationError, match="does not exist"):
+        DbtCliResource(project_dir=TEST_PROJECT_DIR, profiles_dir="nonexistent")
 
-    with pytest.raises(DagsterDbtCliRuntimeError):
-        dbt.cli(["parse"]).wait()
+    # profiles directory must contain profile configuration
+    with pytest.raises(ValidationError, match="specify a valid path to a dbt profile directory"):
+        DbtCliResource(project_dir=TEST_PROJECT_DIR, profiles_dir=f"{TEST_PROJECT_DIR}/models")
 
 
 def test_dbt_without_partial_parse() -> None:


### PR DESCRIPTION
## Summary & Motivation
Resolves https://github.com/dagster-io/dagster/issues/14069.

Do the following things:
- Validate the existence of `project_dir` and `profiles_dir` at definition time
- Validate the `project_dir` and `profiles_dir` are valid directories for dbt (e.g. they have `dbt_project.yml` or `profiles.yml`)
- Automatically convert relative path to absolute path when possible. Otherwise, raise an error.

## How I Tested These Changes
pytest
