### PR TITLE
Add the ability to emit runless AssetMaterialization, AssetObservation, and AssetCheckEvaluation events from sensors

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/run_request.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_request.py
@@ -1,10 +1,22 @@
 from datetime import datetime
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Mapping, NamedTuple, Optional, Sequence, Set, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    List,
+    Mapping,
+    NamedTuple,
+    Optional,
+    Sequence,
+    Set,
+    Union,
+    cast,
+)
 
 import dagster._check as check
-from dagster._annotations import PublicAttr
-from dagster._core.definitions.events import AssetKey
+from dagster._annotations import PublicAttr, experimental_param
+from dagster._core.definitions.asset_check_evaluation import AssetCheckEvaluation
+from dagster._core.definitions.events import AssetKey, AssetMaterialization, AssetObservation
 from dagster._core.definitions.utils import validate_tags
 from dagster._core.instance import DynamicPartitionsStore
 from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus
@@ -339,6 +351,9 @@ class DagsterRunReaction(
         )
 
 
+@experimental_param(
+    param="asset_events", additional_warn_text="Runless asset events are experimental"
+)
 class SensorResult(
     NamedTuple(
         "_SensorResult",
@@ -351,6 +366,10 @@ class SensorResult(
                 Optional[
                     Sequence[Union[DeleteDynamicPartitionsRequest, AddDynamicPartitionsRequest]]
                 ],
+            ),
+            (
+                "asset_events",
+                List[Union[AssetObservation, AssetMaterialization, AssetCheckEvaluation]],
             ),
         ],
     )
@@ -378,6 +397,9 @@ class SensorResult(
         dynamic_partitions_requests: Optional[
             Sequence[Union[DeleteDynamicPartitionsRequest, AddDynamicPartitionsRequest]]
         ] = None,
+        asset_events: Optional[
+            Sequence[Union[AssetObservation, AssetMaterialization, AssetCheckEvaluation]]
+        ] = None,
     ):
         if skip_reason and len(run_requests if run_requests else []) > 0:
             check.failed(
@@ -398,5 +420,12 @@ class SensorResult(
                 dynamic_partitions_requests,
                 "dynamic_partitions_requests",
                 (AddDynamicPartitionsRequest, DeleteDynamicPartitionsRequest),
+            ),
+            asset_events=list(
+                check.opt_sequence_param(
+                    asset_events,
+                    "asset_check_evaluations",
+                    (AssetObservation, AssetMaterialization, AssetCheckEvaluation),
+                )
             ),
         )

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -28,7 +28,13 @@ from typing_extensions import TypeAlias
 
 import dagster._check as check
 from dagster._annotations import public
+from dagster._core.definitions.asset_check_evaluation import AssetCheckEvaluation
+from dagster._core.definitions.events import (
+    AssetMaterialization,
+    AssetObservation,
+)
 from dagster._core.definitions.instigation_logger import InstigationLogger
+from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.partition import (
     CachingDynamicPartitionsLoader,
 )
@@ -55,7 +61,6 @@ from ..decorator_utils import (
 )
 from .asset_selection import AssetSelection
 from .graph_definition import GraphDefinition
-from .job_definition import JobDefinition
 from .run_request import (
     AddDynamicPartitionsRequest,
     DagsterRunReaction,
@@ -723,6 +728,7 @@ class SensorDefinition(IHasInternalInit):
             Sequence[Union[AddDynamicPartitionsRequest, DeleteDynamicPartitionsRequest]]
         ] = []
         updated_cursor = context.cursor
+        asset_events = []
 
         if not result or result == [None]:
             skip_message = "Sensor function returned an empty result"
@@ -748,6 +754,7 @@ class SensorDefinition(IHasInternalInit):
                         "SensorResult.cursor cannot be set if context.update_cursor() was called."
                     )
                 updated_cursor = item.cursor
+                asset_events = item.asset_events
 
             elif isinstance(item, RunRequest):
                 run_requests = [item]
@@ -799,6 +806,7 @@ class SensorDefinition(IHasInternalInit):
             dagster_run_reactions,
             captured_log_key=context.log_key if context.has_captured_logs() else None,
             dynamic_partitions_requests=dynamic_partitions_requests,
+            asset_events=asset_events,
         )
 
     def has_loadable_targets(self) -> bool:
@@ -939,6 +947,10 @@ class SensorExecutionData(
                     Sequence[Union[AddDynamicPartitionsRequest, DeleteDynamicPartitionsRequest]]
                 ],
             ),
+            (
+                "asset_events",
+                Sequence[Union[AssetMaterialization, AssetObservation, AssetCheckEvaluation]],
+            ),
         ],
     )
 ):
@@ -954,6 +966,9 @@ class SensorExecutionData(
         dynamic_partitions_requests: Optional[
             Sequence[Union[AddDynamicPartitionsRequest, DeleteDynamicPartitionsRequest]]
         ] = None,
+        asset_events: Optional[
+            Sequence[Union[AssetMaterialization, AssetObservation, AssetCheckEvaluation]]
+        ] = None,
     ):
         check.opt_sequence_param(run_requests, "run_requests", RunRequest)
         check.opt_str_param(skip_message, "skip_message")
