### PR TITLE
[observable-source-assets] Fix observable job resolution logic

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/external_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/external_asset_graph.py
@@ -272,7 +272,11 @@ class ExternalAssetGraph(AssetGraph):
             for job_name, external_partitions_def in partitions_def_by_job_name.items():
                 if not job_name.startswith(ASSET_BASE_JOB_PREFIX):
                     continue
-                if external_partitions_def == target_partitions_def and all(
+                if (
+                    # unpartitioned observable source assets may be materialized in any job
+                    target_partitions_def is None
+                    or external_partitions_def == target_partitions_def
+                ) and all(
                     asset_key in self._asset_keys_by_job_name[job_name] for asset_key in asset_keys
                 ):
                     return job_name


### PR DESCRIPTION
## Summary & Motivation

Fixes: https://github.com/dagster-io/dagster/issues/16611

The prior logic made sure to appropriately match observable source assets to asset jobs that shared an identical underlying PartitionsDefinition. However, if your code location consists of only partitioned assets, and your observable source asset is unpartitioned, this means that no job can be found to materialize it.

Any unpartitioned asset can be materialized by any partitioned job, so this PR updates the logic to allow for unpartitioned assets to be materialized by partitioned base asset jobs.

## How I Tested These Changes

The added test case is a bit goofy, but it did reproduce the error.
