### PR TITLE
[ConfigEditorHelp] Show type not found instead of crashing page

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/package.json
+++ b/js_modules/dagster-ui/packages/ui-components/package.json
@@ -86,7 +86,7 @@
     "jest": "^29.5.0",
     "jest-environment-jsdom": "^29.5.0",
     "nearest-color": "^0.4.4",
-    "prettier": "2.2.1",
+    "prettier": "3.0.3",
     "react": "^18.2.0",
     "react-docgen-typescript-plugin": "^1.0.5",
     "react-dom": "^18.2.0",

--- a/js_modules/dagster-ui/packages/ui-components/src/components/ConfigTypeSchema.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/ConfigTypeSchema.tsx
@@ -17,12 +17,32 @@ interface ConfigTypeSchemaProps {
   maxDepth?: number;
 }
 
-function renderTypeRecursive(
+// Either type is guaranteed not to be undefined or if its possibly undefined
+// then pass in the type name. This is a union to avoid called of ConfigEditorHelp from needing to pass a type name
+// which doens't make sense at the root
+type renderTypeRecursiveType = ((
   type: TypeData,
   typeLookup: {[typeName: string]: TypeData},
   depth: number,
   props: ConfigTypeSchemaProps,
-): React.ReactElement<HTMLElement> {
+  typeName?: string,
+) => React.ReactElement<HTMLElement>) &
+  ((
+    type: TypeData | undefined,
+    typeLookup: {[typeName: string]: TypeData},
+    depth: number,
+    props: ConfigTypeSchemaProps,
+    typeName: string,
+  ) => React.ReactElement<HTMLElement>);
+
+const renderTypeRecursive: renderTypeRecursiveType = (type, typeLookup, depth, props, typeName) => {
+  if (!type) {
+    return (
+      <span style={{color: Colors.Red500, opacity: 0.6}}>
+        type &quot;{typeName}&quot; not found
+      </span>
+    );
+  }
   if (type.__typename === 'CompositeConfigType' && props.maxDepth && depth === props.maxDepth) {
     return <span>...</span>;
   }
@@ -67,10 +87,11 @@ function renderTypeRecursive(
               {!fieldData.isRequired && Optional}
               {`: `}
               {renderTypeRecursive(
-                typeLookup[fieldData.configTypeKey]!,
+                typeLookup[fieldData.configTypeKey],
                 typeLookup,
                 depth + 1,
                 props,
+                fieldData.configTypeKey,
               )}
             </DictEntry>
           );
@@ -82,7 +103,7 @@ function renderTypeRecursive(
 
   if (type.__typename === 'ArrayConfigType') {
     const ofTypeKey = type.typeParamKeys[0]!;
-    return <>[{renderTypeRecursive(typeLookup[ofTypeKey]!, typeLookup, depth, props)}]</>;
+    return <>[{renderTypeRecursive(typeLookup[ofTypeKey], typeLookup, depth, props, ofTypeKey)}]</>;
   }
 
   if (type.__typename === 'MapConfigType') {
@@ -98,8 +119,15 @@ function renderTypeRecursive(
         {`{`}
         <DictEntry>
           {innerIndent}[{type.keyLabelName ? `${type.keyLabelName}: ` : null}
-          {renderTypeRecursive(typeLookup[keyTypeKey]!, typeLookup, depth + 1, props)}]{`: `}
-          {renderTypeRecursive(typeLookup[valueTypeKey]!, typeLookup, depth + 1, props)}
+          {renderTypeRecursive(typeLookup[keyTypeKey], typeLookup, depth + 1, props, keyTypeKey)}]
+          {`: `}
+          {renderTypeRecursive(
+            typeLookup[valueTypeKey],
+            typeLookup,
+            depth + 1,
+            props,
+            valueTypeKey,
+          )}
         </DictEntry>
         {'  '.repeat(depth) + '}'}
       </>
@@ -110,7 +138,7 @@ function renderTypeRecursive(
     const ofTypeKey = type.typeParamKeys[0]!;
     return (
       <>
-        {renderTypeRecursive(typeLookup[ofTypeKey]!, typeLookup, depth, props)}
+        {renderTypeRecursive(typeLookup[ofTypeKey], typeLookup, depth, props, ofTypeKey)}
         {Optional}
       </>
     );
@@ -118,16 +146,18 @@ function renderTypeRecursive(
 
   if (type.__typename === 'ScalarUnionConfigType') {
     const nonScalarTypeMarkup = renderTypeRecursive(
-      typeLookup[type.nonScalarTypeKey]!,
+      typeLookup[type.nonScalarTypeKey],
       typeLookup,
       depth,
       props,
+      type.nonScalarTypeKey,
     );
     const scalarTypeMarkup = renderTypeRecursive(
-      typeLookup[type.scalarTypeKey]!,
+      typeLookup[type.scalarTypeKey],
       typeLookup,
       depth,
       props,
+      type.scalarTypeKey,
     );
 
     return (
@@ -138,7 +168,7 @@ function renderTypeRecursive(
   }
 
   return <span>{type.givenName}</span>;
-}
+};
 
 export const tryPrettyPrintJSON = (jsonString: string) => {
   try {
@@ -276,8 +306,9 @@ const DictEntry = React.forwardRef(
     props: React.ComponentProps<typeof DictEntryDiv>,
     ref: React.ForwardedRef<HTMLButtonElement>,
   ) => {
-    const {hovered, onMouseEnter, onMouseLeave} =
-      React.useContext(HoveredDictEntryContext).useDictEntryHover();
+    const {hovered, onMouseEnter, onMouseLeave} = React.useContext(
+      HoveredDictEntryContext,
+    ).useDictEntryHover();
 
     return (
       <DictEntryDiv2>

--- a/js_modules/dagster-ui/packages/ui-components/src/components/ConfigTypeSchema.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/ConfigTypeSchema.tsx
@@ -306,9 +306,8 @@ const DictEntry = React.forwardRef(
     props: React.ComponentProps<typeof DictEntryDiv>,
     ref: React.ForwardedRef<HTMLButtonElement>,
   ) => {
-    const {hovered, onMouseEnter, onMouseLeave} = React.useContext(
-      HoveredDictEntryContext,
-    ).useDictEntryHover();
+    const {hovered, onMouseEnter, onMouseLeave} =
+      React.useContext(HoveredDictEntryContext).useDictEntryHover();
 
     return (
       <DictEntryDiv2>

--- a/js_modules/dagster-ui/yarn.lock
+++ b/js_modules/dagster-ui/yarn.lock
@@ -2460,7 +2460,7 @@ __metadata:
     jest: ^29.5.0
     jest-environment-jsdom: ^29.5.0
     nearest-color: ^0.4.4
-    prettier: 2.2.1
+    prettier: 3.0.3
     react: ^18.2.0
     react-docgen-typescript-plugin: ^1.0.5
     react-dom: ^18.2.0
@@ -22323,12 +22323,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:2.2.1":
-  version: 2.2.1
-  resolution: "prettier@npm:2.2.1"
+"prettier@npm:3.0.3, prettier@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "prettier@npm:3.0.3"
   bin:
-    prettier: bin-prettier.js
-  checksum: 800de2df3d37067ab24478c7f32c60ca0c57b01742133287829feeb4a70d239a7bf6bccb56196784777af591ad80fb9ba70c1a49b0fcecf9f5622a764d513edb
+    prettier: bin/prettier.cjs
+  checksum: e10b9af02b281f6c617362ebd2571b1d7fc9fb8a3bd17e371754428cda992e5e8d8b7a046e8f7d3e2da1dcd21aa001e2e3c797402ebb6111b5cd19609dd228e0
   languageName: node
   linkType: hard
 
@@ -22338,15 +22338,6 @@ __metadata:
   bin:
     prettier: bin-prettier.js
   checksum: b49e409431bf129dd89238d64299ba80717b57ff5a6d1c1a8b1a28b590d998a34e083fa13573bc732bb8d2305becb4c9a4407f8486c81fa7d55100eb08263cf8
-  languageName: node
-  linkType: hard
-
-"prettier@npm:^3.0.3":
-  version: 3.0.3
-  resolution: "prettier@npm:3.0.3"
-  bin:
-    prettier: bin/prettier.cjs
-  checksum: e10b9af02b281f6c617362ebd2571b1d7fc9fb8a3bd17e371754428cda992e5e8d8b7a046e8f7d3e2da1dcd21aa001e2e3c797402ebb6111b5cd19609dd228e0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary & Motivation

[datadog shows errors](https://app.datadoghq.com/rum/error-tracking?query=%40application.id%3A7edc09bb-51d0-4555-90cd-b19ca483d1fe&issueId=469b2f24-562f-11ee-9662-da7ad0900002&refresh_mode=sliding&from_ts=1695316756839&to_ts=1695331156839&live=true) where type is undefined here. Instead of using `!` to pass the type in we'll assume it's possibly undefined and show a message saying we couldn't find the type.

## How I Tested These Changes
Example:
<img width="426" alt="Screenshot 2023-09-21 at 5 18 58 PM" src="https://github.com/dagster-io/dagster/assets/2286579/c20e1782-8714-4e94-b54c-007d2f852b62">
