### PR TITLE
change callers of get_materialization_count_by_partition to use get_materialized_partitions

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -369,13 +369,7 @@ def get_partition_subsets(
                 instance, asset_key, partitions_def
             )
         else:
-            materialized_keys = [
-                partition_key
-                for partition_key, count in instance.get_materialization_count_by_partition(
-                    [asset_key]
-                )[asset_key].items()
-                if count > 0
-            ]
+            materialized_keys = instance.get_materialized_partitions(asset_key)
 
         validated_keys = get_validated_partition_keys(
             dynamic_partitions_loader, partitions_def, set(materialized_keys)

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -118,14 +118,6 @@ class AssetDaemonContext:
                 if not self.asset_graph.is_source(key)
             ]
         )
-        self.instance_queryer.prefetch_asset_partition_counts(
-            [
-                key
-                for key in self.target_asset_keys_and_parents
-                if self.asset_graph.is_partitioned(key) and not self.asset_graph.is_source(key)
-            ],
-            after_cursor=cursor.latest_storage_id,
-        )
 
     @property
     def instance_queryer(self) -> "CachingInstanceQueryer":

--- a/python_modules/dagster/dagster/_core/definitions/data_time.py
+++ b/python_modules/dagster/dagster/_core/definitions/data_time.py
@@ -115,18 +115,14 @@ class CachingDataTimeResolver:
             return first_filled_time_window.end
 
         # get a per-partition count of the new materializations
-        new_partition_counts = self._instance_queryer.get_materialized_partition_counts(
-            asset_key, after_cursor=cursor
+        partitions = self._instance_queryer.get_materialized_partitions(asset_key)
+        prev_partitions = self._instance_queryer.get_materialized_partitions(
+            asset_key, before_cursor=cursor
         )
-
-        total_partition_counts = self._instance_queryer.get_materialized_partition_counts(asset_key)
-
-        # these are the partitions that did not exist before this record was created
         net_new_partitions = {
             partition_key
-            for partition_key, new_count in new_partition_counts.items()
-            if new_count == total_partition_counts.get(partition_key)
-            and partitions_def.is_valid_partition_key(partition_key)
+            for partition_key in (partitions - prev_partitions)
+            if partitions_def.is_valid_partition_key(partition_key)
         }
 
         # there are new materializations, but they don't fill any new partitions

--- a/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
@@ -635,9 +635,7 @@ class MultiAssetSensorEvaluationContext(SensorEvaluationContext):
             if len(partitions) == 0:
                 raise DagsterInvalidInvocationError("Must provide at least one partition in list")
 
-        materialization_count_by_partition = self.instance.get_materialization_count_by_partition(
-            [asset_key]
-        ).get(asset_key, {})
+        materialized_partitions = self.instance.get_materialized_partitions(asset_key)
         if not partitions:
             if asset_key not in self._monitored_asset_keys:
                 raise DagsterInvariantViolationError(
@@ -652,9 +650,7 @@ class MultiAssetSensorEvaluationContext(SensorEvaluationContext):
                 )
             partitions = partitions_def.get_partition_keys(dynamic_partitions_store=self.instance)
 
-        return all(
-            [materialization_count_by_partition.get(partition, 0) != 0 for partition in partitions]
-        )
+        return all([partition in materialized_partitions for partition in partitions])
 
     def _get_asset(self, asset_key: AssetKey, fn_name: str) -> AssetsDefinition:
         from dagster._core.definitions.repository_definition import RepositoryDefinition


### PR DESCRIPTION
## Summary & Motivation
Converts call sites from using instance.get_materialization_count_by_partition => instance.get_materialized_partitions.

This unblocks us from keeping summary tables of the first/last materialized events by partition to quickly respond to existence checks instead of scanning the entire table to return full counts.  This should result in better performance.

## How I Tested These Changes
BK
