### PR TITLE
Allow Definitions to take ObservableAssetSpec

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -36,7 +36,7 @@ from dagster._utils.cached_method import cached_method
 from .asset_checks import AssetChecksDefinition
 from .assets import AssetsDefinition
 from .backfill_policy import BackfillPolicy
-from .events import AssetKey, AssetKeyPartitionKey
+from .events import AssetKey, AssetKeyPartitionKey, CoercibleToAssetKey
 from .freshness_policy import FreshnessPolicy
 from .partition import PartitionsDefinition, PartitionsSubset
 from .partition_key_range import PartitionKeyRange
@@ -717,6 +717,14 @@ class InternalAssetGraph(AssetGraph):
     @property
     def asset_checks(self) -> Sequence[AssetChecksDefinition]:
         return self._asset_checks
+
+    def assets_def_for_key(self, key: CoercibleToAssetKey) -> AssetsDefinition:
+        asset_key = AssetKey.from_coercible(key)
+        for assets_def in self._assets:
+            if asset_key in assets_def.keys:
+                return assets_def
+
+        check.failed(f"Could not find assets def for key {key}")
 
 
 def sort_key_for_asset_partition(

--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -19,9 +19,13 @@ from dagster._config.pythonic_config import (
 )
 from dagster._core.definitions.asset_checks import AssetChecksDefinition
 from dagster._core.definitions.asset_graph import InternalAssetGraph
+from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.events import AssetKey, CoercibleToAssetKey
 from dagster._core.definitions.executor_definition import ExecutorDefinition
 from dagster._core.definitions.logger_definition import LoggerDefinition
+from dagster._core.definitions.observable_asset import (
+    create_unexecutable_observable_assets_def,
+)
 from dagster._core.execution.build_resources import wrap_resources_for_execution
 from dagster._core.execution.with_resources import with_resources
 from dagster._core.executor.base import Executor
@@ -240,7 +244,7 @@ def _attach_resources_to_jobs_and_instigator_jobs(
 def _create_repository_using_definitions_args(
     name: str,
     assets: Optional[
-        Iterable[Union[AssetsDefinition, SourceAsset, CacheableAssetsDefinition]]
+        Iterable[Union[AssetsDefinition, SourceAsset, CacheableAssetsDefinition, AssetSpec]]
     ] = None,
     schedules: Optional[
         Iterable[Union[ScheduleDefinition, UnresolvedPartitionedAssetScheduleDefinition]]
@@ -253,7 +257,9 @@ def _create_repository_using_definitions_args(
     asset_checks: Optional[Iterable[AssetChecksDefinition]] = None,
 ):
     check.opt_iterable_param(
-        assets, "assets", (AssetsDefinition, SourceAsset, CacheableAssetsDefinition)
+        assets,
+        "assets",
+        (AssetsDefinition, SourceAsset, CacheableAssetsDefinition, AssetSpec),
     )
     check.opt_iterable_param(
         schedules, "schedules", (ScheduleDefinition, UnresolvedPartitionedAssetScheduleDefinition)
@@ -293,6 +299,15 @@ def _create_repository_using_definitions_args(
         sensors_with_resources,
     ) = _attach_resources_to_jobs_and_instigator_jobs(jobs, schedules, sensors, resource_defs)
 
+    asset_esque_things_to_pass = []
+    for asset_ish in assets or []:
+        if isinstance(asset_ish, AssetSpec):
+            asset_esque_things_to_pass.append(
+                create_unexecutable_observable_assets_def([asset_ish])
+            )
+        else:
+            asset_esque_things_to_pass.append(asset_ish)
+
     @repository(
         name=name,
         default_executor_def=executor_def,
@@ -302,7 +317,7 @@ def _create_repository_using_definitions_args(
     )
     def created_repo():
         return [
-            *with_resources(assets or [], resource_defs),
+            *with_resources(asset_esque_things_to_pass or [], resource_defs),
             *with_resources(asset_checks or [], resource_defs),
             *(schedules_with_resources),
             *(sensors_with_resources),

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_observable_assets.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_observable_assets.py
@@ -292,3 +292,17 @@ def test_how_source_assets_are_backwards_compatible() -> None:
 
     assert result_two.success
     assert result_two.output_for_node("an_asset") == "hardcoded-computed"
+
+
+def test_direct_passing_of_observable_asset_spec_to_definitions() -> None:
+    asset_one = AssetSpec(
+        key="observable_asset_one",
+        # multi-asset does not support description lol
+        # description="desc",
+        metadata={"user_metadata": "value"},
+        group_name="a_group",
+    )
+    # using undocumented API in test case
+    defs = Definitions(assets=[asset_one])  # type: ignore
+
+    assert defs.get_asset_graph().assets_def_for_key("observable_asset_one")


### PR DESCRIPTION
## Summary & Motivation

Add the ability to take `ObservableAssetSpec` in Definitions. Not changing the public type signature for now, but we can use it with type error in test cases.

## How I Tested These Changes

BK
