### PR TITLE
Add AssetChecksDefinitionProps to replace untyped dictionary shenanigans

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_check_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_check_decorator.py
@@ -8,7 +8,6 @@ from dagster._core.definitions.asset_check_result import AssetCheckResult
 from dagster._core.definitions.asset_check_spec import AssetCheckSpec
 from dagster._core.definitions.asset_checks import (
     AssetChecksDefinition,
-    AssetChecksDefinitionInputOutputProps,
 )
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.events import AssetKey, CoercibleToAssetKey
@@ -170,12 +169,10 @@ def asset_check(
             node_def=op_def,
             resource_defs={},
             specs=[spec],
-            input_output_props=AssetChecksDefinitionInputOutputProps(
-                asset_keys_by_input_name={
-                    input_tuples_by_asset_key[resolved_asset_key][0]: resolved_asset_key
-                },
-                asset_check_keys_by_output_name={op_def.output_defs[0].name: spec.key},
-            ),
+            asset_keys_by_input_name={
+                input_tuples_by_asset_key[resolved_asset_key][0]: resolved_asset_key
+            },
+            asset_check_keys_by_output_name={op_def.output_defs[0].name: spec.key},
         )
 
         return checks_def

--- a/python_modules/dagster/dagster/_utils/test/__init__.py
+++ b/python_modules/dagster/dagster/_utils/test/__init__.py
@@ -3,6 +3,7 @@ import shutil
 import tempfile
 from collections import defaultdict
 from contextlib import contextmanager
+from types import ModuleType
 from typing import Any, Dict, List, Mapping, Optional, Type, cast
 
 # top-level include is dangerous in terms of incurring circular deps
@@ -330,12 +331,20 @@ class ConcurrencyEnabledSqliteTestEventLogStorage(SqliteEventLogStorage, Configu
         return claim_status.with_sleep_interval(float(self._sleep_interval))
 
 
-def get_all_direct_subclasses_of_marker(marker_interface_cls: Type) -> List[Type]:
-    import dagster as dagster
+def get_all_direct_subclasses_of_marker(
+    marker_interface_cls: Type, module: Optional[ModuleType] = None
+) -> List[Type]:
+    """Get all direct subclasses of a given marker interface class from a given module. If the
+    module is not specified, it defaults to the dagster module.
+    """
+    if module is None:
+        import dagster as dagster
+
+        module = dagster
 
     return [
         symbol
-        for symbol in dagster.__dict__.values()
+        for symbol in module.__dict__.values()
         if isinstance(symbol, type)
         and issubclass(symbol, marker_interface_cls)
         and marker_interface_cls

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_i_definition_prop_class_matches_init_adherence.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_i_definition_prop_class_matches_init_adherence.py
@@ -1,0 +1,37 @@
+from inspect import signature
+from typing import List, Type
+
+from dagster._core.definitions import asset_checks
+from dagster._core.definitions.asset_checks import (
+    AssetChecksDefinition,
+    AssetChecksDefinitionProps,
+    IDefinitionPropsClassMatchesInit,
+)
+from dagster._utils.test import get_all_direct_subclasses_of_marker
+
+
+def test_adherence_of_all_idef_props_class_matches_init() -> None:
+    def_types: List[Type] = get_all_direct_subclasses_of_marker(
+        IDefinitionPropsClassMatchesInit, module=asset_checks
+    )
+
+    hard_coded_list = [
+        (AssetChecksDefinition, AssetChecksDefinitionProps),
+    ]
+
+    # keep hard_coded_list up-to-date with all subclasses of IDefinitionPropsClassMatchesInit
+    assert set([def_type.__name__ for def_type in def_types]) == set(
+        [entry[0].__name__ for entry in hard_coded_list]
+    ), (
+        "You likely added a subclass of IDefinitionPropsClassMatchesInit without adding it to the"
+        " hard_coded_list"
+    )
+
+    for def_type, props_type in hard_coded_list:
+        init_params = signature(def_type.__init__).parameters
+        init_param_names_minus_self = set(init_params.keys()) - set(["self"])
+        named_tuple_fields = set(props_type._fields)
+        assert init_param_names_minus_self == named_tuple_fields, (
+            f"You have added either added a field to {props_type.__name__} or removed a parameter"
+            f" from {def_type.__name__}.__init__. They must remain in sync"
+        )


### PR DESCRIPTION
## Summary & Motivation

Right in now in `AssetChecksDefinition` and `AssetsDefinition` we have a bunch of keyword arguments to construct definitions objects, and then for places where we need to make copies keep a parallel `get_attributes_dict` method that has to be kept in sync. Instead here we just create a tuple with the "core properties" of the definition and leverage the typing system to keep everything in sync. This mean less code, and the satisfying deletion of the comment "`if adding new fields, make sure to handle them in the get_attributes_dict method`" and its associated `get_attributes_dict` method.

This also has another key advantage. We can, as a rule, have the props object be _exactly_ what was passed in to the origin construction, rather than anything post-processed. That means that copies will more guaranteed fidelity. We are at risk right now––especially in `AssetsDefinition`––of having the `__init__` method process data in subtle ways that might alter behavior when passed through `__init__` again when copies are made. There is an underlying assumption in that pattern that `__init__` is idempotent, and it is difficult to guarantee that assumption. This pattern avoids that issue entirely.

Another nice side benefit if the elimination of `AssetChecksDefinitionInputOutputProps`, which was quite the mouthful. This just hoists its properties into the top-level object.

I would like to eventually use this pattern in `AssetsDefinition` as part of cleanup of that class. However it is easy to add earlier rather than later, so adding this to `AssetChecksDefinition` now before its complexity inevitably grows.

## How I Tested These Changes

BK
