### PR TITLE
Optimize has_dynamic_partition

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -1958,7 +1958,7 @@ class SqlEventLogStorage(EventLogStorage):
     def has_dynamic_partition(self, partitions_def_name: str, partition_key: str) -> bool:
         self._check_partitions_table()
         query = (
-            db_select([1])
+            db_select([DynamicPartitionsTable.c.partition])
             .where(
                 db.and_(
                     DynamicPartitionsTable.c.partitions_def_name == partitions_def_name,

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -1938,7 +1938,9 @@ class SqlEventLogStorage(EventLogStorage):
                 " instance migrate`."
             )
 
-    def _fetch_partition_keys_for_partition_def(self, partitions_def_name: str) -> Sequence[str]:
+    def get_dynamic_partitions(self, partitions_def_name: str) -> Sequence[str]:
+        """Get the list of partition keys for a partition definition."""
+        self._check_partitions_table()
         columns = [
             DynamicPartitionsTable.c.partitions_def_name,
             DynamicPartitionsTable.c.partition,
@@ -1952,11 +1954,6 @@ class SqlEventLogStorage(EventLogStorage):
             rows = conn.execute(query).fetchall()
 
         return [cast(str, row[1]) for row in rows]
-
-    def get_dynamic_partitions(self, partitions_def_name: str) -> Sequence[str]:
-        """Get the list of partition keys for a partition definition."""
-        self._check_partitions_table()
-        return self._fetch_partition_keys_for_partition_def(partitions_def_name)
 
     def has_dynamic_partition(self, partitions_def_name: str, partition_key: str) -> bool:
         self._check_partitions_table()


### PR DESCRIPTION
## Summary & Motivation
The present `has_dynamic_partition` implementation is linear time, which in some cases renders it intolerably slow quite soon. For example, the `image_sensor`-scheme in the [docs](https://docs.dagster.io/concepts/partitions-schedules-sensors/partitions) starts taking several seconds at a few thousand partitions on a typical development machine.

This change moves the check from Python into the SQLAlchemy query, making it much faster. `DynamicPartitionsTable` is already conveniently indexed.

## How I Tested These Changes

Before:
```
>>> instance = DagsterInstance.ephemeral()
... instance.add_dynamic_partitions("def name", [str(uuid4()) for _ in range(2500)])
... %timeit -n 100 -r 1 -o instance.has_dynamic_partition("def name", "key")
...
<TimeitResult : 1.73 ms ± 0 ns per loop (mean ± std. dev. of 1 run, 100 loops each)>

>>> instance = DagsterInstance.ephemeral()
... instance.add_dynamic_partitions("def name", [str(uuid4()) for _ in range(5000)])
... %timeit -n 100 -r 1 -o instance.has_dynamic_partition("def name", "key")
...
<TimeitResult : 3.34 ms ± 0 ns per loop (mean ± std. dev. of 1 run, 100 loops each)>

>>> instance = DagsterInstance.ephemeral()
... instance.add_dynamic_partitions("def name", [str(uuid4()) for _ in range(10000)])
... %timeit -n 100 -r 1 -o instance.has_dynamic_partition("def name", "key")
...
<TimeitResult : 7.06 ms ± 0 ns per loop (mean ± std. dev. of 1 run, 100 loops each)>
```

After:
```
>>> instance = DagsterInstance.ephemeral()
... instance.add_dynamic_partitions("def name", [str(uuid4()) for _ in range(100000)])
... %timeit -n 100 -r 1 -o instance.has_dynamic_partition("def name", "key")
...
<TimeitResult : 402 µs ± 0 ns per loop (mean ± std. dev. of 1 run, 100 loops each)>
```