### PR TITLE
Revert "Temporarily disable k8s-test-suite (#16606)"

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/integration.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/integration.py
@@ -32,8 +32,7 @@ def build_integration_steps() -> List[BuildkiteStep]:
     # test suites
     steps += build_backcompat_suite_steps()
     steps += build_celery_k8s_suite_steps()
-    # schrockn (2023-09-18) Temporarily due to aws incident
-    # steps += build_k8s_suite_steps()
+    steps += build_k8s_suite_steps()
     steps += build_daemon_suite_steps()
 
     return steps

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/__init__.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/__init__.py
@@ -1,4 +1,3 @@
-# making comment to trigger tests
 from dagster._core.libraries import DagsterLibraryRegistry
 
 from .executor import k8s_job_executor as k8s_job_executor

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/__init__.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/__init__.py
@@ -1,3 +1,4 @@
+# making comment to trigger tests
 from dagster._core.libraries import DagsterLibraryRegistry
 
 from .executor import k8s_job_executor as k8s_job_executor


### PR DESCRIPTION
This reverts commit be7ff205049094abb02d8e4122052dc6f7e34475.

## Summary & Motivation

Re-enable k8s tests after aws is back up

## How I Tested These Changes

Stacked a commit https://github.com/dagster-io/dagster/pull/16608/commits/c9c3f7cfae2b63472c5f9953575dab9d6f333fda that edited dagster-k8s over this and ran: https://buildkite.com/dagster/dagster/builds/66467
