### PR TITLE
add storage method to fetch partition existence to replace partition count fetch

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -1992,6 +1992,12 @@ class DagsterInstance(DynamicPartitionsStore):
         return self._event_storage.get_materialization_count_by_partition(asset_keys, after_cursor)
 
     @traced
+    def get_materialized_partitions(
+        self, asset_key: AssetKey, after_cursor: Optional[int] = None
+    ) -> Set[str]:
+        return self._event_storage.get_materialized_partitions(asset_key, after_cursor)
+
+    @traced
     def get_latest_storage_id_by_partition(
         self, asset_key: AssetKey, event_type: "DagsterEventType"
     ) -> Mapping[str, int]:

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -374,6 +374,12 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         """Remove asset index history from event log for given asset_key."""
 
     @abstractmethod
+    def get_materialized_partitions(
+        self, asset_key: AssetKey, after_cursor: Optional[int] = None
+    ) -> Set[str]:
+        pass
+
+    @abstractmethod
     def get_materialization_count_by_partition(
         self, asset_keys: Sequence[AssetKey], after_cursor: Optional[int] = None
     ) -> Mapping[AssetKey, Mapping[str, int]]:

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -475,6 +475,11 @@ class LegacyEventLogStorage(EventLogStorage, ConfigurableClass):
     def wipe_asset(self, asset_key: "AssetKey") -> None:
         return self._storage.event_log_storage.wipe_asset(asset_key)
 
+    def get_materialized_partitions(
+        self, asset_key: AssetKey, after_cursor: Optional[int] = None
+    ) -> Set[str]:
+        return self._storage.event_log_storage.get_materialized_partitions(asset_key, after_cursor)
+
     def get_materialization_count_by_partition(
         self, asset_keys: Sequence["AssetKey"], after_cursor: Optional[int] = None
     ) -> Mapping["AssetKey", Mapping[str, int]]:


### PR DESCRIPTION
## Summary & Motivation
The partition count storage method is pretty inefficient and requires scanning for all materializations for all time.  All of the count callers are just using the count to check for existence, so we should deprecate the count calls and use this method instead.

It should also be serviced by the summary table in Cloud.

## How I Tested These Changes
BK