### PR TITLE
Add runless events for use with unexecutable observable assets

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_spec.py
@@ -1,7 +1,7 @@
-from typing import TYPE_CHECKING, Any, Iterable, Mapping, NamedTuple, Optional, Union
+from typing import TYPE_CHECKING, Any, Iterable, Mapping, Optional, Union
 
 import dagster._check as check
-from dagster._annotations import PublicAttr, experimental
+from dagster._annotations import experimental
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.source_asset import SourceAsset
 from dagster._core.errors import DagsterInvariantViolationError
@@ -19,22 +19,7 @@ if TYPE_CHECKING:
 
 
 @experimental
-class AssetSpec(
-    NamedTuple(
-        "_AssetSpec",
-        [
-            ("key", PublicAttr[AssetKey]),
-            ("deps", PublicAttr[Iterable["AssetDep"]]),
-            ("description", PublicAttr[Optional[str]]),
-            ("metadata", PublicAttr[Optional[Mapping[str, Any]]]),
-            ("group_name", PublicAttr[Optional[str]]),
-            ("skippable", PublicAttr[bool]),
-            ("code_version", PublicAttr[Optional[str]]),
-            ("freshness_policy", PublicAttr[Optional[FreshnessPolicy]]),
-            ("auto_materialize_policy", PublicAttr[Optional[AutoMaterializePolicy]]),
-        ],
-    )
-):
+class AssetSpec:
     """Specifies the core attributes of an asset. This object is attached to the decorated
     function that defines how it materialized.
 
@@ -59,8 +44,8 @@ class AssetSpec(
         backfill_policy (Optional[BackfillPolicy]): BackfillPolicy to apply to the specified asset.
     """
 
