### PR TITLE
Extending schema to include policy ID

### DIFF
--- a/python_modules/libraries/dagster-databricks/dagster_databricks/configs.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/configs.py
@@ -451,9 +451,11 @@ def _define_new_cluster() -> Field:
         ),
         is_required=False,
     )
-    policy_id = Field(String,
-                      description="The ID of the cluster policy used to create the cluster if applicable",
-                      is_required=False)
+    policy_id = Field(
+        String,
+        description="The ID of the cluster policy used to create the cluster if applicable",
+        is_required=False,
+    )
 
     return Field(
         Shape(
@@ -469,7 +471,7 @@ def _define_new_cluster() -> Field:
                 "init_scripts": init_scripts,
                 "spark_env_vars": spark_env_vars,
                 "enable_elastic_disk": enable_elastic_disk,
-                "policy_id": policy_id
+                "policy_id": policy_id,
             }
         )
     )

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/configs.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/configs.py
@@ -451,6 +451,9 @@ def _define_new_cluster() -> Field:
         ),
         is_required=False,
     )
+    policy_id = Field(String,
+                      description="The ID of the cluster policy used to create the cluster if applicable",
+                      is_required=False)
 
     return Field(
         Shape(
@@ -466,6 +469,7 @@ def _define_new_cluster() -> Field:
                 "init_scripts": init_scripts,
                 "spark_env_vars": spark_env_vars,
                 "enable_elastic_disk": enable_elastic_disk,
+                "policy_id": policy_id
             }
         )
     )


### PR DESCRIPTION
## Summary & Motivation
Retry of [this PR](https://github.com/dagster-io/dagster/pull/16322) where I think I messed up the git history when I was rebasing master onto my branch
Policy IDs help enforce what configuration values a cluster is allowed to have and help enforce consistency across an organization. Enabling this will allow users to take advantage of this feature.

## How I Tested These Changes
Spun up a local test environment with the changed library installed via wheel build and ran a test job using the step launcher with a policy ID attached to the cluster.
