### PR TITLE
[ui] Fix undefined value being passed to asset launchpad

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/ExecutionSessionStorage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/ExecutionSessionStorage.tsx
@@ -99,7 +99,11 @@ export const createSingleSession = (initial: IExecutionSessionChanges = {}, key?
     flattenGraphs: false,
     tags: null,
     runId: undefined,
+
+    // This isn't really safe, since it could spread in `undefined` values that
+    // override the default values above.
     ...initial,
+
     configChangedSinceRun: false,
     key: key || `s${Date.now()}`,
   };

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadTransientSessionContainer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadTransientSessionContainer.tsx
@@ -42,9 +42,11 @@ export const LaunchpadTransientSessionContainer = (props: Props) => {
     rootDefaultYaml,
     !flagDisableAutoLoadDefaults,
   );
+
+  // Avoid supplying an undefined `runConfigYaml` to the session.
   const initialSessionComplete = createSingleSession({
     ...sessionPresets,
-    runConfigYaml: initialData.runConfigYaml,
+    ...(initialData.runConfigYaml ? {runConfigYaml: initialData.runConfigYaml} : {}),
   });
 
   const [session, setSession] = React.useState<IExecutionSession>(initialSessionComplete);


### PR DESCRIPTION
## Summary & Motivation

There's a TS loophole in our use of `Partial` when generating a transient execution session for the asset launchpad.

We can inadvertently spread in an `undefined` value for the run config yaml, which isn't caught by TS because it's a key of a `Partial` object. TS assumes the return value from the spread is a fully formed execution session object, with a valid `string` config yaml. This persists downstream and surfaces in the CodeMirror editor, which expects a `string` value and errors when provided an `undefiend`.

Repair the callsite that generates the launchpad session by avoiding the `undefined` value.

## How I Tested These Changes

View asset job that shows this error, with `flagDisableAutoLoadDefaults` turned on to force the launchpad not to show a default config. Shift-click to materialize, verify that the asset launchpad loads properly, with no JS errors.
