### PR TITLE
[ui] Disable materialize buttons for non-executable assets

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/types/useAssetGraphData.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/types/useAssetGraphData.types.ts
@@ -13,6 +13,7 @@ export type AssetGraphQuery = {
     __typename: 'AssetNode';
     id: string;
     groupName: string | null;
+    isExecutable: boolean;
     hasMaterializePermission: boolean;
     graphName: string | null;
     jobNames: Array<string>;
@@ -39,6 +40,7 @@ export type AssetNodeForGraphQueryFragment = {
   __typename: 'AssetNode';
   id: string;
   groupName: string | null;
+  isExecutable: boolean;
   hasMaterializePermission: boolean;
   graphName: string | null;
   jobNames: Array<string>;

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphData.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphData.tsx
@@ -184,6 +184,7 @@ export const ASSET_GRAPH_QUERY = gql`
   fragment AssetNodeForGraphQuery on AssetNode {
     id
     groupName
+    isExecutable
     hasMaterializePermission
     repository {
       id

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetActionMenu.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetActionMenu.tsx
@@ -7,7 +7,10 @@ import {MenuLink} from '../ui/MenuLink';
 import {RepoAddress} from '../workspace/types';
 import {workspacePathFromAddress} from '../workspace/workspacePath';
 
-import {useMaterializationAction} from './LaunchAssetExecutionButton';
+import {
+  executionDisabledMessageForAssets,
+  useMaterializationAction,
+} from './LaunchAssetExecutionButton';
 import {assetDetailsPathForKey} from './assetDetailsPathForKey';
 import {AssetTableDefinitionFragment} from './types/AssetTableFragment.types';
 
@@ -21,10 +24,13 @@ interface Props {
 export const AssetActionMenu: React.FC<Props> = (props) => {
   const {repoAddress, path, definition, onWipe} = props;
   const {
-    permissions: {canWipeAssets, canLaunchPipelineExecution},
+    permissions: {canWipeAssets},
   } = usePermissionsForLocation(repoAddress?.location);
 
   const {onClick, loading, launchpadElement} = useMaterializationAction();
+  const disabledMessage = definition
+    ? executionDisabledMessageForAssets([definition])
+    : 'Asset definition not found in a code location';
 
   return (
     <>
@@ -33,11 +39,7 @@ export const AssetActionMenu: React.FC<Props> = (props) => {
         content={
           <Menu>
             <Tooltip
-              content={
-                !canLaunchPipelineExecution
-                  ? 'You do not have permission to materialize assets'
-                  : 'Shift+click to add configuration'
-              }
+              content={disabledMessage || 'Shift+click to add configuration'}
               placement="left"
               display="block"
               useDisabledButtonTooltipFix
@@ -45,7 +47,7 @@ export const AssetActionMenu: React.FC<Props> = (props) => {
               <MenuItem
                 text="Materialize"
                 icon={loading ? <Spinner purpose="body-text" /> : 'materialization'}
-                disabled={!canLaunchPipelineExecution || loading}
+                disabled={!!disabledMessage || loading}
                 onClick={(e) => onClick([{path}], e)}
               />
             </Tooltip>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeDefinition.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeDefinition.tsx
@@ -287,7 +287,7 @@ const DescriptionAnnotations: React.FC<{
   assetNode: AssetNodeDefinitionFragment;
   repoAddress: RepoAddress;
 }> = ({assetNode, repoAddress}) => (
-  <Box flex={{alignItems: 'baseline', gap: 16, wrap: 'wrap'}} style={{lineHeight: 0}}>
+  <Box flex={{alignItems: 'center', gap: 16, wrap: 'wrap'}} style={{lineHeight: 0}}>
     {assetNode.jobNames
       .filter((jobName) => !isHiddenAssetGroupJob(jobName))
       .map((jobName) => (
@@ -301,9 +301,11 @@ const DescriptionAnnotations: React.FC<{
         </Mono>
       ))}
     <UnderlyingOpsOrGraph assetNode={assetNode} repoAddress={repoAddress} />
-    {assetNode.isSource && (
-      <Caption style={{lineHeight: '16px', marginTop: 2}}>Source Asset</Caption>
-    )}
+    {assetNode.isSource ? (
+      <Caption style={{lineHeight: '16px'}}>Source Asset</Caption>
+    ) : !assetNode.isExecutable ? (
+      <Caption style={{lineHeight: '16px'}}>Non-executable Asset</Caption>
+    ) : undefined}
   </Box>
 );
 
@@ -315,6 +317,8 @@ export const ASSET_NODE_DEFINITION_FRAGMENT = gql`
     opNames
     opVersion
     jobNames
+    isSource
+    isExecutable
     autoMaterializePolicy {
       policyType
     }

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetTableFragment.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetTableFragment.tsx
@@ -7,6 +7,7 @@ export const ASSET_TABLE_DEFINITION_FRAGMENT = gql`
     opNames
     isSource
     isObservable
+    isExecutable
     computeKind
     hasMaterializePermission
     partitionDefinition {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__fixtures__/AssetViewDefinition.fixtures.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__fixtures__/AssetViewDefinition.fixtures.ts
@@ -92,6 +92,7 @@ export const AssetViewDefinitionSourceAsset: MockedResponse<AssetViewDefinitionQ
           computeKind: null,
           isPartitioned: false,
           isObservable: true,
+          isExecutable: true,
           isSource: true,
           assetKey: {
             path: ['observable_source_asset'],
@@ -159,6 +160,7 @@ export const AssetViewDefinitionSDA: MockedResponse<AssetViewDefinitionQuery> = 
           computeKind: null,
           isPartitioned: false,
           isObservable: false,
+          isExecutable: true,
           isSource: false,
           assetKey: {
             path: ['sda_asset'],

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__fixtures__/LaunchAssetExecutionButton.fixtures.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__fixtures__/LaunchAssetExecutionButton.fixtures.ts
@@ -64,10 +64,31 @@ export const UNPARTITIONED_ASSET: AssetNodeForGraphQueryFragment = {
   computeKind: null,
   isPartitioned: false,
   isObservable: false,
+  isExecutable: true,
   isSource: false,
   assetKey: {
     __typename: 'AssetKey',
     path: ['unpartitioned_asset'],
+  },
+};
+
+export const UNPARTITIONED_SOURCE_ASSET: AssetNodeForGraphQueryFragment = {
+  ...UNPARTITIONED_ASSET,
+  id: 'test.py.repo.["unpartitioned_source_asset"]',
+  isSource: true,
+  assetKey: {
+    __typename: 'AssetKey',
+    path: ['unpartitioned_source_asset'],
+  },
+};
+
+export const UNPARTITIONED_NON_EXECUTABLE_ASSET: AssetNodeForGraphQueryFragment = {
+  ...UNPARTITIONED_ASSET,
+  id: 'test.py.repo.["unpartitioned_non_executable_asset"]',
+  isExecutable: false,
+  assetKey: {
+    __typename: 'AssetKey',
+    path: ['unpartitioned_non_executable_asset'],
   },
 };
 
@@ -136,6 +157,7 @@ export const ASSET_DAILY: AssetNodeForGraphQueryFragment = {
   computeKind: null,
   isPartitioned: true,
   isObservable: false,
+  isExecutable: true,
   isSource: false,
   assetKey: {
     __typename: 'AssetKey',
@@ -173,6 +195,7 @@ export const ASSET_WEEKLY: AssetNodeForGraphQueryFragment = {
   computeKind: null,
   isPartitioned: true,
   isObservable: false,
+  isExecutable: true,
   isSource: false,
   assetKey: {
     __typename: 'AssetKey',

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__fixtures__/LaunchAssetLoaderQuery.fixtures.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__fixtures__/LaunchAssetLoaderQuery.fixtures.tsx
@@ -33,6 +33,7 @@ export const assetNodes: AssetNode[] = [
       ],
     }),
     isObservable: false,
+    isExecutable: true,
     isSource: false,
     assetKey: buildAssetKey({
       path: ['release_files'],
@@ -81,6 +82,7 @@ export const assetNodes: AssetNode[] = [
       ],
     }),
     isObservable: false,
+    isExecutable: true,
     isSource: false,
     assetKey: buildAssetKey({
       path: ['release_files_metadata'],
@@ -129,6 +131,7 @@ export const assetNodes: AssetNode[] = [
       ],
     }),
     isObservable: false,
+    isExecutable: true,
     isSource: false,
     assetKey: buildAssetKey({
       path: ['release_zips'],
@@ -177,6 +180,7 @@ export const assetNodes: AssetNode[] = [
       ],
     }),
     isObservable: false,
+    isExecutable: true,
     isSource: false,
     assetKey: buildAssetKey({
       path: ['releases_metadata'],
@@ -212,6 +216,7 @@ export const assetNodes: AssetNode[] = [
     hasMaterializePermission: true,
     partitionDefinition: null,
     isObservable: false,
+    isExecutable: true,
     isSource: false,
     assetKey: buildAssetKey({
       path: ['releases_summary'],

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/buildAssetTabs.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/buildAssetTabs.test.tsx
@@ -66,6 +66,7 @@ describe('buildAssetTabs', () => {
     computeKind: null,
     isPartitioned: true,
     isObservable: false,
+    isExecutable: true,
     isSource: false,
     assetKey: {
       path: ['eager_downstream_3_partitioned'],
@@ -212,6 +213,7 @@ describe('buildAssetTabs', () => {
     computeKind: null,
     isPartitioned: false,
     isObservable: false,
+    isExecutable: true,
     isSource: false,
     assetKey: {
       path: ['lazy_downstream_1'],

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetNodeDefinition.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetNodeDefinition.types.ts
@@ -10,11 +10,12 @@ export type AssetNodeDefinitionFragment = {
   opNames: Array<string>;
   opVersion: string | null;
   jobNames: Array<string>;
+  isSource: boolean;
+  isExecutable: boolean;
   hasMaterializePermission: boolean;
   computeKind: string | null;
   isPartitioned: boolean;
   isObservable: boolean;
-  isSource: boolean;
   autoMaterializePolicy: {
     __typename: 'AutoMaterializePolicy';
     policyType: Types.AutoMaterializePolicyType;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetTableFragment.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetTableFragment.types.ts
@@ -9,6 +9,7 @@ export type AssetTableDefinitionFragment = {
   opNames: Array<string>;
   isSource: boolean;
   isObservable: boolean;
+  isExecutable: boolean;
   computeKind: string | null;
   hasMaterializePermission: boolean;
   description: string | null;
@@ -32,6 +33,7 @@ export type AssetTableFragment = {
     opNames: Array<string>;
     isSource: boolean;
     isObservable: boolean;
+    isExecutable: boolean;
     computeKind: string | null;
     hasMaterializePermission: boolean;
     description: string | null;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetView.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetView.types.ts
@@ -28,11 +28,12 @@ export type AssetViewDefinitionQuery = {
           opNames: Array<string>;
           opVersion: string | null;
           jobNames: Array<string>;
+          isSource: boolean;
+          isExecutable: boolean;
           hasMaterializePermission: boolean;
           computeKind: string | null;
           isPartitioned: boolean;
           isObservable: boolean;
-          isSource: boolean;
           partitionDefinition: {__typename: 'PartitionDefinition'; description: string} | null;
           partitionKeysByDimension: Array<{__typename: 'DimensionPartitionKeys'; name: string}>;
           repository: {
@@ -15740,11 +15741,12 @@ export type AssetViewDefinitionNodeFragment = {
   opNames: Array<string>;
   opVersion: string | null;
   jobNames: Array<string>;
+  isSource: boolean;
+  isExecutable: boolean;
   hasMaterializePermission: boolean;
   computeKind: string | null;
   isPartitioned: boolean;
   isObservable: boolean;
-  isSource: boolean;
   partitionDefinition: {__typename: 'PartitionDefinition'; description: string} | null;
   partitionKeysByDimension: Array<{__typename: 'DimensionPartitionKeys'; name: string}>;
   repository: {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetsCatalogTable.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetsCatalogTable.types.ts
@@ -20,6 +20,7 @@ export type AssetCatalogTableQuery = {
             opNames: Array<string>;
             isSource: boolean;
             isObservable: boolean;
+            isExecutable: boolean;
             computeKind: string | null;
             hasMaterializePermission: boolean;
             description: string | null;
@@ -58,6 +59,7 @@ export type AssetCatalogGroupTableQuery = {
     opNames: Array<string>;
     isSource: boolean;
     isObservable: boolean;
+    isExecutable: boolean;
     computeKind: string | null;
     hasMaterializePermission: boolean;
     description: string | null;
@@ -79,6 +81,7 @@ export type AssetCatalogGroupTableNodeFragment = {
   opNames: Array<string>;
   isSource: boolean;
   isObservable: boolean;
+  isExecutable: boolean;
   computeKind: string | null;
   hasMaterializePermission: boolean;
   description: string | null;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/LaunchAssetExecutionButton.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/LaunchAssetExecutionButton.types.ts
@@ -22,6 +22,7 @@ export type LaunchAssetExecutionAssetNodeFragment = {
   graphName: string | null;
   hasMaterializePermission: boolean;
   isObservable: boolean;
+  isExecutable: boolean;
   isSource: boolean;
   partitionDefinition: {
     __typename: 'PartitionDefinition';
@@ -611,6 +612,7 @@ export type LaunchAssetLoaderQuery = {
     graphName: string | null;
     hasMaterializePermission: boolean;
     isObservable: boolean;
+    isExecutable: boolean;
     isSource: boolean;
     partitionDefinition: {
       __typename: 'PartitionDefinition';

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/types/VirtualizedRepoAssetTable.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/types/VirtualizedRepoAssetTable.types.ts
@@ -9,6 +9,7 @@ export type RepoAssetTableFragment = {
   opNames: Array<string>;
   isSource: boolean;
   isObservable: boolean;
+  isExecutable: boolean;
   computeKind: string | null;
   hasMaterializePermission: boolean;
   description: string | null;

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/types/WorkspaceAssetsRoot.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/types/WorkspaceAssetsRoot.types.ts
@@ -30,6 +30,7 @@ export type WorkspaceAssetsQuery = {
           opNames: Array<string>;
           isSource: boolean;
           isObservable: boolean;
+          isExecutable: boolean;
           computeKind: string | null;
           hasMaterializePermission: boolean;
           description: string | null;


### PR DESCRIPTION
## Summary & Motivation

Quick walkthrough: https://www.loom.com/share/82cd14bd03da40ff8747a1ff809b2814

Builds on the work in https://github.com/dagster-io/dagster/pull/16578

This PR makes a few small changes to the asset "Materialize" workflow:

- If ALL of the assets in your selection are `isExecutable: false`, the Materialize button is disabled with a new tooltip:

<img width="452" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/2b06fa7b-683d-4b47-ba80-5a98dc34621f">


- If SOME of the assets in your selection are `isExecutable: false`, the Materialize button treats them like source assets, removing them from the selection and the count displayed on the button. This means that selection `A, B, C (unexecutable)` shows `Materialize (2)`, and a graph with a mix of executable and non-executable assets lets you click "Materialize All", quietly ignoring the non-executable ones.

## How I Tested These Changes

I added 6 more tests to `LaunchAssetExecutionButton.test.tsx` covering the new tooltips and disabled states. 

Also loaded a small graph into a new asset group using this code and tested in the UI + verified that the updates did not change the behavior of existing source assets or observable source assets using my local repo.

```
from dagster._core.definitions.asset_spec import AssetSpec
from dagster._core.definitions.observable_asset import create_unexecutable_observable_assets_def

unexecutable_upstream_asset2 =  create_unexecutable_observable_assets_def([AssetSpec(key="unexecutable_upstream_asset2", group_name="is_executable")])

@asset(deps=[unexecutable_upstream_asset2], group_name="is_executable")
def executable_downstream_asset():
    return 1


@asset(deps=[unexecutable_upstream_asset2], group_name="is_executable")
def another_executable_downstream_asset():
    return 1
```