### PR TITLE
Make executable assets upstream of non-executable assets illegal

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -858,6 +858,13 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
         """
         return self._check_specs_by_output_name.values()
 
+    @property
+    def is_executable(self) -> bool:
+        for key in self.keys:
+            if not self.is_asset_executable(key):
+                return False
+        return True
+
     @public
     def is_asset_executable(self, asset_key: AssetKey) -> bool:
         """Returns True if the asset key is materializable by this AssetsDefinition.


### PR DESCRIPTION
## Summary & Motivation

This makes it so that executable assets cannot be upstream of non-executable assets for now. Simplifies the problem domain of job construction and execution considerably, and it is not clear if this will ever make sense.
 
## How I Tested These Changes

BK
