### PR TITLE
Support passing a multi asset AssetsDefinition via deps

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -153,7 +153,8 @@ def asset(
             about the input.
         deps (Optional[Sequence[Union[AssetDep, AssetsDefinition, SourceAsset, AssetKey, str]]]):
             The assets that are upstream dependencies, but do not correspond to a parameter of the
-            decorated function.
+            decorated function. If the AssetsDefinition for a multi_asset is provided, dependencies on
+            all assets created by the multi_asset will be created.
         config_schema (Optional[ConfigSchema): The configuration schema for the asset's underlying
             op. If set, Dagster will check that config provided for the op matches this schema and fail
             if it does not. If not set, Dagster will accept any config provided for the op.
@@ -503,7 +504,8 @@ def multi_asset(
             about the input.
         deps (Optional[Sequence[Union[AssetsDefinition, SourceAsset, AssetKey, str]]]):
             The assets that are upstream dependencies, but do not correspond to a parameter of the
-            decorated function.
+            decorated function. If the AssetsDefinition for a multi_asset is provided, dependencies on
+            all assets created by the multi_asset will be created.
         config_schema (Optional[ConfigSchema): The configuration schema for the asset's underlying
             op. If set, Dagster will check that config provided for the op matches this schema and fail
             if it does not. If not set, Dagster will accept any config provided for the op.

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_deps.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_deps.py
@@ -512,8 +512,8 @@ def test_bad_types():
     not_an_asset = NotAnAsset()
 
     with pytest.raises(
-        DagsterInvalidDefinitionError,
-        match=(r"Cannot pass an instance of type .*" " to deps parameter of @asset"),
+        ParameterCheckError,
+        match='Param "asset" is not one of ',
     ):
 
         @asset(deps=[not_an_asset])

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_load_from_instance.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_load_from_instance.py
@@ -13,10 +13,11 @@ from dagster import (
     io_manager,
     materialize,
 )
+from dagster._check import ParameterCheckError
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.definitions.metadata.table import TableColumn, TableSchema
-from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvalidInvocationError
+from dagster._core.errors import DagsterInvalidInvocationError
 from dagster._core.execution.context.init import build_init_resource_context
 from dagster._core.execution.with_resources import with_resources
 from dagster._core.instance_for_test import environ
@@ -284,13 +285,8 @@ def test_load_from_instance_with_downstream_asset_errors():
     )
 
     with pytest.raises(
-        DagsterInvalidDefinitionError,
-        match=(
-            "Cannot pass an instance of type <class"
-            " 'dagster_airbyte.asset_defs.AirbyteInstanceCacheableAssetsDefinition'> to deps"
-            " parameter of @asset. Instead, pass AssetDeps, AssetsDefinitions, SourceAssets, or"
-            " AssetKeys."
-        ),
+        ParameterCheckError,
+        match='Param "asset" is not one of ',
     ):
 
         @asset(deps=[ab_cacheable_assets])


### PR DESCRIPTION
## Summary & Motivation
Adds support for passing multi_assets `AssetsDefinition` objects to `deps`

```python
@multi_asset(
        outs={
            "asset_1": AssetOut(),
            "asset_2": AssetOut(),
        }
    )
    def a_multi_asset():
        return None, None

    @asset(deps=[a_multi_asset])
    def depends_on_both_sub_assets():
        return None
```

When a multi_asset is passed to `deps`, dependencies will be created on all assets in the multi_asset

## How I Tested These Changes
