### PR TITLE
[Asset graph side] Show fullly populated sidebar during empty state

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -75,6 +75,7 @@ export const AssetGraphExplorer: React.FC<Props> = (props) => {
   const {
     fetchResult,
     assetGraphData,
+    fullAssetGraphData,
     graphQueryItems,
     graphAssetKeys,
     allAssetKeys,
@@ -86,7 +87,7 @@ export const AssetGraphExplorer: React.FC<Props> = (props) => {
   return (
     <Loading allowStaleData queryResult={fetchResult}>
       {() => {
-        if (!assetGraphData || !allAssetKeys) {
+        if (!assetGraphData || !allAssetKeys || !fullAssetGraphData) {
           return <NonIdealState icon="error" title="Query Error" />;
         }
 
@@ -105,6 +106,7 @@ export const AssetGraphExplorer: React.FC<Props> = (props) => {
           <AssetGraphExplorerWithData
             key={props.explorerPath.pipelineName}
             assetGraphData={assetGraphData}
+            fullAssetGraphData={fullAssetGraphData}
             allAssetKeys={allAssetKeys}
             graphQueryItems={graphQueryItems}
             applyingEmptyDefault={applyingEmptyDefault}
@@ -121,6 +123,7 @@ export const AssetGraphExplorer: React.FC<Props> = (props) => {
 type WithDataProps = {
   allAssetKeys: AssetKey[];
   assetGraphData: GraphData;
+  fullAssetGraphData: GraphData;
   graphQueryItems: AssetGraphQueryItem[];
   liveDataByNode: LiveData;
   liveDataRefreshState: QueryRefreshState;
@@ -136,6 +139,7 @@ const AssetGraphExplorerWithData: React.FC<WithDataProps> = ({
   liveDataRefreshState,
   liveDataByNode,
   assetGraphData,
+  fullAssetGraphData,
   graphQueryItems,
   applyingEmptyDefault,
   fetchOptions,
@@ -200,8 +204,9 @@ const AssetGraphExplorerWithData: React.FC<WithDataProps> = ({
         }
 
         const existing = explorerPath.opNames[0]!.split(',');
-        nextOpsNameSelection = (
-          existing.includes(token) ? without(existing, token) : uniq([...existing, ...tokensToAdd])
+        nextOpsNameSelection = (existing.includes(token)
+          ? without(existing, token)
+          : uniq([...existing, ...tokensToAdd])
         ).join(',');
       }
 
@@ -508,6 +513,7 @@ const AssetGraphExplorerWithData: React.FC<WithDataProps> = ({
             <AssetGraphExplorerSidebar
               allAssetKeys={allAssetKeys}
               assetGraphData={assetGraphData}
+              fullAssetGraphData={fullAssetGraphData}
               lastSelectedNode={lastSelectedNode}
               selectNode={selectNodeById}
               explorerPath={explorerPath}

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -204,9 +204,8 @@ const AssetGraphExplorerWithData: React.FC<WithDataProps> = ({
         }
 
         const existing = explorerPath.opNames[0]!.split(',');
-        nextOpsNameSelection = (existing.includes(token)
-          ? without(existing, token)
-          : uniq([...existing, ...tokensToAdd])
+        nextOpsNameSelection = (
+          existing.includes(token) ? without(existing, token) : uniq([...existing, ...tokensToAdd])
         ).join(',');
       }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorerSidebar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorerSidebar.tsx
@@ -28,7 +28,7 @@ import {ExplorerPath} from '../pipelines/PipelinePathUtils';
 import {Container, Inner, Row} from '../ui/VirtualizedTable';
 import {buildRepoPathForHuman} from '../workspace/buildRepoAddress';
 
-import {GraphData, GraphNode} from './Utils';
+import {GraphData, GraphNode, tokenForAssetKey} from './Utils';
 
 const COLLATOR = new Intl.Collator(navigator.language, {sensitivity: 'base', numeric: true});
 
@@ -84,7 +84,7 @@ export const AssetGraphExplorerSidebar = React.memo(
       if (!assetGraphData.nodes[id]) {
         try {
           const path = JSON.parse(id);
-          const nextOpsQuery = `${explorerPath.opsQuery} \"${path[path.length - 1]}\"`;
+          const nextOpsQuery = `${explorerPath.opsQuery} \"${tokenForAssetKey({path})}\"`;
           onChangeExplorerPath(
             {
               ...explorerPath,
@@ -444,7 +444,7 @@ const Node = ({
 
   function showDownstreamGraph() {
     const path = JSON.parse(node.id);
-    const newQuery = `\"${path[path.length - 1]}\"*`;
+    const newQuery = `\"${tokenForAssetKey({path})}\"*`;
     const nextOpsQuery = explorerPath.opsQuery.includes(newQuery)
       ? explorerPath.opsQuery
       : `${explorerPath.opsQuery} ${newQuery}`;
@@ -459,7 +459,7 @@ const Node = ({
 
   function showUpstreamGraph() {
     const path = JSON.parse(node.id);
-    const newQuery = `*\"${path[path.length - 1]}\"`;
+    const newQuery = `*\"${tokenForAssetKey({path})}\"`;
     const nextOpsQuery = explorerPath.opsQuery.includes(newQuery)
       ? explorerPath.opsQuery
       : `${explorerPath.opsQuery} ${newQuery}`;

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorerSidebar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorerSidebar.tsx
@@ -81,7 +81,7 @@ export const AssetGraphExplorerSidebar = React.memo(
 
     const selectNode: typeof _selectNode = (e, id) => {
       setSelectWhenDataAvailable([e, id]);
-      if (!graphData.nodes[id]) {
+      if (!assetGraphData.nodes[id]) {
         try {
           const path = JSON.parse(id);
           const nextOpsQuery = `${explorerPath.opsQuery} \"${path[path.length - 1]}\"`;

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphData.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphData.tsx
@@ -47,48 +47,61 @@ export function useAssetGraphData(opsQuery: string, options: AssetGraphFetchScop
 
   const nodes = fetchResult.data?.assetNodes;
 
-  const {assetGraphData, graphQueryItems, graphAssetKeys, allAssetKeys, applyingEmptyDefault} =
-    React.useMemo(() => {
-      if (nodes === undefined) {
-        return {
-          graphAssetKeys: [],
-          graphQueryItems: [],
-          assetGraphData: null,
-          applyingEmptyDefault: false,
-        };
-      }
+  const repoFilteredNodes = React.useMemo(() => {
+    // Apply any filters provided by the caller. This is where we do repo filtering
+    let matching = nodes;
+    if (options.hideNodesMatching) {
+      matching = reject(matching, options.hideNodesMatching);
+    }
+    return matching;
+  }, [nodes, options.hideNodesMatching]);
 
-      // Apply any filters provided by the caller. This is where we do repo filtering
-      let matching = nodes;
-      if (options.hideNodesMatching) {
-        matching = reject(matching, options.hideNodesMatching);
-      }
+  const graphQueryItems = React.useMemo(
+    () => (repoFilteredNodes ? buildGraphQueryItems(repoFilteredNodes) : []),
+    [repoFilteredNodes],
+  );
 
-      // Filter the set of all AssetNodes down to those matching the `opsQuery`.
-      // In the future it might be ideal to move this server-side, but we currently
-      // get to leverage the useQuery cache almost 100% of the time above, making this
-      // super fast after the first load vs a network fetch on every page view.
-      const graphQueryItems = buildGraphQueryItems(matching);
-      const {all, applyingEmptyDefault} = filterByQuery(graphQueryItems, opsQuery);
+  const fullAssetGraphData = React.useMemo(
+    () => (graphQueryItems ? buildGraphData(graphQueryItems.map((n) => n.node)) : null),
+    [graphQueryItems],
+  );
 
-      // Assemble the response into the data structure used for layout, traversal, etc.
-      const assetGraphData = buildGraphData(all.map((n) => n.node));
-      if (options.hideEdgesToNodesOutsideQuery) {
-        removeEdgesToHiddenAssets(assetGraphData, nodes);
-      }
-
+  const {assetGraphData, graphAssetKeys, allAssetKeys, applyingEmptyDefault} = React.useMemo(() => {
+    if (repoFilteredNodes === undefined || graphQueryItems === undefined) {
       return {
-        allAssetKeys: matching.map((n) => n.assetKey),
-        graphAssetKeys: all.map((n) => ({path: n.node.assetKey.path})),
-        assetGraphData,
-        graphQueryItems,
-        applyingEmptyDefault,
+        graphAssetKeys: [],
+        graphQueryItems: [],
+        assetGraphData: null,
+        fullAssetGraphData: null,
+        applyingEmptyDefault: false,
       };
-    }, [nodes, opsQuery, options.hideEdgesToNodesOutsideQuery, options.hideNodesMatching]);
+    }
+
+    // Filter the set of all AssetNodes down to those matching the `opsQuery`.
+    // In the future it might be ideal to move this server-side, but we currently
+    // get to leverage the useQuery cache almost 100% of the time above, making this
+    // super fast after the first load vs a network fetch on every page view.
+    const {all, applyingEmptyDefault} = filterByQuery(graphQueryItems, opsQuery);
+
+    // Assemble the response into the data structure used for layout, traversal, etc.
+    const assetGraphData = buildGraphData(all.map((n) => n.node));
+    if (options.hideEdgesToNodesOutsideQuery) {
+      removeEdgesToHiddenAssets(assetGraphData, repoFilteredNodes);
+    }
+
+    return {
+      allAssetKeys: repoFilteredNodes.map((n) => n.assetKey),
+      graphAssetKeys: all.map((n) => ({path: n.node.assetKey.path})),
+      assetGraphData,
+      graphQueryItems,
+      applyingEmptyDefault,
+    };
+  }, [repoFilteredNodes, graphQueryItems, opsQuery, options.hideEdgesToNodesOutsideQuery]);
 
   return {
     fetchResult,
     assetGraphData,
+    fullAssetGraphData,
     graphQueryItems,
     graphAssetKeys,
     allAssetKeys,


### PR DESCRIPTION
## Summary & Motivation

In the empty state we still want the sidebar to list all assets before you typed an op query in.

## How I Tested These Changes

<img width="1411" alt="Screenshot 2023-09-20 at 9 01 28 PM" src="https://github.com/dagster-io/dagster/assets/2286579/290e83ea-c65d-48f4-b703-685f49434166">
