### PR TITLE
[ui] Fix build error due to use of core GraphQL type

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsGroupsGlobalGraphRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsGroupsGlobalGraphRoot.tsx
@@ -106,10 +106,10 @@ export const AssetsGroupsGlobalGraphRoot: React.FC = () => {
           <AssetGraphExplorerFilters
             assetGroups={assetGroups}
             visibleAssetGroups={React.useMemo(() => filters.groups || [], [filters.groups])}
-            setGroupFilters={React.useCallback((groups) => setFilters({...filters, groups}), [
-              filters,
-              setFilters,
-            ])}
+            setGroupFilters={React.useCallback(
+              (groups) => setFilters({...filters, groups}),
+              [filters, setFilters],
+            )}
           />
         }
         options={{preferAssetRendering: true, explodeComposites: true}}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutomaterializePolicyTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutomaterializePolicyTag.tsx
@@ -21,15 +21,11 @@ export const automaterializePolicyDescription = (policy: {
     <Box flex={{direction: 'column', gap: 12}}>
       This asset will be automatically materialized if it is:
       <ul style={{paddingLeft: 20, margin: 0}}>
-        {MATERIALIZE?.map((rule) => (
-          <li key={rule.description}>{rule.description}</li>
-        ))}
+        {MATERIALIZE?.map((rule) => <li key={rule.description}>{rule.description}</li>)}
       </ul>
       and it is not:
       <ul style={{paddingLeft: 20, margin: 0}}>
-        {SKIP?.map((rule) => (
-          <li key={rule.description}>{rule.description}</li>
-        ))}
+        {SKIP?.map((rule) => <li key={rule.description}>{rule.description}</li>)}
       </ul>
       {DISCARD && DISCARD.length > 0 && (
         <>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutomaterializePolicyTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutomaterializePolicyTag.tsx
@@ -2,7 +2,7 @@ import {Box, Tag} from '@dagster-io/ui-components';
 import groupBy from 'lodash/groupBy';
 import React from 'react';
 
-import {AutoMaterializePolicyType, AutoMaterializeRule} from '../graphql/types';
+import {AutoMaterializeDecisionType, AutoMaterializePolicyType} from '../graphql/types';
 
 export const AutomaterializePolicyTag: React.FC<{
   policy: {
@@ -14,7 +14,7 @@ export const AutomaterializePolicyTag: React.FC<{
 
 export const automaterializePolicyDescription = (policy: {
   policyType: AutoMaterializePolicyType;
-  rules: AutoMaterializeRule[];
+  rules: {description: string; decisionType: AutoMaterializeDecisionType}[];
 }) => {
   const {MATERIALIZE, SKIP, DISCARD} = groupBy(policy.rules, (rule) => rule.decisionType);
   return (

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutomaterializePolicyTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutomaterializePolicyTag.tsx
@@ -2,7 +2,7 @@ import {Box, Tag} from '@dagster-io/ui-components';
 import groupBy from 'lodash/groupBy';
 import React from 'react';
 
-import {AutoMaterializeDecisionType, AutoMaterializePolicyType} from '../graphql/types';
+import {AutoMaterializePolicyType, AutoMaterializeRule} from '../graphql/types';
 
 export const AutomaterializePolicyTag: React.FC<{
   policy: {
@@ -14,7 +14,7 @@ export const AutomaterializePolicyTag: React.FC<{
 
 export const automaterializePolicyDescription = (policy: {
   policyType: AutoMaterializePolicyType;
-  rules: {description: string; decisionType: AutoMaterializeDecisionType}[];
+  rules: Pick<AutoMaterializeRule, 'description' | 'decisionType'>[];
 }) => {
   const {MATERIALIZE, SKIP, DISCARD} = groupBy(policy.rules, (rule) => rule.decisionType);
   return (


### PR DESCRIPTION
## Summary & Motivation

I was using one of the core dagster types in a helper method, and a separate branch added a new property to the core type which was not available at all callsites.

Instead of using the core type, this helper should specify the fields it needs.