### PR TITLE
Store asset check planned events in AssetCheckEvaluationsTable

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_checks.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_checks.py
@@ -168,9 +168,7 @@ def _execution_targets_latest_materialization(
     ]:
         evaluation = cast(
             AssetCheckEvaluation,
-            check.not_none(
-                check.not_none(execution.evaluation_event).dagster_event
-            ).event_specific_data,
+            check.not_none(check.not_none(execution.event).dagster_event).event_specific_data,
         )
         if not evaluation.target_materialization_data:
             # check ran before the materialization was created

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_checks.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_checks.py
@@ -8,6 +8,7 @@ from dagster._core.definitions.asset_check_evaluation import (
     AssetCheckEvaluationTargetMaterializationData,
 )
 from dagster._core.definitions.asset_check_spec import AssetCheckKey, AssetCheckSeverity
+from dagster._core.events import DagsterEventType
 from dagster._core.host_representation.external_data import ExternalAssetCheck
 from dagster._core.storage.asset_check_execution_record import (
     AssetCheckExecutionRecord,
@@ -103,8 +104,9 @@ class GrapheneAssetCheckExecution(graphene.ObjectType):
         self.runId = execution.run_id
         self.status = status
         self.evaluation = (
-            GrapheneAssetCheckEvaluation(execution.evaluation_event)
-            if execution.evaluation_event
+            GrapheneAssetCheckEvaluation(execution.event)
+            if execution.event
+            and execution.event.dagster_event_type == DagsterEventType.ASSET_CHECK_EVALUATION
             else None
         )
         self.timestamp = execution.create_timestamp

--- a/python_modules/dagster/dagster/_core/storage/event_log/schema.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/schema.py
@@ -151,7 +151,9 @@ AssetCheckExecutionsTable = db.Table(
     db.Column("partition", db.Text),  # Currently unused. Planned for future partition support
     db.Column("run_id", db.String(255)),
     db.Column("execution_status", db.String(255)),  # Planned, Success, or Failure
+    # Either an AssetCheckEvaluationPlanned or AssetCheckEvaluation event
     db.Column("evaluation_event", db.Text),
+    # Timestamp for an AssetCheckEvaluationPlanned, then replaced by timestamp for the AssetCheckEvaluation event
     db.Column("evaluation_event_timestamp", db.DateTime),
     db.Column(
         "evaluation_event_storage_id",

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -2536,6 +2536,8 @@ class SqlEventLogStorage(EventLogStorage):
                     check_name=planned.check_name,
                     run_id=event.run_id,
                     execution_status=AssetCheckExecutionRecordStatus.PLANNED.value,
+                    evaluation_event=serialize_value(event),
+                    evaluation_event_timestamp=datetime.utcfromtimestamp(event.timestamp),
                 )
             )
 

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -4047,6 +4047,7 @@ class TestEventLogStorage:
         assert len(checks) == 1
         assert checks[0].status == AssetCheckExecutionRecordStatus.PLANNED
         assert checks[0].run_id == "foo"
+        assert checks[0].event.dagster_event_type == DagsterEventType.ASSET_CHECK_EVALUATION_PLANNED
 
         latest_checks = storage.get_latest_asset_check_execution_by_key([check_key_1, check_key_2])
         assert len(latest_checks) == 1
@@ -4081,10 +4082,9 @@ class TestEventLogStorage:
         checks = storage.get_asset_check_execution_history(check_key_1, limit=10)
         assert len(checks) == 1
         assert checks[0].status == AssetCheckExecutionRecordStatus.SUCCEEDED
+        assert checks[0].event.dagster_event_type == DagsterEventType.ASSET_CHECK_EVALUATION
         assert (
-            checks[
-                0
-            ].evaluation_event.dagster_event.event_specific_data.target_materialization_data.storage_id
+            checks[0].event.dagster_event.event_specific_data.target_materialization_data.storage_id
             == 42
         )
 
@@ -4094,7 +4094,7 @@ class TestEventLogStorage:
         assert (
             latest_checks[
                 check_key_1
-            ].evaluation_event.dagster_event.event_specific_data.target_materialization_data.storage_id
+            ].event.dagster_event.event_specific_data.target_materialization_data.storage_id
             == 42
         )
 


### PR DESCRIPTION
Currently the flow is

1. check planned event logged
2. write row to AssetCheckExecutionsTable, with null evaluation_event and evaluation_timestamp
3 check evaluation event logged
4. update row, and fill in evaluation_event and evaluation_timestamp with the AssetCheckEvaluation event

This changes 2 to write the planned event to storage.

This is useful for getting the step key off the planned event, since we can use it to link to the specific step for a check, and report when the check's step is actually running (currently it shows running as soon as the run is created).