### PR TITLE
provide AssetExecutionContext class to context

### DIFF
--- a/python_modules/dagster-test/dagster_test/toys/asset_checks.py
+++ b/python_modules/dagster-test/dagster_test/toys/asset_checks.py
@@ -144,10 +144,10 @@ def random_fail_check_on_partitioned_asset():
     can_subset=True,
 )
 def multi_asset_1_and_2(context):
-    if AssetKey("multi_asset_piece_1") in context.selected_asset_keys:
+    if AssetKey("multi_asset_piece_1") in context.asset_keys:
         yield Output(1, output_name="one")
         yield AssetCheckResult(success=True, metadata={"foo": "bar"})
-    if AssetKey("multi_asset_piece_2") in context.selected_asset_keys:
+    if AssetKey("multi_asset_piece_2") in context.asset_keys:
         yield Output(1, output_name="two")
 
 

--- a/python_modules/dagster/dagster/_core/decorator_utils.py
+++ b/python_modules/dagster/dagster/_core/decorator_utils.py
@@ -270,3 +270,9 @@ def is_resource_def(obj: Any) -> TypeGuard["ResourceDefinition"]:
     """
     class_names = [cls.__name__ for cls in inspect.getmro(obj.__class__)]
     return "ResourceDefinition" in class_names
+
+
+def is_context_provided(params: Sequence[Parameter]) -> bool:
+    if len(params) == 0:
+        return False
+    return params[0].name in get_valid_name_permutations("context")

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -1340,18 +1340,3 @@ def _get_partition_mappings_from_deps(
             )
 
     return partition_mappings
-
-
-def _validate_context_type_hint(fn):
-    from inspect import _empty as EmptyAnnotation
-
-    from dagster._core.decorator_utils import get_function_params, is_context_provided
-    from dagster._core.execution.context.compute import AssetExecutionContext, OpExecutionContext
-
-    params = get_function_params(fn)
-    if is_context_provided(params):
-        if not isinstance(params[0], (AssetExecutionContext, OpExecutionContext, EmptyAnnotation)):
-            raise DagsterInvalidDefinitionError(
-                f"Cannot annotate `context` parameter with type {params[0].annotation}. `context`"
-                " must be annotated with AssetExecutionContext, OpExecutionContext, or left blank."
-            )

--- a/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
@@ -21,7 +21,7 @@ from dagster._config import UserConfigSchema
 from dagster._core.decorator_utils import (
     format_docstring_for_description,
     get_function_params,
-    get_valid_name_permutations,
+    is_context_provided,
     param_is_var_keyword,
     positional_arg_name_list,
 )
@@ -340,12 +340,6 @@ class NoContextDecoratedOpFunction(DecoratedOpFunction):
     @lru_cache(maxsize=1)
     def has_context_arg(self) -> bool:
         return False
-
-
-def is_context_provided(params: Sequence[Parameter]) -> bool:
-    if len(params) == 0:
-        return False
-    return params[0].name in get_valid_name_permutations("context")
 
 
 def resolve_checked_op_fn_inputs(

--- a/python_modules/dagster/dagster/_core/definitions/source_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/source_asset.py
@@ -63,10 +63,8 @@ SourceAssetObserveFunction: TypeAlias = Callable[..., Any]
 def wrap_source_asset_observe_fn_in_op_compute_fn(
     source_asset: "SourceAsset",
 ) -> "DecoratedOpFunction":
-    from dagster._core.definitions.decorators.op_decorator import (
-        DecoratedOpFunction,
-        is_context_provided,
-    )
+    from dagster._core.decorator_utils import is_context_provided
+    from dagster._core.definitions.decorators.op_decorator import DecoratedOpFunction
     from dagster._core.execution.context.compute import (
         OpExecutionContext,
     )

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -1737,7 +1737,7 @@ def build_execution_context(
     op            AssetExecutionContext     Error - we cannot init an AssetExecutionContext w/o an AssetsDefinition
     op            OpExecutionContext        OpExecutionContext
     op            None                      OpExecutionContext
-    
+
     For ops in graph-backed assets
     step type     annotation                result
     op            AssetExecutionContext     AssetExecutionContext
@@ -1769,14 +1769,16 @@ def build_execution_context(
             " OpExecutionContext, or left blank."
         )
 
+    op_context = OpExecutionContext(step_context)
+
     if context_annotation is EmptyAnnotation:
         # if no type hint has been given, default to:
         # * AssetExecutionContext for sda steps, not in graph-backed assets
         # * OpExecutionContext for non sda steps
         # * OpExecutionContext for ops in graph-backed assets
         if is_op_in_graph_asset or not is_sda_step:
-            return OpExecutionContext(step_context)
-        return AssetExecutionContext(step_context)
+            return op_context
+        return AssetExecutionContext(op_context)
     if context_annotation is AssetExecutionContext:
-        return AssetExecutionContext(step_context)
-    return OpExecutionContext(step_context)
+        return AssetExecutionContext(op_context)
+    return op_context

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -1281,7 +1281,7 @@ class OpExecutionContext(AbstractComputeExecutionContext, metaclass=OpExecutionC
 
 OP_EXECUTION_CONTEXT_ONLY_METHODS = set(
     [
-        "describe_op",  # TODO - used by internals
+        "describe_op",
         "file_manager",
         "has_assets_def",
         "get_mapping_key",

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -41,7 +41,6 @@ from dagster._core.definitions.partition_key_range import PartitionKeyRange
 from dagster._core.definitions.step_launcher import StepLauncher
 from dagster._core.definitions.time_window_partitions import TimeWindow
 from dagster._core.errors import (
-    DagsterInvalidDefinitionError,
     DagsterInvalidPropertyError,
     DagsterInvariantViolationError,
 )

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -1742,7 +1742,11 @@ def build_execution_context(
     op            None                      OpExecutionContext
     """
     is_sda_step = step_context.is_sda_step
