### PR TITLE
[Assets overview] Support custom refetch callback in useQueryRefreshAtInterval

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/QueryRefresh.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/QueryRefresh.tsx
@@ -37,6 +37,7 @@ export function useQueryRefreshAtInterval(
   queryResult: QueryResult<any, any>,
   intervalMs: number,
   enabled = true,
+  customRefetch?: () => void,
 ) {
   const timer = React.useRef<number>();
   const loadingStartMs = React.useRef<number>();
@@ -44,6 +45,9 @@ export function useQueryRefreshAtInterval(
 
   const queryResultRef = React.useRef(queryResult);
   queryResultRef.current = queryResult;
+
+  const customRefetchRef = React.useRef(customRefetch);
+  customRefetchRef.current = customRefetch;
 
   // Sanity check - don't use this hook alongside a useQuery pollInterval
   if (queryResult.networkStatus === NetworkStatus.poll) {
@@ -63,7 +67,7 @@ export function useQueryRefreshAtInterval(
       return;
     }
     if (documentVisible && documentVisiblityDidInterrupt.current) {
-      queryResultRef.current?.refetch();
+      customRefetchRef.current ? customRefetchRef.current() : queryResultRef.current?.refetch();
       documentVisiblityDidInterrupt.current = false;
     }
   }, [documentVisible, enabled]);
@@ -101,7 +105,7 @@ export function useQueryRefreshAtInterval(
         documentVisiblityDidInterrupt.current = true;
         return;
       }
-      queryResultRef.current?.refetch();
+      customRefetchRef.current ? customRefetchRef.current() : queryResultRef.current?.refetch();
     }, adjustedIntervalMs);
 
     return () => {
@@ -122,9 +126,13 @@ export function useQueryRefreshAtInterval(
       nextFireMs,
       nextFireDelay,
       networkStatus: queryResult.networkStatus,
-      refetch: queryResult.refetch,
+      refetch: (...props) => {
+        return customRefetchRef.current
+          ? (customRefetchRef.current() as any)
+          : queryResult.refetch(...props);
+      },
     }),
-    [nextFireMs, nextFireDelay, queryResult.networkStatus, queryResult.refetch],
+    [nextFireMs, nextFireDelay, queryResult],
   );
 }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useLiveDataForAssetKeys.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useLiveDataForAssetKeys.tsx
@@ -95,7 +95,12 @@ export function useLiveDataForAssetKeys(assetKeys: AssetKeyInput[], batched?: bo
 
   // If the event log storage does not support streaming us asset events, fall back to
   // a polling approach and trigger a single refresh when a run is launched for immediate feedback
-  const liveDataRefreshState = useQueryRefreshAtInterval(liveResult, SUBSCRIPTION_IDLE_POLL_RATE);
+  const liveDataRefreshState = useQueryRefreshAtInterval(
+    liveResult,
+    SUBSCRIPTION_IDLE_POLL_RATE,
+    true,
+    refetch,
+  );
 
   useDidLaunchEvent(refetch, SUBSCRIPTION_MAX_POLL_RATE);
 


### PR DESCRIPTION
## Summary & Motivation

https://github.com/dagster-io/dagster/pull/16245 added opt-in batching to `useLiveDataForAssetKeys`, but it neglected to thread the custom refetching logic to `useQueryRefreshAtInterval`, this pr adds that.

## How I Tested These Changes
Locally tested and made sure that when the refresh fires it restarts batching from index 0 if the batched fetch is already complete