### PR TITLE
Upgrades to the AssetGraphSubset class

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
@@ -1,5 +1,6 @@
+import operator
 from collections import defaultdict
-from typing import AbstractSet, Any, Dict, Iterable, Mapping, Optional, Set, Union, cast
+from typing import AbstractSet, Any, Callable, Dict, Iterable, Mapping, Optional, Set, Union, cast
 
 from dagster import _check as check
 from dagster._core.definitions.partition import (
@@ -63,14 +64,23 @@ class AssetGraphSubset:
         for asset_key in self._non_partitioned_asset_keys:
             yield AssetKeyPartitionKey(asset_key, None)
 
-    def __contains__(self, asset_partition: AssetKeyPartitionKey) -> bool:
-        if asset_partition.partition_key is None:
-            return asset_partition.asset_key in self._non_partitioned_asset_keys
+    def __contains__(self, asset: Union[AssetKey, AssetKeyPartitionKey]) -> bool:
+        """If asset is an AssetKeyPartitionKey, check if the given AssetKeyPartitionKey is in the
+        subset. If asset is an AssetKey, check if any of partitions of the given AssetKey are in
+        the subset.
+        """
+        if isinstance(asset, AssetKey):
+            # check if any keys are in the subset
+            if self.asset_graph.is_partitioned(asset):
+                partitions_subset = self.partitions_subsets_by_asset_key.get(asset)
+                return partitions_subset is not None and len(partitions_subset) > 0
+            else:
+                return asset in self._non_partitioned_asset_keys
+        elif asset.partition_key is None:
+            return asset.asset_key in self._non_partitioned_asset_keys
         else:
-            partitions_subset = self.partitions_subsets_by_asset_key.get(asset_partition.asset_key)
-            return (
-                partitions_subset is not None and asset_partition.partition_key in partitions_subset
-            )
+            partitions_subset = self.partitions_subsets_by_asset_key.get(asset.asset_key)
+            return partitions_subset is not None and asset.partition_key in partitions_subset
 
     def to_storage_dict(
         self, dynamic_partitions_store: DynamicPartitionsStore
@@ -95,9 +105,14 @@ class AssetGraphSubset:
             ],
         }
 
