### PR TITLE
Deprecate ExpectationResult

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/events.py
+++ b/python_modules/dagster/dagster/_core/definitions/events.py
@@ -18,7 +18,7 @@ from typing import (
 
 import dagster._check as check
 import dagster._seven as seven
-from dagster._annotations import PublicAttr, experimental_param, public
+from dagster._annotations import PublicAttr, deprecated, experimental_param, public
 from dagster._core.definitions.data_version import DataVersion
 from dagster._core.storage.tags import MULTIDIMENSIONAL_PARTITION_PREFIX, SYSTEM_TAG_PREFIX
 from dagster._serdes import whitelist_for_serdes
@@ -616,9 +616,6 @@ class AssetMaterialization(
             description=description,
             metadata={"path": MetadataValue.path(path)},
         )
-
-
-from dagster._annotations import deprecated
 
 
 @deprecated(

--- a/python_modules/dagster/dagster/_core/definitions/events.py
+++ b/python_modules/dagster/dagster/_core/definitions/events.py
@@ -618,6 +618,13 @@ class AssetMaterialization(
         )
 
 
+from dagster._annotations import deprecated
+
+
+@deprecated(
+    breaking_version="1.7",
+    additional_warn_text="Please use AssetCheckResult and @asset_check instead.",
+)
 @whitelist_for_serdes(
     storage_field_names={"metadata": "metadata_entries"},
     field_serializers={"metadata": MetadataFieldSerializer},

--- a/python_modules/dagster/dagster_tests/execution_tests/test_expectations.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_expectations.py
@@ -8,6 +8,7 @@ from dagster import (
     GraphDefinition,
     op,
 )
+from dagster._annotations import get_deprecated_info, is_deprecated
 from dagster._core.events import DagsterEvent
 from dagster._core.execution.execution_result import ExecutionResult
 
@@ -85,3 +86,11 @@ def test_return_expectation_failure():
         ),
     ):
         job_def.execute_in_process()
+
+
+def test_expectation_result_deprecated() -> None:
+    assert is_deprecated(ExpectationResult)
+    assert (
+        get_deprecated_info(ExpectationResult).additional_warn_text
+        == "Please use AssetCheckResult and @asset_check instead."
+    )


### PR DESCRIPTION
## Summary & Motivation

With real asset checks coming we can deprecate this old, useless class.

## How I Tested These Changes

BK
