### PR TITLE
Rename classes in dagster_pipes except for MessageWriter-related classes

### DIFF
--- a/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/domain_specific_dsl/user_scripts/fetch_the_tickers.py
+++ b/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/domain_specific_dsl/user_scripts/fetch_the_tickers.py
@@ -1,5 +1,5 @@
-from dagster_pipes import init_dagster_ext
+from dagster_pipes import init_dagster_pipes
 
-context = init_dagster_ext()
+context = init_dagster_pipes()
 
 context.log(f"Got tickers: {context.extras['tickers']}")

--- a/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/pure_assets_dsl/sql_script.py
+++ b/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/pure_assets_dsl/sql_script.py
@@ -1,6 +1,6 @@
 import sys
 
-from dagster_pipes import init_dagster_ext
+from dagster_pipes import init_dagster_pipes
 
 
 class SomeSqlClient:
@@ -11,7 +11,7 @@ class SomeSqlClient:
 if __name__ == "__main__":
     sql = sys.argv[1]
 
-    context = init_dagster_ext()
+    context = init_dagster_pipes()
 
     client = SomeSqlClient()
     client.query(sql)

--- a/integration_tests/test_suites/k8s-test-suite/tests/test_external_asset.py
+++ b/integration_tests/test_suites/k8s-test-suite/tests/test_external_asset.py
@@ -11,7 +11,7 @@ from dagster._core.pipes.utils import ExtEnvContextInjector, ext_protocol
 from dagster_k8s import execute_k8s_job
 from dagster_k8s.client import DagsterKubernetesClient
 from dagster_k8s.pipes import ExtK8sPod, K8sPodLogsMessageReader
-from dagster_pipes import ExtContextData, ExtDefaultContextLoader
+from dagster_pipes import DefaultPipesContextLoader, PipesContextData
 from dagster_test.test_project import (
     get_test_project_docker_image,
 )
