### PR TITLE
AssetSpec.asset_key --> AssetSpec.key

### DIFF
--- a/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/domain_specific_dsl/stocks_dsl.py
+++ b/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/domain_specific_dsl/stocks_dsl.py
@@ -77,7 +77,7 @@ def assets_defs_from_stock_assets(stock_assets: StockAssets) -> List[AssetsDefin
     def spec_for_stock_info(stock_info: StockInfo) -> AssetSpec:
         ticker = stock_info.ticker
         return AssetSpec(
-            asset_key=AssetKey(ticker),
+            key=AssetKey(ticker),
             group_name=group_name,
             description=f"Fetch {ticker} from internal service",
         )

--- a/python_modules/dagster/dagster/_core/definitions/asset_dep.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_dep.py
@@ -53,7 +53,7 @@ class AssetDep(
         partition_mapping: Optional[PartitionMapping] = None,
     ):
         if isinstance(asset, AssetSpec):
-            asset_key = asset.asset_key
+            asset_key = asset.key
         else:
             asset_key = AssetKey.from_coercible_or_definition(asset)
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_spec.py
@@ -23,7 +23,7 @@ class AssetSpec(
     NamedTuple(
         "_AssetSpec",
         [
-            ("asset_key", PublicAttr[AssetKey]),
+            ("key", PublicAttr[AssetKey]),
             ("deps", PublicAttr[Iterable["AssetDep"]]),
             ("description", PublicAttr[Optional[str]]),
             ("metadata", PublicAttr[Optional[Mapping[str, Any]]]),
@@ -39,7 +39,7 @@ class AssetSpec(
     function that defines how it materialized.
 
     Attributes:
-        asset_key (AssetKey): The unique identifier for this asset.
+        key (AssetKey): The unique identifier for this asset.
         deps (Optional[AbstractSet[AssetKey]]): The asset keys for the upstream assets that
             materializing this asset depends on.
         description (Optional[str]): Human-readable description of this asset.
@@ -61,7 +61,7 @@ class AssetSpec(
 
     def __new__(
         cls,
-        asset_key: CoercibleToAssetKey,
+        key: CoercibleToAssetKey,
         *,
         deps: Optional[
             Iterable[
@@ -92,13 +92,13 @@ class AssetSpec(
                 if asset_dep.asset_key in dep_set.keys():
                     raise DagsterInvariantViolationError(
                         f"Cannot set a dependency on asset {asset_dep.asset_key} more than once for"
-                        f" AssetSpec {asset_key}"
+                        f" AssetSpec {key}"
                     )
                 dep_set[asset_dep.asset_key] = asset_dep
 
         return super().__new__(
             cls,
-            asset_key=AssetKey.from_coercible(asset_key),
+            key=AssetKey.from_coercible(key),
             deps=list(dep_set.values()),
             description=check.opt_str_param(description, "description"),
             metadata=check.opt_mapping_param(metadata, "metadata", key_type=str),

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -603,8 +603,8 @@ def multi_asset(
             output_tuples_by_asset_key = {}
             for asset_spec in specs:
                 # output names are asset keys joined with _
-                output_name = "_".join(asset_spec.asset_key.path)
-                output_tuples_by_asset_key[asset_spec.asset_key] = (
+                output_name = "_".join(asset_spec.key.path)
+                output_tuples_by_asset_key[asset_spec.key] = (
                     output_name,
                     Out(
                         Nothing,
@@ -730,12 +730,12 @@ def multi_asset(
 
         if specs:
             internal_deps = {
-                spec.asset_key: {dep.asset_key for dep in spec.deps}
+                spec.key: {dep.asset_key for dep in spec.deps}
                 for spec in specs
                 if spec.deps is not None
             }
             props_by_asset_key: Mapping[AssetKey, Union[AssetSpec, AssetOut]] = {
-                spec.asset_key: spec for spec in specs
+                spec.key: spec for spec in specs
             }
             # Add PartitionMappings specified via AssetSpec.deps to partition_mappings dictionary. Error on duplicates
             for spec in specs:

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_asset_partition_mappings.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_asset_partition_mappings.py
@@ -574,13 +574,13 @@ def test_identity_partition_mapping():
 
 
 def test_partition_mapping_with_asset_deps():
-    asset_1 = AssetSpec(asset_key="asset_1")
-    asset_2 = AssetSpec(asset_key="asset_2")
+    asset_1 = AssetSpec(key="asset_1")
+    asset_2 = AssetSpec(key="asset_2")
 
     asset_1_partition_mapping = TimeWindowPartitionMapping(start_offset=-1, end_offset=-1)
     asset_2_partition_mapping = TimeWindowPartitionMapping(start_offset=-2, end_offset=-2)
     asset_3 = AssetSpec(
-        asset_key="asset_3",
+        key="asset_3",
         deps=[
             AssetDep(
                 asset=asset_1,
@@ -593,7 +593,7 @@ def test_partition_mapping_with_asset_deps():
         ],
     )
     asset_4 = AssetSpec(
-        asset_key="asset_4",
+        key="asset_4",
         deps=[
             AssetDep(
                 asset=asset_1,
@@ -639,13 +639,13 @@ def test_partition_mapping_with_asset_deps():
 
 
 def test_conflicting_mappings_with_asset_deps():
-    asset_1 = AssetSpec(asset_key="asset_1")
-    asset_2 = AssetSpec(asset_key="asset_2")
+    asset_1 = AssetSpec(key="asset_1")
+    asset_2 = AssetSpec(key="asset_2")
 
     asset_1_partition_mapping = TimeWindowPartitionMapping(start_offset=-1, end_offset=-1)
     asset_2_partition_mapping = TimeWindowPartitionMapping(start_offset=-2, end_offset=-2)
     asset_3 = AssetSpec(
-        asset_key="asset_3",
+        key="asset_3",
         deps=[
             AssetDep(
                 asset=asset_1,
@@ -658,7 +658,7 @@ def test_conflicting_mappings_with_asset_deps():
         ],
     )
     asset_4 = AssetSpec(
-        asset_key="asset_4",
+        key="asset_4",
         deps=[
             AssetDep(
                 asset=asset_1,
@@ -684,7 +684,7 @@ def test_conflicting_mappings_with_asset_deps():
 
 def test_self_dependent_partition_mapping_with_asset_deps():
     asset_1 = AssetSpec(
-        asset_key="asset_1",
+        key="asset_1",
         deps=[
             AssetDep(
                 asset="asset_1",
@@ -710,10 +710,10 @@ def test_dynamic_partition_mapping_with_asset_deps():
     partitions_def = DynamicPartitionsDefinition(name="fruits")
 
     asset_1 = AssetSpec(
-        asset_key="asset_1",
+        key="asset_1",
     )
     asset_2 = AssetSpec(
-        asset_key="asset_2",
+        key="asset_2",
         deps=[
             AssetDep(
                 asset=asset_1,

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_multipartition_partition_mapping.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_multipartition_partition_mapping.py
@@ -730,8 +730,8 @@ def test_error_multipartitions_mapping():
 
 
 def test_multi_partition_mapping_with_asset_deps():
-    asset_1 = AssetSpec(asset_key="asset_1")
-    asset_2 = AssetSpec(asset_key="asset_2")
+    asset_1 = AssetSpec(key="asset_1")
+    asset_2 = AssetSpec(key="asset_2")
 
     asset_1_partition_mapping = MultiPartitionMapping(
         {
@@ -759,7 +759,7 @@ def test_multi_partition_mapping_with_asset_deps():
     )
 
     asset_3 = AssetSpec(
-        asset_key="asset_3",
+        key="asset_3",
         deps=[
             AssetDep(
                 asset=asset_1,
@@ -772,7 +772,7 @@ def test_multi_partition_mapping_with_asset_deps():
         ],
     )
     asset_4 = AssetSpec(
-        asset_key="asset_4",
+        key="asset_4",
         deps=[
             AssetDep(
                 asset=asset_1,

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -1867,8 +1867,8 @@ def test_multi_asset_no_out():
         pass
 
     _exec_asset(basic_deps)
-    assert table_A.asset_key in basic_deps.asset_deps[table_C.asset_key]
-    assert table_B.asset_key in basic_deps.asset_deps[table_C.asset_key]
+    assert table_A.key in basic_deps.asset_deps[table_C.key]
+    assert table_B.key in basic_deps.asset_deps[table_C.key]
 
     result = basic_deps()
     assert result is None
@@ -1885,8 +1885,8 @@ def test_multi_asset_no_out():
             yield MaterializeResult(asset_key=key)
 
     mats = _exec_asset(basic_subset, ["table_A"])
-    assert table_A.asset_key in {mat.asset_key for mat in mats}
-    assert table_B.asset_key not in {mat.asset_key for mat in mats}
+    assert table_A.key in {mat.asset_key for mat in mats}
+    assert table_B.key not in {mat.asset_key for mat in mats}
 
     # selected_asset_keys breaks direct invocation
     # basic_subset(build_asset_context())
@@ -1901,8 +1901,8 @@ def test_multi_asset_no_out():
         yield MaterializeResult(asset_key="table_A")
 
     mats = _exec_asset(basic_optional)
-    assert table_A.asset_key in {mat.asset_key for mat in mats}
-    assert table_B.asset_key not in {mat.asset_key for mat in mats}
+    assert table_A.key in {mat.asset_key for mat in mats}
+    assert table_B.key not in {mat.asset_key for mat in mats}
 
     basic_optional(build_asset_context())
 
@@ -2050,7 +2050,7 @@ def test_multi_asset_asset_key_on_context():
 
     # test with AssetSpecs
 
-    spec1 = AssetSpec(asset_key="spec1")
+    spec1 = AssetSpec(key="spec1")
 
     @multi_asset(specs=[spec1])
     def asset_key_context_with_specs(context: AssetExecutionContext):
@@ -2058,8 +2058,8 @@ def test_multi_asset_asset_key_on_context():
 
     materialize([asset_key_context_with_specs])
 
-    spec2 = AssetSpec(asset_key="spec2")
-    spec3 = AssetSpec(asset_key="spec3")
+    spec2 = AssetSpec(key="spec2")
+    spec3 = AssetSpec(key="spec3")
 
     @multi_asset(specs=[spec2, spec3])
     def asset_key_context_with_two_specs(context: AssetExecutionContext):


### PR DESCRIPTION
## Summary & Motivation

A discussion in our internal slack with @johannkm and @jamiedemaria––as well as on the ground coding––has convinced me that going to `asset_key` in `AssetSpec` was a mistake. This PR proposes to change `AssetSpec.asset_key` to `AssetSpec.key`.

This is consistent with `AssetsDefinition` and avoids a lot of code that looks like `asset.asset_key` which does not feel great.



## How I Tested These Changes
