### PR TITLE
feat(dbt): validate that `dbt-core>=1.4.0` when using `DbtCliResource`

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resources_v2_version_validation.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resources_v2_version_validation.py
@@ -1,0 +1,16 @@
+import pytest
+from dagster_dbt.core.resources_v2 import DbtCliResource
+from dbt.version import __version__ as dbt_version
+from packaging import version
+from pydantic import ValidationError
+
+from ..conftest import TEST_PROJECT_DIR
+
+
+@pytest.mark.skipif(
+    version.parse(dbt_version) >= version.parse("1.4.0"),
+    reason="Validates invalid dbt core versions only",
+)
+def test_resource_requires_minimum_dbt_version() -> None:
+    with pytest.raises(ValidationError):
+        DbtCliResource(project_dir=TEST_PROJECT_DIR)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_decorator.py
@@ -11,13 +11,14 @@ from dagster import (
     FreshnessPolicy,
     PartitionsDefinition,
     asset,
-    materialize,
 )
 from dagster._core.definitions.utils import DEFAULT_IO_MANAGER_KEY
-from dagster_dbt import DbtCliResource
 from dagster_dbt.asset_decorator import dbt_assets
 from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator
 from dagster_dbt.dbt_manifest import DbtManifestParam
+
+pytest.importorskip("dbt.version", minversion="1.4")
+
 
 manifest_path = Path(__file__).joinpath("..", "sample_manifest.json").resolve()
 manifest = json.loads(manifest_path.read_bytes())
@@ -28,16 +29,6 @@ test_dagster_metadata_manifest_path = (
     .resolve()
 )
 test_dagster_metadata_manifest = json.loads(test_dagster_metadata_manifest_path.read_bytes())
-
-
-def test_materialize(test_project_dir):
-    @dbt_assets(manifest=manifest)
-    def all_dbt_assets(context, dbt: DbtCliResource):
-        yield from dbt.cli(["build"], context=context).stream()
-
-    assert materialize(
-        [all_dbt_assets], resources={"dbt": DbtCliResource(project_dir=test_project_dir)}
-    ).success
 
 
 @pytest.mark.parametrize("manifest", [manifest, manifest_path, os.fspath(manifest_path)])

--- a/python_modules/libraries/dagster-dbt/setup.py
+++ b/python_modules/libraries/dagster-dbt/setup.py
@@ -43,6 +43,7 @@ setup(
         "requests",
         "rich",
         "typer>=0.9.0",
+        "packaging",
     ],
     extras_require={
         "test": [


### PR DESCRIPTION
## Summary & Motivation
A couple of users have run into this, so rather than disclosing this in documentation, enforce it at the framework level.

When using `DbtCliResource`, `dbt-core>=1.4.0` is required as we make use of [dbt's standardized event log structure](https://docs.getdbt.com/reference/events-logging) to emit Dagster events.

Until `dbt-core<1.4` is EOL, we should emit an exception when the user using an older version of `dbt-core`.

## How I Tested These Changes
pytest
