### PR TITLE
s/AssetVarietal/AssetExecutionType

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_spec.py
@@ -27,16 +27,16 @@ SYSTEM_METADATA_KEY_ASSET_EXECUTION_TYPE = "dagster/asset_execution_type"
 
 class AssetExecutionType(Enum):
     UNEXECUTABLE = "UNEXECUTABLE"
-    MATERIALIZEABLE = "MATERIALIZEABLE"
+    MATERIALIZATION = "MATERIALIZATION"
 
     @staticmethod
     def is_executable(varietal_str: Optional[str]) -> bool:
-        return AssetExecutionType.str_to_enum(varietal_str) in {AssetExecutionType.MATERIALIZEABLE}
+        return AssetExecutionType.str_to_enum(varietal_str) in {AssetExecutionType.MATERIALIZATION}
 
     @staticmethod
     def str_to_enum(varietal_str: Optional[str]) -> "AssetExecutionType":
         return (
-            AssetExecutionType.MATERIALIZEABLE
+            AssetExecutionType.MATERIALIZATION
             if varietal_str is None
             else AssetExecutionType(varietal_str)
         )

--- a/python_modules/dagster/dagster/_core/definitions/asset_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_spec.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 
 # SYSTEM_METADATA_KEY_ASSET_EXECUTION_TYPE lives on the metadata of an asset
 # (which currently ends up on the Output associated with the asset key)
-# whih encodes the "varietal" of asset. "Unexecutable" assets are assets
+# whih encodes the execution type the of asset. "Unexecutable" assets are assets
 # that cannot be materialized in Dagster, but can have events in the event
 # log keyed off of them, making Dagster usable as a observability and lineage tool
 # for externally materialized assets.

--- a/python_modules/dagster/dagster/_core/definitions/asset_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_spec.py
@@ -16,27 +16,29 @@ from .metadata import MetadataUserInput
 if TYPE_CHECKING:
     from dagster._core.definitions.asset_dep import AssetDep, CoercibleToAssetDep
 
-# SYSTEM_METADATA_KEY_ASSET_VARIETAL lives on the metadata of an asset
+# SYSTEM_METADATA_KEY_ASSET_EXECUTION_TYPE lives on the metadata of an asset
 # (which currently ends up on the Output associated with the asset key)
 # whih encodes the "varietal" of asset. "Unexecutable" assets are assets
 # that cannot be materialized in Dagster, but can have events in the event
 # log keyed off of them, making Dagster usable as a observability and lineage tool
 # for externally materialized assets.
-SYSTEM_METADATA_KEY_ASSET_VARIETAL = "dagster/asset_varietal"
+SYSTEM_METADATA_KEY_ASSET_EXECUTION_TYPE = "dagster/asset_execution_type"
 
 
-class AssetVarietal(Enum):
+class AssetExecutionType(Enum):
     UNEXECUTABLE = "UNEXECUTABLE"
     MATERIALIZEABLE = "MATERIALIZEABLE"
 
     @staticmethod
     def is_executable(varietal_str: Optional[str]) -> bool:
-        return AssetVarietal.str_to_enum(varietal_str) in {AssetVarietal.MATERIALIZEABLE}
+        return AssetExecutionType.str_to_enum(varietal_str) in {AssetExecutionType.MATERIALIZEABLE}
 
     @staticmethod
