### PR TITLE
[pipes] databricks unstructured log forwarding

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -485,6 +485,7 @@ from dagster._core.pipes.context import (
 from dagster._core.pipes.subprocess import PipesSubprocessClient as PipesSubprocessClient
 from dagster._core.pipes.utils import (
     PipesBlobStoreMessageReader as PipesBlobStoreMessageReader,
+    PipesBlobStoreStdioReader as PipesBlobStoreStdioReader,
     PipesEnvContextInjector as PipesEnvContextInjector,
     PipesFileContextInjector as PipesFileContextInjector,
     PipesFileMessageReader as PipesFileMessageReader,

--- a/python_modules/libraries/dagster-aws/dagster_aws/pipes.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/pipes.py
@@ -9,12 +9,37 @@ from botocore.exceptions import ClientError
 from dagster._core.pipes.client import (
     PipesParams,
 )
-from dagster._core.pipes.utils import PipesBlobStoreMessageReader
+from dagster._core.pipes.utils import PipesBlobStoreMessageReader, PipesBlobStoreStdioReader
 
 
 class PipesS3MessageReader(PipesBlobStoreMessageReader):
-    def __init__(self, *, interval: float = 10, bucket: str, client: boto3.client):
-        super().__init__(interval=interval)
+    """Message reader that reads messages by periodically reading message chunks from a specified S3
+    bucket.
+
+    If `stdout_reader` or `stderr_reader` are passed, this reader will also start them when
+    `read_messages` is called. If they are not passed, then the reader performs no stdout/stderr
+    forwarding.
+
+    Args:
+        interval (float): interval in seconds between attempts to download a chunk
+        bucket (str): The S3 bucket to read from.
+        client (WorkspaceClient): A boto3 client.
+        stdout_reader (Optional[PipesBlobStoreStdioReader]): A reader for reading stdout logs.
+        stderr_reader (Optional[PipesBlobStoreStdioReader]): A reader for reading stderr logs.
+    """
+
+    def __init__(
+        self,
+        *,
+        interval: float = 10,
+        bucket: str,
+        client: boto3.client,
+        stdout_reader: Optional[PipesBlobStoreStdioReader] = None,
+        stderr_reader: Optional[PipesBlobStoreStdioReader] = None,
+    ):
+        super().__init__(
+            interval=interval, stdout_reader=stdout_reader, stderr_reader=stderr_reader
+        )
         self.bucket = check.str_param(bucket, "bucket")
         self.key_prefix = "".join(random.choices(string.ascii_letters, k=30))
         self.client = client

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/__init__.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/__init__.py
@@ -28,6 +28,7 @@ from .pipes import (
     PipesDatabricksClient as PipesDatabricksClient,
     PipesDbfsContextInjector as PipesDbfsContextInjector,
     PipesDbfsMessageReader as PipesDbfsMessageReader,
+    PipesDbfsStdioReader as PipesDbfsStdioReader,
 )
 from .resources import (
     DatabricksClientResource as DatabricksClientResource,

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_pipes.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_pipes.py
@@ -10,7 +10,7 @@ from typing import Any, Callable, Iterator
 import pytest
 from dagster import AssetExecutionContext, asset, materialize
 from dagster._core.errors import DagsterPipesExecutionError
-from dagster_databricks.pipes import PipesDatabricksClient, PipesDbfsMessageReader, dbfs_tempdir
+from dagster_databricks.pipes import PipesDatabricksClient, dbfs_tempdir
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.service import files, jobs
 
@@ -81,6 +81,8 @@ def get_repo_root() -> str:
     return path
 
 
+# Upload the Dagster Pipes wheel to DBFS. Use this fixture to avoid needing to manually reupload
+# dagster-pipes if it has changed between test runs.
 @contextmanager
 def upload_dagster_pipes_whl(client: WorkspaceClient) -> Iterator[None]:
     repo_root = get_repo_root()
@@ -129,11 +131,6 @@ def test_pipes_client(capsys, client: WorkspaceClient):
         resources={
             "pipes_client": PipesDatabricksClient(
                 client,
-                message_reader=PipesDbfsMessageReader(
-                    client=client,
-                    forward_stdout=True,
-                    forward_stderr=True,
-                ),
             )
         },
         raise_on_error=False,

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_pipes.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_pipes.py
@@ -1,6 +1,8 @@
 import base64
 import inspect
 import os
+import re
+import subprocess
 import textwrap
 from contextlib import contextmanager
 from typing import Any, Callable, Iterator
@@ -8,7 +10,7 @@ from typing import Any, Callable, Iterator
 import pytest
 from dagster import AssetExecutionContext, asset, materialize
 from dagster._core.errors import DagsterPipesExecutionError
-from dagster_databricks.pipes import PipesDatabricksClient, dbfs_tempdir
+from dagster_databricks.pipes import PipesDatabricksClient, PipesDbfsMessageReader, dbfs_tempdir
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.service import files, jobs
 
@@ -16,6 +18,8 @@ IS_BUILDKITE = os.getenv("BUILDKITE") is not None
 
 
 def script_fn():
+    import sys
+
     from dagster_pipes import (
         PipesDbfsContextLoader,
         PipesDbfsMessageWriter,
@@ -23,11 +27,13 @@ def script_fn():
     )
 
     with open_dagster_pipes(
-        context_loader=PipesDbfsContextLoader(), message_writer=PipesDbfsMessageWriter()
+        context_loader=PipesDbfsContextLoader(),
+        message_writer=PipesDbfsMessageWriter(),
     ) as context:
         multiplier = context.get_extra("multiplier")
         value = 2 * multiplier
-
+        print("hello from databricks stdout")  # noqa: T201
+        print("hello from databricks stderr", file=sys.stderr)  # noqa: T201
         context.log.info(f"{context.asset_key}: {2} * {multiplier} = {value}")
         context.report_asset_materialization(
             metadata={"value": value},
@@ -62,8 +68,31 @@ CLUSTER_DEFAULTS = {
 
 TASK_KEY = "DAGSTER_PIPES_TASK"
 
+DAGSTER_PIPES_WHL_FILENAME = "dagster_pipes-1!0+dev-py3-none-any.whl"
+
 # This has been manually uploaded to a test DBFS workspace.
-DAGSTER_PIPES_WHL_PATH = "dbfs:/FileStore/jars/dagster_pipes-1!0+dev-py3-none-any.whl"
+DAGSTER_PIPES_WHL_PATH = f"dbfs:/FileStore/jars/{DAGSTER_PIPES_WHL_FILENAME}"
+
+
+def get_repo_root() -> str:
+    path = os.path.dirname(__file__)
+    while not os.path.exists(os.path.join(path, ".git")):
+        path = os.path.dirname(path)
+    return path
+
+
+@contextmanager
+def upload_dagster_pipes_whl(client: WorkspaceClient) -> Iterator[None]:
+    repo_root = get_repo_root()
+    orig_wd = os.getcwd()
+    dagster_pipes_root = os.path.join(repo_root, "python_modules", "dagster-pipes")
+    os.chdir(dagster_pipes_root)
+    subprocess.check_call(["python", "setup.py", "bdist_wheel"])
+    subprocess.check_call(
+        ["dbfs", "cp", "--overwrite", f"dist/{DAGSTER_PIPES_WHL_FILENAME}", DAGSTER_PIPES_WHL_PATH]
+    )
+    os.chdir(orig_wd)
+    yield
 
 
 def _make_submit_task(path: str) -> jobs.SubmitTask:
@@ -83,25 +112,38 @@ def _make_submit_task(path: str) -> jobs.SubmitTask:
 
 
 @pytest.mark.skipif(IS_BUILDKITE, reason="Not configured to run on BK yet.")
-def test_pipes_client(client: WorkspaceClient):
+def test_pipes_client(capsys, client: WorkspaceClient):
     @asset
     def number_x(context: AssetExecutionContext, pipes_client: PipesDatabricksClient):
-        with temp_script(script_fn, client) as script_path:
-            task = _make_submit_task(script_path)
-            return pipes_client.run(
-                task=task,
-                context=context,
-                extras={"multiplier": 2, "storage_root": "fake"},
-            ).get_results()
+        with upload_dagster_pipes_whl(client):
+            with temp_script(script_fn, client) as script_path:
+                task = _make_submit_task(script_path)
+                return pipes_client.run(
+                    task=task,
+                    context=context,
+                    extras={"multiplier": 2, "storage_root": "fake"},
+                ).get_results()
 
     result = materialize(
         [number_x],
-        resources={"pipes_client": PipesDatabricksClient(client)},
+        resources={
+            "pipes_client": PipesDatabricksClient(
+                client,
+                message_reader=PipesDbfsMessageReader(
+                    client=client,
+                    forward_stdout=True,
+                    forward_stderr=True,
+                ),
+            )
+        },
         raise_on_error=False,
     )
     assert result.success
     mats = result.asset_materializations_for_node(number_x.op.name)
     assert mats[0].metadata["value"].value == 4
+    captured = capsys.readouterr()
+    assert re.search(r"hello from databricks stdout\n", captured.out, re.MULTILINE)
+    assert re.search(r"hello from databricks stderr\n", captured.err, re.MULTILINE)
 
 
 @pytest.mark.skipif(IS_BUILDKITE, reason="Not configured to run on BK yet.")


### PR DESCRIPTION
## Summary & Motivation

This adds stdout/stderr forwarding to the dagster-databricks pipes integration. It was a long road getting here with several dead ends.

The current approach in this PR is to modify `PipesBlobStoreMessageReader` with `forward_{stdout,stderr}` boolean params and corresponding hooks for downloading stdout, stderr chunks. If `forward_{stdout,stderr}` is enabled, threads will be launched for the streams (alongside the message chunk thread) that periodically download stderr/stdout chunks and write them to the corresponding orchestration process streams.

In the `PipesDbfsMessageReader`, instead of using an incrementing counter (as is used for messages), the stdout/stderr chunk downloaders are written to track a string index in the  file corresponding to the stream. We repeatedly download the full file. Every time the file is downloaded, we only forward starting from the offset index. This approach of repeatedly downloading the full file and applying the offset only on the orchestration end can surely be improved to just download starting from the offset, but I did not implement that yet (there are some concerns around getting the indexing right given that the files are stored as base64, I think with padding).

While it is possible that other integrations would need to make some changes on the pipes end, I didn't need to make any for databricks, because a DBFS location for `stdout`/`stderr` is configured when launching the job, so we don't need to do anything in the orchestration process. This introduces a potential asymmetry between the `PipesMessageReader` and `PipesMessageWriter`-- probably we will end up with just a `PipesReader`.

There are definitely some other rough patches here:

- Databricks does not let you directly configure the directory where stdout/stderr are written. Instead you set a root directory, and then logs get stored in `<root>/<cluster-id>/driver/{stdout,stderr}`. This introduces a difficulty because the cluster id does not exist until the job is launched (and you can't set it manually). Because the message reader gets set up before the job is launched, the message reader doesn't know where to look.
    - I got around this by setting the log root to a temporary directory and polling that directory for the first child to appear, which will be where the logs are stored. This is not ideal because users may want to retain the logs in DBFS.
    - Another approach would be to send the cluster id back in the new `opened` message, but to then thread this into the message reader requires additional plumbing work.
 
For those who want to play with this, the workflow is to repeatedly run `dagster_databricks_tests/test_pipes.py::test_pipes_client`. This requires you to have `DATABRICKS_HOST` and `DATABRICKS_TOKEN` set in your env. `DATABRICKS_HOST` should be `https://dbc-07902917-6487.cloud.databricks.com`. `DATABRICKS_TOKEN` should be set to a value you generate by going to User Settings > Developer > Access Tokens in the Databricks UI.

## How I Tested These Changes

Tested via `capsys` to make sure logs are forwarded.