+<<<<<<< HEAD
     is_op_in_graph_asset = is_sda_step and step_context.is_op_in_graph
+=======
+    is_op_in_graph_asset = step_context.is_graph_asset_op
+>>>>>>> 83a7271d18 (handle graph assets)
     context_annotation = EmptyAnnotation
     compute_fn = step_context.op_def._compute_fn  # noqa: SLF001
     compute_fn = (

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -1281,7 +1281,7 @@ class OpExecutionContext(AbstractComputeExecutionContext, metaclass=OpExecutionC
 
 OP_EXECUTION_CONTEXT_ONLY_METHODS = set(
     [
-        "describe_op",
+        "describe_op",  # TODO - used by internals
         "file_manager",
         "has_assets_def",
         "get_mapping_key",

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -1742,11 +1742,8 @@ def build_execution_context(
     op            None                      OpExecutionContext
     """
     is_sda_step = step_context.is_sda_step
-<<<<<<< HEAD
     is_op_in_graph_asset = is_sda_step and step_context.is_op_in_graph
-=======
-    is_op_in_graph_asset = step_context.is_graph_asset_op
->>>>>>> 83a7271d18 (handle graph assets)
+
     context_annotation = EmptyAnnotation
     compute_fn = step_context.op_def._compute_fn  # noqa: SLF001
     compute_fn = (

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -41,6 +41,7 @@ from dagster._core.definitions.partition_key_range import PartitionKeyRange
 from dagster._core.definitions.step_launcher import StepLauncher
 from dagster._core.definitions.time_window_partitions import TimeWindow
 from dagster._core.errors import (
+    DagsterInvalidDefinitionError,
     DagsterInvalidPropertyError,
     DagsterInvariantViolationError,
 )
@@ -1722,6 +1723,7 @@ class AssetExecutionContext(OpExecutionContext, IContext):
     def get_asset_provenance(self, asset_key: AssetKey) -> Optional[DataProvenance]:
         return self._op_execution_context.get_asset_provenance(asset_key)
 
+
 def build_execution_context(
     step_context: StepExecutionContext,
 ) -> Union[OpExecutionContext, AssetExecutionContext]:
@@ -1735,6 +1737,7 @@ def build_execution_context(
     op            AssetExecutionContext     Error - we cannot init an AssetExecutionContext w/o an AssetsDefinition
     op            OpExecutionContext        OpExecutionContext
     op            None                      OpExecutionContext
+    
     For ops in graph-backed assets
     step type     annotation                result
     op            AssetExecutionContext     AssetExecutionContext

--- a/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
@@ -36,7 +36,7 @@ from dagster._core.types.dagster_type import DagsterTypeKind, is_generic_output_
 from dagster._utils import is_named_tuple_instance
 from dagster._utils.warnings import disable_dagster_warnings
 
-from ..context.compute import OpExecutionContext
+from ..context.compute import AssetExecutionContext, OpExecutionContext
 
 
 class NoAnnotationSentinel:
@@ -244,6 +244,8 @@ def _check_output_object_name(
 def validate_and_coerce_op_result_to_iterator(
     result: Any, context: OpExecutionContext, output_defs: Sequence[OutputDefinition]
 ) -> Iterator[Any]:
+    if isinstance(context, AssetExecutionContext):
+        context = context.op_execution_context
     if inspect.isgenerator(result):
         # this happens when a user explicitly returns a generator in the op
         for event in result:

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -1585,7 +1585,7 @@ def test_multi_asset_return_none():
         can_subset=True,
     )
     def subset(context: AssetExecutionContext):
-        # ...use context.selected_asset_keys materialize subset of assets without IO manager
+        # ...use context.asset_keys materialize subset of assets without IO manager
         pass
 
     with pytest.raises(
@@ -1882,7 +1882,7 @@ def test_multi_asset_no_out():
         can_subset=True,
     )
     def basic_subset(context: AssetExecutionContext):
-        for key in context.selected_asset_keys:
+        for key in context.asset_keys:
             yield MaterializeResult(asset_key=key)
 
     mats = _exec_asset(basic_subset, ["table_A"])

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
@@ -2738,10 +2738,10 @@ def test_subset_cycle_resolution_basic():
         can_subset=True,
     )
     def foo(context, s, a_prime):
-        context.log.info(context.selected_asset_keys)
-        if AssetKey("a") in context.selected_asset_keys:
+        context.log.info(context.asset_keys)
+        if AssetKey("a") in context.asset_keys:
             yield Output(s + 1, "a")
-        if AssetKey("b") in context.selected_asset_keys:
+        if AssetKey("b") in context.asset_keys:
             yield Output(a_prime + 1, "b")
 
     @multi_asset(
@@ -2753,10 +2753,10 @@ def test_subset_cycle_resolution_basic():
         can_subset=True,
     )
     def foo_prime(context, a, b):
-        context.log.info(context.selected_asset_keys)
-        if AssetKey("a_prime") in context.selected_asset_keys:
+        context.log.info(context.asset_keys)
+        if AssetKey("a_prime") in context.asset_keys:
             yield Output(a + 1, "a_prime")
-        if AssetKey("b_prime") in context.selected_asset_keys:
+        if AssetKey("b_prime") in context.asset_keys:
             yield Output(b + 1, "b_prime")
 
     job = Definitions(

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
@@ -104,7 +104,7 @@ def test_asset_with_inputs_direct_call():
 def test_asset_with_config_schema():
     @asset(config_schema={"foo": int})
     def my_asset(context):
-        assert context.op_config["foo"] == 5
+        assert context.op_execution_context.op_config["foo"] == 5
 
     materialize_to_memory([my_asset], run_config={"ops": {"my_asset": {"config": {"foo": 5}}}})
 
@@ -115,7 +115,7 @@ def test_asset_with_config_schema():
 def test_multi_asset_with_config_schema():
     @multi_asset(outs={"o1": AssetOut()}, config_schema={"foo": int})
     def my_asset(context):
-        assert context.op_config["foo"] == 5
+        assert context.op_execution_context.op_config["foo"] == 5
 
     materialize_to_memory([my_asset], run_config={"ops": {"my_asset": {"config": {"foo": 5}}}})
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_materialize.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_materialize.py
@@ -57,7 +57,7 @@ def test_basic_materialize():
 def test_materialize_config():
     @asset(config_schema={"foo_str": str})
     def the_asset_reqs_config(context):
-        assert context.op_config["foo_str"] == "foo"
+        assert context.op_execution_context.op_config["foo_str"] == "foo"
 
     with instance_for_test() as instance:
         assert materialize(
@@ -268,7 +268,7 @@ def test_materialize_multi_asset():
 def test_materialize_tags():
     @asset
     def the_asset(context):
-        assert context.get_tag("key1") == "value1"
+        assert context.dagster_run.tags.get("key1") == "value1"
 
     with instance_for_test() as instance:
         result = materialize([the_asset], instance=instance, tags={"key1": "value1"})
@@ -279,7 +279,7 @@ def test_materialize_tags():
 def test_materialize_partition_key():
     @asset(partitions_def=DailyPartitionsDefinition(start_date="2022-01-01"))
     def the_asset(context):
-        assert context.asset_partition_key_for_output() == "2022-02-02"
+        assert context.partition_key == "2022-02-02"
 
     with instance_for_test() as instance:
         result = materialize([the_asset], partition_key="2022-02-02", instance=instance)

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_asset_decorator_with_check_specs.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_asset_decorator_with_check_specs.py
@@ -403,10 +403,10 @@ def test_multi_asset_with_check_subset():
         can_subset=True,
     )
     def asset_1_and_2(context: AssetExecutionContext):
-        if AssetKey("asset1") in context.selected_asset_keys:
+        if AssetKey("asset1") in context.asset_keys:
             yield Output(None, output_name="one")
             yield AssetCheckResult(check_name="check1", success=True)
-        if AssetKey("asset2") in context.selected_asset_keys:
+        if AssetKey("asset2") in context.asset_keys:
             yield Output(None, output_name="two")
 
     # no selection


### PR DESCRIPTION
## Summary & Motivation
Introduces the logic to determine which kind of context to provide to which kind of step. 

Follows these rules:
```
@asset + no type annotation -> AssetExecutionContext
@asset + AssetExecutionContext annotation -> AssetExecutionContext
@asset + OpExecutionContext annotation -> OpExecutionContext 
@op + no type annotation -> OpExecutionContext 
@op + AssetExecutionContext annotation -> Error - we need an AssetsDef for AssetExecutionContext init, and op doesn't have one 
@op + OpExecutionContext -> OpExecutionContext 
```
The ops that make up graph backed assets is where is gets funky. This is what would happen in the current implementation:
```
@graph_asset @op + no type annotation -> OpExecutionContext
@graph_asset @op + AssetExecutionContext -> AssetExecutionContext 
@graph_asset @op + OpExecutionContext -> OpExecutionContext
```


The reasoning behind `@graph_asset @op + no type annotation -> OpExecutionContext` is best explained with an example:
Imagine you have an op that is used in both a job and a graph-backed asset 

```python
@op 
def my_fun_op(context):
   context.describe_op # this function is on the OpExecutionContext, but not on the AssetExecutionContext

@job 
def my_fun_job():
    my_fun_op()

@graph_asset 
def my_fun_asset():
    my_fun_op()
```
When executing `my_fun_job`, `my_fun_op` will receive an `OpExecutionContext` and run as expected. When materializing `my_fun_asset`, `my_fun_op` will receive an `AssetExecutionContext`. It will fire a deprecation warning, but still call `describe_op` on the internally held `op_execution_context`. When we deprecate the `__get_attr__` behavior [here](https://github.com/dagster-io/dagster/pull/16487/files#diff-890fa9a676b3b1f25888dcd0c569de82b6c56e3822b969b22c7a923c324fbcbbR1314), `my_fun_op` will instead error. 


## How I Tested These Changes
