### PR TITLE
[ui] Front-end updates for “Terminate all” queued / in progress runs

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/QueuedRunsBanners.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/QueuedRunsBanners.tsx
@@ -1,0 +1,67 @@
+import {gql, useQuery} from '@apollo/client';
+import {Alert, Box} from '@dagster-io/ui-components';
+import React from 'react';
+import {Link} from 'react-router-dom';
+
+import {InstancePageContext} from '../instance/InstancePageContext';
+import {useCanSeeConfig} from '../instance/useCanSeeConfig';
+
+import {
+  QueueDaemonStatusQuery,
+  QueueDaemonStatusQueryVariables,
+} from './types/QueuedRunsBanners.types';
+
+export const QueuedRunsBanners: React.FC = () => {
+  const canSeeConfig = useCanSeeConfig();
+
+  return (
+    <Box flex={{direction: 'column', gap: 8}} style={{minWidth: '100%'}} border="bottom">
+      {canSeeConfig && (
+        <Alert
+          intent="info"
+          title={<Link to="/config#run_coordinator">View queue configuration</Link>}
+        />
+      )}
+      {canSeeConfig && <QueueDaemonAlert />}
+    </Box>
+  );
+};
+
+const QueueDaemonAlert = () => {
+  const {data} = useQuery<QueueDaemonStatusQuery, QueueDaemonStatusQueryVariables>(
+    QUEUE_DAEMON_STATUS_QUERY,
+  );
+  const {pageTitle} = React.useContext(InstancePageContext);
+  const status = data?.instance.daemonHealth.daemonStatus;
+  if (status?.required && !status?.healthy) {
+    return (
+      <Alert
+        intent="warning"
+        title="The queued run coordinator is not healthy."
+        description={
+          <div>
+            View <Link to="/health">{pageTitle}</Link> for details.
+          </div>
+        }
+      />
+    );
+  }
+  return null;
+};
+
+const QUEUE_DAEMON_STATUS_QUERY = gql`
+  query QueueDaemonStatusQuery {
+    instance {
+      id
+      daemonHealth {
+        id
+        daemonStatus(daemonType: "QUEUED_RUN_COORDINATOR") {
+          id
+          daemonType
+          healthy
+          required
+        }
+      }
+    }
+  }
+`;

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunActionButtons.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunActionButtons.tsx
@@ -13,7 +13,7 @@ import {doneStatuses, failedStatuses} from './RunStatuses';
 import {DagsterTag} from './RunTag';
 import {getReexecutionParamsForSelection} from './RunUtils';
 import {StepSelection} from './StepSelection';
-import {TerminationDialog, TerminationState} from './TerminationDialog';
+import {TerminationDialog, TerminationDialogResult} from './TerminationDialog';
 import {RunFragment, RunPageFragment} from './types/RunFragments.types';
 import {useJobAvailabilityErrorForRun} from './useJobAvailabilityErrorForRun';
 import {useJobReexecution} from './useJobReExecution';
