### PR TITLE
remove unused run_ids_for_asset_key storage method

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -1973,11 +1973,6 @@ class DagsterInstance(DynamicPartitionsStore):
         """
         return self._event_storage.get_event_tags_for_asset(asset_key, filter_tags, filter_event_id)
 
-    @traced
-    def run_ids_for_asset_key(self, asset_key: AssetKey) -> Sequence[str]:
-        check.inst_param(asset_key, "asset_key", AssetKey)
-        return self._event_storage.get_asset_run_ids(asset_key)
-
     @public
     @traced
     def wipe_assets(self, asset_keys: Sequence[AssetKey]) -> None:

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -370,10 +370,6 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         pass
 
     @abstractmethod
-    def get_asset_run_ids(self, asset_key: AssetKey) -> Sequence[str]:
-        pass
-
-    @abstractmethod
     def wipe_asset(self, asset_key: AssetKey) -> None:
         """Remove asset index history from event log for given asset_key."""
 

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -1582,30 +1582,6 @@ class SqlEventLogStorage(EventLogStorage):
 
         return list(tags_by_event_id.values())
 
-    def get_asset_run_ids(self, asset_key: AssetKey) -> Sequence[str]:
-        check.inst_param(asset_key, "asset_key", AssetKey)
-        query = (
-            db_select(
-                [SqlEventLogStorageTable.c.run_id, db.func.max(SqlEventLogStorageTable.c.timestamp)]
-            )
-            .where(
-                SqlEventLogStorageTable.c.asset_key == asset_key.to_string(),
-            )
-            .group_by(
-                SqlEventLogStorageTable.c.run_id,
-            )
-            .order_by(db.func.max(SqlEventLogStorageTable.c.timestamp).desc())
-        )
-
-        asset_keys = [asset_key]
-        asset_details = self._get_assets_details(asset_keys)
-        query = self._add_assets_wipe_filter_to_query(query, asset_details, asset_keys)
-
-        with self.index_connection() as conn:
-            results = conn.execute(query).fetchall()
-
-        return [run_id for (run_id, _timestamp) in results]
-
     def _asset_materialization_from_json_column(
         self, json_str: str
     ) -> Optional[AssetMaterialization]:

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -472,9 +472,6 @@ class LegacyEventLogStorage(EventLogStorage, ConfigurableClass):
     ) -> Mapping["AssetKey", Optional["EventLogEntry"]]:
         return self._storage.event_log_storage.get_latest_materialization_events(asset_keys)
 
-    def get_asset_run_ids(self, asset_key: "AssetKey") -> Iterable[str]:
-        return self._storage.event_log_storage.get_asset_run_ids(asset_key)
-
     def wipe_asset(self, asset_key: "AssetKey") -> None:
         return self._storage.event_log_storage.wipe_asset(asset_key)
 

--- a/python_modules/dagster/dagster_tests/core_tests/test_asset_events.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_asset_events.py
@@ -61,6 +61,18 @@ def test_multi_asset_mat_planned_event_step_key():
         )
 
 
+def _get_planned_run_ids(instance, asset_key):
+    return [
+        record.run_id
+        for record in instance.get_event_records(
+            EventRecordsFilter(
+                event_type=DagsterEventType.ASSET_MATERIALIZATION_PLANNED,
+                asset_key=asset_key,
+            )
+        )
+    ]
+
+
 def test_asset_materialization_planned_event_yielded():
     @asset
     def asset_one():
@@ -79,16 +91,16 @@ def test_asset_materialization_planned_event_yielded():
         )
         run_id = result.run_id
 
-        assert instance.run_ids_for_asset_key(AssetKey("asset_one")) == [run_id]
-        assert instance.run_ids_for_asset_key(AssetKey("never_runs_asset")) == []
+        assert _get_planned_run_ids(instance, AssetKey("asset_one")) == [run_id]
+        assert _get_planned_run_ids(instance, AssetKey("never_runs_asset")) == []
 
     with instance_for_test() as instance:  # fresh event log storage
         # test with both assets selected
         result = asset_job.execute_in_process(instance=instance, raise_on_error=False)
         run_id = result.run_id
 
-        assert instance.run_ids_for_asset_key(AssetKey("asset_one")) == [run_id]
-        assert instance.run_ids_for_asset_key(AssetKey("never_runs_asset")) == [run_id]
+        assert _get_planned_run_ids(instance, AssetKey("asset_one")) == [run_id]
+        assert _get_planned_run_ids(instance, AssetKey("never_runs_asset")) == [run_id]
 
 
 def test_non_assets_job_no_register_event():
@@ -123,18 +135,9 @@ def test_multi_asset_asset_materialization_planned_events():
     assets_job = build_assets_job("assets_job", [my_asset])
 
     with instance_for_test() as instance:
-        result = assets_job.execute_in_process(instance=instance)
-        records = instance.get_event_records(
-            EventRecordsFilter(
-                DagsterEventType.ASSET_MATERIALIZATION_PLANNED,
-                AssetKey("my_asset_name"),
-            )
-        )
-        assert result.run_id == records[0].event_log_entry.run_id
-        run_id = result.run_id
-
-        assert instance.run_ids_for_asset_key(AssetKey("my_asset_name")) == [run_id]
-        assert instance.run_ids_for_asset_key(AssetKey("my_other_asset")) == [run_id]
+        assets_job.execute_in_process(instance=instance)
+        [run_id] = _get_planned_run_ids(instance, AssetKey("my_asset_name"))
+        assert _get_planned_run_ids(instance, AssetKey("my_other_asset")) == [run_id]
 
 
 def test_asset_partition_materialization_planned_events():

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -793,12 +793,6 @@ def test_backfill_with_asset_selection(
         assert step_succeeded(instance, run, "foo")
         assert step_succeeded(instance, run, "reusable")
         assert step_succeeded(instance, run, "bar")
-    # selected
-    for asset_key in asset_selection:
-        assert len(instance.run_ids_for_asset_key(asset_key)) == 3
-    # not selected
-    for asset_key in [AssetKey("a2"), AssetKey("b2"), AssetKey("baz")]:
-        assert len(instance.run_ids_for_asset_key(asset_key)) == 0
 
 
 def test_pure_asset_backfill_with_multiple_assets_selected(
@@ -907,12 +901,6 @@ def test_pure_asset_backfill(
         assert step_succeeded(instance, run, "foo")
         assert step_succeeded(instance, run, "reusable")
         assert step_succeeded(instance, run, "bar")
-    # selected
-    for asset_key in asset_selection:
-        assert len(instance.run_ids_for_asset_key(asset_key)) == 3
-    # not selected
-    for asset_key in [AssetKey("a2"), AssetKey("b2"), AssetKey("baz")]:
-        assert len(instance.run_ids_for_asset_key(asset_key)) == 0
 
     list(execute_backfill_iteration(workspace_context, get_default_daemon_logger("BackfillDaemon")))
     backfill = instance.get_backfill("backfill_with_asset_selection")

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -1698,28 +1698,6 @@ class TestEventLogStorage:
                 assert storage.has_asset_key(AssetKey(["path", "to", "asset_3"]))
                 assert not storage.has_asset_key(AssetKey(["path", "to", "bogus", "asset"]))
 
-    def test_asset_run_ids(self, storage, instance):
-        with instance_for_test() as created_instance:
-            if not storage.has_instance:
-                storage.register_instance(created_instance)
-
-            one_run_id = "one"
-            two_run_id = "two"
-
-            one_events, _ = _synthesize_events(
-                lambda: one_asset_op(), run_id=one_run_id, instance=created_instance
-            )
-            two_events, _ = _synthesize_events(
-                lambda: two_asset_ops(), run_id=two_run_id, instance=created_instance
-            )
-
-            with create_and_delete_test_runs(instance, [one_run_id, two_run_id]):
-                for event in one_events + two_events:
-                    storage.store_event(event)
-
-                run_ids = storage.get_asset_run_ids(AssetKey("asset_1"))
-                assert set(run_ids) == set([one_run_id, two_run_id])
-
     def test_asset_normalization(self, storage, test_run_id):
         with instance_for_test() as instance:
             if not storage.has_instance:
@@ -1763,8 +1741,6 @@ class TestEventLogStorage:
                 asset_keys = storage.all_asset_keys()
                 assert len(asset_keys) == 3
                 assert storage.has_asset_key(AssetKey("asset_1"))
-                asset_run_ids = storage.get_asset_run_ids(AssetKey("asset_1"))
-                assert set(asset_run_ids) == set([one_run_id, two_run_id])
 
                 log_count = len(storage.get_logs_for_run(one_run_id))
                 if self.can_wipe():
@@ -1774,8 +1750,6 @@ class TestEventLogStorage:
                     asset_keys = storage.all_asset_keys()
                     assert len(asset_keys) == 0
                     assert not storage.has_asset_key(AssetKey("asset_1"))
-                    asset_run_ids = storage.get_asset_run_ids(AssetKey("asset_1"))
-                    assert set(asset_run_ids) == set()
                     assert log_count == len(storage.get_logs_for_run(one_run_id))
 
                     one_run_id = "one_run_id_2"
@@ -1791,8 +1765,6 @@ class TestEventLogStorage:
                         asset_keys = storage.all_asset_keys()
                         assert len(asset_keys) == 1
                         assert storage.has_asset_key(AssetKey("asset_1"))
-                        asset_run_ids = storage.get_asset_run_ids(AssetKey("asset_1"))
-                        assert set(asset_run_ids) == set([one_run_id])
 
     def test_asset_secondary_index(self, storage, instance):
         with instance_for_test() as created_instance:


### PR DESCRIPTION
## Summary & Motivation
This (non-public) storage/instance method doesn't seem to be used outside of tests.  The implementation is a little weird now that we're splitting out asset event records in cloud anyway, so we should remove to reduce surface area.

## How I Tested These Changes
BK