### PR TITLE
Exploring source asset conversion

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/observable_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/observable_asset.py
@@ -6,7 +6,8 @@ from dagster._core.definitions.asset_spec import (
     AssetSpec,
     AssetVarietal,
 )
-from dagster._core.definitions.decorators.asset_decorator import multi_asset
+from dagster._core.definitions.decorators.asset_decorator import asset, multi_asset
+from dagster._core.definitions.source_asset import SourceAsset
 from dagster._core.errors import DagsterInvariantViolationError
 
 
@@ -48,3 +49,39 @@ def create_unexecutable_observable_assets_def(specs: Sequence[AssetSpec]):
         )
 
     return an_asset
+
+
+def create_unexecutable_observable_assets_def_from_source_asset(source_asset: SourceAsset):
+    check.invariant(
+        source_asset.observe_fn is None,
+        "Observable source assets not supported yet: observe_fn should be None",
+    )
+    check.invariant(
+        source_asset.partitions_def is None,
+        "Observable source assets not supported yet: partitions_def should be None",
+    )
+    check.invariant(
+        source_asset.auto_observe_interval_minutes is None,
+        "Observable source assets not supported yet: auto_observe_interval_minutes should be None",
+    )
+
+    kwargs = {
+        "key": source_asset.key,
+        "metadata": {
+            **source_asset.metadata,
+            **{SYSTEM_METADATA_KEY_ASSET_VARIETAL: AssetVarietal.UNEXECUTABLE.value},
+        },
+        "group_name": source_asset.group_name,
+        "description": source_asset.description,
+    }
+
+    if source_asset.io_manager_def:
+        kwargs["io_manager_def"] = source_asset.io_manager_def
+    elif source_asset.io_manager_key:
+        kwargs["io_manager_key"] = source_asset.io_manager_key
+
+    @asset(**kwargs)
+    def shim_asset() -> None:
+        raise NotImplementedError(f"Asset {source_asset.key} is not executable")
+
+    return shim_asset


### PR DESCRIPTION
## Summary & Motivation

Adding create_unexecutable_observable_assets_def_from_source_asset and a test case to show how this approach will be backwards compatible with SourceAsset. Even if we don't move users over immediately, we should be able to change our internals to use this, which would clean up our implementation considerably.

## How I Tested These Changes

BK