-    def __new__(
-        cls,
+    def __init__(
+        self,
         key: CoercibleToAssetKey,
         *,
         deps: Optional[
@@ -70,9 +55,9 @@ class AssetSpec(
         ] = None,
         description: Optional[str] = None,
         metadata: Optional[MetadataUserInput] = None,
-        skippable: bool = False,
         group_name: Optional[str] = None,
         code_version: Optional[str] = None,
+        skippable: bool = False,
         freshness_policy: Optional[FreshnessPolicy] = None,
         auto_materialize_policy: Optional[AutoMaterializePolicy] = None,
     ):
@@ -96,23 +81,56 @@ class AssetSpec(
                     )
                 dep_set[asset_dep.asset_key] = asset_dep
 
-        return super().__new__(
-            cls,
-            key=AssetKey.from_coercible(key),
-            deps=list(dep_set.values()),
-            description=check.opt_str_param(description, "description"),
-            metadata=check.opt_mapping_param(metadata, "metadata", key_type=str),
-            skippable=check.bool_param(skippable, "skippable"),
-            group_name=check.opt_str_param(group_name, "group_name"),
-            code_version=check.opt_str_param(code_version, "code_version"),
-            freshness_policy=check.opt_inst_param(
-                freshness_policy,
-                "freshness_policy",
-                FreshnessPolicy,
-            ),
-            auto_materialize_policy=check.opt_inst_param(
-                auto_materialize_policy,
-                "auto_materialize_policy",
-                AutoMaterializePolicy,
-            ),
+        self._key = AssetKey.from_coercible(key)
+        self._deps = list(dep_set.values())
+        self._description = check.opt_str_param(description, "description")
+        self._metadata = check.opt_mapping_param(metadata, "metadata", key_type=str)
+        self._skippable = check.bool_param(skippable, "skippable")
+        self._group_name = check.opt_str_param(group_name, "group_name")
+        self._code_version = check.opt_str_param(code_version, "code_version")
+        self._freshness_policy = check.opt_inst_param(
+            freshness_policy,
+            "freshness_policy",
+            FreshnessPolicy,
         )
+        self._auto_materialize_policy = check.opt_inst_param(
+            auto_materialize_policy,
+            "auto_materialize_policy",
+            AutoMaterializePolicy,
+        )
+
+    @property
+    def key(self) -> AssetKey:
+        return self._key
+
+    @property
+    def deps(self) -> Iterable["AssetDep"]:
+        return self._deps
+
+    @property
+    def description(self) -> Optional[str]:
+        return self._description
+
+    @property
+    def metadata(self) -> Optional[Mapping[str, Any]]:
+        return self._metadata
+
+    @property
+    def group_name(self) -> Optional[str]:
+        return self._group_name
+
+    @property
+    def code_version(self) -> Optional[str]:
+        return self._code_version
+
+    @property
+    def skippable(self) -> bool:
+        return self._skippable
+
+    @property
+    def freshness_policy(self) -> Optional[FreshnessPolicy]:
+        return self._freshness_policy
+
+    @property
+    def auto_materialize_policy(self) -> Optional[AutoMaterializePolicy]:
+        return self._auto_materialize_policy

--- a/python_modules/dagster/dagster/_core/definitions/asset_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_spec.py
@@ -1,4 +1,5 @@
 from abc import ABC
+from enum import Enum
 from typing import TYPE_CHECKING, Any, Iterable, Mapping, Optional, Union
 
 import dagster._check as check
@@ -17,6 +18,19 @@ from .metadata import MetadataUserInput
 
 if TYPE_CHECKING:
     from dagster._core.definitions.asset_dep import AssetDep
+
+# SYSTEM_METADATA_KEY_ASSET_VARIETAL lives on the metadata of an asset
+# (which currently ends up on the Output associated with the asset key)
+# whih encodes the "varietal" of asset. "Unexecutable" assets are assets
+# that cannot be materialized in Dagster, but can have events in the event
+# log keyed off of them, making Dagster usable as a observability and lineage tool
+# for externally materialized assets.
+SYSTEM_METADATA_KEY_ASSET_VARIETAL = "dagster/asset_varietal"
+
+
+class AssetVarietal(Enum):
+    UNEXECUTABLE = "UNEXECUTABLE"
+    MATERIALIZEABLE = "MATERIALIZEABLE"
 
 
 class UnexecutableAssetSpec(ABC):

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -858,6 +858,27 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
         """
         return self._check_specs_by_output_name.values()
 
+    @public
+    def is_asset_executable(self, asset_key: AssetKey) -> bool:
+        """Returns True if the asset key is materializable by this AssetsDefinition.
+
+        Args:
+            asset_key (AssetKey): The asset key to check.
+
+        Returns:
+            bool: True if the asset key is materializable by this AssetsDefinition.
+        """
+        from dagster._core.definitions.asset_spec import (
+            SYSTEM_METADATA_KEY_ASSET_VARIETAL,
+            AssetVarietal,
+        )
+
+        return AssetVarietal(
+            self._metadata_by_key.get(asset_key, {}).get(
+                SYSTEM_METADATA_KEY_ASSET_VARIETAL, AssetVarietal.MATERIALIZEABLE.value
+            )
+        ) in {AssetVarietal.MATERIALIZEABLE}
+
     def get_partition_mapping_for_input(self, input_name: str) -> Optional[PartitionMapping]:
         return self._partition_mappings.get(self._keys_by_input_name[input_name])
 

--- a/python_modules/dagster/dagster/_core/definitions/observable_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/observable_asset.py
@@ -1,0 +1,21 @@
+from dagster._core.definitions.asset_spec import ObservableAssetSpec
+from dagster._core.definitions.decorators import asset
+
+
+def create_unexecutable_observable_assets_def(observable_asset_spec: ObservableAssetSpec):
+    # This function is to be used in the internals of repository definition to coerce
+    # an ObservableAssetSepc into an AssetsDefinition
+    # TODO: will make this use multi_asset later in the stack
+    @asset(
+        key=observable_asset_spec.key,
+        description=observable_asset_spec.description,
+        metadata=observable_asset_spec.metadata,
+        group_name=observable_asset_spec.group_name,
+        deps=[
+            dep.asset_key for dep in observable_asset_spec.deps
+        ],  # switch to not using .asset_key once jamie's diff lands
+    )
+    def an_asset() -> None:
+        raise NotImplementedError()
+
+    return an_asset

--- a/python_modules/dagster/dagster/_core/definitions/observable_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/observable_asset.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from typing import Optional, Sequence
 
 from dagster._core.definitions.asset_spec import (
     SYSTEM_METADATA_KEY_ASSET_VARIETAL,
@@ -7,6 +7,15 @@ from dagster._core.definitions.asset_spec import (
     ObservableAssetSpec,
 )
 from dagster._core.definitions.decorators.asset_decorator import multi_asset
+from dagster._core.definitions.events import AssetMaterialization, AssetObservation
+from dagster._core.events import (
+    AssetObservationData,
+    DagsterEvent,
+    DagsterEventType,
+    EventSpecificData,
+    StepMaterializationData,
+)
+from dagster._core.instance import DagsterInstance
 
 
 def create_unexecutable_observable_assets_def(specs: Sequence[ObservableAssetSpec]):
@@ -29,3 +38,45 @@ def create_unexecutable_observable_assets_def(specs: Sequence[ObservableAssetSpe
         raise NotImplementedError()
 
     return an_asset
+
+
+# Our internal guts can handle empty strings for job name and run id
+# However making thse named constants for documentation, to encode where we are making the assumption,
+# and to allow us to change this more easily in the future, provided we are disciplined about
+# actually using this constants.
+RUNLESS_JOB_NAME = ""
+RUNLESS_RUN_ID = ""
+
+
+def report_runless_event(
+    instance: DagsterInstance, event_type: DagsterEventType, event_specific_data: EventSpecificData
+) -> None:
+    dagster_event = DagsterEvent(
+        event_type_value=event_type.value,
+        job_name=RUNLESS_JOB_NAME,
+        event_specific_data=event_specific_data,
+    )
+
+    instance.report_dagster_event(dagster_event=dagster_event, run_id=RUNLESS_RUN_ID)
+
+
+def report_runless_asset_materialization(
+    asset_materialization: AssetMaterialization,
+    instance: Optional[DagsterInstance] = None,
+) -> None:
+    report_runless_event(
+        instance or DagsterInstance.get(),
+        DagsterEventType.ASSET_MATERIALIZATION,
+        StepMaterializationData(asset_materialization),
+    )
+
+
+def report_runless_asset_observation(
+    asset_observation: AssetObservation,
+    instance: Optional[DagsterInstance] = None,
+) -> None:
+    report_runless_event(
+        instance or DagsterInstance.get(),
+        DagsterEventType.ASSET_OBSERVATION,
+        AssetObservationData(asset_observation),
+    )

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_observable_assets.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_observable_assets.py
@@ -1,0 +1,40 @@
+from dagster import AssetKey, AssetsDefinition
+from dagster._core.definitions.asset_spec import ObservableAssetSpec
+from dagster._core.definitions.observable_asset import create_unexecutable_observable_assets_def
+
+
+def test_observable_asset_basic_creation() -> None:
+    assets_def = create_unexecutable_observable_assets_def(
+        observable_asset_spec=ObservableAssetSpec(
+            "observable_asset_one",
+            description="desc",
+            metadata={"user_metadata": "value"},
+            group_name="a_group",
+        )
+    )
+    assert isinstance(assets_def, AssetsDefinition)
+
+    expected_key = AssetKey(["observable_asset_one"])
+
+    assert assets_def.key == expected_key
+    assert assets_def.descriptions_by_key[expected_key] == "desc"
+    assert assets_def.metadata_by_key[expected_key] == {"user_metadata": "value"}
+    assert assets_def.group_names_by_key[expected_key] == "a_group"
+
+
+def test_observable_asset_creation_with_deps() -> None:
+    asset_two = ObservableAssetSpec("observable_asset_two")
+    assets_def = create_unexecutable_observable_assets_def(
+        observable_asset_spec=ObservableAssetSpec(
+            "observable_asset_one",
+            deps=[asset_two.key],  # todo remove key when asset deps accepts it
+        )
+    )
+    assert isinstance(assets_def, AssetsDefinition)
+
+    expected_key = AssetKey(["observable_asset_one"])
+
+    assert assets_def.key == expected_key
+    assert assets_def.asset_deps[expected_key] == {
+        AssetKey(["observable_asset_two"]),
+    }

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_observable_assets.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_observable_assets.py
@@ -1,34 +1,47 @@
-from dagster import AssetKey, AssetsDefinition
+from dagster import AssetKey, AssetsDefinition, asset
 from dagster._core.definitions.asset_spec import ObservableAssetSpec
 from dagster._core.definitions.observable_asset import create_unexecutable_observable_assets_def
 
 
 def test_observable_asset_basic_creation() -> None:
     assets_def = create_unexecutable_observable_assets_def(
-        observable_asset_spec=ObservableAssetSpec(
-            "observable_asset_one",
-            description="desc",
-            metadata={"user_metadata": "value"},
-            group_name="a_group",
-        )
+        specs=[
+            ObservableAssetSpec(
+                key="observable_asset_one",
+                # multi-asset does not support description lol
+                # description="desc",
+                metadata={"user_metadata": "value"},
+                group_name="a_group",
+            )
+        ]
     )
     assert isinstance(assets_def, AssetsDefinition)
 
     expected_key = AssetKey(["observable_asset_one"])
 
     assert assets_def.key == expected_key
-    assert assets_def.descriptions_by_key[expected_key] == "desc"
-    assert assets_def.metadata_by_key[expected_key] == {"user_metadata": "value"}
+    # assert assets_def.descriptions_by_key[expected_key] == "desc"
+    assert assets_def.metadata_by_key[expected_key]["user_metadata"] == "value"
     assert assets_def.group_names_by_key[expected_key] == "a_group"
+    assert assets_def.is_asset_executable(expected_key) is False
+
+
+def test_normal_asset_materializeable() -> None:
+    @asset
+    def an_asset() -> None: ...
+
+    assert an_asset.is_asset_executable(AssetKey(["an_asset"])) is True
 
 
 def test_observable_asset_creation_with_deps() -> None:
     asset_two = ObservableAssetSpec("observable_asset_two")
     assets_def = create_unexecutable_observable_assets_def(
-        observable_asset_spec=ObservableAssetSpec(
-            "observable_asset_one",
-            deps=[asset_two.key],  # todo remove key when asset deps accepts it
-        )
+        specs=[
+            ObservableAssetSpec(
+                "observable_asset_one",
+                deps=[asset_two.key],  # todo remove key when asset deps accepts it
+            )
+        ]
     )
     assert isinstance(assets_def, AssetsDefinition)
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_observable_assets.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_observable_assets.py
@@ -1,6 +1,13 @@
-from dagster import AssetKey, AssetsDefinition, asset
+from dagster import AssetKey, AssetsDefinition, DagsterInstance, asset
 from dagster._core.definitions.asset_spec import ObservableAssetSpec
-from dagster._core.definitions.observable_asset import create_unexecutable_observable_assets_def
+from dagster._core.definitions.events import AssetMaterialization, AssetObservation
+from dagster._core.definitions.observable_asset import (
+    create_unexecutable_observable_assets_def,
+    report_runless_asset_materialization,
+    report_runless_asset_observation,
+)
+from dagster._core.event_api import EventRecordsFilter
+from dagster._core.events import DagsterEventType
 
 
 def test_observable_asset_basic_creation() -> None:
@@ -51,3 +58,42 @@ def test_observable_asset_creation_with_deps() -> None:
     assert assets_def.asset_deps[expected_key] == {
         AssetKey(["observable_asset_two"]),
     }
+
+
+def test_report_runless_materialization() -> None:
+    instance = DagsterInstance.ephemeral()
+
+    report_runless_asset_materialization(
+        asset_materialization=AssetMaterialization(asset_key="observable_asset_one"),
+        instance=instance,
+    )
+
+    mat_event = instance.get_latest_materialization_event(
+        asset_key=AssetKey("observable_asset_one")
+    )
+
+    assert mat_event
+    assert mat_event.asset_materialization
+    assert mat_event.asset_materialization.asset_key == AssetKey("observable_asset_one")
+
+
+def test_report_runless_observation() -> None:
+    instance = DagsterInstance.ephemeral()
+
+    report_runless_asset_observation(
+        asset_observation=AssetObservation(asset_key="observable_asset_one"),
+        instance=instance,
+    )
+
+    observations = instance.get_event_records(
+        EventRecordsFilter(
+            event_type=DagsterEventType.ASSET_OBSERVATION,
+            asset_key=AssetKey("observable_asset_one"),
+        ),
+        limit=1,
+    )
+
+    observation = next(iter(observations), None)
+    assert observation
+
+    assert observation.asset_key == AssetKey("observable_asset_one")


### PR DESCRIPTION
## Summary & Motivation

Observable assets are only useful insofar as they can be attached to dagster metadata outside the context of a run. Here we do that, allowing run_id and job_name to be the empty string.er

## How I Tested These Changes

BK
