### PR TITLE
Storage for auto-materialize ticks

### DIFF
--- a/helm/dagster/schema/schema/charts/dagster/subschema/retention.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/retention.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Optional, Union
 
 from pydantic import BaseModel, Extra
 
@@ -21,6 +21,7 @@ class Retention(BaseModel):
     enabled: bool
     sensor: TickRetention
     schedule: TickRetention
+    autoMaterialize: Optional[TickRetention]
 
     class Config:
         extra = Extra.forbid

--- a/helm/dagster/schema/schema_tests/test_instance.py
+++ b/helm/dagster/schema/schema_tests/test_instance.py
@@ -972,6 +972,14 @@ def test_retention(template: HelmTemplate):
                     started=30,
                 ),
             ),
+            autoMaterialize=TickRetention.construct(
+                purgeAfterDays=TickRetentionByType(
+                    skipped=1,
+                    success=2,
+                    failure=3,
+                    started=4,
+                ),
+            ),
         )
     )
 
@@ -984,6 +992,12 @@ def test_retention(template: HelmTemplate):
     assert instance["retention"]["sensor"]["purge_after_days"]["skipped"] == 7
     assert instance["retention"]["sensor"]["purge_after_days"]["success"] == 30
     assert instance["retention"]["sensor"]["purge_after_days"]["failure"] == 30
+    assert instance["retention"]["auto_materialize"]["purge_after_days"] == {
+        "skipped": 1,
+        "success": 2,
+        "failure": 3,
+        "started": 4,
+    }
 
 
 def _check_valid_instance_yaml(dagster_config, instance_class=K8sRunLauncher):

--- a/helm/dagster/templates/configmap-instance.yaml
+++ b/helm/dagster/templates/configmap-instance.yaml
@@ -146,6 +146,10 @@ data:
       schedule:
         purge_after_days: {{ .Values.retention.schedule.purgeAfterDays | toYaml | nindent 12 }}
       {{- end }}
+      {{- if .Values.retention.autoMaterialize }}
+      auto_materialize:
+        purge_after_days: {{ .Values.retention.autoMaterialize.purgeAfterDays | toYaml | nindent 12 }}
+      {{- end }}
     {{- end }}
 
     {{- if .Values.additionalInstanceConfig }}

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -3001,6 +3001,9 @@
                 },
                 "schedule": {
                     "$ref": "#/definitions/TickRetention"
+                },
+                "autoMaterialize": {
+                    "$ref": "#/definitions/TickRetention"
                 }
             },
             "required": [

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -1315,12 +1315,21 @@ retention:
   schedule:
     # For schedule ticks, specifies after how many days ticks can be removed.  This field can either
     # be a dict of tick types to integers, or an integer (applies to all tick types).  A value of -1
-    # indicates that ticks should be retained indefinitely
+    # indicates that ticks should be retained indefinitely.
     purgeAfterDays: -1
   sensor:
     # For sensor ticks, specifies after how many days ticks can be removed.  This field can either
     # be a dict of tick types to integers, or an integer (applies to all tick types).  A value of -1
-    # indicates that ticks should be retained indefinitely
+    # indicates that ticks should be retained indefinitely.
+    purgeAfterDays:
+      failure: -1
+      skipped: 7
+      started: -1
+      success: -1
+  autoMaterialize:
+    # For auto-materialization ticks, specifies after how many days ticks can be removed.  This
+    # field can either be a dict of tick types to integers, or an integer (applies to all tick
+    # types).  A value of -1 indicates that ticks should be retained indefinitely.
     purgeAfterDays:
       failure: -1
       skipped: 7

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -93,10 +93,13 @@ class AssetDaemonContext:
         target_asset_keys: Optional[AbstractSet[AssetKey]],
         respect_materialization_data_versions: bool,
         logger: logging.Logger,
+        evaluation_time: Optional[datetime.datetime] = None,
     ):
         from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
 
