### PR TITLE
wipe asset checks

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_checks.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_checks.py
@@ -149,9 +149,7 @@ def _execution_targets_latest_materialization(
     ]:
         evaluation = cast(
             AssetCheckEvaluation,
-            check.not_none(
-                check.not_none(execution.evaluation_event).dagster_event
-            ).event_specific_data,
+            check.not_none(check.not_none(execution.event).dagster_event).event_specific_data,
         )
         if not evaluation.target_materialization_data:
             # check ran before the materialization was created

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_checks.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_checks.py
@@ -100,11 +100,7 @@ class GrapheneAssetCheckExecution(graphene.ObjectType):
         self.id = str(execution.id)
         self.runId = execution.run_id
         self.status = status
-        self.evaluation = (
-            GrapheneAssetCheckEvaluation(execution.evaluation_event)
-            if execution.evaluation_event
-            else None
-        )
+        self.evaluation = GrapheneAssetCheckEvaluation(execution.event) if execution.event else None
         self.timestamp = execution.create_timestamp
 
 

--- a/python_modules/dagster/dagster/_core/storage/asset_check_execution_record.py
+++ b/python_modules/dagster/dagster/_core/storage/asset_check_execution_record.py
@@ -1,7 +1,9 @@
 import enum
 from typing import NamedTuple, Optional
 
+import dagster._check as check
 from dagster import EventLogEntry
+from dagster._core.events import DagsterEventType
 
 
 # We store a limit set of statuses in the database, and then resolve them to the actual status
@@ -22,9 +24,36 @@ class AssetCheckExecutionResolvedStatus(enum.Enum):
     SKIPPED = "SKIPPED"  # the run finished, didn't fail, but the check didn't execute
 
 
-class AssetCheckExecutionRecord(NamedTuple):
-    id: int
-    run_id: str
-    status: AssetCheckExecutionRecordStatus
-    evaluation_event: Optional[EventLogEntry]
-    create_timestamp: float
+class AssetCheckExecutionRecord(
+    NamedTuple(
+        "_AssetCheckExecutionRecord",
+        [
+            ("id", int),
+            ("run_id", str),
+            ("status", AssetCheckExecutionRecordStatus),
+            # Either an AssetCheckEvaluationPlanned or AssetCheckEvaluation event.
+            # Optional for backwards compatibility, before we started storing planned events.
+            # Old records won't have an event if the status is PLANNED.
+            ("event", Optional[EventLogEntry]),
+            ("create_timestamp", float),
+        ],
+    )
+):
+    def __new__(cls, id, run_id, status, event, create_timestamp):
+        check.inst_param(status, "status", AssetCheckExecutionRecordStatus)
+        check.opt_inst_param(event, "event", EventLogEntry)
+
+        if status == AssetCheckExecutionRecordStatus.PLANNED:
+            check.invariant(
+                event is None
+                or event.dagster_event_type == DagsterEventType.ASSET_CHECK_EVALUATION_PLANNED
+            )
+
+        return super(AssetCheckExecutionRecord, cls).__new__(
+            cls,
+            id=check.int_param(id, "id"),
+            run_id=check.str_param(run_id, "run_id"),
+            status=check.inst_param(status, "status", AssetCheckExecutionRecordStatus),
+            event=check.opt_inst_param(event, "event", EventLogEntry),
+            create_timestamp=check.float_param(create_timestamp, "create_timestamp"),
+        )

--- a/python_modules/dagster/dagster/_core/storage/event_log/schema.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/schema.py
@@ -151,7 +151,9 @@ AssetCheckExecutionsTable = db.Table(
     db.Column("partition", db.Text),  # Currently unused. Planned for future partition support
     db.Column("run_id", db.String(255)),
     db.Column("execution_status", db.String(255)),  # Planned, Success, or Failure
+    # Either an AssetCheckEvaluationPlanned or AssetCheckEvaluation event
     db.Column("evaluation_event", db.Text),
+    # Timestamp for an AssetCheckEvaluationPlanned, then replaced by timestamp for the AssetCheckEvaluation event
     db.Column("evaluation_event_timestamp", db.DateTime),
     db.Column(
         "evaluation_event_storage_id",

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -2524,6 +2524,8 @@ class SqlEventLogStorage(EventLogStorage):
                     check_name=planned.check_name,
                     run_id=event.run_id,
                     execution_status=AssetCheckExecutionRecordStatus.PLANNED.value,
+                    evaluation_event=serialize_value(event),
+                    evaluation_event_timestamp=datetime.utcfromtimestamp(event.timestamp),
                 )
             )
 
@@ -2652,9 +2654,7 @@ class SqlEventLogStorage(EventLogStorage):
                 id=cast(int, row[0]),
                 run_id=cast(str, row[1]),
                 status=AssetCheckExecutionRecordStatus(row[2]),
-                evaluation_event=(
-                    deserialize_value(cast(str, row[3]), EventLogEntry) if row[3] else None
-                ),
+                event=(deserialize_value(cast(str, row[3]), EventLogEntry) if row[3] else None),
                 create_timestamp=datetime_as_float(cast(datetime, row[4])),
             )
             for row in rows

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -4025,6 +4025,7 @@ class TestEventLogStorage:
         assert len(checks) == 1
         assert checks[0].status == AssetCheckExecutionRecordStatus.PLANNED
         assert checks[0].run_id == "foo"
+        assert checks[0].event.dagster_event_type == DagsterEventType.ASSET_CHECK_EVALUATION_PLANNED
 
         checks = storage.get_asset_check_executions(
             AssetKey(["my_asset"]), "my_check", limit=10, include_planned=False
@@ -4064,10 +4065,9 @@ class TestEventLogStorage:
         checks = storage.get_asset_check_executions(AssetKey(["my_asset"]), "my_check", limit=10)
         assert len(checks) == 1
         assert checks[0].status == AssetCheckExecutionRecordStatus.SUCCEEDED
+        assert checks[0].event.dagster_event_type == DagsterEventType.ASSET_CHECK_EVALUATION
         assert (
-            checks[
-                0
-            ].evaluation_event.dagster_event.event_specific_data.target_materialization_data.storage_id
+            checks[0].event.dagster_event.event_specific_data.target_materialization_data.storage_id
             == 42
         )
 


### PR DESCRIPTION
Hide asset check executions when the target asset is wiped.

Use the timestamp of the planned and evaluation events. As a result if you wipe while the check is in progress we'll ignore the planned event and stop showing in progress, then we will show the evaluation. Kinda odd but it's the same behavior as assets and probably rare.

SELF NOTE: this and https://github.com/dagster-io/dagster/pull/16748 need cloud counterparts