### PR TITLE
Make AssetExecutionContext a subclass of OpExecutionContext

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -1,4 +1,4 @@
-from abc import ABC, abstractmethod
+from abc import ABC, ABCMeta, abstractmethod
 from typing import (
     AbstractSet,
     Any,
@@ -11,8 +11,6 @@ from typing import (
     Set,
     cast,
 )
-
-from typing_extensions import TypeAlias
 
 import dagster._check as check
 from dagster._annotations import deprecated, experimental, public
@@ -46,11 +44,19 @@ from dagster._core.instance import DagsterInstance
 from dagster._core.log_manager import DagsterLogManager
 from dagster._core.storage.dagster_run import DagsterRun
 from dagster._utils.forked_pdb import ForkedPdb
+from dagster._utils.warnings import (
+    deprecation_warning,
+)
 
 from .system import StepExecutionContext
 
 
-class AbstractComputeExecutionContext(ABC):
+# This metaclass has to exist for OpExecutionContext to have a metaclass
+class AbstractComputeMetaclass(ABCMeta):
+    pass
+
+
+class AbstractComputeExecutionContext(ABC, metaclass=AbstractComputeMetaclass):
     """Base class for op context implemented by OpExecutionContext and DagstermillExecutionContext."""
 
     @abstractmethod
@@ -97,7 +103,25 @@ class AbstractComputeExecutionContext(ABC):
         """The parsed config specific to this op."""
 
 
-class OpExecutionContext(AbstractComputeExecutionContext):
+class OpExecutionContextMetaClass(AbstractComputeMetaclass):
+    def __instancecheck__(cls, instance) -> bool:
+        # This makes isinstance(context, OpExecutionContext) throw a deprecation warning when
+        # context is an AssetExecutionContext. This metaclass can be deleted once AssetExecutionContext
+        # has been split into it's own class in 1.7.0
+        if type(instance) is AssetExecutionContext:
+            deprecation_warning(
+                subject="AssetExecutionContext",
+                additional_warn_text=(
+                    "Starting in version 1.7.0 AssetExecutionContext will no longer be a subclass"
+                    " of OpExecutionContext."
+                ),
+                breaking_version="1.7.0",
+                stacklevel=1,
+            )
+        return super().__instancecheck__(instance)
+
+
+class OpExecutionContext(AbstractComputeExecutionContext, metaclass=OpExecutionContextMetaClass):
     """The ``context`` object that can be made available as the first argument to the function
     used for computing an op or asset.
 
@@ -1236,8 +1260,6 @@ class OpExecutionContext(AbstractComputeExecutionContext):
         self._step_execution_context.set_requires_typed_event_stream(error_message=error_message)
 
 
-# actually forking the object type for assets is tricky for users in the cases of:
-#  * manually constructing ops to make AssetsDefinitions
-#  * having ops in a graph that form a graph backed asset
-# so we have a single type that users can call by their preferred name where appropriate
-AssetExecutionContext: TypeAlias = OpExecutionContext
+class AssetExecutionContext(OpExecutionContext):
+    def __init__(self, step_execution_context: StepExecutionContext):
+        super().__init__(step_execution_context=step_execution_context)

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -108,7 +108,7 @@ class OpExecutionContextMetaClass(AbstractComputeMetaclass):
         # This makes isinstance(context, OpExecutionContext) throw a deprecation warning when
         # context is an AssetExecutionContext. This metaclass can be deleted once AssetExecutionContext
         # has been split into it's own class in 1.7.0
-        if type(instance) is AssetExecutionContext:
+        if type(instance) is AssetExecutionContext and cls is not AssetExecutionContext:
             deprecation_warning(
                 subject="AssetExecutionContext",
                 additional_warn_text=(

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_context.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_context.py
@@ -30,6 +30,12 @@ def test_instance_check():
     warnings.resetwarnings()
     warnings.filterwarnings("error")
 
+    class AssetExecutionContextSubclass(AssetExecutionContext):
+        # allows us to confirm isinstance(context, AssetExecutionContext)
+        # does not throw deprecation warnings
+        def __init__(self):
+            pass
+
     @op
     def test_op_context_instance_check(context: OpExecutionContext):
         step_context = context._step_execution_context  # noqa: SLF001
@@ -37,7 +43,22 @@ def test_instance_check():
         op_context = OpExecutionContext(step_execution_context=step_context)
         with pytest.raises(DeprecationWarning):
             isinstance(asset_context, OpExecutionContext)
+        assert not isinstance(op_context, AssetExecutionContext)
+
+        # the instance checks below will not hit the metaclass __instancecheck__ method because
+        # python returns early if the type is the same
+        # https://github.com/python/cpython/blob/b57b4ac042b977e0b42a2f5ddb30ca7edffacfa9/Objects/abstract.c#L2404
+        # but still test for completeness
+        assert isinstance(asset_context, AssetExecutionContext)
         assert isinstance(op_context, OpExecutionContext)
+
+        # since python short circuits when context is AssetExecutionContext and you call
+        # isinstance(context, AssetExecutionContext), make a subclass of AssetExecutionContext
+        # so that we can ensure isinstance(context, AssetExecutionContext) doesn't throw a
+        # deprecation warning
+
+        asset_subclass_context = AssetExecutionContextSubclass()
+        assert isinstance(asset_subclass_context, AssetExecutionContext)
 
     @job
     def test_isinstance():

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_context.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_context.py
@@ -1,5 +1,8 @@
+import warnings
+
 import dagster._check as check
-from dagster import OpExecutionContext, job, op
+import pytest
+from dagster import AssetExecutionContext, OpExecutionContext, job, op
 from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.op_definition import OpDefinition
 from dagster._core.storage.dagster_run import DagsterRun
@@ -20,3 +23,24 @@ def test_op_execution_context():
         ctx_op()
 
     assert foo.execute_in_process().success
+
+
+def test_instance_check():
+    # turn off any outer warnings filters, e.g. ignores that are set in pyproject.toml
+    warnings.resetwarnings()
+    warnings.filterwarnings("error")
+
+    @op
+    def test_op_context_instance_check(context: OpExecutionContext):
+        step_context = context._step_execution_context  # noqa: SLF001
+        asset_context = AssetExecutionContext(step_execution_context=step_context)
+        op_context = OpExecutionContext(step_execution_context=step_context)
+        with pytest.raises(DeprecationWarning):
+            isinstance(asset_context, OpExecutionContext)
+        assert isinstance(op_context, OpExecutionContext)
+
+    @job
+    def test_isinstance():
+        test_op_context_instance_check()
+
+    test_isinstance.execute_in_process()


### PR DESCRIPTION
## Summary & Motivation
Makes `AssetExecutionContext` a subclass of `OpExecutionContext`. Adds a metaclass so that if `context` is an `AssetExecutionContext`, `isinstance(context, OpExecutionContext)` raises a deprecation warning

No methods of `OpExecutionContext` have been overridden in `AssetExecutionContext`. This is just so that we can de-risk making `AssetExecutionContext` a subclass and the changes in #16759 

## How I Tested These Changes
Test is added in #16762 - since getting an `AssetExecutionContext` as the `context` arg requires the changes in #16759 and i couldn't find a way to directly create an `OpExecutionContext` and `AssetExecutionContext` because i couldn't mock the `StepExecutionContext`