### PR TITLE
support direct invocation with AssetExecutionContext

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/op_invocation.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_invocation.py
@@ -18,6 +18,7 @@ from dagster._core.errors import (
     DagsterInvariantViolationError,
     DagsterTypeCheckDidNotPass,
 )
+from dagster._core.execution.context.invocation import UnboundAssetExecutionContext
 
 from .events import (
     AssetMaterialization,
@@ -147,7 +148,9 @@ def direct_invocation_result(
                 " no context was provided when invoking."
             )
         if len(args) > 0:
-            if args[0] is not None and not isinstance(args[0], UnboundOpExecutionContext):
+            if args[0] is not None and not isinstance(
+                args[0], (UnboundOpExecutionContext, UnboundAssetExecutionContext)
+            ):
                 raise DagsterInvalidInvocationError(
                     f"Decorated function '{compute_fn.name}' has context argument, "
                     "but no context was provided when invoking."

--- a/python_modules/dagster/dagster/_core/definitions/op_invocation.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_invocation.py
@@ -156,8 +156,8 @@ def direct_invocation_result(
                     f"Decorated function '{compute_fn.name}' has context argument, "
                     "but no context was provided when invoking."
                 )
-            context = args[0]
-            # context = cast(UnboundExecutionContext, args[0])
+            # context = args[0]
+            context = cast(UnboundExecutionContext, args[0])
             # update args to omit context
             args = args[1:]
         else:  # context argument is provided under kwargs
@@ -168,16 +168,16 @@ def direct_invocation_result(
                     f"'{context_param_name}', but no value for '{context_param_name}' was "
                     f"found when invoking. Provided kwargs: {kwargs}"
                 )
-            context = kwargs[context_param_name]
-            # context = cast(UnboundExecutionContext, kwargs[context_param_name])
+            # context: UnboundExecutionContext = kwargs[context_param_name]
+            context = cast(UnboundExecutionContext, kwargs[context_param_name])
             # update kwargs to remove context
             kwargs = {
                 kwarg: val for kwarg, val in kwargs.items() if not kwarg == context_param_name
             }
     # allow passing context, even if the function doesn't have an arg for it
     elif len(args) > 0 and isinstance(args[0], UnboundExecutionContext):
-        context = args[0]
-        # context = cast(UnboundExecutionContext, args[0])
+        # context = args[0]
+        context = cast(UnboundExecutionContext, args[0])
         args = args[1:]
 
     resource_arg_mapping = {arg.name: arg.name for arg in compute_fn.get_resource_args()}

--- a/python_modules/dagster/dagster/_core/definitions/op_invocation.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_invocation.py
@@ -30,9 +30,7 @@ from .output import DynamicOutputDefinition
 
 if TYPE_CHECKING:
     from ..execution.context.invocation import (
-        BoundAssetExecutionContext,
         BoundExecutionContext,
-        BoundOpExecutionContext,
     )
     from .assets import AssetsDefinition
     from .composition import PendingNodeInvocation
@@ -447,7 +445,7 @@ def _type_check_output_wrapper(
 def _type_check_function_output(
     op_def: "OpDefinition",
     result: T,
-    context: Union["BoundOpExecutionContext", "BoundAssetExecutionContext"],
+    context: "BoundExecutionContext",
 ) -> T:
     from ..execution.plan.compute_generator import validate_and_coerce_op_result_to_iterator
 
@@ -460,7 +458,7 @@ def _type_check_function_output(
 def _type_check_output(
     output_def: "OutputDefinition",
     output: T,
-    context: Union["BoundOpExecutionContext", "BoundAssetExecutionContext"],
+    context: "BoundExecutionContext",
 ) -> T:
     """Validates and performs core type check on a provided output.
 

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -68,7 +68,30 @@ def _property_msg(prop_name: str, method_name: str) -> str:
 
 
 class BoundExecutionContext(ABC):
-    pass
+    @property
+    @abstractmethod
+    def alias(self) -> str:
+        pass
+
+    @abstractmethod
+    def describe_step(self) -> str:
+        pass
+
+    @abstractmethod
+    def for_type(self, dagster_type: DagsterType) -> TypeCheckContext:
+        pass
+
+    @abstractmethod
+    def get_mapping_key(self) -> Optional[str]:
+        pass
+
+    @abstractmethod
+    def observe_output(self, output_name: str, mapping_key: Optional[str] = None) -> None:
+        pass
+
+    @abstractmethod
+    def has_seen_output(self, output_name: str, mapping_key: Optional[str] = None) -> bool:
+        pass
 
 
 class UnboundExecutionContext(ABC):

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -67,7 +67,7 @@ def _property_msg(prop_name: str, method_name: str) -> str:
     )
 
 
-class BoundExecutionContext(ABC):
+class BoundExecutionContext(OpExecutionContext):
     @property
     @abstractmethod
     def alias(self) -> str:
@@ -428,7 +428,7 @@ def _validate_resource_requirements(
                 ensure_requirements_satisfied(resource_defs, [requirement])
 
 
-class BoundOpExecutionContext(OpExecutionContext, BoundExecutionContext):
+class BoundOpExecutionContext(BoundExecutionContext):
     """The op execution context that is passed to the compute function during invocation.
 
     This context is bound to a specific op definition, for which the resources and config have

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -827,10 +827,6 @@ class UnboundAssetExecutionContext(AssetExecutionContext):
             _assets_def=assets_def,
         )
 
-        self._step_execution_context = (
-            self._op_execution_context._step_execution_context  # noqa: SLF001
-        )
-
         self._cm_scope_entered = False
 
     def __enter__(self):

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -869,14 +869,14 @@ class UnboundAssetExecutionContext(AssetExecutionContext):
 
         .. code-block:: python
 
-            from dagster import op, build_op_context, AssetMaterialization, ExpectationResult
+            from dagster import op, build_asset_context, AssetMaterialization, ExpectationResult
 
             @op
             def my_op(context):
                 ...
 
             def test_my_op():
-                context = build_op_context()
+                context = build_asset_context()
                 my_op(context)
                 all_user_events = context.get_events()
                 materializations = [event for event in all_user_events if isinstance(event, AssetMaterialization)]

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -829,19 +829,48 @@ class UnboundAssetExecutionContext(AssetExecutionContext):
             _assets_def=assets_def,
         )
 
-        self._cm_scope_entered = False
-
     def __enter__(self):
-        self._cm_scope_entered = True
+        self._op_execution_context.__enter__()
         return self
 
     def __exit__(self, *exc):
-        self._exit_stack.close()
+        self._op_execution_context.__exit__()
 
     def __del__(self):
-        self._exit_stack.close()
+        self._op_execution_context.__del__()
 
-    # all AssetExecutionContext methods call methods on the internal op_execution_context, so rely
+    # AssetExecutionContext methods that rely on the AssetsDefinition, which is not available to
+    # direct invocation
+
+    @property
+    def assets_def(self) -> AssetsDefinition:
+        raise DagsterInvalidPropertyError(_property_msg("assets_def", "property"))
+
+    @property
+    def asset_keys(self) -> AssetsDefinition:
+        raise DagsterInvalidPropertyError(_property_msg("asset_keys", "property"))
+
+    @property
+    def provenance(self):
+        raise DagsterInvalidPropertyError(_property_msg("provenance", "property"))
+
+    @property
+    def provenance_by_asset_key(self):
+        raise DagsterInvalidPropertyError(_property_msg("provenance_by_asset_key", "property"))
+
+    @property
+    def code_version(self):
+        raise DagsterInvalidPropertyError(_property_msg("code_version", "property"))
+
+    @property
+    def code_version_by_asset_key(self):
+        raise DagsterInvalidPropertyError(_property_msg("code_version_by_asset_key", "property"))
+
+    @property
+    def selected_asset_keys(self):
+        raise DagsterInvalidPropertyError(_property_msg("selected_asset_keys", "property"))
+
+    # all other AssetExecutionContext methods call methods on the internal op_execution_context, so rely
     # on the implementation of UnboundOpExecutionContext for implementation details for direct invocation
 
     def bind(
@@ -903,9 +932,6 @@ class UnboundAssetExecutionContext(AssetExecutionContext):
         if mapping_key and metadata:
             return metadata.get(mapping_key)
         return metadata
-
-    def get_mapping_key(self) -> Optional[str]:
-        return self._op_execution_context._mapping_key  # noqa: SLF001
 
 
 class BoundAssetExecutionContext(AssetExecutionContext):

--- a/python_modules/dagster/dagster/_core/pipes/context.py
+++ b/python_modules/dagster/dagster/_core/pipes/context.py
@@ -29,7 +29,7 @@ from dagster._core.definitions.partition_key_range import PartitionKeyRange
 from dagster._core.definitions.result import MaterializeResult
 from dagster._core.definitions.time_window_partitions import TimeWindow
 from dagster._core.execution.context.compute import OpExecutionContext
-from dagster._core.execution.context.invocation import BoundOpExecutionContext
+from dagster._core.execution.context.invocation import BoundExecutionContext
 from dagster._core.pipes.client import ExtMessageReader
 
 ExtResult: TypeAlias = Union[MaterializeResult, AssetCheckResult]
@@ -221,8 +221,8 @@ def build_external_execution_context_data(
             _convert_time_window(partition_time_window) if partition_time_window else None
         ),
         run_id=context.run_id,
-        job_name=None if isinstance(context, BoundOpExecutionContext) else context.job_name,
-        retry_number=0 if isinstance(context, BoundOpExecutionContext) else context.retry_number,
+        job_name=None if isinstance(context, BoundExecutionContext) else context.job_name,
+        retry_number=0 if isinstance(context, BoundExecutionContext) else context.retry_number,
         extras=extras or {},
     )
 


### PR DESCRIPTION
## Summary & Motivation
updates `build_asset_context` so that it creates a subclass of `AssetExecutionContext`

I'm not very familiar with this part of the code base. My general approach was to follow where `UnboudOpExecutionContext` and `BoundOpExecutionContext` are used and update them to also support `Unbound` and `BoundAssetExecutionContext`. 

## How I Tested These Changes
