### PR TITLE
[RFC] Batch cancel runs

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -195,6 +195,9 @@ class LegacyRunStorage(RunStorage, ConfigurableClass):
     def handle_run_event(self, run_id: str, event: "DagsterEvent") -> None:
         return self._storage.run_storage.handle_run_event(run_id, event)
 
+    def handle_run_events_batch(self, event_by_run_id: Mapping[str, "DagsterEvent"]) -> None:
+        return self._storage.run_storage.handle_run_events_batch(event_by_run_id)
+
     def get_runs(
         self,
         filters: Optional["RunsFilter"] = None,

--- a/python_modules/dagster/dagster/_core/storage/runs/base.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/base.py
@@ -63,6 +63,15 @@ class RunStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance], DaemonCursorSto
         """
 
     @abstractmethod
+    def handle_run_events_batch(self, event_by_run_id: Mapping[str, DagsterEvent]) -> None:
+        """Accepts a batch of DagsterEvents that share the same pipeline run-related DagsterEventType.
+        Updates run storage in accordance to the events.
+
+        Args:
+            event_by_run_id (Mapping[str, DagsterEvent])
+        """
+
+    @abstractmethod
     def get_runs(
         self,
         filters: Optional[RunsFilter] = None,

--- a/python_modules/dagster/dagster_tests/core_tests/test_cancel_all_queued_runs.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_cancel_all_queued_runs.py
@@ -1,0 +1,72 @@
+import sys
+
+from dagster import (
+    DagsterEventType,
+    DagsterRun,
+    DagsterRunStatus,
+)
+from dagster._core.host_representation import (
+    ExternalRepositoryOrigin,
+    ManagedGrpcPythonEnvCodeLocationOrigin,
+)
+from dagster._core.test_utils import instance_for_test
+from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
+
+
+def _create_test_run(job_name: str, status: DagsterRunStatus) -> DagsterRun:
+    origin_one = ExternalRepositoryOrigin(
+        ManagedGrpcPythonEnvCodeLocationOrigin(
+            LoadableTargetOrigin(
+                executable_path=sys.executable, module_name="fake", attribute="fake"
+            ),
+        ),
+        "fake",
+    ).get_job_origin("fake")
+
+    return DagsterRun(
+        job_name=job_name,
+        run_config=None,
+        status=status,
+        external_job_origin=origin_one,
+    )
+
+
+def _assert_run_has_canceled_events(instance, run_id) -> None:
+    logs = instance.all_logs(run_id)
+    assert len(logs) == 2
+    assert logs[0].dagster_event.event_type == DagsterEventType.RUN_CANCELING
+    assert logs[1].dagster_event.event_type == DagsterEventType.RUN_CANCELED
+
+
+def test_cancel_all_queued_runs():
+    with instance_for_test() as instance:
+        run_ids = []
+
+        job_names = [
+            ("job_one", DagsterRunStatus.QUEUED),
+            ("job_two", DagsterRunStatus.QUEUED),
+            ("job_three", DagsterRunStatus.NOT_STARTED),
+        ]
+        for job_name, status in job_names:
+            run = instance.run_storage.add_run(_create_test_run(job_name, status))
+            run_ids.append(run.run_id)
+
+        runs = instance.run_storage.get_runs()
+        assert len(runs) == 3
+
+        instance.cancel_queued_runs()
+
+        run1 = instance.get_run_by_id(run_ids[0])
+        assert run1.status == DagsterRunStatus.CANCELED
+        assert run1.job_name == "job_one"
+        _assert_run_has_canceled_events(instance, run_ids[0])
+
+        run2 = instance.get_run_by_id(run_ids[1])
+        assert run2.status == DagsterRunStatus.CANCELED
+        assert run2.job_name == "job_two"
+        _assert_run_has_canceled_events(instance, run_ids[1])
+
+        run3 = instance.get_run_by_id(run_ids[2])
+        assert run3.status == DagsterRunStatus.NOT_STARTED
+        assert run3.job_name == "job_three"
+        assert len(instance.all_logs(run_ids[2])) == 0


### PR DESCRIPTION
This PR explores a possible implementation for the "stop all queued runs" button.

Terminating queued runs in sequence takes > 15minutes for 5K runs. Most of this time is spent within `handle_run_event`, which is called twice for each run. 

To optimize this, this PR batches the per-run operations into a single query, so that the query to handle run status updates only executes twice (once for the `PIPELINE_CANCELING` event, once for the `PIPELINE_CANCELED` event).

Locally, the new implementation takes 2 minutes to cancel 5K runs. 

Open questions:
- Is there an upper bound on the # of runs that can be canceled this way? Likely depends on the # of runs that can be fetched at a time -- I didn't look into this comprehensively, but 5K runs took 5s to fetch on cloud
- How to handle race conditions that occur where a run is dequeued while the query marks it is canceled?