@@ -964,6 +979,11 @@ class SensorExecutionData(
             dynamic_partitions_requests,
             "dynamic_partitions_requests",
             (AddDynamicPartitionsRequest, DeleteDynamicPartitionsRequest),
+        )
+        check.opt_sequence_param(
+            asset_events,
+            "asset_events",
+            (AssetMaterialization, AssetObservation, AssetCheckEvaluation),
         )
         check.invariant(
             not (run_requests and skip_message), "Found both skip data and run request data"
@@ -976,6 +996,7 @@ class SensorExecutionData(
             dagster_run_reactions=dagster_run_reactions,
             captured_log_key=captured_log_key,
             dynamic_partitions_requests=dynamic_partitions_requests,
+            asset_events=asset_events or [],
         )
 
 

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -679,6 +679,9 @@ def _evaluate_sensor(
 
     assert isinstance(sensor_runtime_data, SensorExecutionData)
 
+    for asset_event in sensor_runtime_data.asset_events:
+        instance.report_runless_asset_event(asset_event)
+
     if sensor_runtime_data.dynamic_partitions_requests:
         for request in sensor_runtime_data.dynamic_partitions_requests:
             existent_partitions = []

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_result.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_result.py
@@ -12,8 +12,12 @@ from dagster import (
     op,
     sensor,
 )
+from dagster._annotations import get_experimental_params
 from dagster._check import CheckError
+from dagster._core.definitions.asset_check_evaluation import AssetCheckEvaluation
+from dagster._core.definitions.events import AssetObservation
 from dagster._core.definitions.run_request import SensorResult
+from dagster._core.instance import DagsterInstance
 from dagster._core.test_utils import instance_for_test
 
 
@@ -240,3 +244,64 @@ def test_yield_and_return():
         build_sensor_context()
     )
     assert len(result_yield_and_return_run_request.run_requests) == 2
+
+
+def test_asset_events_experimental_param_on_sensor_result() -> None:
+    assert "asset_events" in get_experimental_params(SensorResult)
+
+
+def test_asset_materialization_in_sensor() -> None:
+    @sensor()
+    def a_sensor() -> SensorResult:
+        return SensorResult(asset_events=[AssetMaterialization("asset_one")])
+
+    instance = DagsterInstance.ephemeral()
+    sensor_execution_data = a_sensor.evaluate_tick(build_sensor_context(instance=instance))
+    assert len(sensor_execution_data.asset_events) == 1
+    output_mat = sensor_execution_data.asset_events[0]
+    assert isinstance(output_mat, AssetMaterialization)
+    assert output_mat.asset_key == AssetKey("asset_one")
+
+
+def test_asset_observation_in_sensor() -> None:
+    @sensor()
+    def a_sensor() -> SensorResult:
+        return SensorResult(asset_events=[AssetObservation("asset_one")])
+
+    instance = DagsterInstance.ephemeral()
+    sensor_execution_data = a_sensor.evaluate_tick(build_sensor_context(instance=instance))
+    assert len(sensor_execution_data.asset_events) == 1
+    output_mat = sensor_execution_data.asset_events[0]
+    assert isinstance(output_mat, AssetObservation)
+    assert output_mat.asset_key == AssetKey("asset_one")
+
+
+def test_asset_check_evaluation() -> None:
+    @sensor()
+    def a_sensor() -> SensorResult:
+        return SensorResult(
+            asset_events=[
+                AssetCheckEvaluation(
+                    asset_key=AssetKey("asset_one"),
+                    check_name="check_one",
+                    success=True,
+                    metadata={},
+                )
+            ]
+        )
+
+    instance = DagsterInstance.ephemeral()
+    sensor_execution_data = a_sensor.evaluate_tick(build_sensor_context(instance=instance))
+    assert len(sensor_execution_data.asset_events) == 1
+    output_ace = sensor_execution_data.asset_events[0]
+    assert isinstance(output_ace, AssetCheckEvaluation)
+    assert output_ace.asset_key == AssetKey("asset_one")
+
+
+def test_asset_materialization_in_sensor_direct_invocation() -> None:
+    @sensor()
+    def a_sensor() -> SensorResult:
+        return SensorResult(asset_events=[AssetMaterialization("asset_one")])
+
+    instance = DagsterInstance.ephemeral()
+    a_sensor(build_sensor_context(instance=instance))


### PR DESCRIPTION
## Summary & Motivation

This adds the ability to emit runless asset events (`AssetMaterialization`, `AssetObservation`, and `AssetCheckEvaluation`) from sensors. This will enable us to implementation observable source asset sensors in "user space", as well as cover scenarios like a sensor monitoring the exhaust of another system and continuously emitting events to keep the Dagster metastore up-to-date.

## How I Tested These Changes

BK

Full disclosure. The behavior to fetch these assets out of the is not under test. The right place to add that is likely `test_sensor_run.py`, but that is an absolute beast. Included test cases at least get us to complete code coverage and verifying most behavior.