### PR TITLE
fix chunked backfill does not allow more than one asset

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -1198,25 +1198,22 @@ def _get_failed_asset_partitions(
             planned_asset_keys = instance_queryer.get_planned_materializations_for_run(
                 run_id=run.run_id
             )
-            check.invariant(
-                len(planned_asset_keys) == 1, "chunked backfill run should only have one asset key"
-            )
             completed_asset_keys = instance_queryer.get_current_materializations_for_run(
                 run_id=run.run_id
             )
             failed_asset_keys = planned_asset_keys - completed_asset_keys
 
             if failed_asset_keys:
-                asset_key = next(iter(failed_asset_keys))
                 partition_range = PartitionKeyRange(
                     start=check.not_none(run.tags.get(ASSET_PARTITION_RANGE_START_TAG)),
                     end=check.not_none(run.tags.get(ASSET_PARTITION_RANGE_END_TAG)),
                 )
-                result.extend(
-                    asset_graph.get_asset_partitions_in_range(
-                        asset_key, partition_range, instance_queryer
+                for asset_key in failed_asset_keys:
+                    result.extend(
+                        asset_graph.get_asset_partitions_in_range(
+                            asset_key, partition_range, instance_queryer
+                        )
                     )
-                )
         else:
             # a regular backfill run that run on a single partition
             partition_key = run.tags.get(PARTITION_NAME_TAG)

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
@@ -536,17 +536,19 @@ def _requested_asset_partitions_in_run_request(
     partition_range_end = run_request.tags.get(ASSET_PARTITION_RANGE_END_TAG)
     if partition_range_start and partition_range_end and run_request.partition_key is None:
         # backfill was a chunked backfill
-        assert len(asset_keys) == 1
-        asset_key = next(iter(asset_keys))
         partition_range = PartitionKeyRange(
             start=partition_range_start,
             end=partition_range_end,
         )
-        asset_partitions = asset_graph.get_asset_partitions_in_range(
-            asset_key=asset_key,
-            partition_key_range=partition_range,
-            dynamic_partitions_store=MagicMock(),
-        )
+        asset_partitions = []
+        for asset_key in asset_keys:
+            asset_partitions.extend(
+                asset_graph.get_asset_partitions_in_range(
+                    asset_key=asset_key,
+                    partition_key_range=partition_range,
+                    dynamic_partitions_store=MagicMock(),
+                )
+            )
         duplicate_asset_partitions = set(asset_partitions) & requested_asset_partitions
         assert len(duplicate_asset_partitions) == 0, (
             f" {duplicate_asset_partitions} requested twice. Requested:"
@@ -554,7 +556,7 @@ def _requested_asset_partitions_in_run_request(
         )
         requested_asset_partitions.update(asset_partitions)
     else:
-        # backfill was a partiton by partition backfill
+        # backfill was a partition by partition backfill
         for asset_key in asset_keys:
             asset_partition = AssetKeyPartitionKey(asset_key, run_request.partition_key)
             assert (


### PR DESCRIPTION
## Summary & Motivation

Fix an issue where `_get_failed_asset_partitions` expects all runs can only have one AssetKey for the chunked backfill workflow. 

The check was added in the first iteration where only single asset key was expected in a single run. Later revision made the chunked backfill able to encompass more assets in one run if they can run atomically, which is determined by `should_backfill_atomic_asset_partitions_unit`. 

Changes here remove the invariant check and also enable the code to extract multiple asset keys from a single run. 

## How I Tested These Changes
