### PR TITLE
Renaming core clasess in dagster/_core/pipes

### DIFF
--- a/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/__init__.py
+++ b/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/__init__.py
@@ -1,10 +1,10 @@
 from dagster import Definitions
-from dagster._core.pipes.subprocess import ExtSubprocess
+from dagster._core.pipes.subprocess import PipedSubprocess
 
 from .domain_specific_dsl.stocks_dsl import get_stocks_dsl_example_defs
 from .pure_assets_dsl.assets_dsl import get_asset_dsl_example_defs
 
 defs = Definitions(
     assets=get_asset_dsl_example_defs() + get_stocks_dsl_example_defs(),
-    resources={"subprocess_resource": ExtSubprocess()},
+    resources={"subprocess_resource": PipedSubprocess()},
 )

--- a/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/domain_specific_dsl/stocks_dsl.py
+++ b/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/domain_specific_dsl/stocks_dsl.py
@@ -12,7 +12,7 @@ except ImportError:
 
 from dagster import AssetKey, AssetsDefinition, asset, file_relative_path, multi_asset
 from dagster._core.definitions.asset_spec import AssetSpec
-from dagster._core.pipes.subprocess import ExtSubprocess
+from dagster._core.pipes.subprocess import PipedSubprocess
 
 
 def load_yaml(relative_path: str) -> Dict[str, Any]:
