### PR TITLE
[dagster-dbt] include adapter metadata on all materializations

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
@@ -209,7 +209,7 @@ def _events_for_structured_json_line(
         if run_results is not None:
             try:
                 for result in run_results["results"]:
-                    if result["unique_id"] == unique_id:
+                    if result["unique_id"] == unique_id and "adapter_response" in result:
                         metadata.update(_adapter_response_to_metadata(result["adapter_response"]))
             except KeyError:
                 pass

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
@@ -123,7 +123,8 @@ def result_to_events(
     # all versions represent timing the same way
     metadata = {"Status": status, "Execution Time (seconds)": result["execution_time"]}
     metadata.update(_timing_to_metadata(result["timing"]))
-    metadata.update(_adapter_response_to_metadata(result["adapter_response"]))
+    if "adapter_response" in result:
+        metadata.update(_adapter_response_to_metadata(result["adapter_response"]))
 
     # working with a response that contains the node block (RPC and CLI 0.18.x)
     if "node" in result:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
@@ -83,17 +83,13 @@ def _timing_to_metadata(timings: Sequence[Mapping[str, Any]]) -> Mapping[str, Ra
 
 
 def _adapter_response_to_metadata(
-    adapter_response: Mapping[str, Any]
+    adapter_response: Mapping[str, Any] = {}
 ) -> Mapping[str, RawMetadataValue]:
     # adds adapter specific information to output metadata from
     # https://docs.getdbt.com/reference/artifacts/run-results-json
     metadata: Dict[str, RawMetadataValue] = {}
-    if adapter_response.get("query_id") is not None:
-        metadata.update({"Query ID": adapter_response.get("query_id")})
-    if adapter_response.get("rows_affected") is not None:
-        metadata.update({"Rows Affected": adapter_response.get("rows_affected")})
-    if adapter_response.get("bytes_processed") is not None:
-        metadata.update({"Bytes Processed": adapter_response.get("bytes_processed")})
+    for key in adapter_response.keys():
+        metadata.update({key: adapter_response.get(key)})
     return metadata
 
 


### PR DESCRIPTION
## Summary & Motivation

This PR modifies dagster-dbt to include the adapter_response fields of the relevant dbt [run_results](
https://docs.getdbt.com/reference/artifacts/run-results-json) on asset materializations. This adds a bunch of additional context that should be useful even as normal asset metadata but will also be used for some of the cloud insights work as well.

For a sense of what is included by various adapters (usage/scan metrics, query ids, etc):
https://github.com/dbt-labs/dbt-bigquery/blob/27ade3df84b040d4140c1870a033b20c2495b5cd/dbt/adapters/bigquery/connections.py#L93
https://github.com/dbt-labs/dbt-snowflake/blob/eb4fd78ce2e4200a7c437c6411b95c30a34b1840/dbt/adapters/snowflake/connections.py#L55
https://github.com/dbt-athena/dbt-athena/blob/bc576c474bc70f9aec24b02e946183cd66344819/dbt/adapters/athena/connections.py#L44

## How I Tested These Changes

Local pipeline executions

## todos 
- [ ] unittests