-        self._instance_queryer = CachingInstanceQueryer(instance, asset_graph, logger=logger)
+        self._instance_queryer = CachingInstanceQueryer(
+            instance, asset_graph, evaluation_time=evaluation_time, logger=logger
+        )
         self._data_time_resolver = CachingDataTimeResolver(self.instance_queryer)
         self._cursor = cursor
         self._target_asset_keys = target_asset_keys or {

--- a/python_modules/dagster/dagster/_core/definitions/run_request.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_request.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
 class InstigatorType(Enum):
     SCHEDULE = "SCHEDULE"
     SENSOR = "SENSOR"
+    AUTO_MATERIALIZE = "AUTO_MATERIALIZE"
 
 
 @whitelist_for_serdes

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -2751,11 +2751,16 @@ class DagsterInstance(DynamicPartitionsStore):
         from dagster._core.definitions.run_request import InstigatorType
 
         retention_settings = self.get_settings("retention")
-        tick_settings = (
-            retention_settings.get("schedule")
-            if instigator_type == InstigatorType.SCHEDULE
-            else retention_settings.get("sensor")
-        )
+
+        if instigator_type == InstigatorType.SCHEDULE:
+            tick_settings = retention_settings.get("schedule")
+        elif instigator_type == InstigatorType.SENSOR:
+            tick_settings = retention_settings.get("sensor")
+        elif instigator_type == InstigatorType.AUTO_MATERIALIZE:
+            tick_settings = retention_settings.get("auto_materialize")
+        else:
+            raise Exception(f"Unexpected instigator type {instigator_type}")
+
         default_tick_settings = get_default_tick_retention_settings(instigator_type)
         return get_tick_retention_settings(tick_settings, default_tick_settings)
 

--- a/python_modules/dagster/dagster/_core/instance/config.py
+++ b/python_modules/dagster/dagster/_core/instance/config.py
@@ -182,7 +182,7 @@ def get_default_tick_retention_settings(
             TickStatus.SUCCESS: -1,
             TickStatus.FAILURE: -1,
         }
-    # for sensor
+    # for sensor / auto-materialize
     return {
         TickStatus.STARTED: -1,
         TickStatus.SKIPPED: 7,
@@ -213,6 +213,7 @@ def retention_config_schema() -> Field:
         {
             "schedule": _tick_retention_config_schema(),
             "sensor": _tick_retention_config_schema(),
+            "auto_materialize": _tick_retention_config_schema(),
         },
         is_required=False,
     )

--- a/python_modules/dagster/dagster/_core/scheduler/instigation.py
+++ b/python_modules/dagster/dagster/_core/scheduler/instigation.py
@@ -394,7 +394,7 @@ class TickData(
             ("instigator_name", str),
             ("instigator_type", InstigatorType),
             ("status", TickStatus),
-            ("timestamp", float),
+            ("timestamp", float),  # Time the tick started
             ("run_ids", Sequence[str]),
             ("run_keys", Sequence[str]),
             ("error", Optional[SerializableErrorInfo]),
@@ -408,6 +408,7 @@ class TickData(
                 "dynamic_partitions_request_results",
                 Sequence[DynamicPartitionsRequestResult],
             ),
+            ("end_timestamp", Optional[float]),  # Time the tick finished
         ],
     )
 ):
@@ -452,6 +453,7 @@ class TickData(
         dynamic_partitions_request_results: Optional[
             Sequence[DynamicPartitionsRequestResult]
         ] = None,
+        end_timestamp: Optional[float] = None,
     ):
         _validate_tick_args(instigator_type, status, run_ids, error, skip_reason)
         check.opt_list_param(log_key, "log_key", of_type=str)
@@ -476,6 +478,7 @@ class TickData(
                 "dynamic_partitions_request_results",
                 of_type=DynamicPartitionsRequestResult,
             ),