@@ -31,8 +31,8 @@ export const CancelRunButton: React.FC<{run: RunFragment}> = ({run}) => {
   const closeDialog = React.useCallback(() => setShowDialog(false), []);
 
   const onComplete = React.useCallback(
-    async (terminationState: TerminationState) => {
-      const {errors} = terminationState;
+    async (result: TerminationDialogResult) => {
+      const {errors} = result;
       const error = runId && errors[runId];
       if (error && 'message' in error) {
         await showSharedToaster({

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunTable.tsx
@@ -543,7 +543,7 @@ function ActionBar({top, bottom}: {top: React.ReactNode; bottom?: React.ReactNod
           margin={{top: 12}}
           padding={{left: 24, right: 12, top: 8}}
           border="top"
-          flex={{gap: 8}}
+          flex={{gap: 8, wrap: 'wrap'}}
         >
           {bottom}
         </Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunUtils.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunUtils.tsx
@@ -222,24 +222,29 @@ export const DELETE_MUTATION = gql`
 `;
 
 export const TERMINATE_MUTATION = gql`
-  mutation Terminate($runId: String!, $terminatePolicy: TerminateRunPolicy) {
-    terminatePipelineExecution(runId: $runId, terminatePolicy: $terminatePolicy) {
-      ... on TerminateRunFailure {
-        message
-      }
-      ... on RunNotFoundError {
-        message
-      }
-      ... on TerminateRunSuccess {
-        run {
-          id
-          canTerminate
+  mutation Terminate($runIds: [String!]!, $terminatePolicy: TerminateRunPolicy) {
+    terminateRuns(runIds: $runIds, terminatePolicy: $terminatePolicy) {
+      ...PythonErrorFragment
+      ... on TerminateRunsResult {
+        terminateRunResults {
+          ...PythonErrorFragment
+          ... on RunNotFoundError {
+            message
+          }
+          ... on TerminateRunFailure {
+            message
+          }
+          ... on TerminateRunSuccess {
+            run {
+              id
+              canTerminate
+            }
+          }
         }
       }
       ...PythonErrorFragment
     }
   }
-
   ${PYTHON_ERROR_FRAGMENT}
 `;
 

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsRoot.tsx
@@ -1,6 +1,5 @@
-import {ApolloError, gql, useQuery} from '@apollo/client';
+import {ApolloError, gql} from '@apollo/client';
 import {
-  Alert,
   Box,
   ButtonLink,
   CursorHistoryControls,
@@ -12,7 +11,6 @@ import {
 } from '@dagster-io/ui-components';
 import partition from 'lodash/partition';
 import * as React from 'react';
-import {Link} from 'react-router-dom';
 
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {
@@ -23,27 +21,23 @@ import {
 } from '../app/QueryRefresh';
 import {useTrackPageView} from '../app/analytics';
 import {usePortalSlot} from '../hooks/usePortalSlot';
-import {InstancePageContext} from '../instance/InstancePageContext';
-import {useCanSeeConfig} from '../instance/useCanSeeConfig';
 import {Loading} from '../ui/Loading';
 import {StickyTableContainer} from '../ui/StickyTableContainer';
 
+import {QueuedRunsBanners} from './QueuedRunsBanners';
 import {useRunListTabs, useSelectedRunsTab} from './RunListTabs';
-import {RunTable, RUN_TABLE_RUN_FRAGMENT} from './RunTable';
+import {inProgressStatuses, queuedStatuses} from './RunStatuses';
+import {RUN_TABLE_RUN_FRAGMENT, RunTable} from './RunTable';
 import {RunsQueryRefetchContext} from './RunUtils';
 import {
+  RunFilterToken,
   RunFilterTokenType,
   runsFilterForSearchTokens,
   useQueryPersistedRunFilters,
-  RunFilterToken,
   useRunsFilterInput,
 } from './RunsFilterInput';
-import {
-  QueueDaemonStatusQuery,
-  QueueDaemonStatusQueryVariables,
-  RunsRootQuery,
-  RunsRootQueryVariables,
-} from './types/RunsRoot.types';
+import {TerminateAllRunsButton} from './TerminateAllRunsButton';
+import {RunsRootQuery, RunsRootQueryVariables} from './types/RunsRoot.types';
 import {useCursorPaginatedQuery} from './useCursorPaginatedQuery';
 
 const PAGE_SIZE = 25;
@@ -53,7 +47,6 @@ export const RunsRoot = () => {
 
   const [filterTokens, setFilterTokens] = useQueryPersistedRunFilters();
   const filter = runsFilterForSearchTokens(filterTokens);
-  const canSeeConfig = useCanSeeConfig();
 
   const {queryResult, paginationProps} = useCursorPaginatedQuery<
     RunsRootQuery,
@@ -146,9 +139,32 @@ export const RunsRoot = () => {
 
   function actionBar() {
     return (
-      <Box flex={{direction: 'row', alignItems: 'center', gap: 8}}>
-        {tabs}
-        {filtersSlot}
+      <Box style={{width: '100%', marginRight: 8}} flex={{justifyContent: 'space-between'}}>
+        <Box flex={{direction: 'row', alignItems: 'center', gap: 8}}>
+          {tabs}
+          {filtersSlot}
+        </Box>
+        {currentTab === 'queued' ? (
+          <TerminateAllRunsButton
+            refetch={combinedRefreshState.refetch}
+            filter={{statuses: Array.from(queuedStatuses)}}
+            disabled={
+              runQueryResult.data?.queuedCount.__typename === 'Runs'
+                ? runQueryResult.data?.queuedCount.count === 0
+                : true
+            }
+          />
+        ) : currentTab === 'in-progress' ? (
+          <TerminateAllRunsButton
+            refetch={combinedRefreshState.refetch}
+            filter={{statuses: Array.from(inProgressStatuses)}}
+            disabled={
+              runQueryResult.data?.inProgressCount.__typename === 'Runs'
+                ? runQueryResult.data?.inProgressCount.count === 0
+                : true
+            }
+          />
+        ) : undefined}
       </Box>
     );
   }
@@ -160,19 +176,6 @@ export const RunsRoot = () => {
         right={<QueryRefreshCountdown refreshState={combinedRefreshState} />}
       />
       {filtersPortal}
-      {currentTab === 'queued' && canSeeConfig ? (
-        <Box
-          flex={{direction: 'column', gap: 8}}
-          padding={{left: 24, right: 12, vertical: 16}}
-          border="bottom"
-        >
-          <Alert
-            intent="info"
-            title={<Link to="/config#run_coordinator">View queue configuration</Link>}
-          />
-          <QueueDaemonAlert />
-        </Box>
-      ) : null}
       <RunsQueryRefetchContext.Provider value={{refetch: queryResult.refetch}}>
         <Loading
           queryResult={queryResult}
@@ -226,16 +229,17 @@ export const RunsRoot = () => {
                     filter={filter}
                     actionBarComponents={actionBar()}
                     belowActionBarComponents={
-                      activeFiltersJsx.length ? (
+                      currentTab === 'queued' || activeFiltersJsx.length ? (
                         <>
-                          {activeFiltersJsx}
-                          <ButtonLink
-                            onClick={() => {
-                              setFilterTokensWithStatus([]);
-                            }}
-                          >
-                            Clear all
-                          </ButtonLink>
+                          {currentTab === 'queued' && <QueuedRunsBanners />}
+                          {activeFiltersJsx.length > 0 && (
+                            <>
+                              {activeFiltersJsx}
+                              <ButtonLink onClick={() => setFilterTokensWithStatus([])}>
+                                Clear all
+                              </ButtonLink>
+                            </>
+                          )}
                         </>
                       ) : null
                     }
@@ -277,43 +281,4 @@ export const RUNS_ROOT_QUERY = gql`
 
   ${RUN_TABLE_RUN_FRAGMENT}
   ${PYTHON_ERROR_FRAGMENT}
-`;
-
-const QueueDaemonAlert = () => {
-  const {data} = useQuery<QueueDaemonStatusQuery, QueueDaemonStatusQueryVariables>(
-    QUEUE_DAEMON_STATUS_QUERY,
-  );
-  const {pageTitle} = React.useContext(InstancePageContext);
-  const status = data?.instance.daemonHealth.daemonStatus;
-  if (status?.required && !status?.healthy) {
-    return (
-      <Alert
-        intent="warning"
-        title="The queued run coordinator is not healthy."
-        description={
-          <div>
-            View <Link to="/health">{pageTitle}</Link> for details.
-          </div>
-        }
-      />
-    );
-  }
-  return null;
-};
-
-const QUEUE_DAEMON_STATUS_QUERY = gql`
-  query QueueDaemonStatusQuery {
-    instance {
-      id
-      daemonHealth {
-        id
-        daemonStatus(daemonType: "QUEUED_RUN_COORDINATOR") {
-          id
-          daemonType
-          healthy
-          required
-        }
-      }
-    }
-  }
 `;

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/ScheduledRunListRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/ScheduledRunListRoot.tsx
@@ -1,5 +1,14 @@
 import {gql, useQuery} from '@apollo/client';
-import {Page, Alert, ButtonLink, Colors, Group, Box} from '@dagster-io/ui-components';
+import {
+  Page,
+  Alert,
+  ButtonLink,
+  Colors,
+  Group,
+  Box,
+  PageHeader,
+  Heading,
+} from '@dagster-io/ui-components';
 import * as React from 'react';
 
 import {showCustomAlert} from '../app/CustomAlertProvider';
@@ -45,12 +54,15 @@ export const ScheduledRunListRoot = () => {
 
   return (
     <Page>
+      <PageHeader
+        title={<Heading>Runs</Heading>}
+        right={<QueryRefreshCountdown refreshState={combinedRefreshState} />}
+      />
       <Box
         flex={{direction: 'row', gap: 8, alignItems: 'center', justifyContent: 'space-between'}}
-        padding={{vertical: 8, left: 24, right: 12}}
+        padding={{vertical: 12, left: 24, right: 12}}
       >
         {tabs}
-        <QueryRefreshCountdown refreshState={combinedRefreshState} />
       </Box>
       <Loading queryResult={queryResult} allowStaleData>
         {(result) => {

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/TerminateAllRunsButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/TerminateAllRunsButton.tsx
@@ -1,0 +1,64 @@
+import {gql, useApolloClient} from '@apollo/client';
+import {Button} from '@dagster-io/ui-components';
+import isEqual from 'lodash/isEqual';
+import React from 'react';
+
+import {RunsFilter} from '../graphql/types';
+
+import {queuedStatuses} from './RunStatuses';
+import {TerminationDialog} from './TerminationDialog';
+import {
+  TerminateRunIdsQuery,
+  TerminateRunIdsQueryVariables,
+} from './types/TerminateAllRunsButton.types';
+
+export const TerminateAllRunsButton: React.FC<{
+  refetch: () => void;
+  filter: RunsFilter;
+  disabled: boolean;
+}> = ({refetch, filter, disabled}) => {
+  const [terminating, setTerminating] = React.useState<{[runId: string]: boolean} | null>(null);
+  const client = useApolloClient();
+
+  const onTerminateAll = async () => {
+    const queuedRunIds = await client.query<TerminateRunIdsQuery, TerminateRunIdsQueryVariables>({
+      query: TERMINATE_RUN_IDS_QUERY,
+      variables: {filter},
+    });
+    setTerminating(
+      queuedRunIds.data.pipelineRunsOrError.__typename === 'Runs'
+        ? Object.fromEntries(
+            queuedRunIds.data.pipelineRunsOrError.results.map((run) => [run.id, run.canTerminate]),
+          )
+        : {},
+    );
+  };
+  return (
+    <>
+      <TerminationDialog
+        isOpen={terminating !== null}
+        selectedRuns={terminating || {}}
+        selectedRunsAllQueued={isEqual(filter, {statuses: Array.from(queuedStatuses)})}
+        onClose={() => setTerminating(null)}
+        onComplete={() => refetch()}
+      />
+      <Button intent="danger" outlined disabled={disabled} onClick={onTerminateAll}>
+        Terminate all…
+      </Button>
+    </>
+  );
+};
+
+const TERMINATE_RUN_IDS_QUERY = gql`
+  query TerminateRunIdsQuery($filter: RunsFilter!) {
+    pipelineRunsOrError(filter: $filter) {
+      ... on Runs {
+        results {
+          id
+          status
+          canTerminate
+        }
+      }
+    }
+  }
+`;

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/TerminationDialog.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/TerminationDialog.test.tsx
@@ -1,0 +1,226 @@
+import {MockedProvider, MockedResponse} from '@apollo/client/testing';
+import {render, screen, waitFor} from '@testing-library/react';
+import * as React from 'react';
+import {MemoryRouter} from 'react-router';
+
+import {
+  TerminateRunPolicy,
+  TerminateRunsResultOrError,
+  buildPythonError,
+  buildRun,
+  buildTerminateRunFailure,
+  buildTerminateRunSuccess,
+  buildTerminateRunsResult,
+} from '../../graphql/types';
+import {TERMINATE_MUTATION} from '../RunUtils';
+import {TerminationDialog, Props as TerminationDialogProps} from '../TerminationDialog';
+import {TerminateMutation, TerminateMutationVariables} from '../types/RunUtils.types';
+
+// isOpen: boolean;
+// onClose: () => void;
+
+// // Fired when terimation has finished. You may want to refresh data in the parent
+// // view but keep the dialog open so the user can view the results of termination.
+// onComplete: (result: TerminationDialogResult) => void;
+
+// // A map from the run ID to its `canTerminate` value
+// selectedRuns: {[id: string]: boolean};
+// selectedRunsAllQueued?: boolean;
+
+function buildMockTerminateMutation(
+  runIds: string[],
+  terminatePolicy: TerminateRunPolicy,
+  result?: TerminateRunsResultOrError,
+): Omit<MockedResponse<TerminateMutation, TerminateMutationVariables>, 'result'> & {
+  result: jest.Mock;
+} {
+  return {
+    request: {
+      query: TERMINATE_MUTATION,
+      variables: {runIds, terminatePolicy},
+    },
+    result: jest.fn(() => ({
+      data: {
+        __typename: 'Mutation',
+        terminateRuns:
+          result ||
+          buildTerminateRunsResult({
+            terminateRunResults: [
+              buildTerminateRunSuccess({run: buildRun({id: 'run-id-1'})}),
+              buildTerminateRunFailure({
+                run: buildRun({id: 'run-id-2'}),
+                message: 'This is the error',
+              }),
+            ],
+          }),
+      },
+    })),
+  };
+}
+
+describe('TerminationDialog', () => {
+  const Test: React.FC<{
+    mocks?: any;
+    propOverrides?: Partial<TerminationDialogProps>;
+  }> = ({mocks, propOverrides}) => {
+    const props = {
+      isOpen: true,
+      onClose: () => {},
+      onComplete: () => {},
+      selectedRuns: {},
+      ...propOverrides,
+    };
+    return (
+      <MemoryRouter>
+        <MockedProvider mocks={mocks}>
+          <TerminationDialog {...props} />
+        </MockedProvider>
+      </MemoryRouter>
+    );
+  };
+
+  it('shows the option to force termination if any canTerminate is true', async () => {
+    render(<Test propOverrides={{selectedRuns: {'run-id-1': false, 'run-id-2': false}}} />);
+
+    expect(screen.queryByTestId('force-termination-checkbox')).toBeNull();
+
+    render(<Test propOverrides={{selectedRuns: {'run-id-1': true, 'run-id-2': false}}} />);
+
+    expect(screen.queryByTestId('force-termination-checkbox')).not.toBeNull();
+  });
+
+  it('calls the terminate mutation with the SAFE_TERMINATE policy by default', async () => {
+    const terminateMock = buildMockTerminateMutation(
+      ['run-id-1', 'run-id-2'],
+      TerminateRunPolicy.SAFE_TERMINATE,
+    );
+    render(
+      <Test
+        mocks={[terminateMock]}
+        propOverrides={{selectedRuns: {'run-id-1': true, 'run-id-2': true}}}
+      />,
+    );
+
+    await screen.getByTestId('terminate-button').click();
+    await waitFor(() => expect(terminateMock.result).toHaveBeenCalled());
+  });
+
+  it('calls the terminate mutation with the MARK_AS_CANCELED_IMMEDIATELY policy if you check the "Force" checkbox', async () => {
+    const terminateMock = buildMockTerminateMutation(
+      ['run-id-1', 'run-id-2'],
+      TerminateRunPolicy.MARK_AS_CANCELED_IMMEDIATELY,
+    );
+    render(
+      <Test
+        mocks={[terminateMock]}
+        propOverrides={{selectedRuns: {'run-id-1': true, 'run-id-2': true}}}
+      />,
+    );
+
+    await screen.getByTestId('force-termination-checkbox').click();
+    await screen.getByTestId('terminate-button').click();
+    await waitFor(() => expect(terminateMock.result).toHaveBeenCalled());
+  });
+
+  it('calls the terminate mutation with 75 IDs at a time for a large set of runs', async () => {
+    const runIds = new Array(125).fill(0).map((_, idx) => `run-id-${idx}`);
+    const terminateMock1 = buildMockTerminateMutation(
+      runIds.slice(0, 75),
+      TerminateRunPolicy.MARK_AS_CANCELED_IMMEDIATELY,
+    );
+    const terminateMock2 = buildMockTerminateMutation(
+      runIds.slice(75),
+      TerminateRunPolicy.MARK_AS_CANCELED_IMMEDIATELY,
+    );
+    render(
+      <Test
+        mocks={[terminateMock1, terminateMock2]}
+        propOverrides={{selectedRuns: Object.fromEntries(runIds.map((r) => [r, true]))}}
+      />,
+    );
+
+    await screen.getByTestId('force-termination-checkbox').click();
+    await screen.getByTestId('terminate-button').click();
+    await waitFor(() => expect(terminateMock1.result).toHaveBeenCalled());
+    await waitFor(() => expect(terminateMock2.result).toHaveBeenCalled());
+  });
+
+  it('presents a summary of success and error results', async () => {
+    const terminateMock = buildMockTerminateMutation(
+      ['run-id-1', 'run-id-2'],
+      TerminateRunPolicy.SAFE_TERMINATE,
+    );
+    render(
+      <Test
+        mocks={[terminateMock]}
+        propOverrides={{selectedRuns: {'run-id-1': true, 'run-id-2': true}}}
+      />,
+    );
+
+    await screen.getByTestId('terminate-button').click();
+    await waitFor(() => expect(terminateMock.result).toHaveBeenCalled());
+
+    await waitFor(() => {
+      expect(screen.getByText('Successfully requested termination for 1 run.')).toBeVisible();
+      expect(screen.getByText('Could not request termination for 1 run:')).toBeVisible();
+      expect(screen.getByText('run-id-2')).toBeVisible();
+      expect(screen.getByText('This is the error')).toBeVisible();
+    });
+  });
+
+  it('presents a generic error if the mutation fails with a PythonError', async () => {
+    const terminateMock = buildMockTerminateMutation(
+      ['run-id-1', 'run-id-2'],
+      TerminateRunPolicy.SAFE_TERMINATE,
+      buildPythonError({message: 'Oh no python error'}),
+    );
+    render(
+      <Test
+        mocks={[terminateMock]}
+        propOverrides={{selectedRuns: {'run-id-1': true, 'run-id-2': true}}}
+      />,
+    );
+
+    await screen.getByTestId('terminate-button').click();
+    await waitFor(() => expect(terminateMock.result).toHaveBeenCalled());
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Sorry, an error occurred and the runs could not be terminated.'),
+      ).toBeVisible();
+    });
+  });
+
+  describe('when selectedRunsAllQueued is passed', () => {
+    it('does not show the force termination option', async () => {
+      render(
+        <Test
+          propOverrides={{
+            selectedRuns: {'run-id-1': true, 'run-id-2': true},
+            selectedRunsAllQueued: true,
+          }}
+        />,
+      );
+      expect(screen.queryByTestId('force-termination-checkbox')).toBeNull();
+    });
+
+    it('calls the terminate mutation with the MARK_AS_CANCELED_IMMEDIATELY policy', async () => {
+      const terminateMock = buildMockTerminateMutation(
+        ['run-id-1', 'run-id-2'],
+        TerminateRunPolicy.MARK_AS_CANCELED_IMMEDIATELY,
+      );
+      render(
+        <Test
+          mocks={[terminateMock]}
+          propOverrides={{
+            selectedRuns: {'run-id-1': true, 'run-id-2': true},
+            selectedRunsAllQueued: true,
+          }}
+        />,
+      );
+
+      await screen.getByTestId('terminate-button').click();
+      await waitFor(() => expect(terminateMock.result).toHaveBeenCalled());
+    });
+  });
+});

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/QueuedRunsBanners.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/QueuedRunsBanners.types.ts
@@ -1,0 +1,24 @@
+// Generated GraphQL types, do not edit manually.
+
+import * as Types from '../../graphql/types';
+
+export type QueueDaemonStatusQueryVariables = Types.Exact<{[key: string]: never}>;
+
+export type QueueDaemonStatusQuery = {
+  __typename: 'Query';
+  instance: {
+    __typename: 'Instance';
+    id: string;
+    daemonHealth: {
+      __typename: 'DaemonHealth';
+      id: string;
+      daemonStatus: {
+        __typename: 'DaemonStatus';
+        id: string;
+        daemonType: string;
+        healthy: boolean | null;
+        required: boolean;
+      };
+    };
+  };
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunUtils.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunUtils.types.ts
@@ -65,13 +65,13 @@ export type DeleteMutation = {
 };
 
 export type TerminateMutationVariables = Types.Exact<{
-  runId: Types.Scalars['String'];
+  runIds: Array<Types.Scalars['String']> | Types.Scalars['String'];
   terminatePolicy?: Types.InputMaybe<Types.TerminateRunPolicy>;
 }>;
 
 export type TerminateMutation = {
   __typename: 'Mutation';
-  terminatePipelineExecution:
+  terminateRuns:
     | {
         __typename: 'PythonError';
         message: string;
@@ -82,11 +82,26 @@ export type TerminateMutation = {
           error: {__typename: 'PythonError'; message: string; stack: Array<string>};
         }>;
       }
-    | {__typename: 'RunNotFoundError'; message: string}
-    | {__typename: 'TerminateRunFailure'; message: string}
     | {
-        __typename: 'TerminateRunSuccess';
-        run: {__typename: 'Run'; id: string; canTerminate: boolean};
+        __typename: 'TerminateRunsResult';
+        terminateRunResults: Array<
+          | {
+              __typename: 'PythonError';
+              message: string;
+              stack: Array<string>;
+              errorChain: Array<{
+                __typename: 'ErrorChainLink';
+                isExplicitLink: boolean;
+                error: {__typename: 'PythonError'; message: string; stack: Array<string>};
+              }>;
+            }
+          | {__typename: 'RunNotFoundError'; message: string}
+          | {__typename: 'TerminateRunFailure'; message: string}
+          | {
+              __typename: 'TerminateRunSuccess';
+              run: {__typename: 'Run'; id: string; canTerminate: boolean};
+            }
+        >;
       };
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunsRoot.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunsRoot.types.ts
@@ -58,24 +58,3 @@ export type RunsRootQuery = {
         }>;
       };
 };
-
-export type QueueDaemonStatusQueryVariables = Types.Exact<{[key: string]: never}>;
-
-export type QueueDaemonStatusQuery = {
-  __typename: 'Query';
-  instance: {
-    __typename: 'Instance';
-    id: string;
-    daemonHealth: {
-      __typename: 'DaemonHealth';
-      id: string;
-      daemonStatus: {
-        __typename: 'DaemonStatus';
-        id: string;
-        daemonType: string;
-        healthy: boolean | null;
-        required: boolean;
-      };
-    };
-  };
-};

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/TerminateAllRunsButton.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/TerminateAllRunsButton.types.ts
@@ -1,0 +1,23 @@
+// Generated GraphQL types, do not edit manually.
+
+import * as Types from '../../graphql/types';
+
+export type TerminateRunIdsQueryVariables = Types.Exact<{
+  filter: Types.RunsFilter;
+}>;
+
+export type TerminateRunIdsQuery = {
+  __typename: 'Query';
+  pipelineRunsOrError:
+    | {__typename: 'InvalidPipelineRunsFilterError'}
+    | {__typename: 'PythonError'}
+    | {
+        __typename: 'Runs';
+        results: Array<{
+          __typename: 'Run';
+          id: string;
+          status: Types.RunStatus;
+          canTerminate: boolean;
+        }>;
+      };
+};


### PR DESCRIPTION
## Summary & Motivation

This PR adds a prominent red Terminate All button to the In Progress and Queued runs pages. It opens the terminate runs modal, which has been reworked to use a batch mutation that is much faster than the old one thanks to Claire's work in #16707.

Per discussion with Josh I also moved the queued run banners beneath the tabs so that the tabs don't move as you switch pages. I also added the Runs header to the Scheduled tab, which I think was just missing.

<img width="1728" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/31f6edbe-ef91-435d-b48d-0a50d44bff73">

<img width="1400" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/f65e20f0-fdf6-4697-8161-ab7aa5816ec7">

When you're terminating queued runs, the behavior is always "force stop" and there is no checkbox or warning in the modal:

<img width="837" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/21d57292-82b4-4ae2-a0c5-bb00a9fc77fe">

From the in-progress tab you get the additional options:

<img width="698" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/cc8238df-f2e3-431d-b20c-df9545e30a03">


## How I Tested These Changes

I've tested this manually with and without the termination permission (stubbed out the resolver locally to test). I think this also deserves a jest test, will add it tonight.
