### PR TITLE
[ui] Show failed checks in logs in red, truncate checks in asset sidebar

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetSidebarActivitySummary.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetSidebarActivitySummary.tsx
@@ -172,7 +172,7 @@ export const AssetSidebarActivitySummary: React.FC<Props> = ({
             </Link>
           </Box>
 
-          {liveData.assetChecks.map((check) => (
+          {liveData.assetChecks.slice(0, 10).map((check) => (
             <Box
               key={check.name}
               border={{side: 'top', width: 1, color: Colors.KeylineGray}}
@@ -191,6 +191,16 @@ export const AssetSidebarActivitySummary: React.FC<Props> = ({
               />
             </Box>
           ))}
+          {liveData.assetChecks.length > 10 && (
+            <Box
+              padding={{vertical: 12, right: 12, left: 24}}
+              border={{side: 'top', width: 1, color: Colors.KeylineGray}}
+            >
+              <Link to={assetDetailsPathForKey(asset.assetKey, {view: 'checks'})}>
+                View {liveData.assetChecks.length - 10} more…
+              </Link>
+            </Box>
+          )}
         </SidebarSection>
       )}
     </>

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/LogsRowStructuredContent.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/LogsRowStructuredContent.tsx
@@ -440,9 +440,13 @@ const AssetCheckEvaluationContent: React.FC<{
   });
 
   return (
-    <DefaultContent message="" eventType={eventType}>
+    <DefaultContent
+      message=""
+      eventType={eventType}
+      eventIntent={success ? Intent.SUCCESS : Intent.DANGER}
+    >
       <div>
-        <div>
+        <div style={{color: success ? 'inherit' : Colors.Red500}}>
           Check <MetadataEntryLink to={checkLink}>{checkName}</MetadataEntryLink>
           {` ${success ? 'succeeded' : 'failed'} for materialization of `}
           <MetadataEntryLink to={matLink}>{displayNameForAssetKey(assetKey)}</MetadataEntryLink>.


### PR DESCRIPTION
## Summary & Motivation

Two small changes in this PR that were requested in https://www.notion.so/dagster/Asset-checks-UI-followups-8c188b748d0f449ca72a9e5ddf264090:

- In the logs, the color of the event type tag is based on the success/failure of the check, and if the check failed the message is shown in red for consistency with other errors.

<img width="1728" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/c59291f5-e864-4519-b92f-43afcbd4882e">


- In the asset sidebar, the checks section truncates and a link allows you to see the remaining checks on the details page (where we can implement pagination, etc soon)
 
<img width="796" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/0eeabc06-509f-4a61-b937-452577984924">
