### PR TITLE
import useHistory from react-router-dom

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogRoot.tsx
@@ -1,8 +1,7 @@
 import {gql, useQuery} from '@apollo/client';
 import {Box, Colors, Page, Spinner} from '@dagster-io/ui-components';
 import * as React from 'react';
-import {useHistory} from 'react-router';
-import {useParams} from 'react-router-dom';
+import {useHistory, useParams} from 'react-router-dom';
 
 import {useTrackPageView} from '../app/analytics';
 import {displayNameForAssetKey} from '../asset-graph/Utils';

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/useLaunchWithTelemetry.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/useLaunchWithTelemetry.ts
@@ -1,6 +1,6 @@
 import {useMutation} from '@apollo/client';
 import * as React from 'react';
-import {useHistory} from 'react-router';
+import {useHistory} from 'react-router-dom';
 
 import {TelemetryAction, useTelemetryAction} from '../app/Telemetry';
 import {

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/BackfillSelector.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/BackfillSelector.tsx
@@ -13,7 +13,7 @@ import {
   Tooltip,
 } from '@dagster-io/ui-components';
 import * as React from 'react';
-import {useHistory} from 'react-router';
+import {useHistory} from 'react-router-dom';
 
 import {PipelineRunTag} from '../app/ExecutionSessionStorage';
 import {filterByQuery} from '../app/GraphQueryImpl';

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/useJobReExecution.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/useJobReExecution.tsx
@@ -1,6 +1,6 @@
 import {useMutation} from '@apollo/client';
 import * as React from 'react';
-import {useHistory} from 'react-router';
+import {useHistory} from 'react-router-dom';
 
 import {showLaunchError} from '../launchpad/showLaunchError';
 import {useRepositoryForRunWithParentSnapshot} from '../workspace/useRepositoryForRun';


### PR DESCRIPTION
## Summary & Motivation

It should be imported from react-router-dom and not react-router. We might want to restrict react-router imports

# Test plan

Deployed this to dogfood and confirmed [the issue ](https://app.datadoghq.com/rum/sessions?query=%40application.id%3A7edc09bb-51d0-4555-90cd-b19ca483d1fe%20%40type%3Aerror&agg_m=count&agg_q=%40issue.id&agg_t=count&cols=&event=AgAAAYqV4UuxuusyKQAAAAAAAAAYAAAAAEFZcVY0YTFMQUFBcXJjLWNWcF9NTEFBRAAAACQAAAAAMDE4YTk1ZjAtZjljOC00M2UyLWI4YTktOWI4ZTMwZmM3Zjkw&tab=error&from_ts=1678802636052&to_ts=1679407436052&live=true) is fixed