### PR TITLE
[ui] Fix /guess paths

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelineReference.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelineReference.tsx
@@ -36,7 +36,7 @@ export const PipelineReference: React.FC<Props> = ({
 
   const pipeline =
     pipelineHrefContext === 'repo-unknown' ? (
-      <Link to={workspacePipelinePathGuessRepo(pipelineName, isJob)}>{truncatedName}</Link>
+      <Link to={workspacePipelinePathGuessRepo(pipelineName)}>{truncatedName}</Link>
     ) : pipelineHrefContext === 'no-link' ? (
       <>{truncatedName}</>
     ) : (

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/__tests__/PipelineReference.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/__tests__/PipelineReference.test.tsx
@@ -48,7 +48,7 @@ describe('PipelineReference', () => {
       await waitFor(() => {
         const link = screen.getByRole('link', {name: /foobar/i});
         expect(link).toBeVisible();
-        expect(link.getAttribute('href')).toBe('/guess/jobs/foobar');
+        expect(link.getAttribute('href')).toBe('/guess/foobar');
       });
     });
 

--- a/js_modules/dagster-ui/packages/ui-core/src/snapshots/SnapshotNav.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/snapshots/SnapshotNav.tsx
@@ -35,7 +35,6 @@ export const SnapshotNav = (props: SnapshotNavProps) => {
   });
 
   const currentPipelineState = useActivePipelineForName(pipelineName);
-  const isJob = !!currentPipelineState?.isJob;
   const currentSnapshotID = currentPipelineState?.pipelineSnapshotId;
 
   const {data, loading} = useQuery<SnapshotQuery, SnapshotQueryVariables>(SNAPSHOT_PARENT_QUERY, {
@@ -95,7 +94,7 @@ export const SnapshotNav = (props: SnapshotNavProps) => {
         <>
           <Tag icon="schema">
             Snapshot of{' '}
-            <Link to={workspacePipelinePathGuessRepo(explorerPath.pipelineName, isJob)}>
+            <Link to={workspacePipelinePathGuessRepo(explorerPath.pipelineName)}>
               {explorerPath.pipelineName}
             </Link>
           </Tag>

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/workspacePath.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/workspacePath.ts
@@ -27,9 +27,9 @@ export const workspacePipelinePath = ({
   }/${pipelineName}${finalPath}`;
 };
 
-export const workspacePipelinePathGuessRepo = (pipelineName: string, isJob = false, path = '') => {
+export const workspacePipelinePathGuessRepo = (pipelineName: string, path = '') => {
   const finalPath = path === '' ? '' : path.startsWith('/') ? path : `/${path}`;
-  return `/guess/${isJob ? 'jobs' : 'pipelines'}/${pipelineName}${finalPath}`;
+  return `/guess/${pipelineName}${finalPath}`;
 };
 
 export const workspacePathFromAddress = (repoAddress: RepoAddress, path = '') => {
@@ -64,5 +64,5 @@ export const workspacePathFromRunDetails = ({
     });
   }
 
-  return workspacePipelinePathGuessRepo(pipelineName, isJob, path);
+  return workspacePipelinePathGuessRepo(pipelineName, path);
 };


### PR DESCRIPTION
## Summary & Motivation

We're currently producing `/guess` links that use `/guess/jobs` or `/guess/pipelines`, which is incorrect. We just need `/guess/job_or_pipeline_name`.

This becomes a problem when navigating from the tag in the run header than indicates the pipeline/job for the run. If the workspace hasn't loaded yet, we use the `/guess` link, which leads to a page that says that "pipeline" is not found in the workspace.

## How I Tested These Changes

View `/guess/my_pipeline_name` URL, verify that it correctly determines the code location and performs the redirect.
