### PR TITLE
Add ability to merge k8s config deeply instead of shallowly when combining it from multiple sources.

### DIFF
--- a/integration_tests/test_suites/k8s-test-suite/tests/test_k8s_job_op.py
+++ b/integration_tests/test_suites/k8s-test-suite/tests/test_k8s_job_op.py
@@ -3,6 +3,7 @@ import uuid
 import kubernetes
 import pytest
 from dagster import RetryRequested, job, op
+from dagster._core.test_utils import instance_for_test
 from dagster_k8s import execute_k8s_job, k8s_job_op
 from dagster_k8s.client import DagsterK8sError, DagsterKubernetesClient
 from dagster_k8s.job import get_k8s_job_name
@@ -229,6 +230,105 @@ def test_k8s_job_op_with_container_config(namespace, cluster_provider):
     job_name = get_k8s_job_name(run_id, with_container_config.name)
 
     assert "SHELL_FROM_CONTAINER_CONFIG" in _get_pod_logs(cluster_provider, job_name, namespace)
+
+
+@pytest.mark.default
+def test_k8s_job_op_with_deep_merge(namespace, cluster_provider):
+    # Set run launcher config just to pull run_k8s_config when running the op - does not actually
+    # launch the run
+    with instance_for_test(
+        overrides={
+            "run_launcher": {
+                "module": "dagster_k8s",
+                "class": "K8sRunLauncher",
+                "config": {
+                    "instance_config_map": "doesnt_matter",
+                    "service_account_name": "default",
+                    "load_incluster_config": False,
+                    "kubeconfig_file": cluster_provider.kubeconfig_file,
+                    "run_k8s_config": {
+                        "container_config": {
+                            "env": [
+                                {
+                                    "name": "FOO",
+                                    "value": "1",
+                                }
+                            ]
+                        }
+                    },
+                },
+            }
+        }
+    ) as instance:
+
+        @job
+        def with_config_job():
+            k8s_job_op()
+
+        # Shallow merge - only BAR is set
+
+        execute_result = with_config_job.execute_in_process(
+            instance=instance,
+            run_config={
+                "ops": {
+                    "k8s_job_op": {
+                        "config": {
+                            "image": "busybox",
+                            "container_config": {
+                                "command": ["/bin/sh", "-c"],
+                                "args": ['echo "FOO IS $FOO AND BAR IS $BAR"'],
+                                "env": [
+                                    {
+                                        "name": "BAR",
+                                        "value": "2",
+                                    }
+                                ],
+                            },
+                            "namespace": namespace,
+                            "load_incluster_config": False,
+                            "kubeconfig_file": cluster_provider.kubeconfig_file,
+                        }
+                    }
+                }
+            },
+        )
+        run_id = execute_result.dagster_run.run_id
+        job_name = get_k8s_job_name(run_id, k8s_job_op.name)
+
+        assert "FOO IS  AND BAR IS 2" in _get_pod_logs(cluster_provider, job_name, namespace)
+
+        # now with deep merge, both are set
+
+        execute_result = with_config_job.execute_in_process(
+            instance=instance,
+            run_config={
+                "ops": {
+                    "k8s_job_op": {
+                        "config": {
+                            "image": "busybox",
+                            "container_config": {
+                                "command": ["/bin/sh", "-c"],
+                                "args": ['echo "FOO IS $FOO AND BAR IS $BAR"'],
+                                "env": [
+                                    {
+                                        "name": "BAR",
+                                        "value": "2",
+                                    }
+                                ],
+                            },
+                            "namespace": namespace,
+                            "load_incluster_config": False,
+                            "kubeconfig_file": cluster_provider.kubeconfig_file,
+                            "merge_behavior": "DEEP",
+                        }
+                    }
+                }
+            },
+        )
+        run_id = execute_result.dagster_run.run_id
+        job_name = get_k8s_job_name(run_id, k8s_job_op.name)
+
+        assert "FOO IS 1 AND BAR IS 2" in _get_pod_logs(cluster_provider, job_name, namespace)
 
 
 @pytest.mark.default

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/__init__.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/__init__.py
@@ -3,6 +3,7 @@ from dagster._core.libraries import DagsterLibraryRegistry
 from .executor import k8s_job_executor as k8s_job_executor
 from .job import (
     DagsterK8sJobConfig as DagsterK8sJobConfig,
+    K8sConfigMergeBehavior as K8sConfigMergeBehavior,
     construct_dagster_k8s_job as construct_dagster_k8s_job,
 )
 from .launcher import K8sRunLauncher as K8sRunLauncher

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
@@ -3,6 +3,7 @@ import hashlib
 import json
 import random
 import string
