### PR TITLE
[pythonic config] Add warning message when config arg is not named 'config'

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -574,7 +574,10 @@ from dagster._utils.alert import (
 )
 from dagster._utils.dagster_type import check_dagster_type as check_dagster_type
 from dagster._utils.log import get_dagster_logger as get_dagster_logger
-from dagster._utils.warnings import ExperimentalWarning as ExperimentalWarning
+from dagster._utils.warnings import (
+    ConfigArgumentWarning as ConfigArgumentWarning,
+    ExperimentalWarning as ExperimentalWarning,
+)
 from dagster.version import __version__ as __version__
 
 # ruff: isort: split

--- a/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
@@ -31,7 +31,7 @@ from dagster._core.definitions.resource_annotation import (
 )
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.types.dagster_type import DagsterTypeKind
-from dagster._utils.warnings import normalize_renamed_param
+from dagster._utils.warnings import normalize_renamed_param, config_argument_warning
 
 from ..input import In, InputDefinition
 from ..output import Out
@@ -311,11 +311,8 @@ class DecoratedOpFunction(NamedTuple):
         positional_inputs = self.positional_inputs()
         for param in get_function_params(self.decorated_fn):
             if safe_is_subclass(param.annotation, Config) and param.name in positional_inputs:
-                raise DagsterInvalidDefinitionError(
-                    f"Parameter '{param.name}' on op/asset function '{self.name}' was annotated as"
-                    " a dagster.Config type. Did you mean to name this parameter 'config'"
-                    " instead?",
-                )
+                config_argument_warning(param.name, self.name)
+               
 
     def get_config_arg(self) -> Parameter:
         for param in get_function_params(self.decorated_fn):

--- a/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
@@ -31,7 +31,7 @@ from dagster._core.definitions.resource_annotation import (
 )
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.types.dagster_type import DagsterTypeKind
-from dagster._utils.warnings import normalize_renamed_param, config_argument_warning
+from dagster._utils.warnings import config_argument_warning, normalize_renamed_param
 
 from ..input import In, InputDefinition
 from ..output import Out
@@ -306,13 +306,12 @@ class DecoratedOpFunction(NamedTuple):
 
     def validate_malformed_config(self) -> None:
         from dagster._config.pythonic_config.config import Config
-        from dagster._config.pythonic_config.inheritance_utils import safe_is_subclass
+        from dagster._config.pythonic_config.type_check_utils import safe_is_subclass
 
         positional_inputs = self.positional_inputs()
         for param in get_function_params(self.decorated_fn):
             if safe_is_subclass(param.annotation, Config) and param.name in positional_inputs:
                 config_argument_warning(param.name, self.name)
-               
 
     def get_config_arg(self) -> Parameter:
         for param in get_function_params(self.decorated_fn):

--- a/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
@@ -303,17 +303,19 @@ class DecoratedOpFunction(NamedTuple):
                 return True
 
         return False
-    
+
     def validate_malformed_config(self) -> None:
         from dagster._config.pythonic_config.config import Config
         from dagster._config.pythonic_config.inheritance_utils import safe_is_subclass
+
         positional_inputs = self.positional_inputs()
         for param in get_function_params(self.decorated_fn):
             if safe_is_subclass(param.annotation, Config) and param.name in positional_inputs:
                 raise DagsterInvalidDefinitionError(
-                    f"Parameter '{param.name}' on op/asset function '{self.name}' was annotated as a dagster.Config type. Did you mean to name this parameter 'config' instead?",
+                    f"Parameter '{param.name}' on op/asset function '{self.name}' was annotated as"
+                    " a dagster.Config type. Did you mean to name this parameter 'config'"
+                    " instead?",
                 )
-                    
 
     def get_config_arg(self) -> Parameter:
         for param in get_function_params(self.decorated_fn):

--- a/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
@@ -307,8 +307,9 @@ class DecoratedOpFunction(NamedTuple):
     def validate_malformed_config(self) -> None:
         from dagster._config.pythonic_config.config import Config
         from dagster._config.pythonic_config.inheritance_utils import safe_is_subclass
+        positional_inputs = self.positional_inputs()
         for param in get_function_params(self.decorated_fn):
-            if safe_is_subclass(param.annotation, Config) and not param.name == "config":
+            if safe_is_subclass(param.annotation, Config) and param.name in positional_inputs:
                 raise DagsterInvalidDefinitionError(
                     f"Parameter '{param.name}' on op/asset function '{self.name}' was annotated as a dagster.Config type. Did you mean to name this parameter 'config' instead?",
                 )

