### PR TITLE
Add a hook during backfill creation to add additional tags

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
@@ -90,6 +90,9 @@ def create_and_launch_partition_backfill(
     )
 
     tags = {t["key"]: t["value"] for t in backfill_params.get("tags", [])}
+
+    tags = {**tags, **graphene_info.context.get_viewer_tags()}
+
     backfill_timestamp = pendulum.now("UTC").timestamp()
 
     if backfill_params.get("selector") is not None:  # job backfill

--- a/python_modules/dagster/dagster/_core/workspace/context.py
+++ b/python_modules/dagster/dagster/_core/workspace/context.py
@@ -136,6 +136,9 @@ class BaseWorkspaceRequestContext(IWorkspace):
     def show_instance_config(self) -> bool:
         return True
 
+    def get_viewer_tags(self) -> Dict[str, str]:
+        return {}
+
     def get_code_location(self, location_name: str) -> CodeLocation:
         location_entry = self.get_location_entry(location_name)
         if not location_entry:


### PR DESCRIPTION
Summary:
allows the graphql context to expose additional tags that are associated with a backfill.

## Summary & Motivation

## How I Tested These Changes
