### PR TITLE
provide context class based on type hint

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
@@ -284,6 +284,11 @@ class DecoratedOpFunction(NamedTuple):
     def has_context_arg(self) -> bool:
         return is_context_provided(get_function_params(self.decorated_fn))
 
+    def get_context_arg(self) -> Parameter:
+        if self.has_context_arg():
+            return get_function_params(self.decorated_fn)[0]
+        check.failed("Requested context arg on function that does not have one")
+
     @lru_cache(maxsize=1)
     def _get_function_params(self) -> Sequence[Parameter]:
         return get_function_params(self.decorated_fn)

--- a/python_modules/dagster/dagster/_core/definitions/op_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_definition.py
@@ -30,7 +30,11 @@ from dagster._core.definitions.resource_requirement import (
     OutputManagerRequirement,
     ResourceRequirement,
 )
-from dagster._core.errors import DagsterInvalidInvocationError, DagsterInvariantViolationError
+from dagster._core.errors import (
+    DagsterInvalidDefinitionError,
+    DagsterInvalidInvocationError,
+    DagsterInvariantViolationError,
+)
 from dagster._core.types.dagster_type import DagsterType, DagsterTypeKind
 from dagster._utils import IHasInternalInit
 from dagster._utils.warnings import normalize_renamed_param
@@ -143,9 +147,11 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
                 exclude_nothing=True,
             )
             self._compute_fn = compute_fn
+            _validate_context_type_hint(self._compute_fn.decorated_fn)
         else:
             resolved_input_defs = input_defs
             self._compute_fn = check.callable_param(compute_fn, "compute_fn")
