### PR TITLE
[ext] Use MaterializeResult for ext_protocol

### DIFF
--- a/integration_tests/test_suites/k8s-test-suite/tests/test_external_asset.py
+++ b/integration_tests/test_suites/k8s-test-suite/tests/test_external_asset.py
@@ -26,7 +26,7 @@ def test_ext_k8s_pod(namespace, cluster_provider):
         context: AssetExecutionContext,
         ext_k8s_pod: ExtK8sPod,
     ):
-        ext_k8s_pod.run(
+        return ext_k8s_pod.run(
             context=context,
             namespace=namespace,
             image=docker_image,
@@ -138,7 +138,7 @@ def test_ext_k8s_pod_file_inject(namespace, cluster_provider):
             ],
         )
 
-        ext_k8s_pod.run(
+        return ext_k8s_pod.run(
             context=context,
             namespace=namespace,
             extras={
@@ -197,6 +197,7 @@ def test_use_excute_k8s_job(namespace, cluster_provider):
                 k8s_job_name=job_name,
             )
             reader.consume_pod_logs(core_api, job_name, namespace)
+        return ext_context.get_materialize_results()
 
     result = materialize(
         [number_y_job],

--- a/integration_tests/test_suites/k8s-test-suite/tests/test_external_asset.py
+++ b/integration_tests/test_suites/k8s-test-suite/tests/test_external_asset.py
@@ -26,7 +26,7 @@ def test_ext_k8s_pod(namespace, cluster_provider):
         context: AssetExecutionContext,
         ext_k8s_pod: ExtK8sPod,
     ):
-        return ext_k8s_pod.run(
+        yield from ext_k8s_pod.run(
             context=context,
             namespace=namespace,
             image=docker_image,
@@ -138,7 +138,7 @@ def test_ext_k8s_pod_file_inject(namespace, cluster_provider):
             ],
         )
 
-        return ext_k8s_pod.run(
+        yield from ext_k8s_pod.run(
             context=context,
             namespace=namespace,
             extras={
@@ -197,7 +197,7 @@ def test_use_excute_k8s_job(namespace, cluster_provider):
                 k8s_job_name=job_name,
             )
             reader.consume_pod_logs(core_api, job_name, namespace)
-        return ext_context.get_materialize_results()
+        yield from ext_context.get_results()
 
     result = materialize(
         [number_y_job],

--- a/python_modules/dagster-ext/dagster_ext_tests/test_external_execution.py
+++ b/python_modules/dagster-ext/dagster_ext_tests/test_external_execution.py
@@ -9,11 +9,12 @@ from typing import Any, Callable, Iterator
 
 import boto3
 import pytest
+from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.data_version import (
     DATA_VERSION_IS_USER_PROVIDED_TAG,
     DATA_VERSION_TAG,
 )
-from dagster._core.definitions.decorators.asset_decorator import asset
+from dagster._core.definitions.decorators.asset_decorator import asset, multi_asset
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.materialize import materialize
 from dagster._core.definitions.metadata import (
@@ -30,8 +31,8 @@ from dagster._core.definitions.metadata import (
     TextMetadataValue,
     UrlMetadataValue,
 )
-from dagster._core.errors import DagsterExternalExecutionError
-from dagster._core.execution.context.compute import AssetExecutionContext
+from dagster._core.errors import DagsterExternalExecutionError, DagsterInvariantViolationError
+from dagster._core.execution.context.compute import AssetExecutionContext, OpExecutionContext
 from dagster._core.execution.context.invocation import build_asset_context
 from dagster._core.ext.subprocess import (
     ExtSubprocess,
@@ -150,7 +151,7 @@ def test_ext_subprocess(
     def foo(context: AssetExecutionContext, ext: ExtSubprocess):
         extras = {"bar": "baz"}
         cmd = [_PYTHON_EXECUTABLE, external_script]
-        return ext.run(
+        yield from ext.run(
             cmd,
             context=context,
             extras=extras,
@@ -163,11 +164,7 @@ def test_ext_subprocess(
     resource = ExtSubprocess(context_injector=context_injector, message_reader=message_reader)
 
     with instance_for_test() as instance:
-        materialize(
-            [foo],
-            instance=instance,
-            resources={"ext": resource},
-        )
+        materialize([foo], instance=instance, resources={"ext": resource})
         mat = instance.get_latest_materialization_event(foo.key)
         assert mat and mat.asset_materialization
         assert isinstance(mat.asset_materialization.metadata["bar"], MarkdownMetadataValue)
@@ -178,6 +175,35 @@ def test_ext_subprocess(
 
         captured = capsys.readouterr()
         assert re.search(r"dagster - INFO - [^\n]+ - hello world\n", captured.err, re.MULTILINE)
+
+
+def test_ext_multi_asset():
+    def script_fn():
+        from dagster_ext import init_dagster_ext
+
+        context = init_dagster_ext()
+        context.report_asset_materialization(
+            {"foo_meta": "ok"}, data_version="alpha", asset_key="foo"
+        )
+        context.report_asset_materialization(data_version="alpha", asset_key="bar")
+
+    @multi_asset(specs=[AssetSpec("foo"), AssetSpec("bar")])
+    def foo_bar(context: AssetExecutionContext, ext: ExtSubprocess):
+        with temp_script(script_fn) as script_path:
+            cmd = [_PYTHON_EXECUTABLE, script_path]
+            yield from ext.run(cmd, context=context)
+
+    with instance_for_test() as instance:
+        materialize([foo_bar], instance=instance, resources={"ext": ExtSubprocess()})
+        foo_mat = instance.get_latest_materialization_event(AssetKey(["foo"]))
+        assert foo_mat and foo_mat.asset_materialization
+        assert foo_mat.asset_materialization.metadata["foo_meta"].value == "ok"
+        assert foo_mat.asset_materialization.tags
+        assert foo_mat.asset_materialization.tags[DATA_VERSION_TAG] == "alpha"
+        bar_mat = instance.get_latest_materialization_event(AssetKey(["foo"]))
+        assert bar_mat and bar_mat.asset_materialization
+        assert bar_mat.asset_materialization.tags
+        assert bar_mat.asset_materialization.tags[DATA_VERSION_TAG] == "alpha"
 
 
 def test_ext_typed_metadata():
@@ -207,7 +233,7 @@ def test_ext_typed_metadata():
     def foo(context: AssetExecutionContext, ext: ExtSubprocess):
         with temp_script(script_fn) as script_path:
             cmd = [_PYTHON_EXECUTABLE, script_path]
-            return ext.run(cmd, context=context)
+            yield from ext.run(cmd, context=context)
 
     with instance_for_test() as instance:
         materialize(
@@ -254,7 +280,7 @@ def test_ext_asset_failed():
     def foo(context: AssetExecutionContext, ext: ExtSubprocess):
         with temp_script(script_fn) as script_path:
             cmd = [_PYTHON_EXECUTABLE, script_path]
-            ext.run(cmd, context=context)
+            yield from ext.run(cmd, context=context)
 
     with pytest.raises(DagsterExternalExecutionError):
         materialize([foo], resources={"ext": ExtSubprocess()})
@@ -321,9 +347,7 @@ def test_ext_no_client(external_script):
             extras=extras,
         ) as ext_context:
             subprocess.run(cmd, env=ext_context.get_external_process_env_vars(), check=False)
-            _ext_context = ext_context
-        mat_results = _ext_context.get_materialize_results()
-        return mat_results[0] if len(mat_results) == 1 else mat_results
+        yield from ext_context.get_results()
 
     with instance_for_test() as instance:
         materialize(
@@ -338,28 +362,26 @@ def test_ext_no_client(external_script):
         assert mat.asset_materialization.tags[DATA_VERSION_IS_USER_PROVIDED_TAG]
 
 
-def test_ext_no_client_premature_get_results(external_script):
-    @asset
-    def subproc_run(context: AssetExecutionContext):
-        extras = {"bar": "baz"}
-        cmd = [_PYTHON_EXECUTABLE, external_script]
+def test_ext_no_client_no_yield():
+    def script_fn():
+        pass
 
-        with ext_protocol(
-            context,
-            ExtTempFileContextInjector(),
-            ExtTempFileMessageReader(),
-            extras=extras,
-        ) as ext_context:
-            subprocess.run(cmd, env=ext_context.get_external_process_env_vars(), check=False)
-            return ext_context.get_materialize_results()
+    @asset
+    def foo(context: OpExecutionContext):
+        with temp_script(script_fn) as external_script:
+            with ext_protocol(
+                context,
+                ExtTempFileContextInjector(),
+                ExtTempFileMessageReader(),
+            ) as ext_context:
+                cmd = [_PYTHON_EXECUTABLE, external_script]
+                subprocess.run(cmd, env=ext_context.get_external_process_env_vars(), check=False)
 
     with pytest.raises(
-        DagsterExternalExecutionError,
+        DagsterInvariantViolationError,
         match=(
-            "`get_materialize_results` must be called after the `ext_protocol` context manager has"
-            " exited."
+            r"did not yield or return expected outputs.*Did you forget to `yield from"
+            r" ext_context.get_results\(\)`?"
         ),
     ):
-        materialize(
-            [subproc_run],
-        )
+        materialize([foo])

--- a/python_modules/dagster/dagster/_core/ext/client.py
+++ b/python_modules/dagster/dagster/_core/ext/client.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Iterator, Optional
+from typing import TYPE_CHECKING, Iterator, Optional, Tuple, Union
 
 from dagster_ext import (
     ExtContextData,
@@ -11,6 +11,8 @@ from dagster_ext import (
 from dagster._core.execution.context.compute import OpExecutionContext
 
 if TYPE_CHECKING:
+    from dagster._core.definitions.result import MaterializeResult
+
     from .context import ExtMessageHandler
 
 
@@ -21,7 +23,7 @@ class ExtClient(ABC):
         *,
         context: OpExecutionContext,
         extras: Optional[ExtExtras] = None,
-    ) -> None: ...
+    ) -> Union["MaterializeResult", Tuple["MaterializeResult", ...]]: ...
 
 
 class ExtContextInjector(ABC):

--- a/python_modules/dagster/dagster/_core/ext/client.py
+++ b/python_modules/dagster/dagster/_core/ext/client.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Iterator, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Iterator, Optional
 
 from dagster_ext import (
     ExtContextData,
@@ -11,9 +11,7 @@ from dagster_ext import (
 from dagster._core.execution.context.compute import OpExecutionContext
 
 if TYPE_CHECKING:
-    from dagster._core.definitions.result import MaterializeResult
-
-    from .context import ExtMessageHandler
+    from .context import ExtMessageHandler, ExtResult
 
 
 class ExtClient(ABC):
@@ -23,7 +21,7 @@ class ExtClient(ABC):
         *,
         context: OpExecutionContext,
         extras: Optional[ExtExtras] = None,
-    ) -> Union["MaterializeResult", Tuple["MaterializeResult", ...]]: ...
+    ) -> Iterator["ExtResult"]: ...
 
 
 class ExtContextInjector(ABC):

--- a/python_modules/dagster/dagster/_core/ext/utils.py
+++ b/python_modules/dagster/dagster/_core/ext/utils.py
@@ -202,9 +202,11 @@ def ext_protocol(
     ) as ci_params, message_reader.read_messages(
         message_handler,
     ) as mr_params:
-        yield ExtOrchestrationContext(
+        ext_context = ExtOrchestrationContext(
             context_data=context_data,
             message_handler=message_handler,
             context_injector_params=ci_params,
             message_reader_params=mr_params,
         )
+        yield ext_context
+        ext_context.is_task_finished = True

--- a/python_modules/libraries/dagster-docker/dagster_docker/ext.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/ext.py
@@ -1,5 +1,5 @@
 from contextlib import contextmanager
-from typing import Any, Iterator, Mapping, Optional, Sequence, Union
+from typing import Any, Iterator, Mapping, Optional, Sequence, Tuple, Union
 
 import docker
 from dagster import (
@@ -7,6 +7,7 @@ from dagster import (
     ResourceParam,
     _check as check,
 )
+from dagster._core.definitions.result import MaterializeResult
 from dagster._core.ext.client import (
     ExtClient,
     ExtContextInjector,
@@ -94,7 +95,7 @@ class _ExtDocker(ExtClient):
         registry: Optional[Mapping[str, str]] = None,
         container_kwargs: Optional[Mapping[str, Any]] = None,
         extras: Optional[ExtExtras] = None,
-    ) -> None:
+    ) -> Union[MaterializeResult, Tuple[MaterializeResult, ...]]:
         """Create a docker container and run it to completion, enriched with the ext protocol.
 
         Args:
@@ -162,6 +163,7 @@ class _ExtDocker(ExtClient):
                     raise DagsterExtError(f"Container exited with non-zero status code: {result}")
             finally:
                 container.stop()
+        return ext_context.get_materialize_results()
 
     def _create_container(
         self,

--- a/python_modules/libraries/dagster-docker/dagster_docker/ext.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/ext.py
@@ -1,5 +1,5 @@
 from contextlib import contextmanager
-from typing import Any, Iterator, Mapping, Optional, Sequence, Tuple, Union
+from typing import Any, Iterator, Mapping, Optional, Sequence, Union
 
 import docker
 from dagster import (
@@ -7,7 +7,6 @@ from dagster import (
     ResourceParam,
     _check as check,
 )
-from dagster._core.definitions.result import MaterializeResult
 from dagster._core.ext.client import (
     ExtClient,
     ExtContextInjector,
@@ -15,6 +14,7 @@ from dagster._core.ext.client import (
 )
 from dagster._core.ext.context import (
     ExtMessageHandler,
+    ExtResult,
 )
 from dagster._core.ext.utils import (
     ExtEnvContextInjector,
@@ -95,7 +95,7 @@ class _ExtDocker(ExtClient):
         registry: Optional[Mapping[str, str]] = None,
         container_kwargs: Optional[Mapping[str, Any]] = None,
         extras: Optional[ExtExtras] = None,
-    ) -> Union[MaterializeResult, Tuple[MaterializeResult, ...]]:
+    ) -> Iterator[ExtResult]:
         """Create a docker container and run it to completion, enriched with the ext protocol.
 
         Args:
@@ -163,7 +163,7 @@ class _ExtDocker(ExtClient):
                     raise DagsterExtError(f"Container exited with non-zero status code: {result}")
             finally:
                 container.stop()
-        return ext_context.get_materialize_results()
+        return ext_context.get_results()
 
     def _create_container(
         self,

--- a/python_modules/libraries/dagster-docker/dagster_docker_tests/test_ext.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker_tests/test_ext.py
@@ -31,7 +31,7 @@ def test_default():
         context: AssetExecutionContext,
         ext_docker: ExtDocker,
     ):
-        ext_docker.run(
+        yield from ext_docker.run(
             image=docker_image,
             command=[
                 "python",
@@ -88,7 +88,7 @@ def test_file_io():
                 },
             }
 
-            ext_docker.run(
+            yield from ext_docker.run(
                 image=docker_image,
                 command=[
                     "python",

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/ext.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/ext.py
@@ -1,7 +1,7 @@
 import random
 import string
 from contextlib import contextmanager
-from typing import Any, Iterator, Mapping, Optional, Sequence, Union
+from typing import Any, Iterator, Mapping, Optional, Sequence, Tuple, Union
 
 import kubernetes
 from dagster import (
@@ -9,6 +9,7 @@ from dagster import (
     _check as check,
 )
 from dagster._core.definitions.resource_annotation import ResourceParam
+from dagster._core.definitions.result import MaterializeResult
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.ext.client import (
     ExtClient,
@@ -123,7 +124,7 @@ class _ExtK8sPod(ExtClient):
         base_pod_meta: Optional[Mapping[str, Any]] = None,
         base_pod_spec: Optional[Mapping[str, Any]] = None,
         extras: Optional[ExtExtras] = None,
-    ) -> None:
+    ) -> Union[MaterializeResult, Tuple[MaterializeResult, ...]]:
         """Publish a kubernetes pod and wait for it to complete, enriched with the ext protocol.
 
         Args:
@@ -196,6 +197,8 @@ class _ExtK8sPod(ExtClient):
                     )
             finally:
                 client.core_api.delete_namespaced_pod(pod_name, namespace)
+        mats = ext_context.get_materialize_results()
+        return mats[0] if len(mats) == 1 else mats
 
 
 def build_pod_body(

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/ext.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/ext.py
@@ -1,7 +1,7 @@
 import random
 import string
 from contextlib import contextmanager
-from typing import Any, Iterator, Mapping, Optional, Sequence, Tuple, Union
+from typing import Any, Iterator, Mapping, Optional, Sequence, Union
 
 import kubernetes
 from dagster import (
@@ -9,7 +9,6 @@ from dagster import (
     _check as check,
 )
 from dagster._core.definitions.resource_annotation import ResourceParam
-from dagster._core.definitions.result import MaterializeResult
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.ext.client import (
     ExtClient,
@@ -19,6 +18,7 @@ from dagster._core.ext.client import (
 )
 from dagster._core.ext.context import (
     ExtMessageHandler,
+    ExtResult,
 )
 from dagster._core.ext.utils import (
     ExtEnvContextInjector,
@@ -124,7 +124,7 @@ class _ExtK8sPod(ExtClient):
         base_pod_meta: Optional[Mapping[str, Any]] = None,
         base_pod_spec: Optional[Mapping[str, Any]] = None,
         extras: Optional[ExtExtras] = None,
-    ) -> Union[MaterializeResult, Tuple[MaterializeResult, ...]]:
+    ) -> Iterator[ExtResult]:
         """Publish a kubernetes pod and wait for it to complete, enriched with the ext protocol.
 
         Args:
@@ -197,8 +197,7 @@ class _ExtK8sPod(ExtClient):
                     )
             finally:
                 client.core_api.delete_namespaced_pod(pod_name, namespace)
-        mats = ext_context.get_materialize_results()
-        return mats[0] if len(mats) == 1 else mats
+        return ext_context.get_results()
 
 
 def build_pod_body(


### PR DESCRIPTION
## Summary & Motivation

Make ext rely on yielding `MaterializeResult` to register metadata and data version, as opposed to modifying `OpExecutionContext`. This allows results to stream back as they are reported rather than being bulk reported when computation completes.

This required addition of a `report_asset_materialization` method that can be called on the `ExtContext`. This will queue a `MaterializationResult` on the orchestration side. The queue can be cleared from the `ExtOrchestrationContext` at any time by calling `ExtOrchestrationContext.get_results`. Errors are raised if attempting materialize an asset twice or report data version/metadata after materialization.

Once the `ext_protocol` block exits, any as-yet-unmaterialized assets are queued on the `MessageHandler`, so that calling `ExtOrchestrationContext.get_results` after exit will yield all the remaining `MaterializeResult` objects. Note that yielding from this method after `ext_protocol` close is required to guarantee all buffered data is yielded, since there is no guarantee that all messages have been processed before `ext_protocol` completes its exit routine.

To head off the confusing scenario where a user forgets to yield outside the block and sees auto-created materializations that lack any reported metadata, we call `set_require_typed_event_stream` on the `OpExecutionContext`. This will cause an error during output processing if an expected output was not returned/yielded.

## How I Tested These Changes

New unit tests.