-    def str_to_enum(varietal_str: Optional[str]) -> "AssetVarietal":
+    def str_to_enum(varietal_str: Optional[str]) -> "AssetExecutionType":
         return (
-            AssetVarietal.MATERIALIZEABLE if varietal_str is None else AssetVarietal(varietal_str)
+            AssetExecutionType.MATERIALIZEABLE
+            if varietal_str is None
+            else AssetExecutionType(varietal_str)
         )
 
 

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -869,12 +869,12 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
             bool: True if the asset key is materializable by this AssetsDefinition.
         """
         from dagster._core.definitions.asset_spec import (
-            SYSTEM_METADATA_KEY_ASSET_VARIETAL,
-            AssetVarietal,
+            SYSTEM_METADATA_KEY_ASSET_EXECUTION_TYPE,
+            AssetExecutionType,
         )
 
-        return AssetVarietal.is_executable(
-            self._metadata_by_key.get(asset_key, {}).get(SYSTEM_METADATA_KEY_ASSET_VARIETAL)
+        return AssetExecutionType.is_executable(
+            self._metadata_by_key.get(asset_key, {}).get(SYSTEM_METADATA_KEY_ASSET_EXECUTION_TYPE)
         )
 
     def get_partition_mapping_for_input(self, input_name: str) -> Optional[PartitionMapping]:

--- a/python_modules/dagster/dagster/_core/definitions/observable_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/observable_asset.py
@@ -2,9 +2,9 @@ from typing import Sequence
 
 from dagster import _check as check
 from dagster._core.definitions.asset_spec import (
-    SYSTEM_METADATA_KEY_ASSET_VARIETAL,
+    SYSTEM_METADATA_KEY_ASSET_EXECUTION_TYPE,
+    AssetExecutionType,
     AssetSpec,
-    AssetVarietal,
 )
 from dagster._core.definitions.decorators.asset_decorator import multi_asset
 from dagster._core.errors import DagsterInvariantViolationError
@@ -33,7 +33,11 @@ def create_unexecutable_observable_assets_def(specs: Sequence[AssetSpec]):
                 group_name=spec.group_name,
                 metadata={
                     **(spec.metadata or {}),
-                    **{SYSTEM_METADATA_KEY_ASSET_VARIETAL: AssetVarietal.UNEXECUTABLE.value},
+                    **{
+                        SYSTEM_METADATA_KEY_ASSET_EXECUTION_TYPE: (
+                            AssetExecutionType.UNEXECUTABLE.value
+                        )
+                    },
                 },
                 deps=spec.deps,
             )

--- a/python_modules/dagster/dagster/_core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external_data.py
@@ -48,8 +48,8 @@ from dagster._core.definitions import (
 from dagster._core.definitions.asset_check_spec import AssetCheckSpec
 from dagster._core.definitions.asset_sensor_definition import AssetSensorDefinition
 from dagster._core.definitions.asset_spec import (
-    SYSTEM_METADATA_KEY_ASSET_VARIETAL,
-    AssetVarietal,
+    SYSTEM_METADATA_KEY_ASSET_EXECUTION_TYPE,
+    AssetExecutionType,
 )
 from dagster._core.definitions.assets_job import is_base_asset_job_name
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
@@ -1262,7 +1262,7 @@ class ExternalAssetNode(
 
     @property
     def is_executable(self) -> bool:
-        metadata_value = self.metadata.get(SYSTEM_METADATA_KEY_ASSET_VARIETAL)
+        metadata_value = self.metadata.get(SYSTEM_METADATA_KEY_ASSET_EXECUTION_TYPE)
         if not metadata_value:
             varietal_text = None
         else:
@@ -1270,7 +1270,7 @@ class ExternalAssetNode(
             assert isinstance(metadata_value, TextMetadataValue)  # for type checker
             varietal_text = metadata_value.value
 
-        return AssetVarietal.is_executable(varietal_text)
+        return AssetExecutionType.is_executable(varietal_text)
 
 
 ResourceJobUsageMap = Dict[str, List[ResourceJobUsageEntry]]

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
@@ -1203,7 +1203,7 @@ def test_historical_external_asset_node() -> None:
         dependencies=[],
         depended_by=[],
         # purposefully not using constants here so we know when we are breaking ourselves
-        metadata={"dagster/asset_varietal": TextMetadataValue("UNEXECUTABLE")},
+        metadata={"dagster/asset_execution_type": TextMetadataValue("UNEXECUTABLE")},
     ).is_executable
 
     assert ExternalAssetNode(


### PR DESCRIPTION
## Summary & Motivation

Renaming AssetVarietal to AssetExecutionType as AssetVarietal is obtuse and arguably pretentious 

## How I Tested These Changes

BK
