### PR TITLE
[ui] Read canExecuteIndividually for asset check execute button

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/SidebarAssetInfo.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/SidebarAssetInfo.tsx
@@ -17,6 +17,7 @@ import {DependsOnSelfBanner} from '../assets/DependsOnSelfBanner';
 import {PartitionHealthSummary} from '../assets/PartitionHealthSummary';
 import {UnderlyingOpsOrGraph} from '../assets/UnderlyingOpsOrGraph';
 import {Version} from '../assets/Version';
+import {EXECUTE_CHECKS_BUTTON_ASSET_NODE_FRAGMENT} from '../assets/asset-checks/ExecuteChecksButton';
 import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
 import {
   healthRefreshHintFromLiveData,
@@ -233,7 +234,6 @@ const SIDEBAR_ASSET_FRAGMENT = gql`
   fragment SidebarAssetFragment on AssetNode {
     id
     description
-    ...AssetNodeConfigFragment
     metadataEntries {
       ...MetadataEntryFragment
     }
@@ -276,12 +276,15 @@ const SIDEBAR_ASSET_FRAGMENT = gql`
       resourceKey
     }
 
+    ...AssetNodeConfigFragment
     ...AssetNodeOpMetadataFragment
+    ...ExecuteChecksButtonAssetNodeFragment
   }
 
   ${ASSET_NODE_CONFIG_FRAGMENT}
   ${METADATA_ENTRY_FRAGMENT}
   ${ASSET_NODE_OP_METADATA_FRAGMENT}
+  ${EXECUTE_CHECKS_BUTTON_ASSET_NODE_FRAGMENT}
 `;
 
 export const SIDEBAR_ASSET_QUERY = gql`

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/Utils.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/Utils.tsx
@@ -1,22 +1,15 @@
-import {pathVerticalDiagonal, pathHorizontalDiagonal} from '@vx/shape';
+import {pathHorizontalDiagonal, pathVerticalDiagonal} from '@vx/shape';
 
 import {featureEnabled, FeatureFlag} from '../app/Flags';
 import {COMMON_COLLATOR} from '../app/Util';
