### PR TITLE
Refactor asset key resolution in @asset and @graph_asset

### DIFF
--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -2106,7 +2106,7 @@ def test_graph_asset_cannot_use_key_prefix_name_and_key() -> None:
     with pytest.raises(
         DagsterInvalidDefinitionError,
         match=(
-            "Cannot specify a name or key prefix for graph_asset when the key argument is provided"
+            "Cannot specify a name or key prefix for @graph_asset when the key argument is provided"
         ),
     ):
 
@@ -2119,7 +2119,7 @@ def test_graph_asset_cannot_use_key_prefix_name_and_key() -> None:
     with pytest.raises(
         DagsterInvalidDefinitionError,
         match=(
-            "Cannot specify a name or key prefix for graph_asset when the key argument is provided"
+            "Cannot specify a name or key prefix for @graph_asset when the key argument is provided"
         ),
     ):
 
@@ -2132,7 +2132,7 @@ def test_graph_asset_cannot_use_key_prefix_name_and_key() -> None:
     with pytest.raises(
         DagsterInvalidDefinitionError,
         match=(
-            "Cannot specify a name or key prefix for graph_asset when the key argument is provided"
+            "Cannot specify a name or key prefix for @graph_asset when the key argument is provided"
         ),
     ):
 


### PR DESCRIPTION
## Summary & Motivation

Takes the duplicated logic added in https://github.com/dagster-io/dagster/pull/16751 and consolidates it to a single helper function. There is a surprising amount of incidental complexity in this logic, so stuffing it into a common helper is a win.

I did this as a separate PR so that we can revert it independently in case this introduces a bug in `@asset`.

## How I Tested These Changes

BK
