### PR TITLE
[ui-components] Clean up Box border props

### DIFF
--- a/js_modules/dagster-ui/packages/app-oss/src/NUX/CommunityNux.tsx
+++ b/js_modules/dagster-ui/packages/app-oss/src/NUX/CommunityNux.tsx
@@ -95,7 +95,7 @@ const Form: React.FC<{
       <Box
         flex={{direction: 'row', gap: 24, alignItems: 'center'}}
         padding={{bottom: 24}}
-        border={{side: 'bottom', color: Colors.KeylineGray, width: 1}}
+        border="bottom"
       >
         <Box flex={{direction: 'column', gap: 8, alignItems: 'start', justifyContent: 'start'}}>
           <Heading>Join the Dagster community</Heading>

--- a/js_modules/dagster-ui/packages/ui-components/src/components/Box.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/Box.tsx
@@ -2,11 +2,12 @@ import styled, {css} from 'styled-components';
 
 import {assertUnreachable} from '../util/assertUnreachable';
 
-import {BorderSetting, DirectionalSpacing, FlexProperties} from './types';
+import {Colors} from './Colors';
+import {BorderSetting, BorderSide, DirectionalSpacing, FlexProperties} from './types';
 
 interface Props {
   background?: string | null;
-  border?: BorderSetting | null;
+  border?: BorderSide | BorderSetting | null;
   flex?: FlexProperties | null;
   margin?: DirectionalSpacing | null;
   padding?: DirectionalSpacing | null;
@@ -47,18 +48,21 @@ const directionalSpacingToCSS = (property: string, spacing: DirectionalSpacing) 
   `;
 };
 
-const borderSettingToCSS = (border: BorderSetting) => {
-  const {side, width, color} = border;
+const borderSettingToCSS = (border: BorderSide | BorderSetting) => {
+  const borderValue =
+    typeof border === 'string' ? {side: border, width: 1, color: Colors.KeylineGray} : border;
+  const {side, width = 1, color = Colors.KeylineGray} = borderValue;
+
   switch (side) {
     case 'all':
       return css`
         box-shadow: inset 0 0 0 ${width}px ${color};
       `;
-    case 'horizontal':
+    case 'top-and-bottom':
       return css`
         box-shadow: inset 0 ${width}px ${color}, inset 0 -${width}px ${color};
       `;
-    case 'vertical':
+    case 'left-and-right':
       return css`
         box-shadow: inset ${width}px 0 ${color}, inset -${width}px 0 ${color};
       `;

--- a/js_modules/dagster-ui/packages/ui-components/src/components/Dialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/Dialog.tsx
@@ -42,11 +42,7 @@ interface HeaderProps {
 export const DialogHeader: React.FC<HeaderProps> = (props) => {
   const {icon, label} = props;
   return (
-    <Box
-      background={Colors.White}
-      padding={{vertical: 16, horizontal: 20}}
-      border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
-    >
+    <Box background={Colors.White} padding={{vertical: 16, horizontal: 20}} border="bottom">
       <Group direction="row" spacing={8} alignItems="center">
         {icon ? <Icon name={icon} color={Colors.Gray800} /> : null}
         <DialogHeaderText>{label}</DialogHeaderText>
@@ -81,7 +77,7 @@ export const DialogFooter: React.FC<DialogFooterProps> = ({
   return (
     <Box
       padding={{bottom: 16, top: topBorder ? 16 : 8, horizontal: 20}}
-      border={topBorder ? {side: 'top', width: 1, color: Colors.KeylineGray} : null}
+      border={topBorder ? 'top' : null}
       background={Colors.White}
       flex={{direction: 'row', alignItems: 'center', justifyContent: 'space-between'}}
     >

--- a/js_modules/dagster-ui/packages/ui-components/src/components/ErrorBoundary.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/ErrorBoundary.tsx
@@ -64,7 +64,7 @@ export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoun
       return (
         <Box
           style={{width: '100%', height: '100%', flex: 1, overflow: 'hidden'}}
-          border={{width: 1, side: 'all', color: Colors.HighlightRed}}
+          border={{side: 'all', color: Colors.HighlightRed}}
           flex={{direction: 'column', gap: 8}}
           padding={16}
         >

--- a/js_modules/dagster-ui/packages/ui-components/src/components/PageHeader.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/PageHeader.tsx
@@ -21,7 +21,7 @@ export const PageHeader = (props: Props) => {
     <PageHeaderContainer
       background={Colors.Gray50}
       padding={{top: 16, left: 24, right: 12}}
-      border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+      border="bottom"
     >
       <Box flex={{direction: 'row', justifyContent: 'space-between'}} padding={{bottom: 16}}>
         <Box flex={{direction: 'row', alignItems: 'flex-start', gap: 12, wrap: 'wrap'}}>

--- a/js_modules/dagster-ui/packages/ui-components/src/components/VirtualizedTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/VirtualizedTable.tsx
@@ -7,7 +7,7 @@ import {Colors} from './Colors';
 export const HeaderCell = ({children}: {children?: React.ReactNode}) => (
   <CellBox
     padding={{vertical: 8, horizontal: 12}}
-    border={{side: 'right', width: 1, color: Colors.KeylineGray}}
+    border="right"
     style={{whiteSpace: 'nowrap', textOverflow: 'ellipsis', overflow: 'hidden'}}
   >
     {children}
@@ -19,7 +19,7 @@ export const RowCell = ({children}: {children?: React.ReactNode}) => (
     padding={12}
     flex={{direction: 'column', justifyContent: 'flex-start'}}
     style={{color: Colors.Gray500, overflow: 'hidden'}}
-    border={{side: 'right', width: 1, color: Colors.KeylineGray}}
+    border="right"
   >
     {children}
   </CellBox>

--- a/js_modules/dagster-ui/packages/ui-components/src/components/__stories__/Box.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/__stories__/Box.stories.tsx
@@ -34,7 +34,15 @@ export const Padding = () => {
 };
 
 export const BorderSides = () => {
-  const sides: BorderSide[] = ['all', 'horizontal', 'vertical', 'top', 'right', 'bottom', 'left'];
+  const sides: BorderSide[] = [
+    'all',
+    'top-and-bottom',
+    'left-and-right',
+    'top',
+    'right',
+    'bottom',
+    'left',
+  ];
   const widths: BorderWidth[] = [1, 2];
   return (
     <Group direction="column" spacing={16}>

--- a/js_modules/dagster-ui/packages/ui-components/src/components/__stories__/ProgressBar.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/__stories__/ProgressBar.stories.tsx
@@ -15,13 +15,13 @@ export default {
 export const Sizes = () => {
   return (
     <Group direction="column" spacing={32}>
-      <Box padding={20} border={{side: 'all', width: 1, color: Colors.Gray100}}>
+      <Box padding={20} border="all">
         <Group direction="column" spacing={16}>
           <ProgressBar intent="primary" value={0.1} animate={true} />
           <ProgressBar intent="primary" value={0.7} />
         </Group>
       </Box>
-      <Box padding={20} border={{side: 'all', width: 1, color: Colors.Gray100}}>
+      <Box padding={20} border="all">
         <Group direction="column" spacing={16}>
           <ProgressBar intent="primary" value={0.1} animate={true} fillColor={Colors.Blue500} />
           <ProgressBar intent="primary" value={0.7} fillColor={Colors.Blue500} />

--- a/js_modules/dagster-ui/packages/ui-components/src/components/__stories__/Spinner.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/__stories__/Spinner.stories.tsx
@@ -16,7 +16,7 @@ export default {
 export const Sizes = () => {
   return (
     <Group direction="column" spacing={32}>
-      <Box padding={20} border={{side: 'all', width: 1, color: Colors.Gray100}}>
+      <Box padding={20} border="all">
         <Group direction="column" spacing={16}>
           <Code>purpose=&quot;caption-text&quot;</Code>
           <Group direction="row" spacing={8} alignItems="center">
@@ -25,7 +25,7 @@ export const Sizes = () => {
           </Group>
         </Group>
       </Box>
-      <Box padding={20} border={{side: 'all', width: 1, color: Colors.Gray100}}>
+      <Box padding={20} border="all">
         <Group direction="column" spacing={16}>
           <Code>purpose=&quot;body-text&quot;</Code>
           <Group direction="row" spacing={8} alignItems="center">
@@ -34,7 +34,7 @@ export const Sizes = () => {
           </Group>
         </Group>
       </Box>
-      <Box padding={20} border={{side: 'all', width: 1, color: Colors.Gray100}}>
+      <Box padding={20} border="all">
         <Group direction="column" spacing={16}>
           <Code>purpose=&quot;section&quot;</Code>
           <Box flex={{direction: 'row', justifyContent: 'center', gap: 10}} padding={24}>
@@ -43,7 +43,7 @@ export const Sizes = () => {
           </Box>
         </Group>
       </Box>
-      <Box padding={20} border={{side: 'all', width: 1, color: Colors.Gray100}}>
+      <Box padding={20} border="all">
         <Group direction="column" spacing={16}>
           <Code>purpose=&quot;page&quot;</Code>
           <Box flex={{direction: 'row', justifyContent: 'center', gap: 10}} padding={48}>

--- a/js_modules/dagster-ui/packages/ui-components/src/components/types.ts
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/types.ts
@@ -46,6 +46,13 @@ export type FlexProperties = {
   wrap?: FlexWrap;
 };
 
-export type BorderSide = 'top' | 'right' | 'bottom' | 'left' | 'horizontal' | 'vertical' | 'all';
+export type BorderSide =
+  | 'top'
+  | 'right'
+  | 'bottom'
+  | 'left'
+  | 'top-and-bottom'
+  | 'left-and-right'
+  | 'all';
 export type BorderWidth = 1 | 2 | 4;
-export type BorderSetting = {width: BorderWidth; color: string; side: BorderSide};
+export type BorderSetting = {width?: BorderWidth; color?: string; side: BorderSide};

--- a/js_modules/dagster-ui/packages/ui-core/src/app/UserSettingsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/UserSettingsDialog.tsx
@@ -3,7 +3,6 @@ import {
   Button,
   ButtonLink,
   Checkbox,
-  Colors,
   Dialog,
   DialogBody,
   DialogFooter,
@@ -134,7 +133,7 @@ const UserSettingsDialogContent: React.FC<DialogContentProps> = ({onClose, visib
             ]}
           />
         </Box>
-        <Box padding={{top: 16}} border={{side: 'top', width: 1, color: Colors.KeylineGray}}>
+        <Box padding={{top: 16}} border="top">
           <Box padding={{bottom: 8}}>
             <Subheading>Experimental features</Subheading>
           </Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode.tsx
@@ -48,11 +48,7 @@ export const AssetNode: React.FC<{
             </div>
             <div style={{flex: 1}} />
           </Name>
-          <Box
-            style={{padding: '6px 8px'}}
-            flex={{direction: 'column', gap: 4}}
-            border={{side: 'top', width: 1, color: Colors.KeylineGray}}
-          >
+          <Box style={{padding: '6px 8px'}} flex={{direction: 'column', gap: 4}} border="top">
             {definition.description ? (
               <Description $color={Colors.Gray800}>
                 {markdownToPlaintext(definition.description).split('\n')[0]}
@@ -187,7 +183,7 @@ const AssetNodeChecksRow: React.FC<{
     <AssetNodeRowBox
       padding={{horizontal: 8}}
       flex={{justifyContent: 'space-between', alignItems: 'center', gap: 6}}
-      border={{side: 'top', width: 1, color: Colors.KeylineGray}}
+      border="top"
       background={Colors.Gray50}
     >
       Checks

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetDefinedInMultipleReposNotice.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetDefinedInMultipleReposNotice.tsx
@@ -38,10 +38,7 @@ export const AssetDefinedInMultipleReposNotice: React.FC<{
   );
 
   return (
-    <Box
-      padding={padded ? {vertical: 16, left: 24, right: 12} : {}}
-      border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
-    >
+    <Box padding={padded ? {vertical: 16, left: 24, right: 12} : {}} border="bottom">
       <Alert
         intent="warning"
         title={MULTIPLE_DEFINITIONS_WARNING}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEventDetail.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEventDetail.tsx
@@ -36,7 +36,7 @@ export const AssetEventDetail: React.FC<{
     <Box padding={{horizontal: 24, bottom: 24}} style={{flex: 1}}>
       <Box
         padding={{vertical: 24}}
-        border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+        border="bottom"
         flex={{alignItems: 'center', justifyContent: 'space-between'}}
       >
         <Heading>
@@ -45,7 +45,7 @@ export const AssetEventDetail: React.FC<{
       </Box>
       <Box
         style={{display: 'grid', gridTemplateColumns: '1fr 1fr 1fr 1fr', gap: 16}}
-        border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+        border="bottom"
         padding={{vertical: 16}}
       >
         <Box flex={{gap: 4, direction: 'column'}}>
@@ -143,14 +143,14 @@ export const AssetEventDetailEmpty = () => (
   <Box padding={{horizontal: 24}} style={{flex: 1}}>
     <Box
       padding={{vertical: 24}}
-      border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+      border="bottom"
       flex={{alignItems: 'center', justifyContent: 'space-between'}}
     >
       <Heading color={Colors.Gray400}>No event selected</Heading>
     </Box>
     <Box
       style={{display: 'grid', gridTemplateColumns: '1fr 1fr 1fr 1fr', gap: 16}}
-      border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+      border="bottom"
       padding={{vertical: 16}}
     >
       <Box flex={{gap: 4, direction: 'column'}}>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEventList.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEventList.tsx
@@ -66,7 +66,7 @@ export const AssetEventList: React.FC<{
                 style={{height: size}}
                 padding={{left: 24, right: 12}}
                 flex={{direction: 'column', justifyContent: 'center', gap: 8}}
-                border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+                border="bottom"
               >
                 {xAxis === 'partition' ? (
                   <AssetEventListPartitionRow group={group} />

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEvents.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEvents.tsx
@@ -123,7 +123,7 @@ export const AssetEvents: React.FC<Props> = ({
       {assetHasUndefinedPartitions && (
         <Box
           flex={{justifyContent: 'space-between', alignItems: 'center'}}
-          border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+          border="bottom"
           padding={{vertical: 16, horizontal: 24}}
           style={{marginBottom: -1}}
         >
@@ -151,12 +151,12 @@ export const AssetEvents: React.FC<Props> = ({
         <>
           <FailedRunSinceMaterializationBanner
             stepKey={stepKeyForAsset(assetNode)}
-            border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+            border="bottom"
             run={liveData?.runWhichFailedToMaterialize || null}
           />
           <CurrentRunsBanner
             stepKey={stepKeyForAsset(assetNode)}
-            border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+            border="bottom"
             liveData={liveData}
           />
         </>
@@ -177,7 +177,7 @@ export const AssetEvents: React.FC<Props> = ({
             <Box
               flex={{alignItems: 'center', gap: 16}}
               padding={{vertical: 12, horizontal: 24}}
-              border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+              border="bottom"
             >
               <EventTypeSelect
                 value={filters.types}
@@ -202,7 +202,7 @@ export const AssetEvents: React.FC<Props> = ({
         <Box
           flex={{direction: 'column'}}
           style={{flex: 3, minWidth: 0, overflowY: 'auto'}}
-          border={{side: 'left', color: Colors.KeylineGray, width: 1}}
+          border="left"
         >
           <ErrorBoundary region="event" resetErrorOnChange={[focused]}>
             {xAxis === 'partition' ? (

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetMaterializationGraphs.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetMaterializationGraphs.tsx
@@ -42,15 +42,8 @@ export const AssetMaterializationGraphs: React.FC<{
         }}
       >
         {graphLabels.map((label) => (
-          <Box
-            key={label}
-            style={{width: '100%'}}
-            border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
-          >
-            <Box
-              style={{width: '100%'}}
-              border={{side: 'right', width: 1, color: Colors.KeylineGray}}
-            >
+          <Box key={label} style={{width: '100%'}} border="bottom">
+            <Box style={{width: '100%'}} border="right">
               {props.asSidebarSection ? (
                 <Box padding={{horizontal: 24, top: 8}} flex={{justifyContent: 'space-between'}}>
                   <Caption style={{fontWeight: 700}}>{label}</Caption>
@@ -58,7 +51,7 @@ export const AssetMaterializationGraphs: React.FC<{
               ) : (
                 <Box
                   padding={{horizontal: 24, vertical: 16}}
-                  border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+                  border="bottom"
                   flex={{justifyContent: 'space-between'}}
                 >
                   <Subheading>{label}</Subheading>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeDefinition.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeDefinition.tsx
@@ -68,14 +68,10 @@ export const AssetNodeDefinition: React.FC<{
         padded={true}
       />
       <Box flex={{direction: 'row'}} style={{flex: 1}}>
-        <Box
-          style={{flex: 1, minWidth: 0}}
-          flex={{direction: 'column'}}
-          border={{side: 'right', width: 1, color: Colors.KeylineGray}}
-        >
+        <Box style={{flex: 1, minWidth: 0}} flex={{direction: 'column'}} border="right">
           <Box
             padding={{vertical: 16, horizontal: 24}}
-            border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+            border="bottom"
             flex={{justifyContent: 'space-between', gap: 8}}
           >
             <Subheading>Description</Subheading>
@@ -93,10 +89,7 @@ export const AssetNodeDefinition: React.FC<{
           </Box>
           {assetNode.opVersion && (
             <>
-              <Box
-                padding={{vertical: 16, horizontal: 24}}
-                border={{side: 'horizontal', width: 1, color: Colors.KeylineGray}}
-              >
+              <Box padding={{vertical: 16, horizontal: 24}} border="top-and-bottom">
                 <Subheading>Code version</Subheading>
               </Box>
               <Box padding={{vertical: 16, horizontal: 24}} flex={{gap: 12, alignItems: 'center'}}>
@@ -106,10 +99,7 @@ export const AssetNodeDefinition: React.FC<{
           )}
           {assetNode.freshnessPolicy && (
             <>
-              <Box
-                padding={{vertical: 16, horizontal: 24}}
-                border={{side: 'horizontal', width: 1, color: Colors.KeylineGray}}
-              >
+              <Box padding={{vertical: 16, horizontal: 24}} border="top-and-bottom">
                 <Subheading>Freshness policy</Subheading>
               </Box>
               <Box
@@ -129,10 +119,7 @@ export const AssetNodeDefinition: React.FC<{
           )}
           {assetNode.autoMaterializePolicy && (
             <>
-              <Box
-                padding={{vertical: 16, horizontal: 24}}
-                border={{side: 'horizontal', width: 1, color: Colors.KeylineGray}}
-              >
+              <Box padding={{vertical: 16, horizontal: 24}} border="top-and-bottom">
                 <Subheading>Auto-materialize policy</Subheading>
               </Box>
               <Box
@@ -148,7 +135,7 @@ export const AssetNodeDefinition: React.FC<{
           )}
           <Box
             padding={{vertical: 16, horizontal: 24}}
-            border={{side: 'horizontal', width: 1, color: Colors.KeylineGray}}
+            border="top-and-bottom"
             flex={{justifyContent: 'space-between', gap: 8}}
           >
             <Subheading>
@@ -165,7 +152,7 @@ export const AssetNodeDefinition: React.FC<{
           <AssetNodeList items={upstream} liveDataByNode={liveDataByNode} />
           <Box
             padding={{vertical: 16, horizontal: 24}}
-            border={{side: 'horizontal', width: 1, color: Colors.KeylineGray}}
+            border="top-and-bottom"
             flex={{justifyContent: 'space-between', gap: 8}}
           >
             <Subheading>
@@ -183,22 +170,12 @@ export const AssetNodeDefinition: React.FC<{
           <div style={{flex: 1}} />
         </Box>
 
-        <Box
-          border={{side: 'vertical', width: 1, color: Colors.KeylineGray}}
-          style={{flex: 0.5, minWidth: 0}}
-          flex={{direction: 'column'}}
-        >
+        <Box border="left-and-right" style={{flex: 0.5, minWidth: 0}} flex={{direction: 'column'}}>
           <>
-            <Box
-              padding={{vertical: 16, horizontal: 24}}
-              border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
-            >
+            <Box padding={{vertical: 16, horizontal: 24}} border="bottom">
               <Subheading>Required resources</Subheading>
             </Box>
-            <Box
-              padding={{vertical: 16, horizontal: 24}}
-              border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
-            >
+            <Box padding={{vertical: 16, horizontal: 24}} border="bottom">
               {[...assetNode.requiredResources]
                 .sort((a, b) => COMMON_COLLATOR.compare(a.resourceKey, b.resourceKey))
                 .map((resource) => (
@@ -232,16 +209,10 @@ export const AssetNodeDefinition: React.FC<{
           </>
 
           <>
-            <Box
-              padding={{vertical: 16, horizontal: 24}}
-              border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
-            >
+            <Box padding={{vertical: 16, horizontal: 24}} border="bottom">
               <Subheading>Config</Subheading>
             </Box>
-            <Box
-              padding={{vertical: 16, horizontal: 24}}
-              border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
-            >
+            <Box padding={{vertical: 16, horizontal: 24}} border="bottom">
               {assetConfigSchema ? (
                 <ConfigTypeSchema
                   type={assetConfigSchema}
@@ -261,10 +232,7 @@ export const AssetNodeDefinition: React.FC<{
           </>
 
           <>
-            <Box
-              padding={{vertical: 16, horizontal: 24}}
-              border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
-            >
+            <Box padding={{vertical: 16, horizontal: 24}} border="bottom">
               <Subheading>Type</Subheading>
             </Box>
             {assetType && assetType.displayName !== 'Any' ? (
@@ -284,7 +252,7 @@ export const AssetNodeDefinition: React.FC<{
           <>
             <Box
               padding={{vertical: 16, horizontal: 24}}
-              border={{side: 'horizontal', width: 1, color: Colors.KeylineGray}}
+              border="top-and-bottom"
               flex={{justifyContent: 'space-between', gap: 8}}
             >
               <Subheading>Metadata</Subheading>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeLineage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeLineage.tsx
@@ -56,7 +56,7 @@ export const AssetNodeLineage: React.FC<{
       <Box
         flex={{justifyContent: 'space-between', alignItems: 'center', gap: 12}}
         padding={{left: 24, right: 12, vertical: 12}}
-        border={{side: 'bottom', color: Colors.KeylineGray, width: 1}}
+        border="bottom"
       >
         <ButtonGroup<AssetLineageScope>
           activeItems={new Set([params.lineageScope || 'neighbors'])}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitionDetail.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitionDetail.tsx
@@ -197,11 +197,7 @@ export const AssetPartitionDetail: React.FC<{
 
   return (
     <Box padding={{horizontal: 24, bottom: 24}} style={{flex: 1}}>
-      <Box
-        padding={{vertical: 24}}
-        border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
-        flex={{alignItems: 'center'}}
-      >
+      <Box padding={{vertical: 24}} border="bottom" flex={{alignItems: 'center'}}>
         {partition ? (
           <Box flex={{gap: 12, alignItems: 'center'}}>
             <Heading>{partition}</Heading>
@@ -228,7 +224,7 @@ export const AssetPartitionDetail: React.FC<{
           run={currentRun}
           stepKey={stepKey}
           padding={{horizontal: 0, vertical: 16}}
-          border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+          border="bottom"
         />
       )}
       {currentRun && currentRunStatusMessage && (
@@ -246,7 +242,7 @@ export const AssetPartitionDetail: React.FC<{
 
       <Box
         style={{display: 'grid', gridTemplateColumns: '1fr 1fr 1fr 1fr', gap: 16, minHeight: 76}}
-        border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+        border="bottom"
         padding={{vertical: 16}}
       >
         {!latest ? (

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitionList.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitionList.tsx
@@ -1,4 +1,4 @@
-import {Box, Colors} from '@dagster-io/ui-components';
+import {Box} from '@dagster-io/ui-components';
 import {useVirtualizer} from '@tanstack/react-virtual';
 import * as React from 'react';
 
@@ -83,7 +83,7 @@ export const AssetPartitionList: React.FC<AssetPartitionListProps> = ({
                 style={{height: size}}
                 padding={{left: 24, right: 12}}
                 flex={{direction: 'column', justifyContent: 'center', gap: 8}}
-                border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+                border="bottom"
               >
                 <Box flex={{gap: 4, direction: 'row', alignItems: 'center'}}>
                   {dimensionKey}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitions.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitions.tsx
@@ -189,10 +189,7 @@ export const AssetPartitions: React.FC<Props> = ({
   return (
     <>
       {timeDimensionIdx !== -1 && (
-        <Box
-          padding={{vertical: 16, horizontal: 24}}
-          border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
-        >
+        <Box padding={{vertical: 16, horizontal: 24}} border="bottom">
           <DimensionRangeWizard
             partitionKeys={selections[timeDimensionIdx]!.dimension.partitionKeys}
             health={{ranges: rangesForEachDimension[timeDimensionIdx]!}}
@@ -210,7 +207,7 @@ export const AssetPartitions: React.FC<Props> = ({
       <Box
         padding={{vertical: 16, horizontal: 24}}
         flex={{direction: 'row', justifyContent: 'space-between'}}
-        border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+        border="bottom"
       >
         <div data-testid={testId('partitions-selected')}>
           {countsFiltered.toLocaleString()} Partitions Selected
@@ -230,14 +227,14 @@ export const AssetPartitions: React.FC<Props> = ({
               key={selection.dimension.name}
               style={{display: 'flex', flex: 1, paddingRight: 1, minWidth: 200}}
               flex={{direction: 'column'}}
-              border={{side: 'right', color: Colors.KeylineGray, width: 1}}
+              border="right"
               background={Colors.Gray50}
               data-testid={testId(`partitions-${selection.dimension.name}`)}
             >
               <Box
                 flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'center'}}
                 background={Colors.White}
-                border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+                border="bottom"
                 padding={{horizontal: 24, vertical: 8}}
               >
                 <div>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPlots.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPlots.tsx
@@ -1,4 +1,4 @@
-import {Box, ButtonGroup, Colors, Spinner, Subheading} from '@dagster-io/ui-components';
+import {Box, ButtonGroup, Spinner, Subheading} from '@dagster-io/ui-components';
 import * as React from 'react';
 
 import {AssetMaterializationGraphs} from './AssetMaterializationGraphs';
@@ -35,7 +35,7 @@ export const AssetPlots: React.FC<Props> = ({
       <Box>
         <Box
           flex={{justifyContent: 'space-between', alignItems: 'center'}}
-          border={{side: 'bottom', color: Colors.KeylineGray, width: 1}}
+          border="bottom"
           padding={{vertical: 16, left: 24, right: 12}}
           style={{marginBottom: -1}}
         >
@@ -52,7 +52,7 @@ export const AssetPlots: React.FC<Props> = ({
     <Box>
       <Box
         flex={{justifyContent: 'space-between', alignItems: 'center'}}
-        border={{side: 'bottom', color: Colors.KeylineGray, width: 1}}
+        border="bottom"
         padding={{vertical: 16, left: 24, right: 12}}
         style={{marginBottom: -1}}
       >

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetSidebarActivitySummary.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetSidebarActivitySummary.tsx
@@ -66,14 +66,10 @@ export const AssetSidebarActivitySummary: React.FC<Props> = ({
         <>
           <FailedRunSinceMaterializationBanner
             stepKey={stepKey}
-            border={{side: 'top', width: 1, color: Colors.KeylineGray}}
+            border="top"
             run={liveData?.runWhichFailedToMaterialize || null}
           />
-          <CurrentRunsBanner
-            stepKey={stepKey}
-            border={{side: 'top', width: 1, color: Colors.KeylineGray}}
-            liveData={liveData}
-          />
+          <CurrentRunsBanner stepKey={stepKey} border="top" liveData={liveData} />
         </>
       )}
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
@@ -1,13 +1,5 @@
 import {gql, useQuery} from '@apollo/client';
-import {
-  Alert,
-  Box,
-  Colors,
-  NonIdealState,
-  Spinner,
-  Tag,
-  ErrorBoundary,
-} from '@dagster-io/ui-components';
+import {Alert, Box, NonIdealState, Spinner, Tag, ErrorBoundary} from '@dagster-io/ui-components';
 import * as React from 'react';
 import {Link, useLocation} from 'react-router-dom';
 
@@ -440,10 +432,7 @@ const HistoricalViewAlert = ({asOf, hasDefinition}: {asOf: string; hasDefinition
   searchParams.set('time', asOf);
 
   return (
-    <Box
-      padding={{vertical: 16, horizontal: 24}}
-      border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
-    >
+    <Box padding={{vertical: 16, horizontal: 24}} border="bottom">
       <Alert
         intent="info"
         title={

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AssetAutomaterializePolicyPage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AssetAutomaterializePolicyPage.tsx
@@ -81,10 +81,7 @@ export const AssetAutomaterializePolicyPage = ({
       style={{flex: 1, minHeight: 0, color: Colors.Gray700, overflow: 'hidden'}}
       flex={{direction: 'column'}}
     >
-      <Box
-        padding={{horizontal: 24, vertical: 12}}
-        border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
-      >
+      <Box padding={{horizontal: 24, vertical: 12}} border="bottom">
         <AutoMaterializeExperimentalBanner />
       </Box>
       <Box flex={{direction: 'row'}}>
@@ -92,16 +89,12 @@ export const AssetAutomaterializePolicyPage = ({
           <Box
             flex={{alignItems: 'center'}}
             padding={{vertical: 16, horizontal: 24}}
-            border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+            border="bottom"
           >
             <Subheading>Evaluation history</Subheading>
           </Box>
           <Box flex={{direction: 'row'}} style={{flex: 1, minHeight: 0}}>
-            <Box
-              border={{side: 'right', color: Colors.KeylineGray, width: 1}}
-              flex={{grow: 0, direction: 'column'}}
-              style={{flex: '0 0 296px'}}
-            >
+            <Box border="right" flex={{grow: 0, direction: 'column'}} style={{flex: '0 0 296px'}}>
               <AutomaterializeLeftPanel
                 assetHasDefinedPartitions={assetHasDefinedPartitions}
                 evaluations={evaluations}
@@ -124,7 +117,7 @@ export const AssetAutomaterializePolicyPage = ({
             </Box>
           </Box>
         </Box>
-        <Box border={{side: 'left', color: Colors.KeylineGray, width: 1}}>
+        <Box border="left">
           <AutomaterializeRightPanel assetKey={assetKey} />
         </Box>
       </Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AssetKeysDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AssetKeysDialog.tsx
@@ -1,7 +1,6 @@
 import {
   Box,
   Button,
-  Colors,
   Dialog,
   DialogFooter,
   NonIdealState,
@@ -49,7 +48,7 @@ export const AssetKeysDialogHeader = (props: HeaderProps) => {
     <Box
       padding={{horizontal: 24, vertical: 16}}
       flex={{direction: 'row', alignItems: 'center', justifyContent: 'space-between'}}
-      border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+      border="bottom"
     >
       <div style={{fontSize: '16px'}}>{title}</div>
       {showSearch ? (

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeLeftPanel.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeLeftPanel.tsx
@@ -123,11 +123,7 @@ export const AutomaterializeLeftList = (props: ListProps) => {
           </EvaluationListItem>
         );
       })}
-      <Box
-        border={{side: 'top', color: Colors.KeylineGray, width: 1}}
-        padding={{vertical: 20, horizontal: 12}}
-        margin={{top: 12}}
-      >
+      <Box border="top" padding={{vertical: 20, horizontal: 12}} margin={{top: 12}}>
         <Caption>Evaluations are retained for 30 days</Caption>
       </Box>
     </Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeMiddlePanel.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeMiddlePanel.tsx
@@ -1,5 +1,5 @@
 import {useQuery} from '@apollo/client';
-import {Box, Colors, NonIdealState, Subheading} from '@dagster-io/ui-components';
+import {Box, NonIdealState, Subheading} from '@dagster-io/ui-components';
 import * as React from 'react';
 
 import {ErrorWrapper} from '../../app/PythonErrorInfo';
@@ -78,7 +78,7 @@ export const AutomaterializeMiddlePanel = (props: Props) => {
       <Box flex={{direction: 'column', grow: 1}}>
         <Box
           style={{flex: '0 0 48px'}}
-          border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+          border="bottom"
           padding={{horizontal: 16}}
           flex={{alignItems: 'center', justifyContent: 'space-between'}}
         >
@@ -177,7 +177,7 @@ export const AutomaterializeMiddlePanelWithData = ({
       <Box
         style={{flex: '0 0 48px'}}
         padding={{horizontal: 16}}
-        border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+        border="bottom"
         flex={{alignItems: 'center', justifyContent: 'space-between'}}
       >
         <Subheading>Result</Subheading>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeRequestedPartitionsLink.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeRequestedPartitionsLink.tsx
@@ -3,7 +3,6 @@ import {
   Box,
   Button,
   ButtonLink,
-  Colors,
   Dialog,
   DialogFooter,
   NonIdealState,
@@ -89,7 +88,7 @@ export const AutomaterializeRequestedPartitionsLink = ({runIds, partitionKeys, i
         <Box
           padding={{horizontal: 24, vertical: 16}}
           flex={{direction: 'row', alignItems: 'center', justifyContent: 'space-between'}}
-          border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+          border="bottom"
         >
           <div style={{fontSize: '16px'}}>
             {count === 1 ? '1 partition' : `${count} partitions`}
@@ -251,11 +250,7 @@ const VirtualizedPartitionList = ({partitionKeys, runsByPartitionKey}: Virtualiz
               <Box
                 style={{height: '100%'}}
                 flex={{direction: 'row', alignItems: 'center', justifyContent: 'space-between'}}
-                border={
-                  index < partitionKeys.length - 1
-                    ? {side: 'bottom', width: 1, color: Colors.KeylineGray}
-                    : null
-                }
+                border={index < partitionKeys.length - 1 ? 'bottom' : null}
               >
                 <div>{partitionKeys[index]}</div>
                 {showRunTag ? (

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeRightPanel.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeRightPanel.tsx
@@ -1,7 +1,6 @@
 import {gql, useQuery} from '@apollo/client';
 import {
   Box,
-  Colors,
   Subheading,
   Body,
   ExternalAnchorButton,
@@ -41,12 +40,8 @@ export const AutomaterializeRightPanel = ({assetKey}: Props) => {
   const {data, error} = queryResult;
 
   return (
-    <Box
-      flex={{direction: 'column'}}
-      style={{width: '294px', height: '100%'}}
-      border={{side: 'left', width: 1, color: Colors.KeylineGray}}
-    >
-      <Box padding={16} border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}>
+    <Box flex={{direction: 'column'}} style={{width: '294px', height: '100%'}} border="left">
+      <Box padding={16} border="bottom">
         <Subheading>Overview</Subheading>
       </Box>
       <div style={{overflowY: 'auto'}}>
@@ -167,7 +162,7 @@ const RightPanelSection = ({
   return (
     <Box
       flex={{direction: 'column', gap: 12}}
-      border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+      border="bottom"
       padding={{vertical: 12, horizontal: 16}}
     >
       <Subheading>{title}</Subheading>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/CollapsibleSection.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/CollapsibleSection.tsx
@@ -46,14 +46,11 @@ export const Collapsible = ({
 }) => {
   const [isCollapsed, setIsCollapsed] = React.useState(false);
   return (
-    <Box
-      flex={{direction: 'column'}}
-      border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
-    >
+    <Box flex={{direction: 'column'}} border="bottom">
       <Box
         flex={{direction: 'row', alignItems: 'center'}}
         padding={{vertical: 8, horizontal: 16}}
-        border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+        border="bottom"
       >
         <Icon
           name="arrow_drop_down"

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/VirtualizedAssetPartitionListForDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/VirtualizedAssetPartitionListForDialog.tsx
@@ -1,4 +1,4 @@
-import {Box, Colors, Icon} from '@dagster-io/ui-components';
+import {Box, Icon} from '@dagster-io/ui-components';
 import {useVirtualizer} from '@tanstack/react-virtual';
 import * as React from 'react';
 import styled from 'styled-components';
@@ -80,11 +80,7 @@ export function VirtualizedAssetPartitionListForDialog<A>({
               <Box
                 style={{height: '100%'}}
                 flex={{direction: 'row', alignItems: 'center'}}
-                border={
-                  index < allRows.length - 1
-                    ? {side: 'bottom', width: 1, color: Colors.KeylineGray}
-                    : null
-                }
+                border={index < allRows.length - 1 ? 'bottom' : null}
               >
                 {row.type === 'partition-name' ? (
                   <ExpandablePartitionName

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutomaterializeTagWithEvaluation.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutomaterializeTagWithEvaluation.tsx
@@ -1,4 +1,4 @@
-import {Box, Colors, Icon, MiddleTruncate, Popover, Tag} from '@dagster-io/ui-components';
+import {Box, Icon, MiddleTruncate, Popover, Tag} from '@dagster-io/ui-components';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
 
@@ -22,11 +22,7 @@ export const AutomaterializeTagWithEvaluation = ({assetKeys, evaluationId}: Prop
       placement="bottom"
       content={
         <div style={{width: '340px'}}>
-          <Box
-            padding={{vertical: 8, horizontal: 12}}
-            border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
-            style={{fontWeight: 600}}
-          >
+          <Box padding={{vertical: 8, horizontal: 12}} border="bottom" style={{fontWeight: 600}}>
             Auto-materialized
           </Box>
           <Box

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/CurrentRunsBanner.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/CurrentRunsBanner.tsx
@@ -1,5 +1,5 @@
 import {Alert, Box, Spinner} from '@dagster-io/ui-components';
-import {BorderSetting} from '@dagster-io/ui-components/src/components/types';
+import {BorderSide, BorderSetting} from '@dagster-io/ui-components/src/components/types';
 import React from 'react';
 import {Link} from 'react-router-dom';
 
@@ -9,7 +9,7 @@ import {useStepLogs} from '../runs/StepLogsDialog';
 
 export const CurrentRunsBanner: React.FC<{
   liveData?: LiveDataForNode;
-  border: BorderSetting;
+  border: BorderSide | BorderSetting;
   stepKey: string;
 }> = ({stepKey, liveData, border}) => {
   const {inProgressRunIds = [], unstartedRunIds = []} = liveData || {};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/DependsOnSelfBanner.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/DependsOnSelfBanner.tsx
@@ -3,10 +3,7 @@ import React from 'react';
 
 export const DependsOnSelfBanner: React.FC = () => {
   return (
-    <Box
-      padding={{vertical: 16, left: 24, right: 12}}
-      border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
-    >
+    <Box padding={{vertical: 16, left: 24, right: 12}} border="bottom">
       <Alert
         intent="info"
         icon={

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/FailedRunSinceMaterializationBanner.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/FailedRunSinceMaterializationBanner.tsx
@@ -1,5 +1,9 @@
 import {Alert, Box} from '@dagster-io/ui-components';
-import {BorderSetting, DirectionalSpacing} from '@dagster-io/ui-components/src/components/types';
+import {
+  BorderSide,
+  BorderSetting,
+  DirectionalSpacing,
+} from '@dagster-io/ui-components/src/components/types';
 import React from 'react';
 import {Link} from 'react-router-dom';
 
@@ -10,7 +14,7 @@ import {useStepLogs} from '../runs/StepLogsDialog';
 export const FailedRunSinceMaterializationBanner: React.FC<{
   run: AssetLatestInfoRunFragment | null;
   padding?: DirectionalSpacing;
-  border?: BorderSetting;
+  border?: BorderSide | BorderSetting;
   stepKey?: string;
 }> = ({run, stepKey, border, padding = {vertical: 16, left: 24, right: 12}}) => {
   const stepLogs = useStepLogs({runId: run?.id, stepKeys: stepKey ? [stepKey] : []});

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -484,11 +484,7 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
             {selections.map((range, idx) => (
               <Box
                 key={range.dimension.name}
-                border={{
-                  side: 'bottom',
-                  width: 1,
-                  color: Colors.KeylineGray,
-                }}
+                border="bottom"
                 padding={{vertical: 12, horizontal: 24}}
               >
                 <Box as={Subheading} flex={{alignItems: 'center', gap: 8}}>
@@ -634,7 +630,7 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
               margin={{top: 16}}
               flex={{direction: 'column', gap: 8}}
               padding={{vertical: 16, horizontal: 20}}
-              border={{side: 'horizontal', width: 1, color: Colors.KeylineGray}}
+              border="top-and-bottom"
               background={Colors.Gray100}
               style={{
                 marginLeft: -20,
@@ -882,7 +878,7 @@ const ToggleableSection = ({
       <Box
         onClick={() => setIsOpen(!isOpen)}
         background={background ?? Colors.Gray50}
-        border={{side: 'bottom', color: Colors.KeylineGray, width: 1}}
+        border="bottom"
         flex={{alignItems: 'center', direction: 'row'}}
         padding={{vertical: 12, horizontal: 24}}
         style={{cursor: 'pointer'}}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/OverdueTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/OverdueTag.tsx
@@ -1,5 +1,5 @@
 import {gql, useQuery} from '@apollo/client';
-import {Tooltip, Tag, Popover, Box, Colors} from '@dagster-io/ui-components';
+import {Tooltip, Tag, Popover, Box} from '@dagster-io/ui-components';
 import dayjs from 'dayjs';
 import duration from 'dayjs/plugin/duration';
 import relativeTime from 'dayjs/plugin/relativeTime';
@@ -153,7 +153,7 @@ const OverdueLineagePopoverContent: React.FC<{
 
   return (
     <Box style={{width: 600}}>
-      <Box padding={12} border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}>
+      <Box padding={12} border="bottom">
         {currentMinutesLate === 0 // fresh
           ? cronSchedule
             ? `The latest materialization contains all data up to ${maxLagMinutesStr} before ${lastEvaluationStr}. `
@@ -185,18 +185,10 @@ const OverdueLineagePopoverContent: React.FC<{
         </>
       ) : (
         <>
-          <Box
-            padding={12}
-            style={{fontWeight: 600}}
-            border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
-          >
+          <Box padding={12} style={{fontWeight: 600}} border="bottom">
             Latest materialization:
           </Box>
-          <Box
-            padding={12}
-            flex={{justifyContent: 'space-between'}}
-            border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
-          >
+          <Box padding={12} flex={{justifyContent: 'space-between'}} border="bottom">
             <Timestamp timestamp={{ms: Number(timestamp)}} />
             <TimeSinceWithOverdueColor
               timestamp={Number(timestamp)}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/Stale.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/Stale.tsx
@@ -124,20 +124,12 @@ const StaleCausesPopoverSummary: React.FC<{causes: LiveDataForNode['staleCauses'
   causes,
 }) => (
   <Box style={{width: '300px'}}>
-    <Box
-      padding={12}
-      border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
-      style={{fontWeight: 600}}
-    >
+    <Box padding={12} border="bottom" style={{fontWeight: 600}}>
       Changes since last materialization:
     </Box>
     <Box style={{maxHeight: '240px', overflowY: 'auto'}} onClick={(e) => e.stopPropagation()}>
       {causes.map((cause, idx) => (
-        <Box
-          key={idx}
-          border={idx > 0 ? {side: 'top', width: 1, color: Colors.KeylineGray} : null}
-          padding={{vertical: 8, horizontal: 12}}
-        >
+        <Box key={idx} border={idx > 0 ? 'top' : null} padding={{vertical: 8, horizontal: 12}}>
           <Link to={assetDetailsPathForKey(cause.key)}>
             <CaptionMono>{displayNameForAssetKey(cause.key)}</CaptionMono>
           </Link>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetCheckDetailModal.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetCheckDetailModal.tsx
@@ -112,7 +112,7 @@ const AssetCheckDetailModalImpl = ({
     return (
       <Box
         flex={{direction: 'column'}}
-        border={{side: 'top', color: Colors.KeylineGray, width: 1}}
+        border="top"
         // CollapsibleSection uses a white background which covers the border, so add 1px of padding on top for the border
         padding={{top: 1, horizontal: 12}}
       >

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetChecks.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetChecks.tsx
@@ -1,5 +1,5 @@
 import {gql, useQuery} from '@apollo/client';
-import {Body2, Box, Colors, Tag} from '@dagster-io/ui-components';
+import {Body2, Box, Tag} from '@dagster-io/ui-components';
 import React, {useContext} from 'react';
 import {Link} from 'react-router-dom';
 
@@ -77,16 +77,13 @@ export const AssetChecks = ({
           setOpenCheck(undefined);
         }}
       />
-      <Box
-        padding={{horizontal: 24, vertical: 12}}
-        border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
-      >
+      <Box padding={{horizontal: 24, vertical: 12}} border="bottom">
         <AssetChecksBanner />
       </Box>
       <Box
         flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'center', gap: 32}}
         padding={{horizontal: 24, vertical: 16}}
-        border={{side: 'bottom', color: Colors.KeylineGray, width: 1}}
+        border="bottom"
       >
         <Box flex={{direction: 'row', alignItems: 'center', gap: 6}}>
           <Body2>Latest materialization:</Body2>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/VirtualizedAssetCheckTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/VirtualizedAssetCheckTable.tsx
@@ -76,7 +76,7 @@ export const VirtualizedAssetCheckRow = ({assetNode, height, start, row}: AssetC
 
   return (
     <Row $height={height} $start={start} data-testid={testId(`row-#TODO_USE_CHECK_ID`)}>
-      <RowGrid border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}>
+      <RowGrid border="bottom">
         <RowCell style={{flexDirection: 'row', alignItems: 'center'}}>
           <Box flex={{direction: 'column', gap: 4}}>
             <Link
@@ -132,7 +132,7 @@ const CaptionEllipsed = styled(Caption)`
 export const VirtualizedAssetCheckHeader = () => {
   return (
     <Box
-      border={{side: 'horizontal', width: 1, color: Colors.KeylineGray}}
+      border="top-and-bottom"
       style={{
         display: 'grid',
         gridTemplateColumns: TEMPLATE_COLUMNS,

--- a/js_modules/dagster-ui/packages/ui-core/src/dagstertype/DagsterType.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/dagstertype/DagsterType.tsx
@@ -1,5 +1,5 @@
 import {gql} from '@apollo/client';
-import {Box, Colors, FontFamily} from '@dagster-io/ui-components';
+import {Box, FontFamily} from '@dagster-io/ui-components';
 import {Spacing} from '@dagster-io/ui-components/src/components/types';
 import * as React from 'react';
 import styled from 'styled-components';
@@ -63,11 +63,7 @@ export const DagsterTypeSummary: React.FC<{
         </Box>
       )}
       {tableSchemaEntry && (
-        <Box
-          border={{side: 'top', width: 1, color: Colors.KeylineGray}}
-          style={{overflowY: 'auto', marginBottom: -12}}
-          margin={{top: 4}}
-        >
+        <Box border="top" style={{overflowY: 'auto', marginBottom: -12}} margin={{top: 4}}>
           <TableSchema schema={tableSchemaEntry.schema} itemHorizontalPadding={horizontalPadding} />
         </Box>
       )}

--- a/js_modules/dagster-ui/packages/ui-core/src/gantt/__stories__/GanttChart.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/gantt/__stories__/GanttChart.stories.tsx
@@ -1,5 +1,5 @@
 import {MockedProvider, MockedResponse} from '@apollo/client/testing';
-import {Box, Button, Colors, CustomTooltipProvider} from '@dagster-io/ui-components';
+import {Box, Button, CustomTooltipProvider} from '@dagster-io/ui-components';
 import {Meta} from '@storybook/react';
 import React, {useState} from 'react';
 
@@ -86,11 +86,7 @@ const GanttTestCase: React.FC<{
     <MockedProvider mocks={[runGroupMock]}>
       <WorkspaceProvider>
         <CustomTooltipProvider />
-        <Box
-          flex={{gap: 8, alignItems: 'center'}}
-          padding={8}
-          border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
-        >
+        <Box flex={{gap: 8, alignItems: 'center'}} padding={8} border="bottom">
           <Button onClick={() => setProgress(5)}>Reset</Button>
           <Button onClick={() => setProgress(Math.min(logs.length - 1, progress + 1))}>
             Send Next Log

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/SVGViewport.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/SVGViewport.tsx
@@ -193,7 +193,7 @@ const PanAndZoomInteractor: SVGViewportInteractor = {
             background={Colors.White}
             data-zoom-control={true}
             flex={{alignItems: 'center', direction: 'column'}}
-            border={{side: 'vertical', color: Colors.Gray300, width: 1}}
+            border={{side: 'left-and-right', color: Colors.Gray300}}
           >
             <Slider
               vertical

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceConfig.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceConfig.tsx
@@ -83,10 +83,7 @@ export const InstanceConfig = React.memo(() => {
         title={<Heading>{pageTitle}</Heading>}
         tabs={<InstanceTabs tab="config" refreshState={refreshState} />}
       />
-      <Box
-        padding={{vertical: 16, horizontal: 24}}
-        border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
-      >
+      <Box padding={{vertical: 16, horizontal: 24}} border="bottom">
         <Subheading>
           Dagster version: <Code style={{fontSize: '16px'}}>{data.version}</Code>
         </Subheading>

--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/InstigationTick.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/InstigationTick.tsx
@@ -172,7 +172,7 @@ export const FailedRunList: React.FC<{
   }
   return (
     <Group direction="column" spacing={16}>
-      <Box padding={12} border={{side: 'bottom', width: 1, color: Colors.Gray200}}>
+      <Box padding={12} border={{side: 'bottom', color: Colors.Gray200}}>
         <Body>
           Failed Runs
           <Tooltip content="Failed runs this tick reacted on and reported back to.">

--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/TickHistory.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/TickHistory.tsx
@@ -312,10 +312,7 @@ export const TickHistoryTimeline = ({
   if (!data || error) {
     return (
       <>
-        <Box
-          padding={{top: 16, horizontal: 24}}
-          border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
-        >
+        <Box padding={{top: 16, horizontal: 24}} border="bottom">
           <Subheading>Recent ticks</Subheading>
         </Box>
         <Box padding={{vertical: 64}}>
@@ -359,7 +356,7 @@ export const TickHistoryTimeline = ({
       <Box padding={{vertical: 16, horizontal: 24}}>
         <Subheading>Recent ticks</Subheading>
       </Box>
-      <Box border={{side: 'top', width: 1, color: Colors.KeylineGray}}>
+      <Box border="top">
         <LiveTickTimeline
           ticks={ticks}
           nextTick={nextTick}

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadSession.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadSession.tsx
@@ -142,11 +142,7 @@ const LaunchButtonContainer: React.FC<{
 }> = ({launchpadType, children}) => {
   if (launchpadType === 'asset') {
     return (
-      <Box
-        flex={{direction: 'row'}}
-        border={{side: 'top', width: 1, color: Colors.KeylineGray}}
-        padding={{right: 12, vertical: 8}}
-      >
+      <Box flex={{direction: 'row'}} border="top" padding={{right: 12, vertical: 8}}>
         <div style={{flexGrow: 1}} />
         {children}
       </Box>
@@ -678,7 +674,7 @@ const LaunchpadSession: React.FC<LaunchpadSessionProps> = (props) => {
             {pipeline.tags.length || tagsFromSession.length ? (
               <Box
                 padding={{vertical: 8, left: 12, right: 0}}
-                border={{side: 'bottom', width: 1, color: Colors.Gray200}}
+                border={{side: 'bottom', color: Colors.Gray200}}
               >
                 <TagContainer
                   tagsFromDefinition={pipeline.tags}
@@ -690,7 +686,7 @@ const LaunchpadSession: React.FC<LaunchpadSessionProps> = (props) => {
             {refreshableSessionBase ? (
               <Box
                 padding={{vertical: 8, horizontal: 12}}
-                border={{side: 'bottom', width: 1, color: Colors.Gray200}}
+                border={{side: 'bottom', color: Colors.Gray200}}
               >
                 <Group direction="row" spacing={8} alignItems="center">
                   <Icon name="warning" color={Colors.Yellow500} />

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadTabs.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadTabs.tsx
@@ -129,7 +129,7 @@ export const LaunchpadTabs = (props: LaunchpadTabsProps) => {
   };
 
   return (
-    <Box border={{side: 'bottom', width: 1, color: Colors.KeylineGray}} padding={{top: 12}}>
+    <Box border="bottom" padding={{top: 12}}>
       <LaunchpadTabsContainer>
         {sessionKeys.map((key) => (
           <LaunchpadTab

--- a/js_modules/dagster-ui/packages/ui-core/src/metadata/MetadataEntry.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/metadata/MetadataEntry.tsx
@@ -101,7 +101,7 @@ export const MetadataEntry: React.FC<{
               background={Colors.Gray100}
               margin={{bottom: 12}}
               padding={24}
-              border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+              border="bottom"
               style={{whiteSpace: 'pre-wrap', fontFamily: FontFamily.monospace, overflow: 'auto'}}
             >
               {tryPrettyPrintJSON(entry.jsonString)}

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/JobMetadata.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/JobMetadata.tsx
@@ -170,11 +170,7 @@ const RelatedAssetsTag: React.FC<{relatedAssets: string[]}> = ({relatedAssets}) 
           <Box
             key={key}
             padding={{vertical: 12, horizontal: 20}}
-            border={
-              ii < relatedAssets.length - 1
-                ? {side: 'bottom', width: 1, color: Colors.KeylineGray}
-                : null
-            }
+            border={ii < relatedAssets.length - 1 ? 'bottom' : null}
           >
             <Link key={key} to={`/assets/${key}`} style={{wordBreak: 'break-word'}}>
               {key}

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/RepoNavItem.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/RepoNavItem.tsx
@@ -52,11 +52,7 @@ export const RepoNavItem: React.FC<Props> = (props) => {
   };
 
   return (
-    <Box
-      background={Colors.Gray50}
-      padding={{vertical: 12, left: 24, right: 20}}
-      border={{side: 'top', width: 1, color: Colors.KeylineGray}}
-    >
+    <Box background={Colors.Gray50} padding={{vertical: 12, left: 24, right: 20}} border="top">
       <Box flex={{justifyContent: 'space-between', alignItems: 'center'}}>
         <Box flex={{direction: 'row', alignItems: 'center', gap: 8}}>
           <Icon name="folder" />

--- a/js_modules/dagster-ui/packages/ui-core/src/ops/OpsRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ops/OpsRoot.tsx
@@ -212,10 +212,7 @@ const OpsRootWithData: React.FC<Props & {name?: string; usedSolids: Solid[]}> = 
         firstMinSize={420}
         first={
           <OpListColumnContainer>
-            <Box
-              padding={{vertical: 12, horizontal: 24}}
-              border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
-            >
+            <Box padding={{vertical: 12, horizontal: 24}} border="bottom">
               <TokenizingField
                 values={search}
                 onChange={(search) => onSearch(search)}

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewAssetsRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewAssetsRoot.tsx
@@ -189,7 +189,7 @@ const TEMPLATE_COLUMNS = '5fr 1fr 1fr 1fr 1fr';
 function VirtualHeaderRow() {
   return (
     <Box
-      border={{side: 'horizontal', width: 1, color: Colors.KeylineGray}}
+      border="top-and-bottom"
       style={{
         display: 'grid',
         gridTemplateColumns: TEMPLATE_COLUMNS,
@@ -302,7 +302,7 @@ function VirtualRow({height, start, group}: RowProps) {
 
   return (
     <Row $height={height} $start={start}>
-      <RowGrid border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}>
+      <RowGrid border="bottom">
         <Cell>
           <Box flex={{direction: 'row', justifyContent: 'space-between', grow: 1}}>
             <Box flex={{direction: 'column', gap: 2, grow: 1}}>

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewSchedulesRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewSchedulesRoot.tsx
@@ -283,7 +283,7 @@ export const OverviewSchedulesRoot = () => {
       {activeFiltersJsx.length ? (
         <Box
           padding={{vertical: 8, horizontal: 24}}
-          border={{side: 'horizontal', width: 1, color: Colors.KeylineGray}}
+          border="top-and-bottom"
           flex={{direction: 'row', gap: 8}}
         >
           {activeFiltersJsx}
@@ -303,7 +303,7 @@ export const OverviewSchedulesRoot = () => {
           <SchedulerInfo
             daemonHealth={data?.instance.daemonHealth}
             padding={{vertical: 16, horizontal: 24}}
-            border={{side: 'top', width: 1, color: Colors.KeylineGray}}
+            border="top"
           />
           {content()}
         </>
@@ -325,10 +325,7 @@ const UnloadableSchedulesAlert: React.FC<{
 
   return (
     <>
-      <Box
-        padding={{vertical: 16, horizontal: 24}}
-        border={{side: 'top', width: 1, color: Colors.KeylineGray}}
-      >
+      <Box padding={{vertical: 16, horizontal: 24}} border="top">
         <Alert
           intent="warning"
           title={title}

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewSensorsRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewSensorsRoot.tsx
@@ -283,7 +283,7 @@ export const OverviewSensorsRoot = () => {
       {activeFiltersJsx.length ? (
         <Box
           padding={{vertical: 8, horizontal: 24}}
-          border={{side: 'horizontal', width: 1, color: Colors.KeylineGray}}
+          border="top-and-bottom"
           flex={{direction: 'row', gap: 8}}
         >
           {activeFiltersJsx}
@@ -303,7 +303,7 @@ export const OverviewSensorsRoot = () => {
           <SensorInfo
             daemonHealth={data?.instance.daemonHealth}
             padding={{vertical: 16, horizontal: 24}}
-            border={{side: 'top', width: 1, color: Colors.KeylineGray}}
+            border="top"
           />
           {content()}
         </>
@@ -325,10 +325,7 @@ const UnloadableSensorsAlert: React.FC<{
 
   return (
     <>
-      <Box
-        padding={{vertical: 16, horizontal: 24}}
-        border={{side: 'top', width: 1, color: Colors.KeylineGray}}
-      >
+      <Box padding={{vertical: 16, horizontal: 24}} border="top">
         <Alert
           intent="warning"
           title={title}

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/AssetJobPartitionsView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/AssetJobPartitionsView.tsx
@@ -1,4 +1,4 @@
-import {Box, Button, Colors, Subheading, useViewport} from '@dagster-io/ui-components';
+import {Box, Button, Subheading, useViewport} from '@dagster-io/ui-components';
 import React from 'react';
 
 import {useAssetGraphData} from '../asset-graph/useAssetGraphData';
@@ -90,7 +90,7 @@ export const AssetJobPartitionsView: React.FC<{
     <div>
       <Box
         flex={{justifyContent: 'space-between', direction: 'row', alignItems: 'center'}}
-        border={{width: 1, side: 'bottom', color: Colors.KeylineGray}}
+        border="bottom"
         padding={{vertical: 16, horizontal: 24}}
       >
         <Subheading>Status</Subheading>
@@ -104,11 +104,7 @@ export const AssetJobPartitionsView: React.FC<{
           />
         </Box>
       </Box>
-      <Box
-        flex={{direction: 'row', alignItems: 'center'}}
-        border={{width: 1, side: 'bottom', color: Colors.KeylineGray}}
-        padding={{left: 8}}
-      >
+      <Box flex={{direction: 'row', alignItems: 'center'}} border="bottom" padding={{left: 8}}>
         <CountBox count={total} label="Total partitions" />
         <CountBox count={missing} label="Missing partitions" />
       </Box>
@@ -162,7 +158,7 @@ export const AssetJobPartitionsView: React.FC<{
       )}
       <Box
         padding={{horizontal: 24, vertical: 16}}
-        border={{side: 'horizontal', color: Colors.KeylineGray, width: 1}}
+        border="top-and-bottom"
         style={{marginBottom: -1}}
       >
         <Subheading>Backfill history</Subheading>
@@ -218,10 +214,7 @@ const AssetJobPartitionGraphs: React.FC<{
 
   return (
     <>
-      <Box
-        padding={{horizontal: 24, vertical: 16}}
-        border={{side: 'horizontal', width: 1, color: Colors.KeylineGray}}
-      >
+      <Box padding={{horizontal: 24, vertical: 16}} border="top-and-bottom">
         <Subheading>Run duration</Subheading>
       </Box>
 
@@ -234,10 +227,7 @@ const AssetJobPartitionGraphs: React.FC<{
           jobDataByPartition={runDurationData}
         />
       </Box>
-      <Box
-        padding={{horizontal: 24, vertical: 16}}
-        border={{side: 'horizontal', width: 1, color: Colors.KeylineGray}}
-      >
+      <Box padding={{horizontal: 24, vertical: 16}} border="top-and-bottom">
         <Subheading>Step durations</Subheading>
       </Box>
       <Box margin={24}>

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/BackfillSelector.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/BackfillSelector.tsx
@@ -478,11 +478,7 @@ const Section = ({
 }) => (
   <Box flex={{direction: 'column', gap: 4}}>
     <Subheading>{title}</Subheading>
-    <Box
-      flex={{direction: 'column', gap: 8}}
-      padding={{top: 16}}
-      border={{width: 1, color: Colors.KeylineGray, side: 'top'}}
-    >
+    <Box flex={{direction: 'column', gap: 8}} padding={{top: 16}} border="top">
       {children}
     </Box>
   </Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/OpJobPartitionsView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/OpJobPartitionsView.tsx
@@ -5,7 +5,6 @@ import {
   Dialog,
   Icon,
   Tooltip,
-  Colors,
   Subheading,
   useViewport,
   NonIdealState,
@@ -247,7 +246,7 @@ export const OpJobPartitionsViewContent: React.FC<{
 
       <Box
         flex={{justifyContent: 'space-between', direction: 'row', alignItems: 'center'}}
-        border={{width: 1, side: 'bottom', color: Colors.KeylineGray}}
+        border="bottom"
         padding={{vertical: 16, horizontal: 24}}
       >
         <Subheading>Status</Subheading>
@@ -272,11 +271,7 @@ export const OpJobPartitionsViewContent: React.FC<{
           )}
         </Box>
       </Box>
-      <Box
-        flex={{direction: 'row', alignItems: 'center'}}
-        border={{width: 1, side: 'bottom', color: Colors.KeylineGray}}
-        padding={{left: 8}}
-      >
+      <Box flex={{direction: 'row', alignItems: 'center'}} border="bottom" padding={{left: 8}}>
         <CountBox count={partitionNames.length} label="Total partitions" />
         <CountBox
           count={partitionNames.filter((x) => runStatusData[x] === RunStatus.FAILURE).length}
@@ -327,10 +322,7 @@ export const OpJobPartitionsViewContent: React.FC<{
           </Box>
         ) : null}
       </Box>
-      <Box
-        padding={{horizontal: 24, vertical: 16}}
-        border={{side: 'horizontal', width: 1, color: Colors.KeylineGray}}
-      >
+      <Box padding={{horizontal: 24, vertical: 16}} border="top-and-bottom">
         <Subheading>Run duration</Subheading>
       </Box>
       <Box margin={24}>
@@ -360,7 +352,7 @@ export const OpJobPartitionsViewContent: React.FC<{
       ) : null}
       <Box
         padding={{horizontal: 24, vertical: 16}}
-        border={{side: 'horizontal', color: Colors.KeylineGray, width: 1}}
+        border="top-and-bottom"
         style={{marginBottom: -1}}
       >
         <Subheading>Backfill history</Subheading>
@@ -381,7 +373,7 @@ export const CountBox: React.FC<{
   count: number;
   label: string;
 }> = ({count, label}) => (
-  <Box padding={16} style={{flex: 1}} border={{side: 'right', width: 1, color: Colors.KeylineGray}}>
+  <Box padding={16} style={{flex: 1}} border="right">
     <div style={{fontSize: 18, marginBottom: 4}}>
       <strong>{count}</strong>
     </div>

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/SidebarRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/SidebarRoot.tsx
@@ -1,4 +1,4 @@
-import {Box, Colors, Tabs, ErrorBoundary} from '@dagster-io/ui-components';
+import {Box, Tabs, ErrorBoundary} from '@dagster-io/ui-components';
 import * as React from 'react';
 
 import {OpNameOrPath} from '../ops/OpNameOrPath';
@@ -100,10 +100,7 @@ export const SidebarRoot: React.FC<SidebarRootProps> = (props) => {
 
   return (
     <>
-      <Box
-        padding={{horizontal: 24}}
-        border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
-      >
+      <Box padding={{horizontal: 24}} border="bottom">
         <Tabs selectedTabId={activeTab}>
           {TabDefinitions.map(({name, key}) => (
             <TabLink id={key} key={key} to={{search: `?tab=${key}`}} title={name} />

--- a/js_modules/dagster-ui/packages/ui-core/src/resources/ResourceRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/resources/ResourceRoot.tsx
@@ -74,11 +74,7 @@ const resourceDisplayName = (
 
 const SectionHeader = (props: {children: React.ReactNode}) => {
   return (
-    <Box
-      padding={{left: 24, vertical: 16}}
-      background={Colors.Gray50}
-      border={{width: 1, color: Colors.KeylineGray, side: 'all'}}
-    >
+    <Box padding={{left: 24, vertical: 16}} background={Colors.Gray50} border="all">
       {props.children}
     </Box>
   );

--- a/js_modules/dagster-ui/packages/ui-core/src/resources/VirtualizedResourceRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/resources/VirtualizedResourceRow.tsx
@@ -35,7 +35,7 @@ export const VirtualizedResourceRow = (props: ResourceRowProps) => {
 
   return (
     <Row $height={height} $start={start}>
-      <RowGrid border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}>
+      <RowGrid border="bottom">
         <RowCell>
           <Box flex={{direction: 'column', gap: 4}}>
             <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
@@ -81,7 +81,7 @@ export const VirtualizedResourceRow = (props: ResourceRowProps) => {
 export const VirtualizedResourceHeader = () => {
   return (
     <Box
-      border={{side: 'horizontal', width: 1, color: Colors.KeylineGray}}
+      border="top-and-bottom"
       style={{
         display: 'grid',
         gridTemplateColumns: TEMPLATE_COLUMNS,

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunConfigDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunConfigDialog.tsx
@@ -2,7 +2,6 @@ import {useMutation} from '@apollo/client';
 import {
   Box,
   Button,
-  Colors,
   Dialog,
   DialogFooter,
   Group,
@@ -161,10 +160,7 @@ export const RunConfigDialog: React.FC<{run: RunFragment; isJob: boolean}> = ({r
               </div>
             </Box>
             <Box flex={{direction: 'column'}} style={{flex: 1, overflow: 'hidden'}}>
-              <Box
-                border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
-                padding={{left: 24, bottom: 16}}
-              >
+              <Box border="bottom" padding={{left: 24, bottom: 16}}>
                 <Subheading>Config</Subheading>
               </Box>
               <CodeMirrorContainer>

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunTable.tsx
@@ -524,7 +524,7 @@ function ActionBar({top, bottom}: {top: React.ReactNode; bottom?: React.ReactNod
         <Box
           margin={{top: 12}}
           padding={{left: 24, right: 12, top: 8}}
-          border={{side: 'top', width: 1, color: Colors.KeylineGray}}
+          border="top"
           flex={{gap: 8}}
         >
           {bottom}

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunTimeline.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunTimeline.tsx
@@ -150,7 +150,7 @@ export const RunTimeline = (props: Props) => {
         padding={{left: 24}}
         flex={{direction: 'column', justifyContent: 'center'}}
         style={{fontSize: '16px', flex: `0 0 ${DATE_TIME_HEIGHT}px`}}
-        border={{side: 'horizontal', width: 1, color: Colors.KeylineGray}}
+        border="top-and-bottom"
       >
         Jobs
       </Box>
@@ -640,7 +640,7 @@ const RunsEmptyOrLoading = (props: {loading: boolean; includesTicks: boolean}) =
       background={Colors.White}
       padding={{vertical: 24}}
       flex={{direction: 'row', justifyContent: 'center'}}
-      border={{side: 'horizontal', width: 1, color: Colors.KeylineGray}}
+      border="top-and-bottom"
     >
       {content()}
     </Box>
@@ -736,14 +736,14 @@ const RunHoverContent = (props: RunHoverContentProps) => {
 
   return (
     <Box style={{width: '260px'}}>
-      <Box padding={12} border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}>
+      <Box padding={12} border="bottom">
         <HoverContentJobName>{job.jobName}</HoverContentJobName>
       </Box>
       <div style={{maxHeight: '240px', overflowY: 'auto'}}>
         {sliced.map((run, ii) => (
           <Box
             key={run.id}
-            border={ii > 0 ? {side: 'top', width: 1, color: Colors.KeylineGray} : null}
+            border={ii > 0 ? 'top' : null}
             flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'center'}}
             padding={{vertical: 8, horizontal: 12}}
           >
@@ -768,7 +768,7 @@ const RunHoverContent = (props: RunHoverContentProps) => {
         ))}
       </div>
       {remaining > 0 ? (
-        <Box padding={12} border={{side: 'top', width: 1, color: Colors.KeylineGray}}>
+        <Box padding={12} border="top">
           <Link to={`${job.path}/runs`}>+ {remaining} more</Link>
         </Box>
       ) : null}

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsRoot.tsx
@@ -3,7 +3,6 @@ import {
   Alert,
   Box,
   ButtonLink,
-  Colors,
   CursorHistoryControls,
   Heading,
   NonIdealState,
@@ -165,7 +164,7 @@ export const RunsRoot = () => {
         <Box
           flex={{direction: 'column', gap: 8}}
           padding={{horizontal: 24, vertical: 16}}
-          border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+          border="bottom"
         >
           <Alert
             intent="info"

--- a/js_modules/dagster-ui/packages/ui-core/src/schedules/SchedulesNextTicks.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/schedules/SchedulesNextTicks.tsx
@@ -359,10 +359,7 @@ const NextTickDialog: React.FC<{
           ) : null}
         </Box>
         <div>
-          <Box
-            border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
-            padding={{left: 24, bottom: 16}}
-          >
+          <Box border="bottom" padding={{left: 24, bottom: 16}}>
             <Subheading>Config</Subheading>
           </Box>
           <StyledRawCodeMirror

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/VirtualizedItemListForDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/VirtualizedItemListForDialog.tsx
@@ -1,4 +1,4 @@
-import {Box, Colors} from '@dagster-io/ui-components';
+import {Box} from '@dagster-io/ui-components';
 import {useVirtualizer} from '@tanstack/react-virtual';
 import * as React from 'react';
 
@@ -32,11 +32,7 @@ export function VirtualizedItemListForDialog<A>({items, renderItem}: Props<A>) {
               <Box
                 style={{height: '100%'}}
                 flex={{direction: 'row', alignItems: 'center'}}
-                border={
-                  index < items.length - 1
-                    ? {side: 'bottom', width: 1, color: Colors.KeylineGray}
-                    : null
-                }
+                border={index < items.length - 1 ? 'bottom' : null}
               >
                 {renderItem(assetKey)}
               </Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/VirtualizedTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/VirtualizedTable.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 export const HeaderCell = ({children}: {children?: React.ReactNode}) => (
   <CellBox
     padding={{vertical: 8, horizontal: 12}}
-    border={{side: 'right', width: 1, color: Colors.KeylineGray}}
+    border="right"
     style={{whiteSpace: 'nowrap', textOverflow: 'ellipsis', overflow: 'hidden'}}
   >
     {children}
@@ -23,7 +23,7 @@ export const RowCell = ({
     padding={12}
     flex={{direction: 'column', justifyContent: 'flex-start'}}
     style={{color: Colors.Gray500, overflow: 'hidden', ...(style || {})}}
-    border={{side: 'right', width: 1, color: Colors.KeylineGray}}
+    border="right"
   >
     {children}
   </CellBox>

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/GraphRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/GraphRoot.tsx
@@ -1,5 +1,5 @@
 import {gql, useQuery} from '@apollo/client';
-import {Box, Colors, NonIdealState, PageHeader, Tag, Heading} from '@dagster-io/ui-components';
+import {Box, NonIdealState, PageHeader, Tag, Heading} from '@dagster-io/ui-components';
 import React from 'react';
 import {useHistory, useParams} from 'react-router-dom';
 
@@ -48,10 +48,7 @@ export const GraphRoot: React.FC<Props> = (props) => {
           </Tag>
         }
       />
-      <Box
-        border={{side: 'top', width: 1, color: Colors.KeylineGray}}
-        style={{minHeight: 0, flex: 1, display: 'flex'}}
-      >
+      <Box border="top" style={{minHeight: 0, flex: 1, display: 'flex'}}>
         <GraphExplorerRoot repoAddress={repoAddress} />
       </Box>
     </div>

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedAssetRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedAssetRow.tsx
@@ -78,10 +78,7 @@ export const VirtualizedAssetRow = (props: AssetRowProps) => {
 
   return (
     <Row $height={height} $start={start} data-testid={testId(`row-${tokenForAssetKey({path})}`)}>
-      <RowGrid
-        border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
-        $showRepoColumn={showRepoColumn}
-      >
+      <RowGrid border="bottom" $showRepoColumn={showRepoColumn}>
         {showCheckboxColumn ? (
           <RowCell>
             <Checkbox checked={checked} onChange={onChange} />
@@ -214,7 +211,7 @@ export const VirtualizedAssetCatalogHeader: React.FC<{
   return (
     <Box
       background={Colors.White}
-      border={{side: 'horizontal', width: 1, color: Colors.KeylineGray}}
+      border="top-and-bottom"
       style={{
         display: 'grid',
         gridTemplateColumns: TEMPLATE_COLUMNS_FOR_CATALOG,
@@ -240,7 +237,7 @@ export const VirtualizedAssetHeader: React.FC<{
 }> = ({nameLabel}) => {
   return (
     <Box
-      border={{side: 'horizontal', width: 1, color: Colors.KeylineGray}}
+      border="top-and-bottom"
       style={{
         display: 'grid',
         gridTemplateColumns: TEMPLATE_COLUMNS,

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedGraphTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedGraphTable.tsx
@@ -35,7 +35,7 @@ export const VirtualizedGraphTable: React.FC<Props> = ({repoAddress, graphs}) =>
   return (
     <>
       <Box
-        border={{side: 'horizontal', width: 1, color: Colors.KeylineGray}}
+        border="top-and-bottom"
         style={{
           display: 'grid',
           gridTemplateColumns: '100%',
@@ -110,7 +110,7 @@ const GraphRow = (props: GraphRowProps) => {
 
   return (
     <Row $height={height} $start={start}>
-      <RowGrid border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}>
+      <RowGrid border="bottom">
         <RowCell>
           <Box flex={{direction: 'column'}}>
             <div style={{whiteSpace: 'nowrap', fontWeight: 500}}>

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedJobRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedJobRow.tsx
@@ -67,7 +67,7 @@ export const VirtualizedJobRow = (props: JobRowProps) => {
 
   return (
     <Row $height={height} $start={start}>
-      <RowGrid border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}>
+      <RowGrid border="bottom">
         <RowCell>
           <div style={{maxWidth: '100%', whiteSpace: 'nowrap', fontWeight: 500}}>
             <Link to={workspacePathFromAddress(repoAddress, `/jobs/${name}`)}>
@@ -130,7 +130,7 @@ export const VirtualizedJobRow = (props: JobRowProps) => {
 export const VirtualizedJobHeader = () => {
   return (
     <Box
-      border={{side: 'horizontal', width: 1, color: Colors.KeylineGray}}
+      border="top-and-bottom"
       style={{
         display: 'grid',
         gridTemplateColumns: TEMPLATE_COLUMNS,

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedRepoAssetTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedRepoAssetTable.tsx
@@ -144,7 +144,7 @@ const GroupNameRow: React.FC<{
         background={Colors.Gray50}
         flex={{direction: 'row', alignItems: 'center', gap: 8, justifyContent: 'space-between'}}
         padding={{horizontal: 24}}
-        border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+        border="bottom"
         style={{height: '100%'}}
       >
         <Box flex={{alignItems: 'center', gap: 8}}>

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedScheduleRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedScheduleRow.tsx
@@ -121,10 +121,7 @@ export const VirtualizedScheduleRow = (props: ScheduleRowProps) => {
 
   return (
     <Row $height={height} $start={start}>
-      <RowGrid
-        border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
-        $showCheckboxColumn={showCheckboxColumn}
-      >
+      <RowGrid border="bottom" $showCheckboxColumn={showCheckboxColumn}>
         {showCheckboxColumn ? (
           <RowCell>
             <Tooltip
@@ -279,7 +276,7 @@ export const VirtualizedScheduleHeader = (props: {checkbox: React.ReactNode}) =>
   const {checkbox} = props;
   return (
     <Box
-      border={{side: 'horizontal', width: 1, color: Colors.KeylineGray}}
+      border="top-and-bottom"
       style={{
         display: 'grid',
         gridTemplateColumns: checkbox ? TEMPLATE_COLUMNS_WITH_CHECKBOX : TEMPLATE_COLUMNS,

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedSensorRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedSensorRow.tsx
@@ -94,10 +94,7 @@ export const VirtualizedSensorRow = (props: SensorRowProps) => {
 
   return (
     <Row $height={height} $start={start}>
-      <RowGrid
-        border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
-        $showCheckboxColumn={showCheckboxColumn}
-      >
+      <RowGrid border="bottom" $showCheckboxColumn={showCheckboxColumn}>
         {showCheckboxColumn ? (
           <RowCell>
             <Tooltip
@@ -190,7 +187,7 @@ export const VirtualizedSensorHeader = (props: {checkbox: React.ReactNode}) => {
   const {checkbox} = props;
   return (
     <Box
-      border={{side: 'horizontal', width: 1, color: Colors.KeylineGray}}
+      border="top-and-bottom"
       style={{
         display: 'grid',
         gridTemplateColumns: checkbox ? TEMPLATE_COLUMNS_WITH_CHECKBOX : TEMPLATE_COLUMNS,

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceSchedulesRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceSchedulesRoot.tsx
@@ -202,7 +202,7 @@ export const WorkspaceSchedulesRoot = ({repoAddress}: {repoAddress: RepoAddress}
       {activeFiltersJsx.length ? (
         <Box
           padding={{vertical: 8, horizontal: 24}}
-          border={{side: 'horizontal', width: 1, color: Colors.KeylineGray}}
+          border="top-and-bottom"
           flex={{direction: 'row', gap: 8}}
         >
           {activeFiltersJsx}

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceSensorsRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceSensorsRoot.tsx
@@ -196,7 +196,7 @@ export const WorkspaceSensorsRoot = ({repoAddress}: {repoAddress: RepoAddress}) 
       {activeFiltersJsx.length ? (
         <Box
           padding={{vertical: 8, horizontal: 24}}
-          border={{side: 'horizontal', width: 1, color: Colors.KeylineGray}}
+          border="top-and-bottom"
           flex={{direction: 'row', gap: 8}}
         >
           {activeFiltersJsx}


### PR DESCRIPTION
## Summary & Motivation

I've been wanting to do this for a while: simplify the `border` prop on `Box`.

- Allow a shorthand for specifying the border side, e.g. `border="bottom"`. This implicitly applies `width: 1, color: Colors.KeylineGray` for that side.
- Make `width` and `color` optional values in the `BorderSetting` object. These will also default to `width: 1, color: Colors.KeylineGray`.
- Replace `"horizontal"` with `"top-and-bottom"`, replace `"vertical"` with `"left-and-right"`. I am consistently confused by which of these I should use, so this hopefully eliminates the confusion.

I grepped aggressively to find existing callsites and swap in shorthand where possible.

## How I Tested These Changes

View app and Storybook, verify that borders look correct throughout.
