### PR TITLE
Examples quickstart aws minio

### DIFF
--- a/examples/quickstart_aws/README.md
+++ b/examples/quickstart_aws/README.md
@@ -65,6 +65,8 @@ The configurations of the S3 connection are defined in [`quickstart_aws/reposito
   - *Note: `S3Resource` uses boto under the hood, so if you are accessing your private buckets, you will need to provide the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables or follow one of the other boto authentication methods. Check out the [AWS documentation for accessing AWS using your AWS credentials](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html).*
 - `AWS_SECRET_ACCESS_KEY`
 - `S3_BUCKET`
+- `AWS_ENDPOINT_URL_S3` (*optional)
+  - *Note: `AWS_ENDPOINT_URL_S3` is used when using AWS S3 compatible services like MinIO Object Storage. Check out the [Service-specific endpoints](https://docs.aws.amazon.com/sdkref/latest/guide/feature-ss-endpoints.html).*
 
 You can declare environment variables in various ways:
 - **Local development**: [Using `.env` files to load env vars into local environments](https://docs.dagster.io/guides/dagster/using-environment-variables-and-secrets#declaring-environment-variables)

--- a/examples/quickstart_aws/quickstart_aws/assets/hackernews.py
+++ b/examples/quickstart_aws/quickstart_aws/assets/hackernews.py
@@ -83,7 +83,7 @@ def hackernews_topstories_word_cloud(
     # Also, upload the image to S3
     bucket_name = os.environ.get("S3_BUCKET")
     bucket_location = s3.get_client().get_bucket_location(Bucket=bucket_name)["LocationConstraint"]
-    endpoint_url = os.environ.get("AWS_ENDPOINT_URL")
+    endpoint_url = os.environ.get("AWS_ENDPOINT_URL_S3")
     file_name = "hackernews_topstories_word_cloud.png"
     s3.get_client().upload_fileobj(buffer, bucket_name, file_name)
     if endpoint_url:

--- a/examples/quickstart_aws/quickstart_aws/assets/hackernews.py
+++ b/examples/quickstart_aws/quickstart_aws/assets/hackernews.py
@@ -83,9 +83,14 @@ def hackernews_topstories_word_cloud(
     # Also, upload the image to S3
     bucket_name = os.environ.get("S3_BUCKET")
     bucket_location = s3.get_client().get_bucket_location(Bucket=bucket_name)["LocationConstraint"]
+    endpoint_url = os.environ.get("AWS_ENDPOINT_URL")
     file_name = "hackernews_topstories_word_cloud.png"
     s3.get_client().upload_fileobj(buffer, bucket_name, file_name)
-    s3_path = f"https://s3.{bucket_location}.amazonaws.com/{bucket_name}/{file_name}"
+    if endpoint_url:
+        s3_path = f"{endpoint_url}/{bucket_name}/{file_name}"
+    else:
+        s3_path = f"https://s3.{bucket_location}.amazonaws.com/{bucket_name}/{file_name}"
+
     context.add_output_metadata(
         {
             # Attach the Markdown content and s3 file path as metadata to the asset

--- a/examples/quickstart_aws/quickstart_aws/assets/hackernews.py
+++ b/examples/quickstart_aws/quickstart_aws/assets/hackernews.py
@@ -76,6 +76,7 @@ def hackernews_topstories_word_cloud(
     # Save the image to a buffer and embed the image into Markdown content for quick view
     buffer = BytesIO()
     plt.savefig(buffer, format="png")
+    buffer.seek(0) # set the pointer to the beginning
     image_data = base64.b64encode(buffer.getvalue())
     md_content = f"![img](data:image/png;base64,{image_data.decode()})"
 


### PR DESCRIPTION
## Summary & Motivation
When using MinIO, example 'quickstart_aws' don't generate a file (filesize = 0)
## How I Tested These Changes
On Windows 10 and Ubuntu 23.04
python 3.9 from Anaconda env
MinIO on a machine, dagster on an other one
S3 buckets with and without anonymous access
Use local development with '.dev' file


Note: `quickstart_aws/repository.py` is no longer exist (README.md)