### PR TITLE
[auto-materialize] Change default behavior for self-dependent assets

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -369,6 +369,7 @@ class MaterializeOnParentUpdatedRule(
                 # we're within reasonable limits on the number of partitions to check
                 respect_materialization_data_versions=context.daemon_context.respect_materialization_data_versions
                 and len(parent_asset_partitions | has_or_will_update) < 100,
+                ignored_parent_keys={context.asset_key},
             )
             updated_parents = {parent.asset_key for parent in updated_parent_asset_partitions}
             will_update_parents = will_update_parents_by_asset_partition[asset_partition]
@@ -440,9 +441,7 @@ class SkipOnParentOutdatedRule(AutoMaterializeRule, NamedTuple("_SkipOnParentOut
                 asset_partition=candidate
             ):
                 unreconciled_ancestors.update(
-                    context.instance_queryer.get_root_unreconciled_ancestors(
-                        asset_partition=parent,
-                    )
+                    context.instance_queryer.get_root_unreconciled_ancestors(asset_partition=parent)
                 )
             if unreconciled_ancestors:
                 asset_partitions_by_waiting_on_asset_keys[frozenset(unreconciled_ancestors)].add(
@@ -540,18 +539,18 @@ class SkipOnNotAllParentsUpdatedRule(
                 candidate.partition_key,
             ).parent_partitions
 
-            updated_parent_partitions = (
-                context.instance_queryer.get_updated_parent_asset_partitions(
-                    candidate,
-                    parent_partitions,
-                    context.daemon_context.respect_materialization_data_versions,
-                )
-                | set().union(
-                    *[
-                        context.will_materialize_mapping.get(parent, set())
-                        for parent in context.asset_graph.get_parents(context.asset_key)
-                    ]
-                )
+            updated_parent_partitions = context.instance_queryer.get_updated_parent_asset_partitions(
+                candidate,
+                parent_partitions,
+                context.daemon_context.respect_materialization_data_versions,
+                # this is unnecessary to set, as we'll filter out self-dependencies later, but
+                # it doesn't hurt
+                ignored_parent_keys={context.asset_key},
+            ) | set().union(
+                *[
+                    context.will_materialize_mapping.get(parent, set())
+                    for parent in context.asset_graph.get_parents(context.asset_key)
+                ]
             )
 
             if self.require_update_for_all_parent_partitions:
@@ -571,6 +570,9 @@ class SkipOnNotAllParentsUpdatedRule(
                     for parent in parent_asset_keys
                     if not updated_parent_partitions_by_asset_key.get(parent)
                 }
+
+            # do not require past partition of this asset to be updated
+            non_updated_parent_keys.remove(context.asset_key)
 
             if non_updated_parent_keys:
                 asset_partitions_by_waiting_on_asset_keys[frozenset(non_updated_parent_keys)].add(

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
@@ -656,6 +656,18 @@ def observable_source_asset_def(
     return _observable
 
 
+def with_auto_materialize_policy(
+    assets_defs: Sequence[AssetsDefinition], auto_materialize_policy: AutoMaterializePolicy
+) -> Sequence[AssetsDefinition]:
+    """Note: this should be implemented in core dagster at some point, and this implementation is
+    a lazy hack.
+    """
+    ret = []
+    for assets_def in assets_defs:
+        ret.append(assets_def.with_attributes(auto_materialize_policy=auto_materialize_policy))
+    return ret
+
+
 def with_implicit_auto_materialize_policies(
     assets_defs: Sequence[Union[SourceAsset, AssetsDefinition]],
     asset_graph: AssetGraph,

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/auto_materialize_policy_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/auto_materialize_policy_scenarios.py
@@ -1,8 +1,6 @@
 import datetime
-from typing import Sequence
 
 from dagster import (
-    AssetsDefinition,
     PartitionKeyRange,
 )
 from dagster._core.definitions.asset_selection import AssetSelection
@@ -25,6 +23,7 @@ from ..base_scenario import (
     run,
     run_request,
     single_asset_run,
+    with_auto_materialize_policy,
 )
 from .basic_scenarios import diamond
 from .exotic_partition_mapping_scenarios import (
@@ -41,19 +40,6 @@ from .partition_scenarios import (
     two_partitions_partitions_def,
     unpartitioned_with_one_parent_partitioned,
 )
-
-
-def with_auto_materialize_policy(
-    assets_defs: Sequence[AssetsDefinition], auto_materialize_policy: AutoMaterializePolicy
-) -> Sequence[AssetsDefinition]:
-    """Note: this should be implemented in core dagster at some point, and this implementation is
-    a lazy hack.
-    """
-    ret = []
-    for assets_def in assets_defs:
-        ret.append(assets_def.with_attributes(auto_materialize_policy=auto_materialize_policy))
-    return ret
-
 
 lazy_assets_nothing_dep = [
     asset_def("asset1"),

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/exotic_partition_mapping_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/exotic_partition_mapping_scenarios.py
@@ -79,6 +79,20 @@ one_asset_self_dependency_later_start_date = [
         deps={"asset1": TimeWindowPartitionMapping(start_offset=-1, end_offset=-1)},
     )
 ]
+three_assets_self_dependency = [
+    asset_def("asset1", partitions_def=DailyPartitionsDefinition(start_date="2020-01-01")),
+    asset_def(
+        "asset2",
+        partitions_def=DailyPartitionsDefinition(start_date="2020-01-01"),
+        deps={
+            "asset1": TimeWindowPartitionMapping(),
+            "asset2": TimeWindowPartitionMapping(start_offset=-1, end_offset=-1),
+        },
+    ),
+    asset_def(
+        "asset3", ["asset2"], partitions_def=DailyPartitionsDefinition(start_date="2020-01-01")
+    ),
+]
 
 root_assets_different_partitions_same_downstream = [
     asset_def("root1", partitions_def=two_partitions_partitions_def),
@@ -309,6 +323,65 @@ exotic_partition_mapping_scenarios = {
         ),
         expected_run_requests=[run_request(asset_keys=["asset1"], partition_key="2020-01-02")],
         current_time=create_pendulum_time(year=2020, month=1, day=3, hour=4),
+    ),
+    "self_dependency_prior_partition_rematerialized": AssetReconciliationScenario(
+        assets=one_asset_self_dependency,
+        # this is rematerialized
+        unevaluated_runs=[single_asset_run(asset_key="asset1", partition_key="2020-01-01")],
+        cursor_from=AssetReconciliationScenario(
+            assets=one_asset_self_dependency,
+            unevaluated_runs=[
+                single_asset_run(asset_key="asset1", partition_key="2020-01-01"),
+                single_asset_run(asset_key="asset1", partition_key="2020-01-02"),
+                single_asset_run(asset_key="asset1", partition_key="2020-01-03"),
+            ],
+            expected_run_requests=[],
+            current_time=create_pendulum_time(year=2020, month=1, day=4, hour=4),
+        ),
+        # should not rematerialize partition because of this update
+        expected_run_requests=[],
+        current_time=create_pendulum_time(year=2020, month=1, day=4, hour=5),
+    ),
+    "self_dependency_upstream_prior_partition_rematerialized": AssetReconciliationScenario(
+        assets=three_assets_self_dependency,
+        unevaluated_runs=[single_asset_run(asset_key="asset1", partition_key="2020-01-01")],
+        cursor_from=AssetReconciliationScenario(
+            assets=three_assets_self_dependency,
+            unevaluated_runs=[
+                run(["asset1", "asset2", "asset3"], partition_key="2020-01-01"),
+                run(["asset1", "asset2", "asset3"], partition_key="2020-01-02"),
+                run(["asset1", "asset2", "asset3"], partition_key="2020-01-03"),
+            ],
+            expected_run_requests=[],
+            current_time=create_pendulum_time(year=2020, month=1, day=4, hour=4),
+        ),
+        # should respond to an upstream asset being rematerialized
+        expected_run_requests=[run_request(["asset2", "asset3"], partition_key="2020-01-01")],
+        current_time=create_pendulum_time(year=2020, month=1, day=4, hour=4),
+    ),
+    "self_dependency_upstream_prior_partition_outdated_ignore": AssetReconciliationScenario(
+        assets=three_assets_self_dependency,
+        # new day's partition filled in
+        unevaluated_runs=[run(["asset1"], partition_key="2020-01-04")],
+        cursor_from=AssetReconciliationScenario(
+            assets=three_assets_self_dependency,
+            unevaluated_runs=[
+                run(["asset1", "asset2", "asset3"], partition_key="2020-01-01"),
+                run(["asset1", "asset2", "asset3"], partition_key="2020-01-02"),
+                run(["asset1", "asset2", "asset3"], partition_key="2020-01-03"),
+                # old partition is updated
+                run(["asset2"], partition_key="2020-01-02"),
+            ],
+            # only update the downstream, not the next daily partition
+            expected_run_requests=[
+                run_request(["asset3"], partition_key="2020-01-02"),
+            ],
+            current_time=create_pendulum_time(year=2020, month=1, day=4, hour=4),
+        ),
+        # should still be able to materialize the new partition for the self-dep asset (and
+        # downstream), even though an old partition is "outdated"
+        expected_run_requests=[run_request(["asset2", "asset3"], partition_key="2020-01-04")],
+        current_time=create_pendulum_time(year=2020, month=1, day=5, hour=4),
     ),
     "self_dependency_start_date_changed": AssetReconciliationScenario(
         assets=one_asset_self_dependency_later_start_date,


### PR DESCRIPTION
## Summary & Motivation

This makes three changes to how we deal with self-dependent assets with AMP.

1. Updates to past partitions of a self-dependent asset no longer trigger the `AutoMaterializeRule.materialize_on_parent_updated` rule for subsequent partitions of that asset. This prevents "slow motion backfills if a user were to update a random past partition of that asset (kicking off a chain of computations)
2. Past partitions of a self-dependent asset are not used to determine if a future partition of that asset is out of date or not. This means that if a long-past partition of that asset is updated, that won't prevent future partitions of that asset from being updated.
3. Past partitions of a self-dependent asset do not need to be updated in order for the `AutoMaterializeRule.skip_on_not_all_parents_updated` rule to be triggered.

This is not currently toggleable, as it's unclear if the previous default behavior would be desirable.

## How I Tested These Changes
