### PR TITLE
Add OpExecutionContext isinstance deprecation warning test

### DIFF
--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_context.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_context.py
@@ -283,3 +283,22 @@ def test_error_on_invalid_context_annotation():
         @asset
         def the_asset(context: int):
             pass
+
+
+def test_instance_check():
+    # turn off any outer warnings filters, e.g. ignores that are set in pyproject.toml
+    warnings.resetwarnings()
+    warnings.filterwarnings("error")
+
+    @asset
+    def test_op_context_instance_check(context: AssetExecutionContext):
+        isinstance(context, OpExecutionContext)
+
+    with pytest.raises(DeprecationWarning):
+        materialize([test_op_context_instance_check])
+
+    @asset
+    def test_asset_context_instance_check(context: AssetExecutionContext):
+        isinstance(context, AssetExecutionContext)
+
+    assert materialize([test_asset_context_instance_check]).success


### PR DESCRIPTION
## Summary & Motivation
Adds a test for the deprecation warning introduced in #16761 . Ideally, this type of test would be in that PR, but i haven't found a way to do it without the changes introduced in #16759 

## How I Tested These Changes
