### PR TITLE
remove storage methods that group by rows across all materialization history

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -2118,12 +2118,6 @@ class DagsterInstance(DynamicPartitionsStore):
             self._event_storage.wipe_asset(asset_key)
 
     @traced
-    def get_materialization_count_by_partition(
-        self, asset_keys: Sequence[AssetKey], after_cursor: Optional[int] = None
-    ) -> Mapping[AssetKey, Mapping[str, int]]:
-        return self._event_storage.get_materialization_count_by_partition(asset_keys, after_cursor)
-
-    @traced
     def get_materialized_partitions(
         self,
         asset_key: AssetKey,

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -343,12 +343,6 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         pass
 
     @abstractmethod
-    def get_materialization_count_by_partition(
-        self, asset_keys: Sequence[AssetKey], after_cursor: Optional[int] = None
-    ) -> Mapping[AssetKey, Mapping[str, int]]:
-        pass
-
-    @abstractmethod
     def get_latest_storage_id_by_partition(
         self, asset_key: AssetKey, event_type: DagsterEventType
     ) -> Mapping[str, int]:

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -537,13 +537,6 @@ class LegacyEventLogStorage(EventLogStorage, ConfigurableClass):
             asset_key, before_cursor, after_cursor
         )
 
-    def get_materialization_count_by_partition(
-        self, asset_keys: Sequence["AssetKey"], after_cursor: Optional[int] = None
-    ) -> Mapping["AssetKey", Mapping[str, int]]:
-        return self._storage.event_log_storage.get_materialization_count_by_partition(
-            asset_keys, after_cursor
-        )
-
     def get_latest_storage_id_by_partition(
         self, asset_key: "AssetKey", event_type: "DagsterEventType"
     ) -> Mapping[str, int]:


### PR DESCRIPTION
## Summary & Motivation
Removes the get_materialization_count_by_partition storage method.  All callers were switched to using the get_materialized_partitions storage method

## How I Tested These Changes
BK
