### PR TITLE
handle "unexecutable" assets in job building and cross process representation

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -456,8 +456,8 @@ class GrapheneAssetNode(graphene.ObjectType):
     def is_graph_backed_asset(self) -> bool:
         return self.graphName is not None
 
-    def is_source_asset(self) -> bool:
-        return self._external_asset_node.is_source
+    def is_source_or_defined_in_unexecutable_assets_def(self) -> bool:
+        return self._external_asset_node.is_source or not self._external_asset_node.is_executable
 
     def resolve_hasMaterializePermission(
         self,
@@ -582,7 +582,7 @@ class GrapheneAssetNode(graphene.ObjectType):
         ]
 
     def resolve_configField(self, _graphene_info: ResolveInfo) -> Optional[GrapheneConfigTypeField]:
-        if self.is_source_asset():
+        if self.is_source_or_defined_in_unexecutable_assets_def():
             return None
         external_pipeline = self.get_external_job()
         node_def_snap = self.get_node_definition_snap()
@@ -815,7 +815,7 @@ class GrapheneAssetNode(graphene.ObjectType):
         ]
 
     def resolve_isSource(self, _graphene_info: ResolveInfo) -> bool:
-        return self.is_source_asset()
+        return self._external_asset_node.is_source
 
     def resolve_isPartitioned(self, _graphene_info: ResolveInfo) -> bool:
         return self._external_asset_node.partitions_def_data is not None
@@ -979,7 +979,7 @@ class GrapheneAssetNode(graphene.ObjectType):
     def resolve_op(
         self, _graphene_info: ResolveInfo
     ) -> Optional[Union[GrapheneSolidDefinition, GrapheneCompositeSolidDefinition]]:
-        if self.is_source_asset():
+        if self.is_source_or_defined_in_unexecutable_assets_def():
             return None
         external_pipeline = self.get_external_job()
         node_def_snap = self.get_node_definition_snap()
@@ -1058,7 +1058,7 @@ class GrapheneAssetNode(graphene.ObjectType):
     def resolve_required_resources(
         self, _graphene_info: ResolveInfo
     ) -> Sequence[GrapheneResourceRequirement]:
-        if self.is_source_asset():
+        if self.is_source_or_defined_in_unexecutable_assets_def():
             return []
         node_def_snap = self.get_node_definition_snap()
         all_unique_keys = self.get_required_resource_keys(node_def_snap)
@@ -1071,7 +1071,7 @@ class GrapheneAssetNode(graphene.ObjectType):
             "GrapheneListDagsterType", "GrapheneNullableDagsterType", "GrapheneRegularDagsterType"
         ]
     ]:
-        if self.is_source_asset():
+        if self.is_source_or_defined_in_unexecutable_assets_def():
             return None
         external_pipeline = self.get_external_job()
         output_name = self.external_asset_node.output_name

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -916,6 +916,15 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
             self._metadata_by_key.get(asset_key, {}).get(SYSTEM_METADATA_KEY_ASSET_EXECUTION_TYPE)
         )
 
