### PR TITLE
[ext] remove report_asset_metadata, report_asset_data_version

### DIFF
--- a/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/pure_assets_dsl/sql_script.py
+++ b/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/pure_assets_dsl/sql_script.py
@@ -15,5 +15,5 @@ if __name__ == "__main__":
 
     client = SomeSqlClient()
     client.query(sql)
-    context.report_asset_metadata("sql", sql)
+    context.report_asset_materialization(metadata={"sql": sql})
     context.log(f"Ran {sql}")

--- a/python_modules/dagster-ext/dagster_ext/__init__.py
+++ b/python_modules/dagster-ext/dagster_ext/__init__.py
@@ -16,18 +16,20 @@ from typing import (
     TYPE_CHECKING,
     Any,
     ClassVar,
+    Dict,
     Generic,
     Iterator,
     Literal,
     Mapping,
     Optional,
     Sequence,
+    Set,
     TextIO,
     Type,
     TypedDict,
     TypeVar,
+    Union,
     cast,
-    get_args,
 )
 
 if TYPE_CHECKING:
@@ -98,7 +100,19 @@ class ExtDataProvenance(TypedDict):
     is_user_provided: bool
 
 
+ExtMetadataRawValue = Union[int, float, str, Mapping[str, Any], Sequence[Any], bool, None]
+
+
+class ExtMetadataValue(TypedDict):
+    type: "ExtMetadataType"
+    raw_value: ExtMetadataRawValue
+
+
+# Infer the type from the raw value on the orchestration end
+EXT_METADATA_TYPE_INFER = "__infer__"
+
 ExtMetadataType = Literal[
+    "__infer__",
     "text",
     "url",
     "path",
@@ -148,7 +162,10 @@ def _assert_single_asset(data: ExtContextData, key: str) -> None:
 
 
 def _resolve_optionally_passed_asset_key(
-    data: ExtContextData, asset_key: Optional[str], method: str
+    data: ExtContextData,
+    asset_key: Optional[str],
+    method: str,
+    already_materialized_assets: Set[str],
 ) -> str:
     asset_keys = _assert_defined_asset_property(data["asset_keys"], method)
     asset_key = _assert_opt_param_type(asset_key, str, method, "asset_key")
@@ -163,6 +180,11 @@ def _resolve_optionally_passed_asset_key(
                 " targets multiple assets."
             )
         asset_key = asset_keys[0]
+    if asset_key in already_materialized_assets:
+        raise DagsterExtError(
+            f"Calling `{method}` with asset key `{asset_key}` is undefined. Asset has already been"
+            " materialized, so no additional data can be reported for it."
+        )
     return asset_key
 
 
@@ -257,6 +279,33 @@ def _assert_param_json_serializable(value: _T, method: str, param: str) -> _T:
             f" type, got `{type(value)}`."
         )
     return value
+
+
+_METADATA_VALUE_KEYS = frozenset(ExtMetadataValue.__annotations__.keys())
+
+
+def _normalize_param_metadata(
+    metadata: Mapping[str, Union[ExtMetadataRawValue, ExtMetadataValue]], method: str, param: str
+) -> Mapping[str, Union[ExtMetadataRawValue, ExtMetadataValue]]:
+    _assert_param_type(metadata, dict, method, param)
+    new_metadata: Dict[str, ExtMetadataValue] = {}
+    for key, value in metadata.items():
+        if not isinstance(key, str):
+            raise DagsterExtError(
+                f"Invalid type for parameter `{param}` of `{method}`. Expected a dict with string"
+                f" keys, got a key `{key}` of type `{type(key)}`."
+            )
+        elif isinstance(value, dict):
+            if not {*value.keys()} == _METADATA_VALUE_KEYS:
+                raise DagsterExtError(
+                    f"Invalid type for parameter `{param}` of `{method}`. Expected a dict with"
+                    " string keys and values that are either raw metadata values or dictionaries"
+                    f" with schema `{{raw_value: ..., type: ...}}`. Got a value `{value}`."
+                )
+            new_metadata[key] = cast(ExtMetadataValue, value)
+        else:
+            new_metadata[key] = {"raw_value": value, "type": EXT_METADATA_TYPE_INFER}
+    return new_metadata
 
 
 def _param_from_env_var(key: str) -> Any:
@@ -625,6 +674,7 @@ class ExtContext:
     ) -> None:
         self._data = data
         self._message_channel = message_channel
+        self._materialized_assets: set[str] = set()
 
     def _write_message(self, method: str, params: Optional[Mapping[str, Any]] = None) -> None:
         message = ExtMessage(method=method, params=params)
@@ -727,36 +777,28 @@ class ExtContext:
 
     # ##### WRITE
 
-    def report_asset_metadata(
+    def report_asset_materialization(
         self,
-        label: str,
-        value: Any,
-        metadata_type: Optional[ExtMetadataType] = None,
+        metadata: Optional[Mapping[str, Union[ExtMetadataRawValue, ExtMetadataValue]]] = None,
+        data_version: Optional[str] = None,
         asset_key: Optional[str] = None,
-    ) -> None:
+    ):
         asset_key = _resolve_optionally_passed_asset_key(
-            self._data, asset_key, "report_asset_metadata"
+            self._data, asset_key, "report_asset_materialization", self._materialized_assets
         )
