### PR TITLE
Introduce execution taint: Make execute_in_process automatically exclude non-executable asset

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -585,6 +585,19 @@ class AssetLayer(NamedTuple):
         return len(self.assets_defs_by_key) > 0
 
     @property
+    def assets_defs(self) -> Iterable["AssetsDefinition"]:
+        # relying on id is actually quite dangerous, but we do it elsewhere
+        # in the codebase (resolve_assets_def_deps).
+        #
+        # It would be much preferable to generate a data structure that is
+        # the hash of the asset keys and ensures no key collisions during
+        # construction.
+        assets_defs_by_id: Dict[int, "AssetsDefinition"] = {}
+        for assets_def in self.assets_defs_by_key.values():
+            assets_defs_by_id[id(assets_def)] = assets_def
+        return assets_defs_by_id.values()
+
+    @property
     def has_asset_check_defs(self) -> bool:
         return len(self.asset_checks_defs_by_node_handle) > 0
 

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -97,6 +97,9 @@ if TYPE_CHECKING:
 
 DEFAULT_EXECUTOR_DEF = multi_or_in_process_executor
 
+# See create_untainted_job_for_execution for the sad tale of the execution taint in all its glory
+UNEXECUTABLE_TAINT_PROPERTY = "__unexecutable_taint"
+
 
 @experimental_param(param="version_strategy")
 class JobDefinition(IHasInternalInit):
@@ -253,6 +256,8 @@ class JobDefinition(IHasInternalInit):
                     f"Error when constructing JobDefinition '{self.name}': Input value provided for"
                     f" key '{input_name}', but job has no top-level input with that name."
                 )
