### PR TITLE
Move asset source resolution out of build_asset_job

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -840,12 +840,17 @@ def build_asset_selection_job(
             )
 
     if len(included_assets) or len(included_checks) > 0:
+        resolved_source_assets: List[SourceAsset] = []
+        for asset in excluded_assets:
+            resolved_source_assets += asset.to_source_assets()
+
         asset_job = build_assets_job(
             name=name,
             assets=included_assets,
             asset_checks=included_checks,
             config=config,
-            source_assets=[*source_assets, *excluded_assets],
+            source_assets=[*source_assets],
+            resolved_source_assets=resolved_source_assets,
             resource_defs=resource_defs,
             executor_def=executor_def,
             partitions_def=partitions_def,

--- a/python_modules/dagster/dagster/_core/definitions/assets_job.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets_job.py
@@ -217,7 +217,7 @@ def build_assets_job(
         node_defs = [
             asset.node_def
             for asset in source_assets
-            if isinstance(asset, SourceAsset) and asset.is_observable and asset.node_def is not None
+            if asset.is_observable and asset.node_def is not None
         ]
 
     graph = GraphDefinition(

--- a/python_modules/dagster/dagster/_core/definitions/assets_job.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets_job.py
@@ -70,10 +70,6 @@ def get_base_asset_jobs(
     for assets_def in assets:
         assets_by_partitions_def[assets_def.partitions_def].append(assets_def)
 
-    resolved_source_assets: List[SourceAsset] = []
-    for asset in assets:
-        resolved_source_assets += asset.to_source_assets()
-
     # We need to create "empty" jobs for each partitions def that is used by an observable but no
     # materializable asset. They are empty because we don't assign the source asset to the `assets`,
     # but rather the `source_assets` argument of `build_assets_job`.
@@ -87,7 +83,6 @@ def get_base_asset_jobs(
                 assets=assets,
                 asset_checks=asset_checks,
                 source_assets=source_assets,
-                resolved_source_assets=resolved_source_assets,
                 executor_def=executor_def,
                 resource_defs=resource_defs,
             )
@@ -97,6 +92,11 @@ def get_base_asset_jobs(
         partitioned_assets_by_partitions_def = {
             k: v for k, v in assets_by_partitions_def.items() if k is not None
         }
+
+        resolved_source_assets: List[SourceAsset] = []
+        for asset in assets:
+            resolved_source_assets += asset.to_source_assets()
+
         jobs = []
 
         # sort to ensure some stability in the ordering

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_asset_partition_mappings.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_asset_partition_mappings.py
@@ -364,7 +364,7 @@ def test_partition_keys_in_range():
     downstream_job = build_assets_job(
         "downstream_job",
         assets=[downstream],
-        source_assets=[upstream],
+        resolved_source_assets=upstream.to_source_assets(),
         resource_defs={"io_manager": IOManagerDefinition.hardcoded_io_manager(MyIOManager())},
     )
     downstream_job.execute_in_process(partition_key="2022-09-11")

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
@@ -284,7 +284,6 @@ def test_source_asset():
                 AssetKey("source1"), io_manager_key="special_io_manager", metadata={"a": "b"}
             )
         ],
-        resolved_source_assets=asset1.to_source_assets(),
         resource_defs={
             "special_io_manager": my_io_manager.configured({"a": 7}),
             "subresource": ResourceDefinition.hardcoded_resource(9),
@@ -338,7 +337,6 @@ def test_source_op_asset():
         "a",
         [asset1],
         source_assets=[source1],
-        resolved_source_assets=asset1.to_source_assets(),
         resource_defs={"special_io_manager": my_io_manager},
     )
     assert job.graph.node_defs == [asset1.op]

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
@@ -284,6 +284,7 @@ def test_source_asset():
                 AssetKey("source1"), io_manager_key="special_io_manager", metadata={"a": "b"}
             )
         ],
+        resolved_source_assets=asset1.to_source_assets(),
         resource_defs={
             "special_io_manager": my_io_manager.configured({"a": 7}),
             "subresource": ResourceDefinition.hardcoded_resource(9),
@@ -315,9 +316,7 @@ def test_missing_io_manager():
 
 
 def test_source_op_asset():
-    @asset(io_manager_key="special_io_manager")
-    def source1():
-        pass
+    source1 = SourceAsset(AssetKey("source1"), io_manager_key="special_io_manager")
 
     @asset
     def asset1(source1):
@@ -339,6 +338,7 @@ def test_source_op_asset():
         "a",
         [asset1],
         source_assets=[source1],
+        resolved_source_assets=asset1.to_source_assets(),
         resource_defs={"special_io_manager": my_io_manager},
     )
     assert job.graph.node_defs == [asset1.op]

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
@@ -358,7 +358,7 @@ def test_cross_job_different_partitions():
     daily_job = build_assets_job(
         name="daily_job",
         assets=[daily_asset],
-        source_assets=[hourly_asset],
+        resolved_source_assets=hourly_asset.to_source_assets(),
         resource_defs={"io_manager": IOManagerDefinition.hardcoded_io_manager(CustomIOManager())},
     )
     assert daily_job.execute_in_process(partition_key="2021-06-06").success

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
@@ -419,7 +419,9 @@ def test_cross_job_asset_dependency():
         assert asset1 == 1
 
     assets_job1 = build_assets_job("assets_job1", [asset1])
-    assets_job2 = build_assets_job("assets_job2", [asset2], source_assets=[asset1])
+    assets_job2 = build_assets_job(
+        "assets_job2", [asset2], resolved_source_assets=asset1.to_source_assets()
+    )
     external_asset_nodes = external_asset_graph_from_defs(
         [assets_job1, assets_job2], source_assets_by_key={}
     )


### PR DESCRIPTION
## Summary & Motivation

This is the first step towards improving asset loading performance https://github.com/dagster-io/dagster/issues/16129. Function `build_asset_job` runs as an inner loop of `get_base_asset_jobs` and asset source resolution was the first hot spot.

## How I Tested These Changes

I ran the snipped provided in the issue and measured the time. On my machine the reduction is 50% (from 1m26s to 0m58s). Apart from that, I checked if all the existing unit tests pass, and the do (after moving resolution out) except `test_source_op_asset`, which had a buggy asset definition (supposedly source asset was defined as a normal asset). I fixed that test in this PR as well.
