### PR TITLE
Remove asset check definition check

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
@@ -119,13 +119,6 @@ def _process_asset_results_to_events(
             yield output
         elif isinstance(user_event, AssetCheckResult):
             asset_check_evaluation = user_event.to_asset_check_evaluation(step_context)
-            check.not_none(
-                step_context.job_def.asset_layer.get_spec_for_asset_check(
-                    step_context.node_handle, asset_check_evaluation.asset_check_handle
-                ),
-                "If we were able to create an AssetCheckEvaluation from the AssetCheckResult, then"
-                " there should be a spec for the check",
-            )
 
             output_name = step_context.job_def.asset_layer.get_output_name_for_asset_check(
                 asset_check_evaluation.asset_check_handle


### PR DESCRIPTION
This dagster._check check calls `assets_defs_by_node_handle.get(node_handle).get_spec_for_check_handle(handle)`. 

When inside a graph asset, if an op only returns a check and not an output, then we don't have an AssetsDefinition for it in the mapping so this check fails.

I think it's fairly safe to remove this check. We already use get_check_names_by_asset_key_for_node_handle to get here so the check exists. We just don't have an AssetsDefinition for it on the op node (we do on the graph node).