### PR TITLE
[2/n][Asset Graph Sidebar] - Consolidate filtering

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/Flags.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/Flags.tsx
@@ -14,6 +14,7 @@ export const FeatureFlag = {
   flagSidebarResources: 'flagSidebarResources' as const,
   flagHorizontalDAGs: 'flagHorizontalDAGs' as const,
   flagDisableAutoLoadDefaults: 'flagDisableAutoLoadDefaults' as const,
+  flagDAGSidebar: 'flagDAGSidebar' as const,
 };
 export type FeatureFlagType = keyof typeof FeatureFlag;
 

--- a/js_modules/dagster-ui/packages/ui-core/src/app/getVisibleFeatureFlagRows.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/getVisibleFeatureFlagRows.tsx
@@ -32,4 +32,8 @@ export const getVisibleFeatureFlagRows = () => [
     key: 'Experimental horizontal asset DAGs',
     flagType: FeatureFlag.flagHorizontalDAGs,
   },
+  {
+    key: 'Experimental DAG sidebar',
+    flagType: FeatureFlag.flagDAGSidebar,
+  },
 ];

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -309,10 +309,7 @@ const AssetGraphExplorerWithData: React.FC<WithDataProps> = ({
               {graphQueryItems.length === 0 ? (
                 <EmptyDAGNotice nodeType="asset" isGraph />
               ) : applyingEmptyDefault ? (
-                <LargeDAGNotice
-                  nodeType="asset"
-                  anchorLeft={fetchOptionFilters ? '300px' : '40px'}
-                />
+                <LargeDAGNotice nodeType="asset" anchorLeft="40px" />
               ) : Object.keys(assetGraphData.nodes).length === 0 ? (
                 <EntirelyFilteredDAGNotice nodeType="asset" />
               ) : undefined}
@@ -435,10 +432,7 @@ const AssetGraphExplorerWithData: React.FC<WithDataProps> = ({
                 </OptionsOverlay>
               )}
 
-              <Box
-                flex={{direction: 'column', alignItems: 'flex-end', gap: 8}}
-                style={{position: 'absolute', right: 12, top: 8}}
-              >
+              <Box style={{position: 'absolute', right: 12, top: 8}}>
                 <Box flex={{alignItems: 'center', gap: 12}}>
                   <QueryRefreshCountdown
                     refreshState={liveDataRefreshState}

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorerFilters.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorerFilters.tsx
@@ -1,0 +1,114 @@
+import {Box, Icon} from '@dagster-io/ui-components';
+import React from 'react';
+
+import {AssetGroupSelector} from '../graphql/types';
+import {TruncatedTextWithFullTextOnHover} from '../nav/getLeftNavItemsForOption';
+import {useFilters} from '../ui/Filters';
+import {FilterObject} from '../ui/Filters/useFilter';
+import {useStaticSetFilter} from '../ui/Filters/useStaticSetFilter';
+import {DagsterRepoOption, WorkspaceContext} from '../workspace/WorkspaceContext';
+import {buildRepoAddress, buildRepoPathForHuman} from '../workspace/buildRepoAddress';
+
+export const AssetGraphExplorerFilters = React.memo(
+  ({
+    assetGroups,
+    visibleAssetGroups,
+    setGroupFilters,
+  }:
+    | {
+        assetGroups: AssetGroupSelector[];
+        visibleAssetGroups: AssetGroupSelector[];
+        setGroupFilters: (groups: AssetGroupSelector[]) => void;
+      }
+    | {assetGroups?: null; setGroupFilters?: null; visibleAssetGroups?: null}) => {
+    const {allRepos, visibleRepos, toggleVisible} = React.useContext(WorkspaceContext);
+
+    const visibleReposSet = React.useMemo(() => new Set(visibleRepos), [visibleRepos]);
+
+    const reposFilter = useStaticSetFilter<DagsterRepoOption>({
+      name: 'Repository',
+      icon: 'repo',
+      allValues: allRepos.map((repo) => ({
+        key: repo.repository.id,
+        value: repo,
+        match: [buildRepoPathForHuman(repo.repository.name, repo.repositoryLocation.name)],
+      })),
+      menuWidth: '300px',
+      renderLabel: ({value}) => (
+        <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
+          <Icon name="repo" />
+          <TruncatedTextWithFullTextOnHover
+            text={buildRepoPathForHuman(value.repository.name, value.repositoryLocation.name)}
+          />
+        </Box>
+      ),
+      getStringValue: (value) =>
+        buildRepoPathForHuman(value.repository.name, value.repositoryLocation.name),
+      initialState: visibleReposSet,
+      onStateChanged: (values) => {
+        allRepos.forEach((repo) => {
+          if (visibleReposSet.has(repo) !== values.has(repo)) {
+            toggleVisible([buildRepoAddress(repo.repository.name, repo.repositoryLocation.name)]);
+          }
+        });
+      },
+    });
+
+    const groupsFilter = useStaticSetFilter<AssetGroupSelector>({
+      name: 'Asset Groups',
+      icon: 'asset_group',
+      allValues: (assetGroups || []).map((group) => ({
+        key: group.groupName,
+        value:
+          visibleAssetGroups?.find(
+            (visibleGroup) =>
+              visibleGroup.groupName === group.groupName &&
+              visibleGroup.repositoryName === group.repositoryName &&
+              visibleGroup.repositoryLocationName === group.repositoryLocationName,
+          ) ?? group,
+        match: [group.groupName],
+      })),
+      menuWidth: '300px',
+      renderLabel: ({value}) => (
+        <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
+          <Icon name="repo" />
+          <TruncatedTextWithFullTextOnHover
+            tooltipText={
+              value.groupName +
+              ' - ' +
+              buildRepoPathForHuman(value.repositoryName, value.repositoryLocationName)
+            }
+            text={
+              <>
+                {value.groupName}
+                <span style={{opacity: 0.5, paddingLeft: '4px'}}>
+                  {buildRepoPathForHuman(value.repositoryName, value.repositoryLocationName)}
+                </span>
+              </>
+            }
+          />
+        </Box>
+      ),
+      getStringValue: (group) => group.groupName,
+      initialState: React.useMemo(() => new Set(visibleAssetGroups ?? []), [visibleAssetGroups]),
+      onStateChanged: (values) => {
+        if (setGroupFilters) {
+          setGroupFilters(Array.from(values));
+        }
+      },
+    });
+
+    const filters: FilterObject[] = [];
+    if (allRepos.length > 1) {
+      filters.push(reposFilter);
+    }
+    if (assetGroups) {
+      filters.push(groupsFilter);
+    }
+    const {button} = useFilters({filters});
+    if (allRepos.length <= 1 && !assetGroups) {
+      return null;
+    }
+    return button;
+  },
+);

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorerSidebar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorerSidebar.tsx
@@ -12,29 +12,93 @@ import {
   TextInput,
   MiddleTruncate,
   useViewport,
+  MenuDivider,
+  Spinner,
+  ButtonGroup,
+  Tooltip,
 } from '@dagster-io/ui-components';
 import {useVirtualizer} from '@tanstack/react-virtual';
 import React from 'react';
 import styled from 'styled-components';
 
+
+import {showSharedToaster} from '../app/DomUtils';
+import {useMaterializationAction} from '../assets/LaunchAssetExecutionButton';
+import {AssetKey} from '../assets/types';
+import {ExplorerPath} from '../pipelines/PipelinePathUtils';
 import {Container, Inner, Row} from '../ui/VirtualizedTable';
+import {buildRepoPathForHuman} from '../workspace/buildRepoAddress';
 
 import {GraphData, GraphNode} from './Utils';
 
 const COLLATOR = new Intl.Collator(navigator.language, {sensitivity: 'base', numeric: true});
 
+type FolderNodeNonAssetType =
+  | {groupName: string; id: string; level: number}
+  | {locationName: string; id: string; level: number};
+
+type FolderNodeType = FolderNodeNonAssetType | {path: string; id: string; level: number};
+
+type TreeNodeType = {level: number; id: string; path: string};
+
 export const AssetGraphExplorerSidebar = React.memo(
   ({
     assetGraphData,
     lastSelectedNode,
-    selectNode,
+    selectNode: _selectNode,
+    explorerPath,
+    onChangeExplorerPath,
+    allAssetKeys,
+    hideSidebar,
   }: {
     assetGraphData: GraphData;
     lastSelectedNode: GraphNode;
     selectNode: (e: React.MouseEvent<any> | React.KeyboardEvent<any>, nodeId: string) => void;
+    explorerPath: ExplorerPath;
+    onChangeExplorerPath: (path: ExplorerPath, mode: 'replace' | 'push') => void;
+    allAssetKeys: AssetKey[];
+    hideSidebar: () => void;
   }) => {
+    const [selectWhenDataAvailable, setSelectWhenDataAvailable] = React.useState<
+      [React.MouseEvent<any> | React.KeyboardEvent<any>, string] | null
+    >(null);
+    const selectedNodeHasDataAvailable = selectWhenDataAvailable
+      ? !!assetGraphData.nodes[selectWhenDataAvailable[1]]
+      : false;
+
+    React.useEffect(() => {
+      if (selectWhenDataAvailable) {
+        const [e, id] = selectWhenDataAvailable;
+        _selectNode(e, id);
+      }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [selectWhenDataAvailable, selectedNodeHasDataAvailable]);
+
+    const selectNode: typeof _selectNode = (e, id) => {
+      setSelectWhenDataAvailable([e, id]);
+      if (!assetGraphData.nodes[id]) {
+        try {
+          const path = JSON.parse(id);
+          const nextOpsQuery = `${explorerPath.opsQuery} \"${path[path.length - 1]}\"`;
+          onChangeExplorerPath(
+            {
+              ...explorerPath,
+              opsQuery: nextOpsQuery,
+            },
+            'push',
+          );
+        } catch (e) {
+          // Ignore errors. The selected node might be a group or code location so trying to JSON.parse the id will error.
+          // For asset nodes the id is always a JSON array
+        }
+      }
+    };
     const [openNodes, setOpenNodes] = React.useState<Set<string>>(new Set());
-    const [selectedNode, setSelectedNode] = React.useState<null | {id: string; path: string}>(null);
+    const [selectedNode, setSelectedNode] = React.useState<
+      null | {id: string; path: string} | {id: string}
+    >(null);
+
+    const [viewType, setViewType] = React.useState<'tree' | 'folder'>('tree');
 
     const rootNodes = React.useMemo(
       () =>
@@ -57,13 +121,13 @@ export const AssetGraphExplorerSidebar = React.memo(
       [assetGraphData],
     );
 
-    const renderedNodes = React.useMemo(() => {
+    const treeNodes = React.useMemo(() => {
       const queue = rootNodes.map((id) => ({level: 1, id, path: id}));
 
-      const renderedNodes: {level: number; id: string; path: string}[] = [];
+      const treeNodes: TreeNodeType[] = [];
       while (queue.length) {
         const node = queue.shift()!;
-        renderedNodes.push(node);
+        treeNodes.push(node);
         if (openNodes.has(node.path)) {
           const downstream = Object.keys(assetGraphData.downstream[node.id] || {}).filter(
             (id) => assetGraphData.nodes[id],
@@ -73,15 +137,74 @@ export const AssetGraphExplorerSidebar = React.memo(
           );
         }
       }
-      return renderedNodes;
+      return treeNodes;
     }, [assetGraphData.downstream, assetGraphData.nodes, openNodes, rootNodes]);
+
+    const folderNodes = React.useMemo(() => {
+      const folderNodes: FolderNodeType[] = [];
+
+      // Map of Code Locations -> Groups -> Assets
+      const codeLocationNodes: Record<
+        string,
+        {
+          locationName: string;
+          groups: Record<
+            string,
+            {
+              groupName: string;
+              assets: string[];
+            }
+          >;
+        }
+      > = {};
+      Object.entries(assetGraphData.nodes).forEach(([id, node]) => {
+        const locationName = node.definition.repository.location.name;
+        const repositoryName = node.definition.repository.name;
+        const groupName = node.definition.groupName || 'default';
+        const codeLocation = buildRepoPathForHuman(repositoryName, locationName);
+        codeLocationNodes[codeLocation] = codeLocationNodes[codeLocation] || {
+          locationName: codeLocation,
+          groups: {},
+        };
+        codeLocationNodes[codeLocation]!.groups[groupName] = codeLocationNodes[codeLocation]!
+          .groups[groupName] || {
+          groupName,
+          assets: [],
+        };
+        codeLocationNodes[codeLocation]!.groups[groupName]!.assets.push(id);
+      });
+      Object.entries(codeLocationNodes).forEach(([locationName, locationNode]) => {
+        folderNodes.push({locationName, id: locationName, level: 1});
+        if (openNodes.has(locationName)) {
+          Object.entries(locationNode.groups).forEach(([groupName, groupNode]) => {
+            const groupId = locationName + ':' + groupName;
+            folderNodes.push({groupName, id: groupId, level: 2});
+            if (openNodes.has(groupId)) {
+              groupNode.assets
+                .sort((a, b) => COLLATOR.compare(a, b))
+                .forEach((assetKey) => {
+                  folderNodes.push({
+                    id: assetKey,
+                    path: locationName + ':' + groupName + ':' + assetKey,
+                    level: 3,
+                  });
+                });
+            }
+          });
+        }
+      });
+
+      return folderNodes;
+    }, [assetGraphData.nodes, openNodes]);
+
+    const renderedNodes = viewType === 'tree' ? treeNodes : folderNodes;
 
     const containerRef = React.useRef<HTMLDivElement | null>(null);
 
     const rowVirtualizer = useVirtualizer({
       count: renderedNodes.length,
       getScrollElement: () => containerRef.current,
-      estimateSize: () => 38,
+      estimateSize: () => 28,
       overscan: 10,
     });
 
@@ -89,8 +212,23 @@ export const AssetGraphExplorerSidebar = React.memo(
     const items = rowVirtualizer.getVirtualItems();
 
     React.useLayoutEffect(() => {
-      if (lastSelectedNode && lastSelectedNode.id !== selectedNode?.id) {
+      if (lastSelectedNode) {
         setOpenNodes((prevOpenNodes) => {
+          if (viewType === 'folder') {
+            const nextOpenNodes = new Set(prevOpenNodes);
+            const assetNode = assetGraphData.nodes[lastSelectedNode.id];
+            if (assetNode) {
+              const locationName = buildRepoPathForHuman(
+                assetNode.definition.repository.name,
+                assetNode.definition.repository.location.name,
+              );
+              const groupName = assetNode.definition.groupName || 'default';
+              nextOpenNodes.add(locationName);
+              nextOpenNodes.add(locationName + ':' + groupName);
+            }
+            setSelectedNode({id: lastSelectedNode.id});
+            return nextOpenNodes;
+          }
           let path = lastSelectedNode.id;
           let currentId = lastSelectedNode.id;
           let next: string | undefined;
@@ -116,16 +254,31 @@ export const AssetGraphExplorerSidebar = React.memo(
           return nextOpenNodes;
         });
       }
+    }, [
+      lastSelectedNode,
+      assetGraphData,
+      viewType,
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [lastSelectedNode, assetGraphData]);
+      
+      lastSelectedNode &&
+        renderedNodes.findIndex((node) => nodeId(lastSelectedNode) === nodeId(node)),
+    ]);
 
     const indexOfLastSelectedNode = React.useMemo(
-      () =>
-        selectedNode?.path
-          ? renderedNodes.findIndex((node) => node.path === selectedNode?.path)
-          : -1,
+      () => {
+        if (!selectedNode) {
+          return -1;
+        }
+        if (viewType === 'tree') {
+          return 'path' in selectedNode
+            ? renderedNodes.findIndex((node) => 'path' in node && node.path === selectedNode.path)
+            : -1;
+        } else {
+          return renderedNodes.findIndex((node) => nodeId(node) === nodeId(selectedNode));
+        }
+      },
       // eslint-disable-next-line react-hooks/exhaustive-deps
-      [renderedNodes, selectedNode?.path],
+      [viewType, renderedNodes, selectedNode],
     );
 
     React.useLayoutEffect(() => {
@@ -135,15 +288,40 @@ export const AssetGraphExplorerSidebar = React.memo(
     }, [indexOfLastSelectedNode, rowVirtualizer]);
 
     return (
-      <div style={{display: 'grid', gridTemplateRows: 'auto minmax(0, 1fr)', height: '100%'}}>
-        <Box flex={{direction: 'column'}} padding={8}>
+      <div style={{display: 'grid', gridTemplateRows: 'auto auto minmax(0, 1fr)', height: '100%'}}>
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: '1fr auto',
+            gap: '6px',
+            padding: '12px 24px',
+            borderBottom: `1px solid ${Colors.KeylineGray}`,
+          }}
+        >
+          <ButtonGroupWrapper>
+            <ButtonGroup
+              activeItems={new Set([viewType])}
+              buttons={[
+                {id: 'tree', label: 'Tree view', icon: 'gantt_flat'},
+                {id: 'folder', label: 'Folder view', icon: 'folder_open'},
+              ]}
+              onClick={(id: 'tree' | 'folder') => {
+                setViewType(id);
+              }}
+            />
+          </ButtonGroupWrapper>
+          <Tooltip content="Hide sidebar">
+            <Button icon={<Icon name="panel_show_right" />} onClick={hideSidebar} />
+          </Tooltip>
+        </div>
+        <Box padding={{vertical: 8, horizontal: 24}}>
           <SearchFilter
             values={React.useMemo(() => {
-              return Object.entries(assetGraphData.nodes).map(([id, node]) => ({
-                value: id,
-                label: getDisplayName(node),
+              return allAssetKeys.map((key) => ({
+                value: JSON.stringify(key.path),
+                label: key.path[key.path.length - 1]!,
               }));
-            }, [assetGraphData.nodes])}
+            }, [allAssetKeys])}
             onSelectValue={selectNode}
           />
         </Box>
@@ -152,7 +330,10 @@ export const AssetGraphExplorerSidebar = React.memo(
             <Inner $totalHeight={totalHeight}>
               {items.map(({index, key, size, start, measureElement}) => {
                 const node = renderedNodes[index]!;
-                const row = assetGraphData.nodes[node.id];
+                const isCodelocationNode = 'locationName' in node;
+                const isGroupNode = 'groupName' in node;
+                const row =
+                  !isCodelocationNode && !isGroupNode ? assetGraphData.nodes[node.id] : node;
                 return (
                   <Row
                     $height={size}
@@ -163,20 +344,25 @@ export const AssetGraphExplorerSidebar = React.memo(
                   >
                     {row ? (
                       <Node
-                        isOpen={openNodes.has(node.id)}
+                        viewType={viewType}
+                        isOpen={openNodes.has(nodeId(node))}
                         assetGraphData={assetGraphData}
                         node={row}
                         level={node.level}
-                        isSelected={selectedNode?.path === node.path}
+                        isSelected={
+                          selectedNode && 'path' in node && 'path' in selectedNode
+                            ? selectedNode.path === node.path
+                            : selectedNode?.id === node.id
+                        }
                         toggleOpen={() => {
                           setSelectedNode(node);
                           setOpenNodes((nodes) => {
                             const openNodes = new Set(nodes);
-                            const isOpen = openNodes.has(node.path);
+                            const isOpen = openNodes.has(nodeId(node));
                             if (isOpen) {
-                              openNodes.delete(node.path);
+                              openNodes.delete(nodeId(node));
                             } else {
-                              openNodes.add(node.path);
+                              openNodes.add(nodeId(node));
                             }
                             return openNodes;
                           });
@@ -188,6 +374,8 @@ export const AssetGraphExplorerSidebar = React.memo(
                           selectNode(e, node.id);
                           setSelectedNode(node);
                         }}
+                        explorerPath={explorerPath}
+                        onChangeExplorerPath={onChangeExplorerPath}
                       />
                     ) : null}
                   </Row>
@@ -210,58 +398,103 @@ const Node = ({
   isOpen,
   isSelected,
   selectThisNode,
+  explorerPath,
+  onChangeExplorerPath,
+  viewType,
 }: {
   assetGraphData: GraphData;
-  node: GraphNode;
+  node: GraphNode | FolderNodeNonAssetType;
   level: number;
   toggleOpen: () => void;
   selectThisNode: (e: React.MouseEvent<any> | React.KeyboardEvent<any>) => void;
   selectNode: (e: React.MouseEvent<any> | React.KeyboardEvent<any>, nodeId: string) => void;
   isOpen: boolean;
   isSelected: boolean;
+  explorerPath: ExplorerPath;
+  onChangeExplorerPath: (path: ExplorerPath, mode: 'replace' | 'push') => void;
+  viewType: 'tree' | 'folder';
 }) => {
-  const displayName = getDisplayName(node);
+  const isGroupNode = 'groupName' in node;
+  const isLocationNode = 'locationName' in node;
+  const isAssetNode = !isGroupNode && !isLocationNode;
 
-  const upstream = Object.keys(assetGraphData.upstream[node.id] ?? {}).filter(
-    (id) => !!assetGraphData.nodes[id],
-  );
-  const downstream = Object.keys(assetGraphData.downstream[node.id] ?? {}).filter(
-    (id) => !!assetGraphData.nodes[id],
-  );
+  const displayName = React.useMemo(() => {
+    if (isAssetNode) {
+      return getDisplayName(node);
+    } else if (isGroupNode) {
+      return node.groupName;
+    } else {
+      return node.locationName;
+    }
+  }, [isAssetNode, isGroupNode, node]);
+
+  const upstream = Object.keys(assetGraphData.upstream[node.id] ?? {});
+  const downstream = Object.keys(assetGraphData.downstream[node.id] ?? {});
   const elementRef = React.useRef<HTMLDivElement | null>(null);
 
-  const [showDownstream, setShowDownstream] = React.useState(false);
-  const [showUpstream, setShowUpstream] = React.useState(false);
+  const [showDownstreamDialog, setShowDownstreamDialog] = React.useState(false);
+  const [showUpstreamDialog, setShowUpstreamDialog] = React.useState(false);
+
+  function showDownstreamGraph() {
+    const path = JSON.parse(node.id);
+    const newQuery = `\"${path[path.length - 1]}\"*`;
+    const nextOpsQuery = explorerPath.opsQuery.includes(newQuery)
+      ? explorerPath.opsQuery
+      : `${explorerPath.opsQuery} ${newQuery}`;
+    onChangeExplorerPath(
+      {
+        ...explorerPath,
+        opsQuery: nextOpsQuery,
+      },
+      'push',
+    );
+  }
+
+  function showUpstreamGraph() {
+    const path = JSON.parse(node.id);
+    const newQuery = `*\"${path[path.length - 1]}\"`;
+    const nextOpsQuery = explorerPath.opsQuery.includes(newQuery)
+      ? explorerPath.opsQuery
+      : `${explorerPath.opsQuery} ${newQuery}`;
+    onChangeExplorerPath(
+      {
+        ...explorerPath,
+        opsQuery: nextOpsQuery,
+      },
+      'push',
+    );
+  }
+
+  const {onClick, loading, launchpadElement} = useMaterializationAction();
 
   return (
     <>
+      {launchpadElement}
       <UpstreamDownstreamDialog
         title="Downstream assets"
         assets={downstream}
-        assetGraphData={assetGraphData}
-        isOpen={showDownstream}
+        isOpen={showDownstreamDialog}
         close={() => {
-          setShowDownstream(false);
+          setShowDownstreamDialog(false);
         }}
-        selectNode={selectNode}
+        selectNode={(e, id) => {
+          selectNode(e, id);
+        }}
       />
       <UpstreamDownstreamDialog
         title="Upstream assets"
         assets={upstream}
-        assetGraphData={assetGraphData}
-        isOpen={showUpstream}
+        isOpen={showUpstreamDialog}
         close={() => {
-          setShowUpstream(false);
+          setShowUpstreamDialog(false);
         }}
         selectNode={selectNode}
       />
       <Box ref={elementRef} onClick={selectThisNode}>
         <BoxWrapper level={level}>
-          <Box
-            padding={{right: 12, vertical: 2}}
-            flex={{direction: 'row', gap: 2, alignItems: 'center'}}
-          >
-            {downstream.length ? (
+          <Box padding={{right: 12}} flex={{direction: 'row', gap: 2, alignItems: 'center'}}>
+            {!isAssetNode ||
+            (viewType === 'tree' && downstream.filter((id) => assetGraphData.nodes[id]).length) ? (
               <div
                 onClick={(e) => {
                   e.stopPropagation();
@@ -280,49 +513,104 @@ const Node = ({
                 direction: 'row',
                 alignItems: 'center',
                 justifyContent: 'space-between',
-                gap: 12,
+                gap: 6,
                 grow: 1,
                 shrink: 1,
               }}
-              padding={{horizontal: 12, vertical: 8}}
+              padding={{horizontal: 8, vertical: 5 as any}}
               style={{
                 width: '100%',
                 borderRadius: '8px',
                 ...(isSelected ? {background: Colors.LightPurple} : {}),
               }}
             >
-              <MiddleTruncate text={displayName} />
-              {upstream.length || downstream.length ? (
-                <Popover
-                  content={
-                    <Menu>
-                      {upstream.length ? (
-                        <MenuItem
-                          text={`View upstream (${upstream.length})`}
-                          onClick={() => {
-                            setShowUpstream(true);
-                          }}
-                        />
-                      ) : null}
-                      {downstream.length ? (
-                        <MenuItem
-                          text={`View downstream (${downstream.length})`}
-                          onClick={() => {
-                            setShowDownstream(true);
-                          }}
-                        />
-                      ) : null}
-                    </Menu>
-                  }
-                  hoverOpenDelay={100}
-                  hoverCloseDelay={100}
-                  placement="right"
-                  shouldReturnFocusOnClose
+              <div
+                style={{
+                  display: 'grid',
+                  gridTemplateColumns:
+                    isGroupNode || isLocationNode ? 'auto minmax(0, 1fr)' : 'minmax(0, 1fr)',
+                  gap: '6px',
+                }}
+              >
+                {isGroupNode ? <Icon name="asset_group" /> : null}
+                {isLocationNode ? <Icon name="folder_open" /> : null}
+                <MiddleTruncate text={displayName} />
+              </div>
+              {isAssetNode ? (
+                <div
+                  onClick={(e) => {
+                    // stop propagation outside of the popover to prevent parent onClick from being selected
+                    e.stopPropagation();
+                  }}
                 >
-                  <ExpandMore style={{cursor: 'pointer'}}>
-                    <Icon name="expand_more" color={Colors.Gray500} />
-                  </ExpandMore>
-                </Popover>
+                  <Popover
+                    content={
+                      <Menu>
+                        <MenuItem
+                          icon="materialization"
+                          text={
+                            <Box flex={{direction: 'row', alignItems: 'center', gap: 4}}>
+                              <span>Materialize</span>
+                              {loading ? <Spinner purpose="body-text" /> : null}
+                            </Box>
+                          }
+                          onClick={async (e) => {
+                            await showSharedToaster({
+                              intent: 'primary',
+                              message: 'Initiating materialization',
+                              icon: 'materialization',
+                            });
+                            onClick([node.assetKey], e, false);
+                          }}
+                        />
+                        {upstream.length || downstream.length ? <MenuDivider /> : null}
+                        {upstream.length ? (
+                          <MenuItem
+                            text="Select upstream"
+                            icon="panel_show_left"
+                            onClick={() => {
+                              // TODO: Hook up selecting the nodes
+                              showUpstreamGraph();
+                            }}
+                          />
+                        ) : null}
+                        {downstream.length ? (
+                          <MenuItem
+                            text="Select downstream"
+                            icon="panel_show_right"
+                            onClick={() => {
+                              // TODO: Hook up selecting the nodes
+                              showDownstreamGraph();
+                            }}
+                          />
+                        ) : null}
+                        {upstream.length || downstream.length ? <MenuDivider /> : null}
+                        {upstream.length ? (
+                          <MenuItem
+                            text="Show upstream graph"
+                            icon="arrow_back"
+                            onClick={showUpstreamGraph}
+                          />
+                        ) : null}
+                        {downstream.length ? (
+                          <MenuItem
+                            text="Show downstream graph"
+                            icon="arrow_forward"
+                            onClick={showDownstreamGraph}
+                          />
+                        ) : null}
+                      </Menu>
+                    }
+                    hoverOpenDelay={100}
+                    hoverCloseDelay={100}
+                    placement="right"
+                    shouldReturnFocusOnClose
+                  >
+                    <ExpandMore style={{cursor: 'pointer'}}>
+                      <Icon name="expand_more" color={Colors.Gray500} />
+                    </ExpandMore>
+                  </Popover>
+                </div>
               ) : null}
             </GrayOnHoverBox>
           </Box>
@@ -335,14 +623,12 @@ const Node = ({
 const UpstreamDownstreamDialog = ({
   title,
   assets,
-  assetGraphData,
   isOpen,
   close,
   selectNode,
 }: {
   title: string;
   assets: string[];
-  assetGraphData: GraphData;
   isOpen: boolean;
   close: () => void;
   selectNode: (e: React.MouseEvent<any> | React.KeyboardEvent<any>, nodeId: string) => void;
@@ -352,16 +638,14 @@ const UpstreamDownstreamDialog = ({
       <DialogBody>
         <Menu>
           {assets.map((assetId) => {
-            const asset = assetGraphData.nodes[assetId];
-            if (!asset) {
-              return null;
-            }
+            const path = JSON.parse(assetId);
             return (
               <MenuItem
-                text={asset.assetKey.path[asset.assetKey.path.length - 1]}
-                key={asset.id}
+                icon="asset"
+                text={path[path.length - 1]}
+                key={assetId}
                 onClick={(e) => {
-                  selectNode(e, asset.id);
+                  selectNode(e, assetId);
                   close();
                 }}
               />
@@ -383,7 +667,11 @@ const BoxWrapper = ({level, children}: {level: number; children: React.ReactNode
     let sofar = children;
     for (let i = 0; i < level; i++) {
       sofar = (
-        <Box padding={{left: 12}} border={{side: 'left', width: 1, color: Colors.KeylineGray}}>
+        <Box
+          padding={{left: 8}}
+          margin={{left: 8}}
+          border={{side: 'left', width: 1, color: Colors.KeylineGray}}
+        >
           {sofar}
         </Box>
       );
@@ -480,3 +768,17 @@ const GrayOnHoverBox = styled(Box)`
     visibility: hidden;
   }
 `;
+
+const ButtonGroupWrapper = styled.div`
+  > * {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    > * {
+      place-content: center;
+    }
+  }
+`;
+
+function nodeId(node: {path: string; id: string} | {id: string}) {
+  return 'path' in node ? node.path : node.id;
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/Utils.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/Utils.tsx
@@ -261,3 +261,21 @@ export const itemWithAssetKey = (key: {path: string[]}) => {
   const token = tokenForAssetKey(key);
   return (asset: {assetKey: {path: string[]}}) => tokenForAssetKey(asset.assetKey) === token;
 };
+
+export function walkTreeUpwards(
+  nodeId: string,
+  graphData: GraphData,
+  callback: (nodeId: string) => void,
+) {
+  // TODO
+  console.log({nodeId, graphData, callback});
+}
+
+export function walkTreeDownwards(
+  nodeId: string,
+  graphData: GraphData,
+  callback: (nodeId: string) => void,
+) {
+  // TODO
+  console.log({nodeId, graphData, callback});
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeLineageGraph.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeLineageGraph.tsx
@@ -9,7 +9,7 @@ import {AssetGroupNode} from '../asset-graph/AssetGroupNode';
 import {AssetNodeMinimal, AssetNode} from '../asset-graph/AssetNode';
 import {AssetNodeLink} from '../asset-graph/ForeignNode';
 import {GraphData, LiveData, toGraphId} from '../asset-graph/Utils';
-import {SVGViewport} from '../graph/SVGViewport';
+import {DEFAULT_MAX_ZOOM, SVGViewport} from '../graph/SVGViewport';
 import {useAssetLayout} from '../graph/asyncGraphLayout';
 import {AssetKeyInput} from '../graphql/types';
 import {getJSONForKey} from '../hooks/useStateWithStorage';
@@ -64,8 +64,8 @@ export const AssetNodeLineageGraph: React.FC<{
         viewportEl.current?.autocenter(true);
         e.stopPropagation();
       }}
-      maxZoom={1.2}
-      maxAutocenterZoom={1.2}
+      maxZoom={DEFAULT_MAX_ZOOM}
+      maxAutocenterZoom={DEFAULT_MAX_ZOOM}
     >
       {({scale}) => (
         <SVGContainer width={layout.width} height={layout.height}>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsGroupsGlobalGraphRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsGroupsGlobalGraphRoot.tsx
@@ -4,17 +4,17 @@ import * as React from 'react';
 import {useHistory, useParams} from 'react-router-dom';
 
 import {AssetGraphExplorer} from '../asset-graph/AssetGraphExplorer';
+import {AssetGraphExplorerFilters} from '../asset-graph/AssetGraphExplorerFilters';
 import {AssetGraphFetchScope} from '../asset-graph/useAssetGraphData';
 import {AssetLocation} from '../asset-graph/useFindAssetLocation';
 import {AssetGroupSelector} from '../graphql/types';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
-import {RepoFilterButton} from '../instance/RepoFilterButton';
 import {ExplorerPath} from '../pipelines/PipelinePathUtils';
 import {ReloadAllButton} from '../workspace/ReloadAllButton';
 import {WorkspaceContext} from '../workspace/WorkspaceContext';
 
-import {AssetGroupSuggest, buildAssetGroupSelector} from './AssetGroupSuggest';
+import {buildAssetGroupSelector} from './AssetGroupSuggest';
 import {assetDetailsPathForKey} from './assetDetailsPathForKey';
 import {
   globalAssetGraphPathFromString,
@@ -27,7 +27,7 @@ interface AssetGroupRootParams {
 
 export const AssetsGroupsGlobalGraphRoot: React.FC = () => {
   const {0: path} = useParams<AssetGroupRootParams>();
-  const {allRepos, visibleRepos} = React.useContext(WorkspaceContext);
+  const {visibleRepos} = React.useContext(WorkspaceContext);
   const history = useHistory();
 
   const [filters, setFilters] = useQueryPersistedState<{groups: AssetGroupSelector[]}>({
@@ -103,14 +103,14 @@ export const AssetsGroupsGlobalGraphRoot: React.FC = () => {
       <AssetGraphExplorer
         fetchOptions={fetchOptions}
         fetchOptionFilters={
-          <>
-            {allRepos.length > 1 && <RepoFilterButton />}
-            <AssetGroupSuggest
-              assetGroups={assetGroups}
-              value={filters.groups || []}
-              onChange={(groups) => setFilters({...filters, groups})}
-            />
-          </>
+          <AssetGraphExplorerFilters
+            assetGroups={assetGroups}
+            visibleAssetGroups={React.useMemo(() => filters.groups || [], [filters.groups])}
+            setGroupFilters={React.useCallback((groups) => setFilters({...filters, groups}), [
+              filters,
+              setFilters,
+            ])}
+          />
         }
         options={{preferAssetRendering: true, explodeComposites: true}}
         explorerPath={globalAssetGraphPathFromString(path)}

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/OpGraph.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/OpGraph.tsx
@@ -8,7 +8,7 @@ import {OpNameOrPath} from '../ops/OpNameOrPath';
 import {OpEdges} from './OpEdges';
 import {OpNode, OP_NODE_DEFINITION_FRAGMENT, OP_NODE_INVOCATION_FRAGMENT} from './OpNode';
 import {ParentOpNode, SVGLabeledParentRect} from './ParentOpNode';
-import {DETAIL_ZOOM, SVGViewport, SVGViewportInteractor} from './SVGViewport';
+import {DEFAULT_MAX_ZOOM, DETAIL_ZOOM, SVGViewport, SVGViewportInteractor} from './SVGViewport';
 import {OpGraphLayout} from './asyncGraphLayout';
 import {
   Edge,
@@ -199,7 +199,7 @@ export class OpGraph extends React.Component<OpGraphProps> {
       <SVGViewport
         ref={this.viewportEl}
         key={jobName}
-        maxZoom={1.2}
+        maxZoom={DEFAULT_MAX_ZOOM}
         defaultZoom="zoom-to-fit"
         interactor={interactor || SVGViewport.Interactors.PanAndZoom}
         graphWidth={layout.width}

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/SVGViewport.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/SVGViewport.tsx
@@ -50,6 +50,7 @@ export const DETAIL_ZOOM = 0.75;
 const DEFAULT_ZOOM = 0.75;
 const DEFAULT_MAX_AUTOCENTER_ZOOM = 1;
 const DEFAULT_MIN_ZOOM = 0.17;
+export const DEFAULT_MAX_ZOOM = 1.2;
 
 const BUTTON_INCREMENT = 0.05;
 
@@ -433,7 +434,12 @@ export class SVGViewport extends React.Component<SVGViewportProps, SVGViewportSt
   }
 
   public zoomToSVGBox(box: IBounds, animate: boolean, newScale = this.state.scale) {
-    this.zoomToSVGCoords(box.x + box.width / 2, box.y + box.height / 2, animate, newScale);
+    this.zoomToSVGCoords(
+      box.x + box.width / 2,
+      box.y + box.height / 2,
+      animate,
+      newScale === DEFAULT_MIN_ZOOM ? DEFAULT_MAX_ZOOM : newScale,
+    );
   }
 
   public zoomToSVGCoords(x: number, y: number, animate: boolean, scale = this.state.scale) {

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/getLeftNavItemsForOption.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/getLeftNavItemsForOption.tsx
@@ -119,7 +119,7 @@ const Label = styled.div<{$hasIcon: boolean}>`
   white-space: nowrap;
 `;
 
-const LabelTooltipStyles = JSON.stringify({
+export const LabelTooltipStyles = JSON.stringify({
   background: Colors.Gray100,
   filter: `brightness(97%)`,
   color: Colors.Gray900,

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/getLeftNavItemsForOption.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/getLeftNavItemsForOption.tsx
@@ -140,11 +140,18 @@ const TruncatingName = styled.div`
 
 export const TruncatedTextWithFullTextOnHover = React.forwardRef(
   (
-    {text, tooltipStyle, ...rest}: {text: string; tooltipStyle?: string},
+    {
+      text,
+      tooltipStyle,
+      tooltipText,
+      ...rest
+    }:
+      | {text: string; tooltipStyle?: string; tooltipText?: null}
+      | {text: React.ReactNode; tooltipStyle?: string; tooltipText: string},
     ref: React.ForwardedRef<HTMLDivElement>,
   ) => (
     <TruncatingName
-      data-tooltip={text}
+      data-tooltip={tooltipText ?? text}
       data-tooltip-style={tooltipStyle ?? LabelTooltipStyles}
       ref={ref}
       {...rest}

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/FilterDropdown.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/FilterDropdown.tsx
@@ -250,7 +250,7 @@ export const FilterDropdown = ({filters, setIsOpen, setPortaledElements}: Filter
             <Container
               ref={parentRef}
               style={{
-                maxHeight: '500px',
+                maxHeight: `min(500px, 50vh)`,
                 overflowY: 'auto',
                 width: selectedFilter?.menuWidth || 'auto',
               }}


### PR DESCRIPTION
## Summary & Motivation

Consolidate the group and code location filters to use our Filtering component.


## How I Tested These Changes
<img width="335" alt="Screenshot 2023-09-15 at 1 50 53 AM" src="https://github.com/dagster-io/dagster/assets/2286579/88cafb9d-1854-4cc3-90e9-d6dc8b203c03">
<img width="379" alt="Screenshot 2023-09-15 at 1 50 47 AM" src="https://github.com/dagster-io/dagster/assets/2286579/ac918cf6-b0b4-4854-8991-4e48e90a0293">
<img width="289" alt="Screenshot 2023-09-15 at 1 50 45 AM" src="https://github.com/dagster-io/dagster/assets/2286579/12942df9-358a-4ab3-ac7d-cdad1360bcb4">
