### PR TITLE
Store full asset graph layout in IndexDB and invalidate on graph data changing

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/Util.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/Util.tsx
@@ -188,7 +188,7 @@ export function localStorageAsyncMemoize<
       db = {version: versionKey} as DBWithVersion;
     }
 
-    const r = (await fn(versionKey, arg, ...rest)) as R;
+    const r = (await fn(localStorageKey, versionKey, arg, ...rest)) as R;
     db[hashKey] = r;
     localStorage.setItem(key, JSON.stringify(db));
     return r;

--- a/js_modules/dagster-ui/packages/ui-core/src/app/Util.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/Util.tsx
@@ -148,10 +148,11 @@ export function asyncMemoize<T, R, U extends (arg: T, ...rest: any[]) => Promise
   }) as any;
 }
 
-export function indexedDBAsyncMemoize<T, R, U extends (arg: T, ...rest: any[]) => Promise<R>>(
-  fn: U,
-  hashFn?: (arg: T, ...rest: any[]) => any,
-): U {
+export function indexedDBAsyncMemoize<
+  T,
+  R,
+  U extends (cacheKey: string, versionKey: string, arg: T, ...rest: any[]) => Promise<R>,
+>(fn: U, hashFn?: (arg: T, ...rest: any[]) => any): U {
   return (async (cacheKey: string, versionKey: string, arg: T, ...rest: any[]) => {
     const dbName = 'IndexedDBAsyncMemoizeDB';
     const storeName = 'memoizedValues';
@@ -159,7 +160,7 @@ export function indexedDBAsyncMemoize<T, R, U extends (arg: T, ...rest: any[]) =
 
     return new Promise<R>(async (resolve) => {
       async function computeAndStoreLayout() {
-        const result = await fn(arg, ...rest);
+        const result = await fn(cacheKey, versionKey, arg, ...rest);
         // Resolve the promise before storing the result in IndexedDB
         resolve(result);
 

--- a/js_modules/dagster-ui/packages/ui-core/src/app/Util.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/Util.tsx
@@ -151,20 +151,21 @@ export function asyncMemoize<T, R, U extends (arg: T, ...rest: any[]) => Promise
 export function localStorageAsyncMemoize<
   T,
   R,
-  U extends (versionKey: string, arg: T, ...rest: any[]) => Promise<R>,
+  U extends (localStorageKey: string, versionKey: string, arg: T, ...rest: any[]) => Promise<R>,
 >(
   // Key to that acts as a DB for memoized values
-  localStorageKey: string,
   fn: U,
   hashFn?: (arg: T, ...rest: any[]) => any,
 ): U {
-  const key = `localStorageAsyncMemoize:${localStorageKey}`;
   return (async (
+    // Allows for independent db invalidation on per code location + group basis
+    localStorageKey: string,
     // Key that is used to determine if a value in the DB is stale
     versionKey: string,
     arg: T,
     ...rest: any[]
   ) => {
+    const key = `localStorageAsyncMemoize:${localStorageKey}`;
     type DBWithVersion = Record<string, R> & {version: string};
     const hashKey = hashFn ? hashFn(arg, ...rest) : arg;
     let db = {version: versionKey} as DBWithVersion;

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -152,7 +152,8 @@ const AssetGraphExplorerWithData: React.FC<WithDataProps> = ({
   const {layout, loading, async} = useAssetLayout(
     assetGraphData,
     // Use the pathname as part of the key so that different deployments don't invalidate each other's cached layout
-    `explorer:${pathname}`,
+    // Remove the slash at the end in the key so that the same layout is used for both `/path` and `/path/`
+    `explorer:${pathname.endsWith('/') ? pathname.slice(0, pathname.length - 1) : pathname}`,
     fullAssetGraphData,
   );
   const viewportEl = React.useRef<SVGViewport>();

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -13,6 +13,7 @@ import pickBy from 'lodash/pickBy';
 import uniq from 'lodash/uniq';
 import without from 'lodash/without';
 import React from 'react';
+import {useHistory} from 'react-router-dom';
 import styled from 'styled-components';
 
 import {useFeatureFlags} from '../app/Flags';
@@ -147,7 +148,13 @@ const AssetGraphExplorerWithData: React.FC<WithDataProps> = ({
   allAssetKeys,
 }) => {
   const findAssetLocation = useFindAssetLocation();
-  const {layout, loading, async} = useAssetLayout(assetGraphData, fullAssetGraphData);
+  const pathname = useHistory().location.pathname;
+  const {layout, loading, async} = useAssetLayout(
+    assetGraphData,
+    // Use the pathname as part of the key so that different deployments don't invalidate each other's cached layout
+    `explorer:${pathname}`,
+    fullAssetGraphData,
+  );
   const viewportEl = React.useRef<SVGViewport>();
   const {flagHorizontalDAGs, flagDAGSidebar} = useFeatureFlags();
 

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -147,7 +147,7 @@ const AssetGraphExplorerWithData: React.FC<WithDataProps> = ({
   allAssetKeys,
 }) => {
   const findAssetLocation = useFindAssetLocation();
-  const {layout, loading, async} = useAssetLayout(assetGraphData);
+  const {layout, loading, async} = useAssetLayout(assetGraphData, fullAssetGraphData);
   const viewportEl = React.useRef<SVGViewport>();
   const {flagHorizontalDAGs, flagDAGSidebar} = useFeatureFlags();
 

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphData.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphData.tsx
@@ -61,9 +61,14 @@ export function useAssetGraphData(opsQuery: string, options: AssetGraphFetchScop
     [repoFilteredNodes],
   );
 
+  const fullGraphQueryItems = React.useMemo(
+    () => (nodes ? buildGraphQueryItems(nodes) : []),
+    [nodes],
+  );
+
   const fullAssetGraphData = React.useMemo(
-    () => (graphQueryItems ? buildGraphData(graphQueryItems.map((n) => n.node)) : null),
-    [graphQueryItems],
+    () => (fullGraphQueryItems ? buildGraphData(fullGraphQueryItems.map((n) => n.node)) : null),
+    [fullGraphQueryItems],
   );
 
   const {assetGraphData, graphAssetKeys, allAssetKeys, applyingEmptyDefault} = React.useMemo(() => {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeLineageGraph.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeLineageGraph.tsx
@@ -29,7 +29,10 @@ export const AssetNodeLineageGraph: React.FC<{
 
   const [highlighted, setHighlighted] = React.useState<string | null>(null);
 
-  const {layout, loading} = useAssetLayout(assetGraphData);
+  const basePath = useHistory().location.pathname;
+  // Use the pathname as part of the key so that different deployments don't invalidate each other's cached layout
+  // and so that different assets dont invalidate each others layout
+  const {layout, loading} = useAssetLayout(assetGraphData, `node-lineage:${basePath}`);
   const viewportEl = React.useRef<SVGViewport>();
   const history = useHistory();
 

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
@@ -2,7 +2,7 @@ import memoize from 'lodash/memoize';
 import React from 'react';
 
 import {useFeatureFlags} from '../app/Flags';
-import {asyncMemoize, localStorageAsyncMemoize} from '../app/Util';
+import {asyncMemoize, indexedDBAsyncMemoize} from '../app/Util';
 import {GraphData} from '../asset-graph/Utils';
 import {AssetGraphLayout, LayoutAssetGraphOptions, layoutAssetGraph} from '../asset-graph/layout';
 
@@ -45,13 +45,8 @@ const _assetLayoutCacheKey = (graphData: GraphData) => {
 
 const getFullAssetLayout = memoize(layoutAssetGraph, _assetLayoutCacheKey);
 
-const asyncGetFullAssetLayoutLocalStorage = localStorageAsyncMemoize(
-  (
-    _localStorageKey: string,
-    _versionKey: string,
-    graphData: GraphData,
-    opts: LayoutAssetGraphOptions,
-  ) => {
+const asyncGetFullAssetLayoutLocalStorage = indexedDBAsyncMemoize(
+  (graphData: GraphData, opts: LayoutAssetGraphOptions) => {
     return new Promise<AssetGraphLayout>((resolve) => {
       const worker = new Worker(new URL('../workers/dagre_layout.worker', import.meta.url));
       worker.addEventListener('message', (event) => {

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
@@ -46,8 +46,12 @@ const _assetLayoutCacheKey = (graphData: GraphData) => {
 const getFullAssetLayout = memoize(layoutAssetGraph, _assetLayoutCacheKey);
 
 const asyncGetFullAssetLayoutLocalStorage = localStorageAsyncMemoize(
-  'assetGraphLayout',
-  (_versionKey: string, graphData: GraphData, opts: LayoutAssetGraphOptions) => {
+  (
+    _localStorageKey: string,
+    _versionKey: string,
+    graphData: GraphData,
+    opts: LayoutAssetGraphOptions,
+  ) => {
     return new Promise<AssetGraphLayout>((resolve) => {
       const worker = new Worker(new URL('../workers/dagre_layout.worker', import.meta.url));
       worker.addEventListener('message', (event) => {
@@ -151,7 +155,11 @@ export function useOpLayout(ops: ILayoutOp[], parentOp?: ILayoutOp) {
   };
 }
 
-export function useAssetLayout(graphData: GraphData, fullAssetGraphData?: GraphData) {
+export function useAssetLayout(
+  graphData: GraphData,
+  localStorageKey?: string,
+  fullAssetGraphData?: GraphData,
+) {
   const [state, dispatch] = React.useReducer(reducer, initialState);
   const flags = useFeatureFlags();
 
@@ -166,8 +174,13 @@ export function useAssetLayout(graphData: GraphData, fullAssetGraphData?: GraphD
     async function runAsyncLayout() {
       dispatch({type: 'loading'});
       let layout;
-      if (fullDataCacheKey) {
-        layout = await asyncGetFullAssetLayoutLocalStorage(fullDataCacheKey, graphData, opts);
+      if (localStorageKey) {
+        layout = await asyncGetFullAssetLayoutLocalStorage(
+          localStorageKey,
+          fullDataCacheKey ?? cacheKey,
+          graphData,
+          opts,
+        );
       } else {
         layout = await asyncGetFullAssetLayout(graphData, opts);
       }

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
@@ -45,8 +45,8 @@ const _assetLayoutCacheKey = (graphData: GraphData) => {
 
 const getFullAssetLayout = memoize(layoutAssetGraph, _assetLayoutCacheKey);
 
-const asyncGetFullAssetLayoutLocalStorage = indexedDBAsyncMemoize(
-  (graphData: GraphData, opts: LayoutAssetGraphOptions) => {
+const asyncGetFullAssetLayoutIndexDB = indexedDBAsyncMemoize(
+  (_cacheKey, _versionKey, graphData: GraphData, opts: LayoutAssetGraphOptions) => {
     return new Promise<AssetGraphLayout>((resolve) => {
       const worker = new Worker(new URL('../workers/dagre_layout.worker', import.meta.url));
       worker.addEventListener('message', (event) => {
@@ -170,7 +170,7 @@ export function useAssetLayout(
       dispatch({type: 'loading'});
       let layout;
       if (localStorageKey) {
-        layout = await asyncGetFullAssetLayoutLocalStorage(
+        layout = await asyncGetFullAssetLayoutIndexDB(
           localStorageKey,
           fullDataCacheKey ?? cacheKey,
           graphData,
@@ -188,7 +188,7 @@ export function useAssetLayout(
     } else {
       void runAsyncLayout();
     }
-  }, [cacheKey, fullDataCacheKey, graphData, runAsync, flags]);
+  }, [cacheKey, fullDataCacheKey, graphData, runAsync, flags, localStorageKey]);
 
   return {
     loading: state.loading || !state.layout || state.cacheKey !== cacheKey,


### PR DESCRIPTION
## Summary & Motivation

Store the asset graph layout calculation in localstorage and invalidate it on the graph changing:

Should we update the message about rendering a large graph to indicate that this is a one time operation each time the graph changes?

Would be nice if we pre-computed this on behalf of the user in like a lambda or something and sent it from the server, though for the toys repo it's 1.3MB of data.


## How I Tested These Changes

Locally: super fast loading: https://www.loom.com/share/b5e9ea7426a7486286a4871650dfbea8