### PR TITLE
[docs] [tutorial] Fixed type-hinting for DataGenerator resource

### DIFF
--- a/docs/content/tutorial/connecting-to-external-services.mdx
+++ b/docs/content/tutorial/connecting-to-external-services.mdx
@@ -93,6 +93,11 @@ In your `assets.py`, make a new asset called `signups`. In this asset, you'll us
 Copy and paste the code below into the appropriate sections of your `asset.py`.
 
 ```python file=/tutorial/connecting/assets.py startafter=start_add_signsup_asset endbefore=end_add_signsup_asset
+from dagster import (
+    # ... existing imports
+    ResourceParam, # Update the imports at the top to include this
+)
+
 from .resources import DataGeneratorResource
 
 # ...
@@ -100,7 +105,7 @@ from .resources import DataGeneratorResource
 
 @asset
 def signups(
-    context: AssetExecutionContext, hackernews_api: DataGeneratorResource
+    context: AssetExecutionContext, hackernews_api: ResourceParam[DataGeneratorResource]
 ) -> pd.DataFrame:
     signups = pd.DataFrame(hackernews_api.get_signups())
 


### PR DESCRIPTION
## Summary & Motivation

Following the tutorial part 7 on external resources gives the following error when using a resource in the signups asset:

    dagster._core.errors.DagsterInvalidDefinitionError: Input asset '["hackernews_api"]' for asset '["signups"]' is not produced by any of the provided asset ops and is not one of the provided sources

It seems the issue is the type-hinting on the resource to the asset, which should be typed as `ResourceParam`

## How I Tested These Changes

These are documentation changes but I was able to complete the tutorial with this change.