### PR TITLE
[ui] Link "Launched by" tags to schedules/sensors

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunCreatedByCell.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunCreatedByCell.tsx
@@ -1,24 +1,28 @@
 import {Box, Tag} from '@dagster-io/ui-components';
 import React from 'react';
+import {Link} from 'react-router-dom';
 
 import {useLaunchPadHooks} from '../launchpad/LaunchpadHooksContext';
+import {RepoAddress} from '../workspace/types';
+import {workspacePathFromAddress} from '../workspace/workspacePath';
 
 import {DagsterTag} from './RunTag';
 import {RunTagsFragment} from './types/RunTable.types';
 
 type Props = {
+  repoAddress?: RepoAddress | null;
   tags: RunTagsFragment[];
 };
 
-export const RunCreatedByCell = React.memo(({tags}: Props) => {
+export const RunCreatedByCell = React.memo(({repoAddress, tags}: Props) => {
   return (
     <Box flex={{direction: 'column', alignItems: 'flex-start'}}>
-      <RunCreatedByTag tags={tags} />
+      <RunCreatedByTag repoAddress={repoAddress} tags={tags} />
     </Box>
   );
 });
 
-export const RunCreatedByTag = ({tags}: Props) => {
+export const RunCreatedByTag = ({repoAddress, tags}: Props) => {
   const {UserDisplay} = useLaunchPadHooks();
 
   const user = tags.find((tag) => tag.key === DagsterTag.User);
@@ -28,12 +32,26 @@ export const RunCreatedByTag = ({tags}: Props) => {
 
   const scheduleTag = tags.find((tag) => tag.key === DagsterTag.ScheduleName);
   if (scheduleTag) {
-    return <Tag icon="schedule">{scheduleTag.value}</Tag>;
+    const scheduleName = scheduleTag.value;
+    const tagContent = repoAddress ? (
+      <Link to={workspacePathFromAddress(repoAddress, `/schedules/${scheduleName}`)}>
+        {scheduleName}
+      </Link>
+    ) : (
+      scheduleName
+    );
+    return <Tag icon="schedule">{tagContent}</Tag>;
   }
 
   const sensorTag = tags.find((tag) => tag.key === DagsterTag.SensorName);
   if (sensorTag) {
-    return <Tag icon="sensors">{sensorTag.value}</Tag>;
+    const sensorName = sensorTag.value;
+    const tagContent = repoAddress ? (
+      <Link to={workspacePathFromAddress(repoAddress, `/sensors/${sensorName}`)}>{sensorName}</Link>
+    ) : (
+      sensorName
+    );
+    return <Tag icon="sensors">{tagContent}</Tag>;
   }
 
   const automaterialize = tags.some(

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunTable.tsx
@@ -28,6 +28,7 @@ import {useSelectionReducer} from '../hooks/useSelectionReducer';
 import {useStateWithStorage} from '../hooks/useStateWithStorage';
 import {PipelineReference} from '../pipelines/PipelineReference';
 import {AnchorButton} from '../ui/AnchorButton';
+import {buildRepoAddress} from '../workspace/buildRepoAddress';
 import {useRepositoryForRunWithoutSnapshot} from '../workspace/useRepositoryForRun';
 import {workspacePipelinePath, workspacePipelinePathGuessRepo} from '../workspace/workspacePath';
 
@@ -275,6 +276,14 @@ const RunRow: React.FC<{
     return false;
   }, [repo, pipelineName]);
 
+  const repoAddressGuess = React.useMemo(() => {
+    if (repo) {
+      const {match} = repo;
+      return buildRepoAddress(match.repository.name, match.repositoryLocation.name);
+    }
+    return null;
+  }, [repo]);
+
   const onChange = (e: React.FormEvent<HTMLInputElement>) => {
     if (e.target instanceof HTMLInputElement) {
       const {checked} = e.target;
@@ -465,7 +474,7 @@ const RunRow: React.FC<{
       </td>
       {hideCreatedBy ? null : (
         <td>
-          <RunCreatedByCell tags={run.tags || []} />
+          <RunCreatedByCell repoAddress={repoAddressGuess} tags={run.tags || []} />
         </td>
       )}
       <td>


### PR DESCRIPTION
## Summary & Motivation

Resolves #16475.

If a RepoAddress is available for a run, use it to link the schedule/sensor in the "Launched by" column on the Runs table.

## How I Tested These Changes

View runs launched by schedules and sensors in the Runs table. Verify that they are properly linked.

Find some runs that are launched by schedules/sensors that no longer exist in the workspace. Verify that these are not linked.
