### PR TITLE
Add shell for create_unexecutable_observable_assets_def:

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/observable_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/observable_asset.py
@@ -1,0 +1,21 @@
+from dagster._core.definitions.asset_spec import ObservableAssetSpec
+from dagster._core.definitions.decorators import asset
+
+
+def create_unexecutable_observable_assets_def(observable_asset_spec: ObservableAssetSpec):
+    # This function is to be used in the internals of repository definition to coerce
+    # an ObservableAssetSepc into an AssetsDefinition
+    # TODO: will make this use multi_asset later in the stack
+    @asset(
+        key=observable_asset_spec.key,
+        description=observable_asset_spec.description,
+        metadata=observable_asset_spec.metadata,
+        group_name=observable_asset_spec.group_name,
+        deps=[
+            dep.asset_key for dep in observable_asset_spec.deps
+        ],  # switch to not using .asset_key once jamie's diff lands
+    )
+    def an_asset() -> None:
+        raise NotImplementedError()
+
+    return an_asset

--- a/python_modules/dagster/dagster/_core/definitions/observable_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/observable_asset.py
@@ -1,21 +1,24 @@
-from dagster._core.definitions.asset_spec import ObservableAssetSpec
+from dagster._core.errors import DagsterInvariantViolationError
+from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.decorators import asset
 
 
-def create_unexecutable_observable_assets_def(observable_asset_spec: ObservableAssetSpec):
+def create_unexecutable_observable_assets_def(asset_spec: AssetSpec):
     # This function is to be used in the internals of repository definition to coerce
-    # an ObservableAssetSepc into an AssetsDefinition
+    # an AssetSpec into an AssetsDefinition
     # TODO: will make this use multi_asset later in the stack
     @asset(
-        key=observable_asset_spec.key,
-        description=observable_asset_spec.description,
-        metadata=observable_asset_spec.metadata,
-        group_name=observable_asset_spec.group_name,
+        key=asset_spec.key,
+        description=asset_spec.description,
+        metadata=asset_spec.metadata,
+        group_name=asset_spec.group_name,
         deps=[
-            dep.asset_key for dep in observable_asset_spec.deps
+            dep.asset_key for dep in asset_spec.deps
         ],  # switch to not using .asset_key once jamie's diff lands
     )
     def an_asset() -> None:
-        raise NotImplementedError()
+        raise DagsterInvariantViolationError(
+            f"You have attempted to execute an unexecutable asset {asset_spec.key}"
+        )
 
     return an_asset

--- a/python_modules/dagster/dagster/_core/definitions/observable_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/observable_asset.py
@@ -1,6 +1,6 @@
-from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.decorators import asset
+from dagster._core.errors import DagsterInvariantViolationError
 
 
 def create_unexecutable_observable_assets_def(asset_spec: AssetSpec):

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_observable_assets.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_observable_assets.py
@@ -1,0 +1,40 @@
+from dagster import AssetKey, AssetsDefinition
+from dagster._core.definitions.asset_spec import ObservableAssetSpec
+from dagster._core.definitions.observable_asset import create_unexecutable_observable_assets_def
+
+
+def test_observable_asset_basic_creation() -> None:
+    assets_def = create_unexecutable_observable_assets_def(
+        observable_asset_spec=ObservableAssetSpec(
+            "observable_asset_one",
+            description="desc",
+            metadata={"user_metadata": "value"},
+            group_name="a_group",
+        )
+    )
+    assert isinstance(assets_def, AssetsDefinition)
+
+    expected_key = AssetKey(["observable_asset_one"])
+
+    assert assets_def.key == expected_key
+    assert assets_def.descriptions_by_key[expected_key] == "desc"
+    assert assets_def.metadata_by_key[expected_key] == {"user_metadata": "value"}
+    assert assets_def.group_names_by_key[expected_key] == "a_group"
+
+
+def test_observable_asset_creation_with_deps() -> None:
+    asset_two = ObservableAssetSpec("observable_asset_two")
+    assets_def = create_unexecutable_observable_assets_def(
+        observable_asset_spec=ObservableAssetSpec(
+            "observable_asset_one",
+            deps=[asset_two.key],  # todo remove key when asset deps accepts it
+        )
+    )
+    assert isinstance(assets_def, AssetsDefinition)
+
+    expected_key = AssetKey(["observable_asset_one"])
+
+    assert assets_def.key == expected_key
+    assert assets_def.asset_deps[expected_key] == {
+        AssetKey(["observable_asset_two"]),
+    }

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_observable_assets.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_observable_assets.py
@@ -1,11 +1,11 @@
 from dagster import AssetKey, AssetsDefinition
-from dagster._core.definitions.asset_spec import ObservableAssetSpec
+from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.observable_asset import create_unexecutable_observable_assets_def
 
 
 def test_observable_asset_basic_creation() -> None:
     assets_def = create_unexecutable_observable_assets_def(
-        observable_asset_spec=ObservableAssetSpec(
+        asset_spec=AssetSpec(
             "observable_asset_one",
             description="desc",
             metadata={"user_metadata": "value"},
@@ -23,9 +23,9 @@ def test_observable_asset_basic_creation() -> None:
 
 
 def test_observable_asset_creation_with_deps() -> None:
-    asset_two = ObservableAssetSpec("observable_asset_two")
+    asset_two = AssetSpec("observable_asset_two")
     assets_def = create_unexecutable_observable_assets_def(
-        observable_asset_spec=ObservableAssetSpec(
+        asset_spec=AssetSpec(
             "observable_asset_one",
             deps=[asset_two.key],  # todo remove key when asset deps accepts it
         )


### PR DESCRIPTION
## Summary & Motivation

Add create_unexecutable_observable_assets_def. This will be used by the internals of repository creation to create an AssetsDefinition that represents an asset that cannot be materialized. For now it just throws a not implemented exception. In downstream PRs we will annotate this AssetsDefinition so that tools and calling code can know that this cannot be materialized. 

## How I Tested These Changes

BK
