### PR TITLE
Update project-file-reference.mdx

### DIFF
--- a/docs/content/getting-started/project-file-reference.mdx
+++ b/docs/content/getting-started/project-file-reference.mdx
@@ -1,4 +1,4 @@
-f---
+---
 title: Dagster project files | Dagster Docs
 description: "A reference of the files in a Dagster project."
 ---

--- a/docs/content/getting-started/project-file-reference.mdx
+++ b/docs/content/getting-started/project-file-reference.mdx
@@ -1,4 +1,4 @@
----
+f---
 title: Dagster project files | Dagster Docs
 description: "A reference of the files in a Dagster project."
 ---
@@ -140,7 +140,7 @@ Let's take a look at what each of these files and directories does:
         <br />
         <br /> <strong>Note:</strong> <code>pyproject.toml</code> was introduced
         in{" "}
-        <a href="https://peps.python.org/pep-0518/https://peps.python.org/pep-0518/">
+        <a href="https://peps.python.org/pep-0518/">
           PEP-518
         </a>{" "}
         and meant to replace <code>setup.py</code>, but we may still include a{" "}


### PR DESCRIPTION
Fix the url reference for PEP-0518

## Summary & Motivation

https://peps.python.org/pep-0518/ explains the use for TOML file implementation which was inaccessible because it was pasted twice

## How I Tested These Changes

New link is working fine
