### PR TITLE
allow duplicate AssetDeps passed to deps if those AssetDeps are the same

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -1322,7 +1322,8 @@ def _make_asset_deps(deps: Optional[Iterable[CoercibleToAssetDep]]) -> Optional[
 
             # we cannot do deduplication via a set because MultiPartitionMappings have an internal
             # dictionary that cannot be hashed. Instead deduplicate by making a dictionary and checking
-            # for existing keys.
+            # for existing keys. If an asset is specified as a dependency more than once, only error if the
+            # dependency is different (ie has a different PartitionMapping)
             if (
                 asset_dep.asset_key in dep_dict.keys()
                 and asset_dep != dep_dict[asset_dep.asset_key]

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -1323,7 +1323,10 @@ def _make_asset_deps(deps: Optional[Iterable[CoercibleToAssetDep]]) -> Optional[
             # we cannot do deduplication via a set because MultiPartitionMappings have an internal
             # dictionary that cannot be hashed. Instead deduplicate by making a dictionary and checking
             # for existing keys.
-            if asset_dep.asset_key in dep_dict.keys():
+            if (
+                asset_dep.asset_key in dep_dict.keys()
+                and asset_dep != dep_dict[asset_dep.asset_key]
+            ):
                 raise DagsterInvariantViolationError(
                     f"Cannot set a dependency on asset {asset_dep.asset_key} more than once per"
                     " asset."


### PR DESCRIPTION
## Summary & Motivation
With the switch to using AssetDeps, if a user passes the same asset twice to `deps`, they now get an exception. Older versions of the code silently deduplicated the dependencies. This PR goes back to the previous behavior as long as the `AssetDeps` are the same (ie have the same partition mapping)

## How I Tested These Changes
new unit test