### PR TITLE
Add system metadata key to determine executability

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_spec.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from typing import TYPE_CHECKING, Any, Iterable, Mapping, NamedTuple, Optional
 
 import dagster._check as check
@@ -14,6 +15,19 @@ from .metadata import MetadataUserInput
 
 if TYPE_CHECKING:
     from dagster._core.definitions.asset_dep import AssetDep, CoercibleToAssetDep
+
+# SYSTEM_METADATA_KEY_ASSET_VARIETAL lives on the metadata of an asset
+# (which currently ends up on the Output associated with the asset key)
+# whih encodes the "varietal" of asset. "Unexecutable" assets are assets
+# that cannot be materialized in Dagster, but can have events in the event
+# log keyed off of them, making Dagster usable as a observability and lineage tool
+# for externally materialized assets.
+SYSTEM_METADATA_KEY_ASSET_VARIETAL = "dagster/asset_varietal"
+
+
+class AssetVarietal(Enum):
+    UNEXECUTABLE = "UNEXECUTABLE"
+    MATERIALIZEABLE = "MATERIALIZEABLE"
 
 
 @experimental

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -858,6 +858,27 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
         """
         return self._check_specs_by_output_name.values()
 
+    @public
+    def is_asset_executable(self, asset_key: AssetKey) -> bool:
+        """Returns True if the asset key is materializable by this AssetsDefinition.
+
+        Args:
+            asset_key (AssetKey): The asset key to check.
+
+        Returns:
+            bool: True if the asset key is materializable by this AssetsDefinition.
+        """
+        from dagster._core.definitions.asset_spec import (
+            SYSTEM_METADATA_KEY_ASSET_VARIETAL,
+            AssetVarietal,
+        )
+
+        return AssetVarietal(
+            self._metadata_by_key.get(asset_key, {}).get(
+                SYSTEM_METADATA_KEY_ASSET_VARIETAL, AssetVarietal.MATERIALIZEABLE.value
+            )
+        ) in {AssetVarietal.MATERIALIZEABLE}
+
     def get_partition_mapping_for_input(self, input_name: str) -> Optional[PartitionMapping]:
         return self._partition_mappings.get(self._keys_by_input_name[input_name])
 

--- a/python_modules/dagster/dagster/_core/definitions/observable_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/observable_asset.py
@@ -1,24 +1,33 @@
-from dagster._core.definitions.asset_spec import AssetSpec
-from dagster._core.definitions.decorators import asset
+from typing import Sequence
+
+from dagster._core.definitions.asset_spec import (
+    SYSTEM_METADATA_KEY_ASSET_VARIETAL,
+    AssetSpec,
+    AssetVarietal,
+)
+from dagster._core.definitions.decorators.asset_decorator import multi_asset
 from dagster._core.errors import DagsterInvariantViolationError
 
 
-def create_unexecutable_observable_assets_def(asset_spec: AssetSpec):
-    # This function is to be used in the internals of repository definition to coerce
-    # an AssetSpec into an AssetsDefinition
-    # TODO: will make this use multi_asset later in the stack
-    @asset(
-        key=asset_spec.key,
-        description=asset_spec.description,
-        metadata=asset_spec.metadata,
-        group_name=asset_spec.group_name,
-        deps=[
-            dep.asset_key for dep in asset_spec.deps
-        ],  # switch to not using .asset_key once jamie's diff lands
+def create_unexecutable_observable_assets_def(specs: Sequence[AssetSpec]):
+    @multi_asset(
+        specs=[
+            AssetSpec(
+                key=spec.key,
+                description=spec.description,
+                group_name=spec.group_name,
+                metadata={
+                    **(spec.metadata or {}),
+                    **{SYSTEM_METADATA_KEY_ASSET_VARIETAL: AssetVarietal.UNEXECUTABLE.value},
+                },
+                deps=[dep.asset_key for dep in spec.deps],
+            )
+            for spec in specs
+        ]
     )
     def an_asset() -> None:
         raise DagsterInvariantViolationError(
-            f"You have attempted to execute an unexecutable asset {asset_spec.key}"
+            f"You have attempted to execute an unexecutable asset {[spec.key for spec in specs]}"
         )
 
     return an_asset

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_observable_assets.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_observable_assets.py
@@ -1,34 +1,47 @@
-from dagster import AssetKey, AssetsDefinition
+from dagster import AssetKey, AssetsDefinition, asset
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.observable_asset import create_unexecutable_observable_assets_def
 
 
 def test_observable_asset_basic_creation() -> None:
     assets_def = create_unexecutable_observable_assets_def(
-        asset_spec=AssetSpec(
-            "observable_asset_one",
-            description="desc",
-            metadata={"user_metadata": "value"},
-            group_name="a_group",
-        )
+        specs=[
+            AssetSpec(
+                key="observable_asset_one",
+                # multi-asset does not support description lol
+                # description="desc",
+                metadata={"user_metadata": "value"},
+                group_name="a_group",
+            )
+        ]
     )
     assert isinstance(assets_def, AssetsDefinition)
 
     expected_key = AssetKey(["observable_asset_one"])
 
     assert assets_def.key == expected_key
-    assert assets_def.descriptions_by_key[expected_key] == "desc"
-    assert assets_def.metadata_by_key[expected_key] == {"user_metadata": "value"}
+    # assert assets_def.descriptions_by_key[expected_key] == "desc"
+    assert assets_def.metadata_by_key[expected_key]["user_metadata"] == "value"
     assert assets_def.group_names_by_key[expected_key] == "a_group"
+    assert assets_def.is_asset_executable(expected_key) is False
+
+
+def test_normal_asset_materializeable() -> None:
+    @asset
+    def an_asset() -> None: ...
+
+    assert an_asset.is_asset_executable(AssetKey(["an_asset"])) is True
 
 
 def test_observable_asset_creation_with_deps() -> None:
     asset_two = AssetSpec("observable_asset_two")
     assets_def = create_unexecutable_observable_assets_def(
-        asset_spec=AssetSpec(
-            "observable_asset_one",
-            deps=[asset_two.key],  # todo remove key when asset deps accepts it
-        )
+        specs=[
+            AssetSpec(
+                "observable_asset_one",
+                deps=[asset_two.key],  # todo remove key when asset deps accepts it
+            )
+        ]
     )
     assert isinstance(assets_def, AssetsDefinition)
 


### PR DESCRIPTION
## Summary & Motivation

For UIs or calling code to determine if an asset key is executable, we need to add this information to `AssetsDefinition`. Rather than add a property and to go through the associated insanity of adding said property to >10 layers of passing around a new dictionary indexed by assets key, I'm just going to jam it in the user-defined metadata with a new system-level metadata key.

The metadata key is an enum that contains information about the "varietal" of this assets definition. This allows for extension later. I have a near-term extension in mind, as new varietal––executable observable assets––will be reintroduced in short order to supplant observable source assets.

We can reassess this later, but I do not want to introduce API and code thrash for now.

This also makes `create_unexecutable_observable_assets_def` use `multi_asset` instead of an `asset`

## How I Tested These Changes

BK