+    def is_executable(self):
+        """Returns True if this definition represents unexecutable assets.
+        Assumption: either all or none contained assets are unexecutable.
+        """
+        for key in self.keys:
+            if not self.is_asset_executable(key):
+                return False
+        return True
+
     def get_partition_mapping_for_input(self, input_name: str) -> Optional[PartitionMapping]:
         return self._partition_mappings.get(self._keys_by_input_name[input_name])
 

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
@@ -193,7 +193,7 @@ def build_caching_repository_data_from_list(
 
     if assets_defs or source_assets or asset_checks_defs:
         for job_def in get_base_asset_jobs(
-            assets=assets_defs,
+            assets_defs=assets_defs,
             source_assets=source_assets,
             executor_def=default_executor_def,
             resource_defs=top_level_resources,

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
@@ -51,7 +51,9 @@ def to_external_asset_graph(assets, asset_checks=None) -> AssetGraph:
         return assets + (asset_checks or [])
 
     external_asset_nodes = external_asset_nodes_from_defs(
-        repo.get_all_jobs(), source_assets_by_key={}
+        repo.get_all_jobs(),
+        source_assets_by_key={},
+        unexecutable_assets_defs=set(),
     )
     return ExternalAssetGraph.from_repository_handles_and_external_asset_nodes(
         [(MagicMock(), asset_node) for asset_node in external_asset_nodes],

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
@@ -1959,7 +1959,7 @@ def test_get_base_asset_jobs_multiple_partitions_defs():
     def unpartitioned_asset(): ...
 
     jobs = get_base_asset_jobs(
-        assets=[
+        assets_defs=[
             daily_asset,
             daily_asset2,
             daily_asset_different_start_date,
@@ -2004,7 +2004,7 @@ def test_get_base_asset_jobs_multiple_partitions_defs_and_observable_assets():
     def asset_x(asset_b: B): ...
 
     jobs = get_base_asset_jobs(
-        assets=[
+        assets_defs=[
             asset_x,
         ],
         source_assets=[

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
@@ -659,7 +659,9 @@ def external_asset_graph_from_assets_by_repo_name(
         repo = Definitions(assets=assets).get_repository_def()
 
         external_asset_nodes = external_asset_nodes_from_defs(
-            repo.get_all_jobs(), source_assets_by_key=repo.source_assets_by_key
+            repo.get_all_jobs(),
+            source_assets_by_key=repo.source_assets_by_key,
+            unexecutable_assets_defs=set(),
         )
         repo_handle = MagicMock(repository_name=repo_name)
         from_repository_handles_and_external_asset_nodes.extend(

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
@@ -50,7 +50,11 @@ def test_single_asset_job():
         return 1
 
     assets_job = build_assets_job("assets_job", [asset1])
-    external_asset_nodes = external_asset_nodes_from_defs([assets_job], source_assets_by_key={})
+    external_asset_nodes = external_asset_nodes_from_defs(
+        [assets_job],
+        source_assets_by_key={},
+        unexecutable_assets_defs=set(),
+    )
 
     assert external_asset_nodes == [
         ExternalAssetNode(
@@ -75,7 +79,11 @@ def test_asset_with_default_backfill_policy():
         return 1
 
     assets_job = build_assets_job("assets_job", [asset1])
-    external_asset_nodes = external_asset_nodes_from_defs([assets_job], source_assets_by_key={})
+    external_asset_nodes = external_asset_nodes_from_defs(
+        [assets_job],
+        source_assets_by_key={},
+        unexecutable_assets_defs=set(),
+    )
 
     assert external_asset_nodes == [
         ExternalAssetNode(
@@ -101,7 +109,11 @@ def test_asset_with_single_run_backfill_policy():
         return 1
 
     assets_job = build_assets_job("assets_job", [asset1])
-    external_asset_nodes = external_asset_nodes_from_defs([assets_job], source_assets_by_key={})
+    external_asset_nodes = external_asset_nodes_from_defs(
+        [assets_job],
+        source_assets_by_key={},
+        unexecutable_assets_defs=set(),
+    )
 
     assert external_asset_nodes == [
         ExternalAssetNode(
@@ -145,7 +157,11 @@ def test_asset_with_multi_run_backfill_policy():
         return 1
 
     assets_job = build_assets_job("assets_job", [asset1])
-    external_asset_nodes = external_asset_nodes_from_defs([assets_job], source_assets_by_key={})
+    external_asset_nodes = external_asset_nodes_from_defs(
+        [assets_job],
+        source_assets_by_key={},
+        unexecutable_assets_defs=set(),
+    )
 
     assert external_asset_nodes == [
         ExternalAssetNode(
@@ -182,7 +198,11 @@ def test_asset_with_group_name():
         return 1
 
     assets_job = build_assets_job("assets_job", [asset1])
-    external_asset_nodes = external_asset_nodes_from_defs([assets_job], source_assets_by_key={})
+    external_asset_nodes = external_asset_nodes_from_defs(
+        [assets_job],
+        source_assets_by_key={},
+        unexecutable_assets_defs=set(),
+    )
 
     assert external_asset_nodes[0].group_name == "group1"
 
@@ -193,7 +213,11 @@ def test_asset_missing_group_name():
         return 1
 
     assets_job = build_assets_job("assets_job", [asset1])
-    external_asset_nodes = external_asset_nodes_from_defs([assets_job], source_assets_by_key={})
+    external_asset_nodes = external_asset_nodes_from_defs(
+        [assets_job],
+        source_assets_by_key={},
+        unexecutable_assets_defs=set(),
+    )
 
     assert external_asset_nodes[0].group_name == DEFAULT_GROUP_NAME
 
@@ -222,7 +246,11 @@ def test_two_asset_job():
         assert asset1 == 1
 
     assets_job = build_assets_job("assets_job", [asset1, asset2])
-    external_asset_nodes = external_asset_nodes_from_defs([assets_job], source_assets_by_key={})
+    external_asset_nodes = external_asset_nodes_from_defs(
+        [assets_job],
+        source_assets_by_key={},
+        unexecutable_assets_defs=set(),
+    )
 
     assert external_asset_nodes == [
         ExternalAssetNode(
@@ -262,7 +290,11 @@ def test_input_name_matches_output_name():
         pass
 
     assets_job = build_assets_job("assets_job", [something], source_assets=[not_result])
-    external_asset_nodes = external_asset_nodes_from_defs([assets_job], source_assets_by_key={})
+    external_asset_nodes = external_asset_nodes_from_defs(
+        [assets_job],
+        source_assets_by_key={},
+        unexecutable_assets_defs=set(),
+    )
 
     assert external_asset_nodes == [
         ExternalAssetNode(
@@ -313,7 +345,11 @@ def test_assets_excluded_from_subset_not_in_job():
         asset_graph=AssetGraph.from_assets(all_assets)
     )
 
-    external_asset_nodes = external_asset_nodes_from_defs([as_job, cs_job], source_assets_by_key={})
+    external_asset_nodes = external_asset_nodes_from_defs(
+        [as_job, cs_job],
+        source_assets_by_key={},
+        unexecutable_assets_defs=set(),
+    )
 
     assert (
         ExternalAssetNode(
@@ -363,7 +399,11 @@ def test_two_downstream_assets_job():
         assert asset1 == 1
 
     assets_job = build_assets_job("assets_job", [asset1, asset2_a, asset2_b])
-    external_asset_nodes = external_asset_nodes_from_defs([assets_job], source_assets_by_key={})
+    external_asset_nodes = external_asset_nodes_from_defs(
+        [assets_job],
+        source_assets_by_key={},
+        unexecutable_assets_defs=set(),
+    )
 
     assert external_asset_nodes == [
         ExternalAssetNode(
@@ -423,7 +463,9 @@ def test_cross_job_asset_dependency():
     assets_job1 = build_assets_job("assets_job1", [asset1])
     assets_job2 = build_assets_job("assets_job2", [asset2], source_assets=[asset1])
     external_asset_nodes = external_asset_nodes_from_defs(
-        [assets_job1, assets_job2], source_assets_by_key={}
+        [assets_job1, assets_job2],
+        source_assets_by_key={},
+        unexecutable_assets_defs=set(),
     )
 
     assert external_asset_nodes == [
@@ -464,7 +506,11 @@ def test_same_asset_in_multiple_jobs():
     job1 = build_assets_job("job1", [asset1])
     job2 = build_assets_job("job2", [asset1])
 
-    external_asset_nodes = external_asset_nodes_from_defs([job1, job2], source_assets_by_key={})
+    external_asset_nodes = external_asset_nodes_from_defs(
+        [job1, job2],
+        source_assets_by_key={},
+        unexecutable_assets_defs=set(),
+    )
 
     assert external_asset_nodes == [
         ExternalAssetNode(
@@ -496,7 +542,11 @@ def test_basic_multi_asset():
 
     assets_job = build_assets_job("assets_job", [assets])
 
-    external_asset_nodes = external_asset_nodes_from_defs([assets_job], source_assets_by_key={})
+    external_asset_nodes = external_asset_nodes_from_defs(
+        [assets_job],
+        source_assets_by_key={},
+        unexecutable_assets_defs=set(),
+    )
 
     atomic_execution_unit_id = assets.unique_id
 
@@ -550,7 +600,9 @@ def test_inter_op_dependency():
     all_assets_job = build_assets_job("assets_job", [in1, in2, assets, downstream])
 
     external_asset_nodes = external_asset_nodes_from_defs(
-        [subset_job, all_assets_job], source_assets_by_key={}
+        [subset_job, all_assets_job],
+        source_assets_by_key={},
+        unexecutable_assets_defs=set(),
     )
     # sort so that test is deterministic
     sorted_nodes = sorted(
@@ -684,7 +736,11 @@ def test_source_asset_with_op():
 
     assets_job = build_assets_job("assets_job", [bar], source_assets=[foo])
 
-    external_asset_nodes = external_asset_nodes_from_defs([assets_job], source_assets_by_key={})
+    external_asset_nodes = external_asset_nodes_from_defs(
+        [assets_job],
+        source_assets_by_key={},
+        unexecutable_assets_defs=set(),
+    )
     assert external_asset_nodes == [
         ExternalAssetNode(
             asset_key=AssetKey("foo"),
@@ -715,7 +771,9 @@ def test_unused_source_asset():
     bar = SourceAsset(key=AssetKey("bar"), description="def")
 
     external_asset_nodes = external_asset_nodes_from_defs(
-        [], source_assets_by_key={AssetKey("foo"): foo, AssetKey("bar"): bar}
+        [],
+        source_assets_by_key={AssetKey("foo"): foo, AssetKey("bar"): bar},
+        unexecutable_assets_defs=set(),
     )
     assert external_asset_nodes == [
         ExternalAssetNode(
@@ -749,7 +807,9 @@ def test_used_source_asset():
     job1 = build_assets_job("job1", [foo], source_assets=[bar])
 
     external_asset_nodes = external_asset_nodes_from_defs(
-        [job1], source_assets_by_key={AssetKey("bar"): bar}
+        [job1],
+        source_assets_by_key={AssetKey("bar"): bar},
+        unexecutable_assets_defs=set(),
     )
     assert external_asset_nodes == [
         ExternalAssetNode(
@@ -811,7 +871,11 @@ def test_graph_output_metadata_and_description():
 
     assets_job = build_assets_job("assets_job", [zero, three_asset])
 
-    external_asset_nodes = external_asset_nodes_from_defs([assets_job], source_assets_by_key={})
+    external_asset_nodes = external_asset_nodes_from_defs(
+        [assets_job],
+        source_assets_by_key={},
+        unexecutable_assets_defs=set(),
+    )
 
     # sort so that test is deterministic
     sorted_nodes = sorted(
@@ -923,7 +987,11 @@ def test_nasty_nested_graph_asset():
 
     assets_job = build_assets_job("assets_job", [zero, eight_and_five, thirteen_and_six, twenty])
 
-    external_asset_nodes = external_asset_nodes_from_defs([assets_job], source_assets_by_key={})
+    external_asset_nodes = external_asset_nodes_from_defs(
+        [assets_job],
+        source_assets_by_key={},
+        unexecutable_assets_defs=set(),
+    )
     # sort so that test is deterministic
     sorted_nodes = sorted(
         [
@@ -1010,7 +1078,11 @@ def test_deps_resolve_group():
         del asset1
 
     assets_job = build_assets_job("assets_job", [asset1, asset2])
-    external_asset_nodes = external_asset_nodes_from_defs([assets_job], source_assets_by_key={})
+    external_asset_nodes = external_asset_nodes_from_defs(
+        [assets_job],
+        source_assets_by_key={},
+        unexecutable_assets_defs=set(),
+    )
 
     assert external_asset_nodes == [
         ExternalAssetNode(
@@ -1139,7 +1211,11 @@ def test_graph_asset_description():
 
     assets_job = build_assets_job("assets_job", [foo])
 
-    external_asset_nodes = external_asset_nodes_from_defs([assets_job], source_assets_by_key={})
+    external_asset_nodes = external_asset_nodes_from_defs(
+        [assets_job],
+        source_assets_by_key={},
+        unexecutable_assets_defs=set(),
+    )
     assert external_asset_nodes[0].op_description == "bar"
 
 
@@ -1163,7 +1239,11 @@ def test_graph_multi_asset_description():
 
     external_asset_nodes = {
         asset_node.asset_key: asset_node
-        for asset_node in external_asset_nodes_from_defs([assets_job], source_assets_by_key={})
+        for asset_node in external_asset_nodes_from_defs(
+            [assets_job],
+            source_assets_by_key={},
+            unexecutable_assets_defs=set(),
+        )
     }
     assert external_asset_nodes[AssetKey("asset1")].op_description == "bar"
     assert external_asset_nodes[AssetKey("asset2")].op_description == "baz"
@@ -1191,7 +1271,11 @@ def test_external_assets_def_to_external_asset_graph() -> None:
     asset_one = next(iter(external_assets_from_specs([AssetSpec("asset_one")])))
 
     assets_job = build_assets_job("assets_job", [asset_one])
-    external_asset_nodes = external_asset_nodes_from_defs([assets_job], source_assets_by_key={})
+    external_asset_nodes = external_asset_nodes_from_defs(
+        [assets_job],
+        source_assets_by_key={},
+        unexecutable_assets_defs=set(),
+    )
 
     assert len(external_asset_nodes) == 1
     assert next(iter(external_asset_nodes)).is_executable is False


### PR DESCRIPTION
building forward from 
https://github.com/dagster-io/dagster/pull/16575
https://github.com/dagster-io/dagster/pull/16617

This propagates understanding of "unexecutable" assets in to the job building and the inter process representation. 

* unexecutable assets defs are no longer put in to jobs 
* unexceutable assets are transformed in to `SourceAssets` when we build jobs, allowing them to replace `SourceAsset` at the definitions level 


## How I Tested These Changes

* `pytest python_modules/dagster/dagster_tests/definitions_tests/test_observable_assets.py`
* loading
```python
table_a = AssetSpec("table_A")
table_b = AssetSpec("table_B", deps=[table_a])
table_c = AssetSpec("table_C", deps=[table_a])
table_d = AssetSpec("table_D", deps=[table_b, table_c])

those_assets = create_unexecutable_observable_assets_def(
    specs=[table_a, table_b, table_c, table_d]
)

defs = Definitions(assets=[those_assets])
```
in via `dagster-webserver -f` and using `instance.report_runless_asset_event` to update materializations for associated assets . Verify asset graph renders as the nodes and their most recent materializations 