+            end_timestamp=end_timestamp,
         )
 
     def with_status(
@@ -484,6 +487,7 @@ class TickData(
         error: Optional[SerializableErrorInfo] = None,
         timestamp: Optional[float] = None,
         failure_count: Optional[int] = None,
+        end_timestamp: Optional[float] = None,
     ) -> "TickData":
         return TickData(
             **merge_dicts(
@@ -494,6 +498,9 @@ class TickData(
                     "timestamp": timestamp if timestamp is not None else self.timestamp,
                     "failure_count": (
                         failure_count if failure_count is not None else self.failure_count
+                    ),
+                    "end_timestamp": (
+                        end_timestamp if end_timestamp is not None else self.end_timestamp
                     ),
                 },
             )

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -1,4 +1,14 @@
-from typing import Dict, List, Optional, Tuple
+import logging
+import sys
+from collections import defaultdict
+from types import TracebackType
+from typing import (
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    Type,
+)
 
 import pendulum
 
@@ -6,10 +16,21 @@ import dagster._check as check
 from dagster._core.definitions.asset_daemon_context import AssetDaemonContext
 from dagster._core.definitions.asset_daemon_cursor import AssetDaemonCursor
 from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
-from dagster._core.definitions.run_request import RunRequest
+from dagster._core.definitions.run_request import (
+    InstigatorType,
+    RunRequest,
+)
 from dagster._core.definitions.selector import JobSubsetSelector
-from dagster._core.host_representation.external import ExternalExecutionPlan, ExternalJob
+from dagster._core.host_representation.external import (
+    ExternalExecutionPlan,
+    ExternalJob,
+)
 from dagster._core.instance import DagsterInstance
+from dagster._core.scheduler.instigation import (
+    InstigatorTick,
+    TickData,
+    TickStatus,
+)
 from dagster._core.storage.dagster_run import DagsterRunStatus
 from dagster._core.storage.tags import (
     ASSET_EVALUATION_ID_TAG,
@@ -20,11 +41,16 @@ from dagster._core.workspace.context import IWorkspaceProcessContext
 from dagster._core.workspace.workspace import IWorkspace
 from dagster._daemon.daemon import DaemonIterator, IntervalDaemon
 from dagster._utils import hash_collection
+from dagster._utils.error import serializable_error_info_from_exc_info
 
 CURSOR_KEY = "ASSET_DAEMON_CURSOR"
 ASSET_DAEMON_PAUSED_KEY = "ASSET_DAEMON_PAUSED"
 
 EVALUATIONS_TTL_DAYS = 30
+
+FIXED_AUTO_MATERIALIZATION_ORIGIN_ID = "asset_daemon_origin"
+FIXED_AUTO_MATERIALIZATION_SELECTOR_ID = "asset_daemon_selector"
+FIXED_AUTO_MATERIALIZATION_INSTIGATOR_NAME = "asset_daemon"
 
 
 def get_auto_materialize_paused(instance: DagsterInstance) -> bool:
@@ -49,6 +75,72 @@ def _get_raw_cursor(instance: DagsterInstance) -> Optional[str]:
 def get_current_evaluation_id(instance: DagsterInstance) -> Optional[int]:
     raw_cursor = _get_raw_cursor(instance)
     return AssetDaemonCursor.get_evaluation_id_from_serialized(raw_cursor) if raw_cursor else None
+
+
+class AutoMaterializeLaunchContext:
+    def __init__(
+        self,
+        tick: InstigatorTick,
+        instance: DagsterInstance,
+        logger: logging.Logger,
+        tick_retention_settings,
+    ):
+        self._tick = tick
+        self._logger = logger
+        self._instance = instance
+
+        self._purge_settings = defaultdict(set)
+        for status, day_offset in tick_retention_settings.items():
+            self._purge_settings[day_offset].add(status)
+
+    @property
+    def status(self) -> TickStatus:
+        return self._tick.status
+
+    @property
+    def logger(self) -> logging.Logger:
+        return self._logger
+
+    def add_run_info(self, run_id=None):
+        self._tick = self._tick.with_run_info(run_id)
+
+    def update_state(self, status: TickStatus, **kwargs: object):
+        self._tick = self._tick.with_status(status=status, **kwargs)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(
+        self,
+        exception_type: Type[BaseException],
+        exception_value: Exception,
+        traceback: TracebackType,
+    ) -> None:
+        if exception_value and isinstance(exception_value, KeyboardInterrupt):
+            return
+
+        # Log the error if the failure wasn't an interrupt or the daemon generator stopping
+        if exception_value and not isinstance(exception_value, GeneratorExit):
+            error_data = serializable_error_info_from_exc_info(sys.exc_info())
+            tick_finish_timestamp = pendulum.now("UTC").timestamp()
+            self.update_state(
+                TickStatus.FAILURE, error=error_data, end_timestamp=tick_finish_timestamp
+            )
+
+        self._write()
+
+        for day_offset, statuses in self._purge_settings.items():
+            if day_offset <= 0:
+                continue
+            self._instance.purge_ticks(
+                FIXED_AUTO_MATERIALIZATION_ORIGIN_ID,
+                FIXED_AUTO_MATERIALIZATION_SELECTOR_ID,
+                before=pendulum.now("UTC").subtract(days=day_offset).timestamp(),
+                tick_statuses=list(statuses),
+            )
+
+    def _write(self) -> None:
+        self._instance.update_tick(self._tick)
 
 
 class AssetDaemon(IntervalDaemon):
@@ -79,6 +171,8 @@ class AssetDaemon(IntervalDaemon):
                 "Auto materialize evaluations are not getting logged. Run `dagster instance"
                 " migrate` to enable."
             )
+
+        evaluation_time = pendulum.now("UTC")
 
         workspace = workspace_process_context.create_request_context()
         asset_graph = ExternalAssetGraph.from_workspace(workspace)
@@ -116,80 +210,111 @@ class AssetDaemon(IntervalDaemon):
             else AssetDaemonCursor.empty()
         )
 
-        run_requests, new_cursor, evaluations = AssetDaemonContext(
-            asset_graph=asset_graph,
-            target_asset_keys=target_asset_keys,
-            instance=instance,
-            cursor=cursor,
-            materialize_run_tags={
-                AUTO_MATERIALIZE_TAG: "true",
-                **instance.auto_materialize_run_tags,
-            },
-            observe_run_tags={AUTO_OBSERVE_TAG: "true"},
-            auto_observe=True,
-            respect_materialization_data_versions=instance.auto_materialize_respect_materialization_data_versions,
-            logger=self._logger,
-        ).evaluate()
-
-        self._logger.info(
-            f"Tick produced {len(run_requests)} run{'s' if len(run_requests) != 1 else ''} and"
-            f" {len(evaluations)} asset evaluation{'s' if len(evaluations) != 1 else ''} for"
-            f" evaluation ID {new_cursor.evaluation_id}"
+        tick_retention_settings = instance.get_tick_retention_settings(
+            InstigatorType.AUTO_MATERIALIZE
         )
 
-        evaluations_by_asset_key = {evaluation.asset_key: evaluation for evaluation in evaluations}
-
-        pipeline_and_execution_plan_cache: Dict[int, Tuple[ExternalJob, ExternalExecutionPlan]] = {}
-
-        submit_job_inputs: List[Tuple[RunRequest, ExternalJob, ExternalExecutionPlan]] = []
-
-        # First do work that is most likely to fail before doing any writes (to make
-        # double-creation of runs less likely)
-        for run_request in run_requests:
-            yield
-            submit_job_inputs.append(
-                get_asset_run_submit_input(
-                    run_request._replace(
-                        tags={
-                            **run_request.tags,
-                            ASSET_EVALUATION_ID_TAG: str(new_cursor.evaluation_id),
-                        }
-                    ),
-                    instance,
-                    workspace,
-                    asset_graph,
-                    pipeline_and_execution_plan_cache,
-                )
+        tick = instance.create_tick(
+            TickData(
+                instigator_origin_id=FIXED_AUTO_MATERIALIZATION_ORIGIN_ID,
+                instigator_name=FIXED_AUTO_MATERIALIZATION_INSTIGATOR_NAME,
+                instigator_type=InstigatorType.AUTO_MATERIALIZE,
+                status=TickStatus.STARTED,
+                timestamp=evaluation_time.timestamp(),
+                selector_id=FIXED_AUTO_MATERIALIZATION_SELECTOR_ID,
             )
+        )
 
-        # Now submit all runs to the queue
-        for submit_job_input in submit_job_inputs:
-            yield
-
-            run_request, external_job, external_execution_plan = submit_job_input
-
-            asset_keys = check.not_none(run_request.asset_selection)
-
-            run = submit_asset_run(
-                run_request, instance, workspace, external_job, external_execution_plan
-            )
-
-            asset_key_str = ", ".join([asset_key.to_user_string() for asset_key in asset_keys])
+        with AutoMaterializeLaunchContext(
+            tick, instance, self._logger, tick_retention_settings
+        ) as tick_context:
+            run_requests, new_cursor, evaluations = AssetDaemonContext(
+                asset_graph=asset_graph,
+                target_asset_keys=target_asset_keys,
+                instance=instance,
+                cursor=cursor,
+                materialize_run_tags={
+                    AUTO_MATERIALIZE_TAG: "true",
+                    **instance.auto_materialize_run_tags,
+                },
+                observe_run_tags={AUTO_OBSERVE_TAG: "true"},
+                auto_observe=True,
+                respect_materialization_data_versions=instance.auto_materialize_respect_materialization_data_versions,
+                logger=self._logger,
+            ).evaluate()
 
             self._logger.info(
-                f"Launched run {run.run_id} for assets {asset_key_str} with tags {run_request.tags}"
+                f"Tick produced {len(run_requests)} run{'s' if len(run_requests) != 1 else ''} and"
+                f" {len(evaluations)} asset evaluation{'s' if len(evaluations) != 1 else ''} for"
+                f" evaluation ID {new_cursor.evaluation_id}"
             )
 
-            # add run id to evaluations
-            for asset_key in asset_keys:
-                # asset keys for observation runs don't have evaluations
-                if asset_key in evaluations_by_asset_key:
-                    evaluation = evaluations_by_asset_key[asset_key]
-                    evaluations_by_asset_key[asset_key] = evaluation._replace(
-                        run_ids=evaluation.run_ids | {run.run_id}
-                    )
+            evaluations_by_asset_key = {
+                evaluation.asset_key: evaluation for evaluation in evaluations
+            }
 
-        instance.daemon_cursor_storage.set_cursor_values({CURSOR_KEY: new_cursor.serialize()})
+            pipeline_and_execution_plan_cache: Dict[
+                int, Tuple[ExternalJob, ExternalExecutionPlan]
+            ] = {}
+
+            submit_job_inputs: List[Tuple[RunRequest, ExternalJob, ExternalExecutionPlan]] = []
+
+            # First do work that is most likely to fail before doing any writes (to make
+            # double-creation of runs less likely)
+            for run_request in run_requests:
+                yield
+                submit_job_inputs.append(
+                    get_asset_run_submit_input(
+                        run_request._replace(
+                            tags={
+                                **run_request.tags,
+                                ASSET_EVALUATION_ID_TAG: str(new_cursor.evaluation_id),
+                            }
+                        ),
+                        instance,
+                        workspace,
+                        asset_graph,
+                        pipeline_and_execution_plan_cache,
+                    )
+                )
+
+            # Now submit all runs to the queue
+            for submit_job_input in submit_job_inputs:
+                yield
+
+                run_request, external_job, external_execution_plan = submit_job_input
+
+                asset_keys = check.not_none(run_request.asset_selection)
+
+                run = submit_asset_run(
+                    run_request, instance, workspace, external_job, external_execution_plan
+                )
+
+                asset_key_str = ", ".join([asset_key.to_user_string() for asset_key in asset_keys])
+
+                self._logger.info(
+                    f"Launched run {run.run_id} for assets {asset_key_str} with tags"
+                    f" {run_request.tags}"
+                )
+
+                tick_context.add_run_info(run_id=run.run_id)
+
+                # add run id to evaluations
+                for asset_key in asset_keys:
+                    # asset keys for observation runs don't have evaluations
+                    if asset_key in evaluations_by_asset_key:
+                        evaluation = evaluations_by_asset_key[asset_key]
+                        evaluations_by_asset_key[asset_key] = evaluation._replace(
+                            run_ids=evaluation.run_ids | {run.run_id}
+                        )
+
+            tick_finish_timestamp = pendulum.now("UTC").timestamp()
+
+            instance.daemon_cursor_storage.set_cursor_values({CURSOR_KEY: new_cursor.serialize()})
+            tick_context.update_state(
+                TickStatus.SUCCESS if len(run_requests) > 0 else TickStatus.SKIPPED,
+                end_timestamp=tick_finish_timestamp,
+            )
 
         # We enforce uniqueness per (asset key, evaluation id). Store the evaluations after the cursor,
         # so that if the daemon crashes and doesn't update the cursor we don't try to write duplicates.

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
@@ -164,6 +164,7 @@ class AssetReconciliationScenario(
             ("expected_evaluations", Optional[Sequence[AssetEvaluationSpec]]),
             ("requires_respect_materialization_data_versions", bool),
             ("supports_with_external_asset_graph", bool),
+            ("expected_error_message", Optional[str]),
         ],
     )
 ):
@@ -186,6 +187,7 @@ class AssetReconciliationScenario(
         expected_evaluations: Optional[Sequence[AssetEvaluationSpec]] = None,
         requires_respect_materialization_data_versions: bool = False,
         supports_with_external_asset_graph: bool = True,
+        expected_error_message: Optional[str] = None,
     ) -> "AssetReconciliationScenario":
         # For scenarios with no auto-materialize policies, we infer auto-materialize policies
         # and add them to the assets.
@@ -222,6 +224,7 @@ class AssetReconciliationScenario(
             expected_evaluations=expected_evaluations,
             requires_respect_materialization_data_versions=requires_respect_materialization_data_versions,
             supports_with_external_asset_graph=supports_with_external_asset_graph,
+            expected_error_message=expected_error_message,
         )
 
     def _get_code_location_origin(
@@ -490,7 +493,19 @@ class AssetReconciliationScenario(
                     workspace.get_code_location_error("test_location") is None
                 ), workspace.get_code_location_error("test_location")
 
-                list(AssetDaemon(interval_seconds=42).run_iteration(workspace_context))
+                try:
+                    list(AssetDaemon(interval_seconds=42).run_iteration(workspace_context))
+
+                    if self.expected_error_message:
+                        raise Exception(
+                            f"Failed to raise expected error {self.expected_error_message}"
+                        )
+
+                except Exception:
+                    if not self.expected_error_message:
+                        raise
+
+                    assert self.expected_error_message in str(sys.exc_info())
 
 
 def do_run(
@@ -568,6 +583,7 @@ def asset_def(
     freshness_policy: Optional[FreshnessPolicy] = None,
     auto_materialize_policy: Optional[AutoMaterializePolicy] = None,
     code_version: Optional[str] = None,
+    config_schema: Optional[Mapping[str, Field]] = None,
 ) -> AssetsDefinition:
     if deps is None:
         non_argument_deps = None
@@ -587,7 +603,7 @@ def asset_def(
         partitions_def=partitions_def,
         deps=non_argument_deps,
         ins=ins,
-        config_schema={"fail": Field(bool, default_value=False)},
+        config_schema=config_schema or {"fail": Field(bool, default_value=False)},
         freshness_policy=freshness_policy,
         auto_materialize_policy=auto_materialize_policy,
         code_version=code_version,

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/auto_materialize_policy_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/auto_materialize_policy_scenarios.py
@@ -1,7 +1,9 @@
 import datetime
 
 from dagster import (
+    Field,
     PartitionKeyRange,
+    StringSource,
 )
 from dagster._core.definitions.asset_selection import AssetSelection
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
@@ -123,6 +125,18 @@ partitioned_to_unpartitioned_allow_missing_parent = [
         "unpartitioned2", ["unpartitioned1"], auto_materialize_policy=AutoMaterializePolicy.eager()
     ),
 ]
+
+# Asset that triggers an error within the daemon when you try to generate
+# a plan to materialize it
+error_asset = [
+    asset_def(
+        "error_asset",
+        config_schema={
+            "foo": Field(StringSource, default_value={"env": "VAR_THAT_DOES_NOT_EXIST"}),
+        },
+    )
+]
+
 
 get_unpartitioned_with_one_parent_partitioned_skip_on_parents_updated = (
     lambda require_update_for_all_parent_partitions: with_auto_materialize_policy(
@@ -781,5 +795,14 @@ auto_materialize_policy_scenarios = {
             current_time=create_pendulum_time(year=2023, month=1, day=1, hour=4),
             expected_run_requests=[run_request(["asset3"], partition_key="2023-01-01-03:00")],
         )
+    ),
+    "error_asset_scenario": AssetReconciliationScenario(
+        assets=with_auto_materialize_policy(error_asset, AutoMaterializePolicy.eager()),
+        unevaluated_runs=[],
+        expected_run_requests=[run_request(["error_asset"])],
+        expected_error_message=(
+            'You have attempted to fetch the environment variable "VAR_THAT_DOES_NOT_EXIST" which'
+            " is not set"
+        ),
     ),
 }

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/scenarios.py
@@ -2,7 +2,9 @@ from dagster import Definitions
 from dagster._core.definitions.executor_definition import in_process_executor
 
 from .active_run_scenarios import active_run_scenarios
-from .auto_materialize_policy_scenarios import auto_materialize_policy_scenarios
+from .auto_materialize_policy_scenarios import (
+    auto_materialize_policy_scenarios,
+)
 from .auto_observe_scenarios import auto_observe_scenarios
 from .basic_scenarios import basic_scenarios
 from .definition_change_scenarios import definition_change_scenarios

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon.py
@@ -1,11 +1,25 @@
+import pendulum
 import pytest
 from dagster import AssetKey
 from dagster._core.instance_for_test import instance_for_test
+from dagster._core.scheduler.instigation import (
+    InstigatorType,
+    TickData,
+    TickStatus,
+)
 from dagster._core.storage.dagster_run import DagsterRunStatus
 from dagster._core.storage.tags import PARTITION_NAME_TAG
-from dagster._daemon.asset_daemon import get_current_evaluation_id, set_auto_materialize_paused
+from dagster._daemon.asset_daemon import (
+    FIXED_AUTO_MATERIALIZATION_INSTIGATOR_NAME,
+    FIXED_AUTO_MATERIALIZATION_ORIGIN_ID,
+    FIXED_AUTO_MATERIALIZATION_SELECTOR_ID,
+    get_current_evaluation_id,
+    set_auto_materialize_paused,
+)
 
-from .scenarios.auto_materialize_policy_scenarios import auto_materialize_policy_scenarios
+from .scenarios.auto_materialize_policy_scenarios import (
+    auto_materialize_policy_scenarios,
+)
 from .scenarios.auto_observe_scenarios import auto_observe_scenarios
 from .scenarios.multi_code_location_scenarios import multi_code_location_scenarios
 from .scenarios.scenarios import ASSET_RECONCILIATION_SCENARIOS
@@ -53,7 +67,7 @@ daemon_scenarios = {
 
 
 @pytest.fixture
-def daemon_not_paused_instance():
+def daemon_paused_instance():
     with instance_for_test(
         overrides={
             "run_launcher": {
@@ -61,9 +75,205 @@ def daemon_not_paused_instance():
                 "class": "SyncInMemoryRunLauncher",
             }
         }
-    ) as instance:
-        set_auto_materialize_paused(instance, False)
-        yield instance
+    ) as the_instance:
+        yield the_instance
+
+
+@pytest.fixture
+def daemon_not_paused_instance(daemon_paused_instance):
+    set_auto_materialize_paused(daemon_paused_instance, False)
+    return daemon_paused_instance
+
+
+def test_daemon_ticks(daemon_paused_instance):
+    instance = daemon_paused_instance
+    ticks = instance.get_ticks(
+        origin_id=FIXED_AUTO_MATERIALIZATION_ORIGIN_ID,
+        selector_id=FIXED_AUTO_MATERIALIZATION_SELECTOR_ID,
+    )
+    assert len(ticks) == 0
+
+    scenario = daemon_scenarios["auto_materialize_policy_lazy_freshness_missing"]
+    scenario.do_daemon_scenario(
+        instance, scenario_name="auto_materialize_policy_lazy_freshness_missing"
+    )
+
+    ticks = instance.get_ticks(
+        origin_id=FIXED_AUTO_MATERIALIZATION_ORIGIN_ID,
+        selector_id=FIXED_AUTO_MATERIALIZATION_SELECTOR_ID,
+    )
+
+    # Daemon paused, so no ticks
+    assert len(ticks) == 0
+
+    set_auto_materialize_paused(instance, False)
+
+    freeze_datetime = pendulum.now("UTC")
+    with pendulum.test(freeze_datetime):
+        scenario.do_daemon_scenario(
+            instance, scenario_name="auto_materialize_policy_lazy_freshness_missing"
+        )
+        ticks = instance.get_ticks(
+            origin_id=FIXED_AUTO_MATERIALIZATION_ORIGIN_ID,
+            selector_id=FIXED_AUTO_MATERIALIZATION_SELECTOR_ID,
+        )
+
+        assert len(ticks) == 1
+        assert ticks[0]
+        assert ticks[0].status == TickStatus.SUCCESS
+        assert ticks[0].timestamp == freeze_datetime.timestamp()
+        assert ticks[0].tick_data.end_timestamp == freeze_datetime.timestamp()
+        assert len(ticks[0].tick_data.run_ids) == 1
+
+    freeze_datetime = pendulum.now("UTC").add(seconds=40)
+    with pendulum.test(freeze_datetime):
+        scenario.do_daemon_scenario(
+            instance, scenario_name="auto_materialize_policy_lazy_freshness_missing"
+        )
+        ticks = instance.get_ticks(
+            origin_id=FIXED_AUTO_MATERIALIZATION_ORIGIN_ID,
+            selector_id=FIXED_AUTO_MATERIALIZATION_SELECTOR_ID,
+        )
+
+        # No new runs, so tick is now skipped
+
+        assert len(ticks) == 2
+        assert ticks[0]
+        assert ticks[0].status == TickStatus.SKIPPED
+        assert ticks[0].timestamp == freeze_datetime.timestamp()
+        assert ticks[0].tick_data.end_timestamp == freeze_datetime.timestamp()
+
+
+def test_error_daemon_tick(daemon_not_paused_instance):
+    freeze_datetime = pendulum.now("UTC")
+    with pendulum.test(freeze_datetime):
+        error_asset_scenario = daemon_scenarios["error_asset_scenario"]
+        error_asset_scenario.do_daemon_scenario(
+            daemon_not_paused_instance, scenario_name="error_asset_scenario"
+        )
+
+        ticks = daemon_not_paused_instance.get_ticks(
+            origin_id=FIXED_AUTO_MATERIALIZATION_ORIGIN_ID,
+            selector_id=FIXED_AUTO_MATERIALIZATION_SELECTOR_ID,
+        )
+
+        assert len(ticks) == 1
+        assert ticks[0].status == TickStatus.FAILURE
+        assert ticks[0].timestamp == freeze_datetime.timestamp()
+        assert ticks[0].tick_data.end_timestamp == freeze_datetime.timestamp()
+        assert error_asset_scenario.expected_error_message in str(ticks[0].tick_data.error)
+
+
+@pytest.fixture
+def custom_purge_instance():
+    with instance_for_test(
+        overrides={
+            "run_launcher": {
+                "module": "dagster._core.launcher.sync_in_memory_run_launcher",
+                "class": "SyncInMemoryRunLauncher",
+            },
+            "retention": {"auto_materialize": {"purge_after_days": {"skipped": 2}}},
+        }
+    ) as the_instance:
+        set_auto_materialize_paused(the_instance, False)
+        yield the_instance
+
+
+def _create_tick(instance, status, timestamp):
+    return instance.create_tick(
+        TickData(
+            instigator_origin_id=FIXED_AUTO_MATERIALIZATION_ORIGIN_ID,
+            instigator_name=FIXED_AUTO_MATERIALIZATION_INSTIGATOR_NAME,
+            instigator_type=InstigatorType.AUTO_MATERIALIZE,
+            status=status,
+            timestamp=timestamp,
+            selector_id=FIXED_AUTO_MATERIALIZATION_SELECTOR_ID,
+            run_ids=[],
+        )
+    )
+
+
+def test_auto_materialize_purge(daemon_not_paused_instance):
+    freeze_datetime = pendulum.now("UTC")
+
+    tick_1 = _create_tick(
+        daemon_not_paused_instance, TickStatus.SKIPPED, freeze_datetime.subtract(days=1).timestamp()
+    )
+    tick_2 = _create_tick(
+        daemon_not_paused_instance, TickStatus.SKIPPED, freeze_datetime.subtract(days=6).timestamp()
+    )
+    _create_tick(
+        daemon_not_paused_instance, TickStatus.SKIPPED, freeze_datetime.subtract(days=8).timestamp()
+    )
+
+    ticks = daemon_not_paused_instance.get_ticks(
+        origin_id=FIXED_AUTO_MATERIALIZATION_ORIGIN_ID,
+        selector_id=FIXED_AUTO_MATERIALIZATION_SELECTOR_ID,
+    )
+    assert len(ticks) == 3
+
+    with pendulum.test(freeze_datetime):
+        scenario = daemon_scenarios["auto_materialize_policy_lazy_freshness_missing"]
+        scenario.do_daemon_scenario(
+            daemon_not_paused_instance,
+            scenario_name="auto_materialize_policy_lazy_freshness_missing",
+        )
+
+        # creates one SUCCESS tick and purges the old SKIPPED ticks
+        ticks = daemon_not_paused_instance.get_ticks(
+            origin_id=FIXED_AUTO_MATERIALIZATION_ORIGIN_ID,
+            selector_id=FIXED_AUTO_MATERIALIZATION_SELECTOR_ID,
+        )
+
+        assert len(ticks) == 3
+
+        assert ticks[0]
+        assert ticks[0].status == TickStatus.SUCCESS
+        assert ticks[0].timestamp == freeze_datetime.timestamp()
+
+        assert ticks[1] == tick_1
+        assert ticks[2] == tick_2
+
+
+def test_custom_purge(custom_purge_instance):
+    freeze_datetime = pendulum.now("UTC")
+
+    tick_1 = _create_tick(
+        custom_purge_instance, TickStatus.SKIPPED, freeze_datetime.subtract(days=1).timestamp()
+    )
+    _create_tick(
+        custom_purge_instance, TickStatus.SKIPPED, freeze_datetime.subtract(days=6).timestamp()
+    )
+    _create_tick(
+        custom_purge_instance, TickStatus.SKIPPED, freeze_datetime.subtract(days=8).timestamp()
+    )
+
+    ticks = custom_purge_instance.get_ticks(
+        origin_id=FIXED_AUTO_MATERIALIZATION_ORIGIN_ID,
+        selector_id=FIXED_AUTO_MATERIALIZATION_SELECTOR_ID,
+    )
+    assert len(ticks) == 3
+
+    with pendulum.test(freeze_datetime):
+        scenario = daemon_scenarios["auto_materialize_policy_lazy_freshness_missing"]
+        scenario.do_daemon_scenario(
+            custom_purge_instance,
+            scenario_name="auto_materialize_policy_lazy_freshness_missing",
+        )
+
+        # creates one SUCCESS tick and purges the old SKIPPED ticks
+        ticks = custom_purge_instance.get_ticks(
+            origin_id=FIXED_AUTO_MATERIALIZATION_ORIGIN_ID,
+            selector_id=FIXED_AUTO_MATERIALIZATION_SELECTOR_ID,
+        )
+
+        assert len(ticks) == 2
+
+        assert ticks[0]
+        assert ticks[0].status == TickStatus.SUCCESS
+        assert ticks[0].timestamp == freeze_datetime.timestamp()
+
+        assert ticks[1] == tick_1
 
 
 @pytest.mark.parametrize(
@@ -81,7 +291,9 @@ def test_daemon(scenario_item, daemon_not_paused_instance):
     inner_scenario = scenario
     while inner_scenario is not None:
         expected_runs += len(inner_scenario.unevaluated_runs or []) + len(
-            inner_scenario.expected_run_requests or []
+            inner_scenario.expected_run_requests
+            if inner_scenario.expected_run_requests and not inner_scenario.expected_error_message
+            else []
         )
         inner_scenario = inner_scenario.cursor_from
 
@@ -113,12 +325,17 @@ def test_daemon(scenario_item, daemon_not_paused_instance):
         else []
     )
 
-    assert len(submitted_runs_in_scenario) == len(scenario.expected_run_requests), (
-        "Expected the following run requests to be submitted:"
-        f" {scenario.expected_run_requests} \n"
-        " but instead submitted runs with asset and partition selection:"
-        f" {[(list(run.asset_selection), run.tags.get(PARTITION_NAME_TAG)) for run in submitted_runs_in_scenario]}"
-    )
+    if scenario.expected_error_message:
+        assert (
+            len(submitted_runs_in_scenario) == 0
+        ), "scenario should have raised an error, but instead it submitted runs"
+    else:
+        assert len(submitted_runs_in_scenario) == len(scenario.expected_run_requests), (
+            "Expected the following run requests to be submitted:"
+            f" {scenario.expected_run_requests} \n"
+            " but instead submitted runs with asset and partition selection:"
+            f" {[(list(run.asset_selection), run.tags.get(PARTITION_NAME_TAG)) for run in submitted_runs_in_scenario]}"
+        )
 
     sorted_runs = sorted(runs[: len(scenario.expected_run_requests)], key=sort_run_key_fn)
     sorted_expected_run_requests = sorted(


### PR DESCRIPTION
## Summary & Motivation
Adds a new type of tick in the ticks table that can be used for the AMP daemon. Had to use a hard-coded origin ID to access the ticks, but that seems preferable to requiring a schema migration.

Also added an end_timestamp field to the ticks, which allows us to track how long a tick took (and could be useful for sensors as well)

Upcoming:
- graphql APIs for the frontend
- use the ticks to ensure better idempotency / failure recovery if there's an error in the middle of launching runs
 
