### PR TITLE
update build_op_context to build_asset_context where relevant

### DIFF
--- a/docs/content/concepts/testing.mdx
+++ b/docs/content/concepts/testing.mdx
@@ -333,7 +333,7 @@ def test_asset_with_inputs():
 If your asset has a config schema, you can pass a config value to the invocation. The following asset relies on attached config:
 
 ```python file=/concepts/ops_jobs_graphs/unit_tests.py startafter=start_test_config_asset endbefore=end_test_config_asset
-from dagster import asset, Config, build_op_context
+from dagster import asset, Config
 
 
 class MyAssetConfig(Config):
@@ -357,7 +357,7 @@ If your asset requires resources, you can specify them as arguments when invokin
 Consider the following asset, which requires a resource `bar`.
 
 ```python file=/concepts/ops_jobs_graphs/unit_tests.py startafter=start_test_resource_asset endbefore=end_test_resource_asset
-from dagster import asset, ConfigurableResource, build_op_context, with_resources
+from dagster import asset, ConfigurableResource
 
 
 class BarResource(ConfigurableResource):

--- a/examples/development_to_production/development_to_production_tests/test_assets.py
+++ b/examples/development_to_production/development_to_production_tests/test_assets.py
@@ -1,12 +1,12 @@
 import pandas as pd
-from dagster import build_op_context
+from dagster import build_asset_context
 
 from development_to_production.assets import comments, items, stories
 from development_to_production.resources import StubHNClient
 
 
 def test_items():
