### PR TITLE
dagster-webserver: pin urllib3 < 2

### DIFF
--- a/python_modules/dagster-webserver/setup.py
+++ b/python_modules/dagster-webserver/setup.py
@@ -48,6 +48,7 @@ setup(
         f"dagster-graphql{pin}",
         "starlette",
         "uvicorn[standard]",
+        "urllib3 <2",
     ],
     extras_require={
         "notebook": ["nbconvert"],  # notebooks support


### PR DESCRIPTION
## Summary & Motivation

When I use `poetry` to add `dagster-webserver`, it automatically adds `urllib3 >=2`, so I have to manually pin it in `pyproject.toml`. Hope this is the correct way to fix it.

## How I Tested These Changes
(NA)