### PR TITLE
drop @public from is_asset_executable

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -858,7 +858,6 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
         """
         return self._check_specs_by_output_name.values()
 
-    @public
     def is_asset_executable(self, asset_key: AssetKey) -> bool:
         """Returns True if the asset key is materializable by this AssetsDefinition.
 


### PR DESCRIPTION
I am guessing this was not intentional (i overlooked it in review at least) but I think we shouldn't mark this stuff as public yet.

## How I Tested These Changes

eyes