### PR TITLE
[dagster-graphql] add metrics graphql client helper methods

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/__init__.py
+++ b/python_modules/dagster-graphql/dagster_graphql/__init__.py
@@ -1,9 +1,11 @@
 from dagster._core.libraries import DagsterLibraryRegistry
 
 from .client import (
+    AssetMetric as AssetMetric,
     DagsterGraphQLClient as DagsterGraphQLClient,
     DagsterGraphQLClientError as DagsterGraphQLClientError,
     InvalidOutputErrorInfo as InvalidOutputErrorInfo,
+    JobMetric as JobMetric,
     ReloadRepositoryLocationInfo as ReloadRepositoryLocationInfo,
     ReloadRepositoryLocationStatus as ReloadRepositoryLocationStatus,
     ShutdownRepositoryLocationInfo as ShutdownRepositoryLocationInfo,

--- a/python_modules/dagster-graphql/dagster_graphql/client/__init__.py
+++ b/python_modules/dagster-graphql/dagster_graphql/client/__init__.py
@@ -1,7 +1,9 @@
 from .client import DagsterGraphQLClient as DagsterGraphQLClient
 from .utils import (
+    AssetMetric as AssetMetric,
     DagsterGraphQLClientError as DagsterGraphQLClientError,
     InvalidOutputErrorInfo as InvalidOutputErrorInfo,
+    JobMetric as JobMetric,
     ReloadRepositoryLocationInfo as ReloadRepositoryLocationInfo,
     ReloadRepositoryLocationStatus as ReloadRepositoryLocationStatus,
     ShutdownRepositoryLocationInfo as ShutdownRepositoryLocationInfo,

--- a/python_modules/dagster-graphql/dagster_graphql/client/client.py
+++ b/python_modules/dagster-graphql/dagster_graphql/client/client.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Union
 
 import dagster._check as check
 import requests.exceptions
-from dagster import DagsterRunStatus
+from dagster import DagsterRunStatus, OpExecutionContext
 from dagster._annotations import experimental, public
 from dagster._core.definitions.run_config import RunConfig, convert_config_input
 from dagster._core.definitions.utils import validate_tags
@@ -15,14 +15,18 @@ from .client_queries import (
     CLIENT_GET_REPO_LOCATIONS_NAMES_AND_PIPELINES_QUERY,
     CLIENT_SUBMIT_PIPELINE_RUN_MUTATION,
     GET_PIPELINE_RUN_STATUS_QUERY,
+    PUT_CLOUD_METRICS_MUTATION,
     RELOAD_REPOSITORY_LOCATION_MUTATION,
     SHUTDOWN_REPOSITORY_LOCATION_MUTATION,
     TERMINATE_RUN_JOB_MUTATION,
 )
 from .utils import (
+    AssetMetric,
     DagsterGraphQLClientError,
     InvalidOutputErrorInfo,
     JobInfo,
+    JobMetric,
+    Metric,
     ReloadRepositoryLocationInfo,
     ReloadRepositoryLocationStatus,
     ShutdownRepositoryLocationInfo,
@@ -396,3 +400,189 @@ class DagsterGraphQLClient:
             raise DagsterGraphQLClientError("RunNotFoundError", f"Run Id {run_id} not found")
         else:
             raise DagsterGraphQLClientError(query_result_type, query_result["message"])
+
+    @experimental
+    @public
+    def put_metrics(self, metrics: List[Union[AssetMetric, JobMetric]]):
+        """Store metrics in the dagster metrics store. This method is useful when you would like to
+        store run, asset or asset group materialization metric data to view in the insights UI.
+
+        Currently only supported in Dagster Cloud
+
+        Args:
+            metrics (List[Union[AssetMetric, JobMetric]]): metrics to store in the dagster metrics store
+        """
+        check.list_param(metrics, "metrics", of_type=(AssetMetric, JobMetric))
+
+        metric_graphql_inputs = {}
+        for metric in metrics:
+            key = (
+                metric.run_id,
+                metric.step_key,
+                metric.code_location_name,
+                metric.repository_name,
+            )
+            if isinstance(metric, AssetMetric):
+                if key not in metric_graphql_inputs.keys():
+                    metric_graphql_inputs[key] = {
+                        "runId": metric.run_id,
+                        "stepKey": metric.step_key,
+                        "codeLocationName": metric.code_location_name,
+                        "repositoryName": metric.repository_name,
+                        "assetMetricDefinitions": [
+                            {
+                                "assetKey": metric.asset_key,
+                                "assetGroup": metric.asset_group,
+                                "metricValues": [
+                                    {
+                                        "metricValue": metric_def.metric_value,
+                                        "metricName": metric_def.metric_name,
+                                    }
+                                    for metric_def in metric.metrics
+                                ],
+                            }
+                        ],
+                        "jobMetricDefinitions": [],
+                    }
+                else:
+                    metric_graphql_inputs[key]["assetMetricDefinitions"].append(
+                        {
+                            "assetKey": metric.asset_key,
+                            "assetGroup": metric.asset_group,
+                            "metricValues": [
+                                {
+                                    "metricValue": metric_def.metric_value,
+                                    "metricName": metric_def.metric_name,
+                                }
+                                for metric_def in metric.metrics
+                            ],
+                        }
+                    )
+            elif isinstance(metric, JobMetric):
+                if key not in metric_graphql_inputs.keys():
+                    metric_graphql_inputs[key] = {
+                        "runId": metric.run_id,
+                        "stepKey": metric.step_key,
+                        "codeLocationName": metric.code_location_name,
+                        "repositoryName": metric.repository_name,
+                        "assetMetricDefinitions": [],
+                        "jobMetricDefinitions": [
+                            {
+                                "metricValues": [
+                                    {
+                                        "metricValue": metric_def.metric_value,
+                                        "metricName": metric_def.metric_name,
+                                    }
+                                    for metric_def in metric.metrics
+                                ],
+                            }
+                        ],
+                    }
+                else:
+                    metric_graphql_inputs[key]["jobMetricDefinitions"].append(
+                        {
+                            "metricValues": [
+                                {
+                                    "metricValue": metric_def.metric_value,
+                                    "metricName": metric_def.metric_name,
+                                }
+                                for metric_def in metric.metrics
+                            ],
+                        }
+                    )
+            else:
+                raise DagsterGraphQLClientError(
+                    "InvalidMetricTypeError",
+                    f"Metric {metric} is not of type AssetMetric or JobMetric",
+                )
+
+        res_data: Dict[str, Dict[str, Any]] = self._execute(
+            PUT_CLOUD_METRICS_MUTATION,
+            {"metrics": metric_graphql_inputs.values()},
+        )
+
+        store_metric_result: Dict[str, Any] = res_data["createExternalMetrics"]
+        store_metric_result_type: str = store_metric_result["__typename"]
+        if store_metric_result_type == "CreateExternalMetricsSuccess":
+            return
+
+        raise DagsterGraphQLClientError(store_metric_result_type, store_metric_result["message"])
+
+    @experimental
+    @public
+    def put_context_metrics(
+        self,
+        context: OpExecutionContext,
+        metrics: List[Metric],
+    ):
+        """Store metrics in the dagster cloud metrics store. This method is useful when you would like to
+        store run, asset or asset group materialization metric data to view in the insights UI.
+
+        Currently only supported in Dagster Cloud
+
+        Args:
+            metrics (Mapping[str, Any]): metrics to store in the dagster metrics store
+        """
+        check.list_param(metrics, "metrics", of_type=Metric)
+        check.inst_param(context, "context", OpExecutionContext)
+        metric_graphql_input = {}
+
+        if context.dagster_run.external_job_origin is None:
+            raise Exception("dagster run for this context has not started yet")
+
+        if context.has_assets_def:
+            metric_graphql_input = {
+                "assetMetricDefinitions": [
+                    {
+                        "runId": context.run_id,
+                        "stepKey": context.get_step_execution_context().step.key,
+                        "codeLocationName": context.dagster_run.external_job_origin.location_name,
+                        "repositoryName": (
+                            context.dagster_run.external_job_origin.external_repository_origin.repository_name
+                        ),
+                        "assetKey": selected_asset_key,
+                        "assetGroup": context.assets_def.group_names_by_key.get(
+                            selected_asset_key, None
+                        ),
+                        "metricValues": [
+                            {
+                                "metricValue": metric_def.metric_value,
+                                "metricName": metric_def.metric_name,
+                            }
+                            for metric_def in metrics
+                        ],
+                    }
+                    for selected_asset_key in context.selected_asset_keys
+                ]
+            }
+        else:
+            metric_graphql_input = {
+                "jobMetricDefinitions": [
+                    {
+                        "runId": context.run_id,
+                        "stepKey": context.get_step_execution_context().step.key,
+                        "codeLocationName": context.dagster_run.external_job_origin.location_name,
+                        "repositoryName": (
+                            context.dagster_run.external_job_origin.external_repository_origin.repository_name
+                        ),
+                        "metricValues": [
+                            {
+                                "metricValue": metric_def.metric_value,
+                                "metricName": metric_def.metric_name,
+                            }
+                            for metric_def in metrics
+                        ],
+                    }
+                ]
+            }
+
+        res_data: Dict[str, Dict[str, Any]] = self._execute(
+            PUT_CLOUD_METRICS_MUTATION, {"metrics": [metric_graphql_input]}
+        )
+
+        store_metric_result: Dict[str, Any] = res_data["createExternalMetrics"]
+        store_metric_result_type: str = store_metric_result["__typename"]
+        if store_metric_result_type == "CreateExternalMetricsSuccess":
+            return
+
+        raise DagsterGraphQLClientError(store_metric_result_type, store_metric_result["message"])

--- a/python_modules/dagster-graphql/dagster_graphql/client/client_queries.py
+++ b/python_modules/dagster-graphql/dagster_graphql/client/client_queries.py
@@ -146,3 +146,40 @@ mutation TerminateRun($runId: String!) {
   }
 }
 """
+
+PUT_CLOUD_METRICS_MUTATION = """
+mutation CreateOrUpdateExtenalMetrics(
+  $metrics: [ExternalMetricInputs]!) {
+  createOrUpdateExternalMetrics(metrics: $metrics) {
+    __typename
+    ... on CreateOrUpdateExternalMetricsSuccess {
+      status
+      __typename
+    }
+    ...MetricsFailedFragment
+    ...UnauthorizedErrorFragment
+    ...PythonErrorFragment
+  }
+}
+
+fragment PythonErrorFragment on PythonError {
+  __typename
+  message
+  stack
+  causes {
+    message
+    stack
+    __typename
+  }
+}
+
+fragment MetricsFailedFragment on CreateOrUpdateExternalMetricsFailed {
+  __typename
+  message
+}
+
+fragment UnauthorizedErrorFragment on UnauthorizedError {
+  __typename
+  message
+}
+"""

--- a/python_modules/dagster-graphql/dagster_graphql/client/utils.py
+++ b/python_modules/dagster-graphql/dagster_graphql/client/utils.py
@@ -86,3 +86,56 @@ class InvalidOutputErrorInfo(NamedTuple):
 
     step_key: str
     invalid_output_name: str
+
+
+class Metric(NamedTuple):
+    """This class gives information about a Metric.
+
+    Args:
+        metric_name (str): name of the metric
+        metric_value (float): value of the metric
+    """
+
+    metric_name: str
+    metric_value: float
+
+
+class AssetMetric(NamedTuple):
+    """This class gives information about an AssetMetric for a given asset.
+
+    Args:
+        run_id (str): id of the run that materialized the asset
+        step_key (str): key of the step that materialized the asset
+        code_location_name (str): name of the code location that materialized the asset
+        repository_name (str): name of the repository that materialized the asset
+        asset_key (str): key of the asset that was materialized
+        metric_name (str): name of the metric
+        metric_value (float): value of the metric
+    """
+
+    run_id = str
+    step_key = str
+    code_location_name = str
+    repository_name = str
+    asset_key: str
+    metrics: List[Metric]
+    asset_group: Optional[str] = None
+
+
+class JobMetric(NamedTuple):
+    """This class gives information about a JobMetric for a given job.
+
+    Args:
+        run_id (str): id of the job run
+        step_key (str): key of the step in the job
+        code_location_name (str): name of the code location containing the job
+        repository_name (str): name of the repository containing the job
+        metric_name (str): name of the metric
+        metric_value (float): value of the metric
+    """
+
+    run_id = str
+    step_key = str
+    code_location_name = str
+    repository_name = str
+    metrics: List[Metric]

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/client_backcompat/query_snapshots/CLIENT_SUBMIT_PIPELINE_RUN_MUTATION/1!0+dev-2023_09_18.graphql
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/client_backcompat/query_snapshots/CLIENT_SUBMIT_PIPELINE_RUN_MUTATION/1!0+dev-2023_09_18.graphql
@@ -1,0 +1,40 @@
+mutation($executionParams: ExecutionParams!) {
+  launchPipelineExecution(executionParams: $executionParams) {
+    __typename
+    ... on InvalidStepError {
+      invalidStepKey
+    }
+    ... on InvalidOutputError {
+      stepKey
+      invalidOutputName
+    }
+    ... on LaunchPipelineRunSuccess {
+      run {
+        runId
+      }
+    }
+    ... on ConflictingExecutionParamsError {
+      message
+    }
+    ... on PresetNotFoundError {
+      message
+    }
+    ... on PipelineRunConflict {
+      message
+    }
+    ... on PipelineConfigValidationInvalid {
+      errors {
+        __typename
+        message
+        path
+        reason
+      }
+    }
+    ... on PipelineNotFoundError {
+      message
+    }
+    ... on PythonError {
+      message
+    }
+  }
+}

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/client_backcompat/query_snapshots/GET_PIPELINE_RUN_STATUS_QUERY/1!0+dev-2023_09_18.graphql
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/client_backcompat/query_snapshots/GET_PIPELINE_RUN_STATUS_QUERY/1!0+dev-2023_09_18.graphql
@@ -1,0 +1,14 @@
+query($runId: ID!) {
+  pipelineRunOrError(runId: $runId) {
+    __typename
+    ... on PipelineRun {
+        status
+    }
+    ... on PipelineRunNotFoundError {
+      message
+    }
+    ... on PythonError {
+      message
+    }
+  }
+}

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/client_backcompat/query_snapshots/PUT_CLOUD_METRICS_MUTATION/1!0+dev-2023_09_18.graphql
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/client_backcompat/query_snapshots/PUT_CLOUD_METRICS_MUTATION/1!0+dev-2023_09_18.graphql
@@ -1,0 +1,31 @@
+mutation CreateOrUpdateExtenalMetrics(
+  $metrics: [ExternalMetricInputs]!) {
+  createOrUpdateExternalMetrics(metrics: $metrics) {
+    __typename
+    ... on CreateOrUpdateExternalMetricsSuccess {
+      status
+      __typename
+    }
+    ...MetricsFailedFragment
+    ...UnauthorizedErrorFragment
+    ...PythonErrorFragment
+  }
+}
+fragment PythonErrorFragment on PythonError {
+  __typename
+  message
+  stack
+  causes {
+    message
+    stack
+    __typename
+  }
+}
+fragment MetricsFailedFragment on CreateOrUpdateExternalMetricsFailed {
+  __typename
+  message
+}
+fragment UnauthorizedErrorFragment on UnauthorizedError {
+  __typename
+  message
+}


### PR DESCRIPTION
## Summary & Motivation

This PR adds 2 client helper methods for sending insights metrics to the dagster cloud graphql API.

1. `put_metrics`, requires quite a few fields but will assemble the correct graphql request and allows for more flexibility for what step/run a metric will be associated with
2. `put_context_metrics` by accepting an OpExecutionContext any metrics sent to this api will be associated with the step/run/materialization(s) of the context, making it much simpler for users to send metric data

## How I Tested These Changes

local pipeline execution

## Questions

- For now these are cloud only features which might mean that they don't belong in dagster-graphql? or is it ok so long as the docs mention that?

## todo

- [ ] unittest
