### PR TITLE
feat(asset-checks): allow asset check subsetting

### DIFF
--- a/python_modules/dagster-test/dagster_test/toys/asset_checks.py
+++ b/python_modules/dagster-test/dagster_test/toys/asset_checks.py
@@ -413,7 +413,8 @@ def downstream_asset():
 
 
 just_checks_job = define_asset_job(
-    name="just_checks_job", selection=AssetSelection.all_asset_checks()
+    name="just_checks_job",
+    selection=AssetSelection.checks_for_assets(checked_asset),
 )
 
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -508,11 +508,11 @@ class AssetLayer(NamedTuple):
                     )
                     check_key_by_output[node_output_handle] = check_spec.key
 
-            for check_handle in assets_def.asset_check_handles:
+            for check_key in assets_def.asset_check_keys:
                 check_names_by_asset_key = check_names_by_asset_key_by_node_handle.setdefault(
                     node_handle, defaultdict(set)
                 )
-                check_names_by_asset_key[check_handle.asset_key].add(check_handle.name)
+                check_names_by_asset_key[check_key.asset_key].add(check_key.name)
 
         dep_asset_keys_by_node_output_handle = defaultdict(set)
         for asset_key, node_output_handles in dep_node_output_handles_by_asset_key.items():
@@ -559,7 +559,7 @@ class AssetLayer(NamedTuple):
             **{
                 node_handle: assets_def
                 for node_handle, assets_def in assets_defs_by_outer_node_handle.items()
-                if assets_def.asset_check_handles
+                if assets_def.asset_check_keys
             },
         }
 