+            _validate_context_type_hint(self._compute_fn)
 
         code_version = normalize_renamed_param(
             code_version,
@@ -504,3 +510,23 @@ def _resolve_output_defs_from_outs(
         )
 
     return output_defs
+
+
+def _validate_context_type_hint(fn):
+    from inspect import _empty as EmptyAnnotation
+
+    from dagster._core.decorator_utils import get_function_params
+    from dagster._core.definitions.decorators.op_decorator import is_context_provided
+    from dagster._core.execution.context.compute import AssetExecutionContext, OpExecutionContext
+
+    params = get_function_params(fn)
+    if is_context_provided(params):
+        if (
+            params[0].annotation is not AssetExecutionContext
+            and params[0].annotation is not OpExecutionContext
+            and params[0].annotation is not EmptyAnnotation
+        ):
+            raise DagsterInvalidDefinitionError(
+                f"Cannot annotate `context` parameter with type {params[0].annotation}. `context`"
+                " must be annotated with AssetExecutionContext, OpExecutionContext, or left blank."
+            )

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -10,11 +10,9 @@ from typing import (
     Optional,
     Sequence,
     Set,
-    cast,
     Union,
+    cast,
 )
-
-from dagster._core.definitions.decorators.op_decorator import DecoratedOpFunction
 
 import dagster._check as check
 from dagster._annotations import deprecated, experimental, public
@@ -25,6 +23,7 @@ from dagster._core.definitions.data_version import (
     DataVersion,
     extract_data_provenance_from_entry,
 )
+from dagster._core.definitions.decorators.op_decorator import DecoratedOpFunction
 from dagster._core.definitions.dependency import Node, NodeHandle
 from dagster._core.definitions.events import (
     AssetKey,

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -1301,8 +1301,8 @@ def build_execution_context(
         context_param = compute_fn.get_context_arg()
         context_annotation = context_param.annotation
 
-    # TODO - i dont know how to move this check to Definition time since we don't know if the op is
-    # part of a graph-backed asset until we have the step execution context, i think
+    # It would be nice to do this check at definition time, rather than at run time, but we don't
+    # know if the op is part of an op job or a graph-backed asset until we have the step execution context
     if context_annotation is AssetExecutionContext and not is_sda_step:
         # AssetExecutionContext requires an AssetsDefinition during init, so an op in an op job
         # cannot be annotated with AssetExecutionContext

--- a/python_modules/dagster/dagster/_core/execution/context/system.py
+++ b/python_modules/dagster/dagster/_core/execution/context/system.py
@@ -899,6 +899,11 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
         return op_config.config if op_config else None
 
     @property
+    def is_op_in_graph(self) -> bool:
+        """Whether this step corresponds to an op within a graph (either @graph, or @graph_asset)."""
+        return self.step.node_handle.parent is not None
+
+    @property
     def is_sda_step(self) -> bool:
         """Whether this step corresponds to a software define asset, inferred by presence of asset info on outputs.
 

--- a/python_modules/dagster/dagster/_core/execution/plan/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/compute.py
@@ -33,7 +33,7 @@ from dagster._core.definitions.op_definition import OpComputeFunction
 from dagster._core.definitions.result import MaterializeResult
 from dagster._core.errors import DagsterExecutionStepExecutionError, DagsterInvariantViolationError
 from dagster._core.events import DagsterEvent
-from dagster._core.execution.context.compute import OpExecutionContext
+from dagster._core.execution.context.compute import build_execution_context
 from dagster._core.execution.context.system import StepExecutionContext
 from dagster._core.system_config.objects import ResolvedRunConfig
 from dagster._utils import iterate_with_context
@@ -147,7 +147,7 @@ def _yield_compute_results(
 ) -> Iterator[OpOutputUnion]:
     check.inst_param(step_context, "step_context", StepExecutionContext)
 
-    context = OpExecutionContext(step_context)
+    context = build_execution_context(step_context)
     user_event_generator = compute_fn(context, inputs)
 
     if isinstance(user_event_generator, Output):

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_context.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_context.py
@@ -2,9 +2,10 @@ import warnings
 
 import dagster._check as check
 import pytest
-from dagster import AssetExecutionContext, OpExecutionContext, job, op
+from dagster import AssetExecutionContext, OpExecutionContext, job, op, asset, materialize, graph_asset, graph_multi_asset, multi_asset, AssetOut, Output, GraphDefinition
 from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.op_definition import OpDefinition
+from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.storage.dagster_run import DagsterRun
 
 
@@ -65,3 +66,227 @@ def test_instance_check():
         test_op_context_instance_check()
 
     test_isinstance.execute_in_process()
+
+def test_context_provided_to_asset():
+    @asset
+    def no_annotation(context):
+        assert isinstance(context, AssetExecutionContext)
+
+    materialize([no_annotation])
+
+    @asset
+    def asset_annotation(context: AssetExecutionContext):
+        assert isinstance(context, AssetExecutionContext)
+
+    materialize([asset_annotation])
+
+    @asset
+    def op_annotation(context: OpExecutionContext):
+        assert isinstance(context, OpExecutionContext)
+        # AssetExecutionContext is an instance of OpExecutionContext, so add this additional check
+        assert not isinstance(context, AssetExecutionContext)
+
+    materialize([op_annotation])
+
+
+def test_context_provided_to_op():
+    @op
+    def no_annotation(context):
+        assert isinstance(context, OpExecutionContext)
+        # AssetExecutionContext is an instance of OpExecutionContext, so add this additional check
+        assert not isinstance(context, AssetExecutionContext)
+
+    @job
+    def no_annotation_job():
+        no_annotation()
+
+    assert no_annotation_job.execute_in_process().success
+
+    @op
+    def asset_annotation(context: AssetExecutionContext):
+        assert isinstance(context, AssetExecutionContext)
+
+    @job
+    def asset_annotation_job():
+        asset_annotation()
+
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match="Cannot annotate @op `context` parameter with type AssetExecutionContext",
+    ):
+        asset_annotation_job.execute_in_process()
+
+    @op
+    def op_annotation(context: OpExecutionContext):
+        assert isinstance(context, OpExecutionContext)
+        # AssetExecutionContext is an instance of OpExecutionContext, so add this additional check
+        assert not isinstance(context, AssetExecutionContext)
+
+    @job
+    def op_annotation_job():
+        op_annotation()
+
+    assert op_annotation_job.execute_in_process().success
+
+
+def test_context_provided_to_multi_asset():
+    @multi_asset(outs={"out1": AssetOut(dagster_type=None), "out2": AssetOut(dagster_type=None)})
+    def no_annotation(context):
+        assert isinstance(context, AssetExecutionContext)
+        return None, None
+
+    materialize([no_annotation])
+
+    @multi_asset(outs={"out1": AssetOut(dagster_type=None), "out2": AssetOut(dagster_type=None)})
+    def asset_annotation(context: AssetExecutionContext):
+        assert isinstance(context, AssetExecutionContext)
+        return None, None
+
+    materialize([asset_annotation])
+
+    @multi_asset(outs={"out1": AssetOut(dagster_type=None), "out2": AssetOut(dagster_type=None)})
+    def op_annotation(context: OpExecutionContext):
+        assert isinstance(context, OpExecutionContext)
+        # AssetExecutionContext is an instance of OpExecutionContext, so add this additional check
+        assert not isinstance(context, AssetExecutionContext)
+        return None, None
+
+    materialize([op_annotation])
+
+
+def test_context_provided_to_graph_asset():
+    @op
+    def no_annotation_op(context):
+        assert isinstance(context, OpExecutionContext)
+        # AssetExecutionContext is an instance of OpExecutionContext, so add this additional check
+        assert not isinstance(context, AssetExecutionContext)
+
+    @graph_asset
+    def no_annotation_asset():
+        return no_annotation_op()
+
+    materialize([no_annotation_asset])
+
+    @op
+    def asset_annotation_op(context: AssetExecutionContext):
+        assert isinstance(context, AssetExecutionContext)
+
+    @graph_asset
+    def asset_annotation_asset():
+        return asset_annotation_op()
+
+    materialize([asset_annotation_asset])
+
+    @op
+    def op_annotation_op(context: OpExecutionContext):
+        assert isinstance(context, OpExecutionContext)
+        # AssetExecutionContext is an instance of OpExecutionContext, so add this additional check
+        assert not isinstance(context, AssetExecutionContext)
+
+    @graph_asset
+    def op_annotation_asset():
+        return op_annotation_op()
+
+    materialize([op_annotation_asset])
+
+
+def test_context_provided_to_graph_multi_asset():
+    @op
+    def no_annotation_op(context):
+        assert isinstance(context, OpExecutionContext)
+        # AssetExecutionContext is an instance of OpExecutionContext, so add this additional check
+        assert not isinstance(context, AssetExecutionContext)
+
+    @graph_multi_asset(
+        outs={"out1": AssetOut(dagster_type=None), "out2": AssetOut(dagster_type=None)}
+    )
+    def no_annotation_asset():
+        return no_annotation_op(), no_annotation_op()
+
+    materialize([no_annotation_asset])
+
+    @op
+    def asset_annotation_op(context: AssetExecutionContext):
+        assert isinstance(context, AssetExecutionContext)
+
+    @graph_multi_asset(
+        outs={"out1": AssetOut(dagster_type=None), "out2": AssetOut(dagster_type=None)}
+    )
+    def asset_annotation_asset():
+        return asset_annotation_op(), asset_annotation_op()
+
+    materialize([asset_annotation_asset])
+
+    @op
+    def op_annotation_op(context: OpExecutionContext):
+        assert isinstance(context, OpExecutionContext)
+        # AssetExecutionContext is an instance of OpExecutionContext, so add this additional check
+        assert not isinstance(context, AssetExecutionContext)
+
+    @graph_multi_asset(
+        outs={"out1": AssetOut(dagster_type=None), "out2": AssetOut(dagster_type=None)}
+    )
+    def op_annotation_asset():
+        return op_annotation_op(), op_annotation_op()
+
+    materialize([op_annotation_asset])
+
+
+def test_context_provided_to_plain_python():
+    # tests a job created using Definitions classes, not decorators
+
+    def no_annotation(context, *args):
+        assert isinstance(context, OpExecutionContext)
+        # AssetExecutionContext is an instance of OpExecutionContext, so add this additional check
+        assert not isinstance(context, AssetExecutionContext)
+        yield Output(1)
+
+    no_annotation_op = OpDefinition(compute_fn=no_annotation, name="no_annotation_op")
+    no_annotation_graph = GraphDefinition(name="no_annotation_graph", node_defs=[no_annotation_op])
+
+    no_annotation_graph.to_job(name="no_annotation_job").execute_in_process()
+
+    def asset_annotation(context: AssetExecutionContext, *args):
+        assert False, "Test should error during context creation"
+
+    asset_annotation_op = OpDefinition(compute_fn=asset_annotation, name="asset_annotation_op")
+    asset_annotation_graph = GraphDefinition(
+        name="asset_annotation_graph", node_defs=[asset_annotation_op]
+    )
+
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match="Cannot annotate @op `context` parameter with type AssetExecutionContext",
+    ):
+        asset_annotation_graph.to_job(name="asset_annotation_job").execute_in_process()
+
+    def op_annotation(context: OpExecutionContext, *args):
+        assert isinstance(context, OpExecutionContext)
+        # AssetExecutionContext is an instance of OpExecutionContext, so add this additional check
+        assert not isinstance(context, AssetExecutionContext)
+        yield Output(1)
+
+    op_annotation_op = OpDefinition(compute_fn=op_annotation, name="op_annotation_op")
+    op_annotation_graph = GraphDefinition(name="op_annotation_graph", node_defs=[op_annotation_op])
+
+    op_annotation_graph.to_job(name="op_annotation_job").execute_in_process()
+
+
+def test_error_on_invalid_context_annotation():
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match="must be annotated with AssetExecutionContext, OpExecutionContext, or left blank",
+    ):
+
+        @op
+        def the_op(context: int):
+            pass
+
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match="must be annotated with AssetExecutionContext, OpExecutionContext, or left blank",
+    ):
+
+        @asset
+        def the_asset(context: int):
+            pass

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_context.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_context.py
@@ -2,7 +2,20 @@ import warnings
 
 import dagster._check as check
 import pytest
-from dagster import AssetExecutionContext, OpExecutionContext, job, op, asset, materialize, graph_asset, graph_multi_asset, multi_asset, AssetOut, Output, GraphDefinition
+from dagster import (
+    AssetExecutionContext,
+    AssetOut,
+    GraphDefinition,
+    OpExecutionContext,
+    Output,
+    asset,
+    graph_asset,
+    graph_multi_asset,
+    job,
+    materialize,
+    multi_asset,
+    op,
+)
 from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.op_definition import OpDefinition
 from dagster._core.errors import DagsterInvalidDefinitionError
@@ -66,6 +79,7 @@ def test_instance_check():
         test_op_context_instance_check()
 
     test_isinstance.execute_in_process()
+
 
 def test_context_provided_to_asset():
     @asset


### PR DESCRIPTION
## Summary & Motivation
Introduces the logic to determine which kind of context to provide to which kind of step. 

Follows these rules:
```
@asset + no type annotation -> AssetExecutionContext
@asset + AssetExecutionContext annotation -> AssetExecutionContext
@asset + OpExecutionContext annotation -> OpExecutionContext 
@op + no type annotation -> OpExecutionContext 
@op + AssetExecutionContext annotation -> Error (see note)
@op + OpExecutionContext -> OpExecutionContext 
```
note: We error when `AssetExecutionContext` type hint is provided to `@op` because we will likely require an `AssetsDefinition` in the `__init__` of `AssetExecutionContext` once we begin to split methods out (see [here](https://github.com/dagster-io/dagster/pull/16596/files#diff-890fa9a676b3b1f25888dcd0c569de82b6c56e3822b969b22c7a923c324fbcbbR1351)). It will be easier to make a change allowing the `AssetExecutionContext` type annotation than it will be to disallow it, so I think we should error in this case for now

For ops in graph-backed assets, we do:
```
@graph_asset @op + no type annotation -> OpExecutionContext
@graph_asset @op + AssetExecutionContext -> AssetExecutionContext 
@graph_asset @op + OpExecutionContext -> OpExecutionContext
```


The reasoning behind `@graph_asset @op + no type annotation -> OpExecutionContext` is best explained with an example:
Imagine you have an op that is used in both a job and a graph-backed asset 

```python
@op 
def my_fun_op(context):
   context.describe_op # this function is on the OpExecutionContext, but not on the AssetExecutionContext

@job 
def my_fun_job():
    my_fun_op()

@graph_asset 
def my_fun_asset():
    my_fun_op()
```
When executing `my_fun_job`, `my_fun_op` will receive an `OpExecutionContext` and run as expected. When materializing `my_fun_asset`, `my_fun_op` will receive an `AssetExecutionContext`. It will fire a deprecation warning, but still call `describe_op` on the internally held `op_execution_context`. When we deprecate the `__get_attr__` behavior [here](https://github.com/dagster-io/dagster/pull/16487/files#diff-890fa9a676b3b1f25888dcd0c569de82b6c56e3822b969b22c7a923c324fbcbbR1314), `my_fun_op` will instead error. 


## How I Tested These Changes
new unit tests