### PR TITLE
[ui] Suggest component: Repair empty state

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/components/Suggest.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/Suggest.tsx
@@ -7,6 +7,7 @@ import * as React from 'react';
 import {List as _List} from 'react-virtualized';
 import {createGlobalStyle} from 'styled-components';
 
+import {Box} from './Box';
 import {Colors} from './Colors';
 import {IconWrapper} from './Icon';
 import {TextInputContainerStyles, TextInputStyles} from './TextInput';
@@ -59,7 +60,13 @@ interface Props<T> extends React.PropsWithChildren<SuggestProps<T>> {
 }
 
 export const Suggest = <T,>(props: Props<T>) => {
-  const {popoverProps = {}, itemHeight = MENU_ITEM_HEIGHT, menuWidth = MENU_WIDTH, ...rest} = props;
+  const {
+    popoverProps = {},
+    itemHeight = MENU_ITEM_HEIGHT,
+    menuWidth = MENU_WIDTH,
+    noResults,
+    ...rest
+  } = props;
 
   const allPopoverProps: Partial<IPopoverProps> = {
     ...popoverProps,
@@ -77,25 +84,39 @@ export const Suggest = <T,>(props: Props<T>) => {
     <BlueprintSuggest<T>
       {...rest}
       inputProps={inputProps as any}
-      itemListRenderer={(props) => (
-        <List
-          style={{outline: 'none', marginRight: -5, paddingRight: 5}}
-          rowCount={props.filteredItems.length}
-          scrollToIndex={
-            props.activeItem && !isCreateNewItem(props.activeItem)
-              ? props.filteredItems.indexOf(props.activeItem)
-              : undefined
-          }
-          rowHeight={itemHeight}
-          rowRenderer={(a: any) => (
-            <div key={a.index} style={a.style}>
-              {props.renderItem(props.filteredItems[a.index] as T, a.index)}
-            </div>
-          )}
-          width={menuWidth}
-          height={Math.min(props.filteredItems.length * itemHeight, itemHeight * VISIBLE_ITEMS)}
-        />
-      )}
+      itemListRenderer={(props) => {
+        const {filteredItems} = props;
+        if (filteredItems.length === 0 && noResults) {
+          return (
+            <Box
+              padding={{vertical: 8, horizontal: 12}}
+              style={{width: menuWidth, outline: 'none', marginRight: -5, paddingRight: 5}}
+            >
+              {noResults}
+            </Box>
+          );
+        }
+
+        return (
+          <List
+            style={{outline: 'none', marginRight: -5, paddingRight: 5}}
+            rowCount={props.filteredItems.length}
+            scrollToIndex={
+              props.activeItem && !isCreateNewItem(props.activeItem)
+                ? props.filteredItems.indexOf(props.activeItem)
+                : undefined
+            }
+            rowHeight={itemHeight}
+            rowRenderer={(a: any) => (
+              <div key={a.index} style={a.style}>
+                {props.renderItem(props.filteredItems[a.index] as T, a.index)}
+              </div>
+            )}
+            width={menuWidth}
+            height={Math.min(props.filteredItems.length * itemHeight, itemHeight * VISIBLE_ITEMS)}
+          />
+        );
+      }}
       popoverProps={allPopoverProps}
     />
   );


### PR DESCRIPTION
## Summary & Motivation

The `noResults` state of `Suggest` was lost in the shuffle during the virtualization refactor. Add it back.

<img width="469" alt="Screenshot 2023-09-25 at 1 47 33 PM" src="https://github.com/dagster-io/dagster/assets/2823852/67333164-8135-465a-923b-b327be8ac813">

## How I Tested These Changes

In a Suggest use case, type a query that leads to no results. Verify that the empty state appears correctly.
