### PR TITLE
ExtMessageReader --> PipesMessageReader

### DIFF
--- a/python_modules/dagster/dagster/_core/pipes/client.py
+++ b/python_modules/dagster/dagster/_core/pipes/client.py
@@ -11,7 +11,7 @@ from dagster_pipes import (
 from dagster._core.execution.context.compute import OpExecutionContext
 
 if TYPE_CHECKING:
-    from .context import ExtMessageHandler, ExtResult
+    from .context import ExtResult, PipesMessageHandler
 
 
 class PipesClient(ABC):
@@ -30,7 +30,7 @@ class PipesContextInjector(ABC):
     def inject_context(self, context_data: "PipesContextData") -> Iterator[PipesParams]: ...
 
 
-class ExtMessageReader(ABC):
+class PipesMessageReader(ABC):
     @abstractmethod
     @contextmanager
-    def read_messages(self, handler: "ExtMessageHandler") -> Iterator[PipesParams]: ...
+    def read_messages(self, handler: "PipesMessageHandler") -> Iterator[PipesParams]: ...

--- a/python_modules/dagster/dagster/_core/pipes/context.py
+++ b/python_modules/dagster/dagster/_core/pipes/context.py
@@ -30,12 +30,12 @@ from dagster._core.definitions.result import MaterializeResult
 from dagster._core.definitions.time_window_partitions import TimeWindow
 from dagster._core.execution.context.compute import OpExecutionContext
 from dagster._core.execution.context.invocation import BoundOpExecutionContext
-from dagster._core.pipes.client import ExtMessageReader
+from dagster._core.pipes.client import PipesMessageReader
 
 ExtResult: TypeAlias = Union[MaterializeResult, AssetCheckResult]
 
 
-class ExtMessageHandler:
+class PipesMessageHandler:
     def __init__(self, context: OpExecutionContext) -> None:
         self._context = context
         # Queue is thread-safe
@@ -44,7 +44,7 @@ class ExtMessageHandler:
         self._unmaterialized_assets: Set[AssetKey] = set(context.selected_asset_keys)
 
     @contextmanager
-    def handle_messages(self, message_reader: ExtMessageReader) -> Iterator[PipesParams]:
+    def handle_messages(self, message_reader: PipesMessageReader) -> Iterator[PipesParams]:
         with message_reader.read_messages(self) as params:
             yield params
         for key in self._unmaterialized_assets:
@@ -166,7 +166,7 @@ def _ext_params_as_env_vars(
 @dataclass
 class PipesSession:
     context_data: PipesContextData
-    message_handler: ExtMessageHandler
+    message_handler: PipesMessageHandler
     context_injector_params: PipesParams
     message_reader_params: PipesParams
 

--- a/python_modules/dagster/dagster/_core/pipes/subprocess.py
+++ b/python_modules/dagster/dagster/_core/pipes/subprocess.py
@@ -8,14 +8,14 @@ from dagster._core.definitions.resource_annotation import ResourceParam
 from dagster._core.errors import DagsterExternalExecutionError
 from dagster._core.execution.context.compute import OpExecutionContext
 from dagster._core.pipes.client import (
-    ExtMessageReader,
     PipesClient,
     PipesContextInjector,
+    PipesMessageReader,
 )
 from dagster._core.pipes.context import ExtResult
 from dagster._core.pipes.utils import (
     ExtTempFileContextInjector,
-    ExtTempFileMessageReader,
+    PipesTempFileMessageReader,
     open_pipes_session,
 )
 
@@ -38,7 +38,7 @@ class _PipesSubprocess(PipesClient):
         env: Optional[Mapping[str, str]] = None,
         cwd: Optional[str] = None,
         context_injector: Optional[PipesContextInjector] = None,
-        message_reader: Optional[ExtMessageReader] = None,
+        message_reader: Optional[PipesMessageReader] = None,
     ):
         self.env = check.opt_mapping_param(env, "env", key_type=str, value_type=str)
         self.cwd = check.opt_str_param(cwd, "cwd")
@@ -54,9 +54,9 @@ class _PipesSubprocess(PipesClient):
             check.opt_inst_param(
                 message_reader,
                 "message_reader",
-                ExtMessageReader,
+                PipesMessageReader,
             )
-            or ExtTempFileMessageReader()
+            or PipesTempFileMessageReader()
         )
 
     def run(

--- a/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_subprocess.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_subprocess.py
@@ -42,11 +42,11 @@ from dagster._core.pipes.subprocess import (
 from dagster._core.pipes.utils import (
     ExtEnvContextInjector,
     ExtTempFileContextInjector,
-    ExtTempFileMessageReader,
+    PipesTempFileMessageReader,
     open_pipes_session,
 )
 from dagster._core.storage.asset_check_execution_record import AssetCheckExecutionRecordStatus
-from dagster_aws.pipes import ExtS3MessageReader
+from dagster_aws.pipes import PipesS3MessageReader
 from moto.server import ThreadedMotoServer
 
 _PYTHON_EXECUTABLE = shutil.which("python")
@@ -150,9 +150,9 @@ def test_ext_subprocess(
     if message_reader_spec == "default":
         message_reader = None
     elif message_reader_spec == "user/file":
-        message_reader = ExtTempFileMessageReader()
+        message_reader = PipesTempFileMessageReader()
     elif message_reader_spec == "user/s3":
-        message_reader = ExtS3MessageReader(
+        message_reader = PipesS3MessageReader(
             bucket=_S3_TEST_BUCKET, client=s3_client, interval=0.001
         )
     else:
@@ -362,7 +362,7 @@ def test_ext_no_client(external_script):
         with open_pipes_session(
             context,
             ExtTempFileContextInjector(),
-            ExtTempFileMessageReader(),
+            PipesTempFileMessageReader(),
             extras=extras,
         ) as pipes_session:
             subprocess.run(cmd, env=pipes_session.get_pipes_env_vars(), check=False)
@@ -399,7 +399,7 @@ def test_ext_no_client_no_yield():
             with open_pipes_session(
                 context,
                 ExtTempFileContextInjector(),
-                ExtTempFileMessageReader(),
+                PipesTempFileMessageReader(),
             ) as pipes_session:
                 cmd = [_PYTHON_EXECUTABLE, external_script]
                 subprocess.run(cmd, env=pipes_session.get_pipes_env_vars(), check=False)

--- a/python_modules/libraries/dagster-aws/dagster_aws/pipes.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/pipes.py
@@ -9,10 +9,10 @@ from botocore.exceptions import ClientError
 from dagster._core.pipes.client import (
     PipesParams,
 )
-from dagster._core.pipes.utils import ExtBlobStoreMessageReader
+from dagster._core.pipes.utils import PipesBlobStoreMessageReader
 
 
-class ExtS3MessageReader(ExtBlobStoreMessageReader):
+class PipesS3MessageReader(PipesBlobStoreMessageReader):
     def __init__(self, *, interval: float = 10, bucket: str, client: boto3.client):
         super().__init__(interval=interval)
         self.bucket = check.str_param(bucket, "bucket")

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/__init__.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/__init__.py
@@ -27,7 +27,7 @@ from .ops import (
 from .pipes import (
     ExtDatabricks as ExtDatabricks,
     ExtDbfsContextInjector as ExtDbfsContextInjector,
-    ExtDbfsMessageReader as ExtDbfsMessageReader,
+    PipesDbfsMessageReader as PipesDbfsMessageReader,
     dbfs_tempdir as dbfs_tempdir,
 )
 from .resources import (

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
@@ -12,13 +12,13 @@ from dagster._core.definitions.resource_annotation import ResourceParam
 from dagster._core.errors import DagsterExternalExecutionError
 from dagster._core.execution.context.compute import OpExecutionContext
 from dagster._core.pipes.client import (
-    ExtMessageReader,
     PipesClient,
     PipesContextInjector,
+    PipesMessageReader,
 )
 from dagster._core.pipes.context import ExtResult
 from dagster._core.pipes.utils import (
-    ExtBlobStoreMessageReader,
+    PipesBlobStoreMessageReader,
     open_pipes_session,
 )
 from dagster_pipes import (
@@ -49,7 +49,7 @@ class _ExtDatabricks(PipesClient):
         client: WorkspaceClient,
         env: Optional[Mapping[str, str]] = None,
         context_injector: Optional[PipesContextInjector] = None,
-        message_reader: Optional[ExtMessageReader] = None,
+        message_reader: Optional[PipesMessageReader] = None,
     ):
         self.client = client
         self.env = env
@@ -61,8 +61,8 @@ class _ExtDatabricks(PipesClient):
         self.message_reader = check.opt_inst_param(
             message_reader,
             "message_reader",
-            ExtMessageReader,
-        ) or ExtDbfsMessageReader(client=self.client)
+            PipesMessageReader,
+        ) or PipesDbfsMessageReader(client=self.client)
 
     def run(
         self,
@@ -155,7 +155,7 @@ class ExtDbfsContextInjector(PipesContextInjector):
             yield {"path": path}
 
 
-class ExtDbfsMessageReader(ExtBlobStoreMessageReader):
+class PipesDbfsMessageReader(PipesBlobStoreMessageReader):
     def __init__(self, *, interval: int = 10, client: WorkspaceClient):
         super().__init__(interval=interval)
         self.dbfs_client = files.DbfsAPI(client.api_client)

--- a/python_modules/libraries/dagster-docker/dagster_docker/pipes.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/pipes.py
@@ -8,13 +8,13 @@ from dagster import (
     _check as check,
 )
 from dagster._core.pipes.client import (
-    ExtMessageReader,
     PipesClient,
     PipesContextInjector,
+    PipesMessageReader,
 )
 from dagster._core.pipes.context import (
-    ExtMessageHandler,
     ExtResult,
+    PipesMessageHandler,
 )
 from dagster._core.pipes.utils import (
     ExtEnvContextInjector,
@@ -29,11 +29,11 @@ from dagster_pipes import (
 )
 
 
-class DockerLogsMessageReader(ExtMessageReader):
+class DockerLogsMessageReader(PipesMessageReader):
     @contextmanager
     def read_messages(
         self,
-        handler: ExtMessageHandler,
+        handler: PipesMessageHandler,
     ) -> Iterator[PipesParams]:
         self._handler = handler
         try:
@@ -67,7 +67,7 @@ class _ExtDocker(PipesClient):
         env: Optional[Mapping[str, str]] = None,
         registry: Optional[Mapping[str, str]] = None,
         context_injector: Optional[PipesContextInjector] = None,
-        message_reader: Optional[ExtMessageReader] = None,
+        message_reader: Optional[PipesMessageReader] = None,
     ):
         self.env = check.opt_mapping_param(env, "env", key_type=str, value_type=str)
         self.registry = check.opt_mapping_param(registry, "registry", key_type=str, value_type=str)
@@ -81,7 +81,7 @@ class _ExtDocker(PipesClient):
         )
 
         self.message_reader = (
-            check.opt_inst_param(message_reader, "message_reader", ExtMessageReader)
+            check.opt_inst_param(message_reader, "message_reader", PipesMessageReader)
             or DockerLogsMessageReader()
         )
 
@@ -115,7 +115,7 @@ class _ExtDocker(PipesClient):
                 Extra values to pass along as part of the ext protocol.
             context_injector (Optional[PipesContextInjector]):
                 Override the default ext protocol context injection.
-            message_Reader (Optional[ExtMessageReader]):
+            message_Reader (Optional[PipesMessageReader]):
                 Override the default ext protocol message reader.
         """
         with open_pipes_session(

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
@@ -11,14 +11,14 @@ from dagster import (
 from dagster._core.definitions.resource_annotation import ResourceParam
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.pipes.client import (
-    ExtMessageReader,
     PipesClient,
     PipesContextInjector,
+    PipesMessageReader,
     PipesParams,
 )
 from dagster._core.pipes.context import (
-    ExtMessageHandler,
     ExtResult,
+    PipesMessageHandler,
 )
 from dagster._core.pipes.utils import (
     ExtEnvContextInjector,
@@ -45,11 +45,11 @@ def get_pod_name(run_id: str, op_name: str):
 DEFAULT_CONTAINER_NAME = "dagster-pipes-execution"
 
 
-class K8sPodLogsMessageReader(ExtMessageReader):
+class K8sPodLogsMessageReader(PipesMessageReader):
     @contextmanager
     def read_messages(
         self,
-        handler: ExtMessageHandler,
+        handler: PipesMessageHandler,
     ) -> Iterator[PipesParams]:
         self._handler = handler
         try:
@@ -96,7 +96,7 @@ class _ExtK8sPod(PipesClient):
         self,
         env: Optional[Mapping[str, str]] = None,
         context_injector: Optional[PipesContextInjector] = None,
-        message_reader: Optional[ExtMessageReader] = None,
+        message_reader: Optional[PipesMessageReader] = None,
     ):
         self.env = check.opt_mapping_param(env, "env", key_type=str, value_type=str)
         self.context_injector = (
@@ -109,7 +109,7 @@ class _ExtK8sPod(PipesClient):
         )
 
         self.message_reader = (
-            check.opt_inst_param(message_reader, "message_reader", ExtMessageReader)
+            check.opt_inst_param(message_reader, "message_reader", PipesMessageReader)
             or K8sPodLogsMessageReader()
         )
 
@@ -149,7 +149,7 @@ class _ExtK8sPod(PipesClient):
                 Extra values to pass along as part of the ext protocol.
             context_injector (Optional[PipesContextInjector]):
                 Override the default ext protocol context injection.
-            message_Reader (Optional[ExtMessageReader]):
+            message_Reader (Optional[PipesMessageReader]):
                 Override the default ext protocol message reader.
         """
         client = DagsterKubernetesClient.production_client()


### PR DESCRIPTION
## Summary & Motivation

In the original RFC PR `ExtMessageReader` was renamed `PipeableMessageReader`. As in there are pipeable messages, and a reader is reading them. However others translated that class name to "there is a pipeable reader reading message", which ends up being very confusing.

For lack of any better ideas, I'm proposing just calling this `PipesMessageReader`, as in a message reader in the pipes library. I generally avoid class names as generic as `MessageReader`, as they are more likely to collide with classes elsewhere in the python environment and make things like auto-import features in IDEs less useful and more annoying. Unique names also help with greappability in the code base.

I'm open to more suggestions here. I thought about `InboundMessagePipe` or something, but I did not want to introduce pipe as a noun.

## How I Tested These Changes

BK
