### PR TITLE
publish dagster-ext as dagster-ext-process

### DIFF
--- a/python_modules/dagster-ext/setup.cfg
+++ b/python_modules/dagster-ext/setup.cfg
@@ -6,4 +6,4 @@ ignore =
     .coveragerc
     tox.ini
     pytest.ini
-    dagster_external_tests/**
+    dagster_ext_tests/**

--- a/python_modules/dagster-ext/setup.py
+++ b/python_modules/dagster-ext/setup.py
@@ -16,7 +16,7 @@ ver = get_version()
 # dont pin dev installs to avoid pip dep resolver issues
 pin = "" if ver == "1!0+dev" else f"=={ver}"
 setup(
-    name="dagster-ext",
+    name="dagster-ext-process",
     version=get_version(),
     author="Dagster Labs",
     author_email="hello@dagsterlabs.com",


### PR DESCRIPTION
## Summary & Motivation

Publish `dagster-ext` under the PyPI package name `dagster-ext-process`

## How I Tested These Changes

- Published a release candidate by cherrypicking this onto an rc release branch: https://pypi.org/project/dagster-ext-process/
- pip install dagster-ext-process
- python -c 'import dagster_ext'
