### PR TITLE
[daggy u] Repair callouts, external links

### DIFF
--- a/docs/dagster-university/components/Callout.tsx
+++ b/docs/dagster-university/components/Callout.tsx
@@ -1,25 +1,26 @@
 import * as React from 'react';
 
-export function Callout({title, children}) {
+interface Props {
+  children: React.ReactNode;
+}
+
+export const Callout = ({children}) => {
   return (
-    <div className="callout">
-      <strong>{title}</strong>
-      <span>{children}</span>
-      <style jsx>
-        {`
-          .callout {
-            display: flex;
-            flex-direction: column;
-            padding: 12px 16px;
-            background: #f6f9fc;
-            border: 1px solid #dce6e9;
-            border-radius: 4px;
-          }
-          .callout :global(p) {
-            margin: 0;
-          }
-        `}
-      </style>
+    <div className={`callout bg-primary-100 border-l-4 border-primary-500 px-4 py-4`}>
+      <div className="flex items-start">
+        <div className="flex-shrink-0 mt-[1px]">
+          <svg
+            className={`h-5 w-5 text-primary-500`}
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 25 25"
+            fill="currentColor"
+            aria-hidden="true"
+          >
+            <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z" />
+          </svg>
+        </div>
+        <div className="ml-3 text-sm text-gray-900">{children}</div>
+      </div>
     </div>
   );
-}
+};

--- a/docs/dagster-university/markdoc/nodes/index.ts
+++ b/docs/dagster-university/markdoc/nodes/index.ts
@@ -1,3 +1,4 @@
 /* Use this file to export your markdoc nodes */
 export * from './fence.markdoc';
 export * from './heading.markdoc';
+export * from './link.markdoc';

--- a/docs/dagster-university/markdoc/nodes/link.markdoc.ts
+++ b/docs/dagster-university/markdoc/nodes/link.markdoc.ts
@@ -1,0 +1,19 @@
+import {Tag, nodes} from '@markdoc/markdoc';
+import Link from 'next/link';
+
+export const link = {
+  render: Link,
+  attributes: nodes.link.attributes,
+  transform(node, config) {
+    const attributes = node.transformAttributes(config);
+    const children = node.transformChildren(config);
+    const {href} = attributes;
+
+    // If the link is to another site, open in a new window.
+    return new Tag(
+      this.render,
+      {...attributes, target: href.startsWith('http') ? '_blank' : undefined},
+      children,
+    );
+  },
+};

--- a/docs/dagster-university/next.config.js
+++ b/docs/dagster-university/next.config.js
@@ -1,5 +1,5 @@
 const withMarkdoc = require('@markdoc/next.js');
 