@@ -68,7 +68,7 @@ class ExtConfigMapContextInjector(ExtContextInjector):
     @contextmanager
     def inject_context(
         self,
-        context_data: "ExtContextData",
+        context_data: "PipesContextData",
     ):
         context_config_map_body = kubernetes.client.V1ConfigMap(
             metadata=kubernetes.client.V1ObjectMeta(
@@ -80,7 +80,7 @@ class ExtConfigMapContextInjector(ExtContextInjector):
         )
         self._client.core_api.create_namespaced_config_map(self._namespace, context_config_map_body)
         try:
-            yield {ExtDefaultContextLoader.FILE_PATH_KEY: "/mnt/dagster/context.json"}
+            yield {DefaultPipesContextLoader.FILE_PATH_KEY: "/mnt/dagster/context.json"}
         finally:
             self._client.core_api.delete_namespaced_config_map(self._cm_name, self._namespace)
 

--- a/python_modules/dagster-pipes/dagster_pipes/__init__.py
+++ b/python_modules/dagster-pipes/dagster_pipes/__init__.py
@@ -55,10 +55,10 @@ def _param_name_to_env_key(key: str) -> str:
 
 # ##### PARAMETERS
 
-IS_DAGSTER_PIPED_PROCESS_ENV_VAR = "IS_DAGSTER_PIPED_PROCESS"
+IS_DAGSTER_PIPES_PROCESS = "IS_DAGSTER_PIPED_PROCESS"
 
-DAGSTER_PIPED_ENV_KEYS = {
-    k: _param_name_to_env_key(k) for k in (IS_DAGSTER_PIPED_PROCESS_ENV_VAR, "context", "messages")
+DAGSTER_PIPES_ENV_KEYS = {
+    k: _param_name_to_env_key(k) for k in (IS_DAGSTER_PIPES_PROCESS, "context", "messages")
 }
 
 
@@ -74,7 +74,7 @@ class PipesMessage(TypedDict):
     params: Optional[Mapping[str, Any]]
 
 
-# ##### PIPED PROCESS CONTEXT
+###### PIPES CONTEXT
 
 
 class PipesContextData(TypedDict):
@@ -117,7 +117,7 @@ class PipesMetadataValue(TypedDict):
 
 
 # Infer the type from the raw value on the orchestration end
-PIPEABLE_METADATA_TYPE_INFER = "__infer__"
+PIPES_METADATA_TYPE_INFER = "__infer__"
 
 PipesMetadataType = Literal[
     "__infer__",
@@ -308,7 +308,7 @@ def _normalize_param_metadata(
                 )
             new_metadata[key] = cast(PipesMetadataValue, value)
         else:
-            new_metadata[key] = {"raw_value": value, "type": PIPEABLE_METADATA_TYPE_INFER}
+            new_metadata[key] = {"raw_value": value, "type": PIPES_METADATA_TYPE_INFER}
     return new_metadata
 
 
@@ -339,7 +339,7 @@ def _env_var_to_param_name(env_var: str) -> str:
 
 
 def is_dagster_pipes_process() -> bool:
-    return _param_from_env_var(IS_DAGSTER_PIPED_PROCESS_ENV_VAR)
+    return _param_from_env_var(IS_DAGSTER_PIPES_PROCESS)
 
 
 def _emit_orchestration_inactive_warning() -> None:

--- a/python_modules/dagster-pipes/dagster_pipes/__init__.py
+++ b/python_modules/dagster-pipes/dagster_pipes/__init__.py
@@ -40,13 +40,13 @@ if TYPE_CHECKING:
 
 # This represents the version of the protocol, rather than the version of the package. It must be
 # manually updated whenever there are changes to the protocol.
-EXT_PROTOCOL_VERSION = "0.1"
+PIPES_PROTOCOL_VERSION = "0.1"
 
-ExtExtras = Mapping[str, Any]
-ExtParams = Mapping[str, Any]
+PipesExtras = Mapping[str, Any]
+PipesParams = Mapping[str, Any]
 
 
-_ENV_KEY_PREFIX = "DAGSTER_EXT_"
+_ENV_KEY_PREFIX = "DAGSTER_PIPES_"
 
 
 def _param_name_to_env_key(key: str) -> str:
@@ -55,71 +55,71 @@ def _param_name_to_env_key(key: str) -> str:
 
 # ##### PARAMETERS
 
-IS_DAGSTER_EXT_PROCESS_ENV_VAR = "IS_DAGSTER_EXT_PROCESS"
+IS_DAGSTER_PIPED_PROCESS_ENV_VAR = "IS_DAGSTER_PIPED_PROCESS"
 
-DAGSTER_EXT_ENV_KEYS = {
-    k: _param_name_to_env_key(k) for k in (IS_DAGSTER_EXT_PROCESS_ENV_VAR, "context", "messages")
+DAGSTER_PIPED_ENV_KEYS = {
+    k: _param_name_to_env_key(k) for k in (IS_DAGSTER_PIPED_PROCESS_ENV_VAR, "context", "messages")
 }
 
 
 # ##### MESSAGE
 
 # Can't use a constant for TypedDict key so this value is repeated in `ExtMessage` defn.
-EXT_PROTOCOL_VERSION_FIELD = "__dagster_ext_version"
+PIPES_PROTOCOL_VERSION_FIELD = "__dagster_pipes_version"
 
 
-class ExtMessage(TypedDict):
-    __dagster_ext_version: str
+class PipesMessage(TypedDict):
+    __dagster_pipes_version: str
     method: str
     params: Optional[Mapping[str, Any]]
 
 
-# ##### EXT CONTEXT
+# ##### PIPED PROCESS CONTEXT
 
 
-class ExtContextData(TypedDict):
+class PipesContextData(TypedDict):
     asset_keys: Optional[Sequence[str]]
     code_version_by_asset_key: Optional[Mapping[str, Optional[str]]]
-    provenance_by_asset_key: Optional[Mapping[str, Optional["ExtDataProvenance"]]]
+    provenance_by_asset_key: Optional[Mapping[str, Optional["PipesDataProvenance"]]]
     partition_key: Optional[str]
-    partition_key_range: Optional["ExtPartitionKeyRange"]
-    partition_time_window: Optional["ExtTimeWindow"]
+    partition_key_range: Optional["PipesPartitionKeyRange"]
+    partition_time_window: Optional["PipesTimeWindow"]
     run_id: str
     job_name: Optional[str]
     retry_number: int
     extras: Mapping[str, Any]
 
 
-class ExtPartitionKeyRange(TypedDict):
+class PipesPartitionKeyRange(TypedDict):
     start: str
     end: str
 
 
-class ExtTimeWindow(TypedDict):
+class PipesTimeWindow(TypedDict):
     start: str  # timestamp
     end: str  # timestamp
 
 
-class ExtDataProvenance(TypedDict):
+class PipesDataProvenance(TypedDict):
     code_version: str
     input_data_versions: Mapping[str, str]
     is_user_provided: bool
 
 
-ExtAssetCheckSeverity = Literal["WARN", "ERROR"]
+PipesAssetCheckSeverity = Literal["WARN", "ERROR"]
 
-ExtMetadataRawValue = Union[int, float, str, Mapping[str, Any], Sequence[Any], bool, None]
+PipesMetadataRawValue = Union[int, float, str, Mapping[str, Any], Sequence[Any], bool, None]
 
 
-class ExtMetadataValue(TypedDict):
-    type: "ExtMetadataType"
-    raw_value: ExtMetadataRawValue
+class PipesMetadataValue(TypedDict):
+    type: "PipesMetadataType"
+    raw_value: PipesMetadataRawValue
 
 
 # Infer the type from the raw value on the orchestration end
-EXT_METADATA_TYPE_INFER = "__infer__"
+PIPEABLE_METADATA_TYPE_INFER = "__infer__"
 
-ExtMetadataType = Literal[
+PipesMetadataType = Literal[
     "__infer__",
     "text",
     "url",
@@ -143,17 +143,17 @@ ExtMetadataType = Literal[
 _T = TypeVar("_T")
 
 
-class DagsterExtError(Exception):
+class DagsterPipesError(Exception):
     pass
 
 
-class DagsterExtWarning(Warning):
+class DagsterPipesWarning(Warning):
     pass
 
 
 def _assert_not_none(value: Optional[_T], desc: Optional[str] = None) -> _T:
     if value is None:
-        raise DagsterExtError(f"Missing required property: {desc}")
+        raise DagsterPipesError(f"Missing required property: {desc}")
     return value
 
 
@@ -162,27 +162,27 @@ def _assert_defined_asset_property(value: Optional[_T], key: str) -> _T:
 
 
 # This should only be called under the precondition that the current step targets assets.
-def _assert_single_asset(data: ExtContextData, key: str) -> None:
+def _assert_single_asset(data: PipesContextData, key: str) -> None:
     asset_keys = data["asset_keys"]
     assert asset_keys is not None
     if len(asset_keys) != 1:
-        raise DagsterExtError(f"`{key}` is undefined. Current step targets multiple assets.")
+        raise DagsterPipesError(f"`{key}` is undefined. Current step targets multiple assets.")
 
 
 def _resolve_optionally_passed_asset_key(
-    data: ExtContextData,
+    data: PipesContextData,
     asset_key: Optional[str],
     method: str,
 ) -> str:
     asset_keys = _assert_defined_asset_property(data["asset_keys"], method)
     asset_key = _assert_opt_param_type(asset_key, str, method, "asset_key")
     if asset_key and asset_key not in asset_keys:
-        raise DagsterExtError(
+        raise DagsterPipesError(
             f"Invalid asset key. Expected one of `{asset_keys}`, got `{asset_key}`."
         )
     if not asset_key:
         if len(asset_keys) != 1:
-            raise DagsterExtError(
+            raise DagsterPipesError(
                 f"Calling `{method}` without passing an asset key is undefined. Current step"
                 " targets multiple assets."
             )
@@ -197,22 +197,22 @@ def _assert_defined_partition_property(value: Optional[_T], key: str) -> _T:
 
 
 # This should only be called under the precondition that the current steps targets assets.
-def _assert_single_partition(data: ExtContextData, key: str) -> None:
+def _assert_single_partition(data: PipesContextData, key: str) -> None:
     partition_key_range = data["partition_key_range"]
     assert partition_key_range is not None
     if partition_key_range["start"] != partition_key_range["end"]:
-        raise DagsterExtError(f"`{key}` is undefined. Current step targets multiple partitions.")
+        raise DagsterPipesError(f"`{key}` is undefined. Current step targets multiple partitions.")
 
 
-def _assert_defined_extra(extras: ExtExtras, key: str) -> Any:
+def _assert_defined_extra(extras: PipesExtras, key: str) -> Any:
     if key not in extras:
-        raise DagsterExtError(f"Extra `{key}` is undefined. Extras must be provided by user.")
+        raise DagsterPipesError(f"Extra `{key}` is undefined. Extras must be provided by user.")
     return extras[key]
 
 
 def _assert_param_type(value: _T, expected_type: Any, method: str, param: str) -> _T:
     if not isinstance(value, expected_type):
-        raise DagsterExtError(
+        raise DagsterPipesError(
             f"Invalid type for parameter `{param}` of `{method}`. Expected `{expected_type}`, got"
             f" `{type(value)}`."
         )
@@ -221,7 +221,7 @@ def _assert_param_type(value: _T, expected_type: Any, method: str, param: str) -
 
 def _assert_opt_param_type(value: _T, expected_type: Any, method: str, param: str) -> _T:
     if not (isinstance(value, expected_type) or value is None):
-        raise DagsterExtError(
+        raise DagsterPipesError(
             f"Invalid type for parameter `{param}` of `{method}`. Expected"
             f" `Optional[{expected_type}]`, got `{type(value)}`."
         )
@@ -229,11 +229,11 @@ def _assert_opt_param_type(value: _T, expected_type: Any, method: str, param: st
 
 
 def _assert_env_param_type(
-    env_params: ExtParams, key: str, expected_type: Type[_T], cls: Type
+    env_params: PipesParams, key: str, expected_type: Type[_T], cls: Type
 ) -> _T:
     value = env_params.get(key)
     if not isinstance(value, expected_type):
-        raise DagsterExtError(
+        raise DagsterPipesError(
             f"Invalid type for parameter `{key}` passed from orchestration side to"
             f" `{cls.__name__}`. Expected `{expected_type}`, got `{type(value)}`."
         )
@@ -241,11 +241,11 @@ def _assert_env_param_type(
 
 
 def _assert_opt_env_param_type(
-    env_params: ExtParams, key: str, expected_type: Type[_T], cls: Type
+    env_params: PipesParams, key: str, expected_type: Type[_T], cls: Type
 ) -> Optional[_T]:
     value = env_params.get(key)
     if value is not None and not isinstance(value, expected_type):
-        raise DagsterExtError(
+        raise DagsterPipesError(
             f"Invalid type for parameter `{key}` passed from orchestration side to"
             f" `{cls.__name__}`. Expected `Optional[{expected_type}]`, got `{type(value)}`."
         )
@@ -254,7 +254,7 @@ def _assert_opt_env_param_type(
 
 def _assert_param_value(value: _T, expected_values: Sequence[_T], method: str, param: str) -> _T:
     if value not in expected_values:
-        raise DagsterExtError(
+        raise DagsterPipesError(
             f"Invalid value for parameter `{param}` of `{method}`. Expected one of"
             f" `{expected_values}`, got `{value}`."
         )
@@ -265,7 +265,7 @@ def _assert_opt_param_value(
     value: _T, expected_values: Sequence[_T], method: str, param: str
 ) -> _T:
     if value is not None and value not in expected_values:
-        raise DagsterExtError(
+        raise DagsterPipesError(
             f"Invalid value for parameter `{param}` of `{method}`. Expected one of"
             f" `{expected_values}`, got `{value}`."
         )
@@ -276,37 +276,39 @@ def _assert_param_json_serializable(value: _T, method: str, param: str) -> _T:
     try:
         json.dumps(value)
     except (TypeError, OverflowError):
-        raise DagsterExtError(
+        raise DagsterPipesError(
             f"Invalid type for parameter `{param}` of `{method}`. Expected a JSON-serializable"
             f" type, got `{type(value)}`."
         )
     return value
 
 
-_METADATA_VALUE_KEYS = frozenset(ExtMetadataValue.__annotations__.keys())
+_METADATA_VALUE_KEYS = frozenset(PipesMetadataValue.__annotations__.keys())
 
 
 def _normalize_param_metadata(
-    metadata: Mapping[str, Union[ExtMetadataRawValue, ExtMetadataValue]], method: str, param: str
-) -> Mapping[str, Union[ExtMetadataRawValue, ExtMetadataValue]]:
+    metadata: Mapping[str, Union[PipesMetadataRawValue, PipesMetadataValue]],
+    method: str,
+    param: str,
+) -> Mapping[str, Union[PipesMetadataRawValue, PipesMetadataValue]]:
     _assert_param_type(metadata, dict, method, param)
-    new_metadata: Dict[str, ExtMetadataValue] = {}
+    new_metadata: Dict[str, PipesMetadataValue] = {}
     for key, value in metadata.items():
         if not isinstance(key, str):
-            raise DagsterExtError(
+            raise DagsterPipesError(
                 f"Invalid type for parameter `{param}` of `{method}`. Expected a dict with string"
                 f" keys, got a key `{key}` of type `{type(key)}`."
             )
         elif isinstance(value, dict):
             if not {*value.keys()} == _METADATA_VALUE_KEYS:
-                raise DagsterExtError(
+                raise DagsterPipesError(
                     f"Invalid type for parameter `{param}` of `{method}`. Expected a dict with"
                     " string keys and values that are either raw metadata values or dictionaries"
                     f" with schema `{{raw_value: ..., type: ...}}`. Got a value `{value}`."
                 )
-            new_metadata[key] = cast(ExtMetadataValue, value)
+            new_metadata[key] = cast(PipesMetadataValue, value)
         else:
-            new_metadata[key] = {"raw_value": value, "type": EXT_METADATA_TYPE_INFER}
+            new_metadata[key] = {"raw_value": value, "type": PIPEABLE_METADATA_TYPE_INFER}
     return new_metadata
 
 
@@ -336,8 +338,8 @@ def _env_var_to_param_name(env_var: str) -> str:
     return env_var[len(_ENV_KEY_PREFIX) :].lower()
 
 
-def is_dagster_ext_process() -> bool:
-    return _param_from_env_var(IS_DAGSTER_EXT_PROCESS_ENV_VAR)
+def is_dagster_pipes_process() -> bool:
+    return _param_from_env_var(IS_DAGSTER_PIPED_PROCESS_ENV_VAR)
 
 
 def _emit_orchestration_inactive_warning() -> None:
@@ -345,7 +347,7 @@ def _emit_orchestration_inactive_warning() -> None:
         "This process was not launched by a Dagster orchestration process. All calls to the"
         " `dagster-pipes` context or attempts to initialize `dagster-pipes` abstractions"
         " are no-ops.",
-        category=DagsterExtWarning,
+        category=DagsterPipesWarning,
     )
 
 
@@ -360,10 +362,10 @@ def _get_mock() -> "MagicMock":
 # ########################
 
 
-class ExtContextLoader(ABC):
+class PipesContextLoader(ABC):
     @abstractmethod
     @contextmanager
-    def load_context(self, params: ExtParams) -> Iterator[ExtContextData]: ...
+    def load_context(self, params: PipesParams) -> Iterator[PipesContextData]: ...
 
 
 T_MessageChannel = TypeVar("T_MessageChannel", bound="ExtMessageWriterChannel")
@@ -372,20 +374,20 @@ T_MessageChannel = TypeVar("T_MessageChannel", bound="ExtMessageWriterChannel")
 class ExtMessageWriter(ABC, Generic[T_MessageChannel]):
     @abstractmethod
     @contextmanager
-    def open(self, params: ExtParams) -> Iterator[T_MessageChannel]: ...
+    def open(self, params: PipesParams) -> Iterator[T_MessageChannel]: ...
 
 
 class ExtMessageWriterChannel(ABC, Generic[T_MessageChannel]):
     @abstractmethod
-    def write_message(self, message: ExtMessage) -> None: ...
+    def write_message(self, message: PipesMessage) -> None: ...
 
 
-class ExtParamLoader(ABC):
+class PipesParamsLoader(ABC):
     @abstractmethod
-    def load_context_params(self) -> ExtParams: ...
+    def load_context_params(self) -> PipesParams: ...
 
     @abstractmethod
-    def load_messages_params(self) -> ExtParams: ...
+    def load_messages_params(self) -> PipesParams: ...
 
 
 T_BlobStoreMessageWriterChannel = TypeVar(
@@ -398,13 +400,13 @@ class ExtBlobStoreMessageWriter(ExtMessageWriter[T_BlobStoreMessageWriterChannel
         self.interval = interval
 
     @contextmanager
-    def open(self, params: ExtParams) -> Iterator[T_BlobStoreMessageWriterChannel]:
+    def open(self, params: PipesParams) -> Iterator[T_BlobStoreMessageWriterChannel]:
         channel = self.make_channel(params)
         with channel.buffered_upload_loop():
             yield channel
 
     @abstractmethod
-    def make_channel(self, params: ExtParams) -> T_BlobStoreMessageWriterChannel: ...
+    def make_channel(self, params: PipesParams) -> T_BlobStoreMessageWriterChannel: ...
 
 
 class ExtBlobStoreMessageWriterChannel(ExtMessageWriterChannel):
@@ -414,11 +416,11 @@ class ExtBlobStoreMessageWriterChannel(ExtMessageWriterChannel):
         self._buffer = []
         self._counter = 1
 
-    def write_message(self, message: ExtMessage) -> None:
+    def write_message(self, message: PipesMessage) -> None:
         with self._lock:
             self._buffer.append(message)
 
-    def flush_messages(self) -> Sequence[ExtMessage]:
+    def flush_messages(self) -> Sequence[PipesMessage]:
         with self._lock:
             messages = list(self._buffer)
             self._buffer.clear()
@@ -471,12 +473,12 @@ class ExtBufferedFilesystemMessageWriterChannel(ExtBlobStoreMessageWriterChannel
 # ########################
 
 
-class ExtDefaultContextLoader(ExtContextLoader):
+class DefaultPipesContextLoader(PipesContextLoader):
     FILE_PATH_KEY = "path"
     DIRECT_KEY = "data"
 
     @contextmanager
-    def load_context(self, params: ExtParams) -> Iterator[ExtContextData]:
+    def load_context(self, params: PipesParams) -> Iterator[PipesContextData]:
         if self.FILE_PATH_KEY in params:
             path = _assert_env_param_type(params, self.FILE_PATH_KEY, str, self.__class__)
             with open(path, "r") as f:
@@ -484,9 +486,9 @@ class ExtDefaultContextLoader(ExtContextLoader):
                 yield data
         elif self.DIRECT_KEY in params:
             data = _assert_env_param_type(params, self.DIRECT_KEY, dict, self.__class__)
-            yield cast(ExtContextData, data)
+            yield cast(PipesContextData, data)
         else:
-            raise DagsterExtError(
+            raise DagsterPipesError(
                 f'Invalid params for {self.__class__.__name__}, expected key "{self.FILE_PATH_KEY}"'
                 f' or "{self.DIRECT_KEY}", received {params}',
             )
@@ -499,7 +501,7 @@ class ExtDefaultMessageWriter(ExtMessageWriter):
     STDOUT = "stdout"
 
     @contextmanager
-    def open(self, params: ExtParams) -> Iterator[ExtMessageWriterChannel]:
+    def open(self, params: PipesParams) -> Iterator[ExtMessageWriterChannel]:
         if self.FILE_PATH_KEY in params:
             path = _assert_env_param_type(params, self.FILE_PATH_KEY, str, self.__class__)
             yield ExtFileMessageWriterChannel(path)
@@ -510,12 +512,12 @@ class ExtDefaultMessageWriter(ExtMessageWriter):
             elif stream == self.STDOUT:
                 yield ExtStreamMessageWriterChannel(sys.stdout)
             else:
-                raise DagsterExtError(
+                raise DagsterPipesError(
                     f'Invalid value for key "std", expected "{self.STDERR}" or "{self.STDOUT}" but'
                     f" received {stream}"
                 )
         else:
-            raise DagsterExtError(
+            raise DagsterPipesError(
                 f'Invalid params for {self.__class__.__name__}, expected key "path" or "std",'
                 f" received {params}"
             )
@@ -525,7 +527,7 @@ class ExtFileMessageWriterChannel(ExtMessageWriterChannel):
     def __init__(self, path: str):
         self._path = path
 
-    def write_message(self, message: ExtMessage) -> None:
+    def write_message(self, message: PipesMessage) -> None:
         with open(self._path, "a") as f:
             f.write(json.dumps(message) + "\n")
 
@@ -534,15 +536,15 @@ class ExtStreamMessageWriterChannel(ExtMessageWriterChannel):
     def __init__(self, stream: TextIO):
         self._stream = stream
 
-    def write_message(self, message: ExtMessage) -> None:
+    def write_message(self, message: PipesMessage) -> None:
         self._stream.writelines((json.dumps(message), "\n"))
 
 
-class ExtEnvVarParamLoader(ExtParamLoader):
-    def load_context_params(self) -> ExtParams:
+class EnvVarPipesParamsLoader(PipesParamsLoader):
+    def load_context_params(self) -> PipesParams:
         return _param_from_env_var("context")
 
-    def load_messages_params(self) -> ExtParams:
+    def load_messages_params(self) -> PipesParams:
         return _param_from_env_var("messages")
 
 
@@ -561,7 +563,7 @@ class ExtS3MessageWriter(ExtBlobStoreMessageWriter):
 
     def make_channel(
         self,
-        params: ExtParams,
+        params: PipesParams,
     ) -> "ExtS3MessageChannel":
         bucket = _assert_env_param_type(params, "bucket", str, self.__class__)
         key_prefix = _assert_opt_env_param_type(params, "key_prefix", str, self.__class__)
@@ -597,9 +599,9 @@ class ExtS3MessageChannel(ExtBlobStoreMessageWriterChannel):
 # ########################
 
 
-class ExtDbfsContextLoader(ExtContextLoader):
+class DbfsPipesContextLoader(PipesContextLoader):
     @contextmanager
-    def load_context(self, params: ExtParams) -> Iterator[ExtContextData]:
+    def load_context(self, params: PipesParams) -> Iterator[PipesContextData]:
         unmounted_path = _assert_env_param_type(params, "path", str, self.__class__)
         path = os.path.join("/dbfs", unmounted_path.lstrip("/"))
         with open(path, "r") as f:
@@ -609,7 +611,7 @@ class ExtDbfsContextLoader(ExtContextLoader):
 class ExtDbfsMessageWriter(ExtBlobStoreMessageWriter):
     def make_channel(
         self,
-        params: ExtParams,
+        params: PipesParams,
     ) -> "ExtBufferedFilesystemMessageWriterChannel":
         unmounted_path = _assert_env_param_type(params, "path", str, self.__class__)
         return ExtBufferedFilesystemMessageWriterChannel(
@@ -623,46 +625,46 @@ class ExtDbfsMessageWriter(ExtBlobStoreMessageWriter):
 # ########################
 
 
-def init_dagster_ext(
+def init_dagster_pipes(
     *,
-    context_loader: Optional[ExtContextLoader] = None,
+    context_loader: Optional[PipesContextLoader] = None,
     message_writer: Optional[ExtMessageWriter] = None,
-    param_loader: Optional[ExtParamLoader] = None,
-) -> "ExtContext":
-    if ExtContext.is_initialized():
-        return ExtContext.get()
+    params_loader: Optional[PipesParamsLoader] = None,
+) -> "PipesContext":
+    if PipesContext.is_initialized():
+        return PipesContext.get()
 
-    if is_dagster_ext_process():
-        param_loader = param_loader or ExtEnvVarParamLoader()
-        context_params = param_loader.load_context_params()
-        messages_params = param_loader.load_messages_params()
-        context_loader = context_loader or ExtDefaultContextLoader()
+    if is_dagster_pipes_process():
+        params_loader = params_loader or EnvVarPipesParamsLoader()
+        context_params = params_loader.load_context_params()
+        messages_params = params_loader.load_messages_params()
+        context_loader = context_loader or DefaultPipesContextLoader()
         message_writer = message_writer or ExtDefaultMessageWriter()
         stack = ExitStack()
         context_data = stack.enter_context(context_loader.load_context(context_params))
         message_channel = stack.enter_context(message_writer.open(messages_params))
         atexit.register(stack.__exit__, None, None, None)
-        context = ExtContext(context_data, message_channel)
+        context = PipesContext(context_data, message_channel)
     else:
         _emit_orchestration_inactive_warning()
         context = _get_mock()
-    ExtContext.set(context)
+    PipesContext.set(context)
     return context
 
 
-class ExtContext:
-    _instance: ClassVar[Optional["ExtContext"]] = None
+class PipesContext:
+    _instance: ClassVar[Optional["PipesContext"]] = None
 
     @classmethod
     def is_initialized(cls) -> bool:
         return cls._instance is not None
 
     @classmethod
-    def set(cls, context: "ExtContext") -> None:
+    def set(cls, context: "PipesContext") -> None:
         cls._instance = context
 
     @classmethod
-    def get(cls) -> "ExtContext":
+    def get(cls) -> "PipesContext":
         if cls._instance is None:
             raise Exception(
                 "ExtContext has not been initialized. You must call `init_dagster_ext()`."
@@ -671,7 +673,7 @@ class ExtContext:
 
     def __init__(
         self,
-        data: ExtContextData,
+        data: PipesContextData,
         message_channel: ExtMessageWriterChannel,
     ) -> None:
         self._data = data
@@ -679,8 +681,12 @@ class ExtContext:
         self._materialized_assets: set[str] = set()
 
     def _write_message(self, method: str, params: Optional[Mapping[str, Any]] = None) -> None:
-        message = ExtMessage(
-            {EXT_PROTOCOL_VERSION_FIELD: EXT_PROTOCOL_VERSION, "method": method, "params": params}
+        message = PipesMessage(
+            {
+                PIPES_PROTOCOL_VERSION_FIELD: PIPES_PROTOCOL_VERSION,
+                "method": method,
+                "params": params,
+            }
         )
         self._message_channel.write_message(message)
 
@@ -704,7 +710,7 @@ class ExtContext:
         return asset_keys
 
     @property
-    def provenance(self) -> Optional[ExtDataProvenance]:
+    def provenance(self) -> Optional[PipesDataProvenance]:
         provenance_by_asset_key = _assert_defined_asset_property(
             self._data["provenance_by_asset_key"], "provenance"
         )
@@ -712,7 +718,7 @@ class ExtContext:
         return next(iter(provenance_by_asset_key.values()))
 
     @property
-    def provenance_by_asset_key(self) -> Mapping[str, Optional[ExtDataProvenance]]:
+    def provenance_by_asset_key(self) -> Mapping[str, Optional[PipesDataProvenance]]:
         provenance_by_asset_key = _assert_defined_asset_property(
             self._data["provenance_by_asset_key"], "provenance_by_asset_key"
         )
@@ -745,14 +751,14 @@ class ExtContext:
         return partition_key
 
     @property
-    def partition_key_range(self) -> Optional["ExtPartitionKeyRange"]:
+    def partition_key_range(self) -> Optional["PipesPartitionKeyRange"]:
         partition_key_range = _assert_defined_partition_property(
             self._data["partition_key_range"], "partition_key_range"
         )
         return partition_key_range
 
     @property
-    def partition_time_window(self) -> Optional["ExtTimeWindow"]:
+    def partition_time_window(self) -> Optional["PipesTimeWindow"]:
         # None is a valid value for partition_time_window, but we check that a partition key range
         # is defined.
         _assert_defined_partition_property(
@@ -783,7 +789,7 @@ class ExtContext:
 
     def report_asset_materialization(
         self,
-        metadata: Optional[Mapping[str, Union[ExtMetadataRawValue, ExtMetadataValue]]] = None,
+        metadata: Optional[Mapping[str, Union[PipesMetadataRawValue, PipesMetadataValue]]] = None,
         data_version: Optional[str] = None,
         asset_key: Optional[str] = None,
     ):
@@ -791,7 +797,7 @@ class ExtContext:
             self._data, asset_key, "report_asset_materialization"
         )
         if asset_key in self._materialized_assets:
-            raise DagsterExtError(
+            raise DagsterPipesError(
                 f"Calling `report_asset_materialization` with asset key `{asset_key}` is undefined."
                 " Asset has already been materialized, so no additional data can be reported"
                 " for it."
@@ -814,8 +820,8 @@ class ExtContext:
         self,
         check_name: str,
         success: bool,
-        severity: ExtAssetCheckSeverity = "ERROR",
-        metadata: Optional[Mapping[str, Union[ExtMetadataRawValue, ExtMetadataValue]]] = None,
+        severity: PipesAssetCheckSeverity = "ERROR",
+        metadata: Optional[Mapping[str, Union[PipesMetadataRawValue, PipesMetadataValue]]] = None,
         asset_key: Optional[str] = None,
     ) -> None:
         asset_key = _resolve_optionally_passed_asset_key(

--- a/python_modules/dagster-pipes/dagster_pipes_tests/test_context.py
+++ b/python_modules/dagster-pipes/dagster_pipes_tests/test_context.py
@@ -2,15 +2,15 @@ from unittest.mock import MagicMock
 
 import pytest
 from dagster_pipes import (
-    DagsterExtError,
-    ExtContext,
-    ExtContextData,
-    ExtDataProvenance,
-    ExtPartitionKeyRange,
-    ExtTimeWindow,
+    DagsterPipesError,
+    PipesContext,
+    PipesContextData,
+    PipesDataProvenance,
+    PipesPartitionKeyRange,
+    PipesTimeWindow,
 )
 
-TEST_EXT_CONTEXT_DEFAULTS = ExtContextData(
+TEST_EXT_CONTEXT_DEFAULTS = PipesContextData(
     asset_keys=None,
     code_version_by_asset_key=None,
     provenance_by_asset_key=None,
@@ -26,25 +26,25 @@ TEST_EXT_CONTEXT_DEFAULTS = ExtContextData(
 
 def _make_external_execution_context(**kwargs):
     kwargs = {**TEST_EXT_CONTEXT_DEFAULTS, **kwargs}
-    return ExtContext(
-        data=ExtContextData(**kwargs),
+    return PipesContext(
+        data=PipesContextData(**kwargs),
         message_channel=MagicMock(),
     )
 
 
 def _assert_undefined(context, key) -> None:
-    with pytest.raises(DagsterExtError, match=f"`{key}` is undefined"):
+    with pytest.raises(DagsterPipesError, match=f"`{key}` is undefined"):
         getattr(context, key)
 
 
 def _assert_unknown_asset_key(context, method, *args, **kwargs) -> None:
-    with pytest.raises(DagsterExtError, match="Invalid asset key"):
+    with pytest.raises(DagsterPipesError, match="Invalid asset key"):
         getattr(context, method)(*args, **kwargs)
 
 
 def _assert_undefined_asset_key(context, method, *args, **kwargs) -> None:
     with pytest.raises(
-        DagsterExtError, match=f"Calling `{method}` without passing an asset key is undefined"
+        DagsterPipesError, match=f"Calling `{method}` without passing an asset key is undefined"
     ):
         getattr(context, method)(*args, **kwargs)
 
@@ -62,7 +62,7 @@ def test_no_asset_context():
 
 
 def test_single_asset_context():
-    foo_provenance = ExtDataProvenance(
+    foo_provenance = PipesDataProvenance(
         code_version="alpha", input_data_versions={"bar": "baz"}, is_user_provided=False
     )
 
@@ -101,7 +101,7 @@ def test_single_asset_context():
 
 
 def test_multi_asset_context():
-    foo_provenance = ExtDataProvenance(
+    foo_provenance = PipesDataProvenance(
         code_version="alpha", input_data_versions={"bar": "baz"}, is_user_provided=False
     )
     bar_provenance = None
@@ -139,7 +139,7 @@ def test_no_partition_context():
 
 
 def test_single_partition_context():
-    partition_key_range = ExtPartitionKeyRange(start="foo", end="foo")
+    partition_key_range = PipesPartitionKeyRange(start="foo", end="foo")
 
     context = _make_external_execution_context(
         partition_key="foo",
@@ -154,8 +154,8 @@ def test_single_partition_context():
 
 
 def test_multiple_partition_context():
-    partition_key_range = ExtPartitionKeyRange(start="2023-01-01", end="2023-01-02")
-    time_window = ExtTimeWindow(start="2023-01-01", end="2023-01-02")
+    partition_key_range = PipesPartitionKeyRange(start="2023-01-01", end="2023-01-02")
+    time_window = PipesTimeWindow(start="2023-01-01", end="2023-01-02")
 
     context = _make_external_execution_context(
         partition_key=None,
@@ -173,12 +173,12 @@ def test_extras_context():
     context = _make_external_execution_context(extras={"foo": "bar"})
 
     assert context.get_extra("foo") == "bar"
-    with pytest.raises(DagsterExtError, match="Extra `bar` is undefined"):
+    with pytest.raises(DagsterPipesError, match="Extra `bar` is undefined"):
         context.get_extra("bar")
 
 
 def test_report_twice_materialized():
     context = _make_external_execution_context(asset_keys=["foo"])
-    with pytest.raises(DagsterExtError, match="already been materialized"):
+    with pytest.raises(DagsterPipesError, match="already been materialized"):
         context.report_asset_materialization(asset_key="foo")
         context.report_asset_materialization(asset_key="foo")

--- a/python_modules/dagster-test/dagster_test/toys/external_execution/numbers_example/number_sum.py
+++ b/python_modules/dagster-test/dagster_test/toys/external_execution/numbers_example/number_sum.py
@@ -1,8 +1,8 @@
-from dagster_pipes import init_dagster_ext
+from dagster_pipes import init_dagster_pipes
 
 from .util import compute_data_version, load_asset_value, store_asset_value
 
-context = init_dagster_ext()
+context = init_dagster_pipes()
 storage_root = context.get_extra("storage_root")
 number_y = load_asset_value("number_y", storage_root)
 number_x = load_asset_value("number_x", storage_root)

--- a/python_modules/dagster-test/dagster_test/toys/external_execution/numbers_example/number_x.py
+++ b/python_modules/dagster-test/dagster_test/toys/external_execution/numbers_example/number_x.py
@@ -1,8 +1,8 @@
-from dagster_pipes import init_dagster_ext
+from dagster_pipes import init_dagster_pipes
 
 from .util import compute_data_version, store_asset_value
 
-context = init_dagster_ext()
+context = init_dagster_pipes()
 storage_root = context.get_extra("storage_root")
 
 multiplier = context.get_extra("multiplier")

--- a/python_modules/dagster-test/dagster_test/toys/external_execution/numbers_example/number_y.py
+++ b/python_modules/dagster-test/dagster_test/toys/external_execution/numbers_example/number_y.py
@@ -1,10 +1,10 @@
 import os
 
-from dagster_pipes import init_dagster_ext
+from dagster_pipes import init_dagster_pipes
 
 from .util import compute_data_version, store_asset_value
 
-context = init_dagster_ext()
+context = init_dagster_pipes()
 storage_root = context.get_extra("storage_root")
 
 value = int(os.environ["NUMBER_Y"])

--- a/python_modules/dagster/dagster/_core/pipes/client.py
+++ b/python_modules/dagster/dagster/_core/pipes/client.py
@@ -3,9 +3,9 @@ from contextlib import contextmanager
 from typing import TYPE_CHECKING, Iterator, Optional
 
 from dagster_pipes import (
-    ExtContextData,
-    ExtExtras,
-    ExtParams,
+    PipesContextData,
+    PipesExtras,
+    PipesParams,
 )
 
 from dagster._core.execution.context.compute import OpExecutionContext
@@ -20,17 +20,17 @@ class ExtClient(ABC):
         self,
         *,
         context: OpExecutionContext,
-        extras: Optional[ExtExtras] = None,
+        extras: Optional[PipesExtras] = None,
     ) -> Iterator["ExtResult"]: ...
 
 
 class ExtContextInjector(ABC):
     @abstractmethod
     @contextmanager
-    def inject_context(self, context_data: "ExtContextData") -> Iterator[ExtParams]: ...
+    def inject_context(self, context_data: "PipesContextData") -> Iterator[PipesParams]: ...
 
 
 class ExtMessageReader(ABC):
     @abstractmethod
     @contextmanager
-    def read_messages(self, handler: "ExtMessageHandler") -> Iterator[ExtParams]: ...
+    def read_messages(self, handler: "ExtMessageHandler") -> Iterator[PipesParams]: ...

--- a/python_modules/dagster/dagster/_core/pipes/context.py
+++ b/python_modules/dagster/dagster/_core/pipes/context.py
@@ -4,17 +4,17 @@ from queue import Queue
 from typing import Any, Iterator, Mapping, Optional, Set, Union
 
 from dagster_pipes import (
-    DAGSTER_EXT_ENV_KEYS,
-    EXT_METADATA_TYPE_INFER,
-    IS_DAGSTER_EXT_PROCESS_ENV_VAR,
-    ExtContextData,
-    ExtDataProvenance,
-    ExtExtras,
-    ExtMessage,
-    ExtMetadataType,
-    ExtMetadataValue,
-    ExtParams,
-    ExtTimeWindow,
+    DAGSTER_PIPED_ENV_KEYS,
+    IS_DAGSTER_PIPED_PROCESS_ENV_VAR,
+    PIPEABLE_METADATA_TYPE_INFER,
+    PipesContextData,
+    PipesDataProvenance,
+    PipesExtras,
+    PipesMessage,
+    PipesMetadataType,
+    PipesMetadataValue,
+    PipesParams,
+    PipesTimeWindow,
     encode_env_var,
 )
 from typing_extensions import TypeAlias
@@ -44,7 +44,7 @@ class ExtMessageHandler:
         self._unmaterialized_assets: Set[AssetKey] = set(context.selected_asset_keys)
 
     @contextmanager
-    def handle_messages(self, message_reader: ExtMessageReader) -> Iterator[ExtParams]:
+    def handle_messages(self, message_reader: ExtMessageReader) -> Iterator[PipesParams]:
         with message_reader.read_messages(self) as params:
             yield params
         for key in self._unmaterialized_assets:
@@ -55,14 +55,16 @@ class ExtMessageHandler:
             yield self._result_queue.get()
 
     def _resolve_metadata(
-        self, metadata: Mapping[str, ExtMetadataValue]
+        self, metadata: Mapping[str, PipesMetadataValue]
     ) -> Mapping[str, MetadataValue]:
         return {
             k: self._resolve_metadata_value(v["raw_value"], v["type"]) for k, v in metadata.items()
         }
 
-    def _resolve_metadata_value(self, value: Any, metadata_type: ExtMetadataType) -> MetadataValue:
-        if metadata_type == EXT_METADATA_TYPE_INFER:
+    def _resolve_metadata_value(
+        self, value: Any, metadata_type: PipesMetadataType
+    ) -> MetadataValue:
+        if metadata_type == PIPEABLE_METADATA_TYPE_INFER:
             return normalize_metadata_value(value)
         elif metadata_type == "text":
             return MetadataValue.text(value)
@@ -94,7 +96,7 @@ class ExtMessageHandler:
             check.failed(f"Unexpected metadata type {metadata_type}")
 
     # Type ignores because we currently validate in individual handlers
-    def handle_message(self, message: ExtMessage) -> None:
+    def handle_message(self, message: PipesMessage) -> None:
         if message["method"] == "report_asset_materialization":
             self._handle_report_asset_materialization(**message["params"])  # type: ignore
         elif message["method"] == "report_asset_check":
@@ -105,7 +107,7 @@ class ExtMessageHandler:
     def _handle_report_asset_materialization(
         self,
         asset_key: str,
-        metadata: Optional[Mapping[str, ExtMetadataValue]],
+        metadata: Optional[Mapping[str, PipesMetadataValue]],
         data_version: Optional[str],
     ) -> None:
         check.str_param(asset_key, "asset_key")
@@ -128,7 +130,7 @@ class ExtMessageHandler:
         check_name: str,
         success: bool,
         severity: str,
-        metadata: Mapping[str, ExtMetadataValue],
+        metadata: Mapping[str, PipesMetadataValue],
     ) -> None:
         check.str_param(asset_key, "asset_key")
         check.str_param(check_name, "check_name")
@@ -153,24 +155,24 @@ class ExtMessageHandler:
 
 
 def _ext_params_as_env_vars(
-    context_injector_params: ExtParams, message_reader_params: ExtParams
+    context_injector_params: PipesParams, message_reader_params: PipesParams
 ) -> Mapping[str, str]:
     return {
-        DAGSTER_EXT_ENV_KEYS["context"]: encode_env_var(context_injector_params),
-        DAGSTER_EXT_ENV_KEYS["messages"]: encode_env_var(message_reader_params),
+        DAGSTER_PIPED_ENV_KEYS["context"]: encode_env_var(context_injector_params),
+        DAGSTER_PIPED_ENV_KEYS["messages"]: encode_env_var(message_reader_params),
     }
 
 
 @dataclass
 class ExtOrchestrationContext:
-    context_data: ExtContextData
+    context_data: PipesContextData
     message_handler: ExtMessageHandler
-    context_injector_params: ExtParams
-    message_reader_params: ExtParams
+    context_injector_params: PipesParams
+    message_reader_params: PipesParams
 
     def get_external_process_env_vars(self):
         return {
-            DAGSTER_EXT_ENV_KEYS[IS_DAGSTER_EXT_PROCESS_ENV_VAR]: encode_env_var(True),
+            DAGSTER_PIPED_ENV_KEYS[IS_DAGSTER_PIPED_PROCESS_ENV_VAR]: encode_env_var(True),
             **_ext_params_as_env_vars(
                 context_injector_params=self.context_injector_params,
                 message_reader_params=self.message_reader_params,
@@ -183,8 +185,8 @@ class ExtOrchestrationContext:
 
 def build_external_execution_context_data(
     context: OpExecutionContext,
-    extras: Optional[ExtExtras],
-) -> "ExtContextData":
+    extras: Optional[PipesExtras],
+) -> "PipesContextData":
     asset_keys = (
         [_convert_asset_key(key) for key in sorted(context.selected_asset_keys)]
         if context.has_assets_def
@@ -209,7 +211,7 @@ def build_external_execution_context_data(
     partition_key = context.partition_key if context.has_partition_key else None
     partition_time_window = context.partition_time_window if context.has_partition_key else None
     partition_key_range = context.partition_key_range if context.has_partition_key else None
-    return ExtContextData(
+    return PipesContextData(
         asset_keys=asset_keys,
         code_version_by_asset_key=code_version_by_asset_key,
         provenance_by_asset_key=provenance_by_asset_key,
@@ -233,11 +235,11 @@ def _convert_asset_key(asset_key: AssetKey) -> str:
 
 def _convert_data_provenance(
     provenance: Optional[DataProvenance],
-) -> Optional["ExtDataProvenance"]:
+) -> Optional["PipesDataProvenance"]:
     return (
         None
         if provenance is None
-        else ExtDataProvenance(
+        else PipesDataProvenance(
             code_version=provenance.code_version,
             input_data_versions={
                 _convert_asset_key(k): v.value for k, v in provenance.input_data_versions.items()
@@ -249,8 +251,8 @@ def _convert_data_provenance(
 
 def _convert_time_window(
     time_window: TimeWindow,
-) -> "ExtTimeWindow":
-    return ExtTimeWindow(
+) -> "PipesTimeWindow":
+    return PipesTimeWindow(
         start=time_window.start.isoformat(),
         end=time_window.end.isoformat(),
     )
@@ -258,8 +260,8 @@ def _convert_time_window(
 
 def _convert_partition_key_range(
     partition_key_range: PartitionKeyRange,
-) -> "ExtTimeWindow":
-    return ExtTimeWindow(
+) -> "PipesTimeWindow":
+    return PipesTimeWindow(
         start=partition_key_range.start,
         end=partition_key_range.end,
     )

--- a/python_modules/dagster/dagster/_core/pipes/context.py
+++ b/python_modules/dagster/dagster/_core/pipes/context.py
@@ -4,9 +4,9 @@ from queue import Queue
 from typing import Any, Iterator, Mapping, Optional, Set, Union
 
 from dagster_pipes import (
-    DAGSTER_PIPED_ENV_KEYS,
-    IS_DAGSTER_PIPED_PROCESS_ENV_VAR,
-    PIPEABLE_METADATA_TYPE_INFER,
+    DAGSTER_PIPES_ENV_KEYS,
+    IS_DAGSTER_PIPES_PROCESS,
+    PIPES_METADATA_TYPE_INFER,
     PipesContextData,
     PipesDataProvenance,
     PipesExtras,
@@ -64,7 +64,7 @@ class ExtMessageHandler:
     def _resolve_metadata_value(
         self, value: Any, metadata_type: PipesMetadataType
     ) -> MetadataValue:
-        if metadata_type == PIPEABLE_METADATA_TYPE_INFER:
+        if metadata_type == PIPES_METADATA_TYPE_INFER:
             return normalize_metadata_value(value)
         elif metadata_type == "text":
             return MetadataValue.text(value)
@@ -158,8 +158,8 @@ def _ext_params_as_env_vars(
     context_injector_params: PipesParams, message_reader_params: PipesParams
 ) -> Mapping[str, str]:
     return {
-        DAGSTER_PIPED_ENV_KEYS["context"]: encode_env_var(context_injector_params),
-        DAGSTER_PIPED_ENV_KEYS["messages"]: encode_env_var(message_reader_params),
+        DAGSTER_PIPES_ENV_KEYS["context"]: encode_env_var(context_injector_params),
+        DAGSTER_PIPES_ENV_KEYS["messages"]: encode_env_var(message_reader_params),
     }
 
 
@@ -172,7 +172,7 @@ class ExtOrchestrationContext:
 
     def get_external_process_env_vars(self):
         return {
-            DAGSTER_PIPED_ENV_KEYS[IS_DAGSTER_PIPED_PROCESS_ENV_VAR]: encode_env_var(True),
+            DAGSTER_PIPES_ENV_KEYS[IS_DAGSTER_PIPES_PROCESS]: encode_env_var(True),
             **_ext_params_as_env_vars(
                 context_injector_params=self.context_injector_params,
                 message_reader_params=self.message_reader_params,

--- a/python_modules/dagster/dagster/_core/pipes/subprocess.py
+++ b/python_modules/dagster/dagster/_core/pipes/subprocess.py
@@ -1,7 +1,7 @@
 from subprocess import Popen
 from typing import Iterator, Mapping, Optional, Sequence, Union
 
-from dagster_pipes import ExtExtras
+from dagster_pipes import PipesExtras
 
 from dagster import _check as check
 from dagster._core.definitions.resource_annotation import ResourceParam
@@ -64,7 +64,7 @@ class _ExtSubprocess(ExtClient):
         command: Union[str, Sequence[str]],
         *,
         context: OpExecutionContext,
-        extras: Optional[ExtExtras] = None,
+        extras: Optional[PipesExtras] = None,
         env: Optional[Mapping[str, str]] = None,
         cwd: Optional[str] = None,
     ) -> Iterator[ExtResult]:

--- a/python_modules/dagster/dagster/_core/pipes/utils.py
+++ b/python_modules/dagster/dagster/_core/pipes/utils.py
@@ -10,12 +10,12 @@ from threading import Event, Thread
 from typing import Iterator, Optional
 
 from dagster_pipes import (
-    EXT_PROTOCOL_VERSION_FIELD,
-    ExtContextData,
-    ExtDefaultContextLoader,
+    PIPES_PROTOCOL_VERSION_FIELD,
+    DefaultPipesContextLoader,
     ExtDefaultMessageWriter,
-    ExtExtras,
-    ExtParams,
+    PipesContextData,
+    PipesExtras,
+    PipesParams,
 )
 
 from dagster import (
@@ -42,11 +42,11 @@ class ExtFileContextInjector(ExtContextInjector):
         self._path = check.str_param(path, "path")
 
     @contextmanager
-    def inject_context(self, context_data: "ExtContextData") -> Iterator[ExtParams]:
+    def inject_context(self, context_data: "PipesContextData") -> Iterator[PipesParams]:
         with open(self._path, "w") as input_stream:
             json.dump(context_data, input_stream)
         try:
-            yield {ExtDefaultContextLoader.FILE_PATH_KEY: self._path}
+            yield {DefaultPipesContextLoader.FILE_PATH_KEY: self._path}
         finally:
             if os.path.exists(self._path):
                 os.remove(self._path)
@@ -54,7 +54,7 @@ class ExtFileContextInjector(ExtContextInjector):
 
 class ExtTempFileContextInjector(ExtContextInjector):
     @contextmanager
-    def inject_context(self, context: "ExtContextData") -> Iterator[ExtParams]:
+    def inject_context(self, context: "PipesContextData") -> Iterator[PipesParams]:
         with tempfile.TemporaryDirectory() as tempdir:
             with ExtFileContextInjector(
                 os.path.join(tempdir, _CONTEXT_INJECTOR_FILENAME)
@@ -66,9 +66,9 @@ class ExtEnvContextInjector(ExtContextInjector):
     @contextmanager
     def inject_context(
         self,
-        context_data: "ExtContextData",
-    ) -> Iterator[ExtParams]:
-        yield {ExtDefaultContextLoader.DIRECT_KEY: context_data}
+        context_data: "PipesContextData",
+    ) -> Iterator[PipesParams]:
+        yield {DefaultPipesContextLoader.DIRECT_KEY: context_data}
 
 
 class ExtFileMessageReader(ExtMessageReader):
@@ -79,7 +79,7 @@ class ExtFileMessageReader(ExtMessageReader):
     def read_messages(
         self,
         handler: "ExtMessageHandler",
-    ) -> Iterator[ExtParams]:
+    ) -> Iterator[PipesParams]:
         is_task_complete = Event()
         thread = None
         try:
@@ -107,7 +107,7 @@ class ExtTempFileMessageReader(ExtMessageReader):
     def read_messages(
         self,
         handler: "ExtMessageHandler",
-    ) -> Iterator[ExtParams]:
+    ) -> Iterator[PipesParams]:
         with tempfile.TemporaryDirectory() as tempdir:
             with ExtFileMessageReader(
                 os.path.join(tempdir, _MESSAGE_READER_FILENAME)
@@ -127,7 +127,7 @@ class ExtBlobStoreMessageReader(ExtMessageReader):
     def read_messages(
         self,
         handler: "ExtMessageHandler",
-    ) -> Iterator[ExtParams]:
+    ) -> Iterator[PipesParams]:
         with self.get_params() as params:
             is_task_complete = Event()
             thread = None
@@ -150,13 +150,13 @@ class ExtBlobStoreMessageReader(ExtMessageReader):
 
     @abstractmethod
     @contextmanager
-    def get_params(self) -> Iterator[ExtParams]: ...
+    def get_params(self) -> Iterator[PipesParams]: ...
 
     @abstractmethod
-    def download_messages_chunk(self, index: int, params: ExtParams) -> Optional[str]: ...
+    def download_messages_chunk(self, index: int, params: PipesParams) -> Optional[str]: ...
 
     def _reader_thread(
-        self, handler: "ExtMessageHandler", params: ExtParams, is_task_complete: Event
+        self, handler: "ExtMessageHandler", params: PipesParams, is_task_complete: Event
     ) -> None:
         start_or_last_download = datetime.datetime.now()
         while True:
@@ -178,7 +178,7 @@ def extract_message_or_forward_to_stdout(handler: "ExtMessageHandler", log_line:
     # exceptions as control flow, you love to see it
     try:
         message = json.loads(log_line)
-        if EXT_PROTOCOL_VERSION_FIELD in message.keys():
+        if PIPES_PROTOCOL_VERSION_FIELD in message.keys():
             handler.handle_message(message)
     except Exception:
         # move non-message logs in to stdout for compute log capture
@@ -196,7 +196,7 @@ def ext_protocol(
     context: OpExecutionContext,
     context_injector: ExtContextInjector,
     message_reader: ExtMessageReader,
-    extras: Optional[ExtExtras] = None,
+    extras: Optional[PipesExtras] = None,
 ) -> Iterator[ExtOrchestrationContext]:
     """Enter the context managed context injector and message reader that power the EXT protocol and receive the environment variables
     that need to be provided to the external process.

--- a/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_subprocess.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_subprocess.py
@@ -75,9 +75,9 @@ def external_script() -> Iterator[str]:
         import time
 
         from dagster_pipes import (
-            ExtContext,
             ExtS3MessageWriter,
-            init_dagster_ext,
+            PipesContext,
+            init_dagster_pipes,
         )
 
         if os.getenv("MESSAGE_READER_SPEC") == "user/s3":
@@ -90,8 +90,8 @@ def external_script() -> Iterator[str]:
         else:
             message_writer = None  # use default
 
-        init_dagster_ext(message_writer=message_writer)
-        context = ExtContext.get()
+        init_dagster_pipes(message_writer=message_writer)
+        context = PipesContext.get()
         context.log("hello world")
         time.sleep(0.1)  # sleep to make sure that we encompass multiple intervals for blob store IO
         context.report_asset_materialization(
@@ -198,9 +198,9 @@ def test_ext_subprocess(
 
 def test_ext_multi_asset():
     def script_fn():
-        from dagster_pipes import init_dagster_ext
+        from dagster_pipes import init_dagster_pipes
 
-        context = init_dagster_ext()
+        context = init_dagster_pipes()
         context.report_asset_materialization(
             {"foo_meta": "ok"}, data_version="alpha", asset_key="foo"
         )
@@ -227,9 +227,9 @@ def test_ext_multi_asset():
 
 def test_ext_typed_metadata():
     def script_fn():
-        from dagster_pipes import init_dagster_ext
+        from dagster_pipes import init_dagster_pipes
 
-        context = init_dagster_ext()
+        context = init_dagster_pipes()
         context.report_asset_materialization(
             metadata={
                 "infer_meta": "bar",
@@ -307,9 +307,9 @@ def test_ext_asset_failed():
 
 def test_ext_asset_invocation():
     def script_fn():
-        from dagster_pipes import init_dagster_ext
+        from dagster_pipes import init_dagster_pipes
 
-        context = init_dagster_ext()
+        context = init_dagster_pipes()
         context.log("hello world")
 
     @asset
@@ -327,15 +327,15 @@ PATH_WITH_NONEXISTENT_DIR = "/tmp/does-not-exist/foo"
 def test_ext_no_orchestration():
     def script_fn():
         from dagster_pipes import (
-            ExtContext,
-            init_dagster_ext,
-            is_dagster_ext_process,
+            PipesContext,
+            init_dagster_pipes,
+            is_dagster_pipes_process,
         )
 
-        assert not is_dagster_ext_process()
+        assert not is_dagster_pipes_process()
 
-        init_dagster_ext()
-        context = ExtContext.get()
+        init_dagster_pipes()
+        context = PipesContext.get()
         context.log("hello world")
         context.report_asset_materialization(
             metadata={"bar": context.get_extra("bar")},

--- a/python_modules/libraries/dagster-aws/dagster_aws/pipes.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/pipes.py
@@ -7,7 +7,7 @@ import boto3
 import dagster._check as check
 from botocore.exceptions import ClientError
 from dagster._core.pipes.client import (
-    ExtParams,
+    PipesParams,
 )
 from dagster._core.pipes.utils import ExtBlobStoreMessageReader
 
@@ -20,10 +20,10 @@ class ExtS3MessageReader(ExtBlobStoreMessageReader):
         self.client = client
 
     @contextmanager
-    def get_params(self) -> Iterator[ExtParams]:
+    def get_params(self) -> Iterator[PipesParams]:
         yield {"bucket": self.bucket, "key_prefix": self.key_prefix}
 
-    def download_messages_chunk(self, index: int, params: ExtParams) -> Optional[str]:
+    def download_messages_chunk(self, index: int, params: PipesParams) -> Optional[str]:
         key = f"{self.key_prefix}/{index}.json"
         try:
             obj = self.client.get_object(Bucket=self.bucket, Key=key)

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
@@ -18,9 +18,9 @@ from dagster._core.pipes.utils import (
     ext_protocol,
 )
 from dagster_pipes import (
-    ExtContextData,
-    ExtExtras,
-    ExtParams,
+    PipesContextData,
+    PipesExtras,
+    PipesParams,
 )
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.service import files, jobs
@@ -65,7 +65,7 @@ class _ExtDatabricks(ExtClient):
         task: jobs.SubmitTask,
         *,
         context: OpExecutionContext,
-        extras: Optional[ExtExtras] = None,
+        extras: Optional[PipesExtras] = None,
         submit_args: Optional[Mapping[str, str]] = None,
     ) -> Iterator[ExtResult]:
         """Run a Databricks job with the EXT protocol.
@@ -143,7 +143,7 @@ class ExtDbfsContextInjector(ExtContextInjector):
         self.dbfs_client = files.DbfsAPI(client.api_client)
 
     @contextmanager
-    def inject_context(self, context: "ExtContextData") -> Iterator[ExtParams]:
+    def inject_context(self, context: "PipesContextData") -> Iterator[PipesParams]:
         with dbfs_tempdir(self.dbfs_client) as tempdir:
             path = os.path.join(tempdir, _CONTEXT_FILENAME)
             contents = base64.b64encode(json.dumps(context).encode("utf-8")).decode("utf-8")
@@ -157,11 +157,11 @@ class ExtDbfsMessageReader(ExtBlobStoreMessageReader):
         self.dbfs_client = files.DbfsAPI(client.api_client)
 
     @contextmanager
-    def get_params(self) -> Iterator[ExtParams]:
+    def get_params(self) -> Iterator[PipesParams]:
         with dbfs_tempdir(self.dbfs_client) as tempdir:
             yield {"path": tempdir}
 
-    def download_messages_chunk(self, index: int, params: ExtParams) -> Optional[str]:
+    def download_messages_chunk(self, index: int, params: PipesParams) -> Optional[str]:
         message_path = os.path.join(params["path"], f"{index}.json")
         try:
             raw_message = self.dbfs_client.read(message_path)

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_external_asset.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_external_asset.py
@@ -16,10 +16,14 @@ IS_BUILDKITE = os.getenv("BUILDKITE") is not None
 
 
 def script_fn():
-    from dagster_pipes import ExtDbfsContextLoader, ExtDbfsMessageWriter, init_dagster_ext
+    from dagster_pipes import (
+        DbfsPipesContextLoader,
+        ExtDbfsMessageWriter,
+        init_dagster_pipes,
+    )
 
-    context = init_dagster_ext(
-        context_loader=ExtDbfsContextLoader(), message_writer=ExtDbfsMessageWriter()
+    context = init_dagster_pipes(
+        context_loader=DbfsPipesContextLoader(), message_writer=ExtDbfsMessageWriter()
     )
 
     multiplier = context.get_extra("multiplier")

--- a/python_modules/libraries/dagster-docker/dagster_docker/pipes.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/pipes.py
@@ -22,10 +22,10 @@ from dagster._core.pipes.utils import (
     extract_message_or_forward_to_stdout,
 )
 from dagster_pipes import (
-    DagsterExtError,
+    DagsterPipesError,
     ExtDefaultMessageWriter,
-    ExtExtras,
-    ExtParams,
+    PipesExtras,
+    PipesParams,
 )
 
 
@@ -34,7 +34,7 @@ class DockerLogsMessageReader(ExtMessageReader):
     def read_messages(
         self,
         handler: ExtMessageHandler,
-    ) -> Iterator[ExtParams]:
+    ) -> Iterator[PipesParams]:
         self._handler = handler
         try:
             yield {ExtDefaultMessageWriter.STDIO_KEY: ExtDefaultMessageWriter.STDERR}
@@ -94,7 +94,7 @@ class _ExtDocker(ExtClient):
         env: Optional[Mapping[str, str]] = None,
         registry: Optional[Mapping[str, str]] = None,
         container_kwargs: Optional[Mapping[str, Any]] = None,
-        extras: Optional[ExtExtras] = None,
+        extras: Optional[PipesExtras] = None,
     ) -> Iterator[ExtResult]:
         """Create a docker container and run it to completion, enriched with the ext protocol.
 
@@ -111,7 +111,7 @@ class _ExtDocker(ExtClient):
                 with docker client login.
             container_kwargs (Optional[Mapping[str, Any]]:
                 Arguments to be forwarded to docker client containers.create.
-            extras (Optional[ExtExtras]):
+            extras (Optional[PipesExtras]):
                 Extra values to pass along as part of the ext protocol.
             context_injector (Optional[ExtContextInjector]):
                 Override the default ext protocol context injection.
@@ -160,7 +160,7 @@ class _ExtDocker(ExtClient):
 
                 result = container.wait()
                 if result["StatusCode"] != 0:
-                    raise DagsterExtError(f"Container exited with non-zero status code: {result}")
+                    raise DagsterPipesError(f"Container exited with non-zero status code: {result}")
             finally:
                 container.stop()
         return ext_context.get_results()

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
@@ -14,7 +14,7 @@ from dagster._core.pipes.client import (
     ExtClient,
     ExtContextInjector,
     ExtMessageReader,
-    ExtParams,
+    PipesParams,
 )
 from dagster._core.pipes.context import (
     ExtMessageHandler,
@@ -27,7 +27,7 @@ from dagster._core.pipes.utils import (
 )
 from dagster_pipes import (
     ExtDefaultMessageWriter,
-    ExtExtras,
+    PipesExtras,
 )
 
 from dagster_k8s.utils import get_common_labels
@@ -50,7 +50,7 @@ class K8sPodLogsMessageReader(ExtMessageReader):
     def read_messages(
         self,
         handler: ExtMessageHandler,
-    ) -> Iterator[ExtParams]:
+    ) -> Iterator[PipesParams]:
         self._handler = handler
         try:
             yield {ExtDefaultMessageWriter.STDIO_KEY: ExtDefaultMessageWriter.STDERR}
@@ -123,7 +123,7 @@ class _ExtK8sPod(ExtClient):
         env: Optional[Mapping[str, str]] = None,
         base_pod_meta: Optional[Mapping[str, Any]] = None,
         base_pod_spec: Optional[Mapping[str, Any]] = None,
-        extras: Optional[ExtExtras] = None,
+        extras: Optional[PipesExtras] = None,
     ) -> Iterator[ExtResult]:
         """Publish a kubernetes pod and wait for it to complete, enriched with the ext protocol.
 
@@ -145,7 +145,7 @@ class _ExtK8sPod(ExtClient):
                 Raw k8s config for the k8s pod's pod spec
                 (https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec).
                 Keys can either snake_case or camelCase.
-            extras (Optional[ExtExtras]):
+            extras (Optional[PipesExtras]):
                 Extra values to pass along as part of the ext protocol.
             context_injector (Optional[ExtContextInjector]):
                 Override the default ext protocol context injection.


### PR DESCRIPTION
## Summary & Motivation

Take two of https://github.com/dagster-io/dagster/pull/16779. Renaming core classes with feedback incorporated from session this AM.

* `Pipes` prefix on all the things
* `PipesContext` is the context in the external process. `init_dagster_pipes` creates it.
* `PipesContextLoader` rather than `PipedProcessContextLoader`

## How I Tested These Changes