+from enum import Enum
 from typing import Any, List, Mapping, NamedTuple, Optional, Sequence
 
 import dagster._check as check
@@ -10,6 +11,7 @@ import kubernetes
 from dagster import (
     Array,
     BoolSource,
+    Enum as DagsterEnum,
     Field,
     Noneable,
     StringSource,
@@ -49,6 +51,16 @@ MAX_K8S_NAME_LEN = 63
 K8S_RESOURCE_REQUIREMENTS_KEY = "dagster-k8s/resource_requirements"
 K8S_RESOURCE_REQUIREMENTS_SCHEMA = Shape({"limits": Permissive(), "requests": Permissive()})
 
+
+class K8sConfigMergeBehavior(Enum):
+    SHALLOW = (  # Top-level keys in each of 'container_config' / 'pod_spec_config' are replaced
+        "SHALLOW"
+    )
+    DEEP = (  # Dictionaries are deep-merged, lists are appended after removing values that are already present
+        "DEEP"
+    )
+
+
 USER_DEFINED_K8S_CONFIG_KEY = "dagster-k8s/config"
 USER_DEFINED_K8S_CONFIG_SCHEMA = Shape(
     {
@@ -58,6 +70,10 @@ USER_DEFINED_K8S_CONFIG_SCHEMA = Shape(
         "job_config": Permissive(),
         "job_metadata": Permissive(),
         "job_spec_config": Permissive(),
+        "merge_behavior": Field(
+            DagsterEnum.from_python_enum(K8sConfigMergeBehavior),
+            is_required=False,
+        ),
     }
 )
 
@@ -77,6 +93,7 @@ class UserDefinedDagsterK8sConfig(
             ("job_config", Mapping[str, Any]),
             ("job_metadata", Mapping[str, Any]),
             ("job_spec_config", Mapping[str, Any]),
+            ("merge_behavior", K8sConfigMergeBehavior),
         ],
     )
 ):
@@ -88,6 +105,7 @@ class UserDefinedDagsterK8sConfig(
         job_config: Optional[Mapping[str, Any]] = None,
         job_metadata: Optional[Mapping[str, Any]] = None,
         job_spec_config: Optional[Mapping[str, Any]] = None,
+        merge_behavior: K8sConfigMergeBehavior = K8sConfigMergeBehavior.SHALLOW,
     ):
         container_config = check.opt_mapping_param(
             container_config, "container_config", key_type=str
@@ -128,6 +146,9 @@ class UserDefinedDagsterK8sConfig(
             job_config=job_config,
             job_metadata=job_metadata,
             job_spec_config=job_spec_config,
+            merge_behavior=check.inst_param(
+                merge_behavior, "merge_behavior", K8sConfigMergeBehavior
+            ),
         )
 
     def to_dict(self):
@@ -138,6 +159,7 @@ class UserDefinedDagsterK8sConfig(
             "job_config": self.job_config,
             "job_metadata": self.job_metadata,
             "job_spec_config": self.job_spec_config,
+            "merge_behavior": self.merge_behavior.value,
         }
 
     @classmethod
@@ -149,6 +171,9 @@ class UserDefinedDagsterK8sConfig(
             job_config=config_dict.get("job_config"),
             job_metadata=config_dict.get("job_metadata"),
             job_spec_config=config_dict.get("job_spec_config"),
+            merge_behavior=K8sConfigMergeBehavior(
+                config_dict.get("merge_behavior", K8sConfigMergeBehavior.SHALLOW.value)
+            ),
         )
 
 
@@ -188,9 +213,9 @@ def get_user_defined_k8s_config(tags: Mapping[str, str]):
                 result,
             )
 
-        user_defined_k8s_config = result.value
+        user_defined_k8s_config = check.not_none(result.value)
 
-    container_config = user_defined_k8s_config.get("container_config", {})  # type: ignore
+    container_config = user_defined_k8s_config.get("container_config", {})
 
     # Backcompat for resource requirements key
     if K8S_RESOURCE_REQUIREMENTS_KEY in tags:
