### PR TITLE
add support for before_cursor for get_materialized_partitions

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -2008,9 +2008,14 @@ class DagsterInstance(DynamicPartitionsStore):
 
     @traced
     def get_materialized_partitions(
-        self, asset_key: AssetKey, after_cursor: Optional[int] = None
+        self,
+        asset_key: AssetKey,
+        before_cursor: Optional[int] = None,
+        after_cursor: Optional[int] = None,
     ) -> Set[str]:
-        return self._event_storage.get_materialized_partitions(asset_key, after_cursor)
+        return self._event_storage.get_materialized_partitions(
+            asset_key, before_cursor=before_cursor, after_cursor=after_cursor
+        )
 
     @traced
     def get_latest_storage_id_by_partition(

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -375,7 +375,10 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
 
     @abstractmethod
     def get_materialized_partitions(
-        self, asset_key: AssetKey, after_cursor: Optional[int] = None
+        self,
+        asset_key: AssetKey,
+        before_cursor: Optional[int] = None,
+        after_cursor: Optional[int] = None,
     ) -> Set[str]:
         pass
 

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -1643,7 +1643,10 @@ class SqlEventLogStorage(EventLogStorage):
             )
 
     def get_materialized_partitions(
-        self, asset_key: AssetKey, after_cursor: Optional[int] = None
+        self,
+        asset_key: AssetKey,
+        before_cursor: Optional[int] = None,
+        after_cursor: Optional[int] = None,
     ) -> Set[str]:
         query = (
             db_select(
@@ -1668,6 +1671,8 @@ class SqlEventLogStorage(EventLogStorage):
 
         if after_cursor:
             query = query.where(SqlEventLogStorageTable.c.id > after_cursor)
+        if before_cursor:
+            query = query.where(SqlEventLogStorageTable.c.id < before_cursor)
 
         with self.index_connection() as conn:
             results = conn.execute(query).fetchall()
@@ -1675,7 +1680,10 @@ class SqlEventLogStorage(EventLogStorage):
         return set([cast(str, row[0]) for row in results])
 
     def get_materialization_count_by_partition(
-        self, asset_keys: Sequence[AssetKey], after_cursor: Optional[int] = None
+        self,
+        asset_keys: Sequence[AssetKey],
+        after_cursor: Optional[int] = None,
+        before_cursor: Optional[int] = None,
     ) -> Mapping[AssetKey, Mapping[str, int]]:
         check.sequence_param(asset_keys, "asset_keys", AssetKey)
 

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -476,9 +476,14 @@ class LegacyEventLogStorage(EventLogStorage, ConfigurableClass):
         return self._storage.event_log_storage.wipe_asset(asset_key)
 
     def get_materialized_partitions(
-        self, asset_key: AssetKey, after_cursor: Optional[int] = None
+        self,
+        asset_key: AssetKey,
+        before_cursor: Optional[int] = None,
+        after_cursor: Optional[int] = None,
     ) -> Set[str]:
-        return self._storage.event_log_storage.get_materialized_partitions(asset_key, after_cursor)
+        return self._storage.event_log_storage.get_materialized_partitions(
+            asset_key, before_cursor, after_cursor
+        )
 
     def get_materialization_count_by_partition(
         self, asset_keys: Sequence["AssetKey"], after_cursor: Optional[int] = None

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -280,6 +280,15 @@ def _synthesize_events(
     return events, result
 
 
+def _store_op_events(storage, ops_fn, instance, run_id):
+    events, _ = _synthesize_events(lambda: ops_fn(), instance=instance, run_id=run_id)
+    for event in events:
+        storage.store_event(event)
+    result = storage.get_records_for_run(run_id, ascending=False, limit=1)
+    cursor = result.records[0].storage_id
+    return cursor
+
+
 def _fetch_all_events(configured_storage, run_id=None):
     with configured_storage.run_connection(run_id=run_id) as conn:
         res = conn.execute(db.text("SELECT event from event_logs"))
@@ -1928,6 +1937,11 @@ class TestEventLogStorage:
             yield AssetMaterialization(c, partition="a")
             yield Output(None)
 
+        @op
+        def materialize_three():
+            yield AssetMaterialization(c, partition="c")
+            yield Output(None)
+
         with instance_for_test() as created_instance:
             if not storage.has_instance:
                 storage.register_instance(created_instance)
@@ -1935,41 +1949,55 @@ class TestEventLogStorage:
             run_id_1 = make_new_run_id()
             run_id_2 = make_new_run_id()
             run_id_3 = make_new_run_id()
+            run_id_4 = make_new_run_id()
 
             with create_and_delete_test_runs(instance, [run_id_1, run_id_2, run_id_3]):
-                events_one, _ = _synthesize_events(
-                    lambda: materialize(), instance=created_instance, run_id=run_id_1
-                )
-                for event in events_one:
-                    storage.store_event(event)
-
-                cursor_run1 = storage.get_event_records(
-                    EventRecordsFilter(event_type=DagsterEventType.ASSET_MATERIALIZATION),
-                    limit=1,
-                    ascending=False,
-                )[0].storage_id
+                cursor_run1 = _store_op_events(storage, materialize, created_instance, run_id_1)
 
                 assert storage.get_materialized_partitions(a) == set()
                 assert storage.get_materialized_partitions(b) == set()
                 assert storage.get_materialized_partitions(c) == {"a", "b"}
 
-                events_two, _ = _synthesize_events(
-                    lambda: materialize_two(),
-                    instance=created_instance,
-                    run_id=run_id_2,
-                )
-                for event in events_two:
-                    storage.store_event(event)
+                cursor_run2 = _store_op_events(storage, materialize_two, created_instance, run_id_2)
+                _store_op_events(storage, materialize_three, created_instance, run_id_3)
 
                 # test that the cursoring logic works
                 assert storage.get_materialized_partitions(a) == set()
                 assert storage.get_materialized_partitions(b) == set()
-                assert storage.get_materialized_partitions(c) == {"a", "b"}
+                assert storage.get_materialized_partitions(c) == {"a", "b", "c"}
                 assert storage.get_materialized_partitions(d) == {"x"}
+                assert storage.get_materialized_partitions(a, before_cursor=cursor_run1) == set()
+                assert storage.get_materialized_partitions(b, before_cursor=cursor_run1) == set()
+                assert storage.get_materialized_partitions(c, before_cursor=cursor_run1) == {
+                    "a",
+                    "b",
+                }
+                assert storage.get_materialized_partitions(d, before_cursor=cursor_run1) == set()
                 assert storage.get_materialized_partitions(a, after_cursor=cursor_run1) == set()
                 assert storage.get_materialized_partitions(b, after_cursor=cursor_run1) == set()
-                assert storage.get_materialized_partitions(c, after_cursor=cursor_run1) == {"a"}
+                assert storage.get_materialized_partitions(c, after_cursor=cursor_run1) == {
+                    "a",
+                    "c",
+                }
                 assert storage.get_materialized_partitions(d, after_cursor=cursor_run1) == {"x"}
+                assert (
+                    storage.get_materialized_partitions(
+                        a, before_cursor=cursor_run2, after_cursor=cursor_run1
+                    )
+                    == set()
+                )
+                assert (
+                    storage.get_materialized_partitions(
+                        b, before_cursor=cursor_run2, after_cursor=cursor_run1
+                    )
+                    == set()
+                )
+                assert storage.get_materialized_partitions(
+                    c, before_cursor=cursor_run2, after_cursor=cursor_run1
+                ) == {"a"}
+                assert storage.get_materialized_partitions(
+                    d, before_cursor=cursor_run2, after_cursor=cursor_run1
+                ) == {"x"}
                 assert storage.get_materialized_partitions(a, after_cursor=9999999999) == set()
                 assert storage.get_materialized_partitions(b, after_cursor=9999999999) == set()
                 assert storage.get_materialized_partitions(c, after_cursor=9999999999) == set()
@@ -1980,14 +2008,7 @@ class TestEventLogStorage:
                     storage.wipe_asset(c)
                     assert storage.get_materialized_partitions(c) == set()
 
-                    # rematerialize wiped asset
-                    events, _ = _synthesize_events(
-                        lambda: materialize_two(),
-                        instance=created_instance,
-                        run_id=run_id_3,
-                    )
-                    for event in events:
-                        storage.store_event(event)
+                    _store_op_events(storage, materialize_two, created_instance, run_id_4)
 
                     assert storage.get_materialized_partitions(c) == {"a"}
                     assert storage.get_materialized_partitions(d) == {"x"}


### PR DESCRIPTION
## Summary & Motivation
In order to deprecate the `get_materalization_counts_by_partition` storage method, we need to support the time window queries to find net new partitions.  This is only possible if we can diff the sets before and after a particular cursor.

## How I Tested These Changes
BK