### PR TITLE
Make AssetExecutionContext a subclass of OpExecutionContext

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
@@ -160,8 +160,13 @@ def build_graphql_python_client_backcompat_steps() -> List[CommandStep]:
         CommandStepBuilder(":graphql: GraphQL Python Client backcompat")
         .on_test_image(AvailablePythonVersion.get_default())
         .run(
+<<<<<<< HEAD
             "pip install -e python_modules/dagster[test] -e python_modules/dagster-pipes -e"
             " python_modules/dagster-graphql -e python_modules/automation",
+=======
+            "pip install -e python_modules/dagster[test] -e python_modules/dagster-graphql -e "
+            " python_modules/automation -e python_modules/dagster-ext",
+>>>>>>> 49b0a60e1f (random bk)
             "dagster-graphql-client query check",
         )
         .with_skip(

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -1327,7 +1327,8 @@ ALTERNATE_AVAILABLE_METHODS = {
     "get_tag": "use dagster_run.tags.get instead",
     "run_tags": "use dagster_run.tags instead",
     "set_data_version": "use MaterializeResult instead",
-    "run": "use dagster_run instead.",
+    "run": "use dagster_run instead",
+    "asset_check_spec": "use check_specs_by_asset_key instead",
 }
 
 # TODO - add AssetCheck related methods to this list
@@ -1374,6 +1375,10 @@ class AssetExecutionContext(OpExecutionContext):
         }
         self._code_version_by_asset_key = {
             key: self._assets_def.code_versions_by_key[key] for key in self._selected_asset_keys
+        }
+        self._check_specs_by_asset_key = {
+            self._op_execution_context.asset_key_for_output(output_name): check
+            for output_name, check in self._assets_def.check_specs_by_output_name.items()
         }
 
     @public
@@ -1498,9 +1503,10 @@ class AssetExecutionContext(OpExecutionContext):
             asset_keys
         )
 
+    @public
     @property
-    def asset_check_spec(self) -> AssetCheckSpec:
-        return self._op_execution_context.asset_check_spec
+    def check_specs_by_asset_key(self) -> Mapping[AssetKey, AssetCheckSpec]:
+        return self._check_specs_by_asset_key
 
     @public
     @property
@@ -1713,6 +1719,11 @@ class AssetExecutionContext(OpExecutionContext):
     @deprecated(**_get_deprecation_kwargs("has_events"))
     def has_events(self) -> bool:
         return self.op_execution_context.has_events()
