### PR TITLE
[ui] Fix OpTags reduce error

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graph/OpTags.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/OpTags.tsx
@@ -378,7 +378,7 @@ function generateColorForLabel(label = '') {
     label
       .split('')
       .map((c) => c.charCodeAt(0))
-      .reduce((n, a) => n + a) % 360
+      .reduce((n, a) => n + a, 0) % 360
   }, 75%, 45%)`;
 }
 


### PR DESCRIPTION
## Summary & Motivation

Repair a runtime error in `OpTags`:

`TypeError: Reduce of empty array with no initial value`

## How I Tested These Changes

Sanity check that the `0` fixes the issue on a reduce over an empty array.
