### PR TITLE
Add DuckDB config to dagster-duckdb.

### DIFF
--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
@@ -1,12 +1,10 @@
 from abc import abstractmethod
 from contextlib import contextmanager
-from typing import Optional, Sequence, Type, cast
+from typing import Any, Dict, Optional, Sequence, Type, cast
 
 import duckdb
 from dagster import IOManagerDefinition, OutputContext, io_manager
-from dagster._config.pythonic_config import (
-    ConfigurableIOManagerFactory,
-)
+from dagster._config.pythonic_config import ConfigurableIOManagerFactory
 from dagster._core.definitions.time_window_partitions import TimeWindow
 from dagster._core.storage.db_io_manager import (
     DbClient,
@@ -156,9 +154,20 @@ class DuckDBIOManager(ConfigurableIOManagerFactory):
             # my_table will just contain the data from column "a"
             ...
 
+    Set DuckDB configuration options using the config field.
+
+    .. code-block:: python
+
+        defs = Definitions(
+            assets=[my_table],
+            resources={"io_manager": MyDuckDBIOManager(database="my_db.duckdb",
+                                                       config={"arrow_large_buffer_size": True})}
+        )
+
     """
 
     database: str = Field(description="Path to the DuckDB database.")
+    config: Dict[str, Any] = Field(description="DuckDB configuration options.", default={})
     schema_: Optional[str] = Field(
         default=None, alias="schema", description="Name of the schema to use."
     )  # schema is a reserved word for pydantic
@@ -212,7 +221,11 @@ class DuckDbClient(DbClient):
         conn = backoff(
             fn=duckdb.connect,
             retry_on=(RuntimeError, duckdb.IOException),
-            kwargs={"database": context.resource_config["database"], "read_only": False},
+            kwargs={
+                "database": context.resource_config["database"],
+                "read_only": False,
+                "config": context.resource_config["config"],
+            },
             max_retries=10,
         )
 

--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
@@ -154,7 +154,8 @@ class DuckDBIOManager(ConfigurableIOManagerFactory):
             # my_table will just contain the data from column "a"
             ...
 
-    Set DuckDB configuration options using the config field.
+    Set DuckDB configuration options using the config field. See
+    https://duckdb.org/docs/sql/configuration.html for all available settings.
 
     .. code-block:: python
 

--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb/resource.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb/resource.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+from typing import Any, Dict
 
 import duckdb
 from dagster import ConfigurableResource
@@ -33,6 +34,7 @@ class DuckDBResource(ConfigurableResource):
             " database "
         )
     )
+    config: Dict[str, Any] = Field(description="DuckDB configuration options.", default={})
 
     @classmethod
     def _is_dagster_maintained(cls) -> bool:
@@ -43,7 +45,7 @@ class DuckDBResource(ConfigurableResource):
         conn = backoff(
             fn=duckdb.connect,
             retry_on=(RuntimeError, duckdb.IOException),
-            kwargs={"database": self.database, "read_only": False},
+            kwargs={"database": self.database, "read_only": False, "config": self.config},
             max_retries=10,
         )
 


### PR DESCRIPTION
## Summary & Motivation

DuckDB can be configured with [configuration options](https://duckdb.org/docs/sql/configuration.html) at connection time by supplying a config map to the [duckdb.connect](https://duckdb.org/docs/archive/0.8.1/api/python/reference/#duckdb.connect). This PR pipes the config from the Dagster Config to DuckDB.

I needed this because [DuckDBPandasIOManager](https://docs.dagster.io/_apidocs/libraries/dagster-duckdb-pandas#dagster_duckdb_pandas.DuckDBPandasIOManager) and [DuckDBPolarsIOManager](https://docs.dagster.io/_apidocs/libraries/dagster-duckdb-polars#dagster_duckdb_polars.DuckDBPolarsIOManager) failed to load large strings in the db with the error `ArrowInvalid: offset overflow while concatenating arrays`. Based on the discussion [here](https://github.com/apache/arrow/issues/33049), I was able to trace the issue to the [`arrow_large_buffer_size`](https://github.com/duckdb/duckdb/blob/b78b24ad262d6b55793123a44794e77842f7f903/tools/pythonpkg/tests/fast/arrow/test_buffer_size_option.py#L23) configuration. When I set the `arrow_large_buffer_size` through the changes in this PR, I was able to use the DuckDB IOManagers again.

## How I Tested These Changes

DuckDB config can be read using `SELECT current_setting('arrow_large_buffer_size')`. I added unit tests to set the config and read it back using that statement.