@@ -86,7 +86,7 @@ def assets_defs_from_stock_assets(stock_assets: StockAssets) -> List[AssetsDefin
     ticker_specs = [spec_for_stock_info(stock_info) for stock_info in stock_assets.stock_infos]
 
     @multi_asset(specs=ticker_specs)
-    def fetch_the_tickers(context: AssetExecutionContext, subprocess_resource: ExtSubprocess):
+    def fetch_the_tickers(context: AssetExecutionContext, subprocess_resource: PipedSubprocess):
         python_executable = shutil.which("python")
         assert python_executable is not None
         script_path = file_relative_path(__file__, "user_scripts/fetch_the_tickers.py")

--- a/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/pure_assets_dsl/assets_dsl.py
+++ b/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/pure_assets_dsl/assets_dsl.py
@@ -13,7 +13,7 @@ except ImportError:
     from yaml import Loader
 
 from dagster import AssetKey, asset
-from dagster._core.pipes.subprocess import ExtSubprocess
+from dagster._core.pipes.subprocess import PipedSubprocess
 
 
 def load_yaml(relative_path) -> Dict[str, Any]:
@@ -39,7 +39,7 @@ def from_asset_entries(asset_entries: Dict[str, Any]) -> List[AssetsDefinition]:
         @asset(key=asset_key, deps=deps, description=description, group_name=group_name)
         def _assets_def(
             context: AssetExecutionContext,
-            subprocess_resource: ExtSubprocess,
+            subprocess_resource: PipedSubprocess,
         ) -> None:
             # instead of querying a dummy client, do your real data processing here
 

--- a/examples/experimental/assets_yaml_dsl/assets_yaml_dsl_tests/test_assets_dsl.py
+++ b/examples/experimental/assets_yaml_dsl/assets_yaml_dsl_tests/test_assets_dsl.py
@@ -5,7 +5,7 @@ from assets_yaml_dsl.pure_assets_dsl.assets_dsl import from_asset_entries
 from dagster import AssetsDefinition
 from dagster._core.definitions.events import AssetKey
 from dagster._core.execution.context.invocation import build_asset_context
-from dagster._core.pipes.subprocess import ExtSubprocess
+from dagster._core.pipes.subprocess import PipedSubprocess
 
 
 def assets_defs_from_yaml(yaml_string) -> List[AssetsDefinition]:
@@ -69,7 +69,7 @@ assets:
     assert assets_defs
     assert len(assets_defs) == 1
     assets_def = assets_defs[0]
-    assets_def(context=build_asset_context(), subprocess_resource=ExtSubprocess())
+    assets_def(context=build_asset_context(), subprocess_resource=PipedSubprocess())
 
 
 def test_basic_group() -> None:

--- a/examples/experimental/assets_yaml_dsl/assets_yaml_dsl_tests/test_stocks_dsl.py
+++ b/examples/experimental/assets_yaml_dsl/assets_yaml_dsl_tests/test_stocks_dsl.py
@@ -18,7 +18,7 @@ import yaml
 from assets_yaml_dsl.domain_specific_dsl.stocks_dsl import assets_defs_from_stock_assets
 from dagster import AssetKey
 from dagster._core.definitions import materialize
-from dagster._core.pipes.subprocess import ExtSubprocess
+from dagster._core.pipes.subprocess import PipedSubprocess
 from examples.experimental.assets_yaml_dsl.assets_yaml_dsl.domain_specific_dsl.stocks_dsl import (
     build_stock_assets_object,
 )
@@ -55,5 +55,5 @@ def test_materialize_stocks_dsl():
     stock_assets = build_stock_assets_object(stocks_dsl_document)
     assets_defs = assets_defs_from_stock_assets(stock_assets)
     assert materialize(
-        assets=assets_defs, resources={"subprocess_resource": ExtSubprocess()}
+        assets=assets_defs, resources={"subprocess_resource": PipedSubprocess()}
     ).success

--- a/integration_tests/test_suites/k8s-test-suite/tests/test_external_asset.py
+++ b/integration_tests/test_suites/k8s-test-suite/tests/test_external_asset.py
@@ -5,7 +5,7 @@ import kubernetes
 import pytest
 from dagster import AssetExecutionContext, asset, materialize
 from dagster._core.pipes.client import (
-    ExtContextInjector,
+    PipedProcessContextInjector,
 )
 from dagster._core.pipes.utils import ExtEnvContextInjector, pipes_protocol
 from dagster_k8s import execute_k8s_job
@@ -55,7 +55,7 @@ def test_ext_k8s_pod(namespace, cluster_provider):
     assert mats[0].metadata["is_even"].value is True
 
 
-class ExtConfigMapContextInjector(ExtContextInjector):
+class ExtConfigMapContextInjector(PipedProcessContextInjector):
     def __init__(
         self,
         k8s_client: DagsterKubernetesClient,

--- a/python_modules/dagster-test/dagster_test/toys/external_execution/__init__.py
+++ b/python_modules/dagster-test/dagster_test/toys/external_execution/__init__.py
@@ -3,7 +3,7 @@ import sys
 
 from dagster import AssetExecutionContext, Config, Definitions, asset
 from dagster._core.pipes.subprocess import (
-    ExtSubprocess,
+    PipedSubprocess,
 )
 from pydantic import Field
 
@@ -32,13 +32,13 @@ class NumberConfig(Config):
 
 
 @asset
-def number_x(context: AssetExecutionContext, ext: ExtSubprocess, config: NumberConfig) -> None:
+def number_x(context: AssetExecutionContext, ext: PipedSubprocess, config: NumberConfig) -> None:
     extras = {**get_common_extras(context), "multiplier": config.multiplier}
     ext.run(command_for_asset("number_x"), context=context, extras=extras)
 
 
 @asset
-def number_y(context: AssetExecutionContext, ext: ExtSubprocess, config: NumberConfig):
+def number_y(context: AssetExecutionContext, ext: PipedSubprocess, config: NumberConfig):
     ext.run(
         command_for_asset("number_y"),
         context=context,
@@ -48,11 +48,11 @@ def number_y(context: AssetExecutionContext, ext: ExtSubprocess, config: NumberC
 
 
 @asset(deps=[number_x, number_y])
-def number_sum(context: AssetExecutionContext, ext: ExtSubprocess) -> None:
+def number_sum(context: AssetExecutionContext, ext: PipedSubprocess) -> None:
     ext.run(command_for_asset("number_sum"), context=context, extras=get_common_extras(context))
 
 
-ext = ExtSubprocess(
+ext = PipedSubprocess(
     env=get_env(),
 )
 

--- a/python_modules/dagster/dagster/_core/pipes/client.py
+++ b/python_modules/dagster/dagster/_core/pipes/client.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from .context import ExtMessageHandler, ExtResult
 
 
-class ExtClient(ABC):
+class PipedProcessClient(ABC):
     @abstractmethod
     def run(
         self,
@@ -24,7 +24,7 @@ class ExtClient(ABC):
     ) -> Iterator["ExtResult"]: ...
 
 
-class ExtContextInjector(ABC):
+class PipedProcessContextInjector(ABC):
     @abstractmethod
     @contextmanager
     def inject_context(

--- a/python_modules/dagster/dagster/_core/pipes/subprocess.py
+++ b/python_modules/dagster/dagster/_core/pipes/subprocess.py
@@ -8,9 +8,9 @@ from dagster._core.definitions.resource_annotation import ResourceParam
 from dagster._core.errors import DagsterExternalExecutionError
 from dagster._core.execution.context.compute import OpExecutionContext
 from dagster._core.pipes.client import (
-    ExtClient,
-    ExtContextInjector,
     ExtMessageReader,
+    PipedProcessClient,
+    PipedProcessContextInjector,
 )
 from dagster._core.pipes.context import ExtResult
 from dagster._core.pipes.utils import (
@@ -20,8 +20,8 @@ from dagster._core.pipes.utils import (
 )
 
 
-class _ExtSubprocess(ExtClient):
-    """An ext client that runs a subprocess with the given command and environment.
+class _PipedSubprocess(PipedProcessClient):
+    """A pipes client that runs a subprocess with the given command and environment.
 
     By default parameters are injected via environment variables. And then context is passed via
     a temp file, and structured messages are read from from a temp file.
@@ -29,15 +29,15 @@ class _ExtSubprocess(ExtClient):
     Args:
         env (Optional[Mapping[str, str]]): An optional dict of environment variables to pass to the subprocess.
         cwd (Optional[str]): Working directory in which to launch the subprocess command.
-        context_injector (Optional[ExtContextInjector]): An context injector to use to inject context into the subprocess. Defaults to ExtTempFileContextInjector.
-        message_reader (Optional[ExtContextInjector]): An context injector to use to read messages from  the subprocess. Defaults to ExtTempFileMessageReader.
+        context_injector (Optional[PipedProcessContextInjector]): An context injector to use to inject context into the subprocess. Defaults to ExtTempFileContextInjector.
+        message_reader (Optional[PipedProcessContextInjector]): An context injector to use to read messages from  the subprocess. Defaults to ExtTempFileMessageReader.
     """
 
     def __init__(
         self,
         env: Optional[Mapping[str, str]] = None,
         cwd: Optional[str] = None,
-        context_injector: Optional[ExtContextInjector] = None,
+        context_injector: Optional[PipedProcessContextInjector] = None,
         message_reader: Optional[ExtMessageReader] = None,
     ):
         self.env = check.opt_mapping_param(env, "env", key_type=str, value_type=str)
@@ -46,7 +46,7 @@ class _ExtSubprocess(ExtClient):
             check.opt_inst_param(
                 context_injector,
                 "context_injector",
-                ExtContextInjector,
+                PipedProcessContextInjector,
             )
             or ExtTempFileContextInjector()
         )
@@ -93,4 +93,4 @@ class _ExtSubprocess(ExtClient):
         yield from pipes_session.get_results()
 
 
-ExtSubprocess = ResourceParam[_ExtSubprocess]
+PipedSubprocess = ResourceParam[_PipedSubprocess]

--- a/python_modules/dagster/dagster/_core/pipes/utils.py
+++ b/python_modules/dagster/dagster/_core/pipes/utils.py
@@ -23,8 +23,8 @@ from dagster import (
     _check as check,
 )
 from dagster._core.pipes.client import (
-    ExtContextInjector,
     ExtMessageReader,
+    PipedProcessContextInjector,
 )
 from dagster._core.pipes.context import (
     ExtMessageHandler,
@@ -37,7 +37,7 @@ _CONTEXT_INJECTOR_FILENAME = "context"
 _MESSAGE_READER_FILENAME = "messages"
 
 
-class ExtFileContextInjector(ExtContextInjector):
+class ExtFileContextInjector(PipedProcessContextInjector):
     def __init__(self, path: str):
         self._path = check.str_param(path, "path")
 
@@ -52,7 +52,7 @@ class ExtFileContextInjector(ExtContextInjector):
                 os.remove(self._path)
 
 
-class ExtTempFileContextInjector(ExtContextInjector):
+class ExtTempFileContextInjector(PipedProcessContextInjector):
     @contextmanager
     def inject_context(self, context: "PipedProcessContextData") -> Iterator[PipeableParams]:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -62,7 +62,7 @@ class ExtTempFileContextInjector(ExtContextInjector):
                 yield params
 
 
-class ExtEnvContextInjector(ExtContextInjector):
+class ExtEnvContextInjector(PipedProcessContextInjector):
     @contextmanager
     def inject_context(
         self,
@@ -194,7 +194,7 @@ _FAIL_TO_YIELD_ERROR_MESSAGE = (
 @contextmanager
 def pipes_protocol(
     context: OpExecutionContext,
-    context_injector: ExtContextInjector,
+    context_injector: PipedProcessContextInjector,
     message_reader: ExtMessageReader,
     extras: Optional[PipeableExtras] = None,
 ) -> Iterator[PipesSession]:

--- a/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_subprocess.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_subprocess.py
@@ -37,7 +37,7 @@ from dagster._core.execution.context.compute import AssetExecutionContext, OpExe
 from dagster._core.execution.context.invocation import build_asset_context
 from dagster._core.instance_for_test import instance_for_test
 from dagster._core.pipes.subprocess import (
-    ExtSubprocess,
+    PipedSubprocess,
 )
 from dagster._core.pipes.utils import (
     ExtEnvContextInjector,
@@ -159,7 +159,7 @@ def test_ext_subprocess(
         assert False, "Unreachable"
 
     @asset(check_specs=[AssetCheckSpec(name="foo_check", asset=AssetKey(["foo"]))])
-    def foo(context: AssetExecutionContext, ext: ExtSubprocess):
+    def foo(context: AssetExecutionContext, ext: PipedSubprocess):
         extras = {"bar": "baz"}
         cmd = [_PYTHON_EXECUTABLE, external_script]
         yield from ext.run(
@@ -172,7 +172,7 @@ def test_ext_subprocess(
             },
         )
 
-    resource = ExtSubprocess(context_injector=context_injector, message_reader=message_reader)
+    resource = PipedSubprocess(context_injector=context_injector, message_reader=message_reader)
 
     with instance_for_test() as instance:
         materialize([foo], instance=instance, resources={"ext": resource})
@@ -207,13 +207,13 @@ def test_ext_multi_asset():
         context.report_asset_materialization(data_version="alpha", asset_key="bar")
 
     @multi_asset(specs=[AssetSpec("foo"), AssetSpec("bar")])
-    def foo_bar(context: AssetExecutionContext, ext: ExtSubprocess):
+    def foo_bar(context: AssetExecutionContext, ext: PipedSubprocess):
         with temp_script(script_fn) as script_path:
             cmd = [_PYTHON_EXECUTABLE, script_path]
             yield from ext.run(cmd, context=context)
 
     with instance_for_test() as instance:
-        materialize([foo_bar], instance=instance, resources={"ext": ExtSubprocess()})
+        materialize([foo_bar], instance=instance, resources={"ext": PipedSubprocess()})
         foo_mat = instance.get_latest_materialization_event(AssetKey(["foo"]))
         assert foo_mat and foo_mat.asset_materialization
         assert foo_mat.asset_materialization.metadata["foo_meta"].value == "ok"
@@ -249,7 +249,7 @@ def test_ext_typed_metadata():
         )
 
     @asset
-    def foo(context: AssetExecutionContext, ext: ExtSubprocess):
+    def foo(context: AssetExecutionContext, ext: PipedSubprocess):
         with temp_script(script_fn) as script_path:
             cmd = [_PYTHON_EXECUTABLE, script_path]
             yield from ext.run(cmd, context=context)
@@ -258,7 +258,7 @@ def test_ext_typed_metadata():
         materialize(
             [foo],
             instance=instance,
-            resources={"ext": ExtSubprocess()},
+            resources={"ext": PipedSubprocess()},
         )
         mat = instance.get_latest_materialization_event(foo.key)
         assert mat and mat.asset_materialization
@@ -296,13 +296,13 @@ def test_ext_asset_failed():
         raise Exception("foo")
 
     @asset
-    def foo(context: AssetExecutionContext, ext: ExtSubprocess):
+    def foo(context: AssetExecutionContext, ext: PipedSubprocess):
         with temp_script(script_fn) as script_path:
             cmd = [_PYTHON_EXECUTABLE, script_path]
             yield from ext.run(cmd, context=context)
 
     with pytest.raises(DagsterExternalExecutionError):
-        materialize([foo], resources={"ext": ExtSubprocess()})
+        materialize([foo], resources={"ext": PipedSubprocess()})
 
 
 def test_ext_asset_invocation():
@@ -313,12 +313,12 @@ def test_ext_asset_invocation():
         context.log("hello world")
 
     @asset
-    def foo(context: AssetExecutionContext, ext: ExtSubprocess):
+    def foo(context: AssetExecutionContext, ext: PipedSubprocess):
         with temp_script(script_fn) as script_path:
             cmd = [_PYTHON_EXECUTABLE, script_path]
             ext.run(cmd, context=context)
 
-    foo(context=build_asset_context(), ext=ExtSubprocess())
+    foo(context=build_asset_context(), ext=PipedSubprocess())
 
 
 PATH_WITH_NONEXISTENT_DIR = "/tmp/does-not-exist/foo"

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
@@ -11,7 +11,11 @@ import dagster._check as check
 from dagster._core.definitions.resource_annotation import ResourceParam
 from dagster._core.errors import DagsterExternalExecutionError
 from dagster._core.execution.context.compute import OpExecutionContext
-from dagster._core.pipes.client import ExtClient, ExtContextInjector, ExtMessageReader
+from dagster._core.pipes.client import (
+    ExtMessageReader,
+    PipedProcessClient,
+    PipedProcessContextInjector,
+)
 from dagster._core.pipes.context import ExtResult
 from dagster._core.pipes.utils import (
     ExtBlobStoreMessageReader,
@@ -27,7 +31,7 @@ from databricks.sdk.service import files, jobs
 from pydantic import Field
 
 
-class _ExtDatabricks(ExtClient):
+class _ExtDatabricks(PipedProcessClient):
     """Ext client for databricks.
 
     Args:
@@ -44,7 +48,7 @@ class _ExtDatabricks(ExtClient):
         self,
         client: WorkspaceClient,
         env: Optional[Mapping[str, str]] = None,
-        context_injector: Optional[ExtContextInjector] = None,
+        context_injector: Optional[PipedProcessContextInjector] = None,
         message_reader: Optional[ExtMessageReader] = None,
     ):
         self.client = client
@@ -52,7 +56,7 @@ class _ExtDatabricks(ExtClient):
         self.context_injector = check.opt_inst_param(
             context_injector,
             "context_injector",
-            ExtContextInjector,
+            PipedProcessContextInjector,
         ) or ExtDbfsContextInjector(client=self.client)
         self.message_reader = check.opt_inst_param(
             message_reader,
@@ -137,7 +141,7 @@ def dbfs_tempdir(dbfs_client: files.DbfsAPI) -> Iterator[str]:
         dbfs_client.delete(tempdir, recursive=True)
 
 
-class ExtDbfsContextInjector(ExtContextInjector):
+class ExtDbfsContextInjector(PipedProcessContextInjector):
     def __init__(self, *, client: WorkspaceClient):
         super().__init__()
         self.dbfs_client = files.DbfsAPI(client.api_client)

--- a/python_modules/libraries/dagster-docker/dagster_docker/pipes.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/pipes.py
@@ -8,9 +8,9 @@ from dagster import (
     _check as check,
 )
 from dagster._core.pipes.client import (
-    ExtClient,
-    ExtContextInjector,
     ExtMessageReader,
+    PipedProcessClient,
+    PipedProcessContextInjector,
 )
 from dagster._core.pipes.context import (
     ExtMessageHandler,
@@ -49,7 +49,7 @@ class DockerLogsMessageReader(ExtMessageReader):
             extract_message_or_forward_to_stdout(handler, log_line)
 
 
-class _ExtDocker(ExtClient):
+class _ExtDocker(PipedProcessClient):
     """An ext protocol compliant resource for launching docker containers.
 
     By default context is injected via environment variables and messages are parsed out of the
@@ -58,15 +58,15 @@ class _ExtDocker(ExtClient):
     Args:
         env (Optional[Mapping[str, str]]): An optional dict of environment variables to pass to the subprocess.
         register (Optional[Mapping[str, str]]): An optional dict of registry credentials to login the docker client.
-        context_injector (Optional[ExtContextInjector]): An context injector to use to inject context into the docker container process. Defaults to ExtEnvContextInjector.
-        message_reader (Optional[ExtContextInjector]): An context injector to use to read messages from the docker container process. Defaults to DockerLogsMessageReader.
+        context_injector (Optional[PipedProcessContextInjector]): An context injector to use to inject context into the docker container process. Defaults to ExtEnvContextInjector.
+        message_reader (Optional[PipedProcessContextInjector]): An context injector to use to read messages from the docker container process. Defaults to DockerLogsMessageReader.
     """
 
     def __init__(
         self,
         env: Optional[Mapping[str, str]] = None,
         registry: Optional[Mapping[str, str]] = None,
-        context_injector: Optional[ExtContextInjector] = None,
+        context_injector: Optional[PipedProcessContextInjector] = None,
         message_reader: Optional[ExtMessageReader] = None,
     ):
         self.env = check.opt_mapping_param(env, "env", key_type=str, value_type=str)
@@ -75,7 +75,7 @@ class _ExtDocker(ExtClient):
             check.opt_inst_param(
                 context_injector,
                 "context_injector",
-                ExtContextInjector,
+                PipedProcessContextInjector,
             )
             or ExtEnvContextInjector()
         )
@@ -113,7 +113,7 @@ class _ExtDocker(ExtClient):
                 Arguments to be forwarded to docker client containers.create.
             extras (Optional[PipeableExtras]):
                 Extra values to pass along as part of the ext protocol.
-            context_injector (Optional[ExtContextInjector]):
+            context_injector (Optional[PipedProcessContextInjector]):
                 Override the default ext protocol context injection.
             message_Reader (Optional[ExtMessageReader]):
                 Override the default ext protocol message reader.

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
@@ -11,10 +11,10 @@ from dagster import (
 from dagster._core.definitions.resource_annotation import ResourceParam
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.pipes.client import (
-    ExtClient,
-    ExtContextInjector,
     ExtMessageReader,
     PipeableParams,
+    PipedProcessClient,
+    PipedProcessContextInjector,
 )
 from dagster._core.pipes.context import (
     ExtMessageHandler,
@@ -77,7 +77,7 @@ class K8sPodLogsMessageReader(ExtMessageReader):
                 extract_message_or_forward_to_stdout(handler, log_line)
 
 
-class _ExtK8sPod(ExtClient):
+class _ExtK8sPod(PipedProcessClient):
     """An ext protocol compliant resource for launching kubernetes pods.
 
     By default context is injected via environment variables and messages are parsed out of
@@ -88,14 +88,14 @@ class _ExtK8sPod(ExtClient):
 
     Args:
         env (Optional[Mapping[str, str]]): An optional dict of environment variables to pass to the subprocess.
-        context_injector (Optional[ExtContextInjector]): An context injector to use to inject context into the k8s container process. Defaults to ExtEnvContextInjector.
-        message_reader (Optional[ExtContextInjector]): An context injector to use to read messages from the k8s container process. Defaults to K8sPodLogsMessageReader.
+        context_injector (Optional[PipedProcessContextInjector]): An context injector to use to inject context into the k8s container process. Defaults to ExtEnvContextInjector.
+        message_reader (Optional[PipedProcessContextInjector]): An context injector to use to read messages from the k8s container process. Defaults to K8sPodLogsMessageReader.
     """
 
     def __init__(
         self,
         env: Optional[Mapping[str, str]] = None,
-        context_injector: Optional[ExtContextInjector] = None,
+        context_injector: Optional[PipedProcessContextInjector] = None,
         message_reader: Optional[ExtMessageReader] = None,
     ):
         self.env = check.opt_mapping_param(env, "env", key_type=str, value_type=str)
@@ -103,7 +103,7 @@ class _ExtK8sPod(ExtClient):
             check.opt_inst_param(
                 context_injector,
                 "context_injector",
-                ExtContextInjector,
+                PipedProcessContextInjector,
             )
             or ExtEnvContextInjector()
         )
@@ -147,7 +147,7 @@ class _ExtK8sPod(ExtClient):
                 Keys can either snake_case or camelCase.
             extras (Optional[PipeableExtras]):
                 Extra values to pass along as part of the ext protocol.
-            context_injector (Optional[ExtContextInjector]):
+            context_injector (Optional[PipedProcessContextInjector]):
                 Override the default ext protocol context injection.
             message_Reader (Optional[ExtMessageReader]):
                 Override the default ext protocol message reader.


### PR DESCRIPTION
## Summary & Motivation

Renaming the core classes in `dagster._core.pipes`.

Instead of `ExtSubprocess` we have `PipedSubprocess`. Note there is where the use of "piped" is the most problematic as one is dealing with unix pipes when manipulating subprocesses. For other technologies, "piped" is much better e.g. `PipedK8sPod`

Renames:

* `ExtContextInjector` --> `PipedProcessContextInjector`
* `ExtClient` -> `PipedProcessClient`

## How I Tested These Changes

BK