+
+        setattr(self, UNEXECUTABLE_TAINT_PROPERTY, True)
 
     def dagster_internal_init(
         *,
@@ -633,6 +638,10 @@ class JobDefinition(IHasInternalInit):
         from dagster._core.execution.build_resources import wrap_resources_for_execution
         from dagster._core.execution.execute_in_process import core_execute_in_process
 
+        # TODO: Move this entire method body into a function in job_definition_execution
+        # to avoid this set of circular imports
+        from .job_definition_execution import create_untainted_job_for_execution
+
         run_config = check.opt_mapping_param(convert_config_input(run_config), "run_config")
         op_selection = check.opt_sequence_param(op_selection, "op_selection", str)
         asset_selection = check.opt_sequence_param(asset_selection, "asset_selection", AssetKey)
@@ -655,7 +664,7 @@ class JobDefinition(IHasInternalInit):
         input_values = merge_dicts(self.input_values, input_values)
 
         bound_resource_defs = dict(self.resource_defs)
-        ephemeral_job = JobDefinition.dagster_internal_init(
+        base_job = JobDefinition.dagster_internal_init(
             name=self._name,
             graph_def=self._graph_def,
             resource_defs={**_swap_default_io_man(bound_resource_defs, self), **resource_defs},
@@ -675,9 +684,11 @@ class JobDefinition(IHasInternalInit):
             _was_explicitly_provided_resources=True,
         )
 
-        ephemeral_job = ephemeral_job.get_subset(
+        untainted_job_for_execution = create_untainted_job_for_execution(
+            job_def=base_job,
             op_selection=op_selection,
             asset_selection=frozenset(asset_selection) if asset_selection else None,
+            asset_check_selection=None,  # asset_check_selection currently unsupported in this code path
         )
 
         merged_tags = merge_dicts(self.tags, tags or {})
@@ -700,7 +711,7 @@ class JobDefinition(IHasInternalInit):
             )
 
         return core_execute_in_process(
-            ephemeral_job=ephemeral_job,
+            ephemeral_job=untainted_job_for_execution,
             run_config=run_config,
             instance=instance,
             output_capturing_enabled=True,

--- a/python_modules/dagster/dagster/_core/definitions/job_definition_execution.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition_execution.py
@@ -1,0 +1,81 @@
+from typing import (
+    AbstractSet,
+    Iterable,
+    Optional,
+)
+
+from dagster._core.definitions.asset_check_spec import AssetCheckHandle
+from dagster._core.definitions.events import AssetKey
+
+from .job_definition import UNEXECUTABLE_TAINT_PROPERTY, JobDefinition
+
+
+# only this file is allowed to remove taint.
+def _remove_unexecutable_taint(job_def: JobDefinition) -> JobDefinition:
+    setattr(job_def, UNEXECUTABLE_TAINT_PROPERTY, False)
+    return job_def
+
+
+def job_has_unexecutable_taint(job_def: JobDefinition) -> bool:
+    return getattr(job_def, UNEXECUTABLE_TAINT_PROPERTY)
+
+
+# We have a "pattern" in the code base where in execution codepaths we generate
+# job definition subsets in order to do runtime executition selection, e.g.
+# the user provides an asset selection or an op selection at runtime. Unfortunately
+# this is the same codepath that we use at *definition* time to construct job subsets
+# using functions like "build_assets_job" which ends up calling "to_job" on
+# a GraphDefinition. The get_subset function returns a vanilla job definition
+# that has the type as the original, and no lineage. This is highly unfortuante.
+# Without a single "choke point" for runtime subsetting, it is very easy to
+# forget to call get_subset in production execution codepaths, and there is no
+# single place to consolidate runtime subsetting execution logic.
+#
+# The execution taint is the first step in a plan to fix this. Job definitions
+# will be tainted when they are first created. They are only untainted by calling
+# create_untainted_job_for_execution. This function will remove the taint.
+# We will insert invariants deep in the execution machinery to ensure that this
+# is called in user space code before it is passed in for execution.
+#
+# When this process is complete, we could consider adding a different type to
+# represent a chunk of a job to be executed, and remove the taint entirely, transferring
+# that information from this dodgy monkeypatching to the type system. We can't
+# do this in one go, so tainting it shall be.
+#
+# This function very deliberatately does not use default arguments. This is by
+# design to that callers are forced to declare, in code, that they do not support
+# our varietals of execution selection. There shall be no hiding your
+# sins of call-stack-passing omissions and their resulting execution
+# selection bugs from create_untainted_job_for_execution.
+def create_untainted_job_for_execution(
+    *,
+    job_def: JobDefinition,
+    op_selection: Optional[Iterable[str]],
+    asset_selection: Optional[AbstractSet[AssetKey]],
+    asset_check_selection: Optional[AbstractSet[AssetCheckHandle]],
+):
+    return _remove_unexecutable_taint(
+        job_def.get_subset(
+            op_selection=op_selection,
+            asset_selection=exclude_nonexecutables_from_selection(job_def, asset_selection),
+            asset_check_selection=asset_check_selection,
+        )
+    )
+
+
+def exclude_nonexecutables_from_selection(
+    job_def: JobDefinition, asset_selection: Optional[AbstractSet[AssetKey]]
+) -> Optional[AbstractSet[AssetKey]]:
+    if asset_selection:
+        return asset_selection
+
+    nonexecutable_asset_list = []
+    if job_def.asset_layer:
+        for assets_def in job_def.asset_layer.assets_defs:
+            if not assets_def.is_executable:
+                nonexecutable_asset_list.extend(assets_def.keys)
+
+        if nonexecutable_asset_list:
+            asset_selection = set(job_def.asset_layer.asset_keys) - set(nonexecutable_asset_list)
+
+    return asset_selection

--- a/python_modules/dagster/dagster/_core/definitions/observable_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/observable_asset.py
@@ -41,8 +41,10 @@ def create_unexecutable_observable_assets_def(specs: Sequence[AssetSpec]):
 
     @multi_asset(specs=new_specs)
     def an_asset() -> None:
+        keys = [spec.key for spec in specs]
         raise DagsterInvariantViolationError(
-            f"You have attempted to execute an unexecutable asset {[spec.key for spec in specs]}"
+            f"Asset {keys} is not executable. This is an internal framework error and should have"
+            " been caught earlier."
         )
 
     return an_asset

--- a/python_modules/dagster/dagster/_core/execution/api.py
+++ b/python_modules/dagster/dagster/_core/execution/api.py
@@ -706,6 +706,15 @@ def create_execution_plan(
     else:
         job_def = job
 
+    if job_def.asset_layer:
+        for assets_def in job_def.asset_layer.assets_defs:
+            if not assets_def.is_executable:
+                check.failed(
+                    "Cannot pass unexecutable assets defs to create_execution_plan with keys:"
+                    f" {assets_def.keys}. Please call create_untainted_job_for_execution on the "
+                    "job definition before passing it to the execution API you are using"
+                )
+
     run_config = check.opt_mapping_param(run_config, "run_config", key_type=str)
     check.opt_nullable_sequence_param(step_keys_to_execute, "step_keys_to_execute", of_type=str)
     check.opt_inst_param(instance_ref, "instance_ref", InstanceRef)

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_execution_tainting.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_execution_tainting.py
@@ -1,0 +1,19 @@
+from dagster import job, op
+from dagster._core.definitions.job_definition_execution import (
+    create_untainted_job_for_execution,
+    job_has_unexecutable_taint,
+)
+
+
+def test_execution_taint_removal() -> None:
+    @op
+    def an_op() -> None: ...
+    @job
+    def tainted_love() -> None:
+        an_op()
+
+    assert job_has_unexecutable_taint(tainted_love)
+    untainted_love = create_untainted_job_for_execution(
+        job_def=tainted_love, op_selection=None, asset_selection=None, asset_check_selection=None
+    )
+    assert not job_has_unexecutable_taint(untainted_love)

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_observable_assets.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_observable_assets.py
@@ -15,6 +15,7 @@ from dagster import (
     asset,
     materialize,
 )
+from dagster._check import CheckError
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
 from dagster._core.definitions.observable_asset import (
@@ -160,8 +161,6 @@ def test_emit_asset_observation_in_user_space() -> None:
 
 
 def test_executable_upstream_of_nonexecutable_illegal() -> None:
-    pass
-
     @asset
     def upstream_asset() -> None: ...
 
@@ -176,4 +175,35 @@ def test_executable_upstream_of_nonexecutable_illegal() -> None:
         "An executable asset cannot be upstream of a non-executable asset. Non-executable asset"
         ' "downstream_asset" downstream of executable asset "upstream_asset"'
         in str(exc_info.value)
+    )
+
+
+def test_execute_job_that_includes_non_executable_asset() -> None:
+    upstream_asset = create_unexecutable_observable_assets_def(
+        specs=[
+            AssetSpec(
+                "upstream_asset",
+            )
+        ]
+    )
+
+    @asset(deps=[upstream_asset])
+    def downstream_asset() -> None: ...
+
+    defs = Definitions(assets=[upstream_asset, downstream_asset])
+
+    assert (
+        defs.get_implicit_global_asset_job_def()
+        .execute_in_process(instance=DagsterInstance.ephemeral())
+        .success
+    )
+
+    # ensure that explict selection fails
+    with pytest.raises(CheckError) as exc_info:
+        defs.get_implicit_global_asset_job_def().execute_in_process(
+            instance=DagsterInstance.ephemeral(), asset_selection=[AssetKey("upstream_asset")]
+        )
+
+    assert "Cannot pass unexecutable assets defs to create_execution_plan with keys:" in str(
+        exc_info.value
     )


### PR DESCRIPTION
## Summary & Motivation

This PR does two things:

1) Excludes unexecutable assets from execution automatically. This allows someone to defines a job that includes unexecutable assets, when they execute it with specifying any subselection, unexecutable assets will be automatically included.

2) Alongside this this introduces execution tainting.

The docblock in code that describes this.

```python
# We have a "pattern" in the code base where in execution codepaths we generate
# job definition subsets in order to do runtime executition selection, e.g.
# the user provides an asset selection or an op selection at runtime. Unfortunately
# this is the same codepath that we use at *definition* time to construct job subsets
# using functions like "build_assets_job" which ends up calling "to_job" on
# a GraphDefinition. The get_subset function returns a vanilla job definition
# that has the type as the original, and no lineage. This is highly unfortuante.
# Without a single "choke point" for runtime subsetting, it is very easy to
# forget to call get_subset in production execution codepaths, and there is no
# single place to consolidate runtime subsetting execution logic.
#
# The execution taint is the first step in a plan to fix this. Job definitions
# will be tainted when they are first created. They are only untainted by calling
# create_untainted_job_for_execution. This function will remove the taint.
# We will insert invariants deep in the execution machinery to ensure that this
# is called in user space code before it is passed in for execution.
#
# When this process is complete, we could consider adding a different type to
# represent a chunk of a job to be executed, and remove the taint entirely, transferring
# that information from this dodgy monkeypatching to the type system. We can't
# do this in one go, so tainting it shall be.
#
# This function very deliberatately does not use default arguments. This is by
# design to that callers are forced to declare, in code, that they do not support
# our varietals of execution selection. There shall be no hiding your
# sins of call-stack-passing omissions and their resulting execution
# selection bugs from create_tainted_job_for_execution.
```

cc: @johannkm This is going to be the leverage point from which we can fix our selection nightmare where we pass around three different selection mechanisms, `op_selection`, `asset_selection` and `asset_check_selection`. Since we are going to enforce this as a single choke point through which all execution must pass, we can introduce a new internal selection abstraction here and work "up" and "down" the codebase with the new selection object incrementally.


## How I Tested These Changes

BK