-    context = build_op_context(
+    context = build_asset_context(
         resources={"hn_client": StubHNClient()}, op_config={"N": StubHNClient().fetch_max_item_id()}
     )
     hn_dataset = items(context)

--- a/examples/development_to_production/development_to_production_tests/test_assets.py
+++ b/examples/development_to_production/development_to_production_tests/test_assets.py
@@ -7,7 +7,8 @@ from development_to_production.resources import StubHNClient
 
 def test_items():
     context = build_asset_context(
-        resources={"hn_client": StubHNClient()}, op_config={"N": StubHNClient().fetch_max_item_id()}
+        resources={"hn_client": StubHNClient()},
+        asset_config={"N": StubHNClient().fetch_max_item_id()},
     )
     hn_dataset = items(context)
     assert isinstance(hn_dataset, pd.DataFrame)

--- a/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/unit_tests.py
+++ b/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/unit_tests.py
@@ -11,6 +11,7 @@ from dagster import (
     Out,
     op,
     graph,
+    build_op_context,
 )
 
 
@@ -330,7 +331,7 @@ def test_asset_with_inputs():
 
 
 # start_test_resource_asset
-from dagster import asset, ConfigurableResource, build_op_context, with_resources
+from dagster import asset, ConfigurableResource
 
 
 class BarResource(ConfigurableResource):
@@ -351,7 +352,7 @@ def test_asset_requires_bar():
 
 
 # start_test_config_asset
-from dagster import asset, Config, build_op_context
+from dagster import asset, Config
 
 
 class MyAssetConfig(Config):

--- a/examples/docs_snippets/docs_snippets/guides/dagster/development_to_production/test_assets.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/development_to_production/test_assets.py
@@ -1,7 +1,6 @@
 import pandas as pd
 
 from .assets_v2 import ItemsConfig, items
-
 from .resources.resources_v2 import StubHNClient
 
 # start

--- a/examples/docs_snippets/docs_snippets/guides/dagster/development_to_production/test_assets.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/development_to_production/test_assets.py
@@ -1,6 +1,7 @@
 import pandas as pd
 
 from .assets_v2 import ItemsConfig, items
+
 from .resources.resources_v2 import StubHNClient
 
 # start

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/resources_tests/test_pythonic_resources.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/resources_tests/test_pythonic_resources.py
@@ -3,7 +3,6 @@ from typing import Any
 import mock
 import pytest
 
-from dagster import build_init_resource_context, build_op_context
 from dagster._core.definitions.run_config import RunConfig
 from dagster._core.errors import DagsterInvalidConfigError
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
@@ -25,6 +25,7 @@ from dagster import (
     _check as check,
     build_asset_context,
     graph,
+    build_op_context,
     graph_asset,
     graph_multi_asset,
     io_manager,
@@ -613,7 +614,9 @@ def test_kwargs_with_context():
     assert len(my_asset.op.input_defs) == 1
     assert AssetKey("upstream") in my_asset.keys_by_input_name.values()
     assert my_asset(build_asset_context(), upstream=5) == 7
-    assert my_asset.op(build_asset_context(), upstream=5) == 7
+    assert (
+        my_asset.op(build_op_context(), upstream=5) == 7
+    )  # TODO - this test is odd now since my_asset should expect an AssetContext
 
     @asset
     def upstream():
@@ -654,7 +657,7 @@ def test_kwargs_multi_asset_with_context():
     assert len(my_asset.op.input_defs) == 1
     assert AssetKey("upstream") in my_asset.keys_by_input_name.values()
     assert my_asset(build_asset_context(), upstream=5) == (7,)
-    assert my_asset.op(build_asset_context(), upstream=5) == (7,)
+    assert my_asset.op(build_op_context(), upstream=5) == (7,)
 
     @asset
     def upstream():

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
@@ -24,8 +24,8 @@ from dagster import (
     TimeWindowPartitionMapping,
     _check as check,
     build_asset_context,
-    graph,
     build_op_context,
+    graph,
     graph_asset,
     graph_multi_asset,
     io_manager,
@@ -614,9 +614,7 @@ def test_kwargs_with_context():
     assert len(my_asset.op.input_defs) == 1
     assert AssetKey("upstream") in my_asset.keys_by_input_name.values()
     assert my_asset(build_asset_context(), upstream=5) == 7
-    assert (
-        my_asset.op(build_op_context(), upstream=5) == 7
-    )  # TODO - this test is odd now since my_asset should expect an AssetContext
+    assert my_asset.op(build_op_context(), upstream=5) == 7
 
     @asset
     def upstream():

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_direct_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_direct_invocation.py
@@ -440,7 +440,7 @@ def test_direct_invocation_output_metadata():
     def my_other_asset(context):
         context.add_output_metadata({"baz": "qux"})
 
-    ctx = build_op_context()
+    ctx = build_asset_context()
 
     my_asset(ctx)
     assert ctx.get_output_metadata("result") == {"foo": "bar"}
@@ -467,7 +467,7 @@ def test_async_assets_with_shared_context():
 
     # test that we can run two ops/assets with the same context at the same time without
     # overriding op/asset specific attributes
-    ctx = build_op_context()
+    ctx = build_asset_context()
 
     async def main():
         return await asyncio.gather(

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_direct_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_direct_invocation.py
@@ -2,12 +2,14 @@ import asyncio
 
 import pytest
 from dagster import (
+    AssetExecutionContext,
     ConfigurableResource,
+    OpExecutionContext,
     asset,
     op,
 )
 from dagster._core.errors import DagsterInvalidInvocationError, DagsterInvariantViolationError
-from dagster._core.execution.context.invocation import build_op_context
+from dagster._core.execution.context.invocation import build_asset_context, build_op_context
 
 
 def test_direct_op_invocation() -> None:
@@ -15,7 +17,7 @@ def test_direct_op_invocation() -> None:
         a_str: str
 
     @op
-    def my_op(context, my_resource: MyResource) -> str:
+    def my_op(context: OpExecutionContext, my_resource: MyResource) -> str:
         assert my_resource.a_str == "foo"
         return my_resource.a_str
 
@@ -61,7 +63,9 @@ def test_direct_op_invocation_multiple_resources() -> None:
         a_str: str
 
     @op
-    def my_op(context, my_resource: MyResource, my_other_resource: MyResource) -> str:
+    def my_op(
+        context: OpExecutionContext, my_resource: MyResource, my_other_resource: MyResource
+    ) -> str:
         assert my_resource.a_str == "foo"
         assert my_other_resource.a_str == "bar"
         return my_resource.a_str
@@ -122,7 +126,9 @@ def test_direct_op_invocation_with_inputs() -> None:
         z: int
 
     @op
-    def my_wacky_addition_op(context, x: int, y: int, my_resource: MyResource) -> int:
+    def my_wacky_addition_op(
+        context: OpExecutionContext, x: int, y: int, my_resource: MyResource
+    ) -> int:
         return x + y + my_resource.z
 
     # Just providing context is ok, we'll use the resource from the context
@@ -192,12 +198,14 @@ def test_direct_asset_invocation() -> None:
         a_str: str
 
     @asset
-    def my_asset(context, my_resource: MyResource) -> str:
+    def my_asset(context: AssetExecutionContext, my_resource: MyResource) -> str:
         assert my_resource.a_str == "foo"
         return my_resource.a_str
 
     # Just providing context is ok, we'll use the resource from the context
-    assert my_asset(build_op_context(resources={"my_resource": MyResource(a_str="foo")})) == "foo"
+    assert (
+        my_asset(build_asset_context(resources={"my_resource": MyResource(a_str="foo")})) == "foo"
+    )
 
     # Providing both context and resource is not ok, because we don't know which one to use
     with pytest.raises(
@@ -206,17 +214,17 @@ def test_direct_asset_invocation() -> None:
     ):
         assert (
             my_asset(
-                context=build_op_context(resources={"my_resource": MyResource(a_str="foo")}),
+                context=build_asset_context(resources={"my_resource": MyResource(a_str="foo")}),
                 my_resource=MyResource(a_str="foo"),
             )
             == "foo"
         )
 
     # Providing resource only as kwarg is ok, we'll use that (we still need a context though)
-    assert my_asset(context=build_op_context(), my_resource=MyResource(a_str="foo")) == "foo"
+    assert my_asset(context=build_asset_context(), my_resource=MyResource(a_str="foo")) == "foo"
 
     # Providing resource  as arg is ok, we'll use that (we still need a context though)
-    assert my_asset(build_op_context(), MyResource(a_str="foo")) == "foo"
+    assert my_asset(build_asset_context(), MyResource(a_str="foo")) == "foo"
 
     @asset
     def my_asset_no_context(my_resource: MyResource) -> str:
@@ -225,7 +233,7 @@ def test_direct_asset_invocation() -> None:
 
     # Providing context is ok, we just discard it and use the resource from the context
     assert (
-        my_asset_no_context(build_op_context(resources={"my_resource": MyResource(a_str="foo")}))
+        my_asset_no_context(build_asset_context(resources={"my_resource": MyResource(a_str="foo")}))
         == "foo"
     )
 
@@ -238,28 +246,36 @@ def test_direct_asset_invocation_with_inputs() -> None:
         z: int
 
     @asset
-    def my_wacky_addition_asset(context, x: int, y: int, my_resource: MyResource) -> int:
+    def my_wacky_addition_asset(
+        context: AssetExecutionContext, x: int, y: int, my_resource: MyResource
+    ) -> int:
         return x + y + my_resource.z
 
     # Just providing context is ok, we'll use the resource from the context
     # We are successfully able to input x and y as args
     assert (
-        my_wacky_addition_asset(build_op_context(resources={"my_resource": MyResource(z=2)}), 4, 5)
+        my_wacky_addition_asset(
+            build_asset_context(resources={"my_resource": MyResource(z=2)}), 4, 5
+        )
         == 11
     )
     # We can also input x and y as kwargs
     assert (
         my_wacky_addition_asset(
-            build_op_context(resources={"my_resource": MyResource(z=3)}), y=1, x=2
+            build_asset_context(resources={"my_resource": MyResource(z=3)}), y=1, x=2
         )
         == 6
     )
 
     # Providing resource only as kwarg is ok, we'll use that (we still need a context though)
     # We can input x and y as args
-    assert my_wacky_addition_asset(build_op_context(), 10, 20, my_resource=MyResource(z=30)) == 60
+    assert (
+        my_wacky_addition_asset(build_asset_context(), 10, 20, my_resource=MyResource(z=30)) == 60
+    )
     # We can also input x and y as kwargs in this case
-    assert my_wacky_addition_asset(build_op_context(), y=1, x=2, my_resource=MyResource(z=3)) == 6
+    assert (
+        my_wacky_addition_asset(build_asset_context(), y=1, x=2, my_resource=MyResource(z=3)) == 6
+    )
 
     @asset
     def my_wacky_addition_asset_no_context(x: int, y: int, my_resource: MyResource) -> int:
@@ -269,14 +285,14 @@ def test_direct_asset_invocation_with_inputs() -> None:
     # We can input x and y as args
     assert (
         my_wacky_addition_asset_no_context(
-            build_op_context(resources={"my_resource": MyResource(z=2)}), 4, 5
+            build_asset_context(resources={"my_resource": MyResource(z=2)}), 4, 5
         )
         == 11
     )
     # We can also input x and y as kwargs
     assert (
         my_wacky_addition_asset_no_context(
-            build_op_context(resources={"my_resource": MyResource(z=3)}), y=1, x=2
+            build_asset_context(resources={"my_resource": MyResource(z=3)}), y=1, x=2
         )
         == 6
     )
@@ -387,19 +403,21 @@ def test_direct_asset_invocation_many_resource_args_context() -> None:
     executed = {}
 
     @asset
-    def an_asset(context, my_resource: NumResource, my_other_resource: NumResource) -> None:
+    def an_asset(
+        context: AssetExecutionContext, my_resource: NumResource, my_other_resource: NumResource
+    ) -> None:
         assert context.resources.my_resource.num == 1
         assert context.resources.my_other_resource.num == 2
         assert my_resource.num == 1
         assert my_other_resource.num == 2
         executed["yes"] = True
 
-    an_asset(build_op_context(), NumResource(num=1), NumResource(num=2))
+    an_asset(build_asset_context(), NumResource(num=1), NumResource(num=2))
     assert executed["yes"]
     executed.clear()
 
     an_asset(
-        build_op_context(), my_resource=NumResource(num=1), my_other_resource=NumResource(num=2)
+        build_asset_context(), my_resource=NumResource(num=1), my_other_resource=NumResource(num=2)
     )
     assert executed["yes"]
     executed.clear()
@@ -407,7 +425,7 @@ def test_direct_asset_invocation_many_resource_args_context() -> None:
     an_asset(
         my_other_resource=NumResource(num=2),
         my_resource=NumResource(num=1),
-        context=build_op_context(),
+        context=build_asset_context(),
     )
     assert executed["yes"]
     executed.clear()

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_with_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_with_resources.py
@@ -7,7 +7,7 @@ from dagster import (
     IOManager,
     IOManagerDefinition,
     ResourceDefinition,
-    build_op_context,
+    build_asset_context,
     execute_job,
     io_manager,
     mem_io_manager,
@@ -402,7 +402,7 @@ def test_config():
         resource_config_by_key={"foo": {"config": "blah"}, "bar": {"config": "baz"}},
     )[0]
 
-    transformed_asset(build_op_context())
+    transformed_asset(build_asset_context())
 
 
 def test_config_not_satisfied():
@@ -435,7 +435,7 @@ def test_bad_key_provided():
         },
     )[0]
 
-    transformed_asset(build_op_context())
+    transformed_asset(build_asset_context())
 
 
 def test_bad_config_provided():

--- a/python_modules/dagster/dagster_tests/core_tests/test_op_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_op_invocation.py
@@ -1243,6 +1243,9 @@ def test_assets_def_invocation():
     ) as context:
         my_asset(context)
 
+    with build_op_context(
+        partition_key="2023-02-02",
+    ) as context:
         with pytest.raises(DagsterInvalidPropertyError, match="does not have an assets definition"):
             non_asset_op(context)
 

--- a/python_modules/dagster/dagster_tests/core_tests/test_op_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_op_invocation.py
@@ -1238,7 +1238,7 @@ def test_assets_def_invocation():
     def non_asset_op(context):
         context.assets_def  # noqa: B018
 
-    with build_op_context(
+    with build_asset_context(
         partition_key="2023-02-02",
     ) as context:
         my_asset(context)
@@ -1258,7 +1258,7 @@ def test_partitions_time_window_asset_invocation():
         assert start == pendulum.instance(datetime(2023, 2, 2), tz=partitions_def.timezone)
         assert end == pendulum.instance(datetime(2023, 2, 3), tz=partitions_def.timezone)
 
-    context = build_op_context(
+    context = build_asset_context(
         partition_key="2023-02-02",
     )
     partitioned_asset(context)
@@ -1287,7 +1287,7 @@ def test_multipartitioned_time_window_asset_invocation():
         assert context.asset_partitions_time_window_for_output() == time_window
         return 1
 
-    context = build_op_context(
+    context = build_asset_context(
         partition_key="2020-01-01|a",
     )
     my_asset(context)
@@ -1307,7 +1307,7 @@ def test_multipartitioned_time_window_asset_invocation():
         ):
             context.asset_partitions_time_window_for_output()
 
-    context = build_op_context(
+    context = build_asset_context(
         partition_key="a|a",
     )
     static_multipartitioned_asset(context)
@@ -1321,7 +1321,7 @@ def test_partition_range_asset_invocation():
         keys = partitions_def.get_partition_keys_in_range(context.partition_key_range)
         return {k: True for k in keys}
 
-    context = build_op_context(
+    context = build_asset_context(
         partition_key_range=PartitionKeyRange("2023-01-01", "2023-01-02"),
     )
     assert foo(context) == {"2023-01-01": True, "2023-01-02": True}

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_materialize_result.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_materialize_result.py
@@ -13,7 +13,6 @@ from dagster import (
     MaterializeResult,
     StaticPartitionsDefinition,
     asset,
-    build_op_context,
     instance_for_test,
     materialize,
     multi_asset,
@@ -497,7 +496,7 @@ def test_materialize_result_with_partitions_direct_invocation():
     def partitioned_asset(context: AssetExecutionContext) -> MaterializeResult:
         return MaterializeResult(metadata={"key": context.partition_key})
 
-    context = build_op_context(partition_key="red")
+    context = build_asset_context(partition_key="red")
 
     res = partitioned_asset(context)
     assert res.metadata["key"] == "red"


### PR DESCRIPTION
## Summary & Motivation
Updates our tests and examples to use `build_asset_context` for assets that were previously using a context from `build_op_context`

## How I Tested These Changes
BK