### PR TITLE
Demonstrate runless events on observable assets

### DIFF
--- a/python_modules/dagster/dagster_tests/definitions_tests/test_observable_assets.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_observable_assets.py
@@ -3,6 +3,8 @@ from typing import Iterator, Optional
 import pytest
 from dagster import (
     AssetKey,
+    AssetMaterialization,
+    AssetObservation,
     AssetsDefinition,
     AutoMaterializePolicy,
     DagsterInstance,
@@ -12,15 +14,10 @@ from dagster import (
     materialize,
 )
 from dagster._core.definitions.asset_spec import AssetSpec
-from dagster._core.definitions.events import AssetObservation
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
 from dagster._core.definitions.observable_asset import (
     create_unexecutable_observable_assets_def,
 )
-
-# report_runless_asset_materialization,
-# report_runless_asset_observation,
-# TODO
 from dagster._core.event_api import EventLogRecord, EventRecordsFilter
 from dagster._core.events import DagsterEventType
 
@@ -100,37 +97,35 @@ def test_observable_asset_creation_with_deps() -> None:
     }
 
 
-# def test_report_runless_materialization() -> None:
-#     instance = DagsterInstance.ephemeral()
+def test_report_runless_materialization() -> None:
+    instance = DagsterInstance.ephemeral()
 
-#     report_runless_asset_materialization(
-#         asset_materialization=AssetMaterialization(asset_key="observable_asset_one"),
-#         instance=instance,
-#     )
+    instance.report_runless_asset_event(
+        asset_event=AssetMaterialization(asset_key="observable_asset_one"),
+    )
 
-#     mat_event = instance.get_latest_materialization_event(
-#         asset_key=AssetKey("observable_asset_one")
-#     )
+    mat_event = instance.get_latest_materialization_event(
+        asset_key=AssetKey("observable_asset_one")
+    )
 
-#     assert mat_event
-#     assert mat_event.asset_materialization
-#     assert mat_event.asset_materialization.asset_key == AssetKey("observable_asset_one")
+    assert mat_event
+    assert mat_event.asset_materialization
+    assert mat_event.asset_materialization.asset_key == AssetKey("observable_asset_one")
 
 
-# def test_report_runless_observation() -> None:
-#     instance = DagsterInstance.ephemeral()
+def test_report_runless_observation() -> None:
+    instance = DagsterInstance.ephemeral()
 
-#     report_runless_asset_observation(
-#         asset_observation=AssetObservation(asset_key="observable_asset_one"),
-#         instance=instance,
-#     )
+    instance.report_runless_asset_event(
+        asset_event=AssetObservation(asset_key="observable_asset_one"),
+    )
 
-#     observation = get_latest_observation_for_asset_key(
-#         instance, asset_key=AssetKey("observable_asset_one")
-#     )
-#     assert observation
+    observation = get_latest_observation_for_asset_key(
+        instance, asset_key=AssetKey("observable_asset_one")
+    )
+    assert observation
 
-#     assert observation.asset_key == AssetKey("observable_asset_one")
+    assert observation.asset_key == AssetKey("observable_asset_one")
 
 
 def test_emit_asset_observation_in_user_space() -> None:

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_observable_assets.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_observable_assets.py
@@ -1,14 +1,39 @@
+from typing import Iterator, Optional
+
 import pytest
 from dagster import (
     AssetKey,
     AssetsDefinition,
     AutoMaterializePolicy,
+    DagsterInstance,
+    Output,
     _check as check,
     asset,
+    materialize,
 )
 from dagster._core.definitions.asset_spec import AssetSpec
+from dagster._core.definitions.events import AssetObservation
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
-from dagster._core.definitions.observable_asset import create_unexecutable_observable_assets_def
+from dagster._core.definitions.observable_asset import (
+    create_unexecutable_observable_assets_def,
+)
+
+# report_runless_asset_materialization,
+# report_runless_asset_observation,
+from dagster._core.event_api import EventLogRecord, EventRecordsFilter
+from dagster._core.events import DagsterEventType
+
+
+def get_latest_observation_for_asset_key(
+    instance: DagsterInstance, asset_key: AssetKey
+) -> Optional[EventLogRecord]:
+    observations = instance.get_event_records(
+        EventRecordsFilter(event_type=DagsterEventType.ASSET_OBSERVATION, asset_key=asset_key),
+        limit=1,
+    )
+
+    observation = next(iter(observations), None)
+    return observation
 
 
 def test_observable_asset_basic_creation() -> None:
@@ -72,3 +97,65 @@ def test_observable_asset_creation_with_deps() -> None:
     assert assets_def.asset_deps[expected_key] == {
         AssetKey(["observable_asset_two"]),
     }
+
+
+# def test_report_runless_materialization() -> None:
+#     instance = DagsterInstance.ephemeral()
+
+#     report_runless_asset_materialization(
+#         asset_materialization=AssetMaterialization(asset_key="observable_asset_one"),
+#         instance=instance,
+#     )
+
+#     mat_event = instance.get_latest_materialization_event(
+#         asset_key=AssetKey("observable_asset_one")
+#     )
+
+#     assert mat_event
+#     assert mat_event.asset_materialization
+#     assert mat_event.asset_materialization.asset_key == AssetKey("observable_asset_one")
+
+
+# def test_report_runless_observation() -> None:
+#     instance = DagsterInstance.ephemeral()
+
+#     report_runless_asset_observation(
+#         asset_observation=AssetObservation(asset_key="observable_asset_one"),
+#         instance=instance,
+#     )
+
+#     observation = get_latest_observation_for_asset_key(
+#         instance, asset_key=AssetKey("observable_asset_one")
+#     )
+#     assert observation
+
+#     assert observation.asset_key == AssetKey("observable_asset_one")
+
+
+def test_emit_asset_observation_in_user_space() -> None:
+    # This test to exists to demonstrate that you cannot emit an asset observation without
+    # it automatically emitting a materialization because of the None output. We will have
+    # to fix this because being able to supplant observable source assets
+
+    @asset(key="asset_in_user_space")
+    def active_observable_asset_in_user_space() -> Iterator:
+        # not ideal but it works
+        yield AssetObservation(asset_key="asset_in_user_space", metadata={"foo": "bar"})
+        yield Output(None)
+
+    instance = DagsterInstance.ephemeral()
+
+    # to avoid breaking your brain, think of this as "execute" or "refresh", not "materialize"
+    assert materialize(assets=[active_observable_asset_in_user_space], instance=instance).success
+
+    observation = get_latest_observation_for_asset_key(
+        instance, asset_key=AssetKey("asset_in_user_space")
+    )
+    assert observation
+    assert observation.asset_key == AssetKey("asset_in_user_space")
+
+    mat_event = instance.get_latest_materialization_event(asset_key=AssetKey("asset_in_user_space"))
+
+    # we actually want this to be false once we make changes to make mainline assets
+    # replace observable source assets
+    assert mat_event

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_observable_assets.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_observable_assets.py
@@ -20,6 +20,7 @@ from dagster._core.definitions.observable_asset import (
 
 # report_runless_asset_materialization,
 # report_runless_asset_observation,
+# TODO
 from dagster._core.event_api import EventLogRecord, EventRecordsFilter
 from dagster._core.events import DagsterEventType
 


### PR DESCRIPTION
## Summary & Motivation

These test cases are documentation to show how we can us `DagsterInstance.report_runless_asset_event` to report events, and to show that you can emit an `AssetObservation` for an existing asset key, although it produces a materialization as well.

## How I Tested These Changes

BK