@@ -201,11 +226,14 @@ def get_user_defined_k8s_config(tags: Mapping[str, str]):
 
     return UserDefinedDagsterK8sConfig(
         container_config=container_config,
-        pod_template_spec_metadata=user_defined_k8s_config.get("pod_template_spec_metadata"),  # type: ignore
-        pod_spec_config=user_defined_k8s_config.get("pod_spec_config"),  # type: ignore
-        job_config=user_defined_k8s_config.get("job_config"),  # type: ignore
-        job_metadata=user_defined_k8s_config.get("job_metadata"),  # type: ignore
-        job_spec_config=user_defined_k8s_config.get("job_spec_config"),  # type: ignore
+        pod_template_spec_metadata=user_defined_k8s_config.get("pod_template_spec_metadata"),
+        pod_spec_config=user_defined_k8s_config.get("pod_spec_config"),
+        job_config=user_defined_k8s_config.get("job_config"),
+        job_metadata=user_defined_k8s_config.get("job_metadata"),
+        job_spec_config=user_defined_k8s_config.get("job_spec_config"),
+        merge_behavior=K8sConfigMergeBehavior(
+            user_defined_k8s_config.get("merge_behavior", K8sConfigMergeBehavior.SHALLOW.value)
+        ),
     )
 
 
@@ -404,7 +432,16 @@ class DagsterK8sJobConfig(
                     ),
                 ),
                 "run_k8s_config": Field(
-                    USER_DEFINED_K8S_CONFIG_SCHEMA,
+                    Shape(
+                        {
+                            "container_config": Permissive(),
+                            "pod_template_spec_metadata": Permissive(),
+                            "pod_spec_config": Permissive(),
+                            "job_config": Permissive(),
+                            "job_metadata": Permissive(),
+                            "job_spec_config": Permissive(),
+                        }
+                    ),
                     is_required=False,
                     description="Raw Kubernetes configuration for launched runs.",
                 ),
@@ -587,6 +624,10 @@ class DagsterK8sJobConfig(
                             "container_config": Permissive(),
                             "pod_spec_config": Permissive(),
                             "pod_template_spec_metadata": Permissive(),
+                            "merge_behavior": Field(
+                                DagsterEnum.from_python_enum(K8sConfigMergeBehavior),
+                                is_required=False,
+                            ),
                         }
                     ),
                     is_required=False,

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
@@ -206,7 +206,7 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
         pod_name = job_name
 
         job_origin = check.not_none(run.job_code_origin)
-        user_defined_k8s_config = container_context.get_run_user_defined_k8s_config()
+        user_defined_k8s_config = container_context.run_k8s_config
         repository_origin = job_origin.repository_origin
 
         job_config = container_context.get_k8s_job_config(
@@ -362,7 +362,7 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
 
         job_name = get_job_name_from_run_id(run.run_id, resume_attempt_number=resume_attempt_number)
         namespace = container_context.namespace
-        user_defined_k8s_config = container_context.get_run_user_defined_k8s_config()
+        user_defined_k8s_config = container_context.run_k8s_config
         container_name = user_defined_k8s_config.container_config.get("name", "dagster")
         pod_names = self._api_client.get_pod_names_in_job(job_name, namespace=namespace)
         full_msg = ""

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_executor.py
@@ -684,7 +684,7 @@ def test_step_raw_k8s_config_inheritance(
         step_handler_context
     )
 
-    raw_k8s_config = container_context.get_run_user_defined_k8s_config()
+    raw_k8s_config = container_context.run_k8s_config
 
     assert raw_k8s_config.container_config["resources"] == OTHER_RESOURCE_TAGS
     assert raw_k8s_config.container_config["working_dir"] == "MY_WORKING_DIR"


### PR DESCRIPTION
Summary:
Right now if you have a job that specifies e.g. annotations or labels via raw k8s config, there's no way to make it merge in additional labels when combining instance-level config with code-location config with run-level config. This PR adds a new field that you can add to container context that controls how that container context's raw k8s config will be merged with its parent. The default is what it was before (to replace each of the top-level keys, but it can now we set to do deep merges

Arguably this should have been the default all along, since it keeps things consistent with how the top-level fields like env_secrets and labels are combined (add or merge vs. replace). At some point we can consider making that change.

## Summary & Motivation

## How I Tested These Changes