--- a/python_modules/dagster/dagster/_utils/warnings.py
+++ b/python_modules/dagster/dagster/_utils/warnings.py
@@ -96,6 +96,21 @@ def experimental_warning(
 
 
 # ########################
+# ##### Config arg warning
+# ########################
+
+
+def config_argument_warning(
+    param_name: str, function_name: str
+) -> None:
+    warnings.warn(
+        f"Parameter '{param_name}' on op/asset function '{function_name}' was annotated as"
+        " a dagster.Config type. Did you mean to name this parameter 'config'"
+        " instead?",
+        SyntaxWarning,
+    )
+
+# ########################
 # ##### DISABLE DAGSTER WARNINGS
 # ########################
 

--- a/python_modules/dagster/dagster/_utils/warnings.py
+++ b/python_modules/dagster/dagster/_utils/warnings.py
@@ -99,16 +99,27 @@ def experimental_warning(
 # ##### Config arg warning
 # ########################
 
+CONFIG_WARNING_HELP = (
+    "To mute this warning, invoke"
+    ' warnings.filterwarnings("ignore", category=dagster.ConfigArgumentWarning) or use'
+    " one of the other methods described at"
+    " https://docs.python.org/3/library/warnings.html#describing-warning-filters."
+)
 
-def config_argument_warning(
-    param_name: str, function_name: str
-) -> None:
+
+class ConfigArgumentWarning(SyntaxWarning):
+    pass
+
+
+def config_argument_warning(param_name: str, function_name: str) -> None:
     warnings.warn(
         f"Parameter '{param_name}' on op/asset function '{function_name}' was annotated as"
         " a dagster.Config type. Did you mean to name this parameter 'config'"
-        " instead?",
-        SyntaxWarning,
+        " instead?\n\n"
+        f"{CONFIG_WARNING_HELP}",
+        ConfigArgumentWarning,
     )
+
 
 # ########################
 # ##### DISABLE DAGSTER WARNINGS

--- a/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_errors.py
+++ b/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_errors.py
@@ -1,5 +1,5 @@
-from typing import Tuple
 import warnings
+from typing import Tuple
 
 import pytest
 from dagster import (
@@ -459,19 +459,33 @@ def test_config_named_wrong_thing() -> None:
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
 
-
         class DoSomethingConfig(Config):
             a_str: str
+
         assert len(w) == 0
 
-    
         @op
         def my_op(config_named_wrong: DoSomethingConfig):
             pass
-        assert len(w) == 1
 
+        assert len(w) == 1
+        assert (
+            w[0]
+            .message.args[0]  # type: ignore
+            .startswith(
+                "Parameter 'config_named_wrong' on op/asset function 'my_op' was annotated as a dagster.Config type. Did you mean to name this parameter 'config' instead?"
+            )
+        )
 
         @asset
         def my_asset(config_named_wrong: DoSomethingConfig):
             pass
+
         assert len(w) == 2
+        assert (
+            w[1]
+            .message.args[0]  # type: ignore
+            .startswith(
+                "Parameter 'config_named_wrong' on op/asset function 'my_asset' was annotated as a dagster.Config type. Did you mean to name this parameter 'config' instead?"
+            )
+        )

--- a/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_errors.py
+++ b/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_errors.py
@@ -1,4 +1,5 @@
 from typing import Tuple
+import warnings
 
 import pytest
 from dagster import (
@@ -455,29 +456,22 @@ This config type can be a:
 
 
 def test_config_named_wrong_thing() -> None:
-    class DoSomethingConfig(Config):
-        a_str: str
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
 
-    with pytest.raises(
-        DagsterInvalidDefinitionError,
-        match=(
-            "Parameter 'config_named_wrong' on op/asset function 'my_op' was annotated as a"
-            " dagster.Config type. Did you mean to name this parameter 'config' instead?"
-        ),
-    ):
 
+        class DoSomethingConfig(Config):
+            a_str: str
+        assert len(w) == 0
+
+    
         @op
         def my_op(config_named_wrong: DoSomethingConfig):
             pass
+        assert len(w) == 1
 
-    with pytest.raises(
-        DagsterInvalidDefinitionError,
-        match=(
-            "Parameter 'config_named_wrong' on op/asset function 'my_asset' was annotated as a"
-            " dagster.Config type. Did you mean to name this parameter 'config' instead?"
-        ),
-    ):
 
         @asset
         def my_asset(config_named_wrong: DoSomethingConfig):
             pass
+        assert len(w) == 2

--- a/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_errors.py
+++ b/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_errors.py
@@ -452,3 +452,28 @@ This config type can be a:
 
         class MyOpConfig(Config):
             dagster_type_field: DagsterDatetime = datetime(year=2023, month=4, day=30)  # type: ignore
+
+
+def test_config_named_wrong_thing() -> None:
+
+   
+    class DoSomethingConfig(Config):
+        a_str: str
+
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match="Parameter 'config_named_wrong' on op/asset function 'my_op' was annotated as a dagster.Config type. Did you mean to name this parameter 'config' instead?",
+    ):
+
+        @op
+        def my_op(config_named_wrong: DoSomethingConfig):
+            pass
+
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match="Parameter 'config_named_wrong' on op/asset function 'my_asset' was annotated as a dagster.Config type. Did you mean to name this parameter 'config' instead?",
+    ):
+
+        @asset
+        def my_asset(config_named_wrong: DoSomethingConfig):
+            pass

--- a/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_errors.py
+++ b/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_errors.py
@@ -455,14 +455,15 @@ This config type can be a:
 
 
 def test_config_named_wrong_thing() -> None:
-
-   
     class DoSomethingConfig(Config):
         a_str: str
 
     with pytest.raises(
         DagsterInvalidDefinitionError,
-        match="Parameter 'config_named_wrong' on op/asset function 'my_op' was annotated as a dagster.Config type. Did you mean to name this parameter 'config' instead?",
+        match=(
+            "Parameter 'config_named_wrong' on op/asset function 'my_op' was annotated as a"
+            " dagster.Config type. Did you mean to name this parameter 'config' instead?"
+        ),
     ):
 
         @op
@@ -471,7 +472,10 @@ def test_config_named_wrong_thing() -> None:
 
     with pytest.raises(
         DagsterInvalidDefinitionError,
-        match="Parameter 'config_named_wrong' on op/asset function 'my_asset' was annotated as a dagster.Config type. Did you mean to name this parameter 'config' instead?",
+        match=(
+            "Parameter 'config_named_wrong' on op/asset function 'my_asset' was annotated as a"
+            " dagster.Config type. Did you mean to name this parameter 'config' instead?"
+        ),
     ):
 
         @asset

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_direct_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_direct_invocation.py
@@ -336,6 +336,34 @@ def test_direct_asset_invocation_plain_arg_with_resource_definition_no_inputs_no
     assert executed["yes"]
 
 
+from dagster import build_asset_context
+
+
+def test_direct_asset_invocation_ctx() -> None:
+    @asset
+    def hello_asset(context):
+        return "hello"
+
+    @asset
+    def world_asset(an_asset: str, context) -> str:
+        return an_asset + " world"
+
+    assert (
+        world_asset(
+            hello_asset(build_asset_context()),
+            build_asset_context(),
+        )
+        == "hello world"
+    )
+    assert (
+        world_asset(
+            an_asset=hello_asset(build_asset_context()),
+            context=build_asset_context(),
+        )
+        == "hello world"
+    )
+
+
 def test_direct_asset_invocation_kwarg_with_resource_definition_no_inputs_no_context() -> None:
     class NumResource(ConfigurableResource):
         num: int

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_direct_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_direct_invocation.py
@@ -336,34 +336,6 @@ def test_direct_asset_invocation_plain_arg_with_resource_definition_no_inputs_no
     assert executed["yes"]
 
 
-from dagster import build_asset_context
-
-
-def test_direct_asset_invocation_ctx() -> None:
-    @asset
-    def hello_asset(context):
-        return "hello"
-
-    @asset
-    def world_asset(an_asset: str, context) -> str:
-        return an_asset + " world"
-
-    assert (
-        world_asset(
-            hello_asset(build_asset_context()),
-            build_asset_context(),
-        )
-        == "hello world"
-    )
-    assert (
-        world_asset(
-            an_asset=hello_asset(build_asset_context()),
-            context=build_asset_context(),
-        )
-        == "hello world"
-    )
-
-
 def test_direct_asset_invocation_kwarg_with_resource_definition_no_inputs_no_context() -> None:
     class NumResource(ConfigurableResource):
         num: int


### PR DESCRIPTION
## Summary

Raises a warning message if an op/asset function has a parameter annotated with `dagster.Config` subclass that is not called `config`:

```python
>>> @op
... def my_op(not_called_config: MyConfig):
...    pass
...
ConfigArgumentWarning: Parameter 'not_called_config' on op/asset function 'my_op' was annotated as a dagster.Config type. Did you mean to name this parameter 'config' instead?

To mute this warning, invoke warnings.filterwarnings("ignore", category=dagster.ConfigArgumentWarning) or use one of the other methods described at https://docs.python.org/3/library/warnings.html#describing-warning-filters.
  warnings.warn(
```

Meant to address/improve situations like https://github.com/dagster-io/internal/pull/6683#discussion_r1318072959

The user may quiet this warning by muting the new `dagster.ConfigArgumentWarning` warning type.

## Test Plan

New unit test.
