### PR TITLE
Remove AssetCheckResult whitelist_for_serdes

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_check_result.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_result.py
@@ -15,14 +15,12 @@ from dagster._core.definitions.events import (
     normalize_metadata,
 )
 from dagster._core.errors import DagsterInvariantViolationError
-from dagster._serdes import whitelist_for_serdes
 
 if TYPE_CHECKING:
     from dagster._core.execution.context.compute import StepExecutionContext
 
 
 @experimental
-@whitelist_for_serdes
 class AssetCheckResult(
     NamedTuple(
         "_AssetCheckResult",


### PR DESCRIPTION
Afaik we don't serialize this- we convert it in to an evaluation