### PR TITLE
[dbt] Raise error on package conflicts in dagster-dbt project scaffold

### DIFF
--- a/python_modules/dagster/dagster/_cli/project.py
+++ b/python_modules/dagster/dagster/_cli/project.py
@@ -3,6 +3,7 @@ import sys
 from typing import Optional, Sequence
 
 import click
+import requests
 
 from dagster._generate import (
     download_example_from_github,
@@ -12,8 +13,6 @@ from dagster._generate import (
 )
 from dagster._generate.download import AVAILABLE_EXAMPLES
 from dagster.version import __version__ as dagster_version
-
-import requests
 
 
 @click.group(name="project")
@@ -53,8 +52,7 @@ list_examples_command_help_text = "List the examples that available to bootstrap
 
 
 def check_if_pypi_package_conflict_exists(project_name: str) -> bool:
-    """
-    Checks if the project name contains any flagged keywords. If so, raises a warning if a PyPI
+    """Checks if the project name contains any flagged keywords. If so, raises a warning if a PyPI
     package with the same name exists. This is to prevent import errors from occurring due to a
     project name that conflicts with an imported package.
 
@@ -136,13 +134,12 @@ def scaffold_code_location_command(name: str):
     help="Name of the new Dagster project",
 )
 @click.option(
-    "--force",
-    "-f",
+    "--ignore-package-conflict",
     is_flag=True,
     default=False,
-    help="Skip checking if the name conflicts with a PyPI package.",
+    help="Controls whether the project name can conflict with an existing PyPI package.",
 )
-def scaffold_command(name: str, force: bool):
+def scaffold_command(name: str, ignore_package_conflict: bool):
     dir_abspath = os.path.abspath(name)
     if os.path.isdir(dir_abspath) and os.path.exists(dir_abspath):
         click.echo(
@@ -151,12 +148,12 @@ def scaffold_command(name: str, force: bool):
         )
         sys.exit(1)
 
-    if not force and check_if_pypi_package_conflict_exists(name):
+    if not ignore_package_conflict and check_if_pypi_package_conflict_exists(name):
         click.echo(
             click.style(
                 f"The project name '{name}' conflicts with an existing PyPI package. This will"
                 " cause import errors in your project if the package is required. Please choose"
-                " another name, or add the `--force` flag to bypass this check.",
+                " another name, or add the `--ignore-package-conflict` flag to bypass this check.",
                 fg="yellow",
             )
         )

--- a/python_modules/dagster/dagster_tests/cli_tests/test_project_commands.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/test_project_commands.py
@@ -23,6 +23,17 @@ def test_project_scaffold_command_fails_when_dir_path_exists():
         assert result.exit_code != 0
 
 
+def test_project_scaffold_command_fails_on_package_conflict():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(scaffold_command, ["--name", "dagster"])
+        assert "conflicts with an existing PyPI package" in result.output
+        assert result.exit_code != 0
+
+        result = runner.invoke(scaffold_command, ["--name", "dagster", "--ignore-package-conflict"])
+        assert result.exit_code == 0
+
+
 def test_project_scaffold_command_succeeds():
     runner = CliRunner()
     with runner.isolated_filesystem():

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/app.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/app.py
@@ -139,7 +139,7 @@ def copy_scaffold(
 def _check_and_error_on_package_conflicts(project_name: str) -> None:
     package_check_result = check_if_pypi_package_conflict_exists(project_name)
     if package_check_result.request_error_msg:
-        raise typer.Exit(
+        typer.echo(
             f"An error occurred while checking if project name '{project_name}' conflicts with"
             f" an existing PyPI package: {package_check_result.request_error_msg}."
             " \n\nConflicting package names will cause import errors in your project if the"
@@ -147,6 +147,7 @@ def _check_and_error_on_package_conflicts(project_name: str) -> None:
             " desired, this check can be skipped by adding the `--ignore-package-conflict`"
             " flag."
         )
+        raise typer.Exit(1)
 
     if package_check_result.conflict_exists:
         raise typer.BadParameter(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/app.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/app.py
@@ -5,6 +5,7 @@ from typing import Any, Dict
 
 import typer
 import yaml
+from dagster._cli.project import check_if_pypi_package_conflict_exists
 from dbt.version import __version__ as dbt_version
 from jinja2 import Environment, FileSystemLoader
 from packaging import version
@@ -14,8 +15,6 @@ from typing_extensions import Annotated
 
 from ..include import STARTER_PROJECT_PATH
 from ..version import __version__ as dagster_dbt_version
-
-from dagster._cli.project import check_if_pypi_package_conflict_exists
 
 app = typer.Typer(
     no_args_is_help=True,
@@ -190,12 +189,11 @@ def project_scaffold_command(
     """This command will initialize a new Dagster project and create directories and files that
     load assets from an existing dbt project.
     """
-
     if not ignore_package_conflict and check_if_pypi_package_conflict_exists(project_name):
         raise typer.BadParameter(
             f"The project name '{project_name}' conflicts with an existing PyPI package. This will"
             " cause import errors in your project if the package is required. Please choose"
-            " another name, or call `dagster-dbt project scaffold --ignore-package-conflicts` to"
+            " another name, or call `dagster-dbt project scaffold --ignore-package-conflict` to"
             " bypass this check."
         )
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_app.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_app.py
@@ -220,3 +220,39 @@ def test_project_scaffold_command_on_invalid_dbt_project(
 
     assert result.exit_code != 0
     assert not dagster_project_dir.exists()
+
+
+@pytest.mark.parametrize("project_name", ["dagster", "dagster_dbt"])
+def test_project_scaffold_command_on_package_conflict(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, dbt_project_dir: Path, project_name: str
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(
+        app,
+        [
+            "project",
+            "scaffold",
+            "--project-name",
+            project_name,
+            "--dbt-project-dir",
+            os.fspath(dbt_project_dir),
+        ],
+    )
+
+    assert result.exit_code != 0
+
+    result = runner.invoke(
+        app,
+        [
+            "project",
+            "scaffold",
+            "--project-name",
+            project_name,
+            "--dbt-project-dir",
+            os.fspath(dbt_project_dir),
+            "--ignore-package-conflict",
+        ],
+    )
+
+    assert result.exit_code == 0


### PR DESCRIPTION
Resolves https://github.com/dagster-io/dagster/issues/16367.

Users are experiencing import errors when dagster projects are scaffolded using names that conflict with required PyPI packages i.e. `dagster` or `dagster_dbt`.

This PR fixes the issue by raising an error in `dagster project scaffold` and `dagster-dbt project scaffold` CLIs when the code location name causes a conflict with an existing package. It only checks for existing packages if the code location name contains dagster or dbt--this is because a lot of names are valid python packages (I.e. hello, foo, and yay are all PyPI packages) and it seems restrictive to block all of these words.

We raise an error when package collisions exist regardless of hyphen/underscore:
- when dagster-dbt is provided, this could prevent the actual dagster-dbt package from being installed
- when dagster_dbt is provided, this causes import errors in code i.e. when from dagster_dbt import DbtCliResource is called

If users want to bypass the error, they can provide an optional `--ignore-package-conflict` flag to bypass the package conflict check.