-import {
-  AssetCheckExecutionResolvedStatus,
-  AssetCheckSeverity,
-  Maybe,
-  RunStatus,
-  StaleCauseCategory,
-  StaleStatus,
-} from '../graphql/types';
+import {RunStatus, StaleStatus} from '../graphql/types';
 
 import {AssetNodeKeyFragment} from './types/AssetNode.types';
 import {AssetNodeForGraphQueryFragment} from './types/useAssetGraphData.types';
 import {
+  AssetGraphLiveQuery,
   AssetLatestInfoFragment,
   AssetLatestInfoRunFragment,
-  AssetGraphLiveQuery,
   AssetNodeLiveFragment,
   AssetNodeLiveFreshnessInfoFragment,
   AssetNodeLiveMaterializationFragment,
@@ -147,28 +140,14 @@ export interface LiveDataForNode {
   freshnessInfo: AssetNodeLiveFreshnessInfoFragment | null;
   lastObservation: AssetNodeLiveObservationFragment | null;
   staleStatus: StaleStatus | null;
-  staleCauses: {
-    dependency: Maybe<AssetKey>;
-    category: StaleCauseCategory;
-    key: AssetKey;
-    reason: string;
-  }[];
+  staleCauses: AssetGraphLiveQuery['assetNodes'][0]['staleCauses'];
+  assetChecks: AssetGraphLiveQuery['assetNodes'][0]['assetChecks'];
   partitionStats: {
     numMaterialized: number;
     numMaterializing: number;
     numPartitions: number;
     numFailed: number;
   } | null;
-  assetChecks: {
-    name: string;
-    executionForLatestMaterialization: {
-      runId: string;
-      status: AssetCheckExecutionResolvedStatus;
-      evaluation: {
-        severity: AssetCheckSeverity;
-      } | null;
-    } | null;
-  }[];
 }
 
 export const MISSING_LIVE_DATA: LiveDataForNode = {

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__fixtures__/AssetNode.fixtures.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__fixtures__/AssetNode.fixtures.ts
@@ -5,6 +5,9 @@ import {
   StaleCauseCategory,
   AssetCheckSeverity,
   AssetCheckExecutionResolvedStatus,
+  buildAssetCheckExecution,
+  buildAssetCheckEvaluation,
+  buildAssetCheck,
 } from '../../graphql/types';
 import {LiveDataForNode} from '../Utils';
 import {AssetNodeFragment} from '../types/AssetNode.types';
@@ -177,56 +180,56 @@ export const LiveDataForNodeMaterializedWithChecks: LiveDataForNode = {
   staleStatus: StaleStatus.FRESH,
   staleCauses: [],
   assetChecks: [
-    {
+    buildAssetCheck({
       name: 'check_1',
-      executionForLatestMaterialization: {
+      executionForLatestMaterialization: buildAssetCheckExecution({
         runId: '1234',
         status: AssetCheckExecutionResolvedStatus.FAILED,
-        evaluation: {
+        evaluation: buildAssetCheckEvaluation({
           severity: AssetCheckSeverity.WARN,
-        },
-      },
-    },
-    {
+        }),
+      }),
+    }),
+    buildAssetCheck({
       name: 'check_2',
-      executionForLatestMaterialization: {
+      executionForLatestMaterialization: buildAssetCheckExecution({
         runId: '1234',
         status: AssetCheckExecutionResolvedStatus.FAILED,
-        evaluation: {
+        evaluation: buildAssetCheckEvaluation({
           severity: AssetCheckSeverity.ERROR,
-        },
-      },
-    },
-    {
+        }),
+      }),
+    }),
+    buildAssetCheck({
       name: 'check_3',
-      executionForLatestMaterialization: {
+      executionForLatestMaterialization: buildAssetCheckExecution({
         runId: '1234',
         status: AssetCheckExecutionResolvedStatus.IN_PROGRESS,
-        evaluation: {
+        evaluation: buildAssetCheckEvaluation({
           severity: AssetCheckSeverity.WARN,
-        },
-      },
-    },
-    {
+        }),
+      }),
+    }),
+    buildAssetCheck({
       name: 'check_4',
-      executionForLatestMaterialization: {
+      executionForLatestMaterialization: buildAssetCheckExecution({
         runId: '1234',
         status: AssetCheckExecutionResolvedStatus.SKIPPED,
-        evaluation: {
+        evaluation: buildAssetCheckEvaluation({
           severity: AssetCheckSeverity.WARN,
-        },
-      },
-    },
-    {
+        }),
+      }),
+    }),
+    buildAssetCheck({
       name: 'check_5',
-      executionForLatestMaterialization: {
+      executionForLatestMaterialization: buildAssetCheckExecution({
         runId: '1234',
         status: AssetCheckExecutionResolvedStatus.SUCCEEDED,
-        evaluation: {
+        evaluation: buildAssetCheckEvaluation({
           severity: AssetCheckSeverity.WARN,
-        },
-      },
-    },
+        }),
+      }),
+    }),
   ],
   freshnessInfo: null,
   partitionStats: null,

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/types/useLiveDataForAssetKeys.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/types/useLiveDataForAssetKeys.types.ts
@@ -38,6 +38,7 @@ export type AssetNodeLiveFragment = {
   assetChecks: Array<{
     __typename: 'AssetCheck';
     name: string;
+    canExecuteIndividually: Types.AssetCheckCanExecuteIndividually;
     executionForLatestMaterialization: {
       __typename: 'AssetCheckExecution';
       id: string;
@@ -102,6 +103,7 @@ export type AssetGraphLiveQuery = {
     assetChecks: Array<{
       __typename: 'AssetCheck';
       name: string;
+      canExecuteIndividually: Types.AssetCheckCanExecuteIndividually;
       executionForLatestMaterialization: {
         __typename: 'AssetCheckExecution';
         id: string;

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useLiveDataForAssetKeys.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useLiveDataForAssetKeys.tsx
@@ -178,6 +178,7 @@ const ASSET_NODE_LIVE_FRAGMENT = gql`
     }
     assetChecks {
       name
+      canExecuteIndividually
       executionForLatestMaterialization {
         id
         runId

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetSidebarActivitySummary.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetSidebarActivitySummary.tsx
@@ -1,4 +1,4 @@
-import {Body, Box, Colors, Icon, Spinner, Table} from '@dagster-io/ui-components';
+import {Body, Box, Colors, Icon, MiddleTruncate, Spinner} from '@dagster-io/ui-components';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
 
@@ -17,7 +17,7 @@ import {FailedRunSinceMaterializationBanner} from './FailedRunSinceMaterializati
 import {LatestMaterializationMetadata} from './LastMaterializationMetadata';
 import {OverdueTag, freshnessPolicyDescription} from './OverdueTag';
 import {AssetCheckStatusTag} from './asset-checks/AssetCheckStatusTag';
-import {ExexcuteChecksButton} from './asset-checks/ExecuteChecksButton';
+import {ExecuteChecksButton} from './asset-checks/ExecuteChecksButton';
 import {assetDetailsPathForKey} from './assetDetailsPathForKey';
 import {useGroupedEvents} from './groupByPartition';
 import {useRecentAssetEvents} from './useRecentAssetEvents';
@@ -166,27 +166,31 @@ export const AssetSidebarActivitySummary: React.FC<Props> = ({
       {liveData && liveData.assetChecks.length > 0 && (
         <SidebarSection title="Checks">
           <Box padding={{horizontal: 24, vertical: 12}} flex={{gap: 12, alignItems: 'center'}}>
-            <ExexcuteChecksButton assetNode={asset} checks={liveData.assetChecks} />
+            <ExecuteChecksButton assetNode={asset} checks={liveData.assetChecks} />
             <Link to={assetDetailsPathForKey(asset.assetKey, {view: 'checks'})}>
               View all check details
             </Link>
           </Box>
 
-          <Table $compact>
-            <tbody>
-              {liveData.assetChecks.map((check) => (
-                <tr key={check.name}>
-                  <td style={{paddingLeft: 24}}>{check.name}</td>
-                  <td>
-                    <AssetCheckStatusTag
-                      check={check}
-                      execution={check.executionForLatestMaterialization}
-                    />
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </Table>
+          {liveData.assetChecks.map((check) => (
+            <Box
+              key={check.name}
+              border={{side: 'top', width: 1, color: Colors.KeylineGray}}
+              padding={{vertical: 8, right: 12, left: 24}}
+              flex={{
+                gap: 8,
+                direction: 'row',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+              }}
+            >
+              <MiddleTruncate text={`${check.name}`} />
+              <AssetCheckStatusTag
+                check={check}
+                execution={check.executionForLatestMaterialization}
+              />
+            </Box>
+          ))}
         </SidebarSection>
       )}
     </>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetChecks.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetChecks.tsx
@@ -11,14 +11,13 @@ import {AssetFeatureContext} from '../AssetFeatureContext';
 import {assetDetailsPathForKey} from '../assetDetailsPathForKey';
 import {AssetKey} from '../types';
 
+import {AssetCheckDetailModal, MigrationRequired, NoChecks} from './AssetCheckDetailModal';
 import {
-  ASSET_CHECK_EXECUTION_FRAGMENT,
-  AssetCheckDetailModal,
-  MigrationRequired,
-  NoChecks,
-} from './AssetCheckDetailModal';
-import {ExexcuteChecksButton} from './ExecuteChecksButton';
-import {VirtualizedAssetCheckTable} from './VirtualizedAssetCheckTable';
+  EXECUTE_CHECKS_BUTTON_ASSET_NODE_FRAGMENT,
+  EXECUTE_CHECKS_BUTTON_CHECK_FRAGMENT,
+  ExecuteChecksButton,
+} from './ExecuteChecksButton';
+import {ASSET_CHECK_TABLE_FRAGMENT, VirtualizedAssetCheckTable} from './VirtualizedAssetCheckTable';
 import {AssetChecksQuery, AssetChecksQueryVariables} from './types/AssetChecks.types';
 
 export const AssetChecks = ({
@@ -63,7 +62,7 @@ export const AssetChecks = ({
     if (checksOrError?.__typename !== 'AssetChecks' || assetNode?.__typename !== 'AssetNode') {
       return <span />;
     }
-    return <ExexcuteChecksButton assetNode={assetNode} checks={checksOrError.checks} />;
+    return <ExecuteChecksButton assetNode={assetNode} checks={checksOrError.checks} />;
   }
 
   const {AssetChecksBanner} = useContext(AssetFeatureContext);
@@ -115,18 +114,7 @@ export const ASSET_CHECKS_QUERY = gql`
     assetNodeOrError(assetKey: $assetKey) {
       ... on AssetNode {
         id
-        jobNames
-        assetKey {
-          path
-        }
-        repository {
-          id
-          name
-          location {
-            id
-            name
-          }
-        }
+        ...ExecuteChecksButtonAssetNodeFragment
       }
     }
     assetChecksOrError(assetKey: $assetKey) {
@@ -135,14 +123,13 @@ export const ASSET_CHECKS_QUERY = gql`
       }
       ... on AssetChecks {
         checks {
-          name
-          description
-          executionForLatestMaterialization {
-            ...AssetCheckExecutionFragment
-          }
+          ...AssetCheckTableFragment
+          ...ExecuteChecksButtonCheckFragment
         }
       }
     }
   }
-  ${ASSET_CHECK_EXECUTION_FRAGMENT}
+  ${EXECUTE_CHECKS_BUTTON_ASSET_NODE_FRAGMENT}
+  ${EXECUTE_CHECKS_BUTTON_CHECK_FRAGMENT}
+  ${ASSET_CHECK_TABLE_FRAGMENT}
 `;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/VirtualizedAssetCheckTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/VirtualizedAssetCheckTable.tsx
@@ -1,3 +1,4 @@
+import {gql} from '@apollo/client';
 import {Body2, Box, Caption, Colors} from '@dagster-io/ui-components';
 import {useVirtualizer} from '@tanstack/react-virtual';
 import * as React from 'react';
@@ -9,19 +10,15 @@ import {testId} from '../../testing/testId';
 import {HeaderCell, Row, RowCell, Container, Inner} from '../../ui/VirtualizedTable';
 import {assetDetailsPathForAssetCheck} from '../assetDetailsPathForKey';
 
-import {MetadataCell} from './AssetCheckDetailModal';
+import {ASSET_CHECK_EXECUTION_FRAGMENT, MetadataCell} from './AssetCheckDetailModal';
 import {AssetCheckStatusTag} from './AssetCheckStatusTag';
-import {EvaluateChecksAssetNode, ExexcuteChecksButton} from './ExecuteChecksButton';
-import {AssetChecksQuery} from './types/AssetChecks.types';
-
-type Check = Extract<
-  AssetChecksQuery['assetChecksOrError'],
-  {__typename: 'AssetChecks'}
->['checks'][0];
+import {ExecuteChecksButton} from './ExecuteChecksButton';
+import {ExecuteChecksButtonAssetNodeFragment} from './types/ExecuteChecksButton.types';
+import {AssetCheckTableFragment} from './types/VirtualizedAssetCheckTable.types';
 
 type Props = {
-  assetNode: EvaluateChecksAssetNode;
-  rows: Check[];
+  assetNode: ExecuteChecksButtonAssetNodeFragment;
+  rows: AssetCheckTableFragment[];
 };
 
 export const VirtualizedAssetCheckTable: React.FC<Props> = ({assetNode, rows}: Props) => {
@@ -44,7 +41,7 @@ export const VirtualizedAssetCheckTable: React.FC<Props> = ({assetNode, rows}: P
         <VirtualizedAssetCheckHeader />
         <Inner $totalHeight={totalHeight}>
           {items.map(({index, key, size, start}) => {
-            const row: Check = rows[index]!;
+            const row: AssetCheckTableFragment = rows[index]!;
             return (
               <VirtualizedAssetCheckRow
                 assetNode={assetNode}
@@ -61,13 +58,13 @@ export const VirtualizedAssetCheckTable: React.FC<Props> = ({assetNode, rows}: P
   );
 };
 
-const TEMPLATE_COLUMNS = '2fr 150px 1fr 1fr 140px';
+const TEMPLATE_COLUMNS = '2fr 150px 1fr 1.5fr 120px';
 
 interface AssetCheckRowProps {
-  assetNode: EvaluateChecksAssetNode;
+  row: AssetCheckTableFragment;
+  assetNode: ExecuteChecksButtonAssetNodeFragment;
   height: number;
   start: number;
-  row: Check;
 }
 
 export const VirtualizedAssetCheckRow = ({assetNode, height, start, row}: AssetCheckRowProps) => {
@@ -106,7 +103,7 @@ export const VirtualizedAssetCheckRow = ({assetNode, height, start, row}: AssetC
         </RowCell>
         <RowCell>
           <Box flex={{justifyContent: 'flex-end'}}>
-            <ExexcuteChecksButton
+            <ExecuteChecksButton
               assetNode={assetNode}
               checks={[row]}
               label="Execute"
@@ -151,4 +148,16 @@ const RowGrid = styled(Box)`
   display: grid;
   grid-template-columns: ${TEMPLATE_COLUMNS};
   height: 100%;
+`;
+
+export const ASSET_CHECK_TABLE_FRAGMENT = gql`
+  fragment AssetCheckTableFragment on AssetCheck {
+    name
+    description
+    canExecuteIndividually
+    executionForLatestMaterialization {
+      ...AssetCheckExecutionFragment
+    }
+  }
+  ${ASSET_CHECK_EXECUTION_FRAGMENT}
 `;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/types/AssetChecks.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/types/AssetChecks.types.ts
@@ -30,6 +30,7 @@ export type AssetChecksQuery = {
           __typename: 'AssetCheck';
           name: string;
           description: string | null;
+          canExecuteIndividually: Types.AssetCheckCanExecuteIndividually;
           executionForLatestMaterialization: {
             __typename: 'AssetCheckExecution';
             id: string;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/types/ExecuteChecksButton.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/types/ExecuteChecksButton.types.ts
@@ -1,0 +1,22 @@
+// Generated GraphQL types, do not edit manually.
+
+import * as Types from '../../../graphql/types';
+
+export type ExecuteChecksButtonCheckFragment = {
+  __typename: 'AssetCheck';
+  name: string;
+  canExecuteIndividually: Types.AssetCheckCanExecuteIndividually;
+};
+
+export type ExecuteChecksButtonAssetNodeFragment = {
+  __typename: 'AssetNode';
+  id: string;
+  jobNames: Array<string>;
+  assetKey: {__typename: 'AssetKey'; path: Array<string>};
+  repository: {
+    __typename: 'Repository';
+    id: string;
+    name: string;
+    location: {__typename: 'RepositoryLocation'; id: string; name: string};
+  };
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/types/VirtualizedAssetCheckTable.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/types/VirtualizedAssetCheckTable.types.ts
@@ -1,0 +1,134 @@
+// Generated GraphQL types, do not edit manually.
+
+import * as Types from '../../../graphql/types';
+
+export type AssetCheckTableFragment = {
+  __typename: 'AssetCheck';
+  name: string;
+  description: string | null;
+  canExecuteIndividually: Types.AssetCheckCanExecuteIndividually;
+  executionForLatestMaterialization: {
+    __typename: 'AssetCheckExecution';
+    id: string;
+    runId: string;
+    status: Types.AssetCheckExecutionResolvedStatus;
+    evaluation: {
+      __typename: 'AssetCheckEvaluation';
+      severity: Types.AssetCheckSeverity;
+      timestamp: number;
+      targetMaterialization: {
+        __typename: 'AssetCheckEvaluationTargetMaterializationData';
+        timestamp: number;
+        runId: string;
+      } | null;
+      metadataEntries: Array<
+        | {
+            __typename: 'AssetMetadataEntry';
+            label: string;
+            description: string | null;
+            assetKey: {__typename: 'AssetKey'; path: Array<string>};
+          }
+        | {
+            __typename: 'BoolMetadataEntry';
+            boolValue: boolean | null;
+            label: string;
+            description: string | null;
+          }
+        | {
+            __typename: 'FloatMetadataEntry';
+            floatValue: number | null;
+            label: string;
+            description: string | null;
+          }
+        | {
+            __typename: 'IntMetadataEntry';
+            intValue: number | null;
+            intRepr: string;
+            label: string;
+            description: string | null;
+          }
+        | {
+            __typename: 'JsonMetadataEntry';
+            jsonString: string;
+            label: string;
+            description: string | null;
+          }
+        | {
+            __typename: 'MarkdownMetadataEntry';
+            mdStr: string;
+            label: string;
+            description: string | null;
+          }
+        | {
+            __typename: 'NotebookMetadataEntry';
+            path: string;
+            label: string;
+            description: string | null;
+          }
+        | {__typename: 'NullMetadataEntry'; label: string; description: string | null}
+        | {__typename: 'PathMetadataEntry'; path: string; label: string; description: string | null}
+        | {
+            __typename: 'PipelineRunMetadataEntry';
+            runId: string;
+            label: string;
+            description: string | null;
+          }
+        | {
+            __typename: 'PythonArtifactMetadataEntry';
+            module: string;
+            name: string;
+            label: string;
+            description: string | null;
+          }
+        | {
+            __typename: 'TableMetadataEntry';
+            label: string;
+            description: string | null;
+            table: {
+              __typename: 'Table';
+              records: Array<string>;
+              schema: {
+                __typename: 'TableSchema';
+                columns: Array<{
+                  __typename: 'TableColumn';
+                  name: string;
+                  description: string | null;
+                  type: string;
+                  constraints: {
+                    __typename: 'TableColumnConstraints';
+                    nullable: boolean;
+                    unique: boolean;
+                    other: Array<string>;
+                  };
+                }>;
+                constraints: {__typename: 'TableConstraints'; other: Array<string>} | null;
+              };
+            };
+          }
+        | {
+            __typename: 'TableSchemaMetadataEntry';
+            label: string;
+            description: string | null;
+            schema: {
+              __typename: 'TableSchema';
+              columns: Array<{
+                __typename: 'TableColumn';
+                name: string;
+                description: string | null;
+                type: string;
+                constraints: {
+                  __typename: 'TableColumnConstraints';
+                  nullable: boolean;
+                  unique: boolean;
+                  other: Array<string>;
+                };
+              }>;
+              constraints: {__typename: 'TableConstraints'; other: Array<string>} | null;
+            };
+          }
+        | {__typename: 'TextMetadataEntry'; text: string; label: string; description: string | null}
+        | {__typename: 'UrlMetadataEntry'; url: string; label: string; description: string | null}
+      >;
+    } | null;
+  } | null;
+};


### PR DESCRIPTION
## Summary & Motivation

This PR reads the new `canExecuteIndividually` value from ticks and disables the "Execute" button as necessary.

I also changed the rendering of the checks in the asset sidebar slightly so that they can middle truncate, and so that the status tags are right justified so they don't move left/right slightly as you switch between assets. 

Note: If an asset hypothetically had one executable check and one non-executable check, the Execute All button is still shown but only executes the one that it can. I think that is ok because you can see on the checks page that some of the execute buttons are disabled (and also may not be a real scenario?)

## How I Tested These Changes

I updated the stories to include the disabled state so I could see this scenario.

<img width="620" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/df80de28-e7cf-4bc7-a318-a49b148f5ac6">

<img width="1140" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/423a3fa4-0af2-4438-9f64-3a0262266a6c">

