### PR TITLE
fix branch deployments page formatting

### DIFF
--- a/docs/content/guides/dagster/branch_deployments.mdx
+++ b/docs/content/guides/dagster/branch_deployments.mdx
@@ -267,7 +267,8 @@ defs = Definitions(
 
 <TabGroup>
   <TabItem name="Using GitHub Actions">
-    The `branch_deployments.yml` file located in `.github/workflows/branch_deployments.yml` defines a `dagster_cloud_build_push` job with a series of steps that launch a branch deployment. Because we want to queue a run of `clone_prod` within each deployment after it launches, we'll add an additional step at the end `dagster_cloud_build_push`. This job is triggered on multiple pull request events: `opened`, `synchronize`, `reopen`, and `closed`. This means that upon future pushes to the branch, we'll trigger a run of `clone_prod`. The `if` condition below ensures that `clone_prod` will not run if the pull request is closed:
+
+The `branch_deployments.yml` file located in `.github/workflows/branch_deployments.yml` defines a `dagster_cloud_build_push` job with a series of steps that launch a branch deployment. Because we want to queue a run of `clone_prod` within each deployment after it launches, we'll add an additional step at the end `dagster_cloud_build_push`. This job is triggered on multiple pull request events: `opened`, `synchronize`, `reopen`, and `closed`. This means that upon future pushes to the branch, we'll trigger a run of `clone_prod`. The `if` condition below ensures that `clone_prod` will not run if the pull request is closed:
 
 ```yaml file=/guides/dagster/development_to_production/branch_deployments/clone_prod.yaml
 # .github/workflows/branch_deployments.yml
@@ -318,9 +319,7 @@ alt="instance-overview"
 src="/images/guides/development_to_production/branch_deployments/snowflake.png"
 width={1431}
 height={537}
-/>
-
-  </TabItem>
+/> </TabItem>
 
   <TabItem name="Using Gitlab CI/CD">
 
@@ -390,7 +389,9 @@ alt="instance-overview"
 src="/images/guides/development_to_production/branch_deployments/snowflake.png"
 width={1431}
 height={537}
-/> </TabItem>
+/>
+
+</TabItem>
 
 </TabGroup>
 


### PR DESCRIPTION
Summary:
The code ticks here were not showing up, I think because of the indentation

## Summary & Motivation

## How I Tested These Changes
