### PR TITLE
Extract helper function to find all subclasses of a marker interface

### DIFF
--- a/python_modules/dagster/dagster/_utils/test/__init__.py
+++ b/python_modules/dagster/dagster/_utils/test/__init__.py
@@ -3,7 +3,7 @@ import shutil
 import tempfile
 from collections import defaultdict
 from contextlib import contextmanager
-from typing import Any, Dict, Mapping, Optional, cast
+from typing import Any, Dict, List, Mapping, Optional, Type, cast
 
 # top-level include is dangerous in terms of incurring circular deps
 from dagster import (
@@ -328,3 +328,16 @@ class ConcurrencyEnabledSqliteTestEventLogStorage(SqliteEventLogStorage, Configu
         if not self._sleep_interval:
             return claim_status
         return claim_status.with_sleep_interval(float(self._sleep_interval))
+
+
+def get_all_direct_subclasses_of_marker(marker_interface_cls: Type) -> List[Type]:
+    import dagster as dagster
+
+    return [
+        symbol
+        for symbol in dagster.__dict__.values()
+        if isinstance(symbol, type)
+        and issubclass(symbol, marker_interface_cls)
+        and marker_interface_cls
+        in symbol.__bases__  # ensure that the class is a direct subclass of marker_interface_cls (not a subclass of a subclass)
+    ]

--- a/python_modules/dagster/dagster_tests/general_tests/test_internal_init_implementations.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_internal_init_implementations.py
@@ -4,15 +4,9 @@ from typing import Type
 import dagster as dagster
 import pytest
 from dagster._utils import IHasInternalInit
+from dagster._utils.test import get_all_direct_subclasses_of_marker
 
-INTERNAL_INIT_SUBCLASSES = [
-    symbol
-    for symbol in dagster.__dict__.values()
-    if isinstance(symbol, type)
-    and issubclass(symbol, IHasInternalInit)
-    and IHasInternalInit
-    in symbol.__bases__  # ensure that the class is a direct subclass of IHasInternalInit (not a subclass of a subclass)
-]
+INTERNAL_INIT_SUBCLASSES = get_all_direct_subclasses_of_marker(IHasInternalInit)
 
 
 @pytest.mark.parametrize("cls", INTERNAL_INIT_SUBCLASSES)

--- a/python_modules/dagster/dagster_tests/utils_tests/test_reflection_helpers.py
+++ b/python_modules/dagster/dagster_tests/utils_tests/test_reflection_helpers.py
@@ -1,0 +1,8 @@
+from dagster import AssetsDefinition
+from dagster._utils.internal_init import IHasInternalInit
+from dagster._utils.test import get_all_direct_subclasses_of_marker
+
+
+def test_ihas_init_reflection_helper() -> None:
+    all_types = get_all_direct_subclasses_of_marker(IHasInternalInit)
+    assert AssetsDefinition in all_types


### PR DESCRIPTION
## Summary & Motivation

This was a useful piece of logic implemented to do metaprogramming tests of our own code artifacts. I'd like to use it to do another test of this nature, so extracting into a helper function.

## How I Tested These Changes

BK
