### PR TITLE
Fix double instance initialization

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -99,7 +99,7 @@ class UnboundOpExecutionContext(OpExecutionContext):
         self._resources = self._exit_stack.enter_context(
             build_resources(
                 resources=self._resource_defs,
-                instance=instance,
+                instance=self._instance,
                 resource_config=resources_config,
             )
         )


### PR DESCRIPTION
Summary:
If you don't pass in an instance, the instance gets initialied twice

Test Plan:
Run build_asset_context() in a script, see only one instance being created

## Summary & Motivation

## How I Tested These Changes