@@ -828,10 +828,10 @@ def build_asset_selection_job(
     else:
         if asset_selection is not None or asset_check_selection is not None:
             selected_asset_keys = asset_selection or set()
-            selected_asset_check_handles = asset_check_selection
+            selected_asset_check_keys = asset_check_selection
 
             (included_assets, excluded_assets) = _subset_assets_defs(
-                assets, selected_asset_keys, selected_asset_check_handles
+                assets, selected_asset_keys, selected_asset_check_keys
             )
             included_source_assets = _subset_source_assets(source_assets, selected_asset_keys)
 
@@ -897,7 +897,7 @@ def build_asset_selection_job(
 def _subset_assets_defs(
     assets: Iterable["AssetsDefinition"],
     selected_asset_keys: AbstractSet[AssetKey],
-    selected_asset_check_handles: Optional[AbstractSet[AssetCheckHandle]],
+    selected_asset_check_keys: Optional[AbstractSet[AssetCheckKey]],
 ) -> Tuple[Sequence["AssetsDefinition"], Sequence["AssetsDefinition"],]:
     """Given a list of asset key selection queries, generate a set of AssetsDefinition objects
     representing the included/excluded definitions.
@@ -910,18 +910,16 @@ def _subset_assets_defs(
         selected_subset = selected_asset_keys & asset.keys
 
         # if specific checks were selected, only include those
-        if selected_asset_check_handles is not None:
-            selected_check_subset = selected_asset_check_handles & asset.asset_check_handles
+        if selected_asset_check_keys is not None:
+            selected_check_subset = selected_asset_check_keys & asset.asset_check_keys
         # if no checks were selected, filter to checks that target selected assets
         else:
             selected_check_subset = {
-                handle
-                for handle in asset.asset_check_handles
-                if handle.asset_key in selected_subset
+                handle for handle in asset.asset_check_keys if handle.asset_key in selected_subset
             }
 
         # all assets in this def are selected
-        if selected_subset == asset.keys and selected_check_subset == asset.asset_check_handles:
+        if selected_subset == asset.keys and selected_check_subset == asset.asset_check_keys:
             included_assets.add(asset)
         # no assets in this def are selected
         elif len(selected_subset) == 0 and len(selected_check_subset) == 0:
@@ -934,8 +932,8 @@ def _subset_assets_defs(
             excluded_assets.add(
                 asset.subset_for(
                     selected_asset_keys=asset.keys - subset_asset.keys,
-                    selected_asset_check_handles=(
-                        asset.asset_check_handles - subset_asset.asset_check_handles
+                    selected_asset_check_keys=(
+                        asset.asset_check_keys - subset_asset.asset_check_keys
                     ),
                 )
             )

--- a/python_modules/dagster/dagster/_core/definitions/assets_job.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets_job.py
@@ -581,7 +581,7 @@ def _attempt_resolve_cycles(
             ret.append(assets_def)
         else:
             for asset_keys in color_mapping.values():
-                ret.append(assets_def.subset_for(asset_keys))
+                ret.append(assets_def.subset_for(asset_keys, selected_asset_check_keys=None))
 
     return ret
 

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -476,6 +476,7 @@ class _Asset:
             metadata_by_key={out_asset_key: self.metadata} if self.metadata else None,
             descriptions_by_key=None,  # not supported for now
             check_specs_by_output_name=check_specs_by_output_name,
+            selected_asset_check_handles=None,  # no subselection in decorator
         )
 
 
@@ -848,6 +849,7 @@ def multi_asset(
             descriptions_by_key=None,  # not supported for now
             metadata_by_key=metadata_by_key,
             check_specs_by_output_name=check_specs_by_output_name,
+            selected_asset_check_handles=None,  # no subselection in decorator
         )
 
     return inner

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -476,7 +476,7 @@ class _Asset:
             metadata_by_key={out_asset_key: self.metadata} if self.metadata else None,
             descriptions_by_key=None,  # not supported for now
             check_specs_by_output_name=check_specs_by_output_name,
-            selected_asset_check_handles=None,  # no subselection in decorator
+            selected_asset_check_keys=None,  # no subselection in decorator
         )
 
 
@@ -849,7 +849,7 @@ def multi_asset(
             descriptions_by_key=None,  # not supported for now
             metadata_by_key=metadata_by_key,
             check_specs_by_output_name=check_specs_by_output_name,
-            selected_asset_check_handles=None,  # no subselection in decorator
+            selected_asset_check_keys=None,  # no subselection in decorator
         )
 
     return inner

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -593,9 +593,9 @@ class OpExecutionContext(AbstractComputeExecutionContext, metaclass=OpExecutionC
 
     @public
     @property
-    def selected_asset_check_handles(self) -> AbstractSet[Tuple[AssetKey, str]]:
+    def selected_asset_check_keys(self) -> AbstractSet[Tuple[AssetKey, str]]:
         if self.has_assets_def:
-            return self.assets_def.check_handles
+            return self.assets_def.check_keys
 
         if self.has_asset_checks_def:
             check.failed("Subset selection is not yet supported within an AssetChecksDefinition")

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -10,14 +10,13 @@ from typing import (
     Optional,
     Sequence,
     Set,
-    Tuple,
     Union,
     cast,
 )
 
 import dagster._check as check
 from dagster._annotations import deprecated, experimental, public
-from dagster._core.definitions.asset_check_spec import AssetCheckSpec
+from dagster._core.definitions.asset_check_spec import AssetCheckKey, AssetCheckSpec
 from dagster._core.definitions.asset_checks import AssetChecksDefinition
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.data_version import (
@@ -593,7 +592,7 @@ class OpExecutionContext(AbstractComputeExecutionContext, metaclass=OpExecutionC
 
     @public
     @property
-    def selected_asset_check_keys(self) -> AbstractSet[Tuple[AssetKey, str]]:
+    def selected_asset_check_keys(self) -> AbstractSet[AssetCheckKey]:
         if self.has_assets_def:
             return self.assets_def.check_keys
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -111,7 +111,9 @@ def test_subset_for(subset, expected_keys, expected_inputs, expected_outputs):
     def abc_(context, in1, in2, in3):
         pass
 
-    subbed = abc_.subset_for({AssetKey(key) for key in subset.split(",")})
+    subbed = abc_.subset_for(
+        {AssetKey(key) for key in subset.split(",")}, selected_asset_check_keys=None
+    )
 
     assert subbed.keys == (
         {AssetKey(key) for key in expected_keys.split(",")} if expected_keys else set()
@@ -293,7 +295,7 @@ def test_retain_group_subset():
         can_subset=True,
     )
 
-    subset = ma.subset_for({AssetKey("b")})
+    subset = ma.subset_for({AssetKey("b")}, selected_asset_check_keys=None)
     assert subset.group_names_by_key[AssetKey("b")] == "bar"
 
 
@@ -349,7 +351,8 @@ def test_chain_replace_and_subset_for():
     }
 
     subbed_1 = replaced_1.subset_for(
-        {AssetKey(["foo", "bar_in1"]), AssetKey("in3"), AssetKey(["foo", "foo_a"]), AssetKey("b")}
+        {AssetKey(["foo", "bar_in1"]), AssetKey("in3"), AssetKey(["foo", "foo_a"]), AssetKey("b")},
+        selected_asset_check_keys=None,
     )
     assert subbed_1.keys == {AssetKey(["foo", "foo_a"]), AssetKey("b")}
 
@@ -387,7 +390,8 @@ def test_chain_replace_and_subset_for():
             AssetKey(["again", "foo", "bar_in1"]),
             AssetKey(["again", "foo", "foo_a"]),
             AssetKey(["c"]),
-        }
+        },
+        selected_asset_check_keys=None,
     )
     assert subbed_2.keys == {AssetKey(["again", "foo", "foo_a"])}
 
@@ -398,7 +402,7 @@ def test_fail_on_subset_for_nonsubsettable():
         pass
 
     with pytest.raises(CheckError, match="can_subset=False"):
-        abc_.subset_for({AssetKey("start"), AssetKey("a")})
+        abc_.subset_for({AssetKey("start"), AssetKey("a")}, selected_asset_check_keys=None)
 
 
 def test_fail_for_non_topological_order():

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
@@ -513,8 +513,12 @@ def do_run(
             elif not selected_keys:
                 assets_in_run.extend(a.to_source_assets())
             else:
-                assets_in_run.append(a.subset_for(asset_keys_set))
-                assets_in_run.extend(a.subset_for(a.keys - selected_keys).to_source_assets())
+                assets_in_run.append(a.subset_for(asset_keys_set, selected_asset_check_keys=None))
+                assets_in_run.extend(
+                    a.subset_for(
+                        a.keys - selected_keys, selected_asset_check_keys=None
+                    ).to_source_assets()
+                )
     materialize_to_memory(
         instance=instance,
         partition_key=partition_key,

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_perf.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_perf.py
@@ -176,7 +176,9 @@ class InstanceSnapshot(NamedTuple):
                                 )
 
                             selected_keys = selection.resolve(asset_graph)
-                            sampled_multi_asset = multi_asset.subset_for(selected_keys)
+                            sampled_multi_asset = multi_asset.subset_for(
+                                selected_keys, selected_asset_check_keys=None
+                            )
                             sampled_roots = [ra for ra in roots if ra.key in selected_keys]
                             to_materialize = [*sampled_roots, sampled_multi_asset]
                         else:

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_asset_decorator_with_check_specs.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_asset_decorator_with_check_specs.py
@@ -20,7 +20,7 @@ from dagster import (
     multi_asset,
     op,
 )
-from dagster._core.definitions.asset_check_spec import AssetCheckHandle
+from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.asset_selection import AssetChecksForHandles, AssetSelection
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.errors import (
@@ -562,7 +562,7 @@ def test_can_subset_no_selection() -> None:
     )
     def foo(context: AssetExecutionContext):
         assert context.selected_asset_keys == {AssetKey("asset1"), AssetKey("asset2")}
-        assert context.selected_asset_check_handles == {
+        assert context.selected_asset_check_keys == {
             (AssetKey("asset1"), "check1"),
             (AssetKey("asset2"), "check2"),
         }
@@ -591,7 +591,7 @@ def test_can_subset() -> None:
     )
     def foo(context: AssetExecutionContext):
         assert context.selected_asset_keys == {AssetKey("asset1")}
-        assert context.selected_asset_check_handles == {(AssetKey("asset1"), "check1")}
+        assert context.selected_asset_check_keys == {(AssetKey("asset1"), "check1")}
 
         yield Output(value=None, output_name="asset1")
         yield AssetCheckResult(asset_key="asset1", check_name="check1", success=True)
@@ -617,7 +617,7 @@ def test_can_subset_result_for_unselected_check() -> None:
     )
     def foo(context: AssetExecutionContext):
         assert context.selected_asset_keys == {AssetKey("asset1")}
-        assert context.selected_asset_check_handles == {(AssetKey("asset1"), "check1")}
+        assert context.selected_asset_check_keys == {(AssetKey("asset1"), "check1")}
 
         yield Output(value=None, output_name="asset1")
         yield AssetCheckResult(asset_key="asset1", check_name="check1", success=True)
@@ -638,7 +638,7 @@ def test_can_subset_select_only_asset() -> None:
     )
     def foo(context: AssetExecutionContext):
         assert context.selected_asset_keys == {AssetKey("asset1")}
-        assert context.selected_asset_check_handles == set()
+        assert context.selected_asset_check_keys == set()
 
         yield Output(value=None, output_name="asset1")
 
@@ -665,18 +665,18 @@ def test_can_subset_select_only_check() -> None:
     )
     def foo(context: AssetExecutionContext):
         assert context.selected_asset_keys == set()
-        assert context.selected_asset_check_handles == {(AssetKey("asset1"), "check1")}
+        assert context.selected_asset_check_keys == {(AssetKey("asset1"), "check1")}
 
         if context.selected_asset_keys:
             yield Output(value=None, output_name="asset1")
 
-        if context.selected_asset_check_handles:
+        if context.selected_asset_check_keys:
             yield AssetCheckResult(asset_key="asset1", check_name="check1", success=True)
 
     result = materialize(
         [foo],
         selection=AssetChecksForHandles(
-            [AssetCheckHandle(asset_key=AssetKey("asset1"), name="check1")]
+            [AssetCheckKey(asset_key=AssetKey("asset1"), name="check1")]
         ),
     )
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_asset_decorator_with_check_specs.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_asset_decorator_with_check_specs.py
@@ -563,8 +563,8 @@ def test_can_subset_no_selection() -> None:
     def foo(context: AssetExecutionContext):
         assert context.selected_asset_keys == {AssetKey("asset1"), AssetKey("asset2")}
         assert context.selected_asset_check_keys == {
-            (AssetKey("asset1"), "check1"),
-            (AssetKey("asset2"), "check2"),
+            AssetCheckKey(AssetKey("asset1"), "check1"),
+            AssetCheckKey(AssetKey("asset2"), "check2"),
         }
 
         yield Output(value=None, output_name="asset1")
@@ -591,7 +591,7 @@ def test_can_subset() -> None:
     )
     def foo(context: AssetExecutionContext):
         assert context.selected_asset_keys == {AssetKey("asset1")}
-        assert context.selected_asset_check_keys == {(AssetKey("asset1"), "check1")}
+        assert context.selected_asset_check_keys == {AssetCheckKey(AssetKey("asset1"), "check1")}
 
         yield Output(value=None, output_name="asset1")
         yield AssetCheckResult(asset_key="asset1", check_name="check1", success=True)
@@ -617,7 +617,7 @@ def test_can_subset_result_for_unselected_check() -> None:
     )
     def foo(context: AssetExecutionContext):
         assert context.selected_asset_keys == {AssetKey("asset1")}
-        assert context.selected_asset_check_keys == {(AssetKey("asset1"), "check1")}
+        assert context.selected_asset_check_keys == {AssetCheckKey(AssetKey("asset1"), "check1")}
 
         yield Output(value=None, output_name="asset1")
         yield AssetCheckResult(asset_key="asset1", check_name="check1", success=True)
@@ -665,13 +665,9 @@ def test_can_subset_select_only_check() -> None:
     )
     def foo(context: AssetExecutionContext):
         assert context.selected_asset_keys == set()
-        assert context.selected_asset_check_keys == {(AssetKey("asset1"), "check1")}
+        assert context.selected_asset_check_keys == {AssetCheckKey(AssetKey("asset1"), "check1")}
 
-        if context.selected_asset_keys:
-            yield Output(value=None, output_name="asset1")
-
-        if context.selected_asset_check_keys:
-            yield AssetCheckResult(asset_key="asset1", check_name="check1", success=True)
+        yield AssetCheckResult(asset_key="asset1", check_name="check1", success=True)
 
     result = materialize(
         [foo],

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_asset_decorator_with_check_specs.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_asset_decorator_with_check_specs.py
@@ -20,6 +20,9 @@ from dagster import (
     multi_asset,
     op,
 )
+from dagster._core.definitions.asset_check_spec import AssetCheckHandle
+from dagster._core.definitions.asset_selection import AssetChecksForHandles, AssetSelection
+from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.errors import (
     DagsterInvalidDefinitionError,
     DagsterInvariantViolationError,
@@ -546,3 +549,140 @@ def test_graph_multi_asset():
     assert check_eval.asset_key == AssetKey("asset_one")
     assert check_eval.check_name == "check1"
     assert check_eval.metadata == {"foo": MetadataValue.text("bar")}
+
+
+def test_can_subset_no_selection() -> None:
+    @multi_asset(
+        can_subset=True,
+        specs=[AssetSpec("asset1"), AssetSpec("asset2")],
+        check_specs=[
+            AssetCheckSpec("check1", asset="asset1"),
+            AssetCheckSpec("check2", asset="asset2"),
+        ],
+    )
+    def foo(context: AssetExecutionContext):
+        assert context.selected_asset_keys == {AssetKey("asset1"), AssetKey("asset2")}
+        assert context.selected_asset_check_handles == {
+            (AssetKey("asset1"), "check1"),
+            (AssetKey("asset2"), "check2"),
+        }
+
+        yield Output(value=None, output_name="asset1")
+        yield AssetCheckResult(asset_key="asset1", check_name="check1", success=True)
+
+    result = materialize([foo])
+
+    assert len(result.get_asset_materialization_events()) == 1
+
+    [check_eval] = result.get_asset_check_evaluations()
+
+    assert check_eval.asset_key == AssetKey("asset1")
+    assert check_eval.check_name == "check1"
+
+
+def test_can_subset() -> None:
+    @multi_asset(
+        can_subset=True,
+        specs=[AssetSpec("asset1"), AssetSpec("asset2")],
+        check_specs=[
+            AssetCheckSpec("check1", asset="asset1"),
+            AssetCheckSpec("check2", asset="asset2"),
+        ],
+    )
+    def foo(context: AssetExecutionContext):
+        assert context.selected_asset_keys == {AssetKey("asset1")}
+        assert context.selected_asset_check_handles == {(AssetKey("asset1"), "check1")}
+
+        yield Output(value=None, output_name="asset1")
+        yield AssetCheckResult(asset_key="asset1", check_name="check1", success=True)
+
+    result = materialize([foo], selection=["asset1"])
+
+    assert len(result.get_asset_materialization_events()) == 1
+
+    [check_eval] = result.get_asset_check_evaluations()
+
+    assert check_eval.asset_key == AssetKey("asset1")
+    assert check_eval.check_name == "check1"
+
+
+def test_can_subset_result_for_unselected_check() -> None:
+    @multi_asset(
+        can_subset=True,
+        specs=[AssetSpec("asset1"), AssetSpec("asset2")],
+        check_specs=[
+            AssetCheckSpec("check1", asset="asset1"),
+            AssetCheckSpec("check2", asset="asset2"),
+        ],
+    )
+    def foo(context: AssetExecutionContext):
+        assert context.selected_asset_keys == {AssetKey("asset1")}
+        assert context.selected_asset_check_handles == {(AssetKey("asset1"), "check1")}
+
+        yield Output(value=None, output_name="asset1")
+        yield AssetCheckResult(asset_key="asset1", check_name="check1", success=True)
+        yield AssetCheckResult(asset_key="asset2", check_name="check2", success=True)
+
+    with pytest.raises(DagsterInvariantViolationError):
+        materialize([foo], selection=["asset1"])
+
+
+def test_can_subset_select_only_asset() -> None:
+    @multi_asset(
+        can_subset=True,
+        specs=[AssetSpec("asset1"), AssetSpec("asset2")],
+        check_specs=[
+            AssetCheckSpec("check1", asset="asset1"),
+            AssetCheckSpec("check2", asset="asset2"),
+        ],
+    )
+    def foo(context: AssetExecutionContext):
+        assert context.selected_asset_keys == {AssetKey("asset1")}
+        assert context.selected_asset_check_handles == set()
+
+        yield Output(value=None, output_name="asset1")
+
+    result = materialize(
+        [foo],
+        selection=AssetSelection.keys(AssetKey("asset1")) - AssetSelection.checks_for_assets(foo),
+    )
+
+    assert len(result.get_asset_materialization_events()) == 1
+
+    check_evals = result.get_asset_check_evaluations()
+
+    assert len(check_evals) == 0
+
+
+def test_can_subset_select_only_check() -> None:
+    @multi_asset(
+        can_subset=True,
+        specs=[AssetSpec("asset1"), AssetSpec("asset2")],
+        check_specs=[
+            AssetCheckSpec("check1", asset="asset1"),
+            AssetCheckSpec("check2", asset="asset2"),
+        ],
+    )
+    def foo(context: AssetExecutionContext):
+        assert context.selected_asset_keys == set()
+        assert context.selected_asset_check_handles == {(AssetKey("asset1"), "check1")}
+
+        if context.selected_asset_keys:
+            yield Output(value=None, output_name="asset1")
+
+        if context.selected_asset_check_handles:
+            yield AssetCheckResult(asset_key="asset1", check_name="check1", success=True)
+
+    result = materialize(
+        [foo],
+        selection=AssetChecksForHandles(
+            [AssetCheckHandle(asset_key=AssetKey("asset1"), name="check1")]
+        ),
+    )
+
+    assert len(result.get_asset_materialization_events()) == 0
+
+    [check_eval] = result.get_asset_check_evaluations()
+
+    assert check_eval.asset_key == AssetKey("asset1")
+    assert check_eval.check_name == "check1"


### PR DESCRIPTION
## Summary & Motivation
Build on https://github.com/dagster-io/dagster/pull/16610 and https://github.com/dagster-io/dagster/pull/16219 to enable asset check subselection. This change was painful and a doozy.

To wrangle this complexity in the future we need to:
- Encompass a succinct and interpretable version of `XXXSelection` to seamlessly enable the asset selection and asset check selection use case
- Standardize our usage of `None`, `[]`, `{}`, when indicating that a selection is defaulting to select all the objects (assets and asset checks).
  - Rather than using `None`, an explicit sentinel value should be used (e.g. `XXXSelection.ALL`, so that the value indicates its usage. Likewise, `[]` and `{}` should be replaced with `XXXSelection.EMPTY`). 

## How I Tested These Changes
- When materializing a subsetted asset, there are four cases:
  - Materialize without a selection
  - Materialize with a selection of assets and checks
  - Materialize with only a selection of assets
  - Materialize with only a selection of checks
- Remove any usages of `AssetSelection` that break the new subsetting invariants (e.g. https://github.com/dagster-io/dagster/pull/16638)
- Existing pytest
- Stack on dbt implementation