+
+    @deprecated(**_get_deprecation_kwargs("asset_check_spec"))
+    @property
+    def asset_check_spec(self) -> AssetCheckSpec:
+        return self._op_execution_context.asset_check_spec
 
 def build_execution_context(
     step_context: StepExecutionContext,

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -1364,9 +1364,6 @@ class AssetExecutionContext(OpExecutionContext):
         self._op_execution_context = check.inst_param(
             op_execution_context, "op_execution_context", OpExecutionContext
         )
-        self._step_execution_context = (
-            self._op_execution_context._step_execution_context  # noqa: SLF001
-        )
 
     @public
     @property
@@ -1445,13 +1442,13 @@ class AssetExecutionContext(OpExecutionContext):
     @property
     def instance(self) -> DagsterInstance:
         """DagsterInstance: The current Dagster instance."""
-        return self._step_execution_context.instance
+        return self._op_execution_context.instance
 
     @public
     @property
     def dagster_run(self) -> DagsterRun:
         """PipelineRun: The current pipeline run."""
-        return self._step_execution_context.dagster_run
+        return self._op_execution_context.dagster_run
 
     @public
     @property
@@ -1508,13 +1505,13 @@ class AssetExecutionContext(OpExecutionContext):
     @property
     def resources(self) -> Any:
         """Resources: The currently available resources."""
-        return self._step_execution_context.resources
+        return self._op_execution_context.resources
 
     @public
     @property
     def run_config(self) -> Mapping[str, object]:
         """dict: The run config for the current execution."""
-        return self._step_execution_context.run_config
+        return self._op_execution_context.run_config
 
     # deprecated methods. All remaining methods on OpExecutionContext should be here with the
     # appropriate deprecation warning

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -1498,17 +1498,13 @@ class AssetExecutionContext(OpExecutionContext):
     # deprecated methods. All remaining methods on OpExecutionContext should be here with the
     # appropriate deprecation warning
 
-    @deprecated(
-        **_get_deprecation_kwargs("op_config"),
-    )
+    @deprecated(**_get_deprecation_kwargs("op_config"))
     @public
     @property
     def op_config(self) -> Any:
         return super().op_config
 
-    @deprecated(
-        **_get_deprecation_kwargs("file_manager"),
-    )
+    @deprecated(**_get_deprecation_kwargs("file_manager"))
     @property
     def file_manager(self):
         return super().file_manager

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -1297,7 +1297,7 @@ OP_EXECUTION_CONTEXT_ONLY_METHODS = set(
 )
 
 
-PARTITION_KEY_RANGE_AS_ALT = "use partition_key_range or partition_key_range_for_asset instead"
+PARTITION_KEY_RANGE_AS_ALT = "use partition_key_range or partition_key_range_for_asset_key instead"
 INPUT_OUTPUT_ALT = "not use input or output names and instead use asset keys directly"
 OUTPUT_METADATA_ALT = "return MaterializeResult from the asset instead"
 
@@ -1324,7 +1324,7 @@ DEPRECATED_IO_MANAGER_CENTRIC_CONTEXT_METHODS = {
 
 ALTERNATE_AVAILABLE_METHODS = {
     "has_tag": "use dagster_run.has_tag instead",
-    "get_tag": "use dagster_run.get_tag instead",
+    "get_tag": "use dagster_run.tags.get instead",
     "run_tags": "use dagster_run.tags instead",
     "set_data_version": "use MaterializeResult instead",
     "run": "use dagster_run instead.",
@@ -1417,7 +1417,7 @@ class AssetExecutionContext(OpExecutionContext):
     @public
     @property
     def partition_key_range(self) -> PartitionKeyRange:
-        return self._op_execution_context.asset_partition_key_range
+        return self._op_execution_context.partition_key_range
 
     @property
     def partition_time_window(self) -> TimeWindow:

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -1297,6 +1297,7 @@ OP_EXECUTION_CONTEXT_ONLY_METHODS = set(
         "has_events",
         "consume_events",
         "log_event",
+        "get_asset_provenance",
     ]
 )
 
@@ -1692,6 +1693,11 @@ class AssetExecutionContext(OpExecutionContext, IContext):
     @deprecated(**_get_deprecation_kwargs("log_event"))
     def log_event(self, event: UserEvent) -> None:
         return self._op_execution_context.log_event(event)
+
+    @deprecated(**_get_deprecation_kwargs("get_asset_provenance"))
+    @experimental
+    def get_asset_provenance(self, asset_key: AssetKey) -> Optional[DataProvenance]:
+        return self._op_execution_context.get_asset_provenance(asset_key)
 
 def build_execution_context(
     step_context: StepExecutionContext,

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -14,7 +14,8 @@ from typing import (
     cast,
 )
 
-# from dagster_ext import IContext
+from dagster_ext import IContext
+
 import dagster._check as check
 from dagster._annotations import deprecated, experimental, public
 from dagster._core.definitions.asset_check_spec import AssetCheckSpec
@@ -1361,7 +1362,7 @@ def _get_deprecation_kwargs(attr: str):
     return deprecation_kwargs
 
 
-class AssetExecutionContext(OpExecutionContext):
+class AssetExecutionContext(OpExecutionContext, IContext):
     def __init__(self, op_execution_context: OpExecutionContext) -> None:
         self._op_execution_context = check.inst_param(
             op_execution_context, "op_execution_context", OpExecutionContext

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -50,6 +50,7 @@ from dagster._core.storage.dagster_run import DagsterRun
 from dagster._utils.forked_pdb import ForkedPdb
 from dagster._utils.warnings import (
     deprecation_warning,
+    disable_dagster_warnings,
 )
 
 from .system import StepExecutionContext
@@ -1367,16 +1368,16 @@ class AssetExecutionContext(OpExecutionContext):
         self._selected_asset_keys = self._op_execution_context.selected_asset_keys
         self._assets_def = self._op_execution_context.assets_def
 
-        self._provenance_by_asset_key = {
-            key: self._op_execution_context.get_asset_provenance(key)
-            for key in self._selected_asset_keys
-        }
+        with disable_dagster_warnings():
+            self._provenance_by_asset_key = {
+                key: self._op_execution_context.get_asset_provenance(key)
+                for key in self._selected_asset_keys
+            }
         self._code_version_by_asset_key = {
             key: self._assets_def.code_versions_by_key[key] for key in self._selected_asset_keys
         }
         self._check_specs_by_asset_key = {
-            self._op_execution_context.asset_key_for_output(output_name): check
-            for output_name, check in self._assets_def.check_specs_by_output_name.items()
+            check.asset_key: check for check in self._assets_def.check_specs_by_output_name.values()
         }
 
     @public

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -14,6 +14,8 @@ from typing import (
     cast,
 )
 
+from dagster_ext import IContext
+
 import dagster._check as check
 from dagster._annotations import deprecated, experimental, public
 from dagster._core.definitions.asset_check_spec import AssetCheckSpec
@@ -1359,7 +1361,7 @@ def _get_deprecation_kwargs(attr: str):
     return deprecation_kwargs
 
 
-class AssetExecutionContext(OpExecutionContext):
+class AssetExecutionContext(OpExecutionContext, IContext):
     def __init__(self, op_execution_context: OpExecutionContext) -> None:
         self._op_execution_context = check.inst_param(
             op_execution_context, "op_execution_context", OpExecutionContext

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -1264,10 +1264,441 @@ class OpExecutionContext(AbstractComputeExecutionContext, metaclass=OpExecutionC
         self._step_execution_context.set_requires_typed_event_stream(error_message=error_message)
 
 
-class AssetExecutionContext(OpExecutionContext):
-    def __init__(self, step_execution_context: StepExecutionContext):
-        super().__init__(step_execution_context=step_execution_context)
+############################
+##### AssetExecutionContext
+############################
 
+# To preserve backwards compatibility, AssetExecutionContext is being written as a subclass of
+# OpExecutionContext until we can split it into its own class. All methods on OpExecutionContext
+# that will not be included in the eventual AssetExecutionContext will be marked with deprecation
+# warnings according to how the user should access that functionality in the future
+#
+# The following sets/maps are used to determine which methods need deprecation warnings, and how to
+# direct users to the correct method to use
+
+
+OP_EXECUTION_CONTEXT_ONLY_METHODS = set(
+    [
+        "describe_op",
+        "file_manager",
+        "has_assets_def",
+        "get_mapping_key",
+        # "get_step_execution_context", # used by internals
+        "job_def",
+        "node_handle",
+        "op",
+        "op_config",
+        # "op_def", # used by internals
+        "op_handle",
+        "step_launcher",
+        # "has_events", # used by internals
+        "consume_events",
+    ]
+)
+
+
+PARTITION_KEY_RANGE_AS_ALT = "use partition_key_range or partition_key_range_for_asset instead"
+INPUT_OUTPUT_ALT = "not use input or output names and instead use asset keys directly"
+OUTPUT_METADATA_ALT = "return MaterializeResult from the asset instead"
+
+DEPRECATED_IO_MANAGER_CENTRIC_CONTEXT_METHODS = {
+    "add_output_metadata": OUTPUT_METADATA_ALT,
+    "asset_key_for_input": INPUT_OUTPUT_ALT,
+    "asset_key_for_output": INPUT_OUTPUT_ALT,
+    "asset_partition_key_for_input": PARTITION_KEY_RANGE_AS_ALT,
+    "asset_partition_key_for_output": PARTITION_KEY_RANGE_AS_ALT,
+    "asset_partition_key_range_for_input": PARTITION_KEY_RANGE_AS_ALT,
+    "asset_partition_key_range_for_output": PARTITION_KEY_RANGE_AS_ALT,
+    "asset_partition_keys_for_input": PARTITION_KEY_RANGE_AS_ALT,
+    "asset_partition_keys_for_output": PARTITION_KEY_RANGE_AS_ALT,
+    "asset_partitions_time_window_for_input": PARTITION_KEY_RANGE_AS_ALT,
+    "asset_partitions_time_window_for_output": PARTITION_KEY_RANGE_AS_ALT,
+    "asset_partitions_def_for_input": PARTITION_KEY_RANGE_AS_ALT,
+    "asset_partitions_def_for_output": PARTITION_KEY_RANGE_AS_ALT,
+    "get_output_metadata": "use op_execution_context.op_def.get_output(...).metadata",
+    # "merge_output_metadata": OUTPUT_METADATA_ALT, # TODO - this method doesn't exist, check if it has a different name
+    "output_for_asset_key": INPUT_OUTPUT_ALT,
+    "selected_output_names": INPUT_OUTPUT_ALT,
+}
+
+ALTERNATE_AVAILABLE_METHODS = {
+    "has_tag": (
+        "use dagster_run.has_tag instead"
+    ),  # TODO - was dagster_run intended to be a method/attr on AssetExecutionContext?
+    "get_tag": "use dagster_run.get_tag instead",
+    "run_tags": "use dagster_run.tags instead",
+    "set_data_version": "use MaterializeResult instead",
+}
+
+# TODO - add AssetCheck related methods to this list
+
+
+def _get_deprecation_kwargs(attr: str):
+    deprecation_kwargs = {"breaking_version": "1.7.0"}
+    deprecation_kwargs["subject"] = f"AssetExecutionContext.{attr}"
+
+    if attr in OP_EXECUTION_CONTEXT_ONLY_METHODS:
+        deprecation_kwargs["additional_warn_text"] = (
+            f"You have called the deprecated method {attr} on AssetExecutionContext. Use"
+            " the underlying OpExecutionContext instead by calling"
+            f" context.op_execution_context.{attr}."
+        )
+
+    if attr in DEPRECATED_IO_MANAGER_CENTRIC_CONTEXT_METHODS:
+        alt = DEPRECATED_IO_MANAGER_CENTRIC_CONTEXT_METHODS[attr]
+        deprecation_kwargs["additional_warn_text"] = (
+            f"You have called method {attr} on AssetExecutionContext that is oriented"
+            f" around I/O managers. If you not using I/O managers we suggest you {alt}. If"
+            " you are using I/O managers the method still exists at"
+            f" context.op_execution_context.{attr}."
+        )
+
+    if attr in ALTERNATE_AVAILABLE_METHODS:
+        deprecation_kwargs["additional_warn_text"] = f"Instead {ALTERNATE_AVAILABLE_METHODS[attr]}."
+
+    return deprecation_kwargs
+
+
+class AssetExecutionContext(OpExecutionContext):
+    def __init__(self, op_execution_context: OpExecutionContext) -> None:
+        self._op_execution_context = check.inst_param(
+            op_execution_context, "op_execution_context", OpExecutionContext
+        )
+        self._step_execution_context = (
+            self._op_execution_context._step_execution_context  # noqa: SLF001
+        )
+
+    @public
+    @property
+    def op_execution_context(self) -> OpExecutionContext:
+        return self._op_execution_context
+
+    # IContext interface methods
+
+    @property
+    def is_asset_step(self) -> bool:
+        return self.op_execution_context.has_assets_def
+
+    @public
+    @property
+    def asset_key(self) -> AssetKey:
+        return self._op_execution_context.asset_key
+
+    @property
+    def asset_keys(self) -> Sequence[AssetKey]:
+        return list(self.op_execution_context.assets_def.keys_by_output_name.values())
+
+    @property
+    def provenance(self) -> Optional[DataProvenance]:
+        return self.get_asset_provenance(self.asset_key)
+
+    @property
+    def provenance_by_asset_key(self) -> Mapping[AssetKey, Optional[DataProvenance]]:
+        provenance_map = {}
+        for key in self.asset_keys:
+            provenance_map[key] = self.get_asset_provenance(key)
+
+        return provenance_map
+
+    @property
+    def code_version(self) -> Optional[str]:
+        return self.get_assets_code_version([self.asset_key])[self.asset_key]
+
+    @property
+    def code_version_by_asset_key(self) -> Mapping[AssetKey, Optional[str]]:
+        return self.get_assets_code_version(self.asset_keys)
+
+    @public
+    @property
+    def is_partition_step(self) -> bool:
+        return self._op_execution_context.has_partition_key
+
+    @property
+    def partition_key(self) -> str:
+        return self.op_execution_context.partition_key
+
+    @public
+    @property
+    def partition_key_range(self) -> PartitionKeyRange:
+        return self._op_execution_context.asset_partition_key_range
+
+    @property
+    def partition_time_window(self) -> TimeWindow:
+        return self.op_execution_context.partition_time_window
+
+    @public
+    @property
+    def run_id(self) -> str:
+        return self._op_execution_context.run_id
+
+    @property
+    def job_name(self) -> Optional[str]:
+        return self.op_execution_context.job_name
+
+    @property
+    def retry_number(self) -> int:
+        return self.op_execution_context.retry_number
+
+    # Additional methods
+
+    @public
+    @property
+    def dagster_run(self) -> DagsterRun:
+        """PipelineRun: The current pipeline run."""
+        return self._step_execution_context.dagster_run
+
+    @public
+    @property
+    def pdb(self) -> ForkedPdb:
+        return self._op_execution_context.pdb
+
+    @public
+    @property
+    def log(self) -> DagsterLogManager:
+        """DagsterLogManager: The log manager available in the execution context."""
+        return self._op_execution_context.log
+
+    @public
+    def log_event(self, event: UserEvent) -> None:
+        return self._op_execution_context.log_event(event)
+
+    @public
+    @property
+    def assets_def(self) -> AssetsDefinition:
+        return self._op_execution_context.assets_def
+
+    @public
+    @property
+    def selected_asset_keys(self) -> AbstractSet[AssetKey]:
+        return self._op_execution_context.selected_asset_keys
+
+    @public
+    @experimental
+    def get_asset_provenance(self, asset_key: AssetKey) -> Optional[DataProvenance]:
+        return self._op_execution_context.get_asset_provenance(asset_key)
+
+    @public
+    # TODO - method naming. this needs work
+    def get_assets_code_version(
+        self, asset_keys: Sequence[AssetKey]
+    ) -> Mapping[AssetKey, Optional[str]]:
+        return self.op_execution_context.instance.get_latest_materialization_code_versions(
+            asset_keys
+        )
+
+    @property
+    def asset_check_spec(self) -> AssetCheckSpec:
+        return self._op_execution_context.asset_check_spec
+
+    @public
+    def partition_key_range_for_asset_key(self, asset_key: AssetKey) -> PartitionKeyRange:
+        """TODO - implement in stacked pr."""
+        pass
+
+    # deprecated methods. All remaining methods on OpExecutionContext should be here with the
+    # appropriate deprecation warning
+
+    @deprecated(
+        **_get_deprecation_kwargs("op_config"),
+    )
+    @public
+    @property
+    def op_config(self) -> Any:
+        return super().op_config
+
+    @deprecated(
+        **_get_deprecation_kwargs("file_manager"),
+    )
+    @property
+    def file_manager(self):
+        return super().file_manager
+
+    @deprecated(
+        **_get_deprecation_kwargs("has_assets_def"),
+    )
+    @public
+    @property
+    def has_assets_def(self) -> bool:
+        return super().has_assets_def
+
+    @deprecated(
+        **_get_deprecation_kwargs("get_mapping_key"),
+    )
+    @public
+    def get_mapping_key(self) -> Optional[str]:
+        return super().get_mapping_key()
+
+    @deprecated(
+        **_get_deprecation_kwargs("job_def"),
+    )
+    @public
+    @property
+    def job_def(self) -> JobDefinition:
+        return super().job_def
+
+    @deprecated(
+        **_get_deprecation_kwargs("node_handle"),
+    )
+    @property
+    def node_handle(self) -> NodeHandle:
+        return super().node_handle
+
+    @deprecated(
+        **_get_deprecation_kwargs("op"),
+    )
+    @property
+    def op(self) -> Node:
+        return super().op
+
+    @deprecated(
+        **_get_deprecation_kwargs("describe_op"),
+    )
+    def describe_op(self):
+        return super().describe_op()
+
+    @deprecated(
+        **_get_deprecation_kwargs("op_handle"),
+    )
+    @property
+    def op_handle(self) -> NodeHandle:
+        return super().op_handle
+
+    @deprecated(
+        **_get_deprecation_kwargs("step_launcher"),
+    )
+    @property
+    def step_launcher(self) -> Optional[StepLauncher]:
+        return super().step_launcher
+
+    @deprecated(
+        **_get_deprecation_kwargs("consume_events"),
+    )
+    def consume_events(self) -> Iterator[DagsterEvent]:
+        return super().consume_events()
+
+    @deprecated(
+        **_get_deprecation_kwargs("add_output_metadata"),
+    )
+    @public
+    def add_output_metadata(
+        self,
+        metadata: Mapping[str, Any],
+        output_name: Optional[str] = None,
+        mapping_key: Optional[str] = None,
+    ) -> None:
+        return super().add_output_metadata(
+            metadata=metadata, output_name=output_name, mapping_key=mapping_key
+        )
+
+    @deprecated(
+        **_get_deprecation_kwargs("asset_key_for_input"),
+    )
+    @public
+    def asset_key_for_input(self, input_name: str) -> AssetKey:
+        return super().asset_key_for_input(input_name=input_name)
+
+    @deprecated(
+        **_get_deprecation_kwargs("asset_key_for_output"),
+    )
+    @public
+    def asset_key_for_output(self, output_name: str = "result") -> AssetKey:
+        return super().asset_key_for_output(output_name=output_name)
+
+    @deprecated(
+        **_get_deprecation_kwargs("asset_partition_key_for_input"),
+    )
+    @public
+    def asset_partition_key_for_input(self, input_name: str) -> str:
+        return super().asset_partition_key_for_input(input_name=input_name)
+
+    @deprecated(
+        **_get_deprecation_kwargs("asset_partition_key_for_output"),
+    )
+    @public
+    def asset_partition_key_for_output(self, output_name: str = "result") -> str:
+        return super().asset_partition_key_for_output(output_name=output_name)
+
+    @deprecated(
+        **_get_deprecation_kwargs("asset_partition_key_range_for_input"),
+    )
+    @public
+    def asset_partition_key_range_for_input(self, input_name: str) -> PartitionKeyRange:
+        return super().asset_partition_key_range_for_input(input_name=input_name)
+
+    @deprecated(
+        **_get_deprecation_kwargs("asset_partition_key_range_for_output"),
+    )
+    @public
+    def asset_partition_key_range_for_output(
+        self, output_name: str = "result"
+    ) -> PartitionKeyRange:
+        return super().asset_partition_key_range_for_output(output_name=output_name)
+
+    @deprecated(**_get_deprecation_kwargs("asset_partition_keys_for_input"))
+    @public
+    def asset_partition_keys_for_input(self, input_name: str) -> Sequence[str]:
+        return super().asset_partition_keys_for_input(input_name=input_name)
+
+    @deprecated(**_get_deprecation_kwargs("asset_partition_keys_for_output"))
+    @public
+    def asset_partition_keys_for_output(self, output_name: str = "result") -> Sequence[str]:
+        return super().asset_partition_keys_for_output(output_name=output_name)
+
+    @deprecated(**_get_deprecation_kwargs("asset_partitions_time_window_for_input"))
+    @public
+    def asset_partitions_time_window_for_input(self, input_name: str = "result") -> TimeWindow:
+        return super().asset_partitions_time_window_for_input(input_name=input_name)
+
+    @deprecated(**_get_deprecation_kwargs("asset_partitions_time_window_for_output"))
+    @public
+    def asset_partitions_time_window_for_output(self, output_name: str = "result") -> TimeWindow:
+        return super().asset_partitions_time_window_for_output(output_name=output_name)
+
+    @deprecated(**_get_deprecation_kwargs("asset_partitions_def_for_input"))
+    @public
+    def asset_partitions_def_for_input(self, input_name: str) -> PartitionsDefinition:
+        return super().asset_partitions_def_for_input(input_name=input_name)
+
+    @deprecated(**_get_deprecation_kwargs("asset_partitions_def_for_output"))
+    @public
+    def asset_partitions_def_for_output(self, output_name: str = "result") -> PartitionsDefinition:
+        return super().asset_partitions_def_for_output(output_name=output_name)
+
+    @deprecated(**_get_deprecation_kwargs("get_output_metadata"))
+    def get_output_metadata(
+        self, output_name: str, mapping_key: Optional[str] = None
+    ) -> Optional[Mapping[str, Any]]:
+        return super().get_output_metadata(output_name=output_name, mapping_key=mapping_key)
+
+    @deprecated(**_get_deprecation_kwargs("output_for_asset_key"))
+    @public
+    def output_for_asset_key(self, asset_key: AssetKey) -> str:
+        return super().output_for_asset_key(asset_key=asset_key)
+
+    @deprecated(**_get_deprecation_kwargs("selected_output_names"))
+    @public
+    @property
+    def selected_output_names(self) -> AbstractSet[str]:
+        return super().selected_output_names
+
+    @deprecated(**_get_deprecation_kwargs("has_tag"))
+    @public
+    def has_tag(self, key: str) -> bool:
+        return super().has_tag(key=key)
+
+    @deprecated(**_get_deprecation_kwargs("get_tag"))
+    @public
+    def get_tag(self, key: str) -> Optional[str]:
+        return super().get_tag(key=key)
+
+    @deprecated(**_get_deprecation_kwargs("run_tags"))
+    @property
+    def run_tags(self) -> Mapping[str, str]:
+        return super().run_tags
+
+    @deprecated(**_get_deprecation_kwargs("set_data_version"))
+    def set_data_version(self, asset_key: AssetKey, data_version: DataVersion) -> None:
+        return super().set_data_version(asset_key=asset_key, data_version=data_version)
 
 def build_execution_context(
     step_context: StepExecutionContext,

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -1584,13 +1584,11 @@ class AssetExecutionContext(OpExecutionContext):
     # appropriate deprecation warning
 
     @deprecated(**_get_deprecation_kwargs("op_def"))
-    @public
     @property
     def op_def(self) -> OpDefinition:
         return self.op_execution_context.op_def
 
     @deprecated(**_get_deprecation_kwargs("op_config"))
-    @public
     @property
     def op_config(self) -> Any:
         return self.op_execution_context.op_config
@@ -1601,18 +1599,15 @@ class AssetExecutionContext(OpExecutionContext):
         return self.op_execution_context.file_manager
 
     @deprecated(**_get_deprecation_kwargs("has_assets_def"))
-    @public
     @property
     def has_assets_def(self) -> bool:
         return self.op_execution_context.has_assets_def
 
     @deprecated(**_get_deprecation_kwargs("get_mapping_key"))
-    @public
     def get_mapping_key(self) -> Optional[str]:
         return self.op_execution_context.get_mapping_key()
 
     @deprecated(**_get_deprecation_kwargs("job_def"))
-    @public
     @property
     def job_def(self) -> JobDefinition:
         return self.op_execution_context.job_def
@@ -1646,7 +1641,6 @@ class AssetExecutionContext(OpExecutionContext):
         return self.op_execution_context.consume_events()
 
     @deprecated(**_get_deprecation_kwargs("add_output_metadata"))
-    @public
     def add_output_metadata(
         self,
         metadata: Mapping[str, Any],
@@ -1658,12 +1652,10 @@ class AssetExecutionContext(OpExecutionContext):
         )
 
     @deprecated(**_get_deprecation_kwargs("asset_key_for_input"))
-    @public
     def asset_key_for_input(self, input_name: str) -> AssetKey:
         return self.op_execution_context.asset_key_for_input(input_name=input_name)
 
     @deprecated(**_get_deprecation_kwargs("asset_key_for_output"))
-    @public
     def asset_key_for_output(self, output_name: str = "result") -> AssetKey:
         return self.op_execution_context.asset_key_for_output(output_name=output_name)
 
@@ -1676,23 +1668,19 @@ class AssetExecutionContext(OpExecutionContext):
         )
 
     @deprecated(**_get_deprecation_kwargs("output_for_asset_key"))
-    @public
     def output_for_asset_key(self, asset_key: AssetKey) -> str:
         return self.op_execution_context.output_for_asset_key(asset_key=asset_key)
 
     @deprecated(**_get_deprecation_kwargs("selected_output_names"))
-    @public
     @property
     def selected_output_names(self) -> AbstractSet[str]:
         return self.op_execution_context.selected_output_names
 
     @deprecated(**_get_deprecation_kwargs("has_tag"))
-    @public
     def has_tag(self, key: str) -> bool:
         return self.op_execution_context.has_tag(key=key)
 
     @deprecated(**_get_deprecation_kwargs("get_tag"))
-    @public
     def get_tag(self, key: str) -> Optional[str]:
         return self.op_execution_context.get_tag(key=key)
 

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -1388,11 +1388,6 @@ class AssetExecutionContext(OpExecutionContext):
         return self._op_execution_context
 
     # IContext interface methods
-
-    @property
-    def is_asset_step(self) -> bool:
-        return self.op_execution_context.has_assets_def
-
     @public
     @property
     def asset_key(self) -> AssetKey:
@@ -1420,21 +1415,8 @@ class AssetExecutionContext(OpExecutionContext):
 
     @public
     @property
-    def is_partition_step(self) -> bool:
+    def is_partitioned(self) -> bool:
         return self._op_execution_context.has_partition_key
-
-    @property
-    def partition_key(self) -> str:
-        return self.op_execution_context.partition_key
-
-    @public
-    @property
-    def partition_key_range(self) -> PartitionKeyRange:
-        return self._op_execution_context.partition_key_range
-
-    @property
-    def partition_time_window(self) -> TimeWindow:
-        return self.op_execution_context.partition_time_window
 
     @public
     @property
@@ -1517,7 +1499,19 @@ class AssetExecutionContext(OpExecutionContext):
         """dict: The run config for the current execution."""
         return self._op_execution_context.run_config
 
-    # partition methods that will be marked deprecated once we have aligned on future partition methods
+    # partition methods that may be marked deprecated once we have aligned on future partition methods
+    @property
+    def partition_key(self) -> str:
+        return self.op_execution_context.partition_key
+
+    @public
+    @property
+    def partition_key_range(self) -> PartitionKeyRange:
+        return self._op_execution_context.partition_key_range
+
+    @property
+    def partition_time_window(self) -> TimeWindow:
+        return self.op_execution_context.partition_time_window
 
     @public
     def asset_partition_key_for_input(self, input_name: str) -> str:

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -1509,72 +1509,52 @@ class AssetExecutionContext(OpExecutionContext):
     def file_manager(self):
         return super().file_manager
 
-    @deprecated(
-        **_get_deprecation_kwargs("has_assets_def"),
-    )
+    @deprecated(**_get_deprecation_kwargs("has_assets_def"))
     @public
     @property
     def has_assets_def(self) -> bool:
         return super().has_assets_def
 
-    @deprecated(
-        **_get_deprecation_kwargs("get_mapping_key"),
-    )
+    @deprecated(**_get_deprecation_kwargs("get_mapping_key"))
     @public
     def get_mapping_key(self) -> Optional[str]:
         return super().get_mapping_key()
 
-    @deprecated(
-        **_get_deprecation_kwargs("job_def"),
-    )
+    @deprecated(**_get_deprecation_kwargs("job_def"))
     @public
     @property
     def job_def(self) -> JobDefinition:
         return super().job_def
 
-    @deprecated(
-        **_get_deprecation_kwargs("node_handle"),
-    )
+    @deprecated(**_get_deprecation_kwargs("node_handle"))
     @property
     def node_handle(self) -> NodeHandle:
         return super().node_handle
 
-    @deprecated(
-        **_get_deprecation_kwargs("op"),
-    )
+    @deprecated(**_get_deprecation_kwargs("op"))
     @property
     def op(self) -> Node:
         return super().op
 
-    @deprecated(
-        **_get_deprecation_kwargs("describe_op"),
-    )
+    @deprecated(**_get_deprecation_kwargs("describe_op"))
     def describe_op(self):
         return super().describe_op()
 
-    @deprecated(
-        **_get_deprecation_kwargs("op_handle"),
-    )
+    @deprecated(**_get_deprecation_kwargs("op_handle"))
     @property
     def op_handle(self) -> NodeHandle:
         return super().op_handle
 
-    @deprecated(
-        **_get_deprecation_kwargs("step_launcher"),
-    )
+    @deprecated(**_get_deprecation_kwargs("step_launcher"))
     @property
     def step_launcher(self) -> Optional[StepLauncher]:
         return super().step_launcher
 
-    @deprecated(
-        **_get_deprecation_kwargs("consume_events"),
-    )
+    @deprecated(**_get_deprecation_kwargs("consume_events"))
     def consume_events(self) -> Iterator[DagsterEvent]:
         return super().consume_events()
 
-    @deprecated(
-        **_get_deprecation_kwargs("add_output_metadata"),
-    )
+    @deprecated(**_get_deprecation_kwargs("add_output_metadata"))
     @public
     def add_output_metadata(
         self,
@@ -1586,44 +1566,32 @@ class AssetExecutionContext(OpExecutionContext):
             metadata=metadata, output_name=output_name, mapping_key=mapping_key
         )
 
-    @deprecated(
-        **_get_deprecation_kwargs("asset_key_for_input"),
-    )
+    @deprecated(**_get_deprecation_kwargs("asset_key_for_input"))
     @public
     def asset_key_for_input(self, input_name: str) -> AssetKey:
         return super().asset_key_for_input(input_name=input_name)
 
-    @deprecated(
-        **_get_deprecation_kwargs("asset_key_for_output"),
-    )
+    @deprecated(**_get_deprecation_kwargs("asset_key_for_output"))
     @public
     def asset_key_for_output(self, output_name: str = "result") -> AssetKey:
         return super().asset_key_for_output(output_name=output_name)
 
-    @deprecated(
-        **_get_deprecation_kwargs("asset_partition_key_for_input"),
-    )
+    @deprecated(**_get_deprecation_kwargs("asset_partition_key_for_input"))
     @public
     def asset_partition_key_for_input(self, input_name: str) -> str:
         return super().asset_partition_key_for_input(input_name=input_name)
 
-    @deprecated(
-        **_get_deprecation_kwargs("asset_partition_key_for_output"),
-    )
+    @deprecated(**_get_deprecation_kwargs("asset_partition_key_for_output"))
     @public
     def asset_partition_key_for_output(self, output_name: str = "result") -> str:
         return super().asset_partition_key_for_output(output_name=output_name)
 
-    @deprecated(
-        **_get_deprecation_kwargs("asset_partition_key_range_for_input"),
-    )
+    @deprecated(**_get_deprecation_kwargs("asset_partition_key_range_for_input"))
     @public
     def asset_partition_key_range_for_input(self, input_name: str) -> PartitionKeyRange:
         return super().asset_partition_key_range_for_input(input_name=input_name)
 
-    @deprecated(
-        **_get_deprecation_kwargs("asset_partition_key_range_for_output"),
-    )
+    @deprecated(**_get_deprecation_kwargs("asset_partition_key_range_for_output"))
     @public
     def asset_partition_key_range_for_output(
         self, output_name: str = "result"

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -1318,15 +1318,12 @@ DEPRECATED_IO_MANAGER_CENTRIC_CONTEXT_METHODS = {
     "asset_partitions_def_for_input": PARTITION_KEY_RANGE_AS_ALT,
     "asset_partitions_def_for_output": PARTITION_KEY_RANGE_AS_ALT,
     "get_output_metadata": "use op_execution_context.op_def.get_output(...).metadata",
-    # "merge_output_metadata": OUTPUT_METADATA_ALT, # TODO - this method doesn't exist, check if it has a different name
     "output_for_asset_key": INPUT_OUTPUT_ALT,
     "selected_output_names": INPUT_OUTPUT_ALT,
 }
 
 ALTERNATE_AVAILABLE_METHODS = {
-    "has_tag": (
-        "use dagster_run.has_tag instead"
-    ),  # TODO - was dagster_run intended to be a method/attr on AssetExecutionContext?
+    "has_tag": "use dagster_run.has_tag instead",
     "get_tag": "use dagster_run.get_tag instead",
     "run_tags": "use dagster_run.tags instead",
     "set_data_version": "use MaterializeResult instead",

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -1364,6 +1364,17 @@ class AssetExecutionContext(OpExecutionContext):
         self._op_execution_context = check.inst_param(
             op_execution_context, "op_execution_context", OpExecutionContext
         )
+        self._asset_keys = list(self.op_execution_context.assets_def.keys_by_output_name.values())
+        self._selected_asset_keys = self._op_execution_context.selected_asset_keys
+        self._assets_def = self._op_execution_context.assets_def
+
+        self._provenance_by_asset_key = {
+            key: self._op_execution_context.get_asset_provenance(key)
+            for key in self._selected_asset_keys
+        }
+        self._code_version_by_asset_key = {
+            key: self._assets_def.code_versions_by_key[key] for key in self._selected_asset_keys
+        }
 
     @public
     @property
@@ -1383,27 +1394,23 @@ class AssetExecutionContext(OpExecutionContext):
 
     @property
     def asset_keys(self) -> Sequence[AssetKey]:
-        return list(self.op_execution_context.assets_def.keys_by_output_name.values())
+        return self._asset_keys
 
     @property
     def provenance(self) -> Optional[DataProvenance]:
-        return self.get_asset_provenance(self.asset_key)
+        return self._provenance_by_asset_key[self.asset_key]
 
     @property
     def provenance_by_asset_key(self) -> Mapping[AssetKey, Optional[DataProvenance]]:
-        provenance_map = {}
-        for key in self.asset_keys:
-            provenance_map[key] = self.get_asset_provenance(key)
-
-        return provenance_map
+        return self._provenance_by_asset_key
 
     @property
     def code_version(self) -> Optional[str]:
-        return self.get_assets_code_version([self.asset_key])[self.asset_key]
+        return self.code_version_by_asset_key[self.asset_key]
 
     @property
     def code_version_by_asset_key(self) -> Mapping[AssetKey, Optional[str]]:
-        return self.get_assets_code_version(self.asset_keys)
+        return self._code_version_by_asset_key
 
     @public
     @property
@@ -1468,13 +1475,15 @@ class AssetExecutionContext(OpExecutionContext):
     @public
     @property
     def assets_def(self) -> AssetsDefinition:
-        return self._op_execution_context.assets_def
+        return self._assets_def
 
     @public
     @property
     def selected_asset_keys(self) -> AbstractSet[AssetKey]:
-        return self._op_execution_context.selected_asset_keys
+        return self._selected_asset_keys
 
+    # TODO - both get_asset_provenance and get_assets_code_version query the instance - do we want to
+    # disallow this, or make the function name more indicative that they are querying the db?
     @public
     @experimental
     def get_asset_provenance(self, asset_key: AssetKey) -> Optional[DataProvenance]:

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -1387,50 +1387,69 @@ class AssetExecutionContext(OpExecutionContext, IContext):
     @public
     @property
     def op_execution_context(self) -> OpExecutionContext:
+        """An instance of OpExecutionContext created for the execution of this step."""
         return self._op_execution_context
 
     # IContext interface methods
     @public
     @property
     def asset_key(self) -> AssetKey:
+        """The AssetKey for the current asset. Errors if the current step is not an asset, or is a
+        multi_asset. For multi_assets, use asset_keys.
+        """
         return self._op_execution_context.asset_key
 
     @property
-    def asset_keys(self) -> Sequence[AssetKey]:
+    def asset_keys(self) -> AbstractSet[AssetKey]:
+        """The set of AssetKeys that are being materialized by the current asset. Errors if the current
+        step is not an asset.
+        """
         return self._asset_keys
 
     @property
     def provenance(self) -> Optional[DataProvenance]:
+        """The data provenance for the current asset. For multi_assets, use provenance_by_asset_key."""
         return self._provenance_by_asset_key[self.asset_key]
 
     @property
     def provenance_by_asset_key(self) -> Mapping[AssetKey, Optional[DataProvenance]]:
+        """A dictionary of AssetKey: DataProvenance of the provenance of each asset being materialized
+        by the current asset.
+        """
         return self._provenance_by_asset_key
 
     @property
     def code_version(self) -> Optional[str]:
+        """The code version for the current asset. For multi_assets, use code_version_by_asset_key."""
         return self.code_version_by_asset_key[self.asset_key]
 
     @property
     def code_version_by_asset_key(self) -> Mapping[AssetKey, Optional[str]]:
+        """A dictionary of AssetKey: code version of the code version of each asset being materialized
+        by the current asset.
+        """
         return self._code_version_by_asset_key
 
     @public
     @property
     def is_partitioned(self) -> bool:
+        """True if the current execution is partitioned."""
         return self._op_execution_context.has_partition_key
 
     @public
     @property
     def run_id(self) -> str:
+        """The run id of the current execution."""
         return self._op_execution_context.run_id
 
     @property
     def job_name(self) -> Optional[str]:
+        """The name of the currently executing job."""
         return self.op_execution_context.job_name
 
     @property
     def retry_number(self) -> int:
+        """The number of attempted retries for this step."""
         return self.op_execution_context.retry_number
 
     # Additional methods
@@ -1450,6 +1469,7 @@ class AssetExecutionContext(OpExecutionContext, IContext):
     @public
     @property
     def pdb(self) -> ForkedPdb:
+        """An instance of pdb for debugging."""
         return self._op_execution_context.pdb
 
     @public
@@ -1461,11 +1481,15 @@ class AssetExecutionContext(OpExecutionContext, IContext):
     @public
     @property
     def assets_def(self) -> AssetsDefinition:
+        """The AssetsDefinition for the current asset."""
         return self._assets_def
 
     @public
     @property
     def check_specs_by_asset_key(self) -> Mapping[AssetKey, AssetCheckSpec]:
+        """A dictionary of AssetKey: AssetCheckSpec of the AssetCheckSpec for each asset being materialized
+        by the current asset.
+        """
         return self._check_specs_by_asset_key
 
     @public

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -14,8 +14,7 @@ from typing import (
     cast,
 )
 
-from dagster_ext import IContext
-
+# from dagster_ext import IContext
 import dagster._check as check
 from dagster._annotations import deprecated, experimental, public
 from dagster._core.definitions.asset_check_spec import AssetCheckSpec
@@ -1296,6 +1295,7 @@ OP_EXECUTION_CONTEXT_ONLY_METHODS = set(
         "step_launcher",
         "has_events",
         "consume_events",
+        "log_event",
     ]
 )
 
@@ -1361,7 +1361,7 @@ def _get_deprecation_kwargs(attr: str):
     return deprecation_kwargs
 
 
-class AssetExecutionContext(OpExecutionContext, IContext):
+class AssetExecutionContext(OpExecutionContext):
     def __init__(self, op_execution_context: OpExecutionContext) -> None:
         self._op_execution_context = check.inst_param(
             op_execution_context, "op_execution_context", OpExecutionContext
@@ -1473,10 +1473,6 @@ class AssetExecutionContext(OpExecutionContext, IContext):
     def log(self) -> DagsterLogManager:
         """DagsterLogManager: The log manager available in the execution context."""
         return self._op_execution_context.log
-
-    @public
-    def log_event(self, event: UserEvent) -> None:
-        return self._op_execution_context.log_event(event)
 
     @public
     @property
@@ -1713,6 +1709,10 @@ class AssetExecutionContext(OpExecutionContext, IContext):
     @property
     def asset_check_spec(self) -> AssetCheckSpec:
         return self._op_execution_context.asset_check_spec
+
+    @deprecated(**_get_deprecation_kwargs("log_event"))
+    def log_event(self, event: UserEvent) -> None:
+        return self._op_execution_context.log_event(event)
 
 def build_execution_context(
     step_context: StepExecutionContext,

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -1283,15 +1283,15 @@ OP_EXECUTION_CONTEXT_ONLY_METHODS = set(
         "file_manager",
         "has_assets_def",
         "get_mapping_key",
-        # "get_step_execution_context", # used by internals
+        "get_step_execution_context",  # TODO - used by internals
         "job_def",
         "node_handle",
         "op",
         "op_config",
-        # "op_def", # used by internals
+        "op_def",  # TODO - used by internals
         "op_handle",
         "step_launcher",
-        # "has_events", # used by internals
+        "has_events",  # TODO - used by internals
         "consume_events",
     ]
 )
@@ -1305,10 +1305,12 @@ DEPRECATED_IO_MANAGER_CENTRIC_CONTEXT_METHODS = {
     "add_output_metadata": OUTPUT_METADATA_ALT,
     "asset_key_for_input": INPUT_OUTPUT_ALT,
     "asset_key_for_output": INPUT_OUTPUT_ALT,
+    "has_partition_key": "use is_partition_step instead.",
     "asset_partition_key_for_input": PARTITION_KEY_RANGE_AS_ALT,
     "asset_partition_key_for_output": PARTITION_KEY_RANGE_AS_ALT,
     "asset_partition_key_range_for_input": PARTITION_KEY_RANGE_AS_ALT,
     "asset_partition_key_range_for_output": PARTITION_KEY_RANGE_AS_ALT,
+    "asset_partition_key_range": PARTITION_KEY_RANGE_AS_ALT,
     "asset_partition_keys_for_input": PARTITION_KEY_RANGE_AS_ALT,
     "asset_partition_keys_for_output": PARTITION_KEY_RANGE_AS_ALT,
     "asset_partitions_time_window_for_input": PARTITION_KEY_RANGE_AS_ALT,
@@ -1328,6 +1330,7 @@ ALTERNATE_AVAILABLE_METHODS = {
     "get_tag": "use dagster_run.get_tag instead",
     "run_tags": "use dagster_run.tags instead",
     "set_data_version": "use MaterializeResult instead",
+    "run": "use dagster_run instead.",
 }
 
 # TODO - add AssetCheck related methods to this list
@@ -1443,6 +1446,12 @@ class AssetExecutionContext(OpExecutionContext):
 
     @public
     @property
+    def instance(self) -> DagsterInstance:
+        """DagsterInstance: The current Dagster instance."""
+        return self._step_execution_context.instance
+
+    @public
+    @property
     def dagster_run(self) -> DagsterRun:
         """PipelineRun: The current pipeline run."""
         return self._step_execution_context.dagster_run
@@ -1495,64 +1504,85 @@ class AssetExecutionContext(OpExecutionContext):
         """TODO - implement in stacked pr."""
         pass
 
+    # TODO the below methods weren't originally part of the deprecated list, but are also not part
+    # of the context interface. What should we do with them?
+
+    @public
+    @property
+    def resources(self) -> Any:
+        """Resources: The currently available resources."""
+        return self._step_execution_context.resources
+
+    @public
+    @property
+    def run_config(self) -> Mapping[str, object]:
+        """dict: The run config for the current execution."""
+        return self._step_execution_context.run_config
+
     # deprecated methods. All remaining methods on OpExecutionContext should be here with the
     # appropriate deprecation warning
+
+    @deprecated(**_get_deprecation_kwargs("op_def"))
+    @public
+    @property
+    def op_def(self) -> OpDefinition:
+        return self.op_execution_context.op_def
 
     @deprecated(**_get_deprecation_kwargs("op_config"))
     @public
     @property
     def op_config(self) -> Any:
-        return super().op_config
+        return self.op_execution_context.op_config
 
     @deprecated(**_get_deprecation_kwargs("file_manager"))
     @property
     def file_manager(self):
-        return super().file_manager
+        return self.op_execution_context.file_manager
 
     @deprecated(**_get_deprecation_kwargs("has_assets_def"))
     @public
     @property
     def has_assets_def(self) -> bool:
-        return super().has_assets_def
+        return self.op_execution_context.has_assets_def
 
     @deprecated(**_get_deprecation_kwargs("get_mapping_key"))
     @public
     def get_mapping_key(self) -> Optional[str]:
-        return super().get_mapping_key()
+        return self.op_execution_context.get_mapping_key()
 
     @deprecated(**_get_deprecation_kwargs("job_def"))
     @public
     @property
     def job_def(self) -> JobDefinition:
-        return super().job_def
+        return self.op_execution_context.job_def
 
     @deprecated(**_get_deprecation_kwargs("node_handle"))
     @property
     def node_handle(self) -> NodeHandle:
-        return super().node_handle
+        return self.op_execution_context.node_handle
 
     @deprecated(**_get_deprecation_kwargs("op"))
     @property
     def op(self) -> Node:
-        return super().op
+        return self.op_execution_context.op
 
     @deprecated(**_get_deprecation_kwargs("describe_op"))
     def describe_op(self):
-        return super().describe_op()
+        return self.op_execution_context.describe_op()
 
     @deprecated(**_get_deprecation_kwargs("op_handle"))
     @property
     def op_handle(self) -> NodeHandle:
-        return super().op_handle
+        return self.op_execution_context.op_handle
 
     @deprecated(**_get_deprecation_kwargs("step_launcher"))
     @property
     def step_launcher(self) -> Optional[StepLauncher]:
-        return super().step_launcher
+        return self.op_execution_context.step_launcher
 
     @deprecated(**_get_deprecation_kwargs("consume_events"))
     def consume_events(self) -> Iterator[DagsterEvent]:
-        return super().consume_events()
+        return self.op_execution_context.consume_events()
 
     @deprecated(**_get_deprecation_kwargs("add_output_metadata"))
     @public
@@ -1562,107 +1592,142 @@ class AssetExecutionContext(OpExecutionContext):
         output_name: Optional[str] = None,
         mapping_key: Optional[str] = None,
     ) -> None:
-        return super().add_output_metadata(
+        return self.op_execution_context.add_output_metadata(
             metadata=metadata, output_name=output_name, mapping_key=mapping_key
         )
 
     @deprecated(**_get_deprecation_kwargs("asset_key_for_input"))
     @public
     def asset_key_for_input(self, input_name: str) -> AssetKey:
-        return super().asset_key_for_input(input_name=input_name)
+        return self.op_execution_context.asset_key_for_input(input_name=input_name)
 
     @deprecated(**_get_deprecation_kwargs("asset_key_for_output"))
     @public
     def asset_key_for_output(self, output_name: str = "result") -> AssetKey:
-        return super().asset_key_for_output(output_name=output_name)
+        return self.op_execution_context.asset_key_for_output(output_name=output_name)
 
     @deprecated(**_get_deprecation_kwargs("asset_partition_key_for_input"))
     @public
     def asset_partition_key_for_input(self, input_name: str) -> str:
-        return super().asset_partition_key_for_input(input_name=input_name)
+        return self.op_execution_context.asset_partition_key_for_input(input_name=input_name)
 
     @deprecated(**_get_deprecation_kwargs("asset_partition_key_for_output"))
     @public
     def asset_partition_key_for_output(self, output_name: str = "result") -> str:
-        return super().asset_partition_key_for_output(output_name=output_name)
+        return self.op_execution_context.asset_partition_key_for_output(output_name=output_name)
 
     @deprecated(**_get_deprecation_kwargs("asset_partition_key_range_for_input"))
     @public
     def asset_partition_key_range_for_input(self, input_name: str) -> PartitionKeyRange:
-        return super().asset_partition_key_range_for_input(input_name=input_name)
+        return self.op_execution_context.asset_partition_key_range_for_input(input_name=input_name)
 
     @deprecated(**_get_deprecation_kwargs("asset_partition_key_range_for_output"))
     @public
     def asset_partition_key_range_for_output(
         self, output_name: str = "result"
     ) -> PartitionKeyRange:
-        return super().asset_partition_key_range_for_output(output_name=output_name)
+        return self.op_execution_context.asset_partition_key_range_for_output(
+            output_name=output_name
+        )
+
+    @deprecated(**_get_deprecation_kwargs("has_partition_key"))
+    @public
+    @property
+    def has_partition_key(self) -> bool:
+        return self.op_execution_context.has_partition_key
+
+    @deprecated(**_get_deprecation_kwargs("asset_partition_key_range"))
+    @public
+    @property
+    def asset_partition_key_range(self) -> PartitionKeyRange:
+        return self.op_execution_context.asset_partition_key_range
 
     @deprecated(**_get_deprecation_kwargs("asset_partition_keys_for_input"))
     @public
     def asset_partition_keys_for_input(self, input_name: str) -> Sequence[str]:
-        return super().asset_partition_keys_for_input(input_name=input_name)
+        return self.op_execution_context.asset_partition_keys_for_input(input_name=input_name)
 
     @deprecated(**_get_deprecation_kwargs("asset_partition_keys_for_output"))
     @public
     def asset_partition_keys_for_output(self, output_name: str = "result") -> Sequence[str]:
-        return super().asset_partition_keys_for_output(output_name=output_name)
+        return self.op_execution_context.asset_partition_keys_for_output(output_name=output_name)
 
     @deprecated(**_get_deprecation_kwargs("asset_partitions_time_window_for_input"))
     @public
     def asset_partitions_time_window_for_input(self, input_name: str = "result") -> TimeWindow:
-        return super().asset_partitions_time_window_for_input(input_name=input_name)
+        return self.op_execution_context.asset_partitions_time_window_for_input(
+            input_name=input_name
+        )
 
     @deprecated(**_get_deprecation_kwargs("asset_partitions_time_window_for_output"))
     @public
     def asset_partitions_time_window_for_output(self, output_name: str = "result") -> TimeWindow:
-        return super().asset_partitions_time_window_for_output(output_name=output_name)
+        return self.op_execution_context.asset_partitions_time_window_for_output(
+            output_name=output_name
+        )
 
     @deprecated(**_get_deprecation_kwargs("asset_partitions_def_for_input"))
     @public
     def asset_partitions_def_for_input(self, input_name: str) -> PartitionsDefinition:
-        return super().asset_partitions_def_for_input(input_name=input_name)
+        return self.op_execution_context.asset_partitions_def_for_input(input_name=input_name)
 
     @deprecated(**_get_deprecation_kwargs("asset_partitions_def_for_output"))
     @public
     def asset_partitions_def_for_output(self, output_name: str = "result") -> PartitionsDefinition:
-        return super().asset_partitions_def_for_output(output_name=output_name)
+        return self.op_execution_context.asset_partitions_def_for_output(output_name=output_name)
 
     @deprecated(**_get_deprecation_kwargs("get_output_metadata"))
     def get_output_metadata(
         self, output_name: str, mapping_key: Optional[str] = None
     ) -> Optional[Mapping[str, Any]]:
-        return super().get_output_metadata(output_name=output_name, mapping_key=mapping_key)
+        return self.op_execution_context.get_output_metadata(
+            output_name=output_name, mapping_key=mapping_key
+        )
 
     @deprecated(**_get_deprecation_kwargs("output_for_asset_key"))
     @public
     def output_for_asset_key(self, asset_key: AssetKey) -> str:
-        return super().output_for_asset_key(asset_key=asset_key)
+        return self.op_execution_context.output_for_asset_key(asset_key=asset_key)
 
     @deprecated(**_get_deprecation_kwargs("selected_output_names"))
     @public
     @property
     def selected_output_names(self) -> AbstractSet[str]:
-        return super().selected_output_names
+        return self.op_execution_context.selected_output_names
 
     @deprecated(**_get_deprecation_kwargs("has_tag"))
     @public
     def has_tag(self, key: str) -> bool:
-        return super().has_tag(key=key)
+        return self.op_execution_context.has_tag(key=key)
 
     @deprecated(**_get_deprecation_kwargs("get_tag"))
     @public
     def get_tag(self, key: str) -> Optional[str]:
-        return super().get_tag(key=key)
+        return self.op_execution_context.get_tag(key=key)
 
-    @deprecated(**_get_deprecation_kwargs("run_tags"))
     @property
+    @deprecated(**_get_deprecation_kwargs("run_tags"))
     def run_tags(self) -> Mapping[str, str]:
-        return super().run_tags
+        return self.op_execution_context.run_tags
 
     @deprecated(**_get_deprecation_kwargs("set_data_version"))
     def set_data_version(self, asset_key: AssetKey, data_version: DataVersion) -> None:
-        return super().set_data_version(asset_key=asset_key, data_version=data_version)
+        return self.op_execution_context.set_data_version(
+            asset_key=asset_key, data_version=data_version
+        )
+
+    @deprecated(**_get_deprecation_kwargs("run"))
+    @property
+    def run(self) -> DagsterRun:
+        return self.op_execution_context.run
+
+    @deprecated(**_get_deprecation_kwargs("get_step_execution_context"))
+    def get_step_execution_context(self) -> StepExecutionContext:
+        return self.op_execution_context.get_step_execution_context()
+
+    @deprecated(**_get_deprecation_kwargs("has_events"))
+    def has_events(self) -> bool:
+        return self.op_execution_context.has_events()
 
 def build_execution_context(
     step_context: StepExecutionContext,

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -1283,15 +1283,15 @@ OP_EXECUTION_CONTEXT_ONLY_METHODS = set(
         "file_manager",
         "has_assets_def",
         "get_mapping_key",
-        "get_step_execution_context",  # TODO - used by internals
+        "get_step_execution_context",
         "job_def",
         "node_handle",
         "op",
         "op_config",
-        "op_def",  # TODO - used by internals
+        "op_def",
         "op_handle",
         "step_launcher",
-        "has_events",  # TODO - used by internals
+        "has_events",
         "consume_events",
     ]
 )
@@ -1496,10 +1496,9 @@ class AssetExecutionContext(OpExecutionContext):
     @public
     def partition_key_range_for_asset_key(self, asset_key: AssetKey) -> PartitionKeyRange:
         """TODO - implement in stacked pr."""
-        pass
-
-    # TODO the below methods weren't originally part of the deprecated list, but are also not part
-    # of the context interface. What should we do with them?
+        raise NotImplementedError(
+            "partition_key_range_for_asset_key not implemented in this branch"
+        )
 
     @public
     @property

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -1331,8 +1331,6 @@ ALTERNATE_AVAILABLE_METHODS = {
     "asset_check_spec": "use check_specs_by_asset_key instead",
 }
 
-# TODO - add AssetCheck related methods to this list
-
 
 def _get_deprecation_kwargs(attr: str):
     deprecation_kwargs = {"breaking_version": "1.7.0"}
@@ -1495,7 +1493,7 @@ class AssetExecutionContext(OpExecutionContext):
         return self._op_execution_context.get_asset_provenance(asset_key)
 
     @public
-    # TODO - method naming. this needs work
+    # TODO - method naming
     def get_assets_code_version(
         self, asset_keys: Sequence[AssetKey]
     ) -> Mapping[AssetKey, Optional[str]]:

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -1333,6 +1333,7 @@ ALTERNATE_AVAILABLE_METHODS = {
     "set_data_version": "use MaterializeResult instead",
     "run": "use dagster_run instead",
     "asset_check_spec": "use check_specs_by_asset_key instead",
+    "selected_asset_keys": "use asset_keys instead",
 }
 
 
@@ -1367,17 +1368,16 @@ class AssetExecutionContext(OpExecutionContext, IContext):
         self._op_execution_context = check.inst_param(
             op_execution_context, "op_execution_context", OpExecutionContext
         )
-        self._asset_keys = list(self.op_execution_context.assets_def.keys_by_output_name.values())
-        self._selected_asset_keys = self._op_execution_context.selected_asset_keys
+        self._asset_keys = self._op_execution_context.selected_asset_keys
         self._assets_def = self._op_execution_context.assets_def
 
         with disable_dagster_warnings():
             self._provenance_by_asset_key = {
                 key: self._op_execution_context.get_asset_provenance(key)
-                for key in self._selected_asset_keys
+                for key in self._asset_keys
             }
         self._code_version_by_asset_key = {
-            key: self._assets_def.code_versions_by_key[key] for key in self._selected_asset_keys
+            key: self._assets_def.code_versions_by_key[key] for key in self._asset_keys
         }
         self._check_specs_by_asset_key = {
             check.asset_key: check for check in self._assets_def.check_specs_by_output_name.values()
@@ -1461,27 +1461,6 @@ class AssetExecutionContext(OpExecutionContext, IContext):
     @property
     def assets_def(self) -> AssetsDefinition:
         return self._assets_def
-
-    @public
-    @property
-    def selected_asset_keys(self) -> AbstractSet[AssetKey]:
-        return self._selected_asset_keys
-
-    # TODO - both get_asset_provenance and get_assets_code_version query the instance - do we want to
-    # disallow this, or make the function name more indicative that they are querying the db?
-    @public
-    @experimental
-    def get_asset_provenance(self, asset_key: AssetKey) -> Optional[DataProvenance]:
-        return self._op_execution_context.get_asset_provenance(asset_key)
-
-    @public
-    # TODO - method naming
-    def get_assets_code_version(
-        self, asset_keys: Sequence[AssetKey]
-    ) -> Mapping[AssetKey, Optional[str]]:
-        return self.op_execution_context.instance.get_latest_materialization_code_versions(
-            asset_keys
-        )
 
     @public
     @property
@@ -1574,6 +1553,11 @@ class AssetExecutionContext(OpExecutionContext, IContext):
 
     # deprecated methods. All remaining methods on OpExecutionContext should be here with the
     # appropriate deprecation warning
+
+    @deprecated(**_get_deprecation_kwargs("selected_asset_keys"))
+    @property
+    def selected_asset_keys(self) -> AbstractSet[AssetKey]:
+        return self.op_execution_context.selected_asset_keys
 
     @deprecated(**_get_deprecation_kwargs("op_def"))
     @property

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -1494,13 +1494,6 @@ class AssetExecutionContext(OpExecutionContext):
         return self._op_execution_context.asset_check_spec
 
     @public
-    def partition_key_range_for_asset_key(self, asset_key: AssetKey) -> PartitionKeyRange:
-        """TODO - implement in stacked pr."""
-        raise NotImplementedError(
-            "partition_key_range_for_asset_key not implemented in this branch"
-        )
-
-    @public
     @property
     def resources(self) -> Any:
         """Resources: The currently available resources."""
@@ -1511,6 +1504,66 @@ class AssetExecutionContext(OpExecutionContext):
     def run_config(self) -> Mapping[str, object]:
         """dict: The run config for the current execution."""
         return self._op_execution_context.run_config
+
+    # partition methods that will be marked deprecated once we have aligned on future partition methods
+
+    @public
+    def asset_partition_key_for_input(self, input_name: str) -> str:
+        return self.op_execution_context.asset_partition_key_for_input(input_name=input_name)
+
+    @public
+    def asset_partition_key_for_output(self, output_name: str = "result") -> str:
+        return self.op_execution_context.asset_partition_key_for_output(output_name=output_name)
+
+    @public
+    def asset_partition_key_range_for_input(self, input_name: str) -> PartitionKeyRange:
+        return self.op_execution_context.asset_partition_key_range_for_input(input_name=input_name)
+
+    @public
+    def asset_partition_key_range_for_output(
+        self, output_name: str = "result"
+    ) -> PartitionKeyRange:
+        return self.op_execution_context.asset_partition_key_range_for_output(
+            output_name=output_name
+        )
+
+    @public
+    @property
+    def has_partition_key(self) -> bool:
+        return self.op_execution_context.has_partition_key
+
+    @public
+    @property
+    def asset_partition_key_range(self) -> PartitionKeyRange:
+        return self.op_execution_context.asset_partition_key_range
+
+    @public
+    def asset_partition_keys_for_input(self, input_name: str) -> Sequence[str]:
+        return self.op_execution_context.asset_partition_keys_for_input(input_name=input_name)
+
+    @public
+    def asset_partition_keys_for_output(self, output_name: str = "result") -> Sequence[str]:
+        return self.op_execution_context.asset_partition_keys_for_output(output_name=output_name)
+
+    @public
+    def asset_partitions_time_window_for_input(self, input_name: str = "result") -> TimeWindow:
+        return self.op_execution_context.asset_partitions_time_window_for_input(
+            input_name=input_name
+        )
+
+    @public
+    def asset_partitions_time_window_for_output(self, output_name: str = "result") -> TimeWindow:
+        return self.op_execution_context.asset_partitions_time_window_for_output(
+            output_name=output_name
+        )
+
+    @public
+    def asset_partitions_def_for_input(self, input_name: str) -> PartitionsDefinition:
+        return self.op_execution_context.asset_partitions_def_for_input(input_name=input_name)
+
+    @public
+    def asset_partitions_def_for_output(self, output_name: str = "result") -> PartitionsDefinition:
+        return self.op_execution_context.asset_partitions_def_for_output(output_name=output_name)
 
     # deprecated methods. All remaining methods on OpExecutionContext should be here with the
     # appropriate deprecation warning
@@ -1598,76 +1651,6 @@ class AssetExecutionContext(OpExecutionContext):
     @public
     def asset_key_for_output(self, output_name: str = "result") -> AssetKey:
         return self.op_execution_context.asset_key_for_output(output_name=output_name)
-
-    @deprecated(**_get_deprecation_kwargs("asset_partition_key_for_input"))
-    @public
-    def asset_partition_key_for_input(self, input_name: str) -> str:
-        return self.op_execution_context.asset_partition_key_for_input(input_name=input_name)
-
-    @deprecated(**_get_deprecation_kwargs("asset_partition_key_for_output"))
-    @public
-    def asset_partition_key_for_output(self, output_name: str = "result") -> str:
-        return self.op_execution_context.asset_partition_key_for_output(output_name=output_name)
-
-    @deprecated(**_get_deprecation_kwargs("asset_partition_key_range_for_input"))
-    @public
-    def asset_partition_key_range_for_input(self, input_name: str) -> PartitionKeyRange:
-        return self.op_execution_context.asset_partition_key_range_for_input(input_name=input_name)
-
-    @deprecated(**_get_deprecation_kwargs("asset_partition_key_range_for_output"))
-    @public
-    def asset_partition_key_range_for_output(
-        self, output_name: str = "result"
-    ) -> PartitionKeyRange:
-        return self.op_execution_context.asset_partition_key_range_for_output(
-            output_name=output_name
-        )
-
-    @deprecated(**_get_deprecation_kwargs("has_partition_key"))
-    @public
-    @property
-    def has_partition_key(self) -> bool:
-        return self.op_execution_context.has_partition_key
-
-    @deprecated(**_get_deprecation_kwargs("asset_partition_key_range"))
-    @public
-    @property
-    def asset_partition_key_range(self) -> PartitionKeyRange:
-        return self.op_execution_context.asset_partition_key_range
-
-    @deprecated(**_get_deprecation_kwargs("asset_partition_keys_for_input"))
-    @public
-    def asset_partition_keys_for_input(self, input_name: str) -> Sequence[str]:
-        return self.op_execution_context.asset_partition_keys_for_input(input_name=input_name)
-
-    @deprecated(**_get_deprecation_kwargs("asset_partition_keys_for_output"))
-    @public
-    def asset_partition_keys_for_output(self, output_name: str = "result") -> Sequence[str]:
-        return self.op_execution_context.asset_partition_keys_for_output(output_name=output_name)
-
-    @deprecated(**_get_deprecation_kwargs("asset_partitions_time_window_for_input"))
-    @public
-    def asset_partitions_time_window_for_input(self, input_name: str = "result") -> TimeWindow:
-        return self.op_execution_context.asset_partitions_time_window_for_input(
-            input_name=input_name
-        )
-
-    @deprecated(**_get_deprecation_kwargs("asset_partitions_time_window_for_output"))
-    @public
-    def asset_partitions_time_window_for_output(self, output_name: str = "result") -> TimeWindow:
-        return self.op_execution_context.asset_partitions_time_window_for_output(
-            output_name=output_name
-        )
-
-    @deprecated(**_get_deprecation_kwargs("asset_partitions_def_for_input"))
-    @public
-    def asset_partitions_def_for_input(self, input_name: str) -> PartitionsDefinition:
-        return self.op_execution_context.asset_partitions_def_for_input(input_name=input_name)
-
-    @deprecated(**_get_deprecation_kwargs("asset_partitions_def_for_output"))
-    @public
-    def asset_partitions_def_for_output(self, output_name: str = "result") -> PartitionsDefinition:
-        return self.op_execution_context.asset_partitions_def_for_output(output_name=output_name)
 
     @deprecated(**_get_deprecation_kwargs("get_output_metadata"))
     def get_output_metadata(


### PR DESCRIPTION
## Summary & Motivation
Makes the `AssetExecutionContext` a subclass of `OpExecutionContext`. Since the plan is to split `AssetExecutionContext` into it's own class, we need to fire deprecation warnings for all methods on `OpExecutionContext` that we do not intend to keep on `AssetExecutionContext` longterm. We also fire a deprecation warning on `isinstance(context, OpExecutionContext)`  when context is an `AssetExecutionContext`. 


This class should implement the IContext from https://github.com/dagster-io/dagster/pull/16480, but I can't import from dagster-ext so need to figure that part out first...

## How I Tested These Changes
stacked PR https://github.com/dagster-io/dagster/pull/16598