-        label = _assert_param_type(label, str, "report_asset_metadata", "label")
-        value = _assert_param_json_serializable(value, "report_asset_metadata", "value")
-        metadata_type = _assert_opt_param_value(
-            metadata_type, get_args(ExtMetadataType), "report_asset_metadata", "type"
+        metadata = (
+            _normalize_param_metadata(metadata, "report_asset_materialization", "metadata")
+            if metadata
+            else None
+        )
+        data_version = _assert_opt_param_type(
+            data_version, str, "report_asset_materialization", "data_version"
         )
         self._write_message(
-            "report_asset_metadata",
-            {"asset_key": asset_key, "label": label, "value": value, "type": metadata_type},
+            "report_asset_materialization",
+            {"asset_key": asset_key, "data_version": data_version, "metadata": metadata},
         )
-
-    def report_asset_data_version(self, data_version: str, asset_key: Optional[str] = None) -> None:
-        asset_key = _resolve_optionally_passed_asset_key(
-            self._data, asset_key, "report_asset_data_version"
-        )
-        data_version = _assert_param_type(
-            data_version, str, "report_asset_data_version", "data_version"
-        )
-        self._write_message(
-            "report_asset_data_version", {"asset_key": asset_key, "data_version": data_version}
-        )
+        self._materialized_assets.add(asset_key)
 
     def log(self, message: str, level: str = "info") -> None:
         message = _assert_param_type(message, str, "log", "asset_key")

--- a/python_modules/dagster-test/dagster_test/toys/external_execution/numbers_example/number_sum.py
+++ b/python_modules/dagster-test/dagster_test/toys/external_execution/numbers_example/number_sum.py
@@ -10,4 +10,4 @@ value = number_x + number_y
 store_asset_value("number_sum", storage_root, value)
 
 context.log(f"{context.asset_key}: {number_x} + {number_y} = {value}")
-context.report_asset_data_version(compute_data_version(value))
+context.report_asset_materialization(data_version=compute_data_version(value))

--- a/python_modules/dagster-test/dagster_test/toys/external_execution/numbers_example/number_x.py
+++ b/python_modules/dagster-test/dagster_test/toys/external_execution/numbers_example/number_x.py
@@ -10,4 +10,4 @@ value = 2 * multiplier
 store_asset_value("number_x", storage_root, value)
 
 context.log(f"{context.asset_key}: {2} * {multiplier} = {value}")
-context.report_asset_data_version(compute_data_version(value))
+context.report_asset_materialization(data_version=compute_data_version(value))

--- a/python_modules/dagster-test/dagster_test/toys/external_execution/numbers_example/number_y.py
+++ b/python_modules/dagster-test/dagster_test/toys/external_execution/numbers_example/number_y.py
@@ -11,5 +11,7 @@ value = int(os.environ["NUMBER_Y"])
 store_asset_value("number_y", storage_root, value)
 
 context.log(f"{context.asset_key}: {value} read from $NUMBER_Y environment variable.")
-context.report_asset_metadata("is_even", value % 2 == 0)
-context.report_asset_data_version(compute_data_version(value))
+context.report_asset_materialization(
+    metadata={"is_even": value % 2 == 0},
+    data_version=compute_data_version(value),
+)

--- a/python_modules/libraries/dagster-databricks/README.md
+++ b/python_modules/libraries/dagster-databricks/README.md
@@ -95,13 +95,14 @@ context.log(f"Using sample rate: {sample_rate}")
 
 # ... your code that computes and persists the asset
 
-# Stream arbitrary metadata back to Dagster. This will be attached to the
-# associated `AssetMaterialization`
-context.report_asset_metadata("some_metric", get_metric(), metadata_type="text")
-
-# Stream data version back to Dagster. This will also be attached to the
-# associated `AssetMaterialization`.
-context.report_asset_data_version(get_data_version())
+# Stream asset materialization metadata and data version back to Dagster.
+# This should be called after you've computed and stored the asset value. We
+# omit the asset key here because there is only one asset in scope, but for
+# multi-assets you can pass an `asset_key` parameter.
+context.report_asset_materialization(
+    metadata={"some_metric", {"raw_value": get_metric(), "type": "text"}},
+    data_version = get_data_version()
+)
 ```
 
 ### (2) `ext_protocol` context manager

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_external_asset.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_external_asset.py
@@ -26,8 +26,10 @@ def script_fn():
     value = 2 * multiplier
 
     context.log(f"{context.asset_key}: {2} * {multiplier} = {value}")
-    context.report_asset_metadata("value", value)
-    context.report_asset_data_version("alpha")
+    context.report_asset_materialization(
+        metadata={"value": value},
+        data_version="alpha",
+    )
 
 
 @contextmanager


### PR DESCRIPTION
## Summary & Motivation

Remove `report_asset_metadata` and `report_asset_data_version` in favor of a single `report_asset_materialization` method, which requires reporting all of the data associated with a materialization at once. Calling `report_asset_materialization` twice for the same asset is an error.

## How I Tested These Changes

Updated unit tests.