-    def __or__(
-        self, other: Union["AssetGraphSubset", AbstractSet[AssetKeyPartitionKey]]
+    def _oper(
+        self, other: Union["AssetGraphSubset", AbstractSet[AssetKeyPartitionKey]], oper: Callable
     ) -> "AssetGraphSubset":
+        """Returns the AssetGraphSubset that results from applying the given operator to the set of
+        asset partitions in self and other.
+
+        Note: Not all operators are supported on the underlying PartitionsSubset objects.
+        """
         result_partition_subsets_by_asset_key = {**self.partitions_subsets_by_asset_key}
         result_non_partitioned_asset_keys = set(self._non_partitioned_asset_keys)
 
@@ -107,12 +122,14 @@ class AssetGraphSubset:
         for asset_key in other.asset_keys:
             if asset_key in other.non_partitioned_asset_keys:
                 check.invariant(asset_key not in self.partitions_subsets_by_asset_key)
-                result_non_partitioned_asset_keys.add(asset_key)
+                result_non_partitioned_asset_keys = oper(
+                    result_non_partitioned_asset_keys, {asset_key}
+                )
             else:
                 subset = self.get_partitions_subset(asset_key)
                 check.invariant(asset_key not in self.non_partitioned_asset_keys)
-                result_partition_subsets_by_asset_key[asset_key] = (
-                    subset | other.get_partitions_subset(asset_key)
+                result_partition_subsets_by_asset_key[asset_key] = oper(
+                    subset, other.get_partitions_subset(asset_key)
                 )
 
         return AssetGraphSubset(
@@ -120,6 +137,16 @@ class AssetGraphSubset:
             result_partition_subsets_by_asset_key,
             result_non_partitioned_asset_keys,
         )
+
+    def __or__(
+        self, other: Union["AssetGraphSubset", AbstractSet[AssetKeyPartitionKey]]
+    ) -> "AssetGraphSubset":
+        return self._oper(other, operator.or_)
+
+    def __sub__(
+        self, other: Union["AssetGraphSubset", AbstractSet[AssetKeyPartitionKey]]
+    ) -> "AssetGraphSubset":
+        return self._oper(other, operator.sub)
 
     def filter_asset_keys(self, asset_keys: AbstractSet[AssetKey]) -> "AssetGraphSubset":
         return AssetGraphSubset(
@@ -204,29 +231,59 @@ class AssetGraphSubset:
 
     @classmethod
     def from_storage_dict(
-        cls, serialized_dict: Mapping[str, Any], asset_graph: AssetGraph
+        cls,
+        serialized_dict: Mapping[str, Any],
+        asset_graph: AssetGraph,
+        allow_partial: bool = False,
     ) -> "AssetGraphSubset":
+        serializable_partitions_ids = serialized_dict.get(
+            "serializable_partitions_def_ids_by_asset_key", {}
+        )
+
+        partitions_def_class_names_by_asset_key = serialized_dict.get(
+            "partitions_def_class_names_by_asset_key", {}
+        )
         partitions_subsets_by_asset_key: Dict[AssetKey, PartitionsSubset] = {}
         for key, value in serialized_dict["partitions_subsets_by_asset_key"].items():
             asset_key = AssetKey.from_user_string(key)
 
             if asset_key not in asset_graph.all_asset_keys:
-                raise DagsterDefinitionChangedDeserializationError(
-                    f"Asset {key} existed at storage-time, but no longer does"
-                )
+                if not allow_partial:
+                    raise DagsterDefinitionChangedDeserializationError(
+                        f"Asset {key} existed at storage-time, but no longer does"
+                    )
+                continue
 
             partitions_def = asset_graph.get_partitions_def(asset_key)
 
             if partitions_def is None:
-                raise DagsterDefinitionChangedDeserializationError(
-                    f"Asset {key} had a PartitionsDefinition at storage-time, but no longer does"
-                )
+                if not allow_partial:
+                    raise DagsterDefinitionChangedDeserializationError(
+                        f"Asset {key} had a PartitionsDefinition at storage-time, but no longer"
+                        " does"
+                    )
+                continue
+
+            if not partitions_def.can_deserialize_subset(
+                value,
+                serialized_partitions_def_unique_id=serializable_partitions_ids.get(key),
+                serialized_partitions_def_class_name=partitions_def_class_names_by_asset_key.get(
+                    key
+                ),
+            ):
+                if not allow_partial:
+                    raise DagsterDefinitionChangedDeserializationError(
+                        f"Cannot deserialize stored partitions subset for asset {key}. This likely"
+                        " indicates that the partitions definition has changed since this was"
+                        " stored"
+                    )
+                continue
 
             partitions_subsets_by_asset_key[asset_key] = partitions_def.deserialize_subset(value)
 
         non_partitioned_asset_keys = {
             AssetKey.from_user_string(key) for key in serialized_dict["non_partitioned_asset_keys"]
-        }
+        } & asset_graph.all_asset_keys
 
         return AssetGraphSubset(
             asset_graph, partitions_subsets_by_asset_key, non_partitioned_asset_keys

--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -983,6 +983,13 @@ class PartitionsSubset(ABC, Generic[T_str]):
             return self
         return self.with_partition_keys(other.get_partition_keys())
 
+    def __sub__(self, other: "PartitionsSubset") -> "PartitionsSubset[T_str]":
+        if self is other:
+            return self.partitions_def.empty_subset()
+        return self.partitions_def.empty_subset().with_partition_keys(
+            set(self.get_partition_keys()).difference(set(other.get_partition_keys()))
+        )
+
     @abstractmethod
     def serialize(self) -> str: ...
 

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -1612,6 +1612,9 @@ class TimeWindowPartitionsSubset(PartitionsSubset):
 
         if (
             serialized_partitions_def_class_name
+            # note: all TimeWindowPartitionsDefinition subclasses will get serialized as raw
+            # TimeWindowPartitionsDefinitions, so this class name check will not always pass,
+            # hence the unique id check above
             and serialized_partitions_def_class_name != partitions_def.__class__.__name__
         ):
             return False

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -1604,17 +1604,17 @@ class TimeWindowPartitionsSubset(PartitionsSubset):
         serialized_partitions_def_unique_id: Optional[str],
         serialized_partitions_def_class_name: Optional[str],
     ) -> bool:
-        if (
-            serialized_partitions_def_class_name
-            and serialized_partitions_def_class_name != partitions_def.__class__.__name__
-        ):
-            return False
-
         if serialized_partitions_def_unique_id:
             return (
                 partitions_def.get_serializable_unique_identifier()
                 == serialized_partitions_def_unique_id
             )
+
+        if (
+            serialized_partitions_def_class_name
+            and serialized_partitions_def_class_name != partitions_def.__class__.__name__
+        ):
+            return False
 
         data = json.loads(serialized)
         return isinstance(data, list) or (

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
@@ -34,7 +34,7 @@ from dagster._core.definitions.source_asset import SourceAsset
 from dagster._core.errors import (
     DagsterDefinitionChangedDeserializationError,
 )
-from dagster._core.host_representation.external_data import external_asset_graph_from_defs
+from dagster._core.host_representation.external_data import external_asset_nodes_from_defs
 from dagster._core.instance import DynamicPartitionsStore
 from dagster._core.test_utils import instance_for_test
 from dagster._seven.compat.pendulum import create_pendulum_time


### PR DESCRIPTION
## Summary & Motivation

This contains some small upgrades to the AssetGraphSubset class, in preparation for potentially using it within the AssetDaemonCursor (https://github.com/dagster-io/dagster/pull/16089/files).

The changes are all basically QoL improvements:
1. make it possible to subtract one subset from another (also applies to PartitionsSubset)
2. make it possible to tell if an asset key in general is in an AssetGraphSubset, regardless of if it's partitioned or not
3. make it possible to partially deserialize an AssetGraphSubset (i.e. ignore any partition subsets which are no longer possible to deserialize)

## How I Tested These Changes
