### PR TITLE
Add asset checks, data version to MaterializeResult

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_check_result.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_result.py
@@ -143,3 +143,11 @@ class AssetCheckResult(
             target_materialization_data=target_materialization_data,
             severity=self.severity,
         )
+
+    def get_spec_python_identifier(self, asset_key: Optional[AssetKey]) -> str:
+        """Returns a string uniquely identifying the asset check spec associated with this result.
+        This is used for the output name associated with an `AssetCheckResult`.
+        """
+        asset_key = asset_key or self.asset_key
+        assert asset_key is not None, "Asset key must be provided if not set on spec"
+        return f"{asset_key.to_python_identifier()}_{self.check_name}"

--- a/python_modules/dagster/dagster/_core/definitions/result.py
+++ b/python_modules/dagster/dagster/_core/definitions/result.py
@@ -1,6 +1,9 @@
-from typing import NamedTuple, Optional
+from typing import NamedTuple, Optional, Sequence
 
+import dagster._check as check
 from dagster._annotations import PublicAttr, experimental
+from dagster._core.definitions.asset_check_result import AssetCheckResult
+from dagster._core.definitions.data_version import DataVersion
 
 from .events import (
     AssetKey,
@@ -16,6 +19,8 @@ class MaterializeResult(
         [
             ("asset_key", PublicAttr[Optional[AssetKey]]),
             ("metadata", PublicAttr[Optional[MetadataUserInput]]),
+            ("check_results", PublicAttr[Optional[Sequence[AssetCheckResult]]]),
+            ("data_version", PublicAttr[Optional[DataVersion]]),
         ],
     )
 ):
@@ -33,11 +38,21 @@ class MaterializeResult(
         *,  # enforce kwargs
         asset_key: Optional[CoercibleToAssetKey] = None,
         metadata: Optional[MetadataUserInput] = None,
+        check_results: Optional[Sequence[AssetCheckResult]] = None,
+        data_version: Optional[DataVersion] = None,
     ):
         asset_key = AssetKey.from_coercible(asset_key) if asset_key else None
 
         return super().__new__(
             cls,
             asset_key=asset_key,
-            metadata=metadata,  # check?
+            metadata=check.opt_nullable_mapping_param(
+                metadata,
+                "metadata",
+                key_type=str,
+            ),
+            check_results=check.opt_nullable_sequence_param(
+                check_results, "check_results", of_type=AssetCheckResult
+            ),
+            data_version=check.opt_inst_param(data_version, "data_version", DataVersion),
         )

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
@@ -91,45 +91,53 @@ def _process_asset_results_to_events(
          to create a full picture of the asset check's evaluation.
     """
     for user_event in user_event_sequence:
-        if isinstance(user_event, MaterializeResult):
-            assets_def = step_context.job_def.asset_layer.assets_def_for_node(
-                step_context.node_handle
+        yield from _process_user_event(step_context, user_event)
+
+
+def _process_user_event(
+    step_context: StepExecutionContext, user_event: OpOutputUnion
+) -> Iterator[OpOutputUnion]:
+    if isinstance(user_event, MaterializeResult):
+        assets_def = step_context.job_def.asset_layer.assets_def_for_node(step_context.node_handle)
+        if not assets_def:
+            raise DagsterInvariantViolationError(
+                "MaterializeResult is only valid within asset computations, no backing"
+                " AssetsDefinition found."
             )
-            if not assets_def:
-                raise DagsterInvariantViolationError(
-                    "MaterializeResult is only valid within asset computations, no backing"
-                    " AssetsDefinition found."
-                )
-            if user_event.asset_key:
-                asset_key = user_event.asset_key
-            else:
-                if len(assets_def.keys) != 1:
-                    raise DagsterInvariantViolationError(
-                        "MaterializeResult did not include asset_key and it can not be inferred."
-                        f" Specify which asset_key, options are: {assets_def.keys}."
-                    )
-                asset_key = assets_def.key
-
-            output_name = assets_def.get_output_name_for_asset_key(asset_key)
-            output = Output(
-                value=None,
-                output_name=output_name,
-                metadata=user_event.metadata,
-            )
-            yield output
-        elif isinstance(user_event, AssetCheckResult):
-            asset_check_evaluation = user_event.to_asset_check_evaluation(step_context)
-
-            output_name = step_context.job_def.asset_layer.get_output_name_for_asset_check(
-                asset_check_evaluation.asset_check_handle
-            )
-            output = Output(value=None, output_name=output_name)
-
-            yield asset_check_evaluation
-
-            yield output
+        if user_event.asset_key:
+            asset_key = user_event.asset_key
         else:
-            yield user_event
+            if len(assets_def.keys) != 1:
+                raise DagsterInvariantViolationError(
+                    "MaterializeResult did not include asset_key and it can not be inferred."
+                    f" Specify which asset_key, options are: {assets_def.keys}."
+                )
+            asset_key = assets_def.key
+
+        output_name = assets_def.get_output_name_for_asset_key(asset_key)
+
+        for check_result in user_event.check_results or []:
+            yield from _process_user_event(step_context, check_result)
+
+        yield Output(
+            value=None,
+            output_name=output_name,
+            metadata=user_event.metadata,
+            data_version=user_event.data_version,
+        )
+    elif isinstance(user_event, AssetCheckResult):
+        asset_check_evaluation = user_event.to_asset_check_evaluation(step_context)
+
+        output_name = step_context.job_def.asset_layer.get_output_name_for_asset_check(
+            asset_check_evaluation.asset_check_handle
+        )
+        output = Output(value=None, output_name=output_name)
+
+        yield asset_check_evaluation
+
+        yield output
+    else:
+        yield user_event
 
 
 def _step_output_error_checked_user_event_sequence(


### PR DESCRIPTION
## Summary & Motivation

Add `check_results` and `data_version` to `MaterializeResult`. This supports streaming asset check results back from an ext process added upstack in #16466.

## How I Tested These Changes

New unit test.
