### PR TITLE
Don't set a dagster/solid_selection tag when you materialize a set of assets (take 2, much simpler fix)

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadSession.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadSession.tsx
@@ -329,9 +329,9 @@ const LaunchpadSession: React.FC<LaunchpadSessionProps> = (props) => {
         executionMetadata: {
           tags: uniqBy(
             [
-              // pass solid selection query via tags
-              // clean up https://github.com/dagster-io/dagster/issues/2495
-              ...(currentSession.solidSelectionQuery
+              // Include a dagster/solid_selection tag for non-asset jobs
+              // (asset jobs indicate elsewhere in the UI which assets were selected)
+              ...(currentSession.solidSelectionQuery && !pipeline.isAssetJob
                 ? [
                     {
                       key: DagsterTag.SolidSelection,


### PR DESCRIPTION
Summary:
Solution in https://github.com/dagster-io/dagster/pull/16636 to this problem had some issues (adding the tags to the storage made them editable which is weird)

Instead, just don't set the dagster/solid_selection tag for asset jobs.

Test Plan:
Load an asset job locally, press "materialize all" in the launchpad - all assets materialize but the giant tag is no longer there
In a non-asset job, materailize an op subset - tag is still there on the resulting job

## Summary & Motivation

## How I Tested These Changes
