### PR TITLE
Disallow explicit selection of non-executable assets

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/job_definition_execution.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition_execution.py
@@ -6,6 +6,7 @@ from typing import (
 
 from dagster._core.definitions.asset_check_spec import AssetCheckHandle
 from dagster._core.definitions.events import AssetKey
+from dagster._core.errors import DagsterInvariantViolationError
 
 from .job_definition import UNEXECUTABLE_TAINT_PROPERTY, JobDefinition
 
@@ -54,6 +55,18 @@ def create_untainted_job_for_execution(
     asset_selection: Optional[AbstractSet[AssetKey]],
     asset_check_selection: Optional[AbstractSet[AssetCheckHandle]],
 ):
+    if asset_selection:
+        for asset_key in asset_selection:
+            if asset_key not in job_def.asset_layer.assets_defs_by_key:
+                # disconnected asset key
+                continue
+
+            if not job_def.asset_layer.assets_defs_by_key[asset_key].is_asset_executable(asset_key):
+                raise DagsterInvariantViolationError(
+                    f'You have attempted to explicitly select asset "{asset_key.to_user_string()}"'
+                    " for execution. This is not allowed as it is not executable."
+                )
+
     return _remove_unexecutable_taint(
         job_def.get_subset(
             op_selection=op_selection,

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_observable_assets.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_observable_assets.py
@@ -208,13 +208,7 @@ def test_execute_job_that_implicitly_includes_non_executable_asset() -> None:
 
 
 def test_execute_job_that_explicitly_includes_non_executable_asset() -> None:
-    upstream_asset = create_unexecutable_observable_assets_def(
-        specs=[
-            ObservableAssetSpec(
-                "upstream_asset",
-            )
-        ]
-    )
+    upstream_asset = create_unexecutable_observable_assets_def(specs=[AssetSpec("upstream_asset")])
 
     @asset(deps=[upstream_asset])
     def downstream_asset() -> None: ...

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_observable_assets.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_observable_assets.py
@@ -23,6 +23,7 @@ from dagster._core.definitions.observable_asset import (
 )
 from dagster._core.event_api import EventLogRecord, EventRecordsFilter
 from dagster._core.events import DagsterEventType
+from dagster._core.execution.api import create_execution_plan
 
 
 def get_latest_observation_for_asset_key(
@@ -178,7 +179,7 @@ def test_executable_upstream_of_nonexecutable_illegal() -> None:
     )
 
 
-def test_execute_job_that_includes_non_executable_asset() -> None:
+def test_execute_job_that_implicitly_includes_non_executable_asset() -> None:
     upstream_asset = create_unexecutable_observable_assets_def(
         specs=[
             AssetSpec(
@@ -198,12 +199,35 @@ def test_execute_job_that_includes_non_executable_asset() -> None:
         .success
     )
 
-    # ensure that explict selection fails
     with pytest.raises(CheckError) as exc_info:
-        defs.get_implicit_global_asset_job_def().execute_in_process(
-            instance=DagsterInstance.ephemeral(), asset_selection=[AssetKey("upstream_asset")]
-        )
+        create_execution_plan(defs.get_implicit_global_asset_job_def())
 
     assert "Cannot pass unexecutable assets defs to create_execution_plan with keys:" in str(
         exc_info.value
+    )
+
+
+def test_execute_job_that_explicitly_includes_non_executable_asset() -> None:
+    upstream_asset = create_unexecutable_observable_assets_def(
+        specs=[
+            ObservableAssetSpec(
+                "upstream_asset",
+            )
+        ]
+    )
+
+    @asset(deps=[upstream_asset])
+    def downstream_asset() -> None: ...
+
+    defs = Definitions(assets=[upstream_asset, downstream_asset])
+
+    with pytest.raises(DagsterInvariantViolationError) as exc_info:
+        defs.get_implicit_global_asset_job_def().execute_in_process(
+            instance=DagsterInstance.ephemeral(), asset_selection=[upstream_asset.key]
+        )
+
+    assert (
+        'You have attempted to explicitly select asset "upstream_asset" for execution.'
+        " This is not allowed as it is not executable."
+        in str(exc_info.value)
     )


### PR DESCRIPTION
## Summary & Motivation

This PR explicitly disallows the explicit selection of non-executable assets through execution code paths. This is going impose some frontend (meaning UI + graphql) complexity as the frontend cannot pass selections that include executables. However it is almost certainly a _transfer_ of that complexity, as our frontend has to be source-asset-aware anyways with similar logic.

## How I Tested These Changes

BK