-module.exports = withMarkdoc(/* config: https://markdoc.io/docs/nextjs#options */)({
+module.exports = withMarkdoc({schemaPath: './markdoc', mode: 'static'})({
   pageExtensions: ['js', 'jsx', 'ts', 'tsx', 'md', 'mdoc'],
 });

--- a/docs/dagster-university/pages/_app.tsx
+++ b/docs/dagster-university/pages/_app.tsx
@@ -69,7 +69,7 @@ export default function MyApp({Component, pageProps}: AppProps<MyAppProps>) {
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <div className="page">
-        <main className="flex column prose max-w-none">
+        <main className="prose max-w-5xl">
           <Component {...pageProps} />
         </main>
       </div>

--- a/docs/dagster-university/pages/dagster-essentials/lesson-1/why-is-asset-centric-orchestration-good-for-data-engineering.md
+++ b/docs/dagster-university/pages/dagster-essentials/lesson-1/why-is-asset-centric-orchestration-good-for-data-engineering.md
@@ -59,9 +59,9 @@ With a task-centric approach, it may not be immediately obvious how and when ass
 
   In the real world, think of this as the ability to use an asset as input to another asset. For example, creating a database table using multiple tables.
 
-- 1.  Figure out where in the workflow cookie dough is created
-  2.  Add a fork to add in peanuts
-  3.  Remake cookies from start to finish
+- 1. Figure out where in the workflow cookie dough is created
+  2. Add a fork to add in peanuts
+  3. Remake cookies from start to finish
 - 1. Add two new assets: peanuts and peanut cookie dough
   2. Add peanuts to cookie dough
   3. Result is peanut cookie dough

--- a/docs/dagster-university/pages/dagster-essentials/lesson-2/project-files.md
+++ b/docs/dagster-university/pages/dagster-essentials/lesson-2/project-files.md
@@ -62,7 +62,7 @@ The columns in the following table are as follows:
 
 - **dagster_university/**
 - Dagster
-- - A Python module that will contain your Dagster code. This directory also contains the following:
+- A Python module that will contain your Dagster code. This directory also contains the following:
   - `__init__.py` - This file includes a `Definitions` object that defines that is loaded in your project, such as assets and sensors. This allows Dagster to load the definitions in a module. We’ll discuss this topic, and this file, later in this course.
   - Several directories, for example: `/assets`. These directories follow our recommended best practices and will be used to contain the definitions - like assets - you create in the following lessons. We’ll discuss the files they contain later, too.
 

--- a/docs/dagster-university/pages/dagster-essentials/lesson-2/requirements-and-installation.md
+++ b/docs/dagster-university/pages/dagster-essentials/lesson-2/requirements-and-installation.md
@@ -24,7 +24,9 @@ pip --version
 
 ## Installation
 
-> 💡 Heads up! We strongly recommend installing Dagster inside a Python virtual environment. If you need a primer on virtual environments, including creating and activating one, check out this [blog post](https://dagster.io/blog/python-packages-primer-2).
+{% callout %}
+💡 Heads up! We strongly recommend installing Dagster inside a Python virtual environment. If you need a primer on virtual environments, including creating and activating one, check out this [blog post](https://dagster.io/blog/python-packages-primer-2).
+{% /callout %}
 
 To install Dagster into your current Python environment:
 

--- a/docs/dagster-university/pages/dagster-essentials/lesson-3/asset-materialization.md
+++ b/docs/dagster-university/pages/dagster-essentials/lesson-3/asset-materialization.md
@@ -47,7 +47,7 @@ If you don’t still have the Dagster UI running from Lesson 2, use the command 
 dagster dev
 ```
 
-Navigate to `[localhost:3000](http://localhost:3000/)` in your browser. The page should look like the following - if it doesn’t, click **Overview** in the top navigation bar:
+Navigate to [`localhost:3000`](http://localhost:3000/) in your browser. The page should look like the following - if it doesn’t, click **Overview** in the top navigation bar:
 
 ![The Overview page in the Dagster UI](/images/dagster-essentials/lesson-3/overview-page.png)
 

--- a/docs/dagster-university/pages/index.md
+++ b/docs/dagster-university/pages/index.md
@@ -19,7 +19,7 @@ title: Dagster University Course Content
     - [Overview](/dagster-essentials/lesson-3/overview)
     - [What's an asset?](/dagster-essentials/lesson-3/whats-an-asset)
     - [Defining your first asset](/dagster-essentials/lesson-3/defining-your-first-asset)
-    - [Asseet materialization](/dagster-essentials/lesson-3/asset-materialization)
+    - [Asset materialization](/dagster-essentials/lesson-3/asset-materialization)
     - [Viewing run details](/dagster-essentials/lesson-3/viewing-run-details)
     - [Troubleshooting failed runs](/dagster-essentials/lesson-3/troubleshooting-failed-runs)
     - [Coding practice: Create a taxi_zones_file asset](/dagster-essentials/lesson-3/coding-practice-taxi-zones-file-asset)

--- a/docs/dagster-university/styles/globals.css
+++ b/docs/dagster-university/styles/globals.css
@@ -30,20 +30,24 @@ page {
   display: flex;
   width: 100vw;
   flex-grow: 1;
-  /* max-width: 1280px; */
+  max-width: 1280px;
 }
 
 main {
-  overflow: auto;
   height: calc(100vh - var(--top-nav-height));
+  margin: 0 auto;
   flex-grow: 1;
   font-size: 16px;
-  padding: 0 5rem 5rem;
 }
 
-.codeBlock code[class*='language-'], .codeBlock pre[class*='language-'] {
+.codeBlock code[class*='language-'],
+.codeBlock pre[class*='language-'] {
   font-family: theme('fontFamily.mono');
   font-size: 14px;
   text-shadow: none;
   border-radius: 4px;
+}
+
+.callout p {
+  margin: 0;
 }


### PR DESCRIPTION
## Summary & Motivation

Some more fixes to Dagster University contents.

- Update the "Callout" style to match Docs site.
- If a link href starts with `http`, make it open in a new tab.
- Put some width restrictions on the page, which should help prevent images from breaking things.
- A couple other minor fixes like typo repairs.

<img width="1146" alt="Screenshot 2023-09-14 at 9 30 43 AM" src="https://github.com/dagster-io/dagster/assets/2823852/94bca694-d9d2-48d1-9c24-19a19f6f022e">

## How I Tested These Changes

yarn dev
