### PR TITLE
Renaming core clasess in dagster/_core/pipes

### DIFF
--- a/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/__init__.py
+++ b/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/__init__.py
@@ -1,10 +1,10 @@
 from dagster import Definitions
-from dagster._core.pipes.subprocess import PipedSubprocess
+from dagster._core.pipes.subprocess import PipesSubprocess
 
 from .domain_specific_dsl.stocks_dsl import get_stocks_dsl_example_defs
 from .pure_assets_dsl.assets_dsl import get_asset_dsl_example_defs
 
 defs = Definitions(
     assets=get_asset_dsl_example_defs() + get_stocks_dsl_example_defs(),
-    resources={"subprocess_resource": PipedSubprocess()},
+    resources={"subprocess_resource": PipesSubprocess()},
 )

--- a/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/__init__.py
+++ b/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/__init__.py
@@ -1,10 +1,10 @@
 from dagster import Definitions
-from dagster._core.pipes.subprocess import ExtSubprocess
+from dagster._core.pipes.subprocess import PipedSubprocess
 
 from .domain_specific_dsl.stocks_dsl import get_stocks_dsl_example_defs
 from .pure_assets_dsl.assets_dsl import get_asset_dsl_example_defs
 
 defs = Definitions(
     assets=get_asset_dsl_example_defs() + get_stocks_dsl_example_defs(),
-    resources={"subprocess_resource": ExtSubprocess()},
+    resources={"subprocess_resource": PipedSubprocess()},
 )

--- a/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/domain_specific_dsl/stocks_dsl.py
+++ b/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/domain_specific_dsl/stocks_dsl.py
@@ -12,7 +12,7 @@ except ImportError:
 
 from dagster import AssetKey, AssetsDefinition, asset, file_relative_path, multi_asset
 from dagster._core.definitions.asset_spec import AssetSpec
-from dagster._core.pipes.subprocess import ExtSubprocess
+from dagster._core.pipes.subprocess import PipedSubprocess
 
 
 def load_yaml(relative_path: str) -> Dict[str, Any]:
@@ -86,7 +86,7 @@ def assets_defs_from_stock_assets(stock_assets: StockAssets) -> List[AssetsDefin
     ticker_specs = [spec_for_stock_info(stock_info) for stock_info in stock_assets.stock_infos]
 
     @multi_asset(specs=ticker_specs)
-    def fetch_the_tickers(context: AssetExecutionContext, subprocess_resource: ExtSubprocess):
+    def fetch_the_tickers(context: AssetExecutionContext, subprocess_resource: PipedSubprocess):
         python_executable = shutil.which("python")
         assert python_executable is not None
         script_path = file_relative_path(__file__, "user_scripts/fetch_the_tickers.py")

--- a/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/domain_specific_dsl/stocks_dsl.py
+++ b/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/domain_specific_dsl/stocks_dsl.py
@@ -12,7 +12,7 @@ except ImportError:
 
 from dagster import AssetKey, AssetsDefinition, asset, file_relative_path, multi_asset
 from dagster._core.definitions.asset_spec import AssetSpec
-from dagster._core.pipes.subprocess import PipedSubprocess
+from dagster._core.pipes.subprocess import PipesSubprocess
 
 
 def load_yaml(relative_path: str) -> Dict[str, Any]:
@@ -86,7 +86,7 @@ def assets_defs_from_stock_assets(stock_assets: StockAssets) -> List[AssetsDefin
     ticker_specs = [spec_for_stock_info(stock_info) for stock_info in stock_assets.stock_infos]
 
     @multi_asset(specs=ticker_specs)
-    def fetch_the_tickers(context: AssetExecutionContext, subprocess_resource: PipedSubprocess):
+    def fetch_the_tickers(context: AssetExecutionContext, subprocess_resource: PipesSubprocess):
         python_executable = shutil.which("python")
         assert python_executable is not None
         script_path = file_relative_path(__file__, "user_scripts/fetch_the_tickers.py")

--- a/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/domain_specific_dsl/user_scripts/fetch_the_tickers.py
+++ b/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/domain_specific_dsl/user_scripts/fetch_the_tickers.py
@@ -1,5 +1,5 @@
-from dagster_pipes import init_dagster_ext
+from dagster_pipes import init_dagster_pipes
 
-context = init_dagster_ext()
+context = init_dagster_pipes()
 
 context.log(f"Got tickers: {context.extras['tickers']}")

--- a/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/pure_assets_dsl/assets_dsl.py
+++ b/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/pure_assets_dsl/assets_dsl.py
@@ -13,7 +13,7 @@ except ImportError:
     from yaml import Loader
 
 from dagster import AssetKey, asset
-from dagster._core.pipes.subprocess import PipedSubprocess
+from dagster._core.pipes.subprocess import PipesSubprocess
 
 
 def load_yaml(relative_path) -> Dict[str, Any]:
@@ -39,7 +39,7 @@ def from_asset_entries(asset_entries: Dict[str, Any]) -> List[AssetsDefinition]:
         @asset(key=asset_key, deps=deps, description=description, group_name=group_name)
         def _assets_def(
             context: AssetExecutionContext,
-            subprocess_resource: PipedSubprocess,
+            subprocess_resource: PipesSubprocess,
         ) -> None:
             # instead of querying a dummy client, do your real data processing here
 

--- a/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/pure_assets_dsl/assets_dsl.py
+++ b/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/pure_assets_dsl/assets_dsl.py
@@ -13,7 +13,7 @@ except ImportError:
     from yaml import Loader
 
 from dagster import AssetKey, asset
-from dagster._core.pipes.subprocess import ExtSubprocess
+from dagster._core.pipes.subprocess import PipedSubprocess
 
 
 def load_yaml(relative_path) -> Dict[str, Any]:
@@ -39,7 +39,7 @@ def from_asset_entries(asset_entries: Dict[str, Any]) -> List[AssetsDefinition]:
         @asset(key=asset_key, deps=deps, description=description, group_name=group_name)
         def _assets_def(
             context: AssetExecutionContext,
-            subprocess_resource: ExtSubprocess,
+            subprocess_resource: PipedSubprocess,
         ) -> None:
             # instead of querying a dummy client, do your real data processing here
 

--- a/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/pure_assets_dsl/sql_script.py
+++ b/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/pure_assets_dsl/sql_script.py
@@ -1,6 +1,6 @@
 import sys
 
-from dagster_pipes import init_dagster_ext
+from dagster_pipes import init_dagster_pipes
 
 
 class SomeSqlClient:
@@ -11,7 +11,7 @@ class SomeSqlClient:
 if __name__ == "__main__":
     sql = sys.argv[1]
 
-    context = init_dagster_ext()
+    context = init_dagster_pipes()
 
     client = SomeSqlClient()
     client.query(sql)

--- a/examples/experimental/assets_yaml_dsl/assets_yaml_dsl_tests/test_assets_dsl.py
+++ b/examples/experimental/assets_yaml_dsl/assets_yaml_dsl_tests/test_assets_dsl.py
@@ -5,7 +5,7 @@ from assets_yaml_dsl.pure_assets_dsl.assets_dsl import from_asset_entries
 from dagster import AssetsDefinition
 from dagster._core.definitions.events import AssetKey
 from dagster._core.execution.context.invocation import build_asset_context
-from dagster._core.pipes.subprocess import ExtSubprocess
+from dagster._core.pipes.subprocess import PipedSubprocess
 
 
 def assets_defs_from_yaml(yaml_string) -> List[AssetsDefinition]:
@@ -69,7 +69,7 @@ assets:
     assert assets_defs
     assert len(assets_defs) == 1
     assets_def = assets_defs[0]
-    assets_def(context=build_asset_context(), subprocess_resource=ExtSubprocess())
+    assets_def(context=build_asset_context(), subprocess_resource=PipedSubprocess())
 
 
 def test_basic_group() -> None:

--- a/examples/experimental/assets_yaml_dsl/assets_yaml_dsl_tests/test_assets_dsl.py
+++ b/examples/experimental/assets_yaml_dsl/assets_yaml_dsl_tests/test_assets_dsl.py
@@ -5,7 +5,7 @@ from assets_yaml_dsl.pure_assets_dsl.assets_dsl import from_asset_entries
 from dagster import AssetsDefinition
 from dagster._core.definitions.events import AssetKey
 from dagster._core.execution.context.invocation import build_asset_context
-from dagster._core.pipes.subprocess import PipedSubprocess
+from dagster._core.pipes.subprocess import PipesSubprocess
 
 
 def assets_defs_from_yaml(yaml_string) -> List[AssetsDefinition]:
@@ -69,7 +69,7 @@ assets:
     assert assets_defs
     assert len(assets_defs) == 1
     assets_def = assets_defs[0]
-    assets_def(context=build_asset_context(), subprocess_resource=PipedSubprocess())
+    assets_def(context=build_asset_context(), subprocess_resource=PipesSubprocess())
 
 
 def test_basic_group() -> None:

--- a/examples/experimental/assets_yaml_dsl/assets_yaml_dsl_tests/test_stocks_dsl.py
+++ b/examples/experimental/assets_yaml_dsl/assets_yaml_dsl_tests/test_stocks_dsl.py
@@ -18,7 +18,7 @@ import yaml
 from assets_yaml_dsl.domain_specific_dsl.stocks_dsl import assets_defs_from_stock_assets
 from dagster import AssetKey
 from dagster._core.definitions import materialize
-from dagster._core.pipes.subprocess import PipedSubprocess
+from dagster._core.pipes.subprocess import PipesSubprocess
 from examples.experimental.assets_yaml_dsl.assets_yaml_dsl.domain_specific_dsl.stocks_dsl import (
     build_stock_assets_object,
 )
@@ -55,5 +55,5 @@ def test_materialize_stocks_dsl():
     stock_assets = build_stock_assets_object(stocks_dsl_document)
     assets_defs = assets_defs_from_stock_assets(stock_assets)
     assert materialize(
-        assets=assets_defs, resources={"subprocess_resource": PipedSubprocess()}
+        assets=assets_defs, resources={"subprocess_resource": PipesSubprocess()}
     ).success

--- a/examples/experimental/assets_yaml_dsl/assets_yaml_dsl_tests/test_stocks_dsl.py
+++ b/examples/experimental/assets_yaml_dsl/assets_yaml_dsl_tests/test_stocks_dsl.py
@@ -18,7 +18,7 @@ import yaml
 from assets_yaml_dsl.domain_specific_dsl.stocks_dsl import assets_defs_from_stock_assets
 from dagster import AssetKey
 from dagster._core.definitions import materialize
-from dagster._core.pipes.subprocess import ExtSubprocess
+from dagster._core.pipes.subprocess import PipedSubprocess
 from examples.experimental.assets_yaml_dsl.assets_yaml_dsl.domain_specific_dsl.stocks_dsl import (
     build_stock_assets_object,
 )
@@ -55,5 +55,5 @@ def test_materialize_stocks_dsl():
     stock_assets = build_stock_assets_object(stocks_dsl_document)
     assets_defs = assets_defs_from_stock_assets(stock_assets)
     assert materialize(
-        assets=assets_defs, resources={"subprocess_resource": ExtSubprocess()}
+        assets=assets_defs, resources={"subprocess_resource": PipedSubprocess()}
     ).success

--- a/integration_tests/test_suites/k8s-test-suite/tests/test_external_asset.py
+++ b/integration_tests/test_suites/k8s-test-suite/tests/test_external_asset.py
@@ -5,7 +5,7 @@ import kubernetes
 import pytest
 from dagster import AssetExecutionContext, asset, materialize
 from dagster._core.pipes.client import (
-    ExtContextInjector,
+    PipedProcessContextInjector,
 )
 from dagster._core.pipes.utils import ExtEnvContextInjector, pipes_protocol
 from dagster_k8s import execute_k8s_job
@@ -55,7 +55,7 @@ def test_ext_k8s_pod(namespace, cluster_provider):
     assert mats[0].metadata["is_even"].value is True
 
 
-class ExtConfigMapContextInjector(ExtContextInjector):
+class ExtConfigMapContextInjector(PipedProcessContextInjector):
     def __init__(
         self,
         k8s_client: DagsterKubernetesClient,

--- a/integration_tests/test_suites/k8s-test-suite/tests/test_external_asset.py
+++ b/integration_tests/test_suites/k8s-test-suite/tests/test_external_asset.py
@@ -11,7 +11,7 @@ from dagster._core.pipes.utils import ExtEnvContextInjector, ext_protocol
 from dagster_k8s import execute_k8s_job
 from dagster_k8s.client import DagsterKubernetesClient
 from dagster_k8s.pipes import ExtK8sPod, K8sPodLogsMessageReader
-from dagster_pipes import ExtContextData, ExtDefaultContextLoader
+from dagster_pipes import DefaultPipesContextLoader, PipesContextData
 from dagster_test.test_project import (
     get_test_project_docker_image,
 )
@@ -68,7 +68,7 @@ class ExtConfigMapContextInjector(ExtContextInjector):
     @contextmanager
     def inject_context(
         self,
-        context_data: "ExtContextData",
+        context_data: "PipesContextData",
     ):
         context_config_map_body = kubernetes.client.V1ConfigMap(
             metadata=kubernetes.client.V1ObjectMeta(
@@ -80,7 +80,7 @@ class ExtConfigMapContextInjector(ExtContextInjector):
         )
         self._client.core_api.create_namespaced_config_map(self._namespace, context_config_map_body)
         try:
-            yield {ExtDefaultContextLoader.FILE_PATH_KEY: "/mnt/dagster/context.json"}
+            yield {DefaultPipesContextLoader.FILE_PATH_KEY: "/mnt/dagster/context.json"}
         finally:
             self._client.core_api.delete_namespaced_config_map(self._cm_name, self._namespace)
 

--- a/integration_tests/test_suites/k8s-test-suite/tests/test_external_asset.py
+++ b/integration_tests/test_suites/k8s-test-suite/tests/test_external_asset.py
@@ -7,7 +7,7 @@ from dagster import AssetExecutionContext, asset, materialize
 from dagster._core.pipes.client import (
     ExtContextInjector,
 )
-from dagster._core.pipes.utils import ExtEnvContextInjector, ext_protocol
+from dagster._core.pipes.utils import ExtEnvContextInjector, pipes_protocol
 from dagster_k8s import execute_k8s_job
 from dagster_k8s.client import DagsterKubernetesClient
 from dagster_k8s.pipes import ExtK8sPod, K8sPodLogsMessageReader
@@ -169,12 +169,12 @@ def test_use_excute_k8s_job(namespace, cluster_provider):
     def number_y_job(context: AssetExecutionContext):
         core_api = kubernetes.client.CoreV1Api()
         reader = K8sPodLogsMessageReader()
-        with ext_protocol(
+        with pipes_protocol(
             context,
             ExtEnvContextInjector(),
             reader,
             extras={"storage_root": "/tmp/"},
-        ) as ext_context:
+        ) as pipes_session:
             job_name = "number_y_asset_job"
 
             # stand-in for any means of creating kubernetes work
@@ -191,13 +191,13 @@ def test_use_excute_k8s_job(namespace, cluster_provider):
                     for k, v in {
                         "PYTHONPATH": "/dagster_test/toys/external_execution/",
                         "NUMBER_Y": "2",
-                        **ext_context.get_external_process_env_vars(),
+                        **pipes_session.get_piped_process_env_vars(),
                     }.items()
                 ],
                 k8s_job_name=job_name,
             )
             reader.consume_pod_logs(core_api, job_name, namespace)
-        yield from ext_context.get_results()
+        yield from pipes_session.get_results()
 
     result = materialize(
         [number_y_job],

--- a/integration_tests/test_suites/k8s-test-suite/tests/test_external_asset.py
+++ b/integration_tests/test_suites/k8s-test-suite/tests/test_external_asset.py
@@ -5,7 +5,7 @@ import kubernetes
 import pytest
 from dagster import AssetExecutionContext, asset, materialize
 from dagster._core.pipes.client import (
-    PipedProcessContextInjector,
+    PipesContextInjector,
 )
 from dagster._core.pipes.utils import ExtEnvContextInjector, pipes_protocol
 from dagster_k8s import execute_k8s_job
@@ -55,7 +55,7 @@ def test_ext_k8s_pod(namespace, cluster_provider):
     assert mats[0].metadata["is_even"].value is True
 
 
-class ExtConfigMapContextInjector(PipedProcessContextInjector):
+class ExtConfigMapContextInjector(PipesContextInjector):
     def __init__(
         self,
         k8s_client: DagsterKubernetesClient,

--- a/python_modules/dagster-pipes/dagster_pipes/__init__.py
+++ b/python_modules/dagster-pipes/dagster_pipes/__init__.py
@@ -55,10 +55,10 @@ def _param_name_to_env_key(key: str) -> str:
 
 # ##### PARAMETERS
 
-IS_DAGSTER_PIPED_PROCESS_ENV_VAR = "IS_DAGSTER_PIPED_PROCESS"
+IS_DAGSTER_PIPES_PROCESS = "IS_DAGSTER_PIPED_PROCESS"
 
-DAGSTER_PIPED_ENV_KEYS = {
-    k: _param_name_to_env_key(k) for k in (IS_DAGSTER_PIPED_PROCESS_ENV_VAR, "context", "messages")
+DAGSTER_PIPES_ENV_KEYS = {
+    k: _param_name_to_env_key(k) for k in (IS_DAGSTER_PIPES_PROCESS, "context", "messages")
 }
 
 
@@ -74,7 +74,7 @@ class PipesMessage(TypedDict):
     params: Optional[Mapping[str, Any]]
 
 
-# ##### PIPED PROCESS CONTEXT
+###### PIPES CONTEXT
 
 
 class PipesContextData(TypedDict):
@@ -117,7 +117,7 @@ class PipesMetadataValue(TypedDict):
 
 
 # Infer the type from the raw value on the orchestration end
-PIPEABLE_METADATA_TYPE_INFER = "__infer__"
+PIPES_METADATA_TYPE_INFER = "__infer__"
 
 PipesMetadataType = Literal[
     "__infer__",
@@ -308,7 +308,7 @@ def _normalize_param_metadata(
                 )
             new_metadata[key] = cast(PipesMetadataValue, value)
         else:
-            new_metadata[key] = {"raw_value": value, "type": PIPEABLE_METADATA_TYPE_INFER}
+            new_metadata[key] = {"raw_value": value, "type": PIPES_METADATA_TYPE_INFER}
     return new_metadata
 
 
@@ -339,7 +339,7 @@ def _env_var_to_param_name(env_var: str) -> str:
 
 
 def is_dagster_pipes_process() -> bool:
-    return _param_from_env_var(IS_DAGSTER_PIPED_PROCESS_ENV_VAR)
+    return _param_from_env_var(IS_DAGSTER_PIPES_PROCESS)
 
 
 def _emit_orchestration_inactive_warning() -> None:

--- a/python_modules/dagster-pipes/dagster_pipes/__init__.py
+++ b/python_modules/dagster-pipes/dagster_pipes/__init__.py
@@ -40,13 +40,13 @@ if TYPE_CHECKING:
 
 # This represents the version of the protocol, rather than the version of the package. It must be
 # manually updated whenever there are changes to the protocol.
-EXT_PROTOCOL_VERSION = "0.1"
+PIPES_PROTOCOL_VERSION = "0.1"
 
-ExtExtras = Mapping[str, Any]
-ExtParams = Mapping[str, Any]
+PipesExtras = Mapping[str, Any]
+PipesParams = Mapping[str, Any]
 
 
-_ENV_KEY_PREFIX = "DAGSTER_EXT_"
+_ENV_KEY_PREFIX = "DAGSTER_PIPES_"
 
 
 def _param_name_to_env_key(key: str) -> str:
@@ -55,71 +55,71 @@ def _param_name_to_env_key(key: str) -> str:
 
 # ##### PARAMETERS
 
-IS_DAGSTER_EXT_PROCESS_ENV_VAR = "IS_DAGSTER_EXT_PROCESS"
+IS_DAGSTER_PIPED_PROCESS_ENV_VAR = "IS_DAGSTER_PIPED_PROCESS"
 
-DAGSTER_EXT_ENV_KEYS = {
-    k: _param_name_to_env_key(k) for k in (IS_DAGSTER_EXT_PROCESS_ENV_VAR, "context", "messages")
+DAGSTER_PIPED_ENV_KEYS = {
+    k: _param_name_to_env_key(k) for k in (IS_DAGSTER_PIPED_PROCESS_ENV_VAR, "context", "messages")
 }
 
 
 # ##### MESSAGE
 
 # Can't use a constant for TypedDict key so this value is repeated in `ExtMessage` defn.
-EXT_PROTOCOL_VERSION_FIELD = "__dagster_ext_version"
+PIPES_PROTOCOL_VERSION_FIELD = "__dagster_pipes_version"
 
 
-class ExtMessage(TypedDict):
-    __dagster_ext_version: str
+class PipesMessage(TypedDict):
+    __dagster_pipes_version: str
     method: str
     params: Optional[Mapping[str, Any]]
 
 
-# ##### EXT CONTEXT
+# ##### PIPED PROCESS CONTEXT
 
 
-class ExtContextData(TypedDict):
+class PipesContextData(TypedDict):
     asset_keys: Optional[Sequence[str]]
     code_version_by_asset_key: Optional[Mapping[str, Optional[str]]]
-    provenance_by_asset_key: Optional[Mapping[str, Optional["ExtDataProvenance"]]]
+    provenance_by_asset_key: Optional[Mapping[str, Optional["PipesDataProvenance"]]]
     partition_key: Optional[str]
-    partition_key_range: Optional["ExtPartitionKeyRange"]
-    partition_time_window: Optional["ExtTimeWindow"]
+    partition_key_range: Optional["PipesPartitionKeyRange"]
+    partition_time_window: Optional["PipesTimeWindow"]
     run_id: str
     job_name: Optional[str]
     retry_number: int
     extras: Mapping[str, Any]
 
 
-class ExtPartitionKeyRange(TypedDict):
+class PipesPartitionKeyRange(TypedDict):
     start: str
     end: str
 
 
-class ExtTimeWindow(TypedDict):
+class PipesTimeWindow(TypedDict):
     start: str  # timestamp
     end: str  # timestamp
 
 
-class ExtDataProvenance(TypedDict):
+class PipesDataProvenance(TypedDict):
     code_version: str
     input_data_versions: Mapping[str, str]
     is_user_provided: bool
 
 
-ExtAssetCheckSeverity = Literal["WARN", "ERROR"]
+PipesAssetCheckSeverity = Literal["WARN", "ERROR"]
 
-ExtMetadataRawValue = Union[int, float, str, Mapping[str, Any], Sequence[Any], bool, None]
+PipesMetadataRawValue = Union[int, float, str, Mapping[str, Any], Sequence[Any], bool, None]
 
 
-class ExtMetadataValue(TypedDict):
-    type: "ExtMetadataType"
-    raw_value: ExtMetadataRawValue
+class PipesMetadataValue(TypedDict):
+    type: "PipesMetadataType"
+    raw_value: PipesMetadataRawValue
 
 
 # Infer the type from the raw value on the orchestration end
-EXT_METADATA_TYPE_INFER = "__infer__"
+PIPEABLE_METADATA_TYPE_INFER = "__infer__"
 
-ExtMetadataType = Literal[
+PipesMetadataType = Literal[
     "__infer__",
     "text",
     "url",
@@ -143,17 +143,17 @@ ExtMetadataType = Literal[
 _T = TypeVar("_T")
 
 
-class DagsterExtError(Exception):
+class DagsterPipesError(Exception):
     pass
 
 
-class DagsterExtWarning(Warning):
+class DagsterPipesWarning(Warning):
     pass
 
 
 def _assert_not_none(value: Optional[_T], desc: Optional[str] = None) -> _T:
     if value is None:
-        raise DagsterExtError(f"Missing required property: {desc}")
+        raise DagsterPipesError(f"Missing required property: {desc}")
     return value
 
 
@@ -162,27 +162,27 @@ def _assert_defined_asset_property(value: Optional[_T], key: str) -> _T:
 
 
 # This should only be called under the precondition that the current step targets assets.
-def _assert_single_asset(data: ExtContextData, key: str) -> None:
+def _assert_single_asset(data: PipesContextData, key: str) -> None:
     asset_keys = data["asset_keys"]
     assert asset_keys is not None
     if len(asset_keys) != 1:
-        raise DagsterExtError(f"`{key}` is undefined. Current step targets multiple assets.")
+        raise DagsterPipesError(f"`{key}` is undefined. Current step targets multiple assets.")
 
 
 def _resolve_optionally_passed_asset_key(
-    data: ExtContextData,
+    data: PipesContextData,
     asset_key: Optional[str],
     method: str,
 ) -> str:
     asset_keys = _assert_defined_asset_property(data["asset_keys"], method)
     asset_key = _assert_opt_param_type(asset_key, str, method, "asset_key")
     if asset_key and asset_key not in asset_keys:
-        raise DagsterExtError(
+        raise DagsterPipesError(
             f"Invalid asset key. Expected one of `{asset_keys}`, got `{asset_key}`."
         )
     if not asset_key:
         if len(asset_keys) != 1:
-            raise DagsterExtError(
+            raise DagsterPipesError(
                 f"Calling `{method}` without passing an asset key is undefined. Current step"
                 " targets multiple assets."
             )
@@ -197,22 +197,22 @@ def _assert_defined_partition_property(value: Optional[_T], key: str) -> _T:
 
 
 # This should only be called under the precondition that the current steps targets assets.
-def _assert_single_partition(data: ExtContextData, key: str) -> None:
+def _assert_single_partition(data: PipesContextData, key: str) -> None:
     partition_key_range = data["partition_key_range"]
     assert partition_key_range is not None
     if partition_key_range["start"] != partition_key_range["end"]:
-        raise DagsterExtError(f"`{key}` is undefined. Current step targets multiple partitions.")
+        raise DagsterPipesError(f"`{key}` is undefined. Current step targets multiple partitions.")
 
 
-def _assert_defined_extra(extras: ExtExtras, key: str) -> Any:
+def _assert_defined_extra(extras: PipesExtras, key: str) -> Any:
     if key not in extras:
-        raise DagsterExtError(f"Extra `{key}` is undefined. Extras must be provided by user.")
+        raise DagsterPipesError(f"Extra `{key}` is undefined. Extras must be provided by user.")
     return extras[key]
 
 
 def _assert_param_type(value: _T, expected_type: Any, method: str, param: str) -> _T:
     if not isinstance(value, expected_type):
-        raise DagsterExtError(
+        raise DagsterPipesError(
             f"Invalid type for parameter `{param}` of `{method}`. Expected `{expected_type}`, got"
             f" `{type(value)}`."
         )
@@ -221,7 +221,7 @@ def _assert_param_type(value: _T, expected_type: Any, method: str, param: str) -
 
 def _assert_opt_param_type(value: _T, expected_type: Any, method: str, param: str) -> _T:
     if not (isinstance(value, expected_type) or value is None):
-        raise DagsterExtError(
+        raise DagsterPipesError(
             f"Invalid type for parameter `{param}` of `{method}`. Expected"
             f" `Optional[{expected_type}]`, got `{type(value)}`."
         )
@@ -229,11 +229,11 @@ def _assert_opt_param_type(value: _T, expected_type: Any, method: str, param: st
 
 
 def _assert_env_param_type(
-    env_params: ExtParams, key: str, expected_type: Type[_T], cls: Type
+    env_params: PipesParams, key: str, expected_type: Type[_T], cls: Type
 ) -> _T:
     value = env_params.get(key)
     if not isinstance(value, expected_type):
-        raise DagsterExtError(
+        raise DagsterPipesError(
             f"Invalid type for parameter `{key}` passed from orchestration side to"
             f" `{cls.__name__}`. Expected `{expected_type}`, got `{type(value)}`."
         )
@@ -241,11 +241,11 @@ def _assert_env_param_type(
 
 
 def _assert_opt_env_param_type(
-    env_params: ExtParams, key: str, expected_type: Type[_T], cls: Type
+    env_params: PipesParams, key: str, expected_type: Type[_T], cls: Type
 ) -> Optional[_T]:
     value = env_params.get(key)
     if value is not None and not isinstance(value, expected_type):
-        raise DagsterExtError(
+        raise DagsterPipesError(
             f"Invalid type for parameter `{key}` passed from orchestration side to"
             f" `{cls.__name__}`. Expected `Optional[{expected_type}]`, got `{type(value)}`."
         )
@@ -254,7 +254,7 @@ def _assert_opt_env_param_type(
 
 def _assert_param_value(value: _T, expected_values: Sequence[_T], method: str, param: str) -> _T:
     if value not in expected_values:
-        raise DagsterExtError(
+        raise DagsterPipesError(
             f"Invalid value for parameter `{param}` of `{method}`. Expected one of"
             f" `{expected_values}`, got `{value}`."
         )
@@ -265,7 +265,7 @@ def _assert_opt_param_value(
     value: _T, expected_values: Sequence[_T], method: str, param: str
 ) -> _T:
     if value is not None and value not in expected_values:
-        raise DagsterExtError(
+        raise DagsterPipesError(
             f"Invalid value for parameter `{param}` of `{method}`. Expected one of"
             f" `{expected_values}`, got `{value}`."
         )
@@ -276,37 +276,39 @@ def _assert_param_json_serializable(value: _T, method: str, param: str) -> _T:
     try:
         json.dumps(value)
     except (TypeError, OverflowError):
-        raise DagsterExtError(
+        raise DagsterPipesError(
             f"Invalid type for parameter `{param}` of `{method}`. Expected a JSON-serializable"
             f" type, got `{type(value)}`."
         )
     return value
 
 
-_METADATA_VALUE_KEYS = frozenset(ExtMetadataValue.__annotations__.keys())
+_METADATA_VALUE_KEYS = frozenset(PipesMetadataValue.__annotations__.keys())
 
 
 def _normalize_param_metadata(
-    metadata: Mapping[str, Union[ExtMetadataRawValue, ExtMetadataValue]], method: str, param: str
-) -> Mapping[str, Union[ExtMetadataRawValue, ExtMetadataValue]]:
+    metadata: Mapping[str, Union[PipesMetadataRawValue, PipesMetadataValue]],
+    method: str,
+    param: str,
+) -> Mapping[str, Union[PipesMetadataRawValue, PipesMetadataValue]]:
     _assert_param_type(metadata, dict, method, param)
-    new_metadata: Dict[str, ExtMetadataValue] = {}
+    new_metadata: Dict[str, PipesMetadataValue] = {}
     for key, value in metadata.items():
         if not isinstance(key, str):
-            raise DagsterExtError(
+            raise DagsterPipesError(
                 f"Invalid type for parameter `{param}` of `{method}`. Expected a dict with string"
                 f" keys, got a key `{key}` of type `{type(key)}`."
             )
         elif isinstance(value, dict):
             if not {*value.keys()} == _METADATA_VALUE_KEYS:
-                raise DagsterExtError(
+                raise DagsterPipesError(
                     f"Invalid type for parameter `{param}` of `{method}`. Expected a dict with"
                     " string keys and values that are either raw metadata values or dictionaries"
                     f" with schema `{{raw_value: ..., type: ...}}`. Got a value `{value}`."
                 )
-            new_metadata[key] = cast(ExtMetadataValue, value)
+            new_metadata[key] = cast(PipesMetadataValue, value)
         else:
-            new_metadata[key] = {"raw_value": value, "type": EXT_METADATA_TYPE_INFER}
+            new_metadata[key] = {"raw_value": value, "type": PIPEABLE_METADATA_TYPE_INFER}
     return new_metadata
 
 
@@ -336,8 +338,8 @@ def _env_var_to_param_name(env_var: str) -> str:
     return env_var[len(_ENV_KEY_PREFIX) :].lower()
 
 
-def is_dagster_ext_process() -> bool:
-    return _param_from_env_var(IS_DAGSTER_EXT_PROCESS_ENV_VAR)
+def is_dagster_pipes_process() -> bool:
+    return _param_from_env_var(IS_DAGSTER_PIPED_PROCESS_ENV_VAR)
 
 
 def _emit_orchestration_inactive_warning() -> None:
@@ -345,7 +347,7 @@ def _emit_orchestration_inactive_warning() -> None:
         "This process was not launched by a Dagster orchestration process. All calls to the"
         " `dagster-pipes` context or attempts to initialize `dagster-pipes` abstractions"
         " are no-ops.",
-        category=DagsterExtWarning,
+        category=DagsterPipesWarning,
     )
 
 
@@ -360,10 +362,10 @@ def _get_mock() -> "MagicMock":
 # ########################
 
 
-class ExtContextLoader(ABC):
+class PipesContextLoader(ABC):
     @abstractmethod
     @contextmanager
-    def load_context(self, params: ExtParams) -> Iterator[ExtContextData]: ...
+    def load_context(self, params: PipesParams) -> Iterator[PipesContextData]: ...
 
 
 T_MessageChannel = TypeVar("T_MessageChannel", bound="ExtMessageWriterChannel")
@@ -372,20 +374,20 @@ T_MessageChannel = TypeVar("T_MessageChannel", bound="ExtMessageWriterChannel")
 class ExtMessageWriter(ABC, Generic[T_MessageChannel]):
     @abstractmethod
     @contextmanager
-    def open(self, params: ExtParams) -> Iterator[T_MessageChannel]: ...
+    def open(self, params: PipesParams) -> Iterator[T_MessageChannel]: ...
 
 
 class ExtMessageWriterChannel(ABC, Generic[T_MessageChannel]):
     @abstractmethod
-    def write_message(self, message: ExtMessage) -> None: ...
+    def write_message(self, message: PipesMessage) -> None: ...
 
 
-class ExtParamLoader(ABC):
+class PipesParamsLoader(ABC):
     @abstractmethod
-    def load_context_params(self) -> ExtParams: ...
+    def load_context_params(self) -> PipesParams: ...
 
     @abstractmethod
-    def load_messages_params(self) -> ExtParams: ...
+    def load_messages_params(self) -> PipesParams: ...
 
 
 T_BlobStoreMessageWriterChannel = TypeVar(
@@ -398,13 +400,13 @@ class ExtBlobStoreMessageWriter(ExtMessageWriter[T_BlobStoreMessageWriterChannel
         self.interval = interval
 
     @contextmanager
-    def open(self, params: ExtParams) -> Iterator[T_BlobStoreMessageWriterChannel]:
+    def open(self, params: PipesParams) -> Iterator[T_BlobStoreMessageWriterChannel]:
         channel = self.make_channel(params)
         with channel.buffered_upload_loop():
             yield channel
 
     @abstractmethod
-    def make_channel(self, params: ExtParams) -> T_BlobStoreMessageWriterChannel: ...
+    def make_channel(self, params: PipesParams) -> T_BlobStoreMessageWriterChannel: ...
 
 
 class ExtBlobStoreMessageWriterChannel(ExtMessageWriterChannel):
@@ -414,11 +416,11 @@ class ExtBlobStoreMessageWriterChannel(ExtMessageWriterChannel):
         self._buffer = []
         self._counter = 1
 
-    def write_message(self, message: ExtMessage) -> None:
+    def write_message(self, message: PipesMessage) -> None:
         with self._lock:
             self._buffer.append(message)
 
-    def flush_messages(self) -> Sequence[ExtMessage]:
+    def flush_messages(self) -> Sequence[PipesMessage]:
         with self._lock:
             messages = list(self._buffer)
             self._buffer.clear()
@@ -471,12 +473,12 @@ class ExtBufferedFilesystemMessageWriterChannel(ExtBlobStoreMessageWriterChannel
 # ########################
 
 
-class ExtDefaultContextLoader(ExtContextLoader):
+class DefaultPipesContextLoader(PipesContextLoader):
     FILE_PATH_KEY = "path"
     DIRECT_KEY = "data"
 
     @contextmanager
-    def load_context(self, params: ExtParams) -> Iterator[ExtContextData]:
+    def load_context(self, params: PipesParams) -> Iterator[PipesContextData]:
         if self.FILE_PATH_KEY in params:
             path = _assert_env_param_type(params, self.FILE_PATH_KEY, str, self.__class__)
             with open(path, "r") as f:
@@ -484,9 +486,9 @@ class ExtDefaultContextLoader(ExtContextLoader):
                 yield data
         elif self.DIRECT_KEY in params:
             data = _assert_env_param_type(params, self.DIRECT_KEY, dict, self.__class__)
-            yield cast(ExtContextData, data)
+            yield cast(PipesContextData, data)
         else:
-            raise DagsterExtError(
+            raise DagsterPipesError(
                 f'Invalid params for {self.__class__.__name__}, expected key "{self.FILE_PATH_KEY}"'
                 f' or "{self.DIRECT_KEY}", received {params}',
             )
@@ -499,7 +501,7 @@ class ExtDefaultMessageWriter(ExtMessageWriter):
     STDOUT = "stdout"
 
     @contextmanager
-    def open(self, params: ExtParams) -> Iterator[ExtMessageWriterChannel]:
+    def open(self, params: PipesParams) -> Iterator[ExtMessageWriterChannel]:
         if self.FILE_PATH_KEY in params:
             path = _assert_env_param_type(params, self.FILE_PATH_KEY, str, self.__class__)
             yield ExtFileMessageWriterChannel(path)
@@ -510,12 +512,12 @@ class ExtDefaultMessageWriter(ExtMessageWriter):
             elif stream == self.STDOUT:
                 yield ExtStreamMessageWriterChannel(sys.stdout)
             else:
-                raise DagsterExtError(
+                raise DagsterPipesError(
                     f'Invalid value for key "std", expected "{self.STDERR}" or "{self.STDOUT}" but'
                     f" received {stream}"
                 )
         else:
-            raise DagsterExtError(
+            raise DagsterPipesError(
                 f'Invalid params for {self.__class__.__name__}, expected key "path" or "std",'
                 f" received {params}"
             )
@@ -525,7 +527,7 @@ class ExtFileMessageWriterChannel(ExtMessageWriterChannel):
     def __init__(self, path: str):
         self._path = path
 
-    def write_message(self, message: ExtMessage) -> None:
+    def write_message(self, message: PipesMessage) -> None:
         with open(self._path, "a") as f:
             f.write(json.dumps(message) + "\n")
 
@@ -534,15 +536,15 @@ class ExtStreamMessageWriterChannel(ExtMessageWriterChannel):
     def __init__(self, stream: TextIO):
         self._stream = stream
 
-    def write_message(self, message: ExtMessage) -> None:
+    def write_message(self, message: PipesMessage) -> None:
         self._stream.writelines((json.dumps(message), "\n"))
 
 
-class ExtEnvVarParamLoader(ExtParamLoader):
-    def load_context_params(self) -> ExtParams:
+class EnvVarPipesParamsLoader(PipesParamsLoader):
+    def load_context_params(self) -> PipesParams:
         return _param_from_env_var("context")
 
-    def load_messages_params(self) -> ExtParams:
+    def load_messages_params(self) -> PipesParams:
         return _param_from_env_var("messages")
 
 
@@ -561,7 +563,7 @@ class ExtS3MessageWriter(ExtBlobStoreMessageWriter):
 
     def make_channel(
         self,
-        params: ExtParams,
+        params: PipesParams,
     ) -> "ExtS3MessageChannel":
         bucket = _assert_env_param_type(params, "bucket", str, self.__class__)
         key_prefix = _assert_opt_env_param_type(params, "key_prefix", str, self.__class__)
@@ -597,9 +599,9 @@ class ExtS3MessageChannel(ExtBlobStoreMessageWriterChannel):
 # ########################
 
 
-class ExtDbfsContextLoader(ExtContextLoader):
+class DbfsPipesContextLoader(PipesContextLoader):
     @contextmanager
-    def load_context(self, params: ExtParams) -> Iterator[ExtContextData]:
+    def load_context(self, params: PipesParams) -> Iterator[PipesContextData]:
         unmounted_path = _assert_env_param_type(params, "path", str, self.__class__)
         path = os.path.join("/dbfs", unmounted_path.lstrip("/"))
         with open(path, "r") as f:
@@ -609,7 +611,7 @@ class ExtDbfsContextLoader(ExtContextLoader):
 class ExtDbfsMessageWriter(ExtBlobStoreMessageWriter):
     def make_channel(
         self,
-        params: ExtParams,
+        params: PipesParams,
     ) -> "ExtBufferedFilesystemMessageWriterChannel":
         unmounted_path = _assert_env_param_type(params, "path", str, self.__class__)
         return ExtBufferedFilesystemMessageWriterChannel(
@@ -623,46 +625,46 @@ class ExtDbfsMessageWriter(ExtBlobStoreMessageWriter):
 # ########################
 
 
-def init_dagster_ext(
+def init_dagster_pipes(
     *,
-    context_loader: Optional[ExtContextLoader] = None,
+    context_loader: Optional[PipesContextLoader] = None,
     message_writer: Optional[ExtMessageWriter] = None,
-    param_loader: Optional[ExtParamLoader] = None,
-) -> "ExtContext":
-    if ExtContext.is_initialized():
-        return ExtContext.get()
+    params_loader: Optional[PipesParamsLoader] = None,
+) -> "PipesContext":
+    if PipesContext.is_initialized():
+        return PipesContext.get()
 
-    if is_dagster_ext_process():
-        param_loader = param_loader or ExtEnvVarParamLoader()
-        context_params = param_loader.load_context_params()
-        messages_params = param_loader.load_messages_params()
-        context_loader = context_loader or ExtDefaultContextLoader()
+    if is_dagster_pipes_process():
+        params_loader = params_loader or EnvVarPipesParamsLoader()
+        context_params = params_loader.load_context_params()
+        messages_params = params_loader.load_messages_params()
+        context_loader = context_loader or DefaultPipesContextLoader()
         message_writer = message_writer or ExtDefaultMessageWriter()
         stack = ExitStack()
         context_data = stack.enter_context(context_loader.load_context(context_params))
         message_channel = stack.enter_context(message_writer.open(messages_params))
         atexit.register(stack.__exit__, None, None, None)
-        context = ExtContext(context_data, message_channel)
+        context = PipesContext(context_data, message_channel)
     else:
         _emit_orchestration_inactive_warning()
         context = _get_mock()
-    ExtContext.set(context)
+    PipesContext.set(context)
     return context
 
 
-class ExtContext:
-    _instance: ClassVar[Optional["ExtContext"]] = None
+class PipesContext:
+    _instance: ClassVar[Optional["PipesContext"]] = None
 
     @classmethod
     def is_initialized(cls) -> bool:
         return cls._instance is not None
 
     @classmethod
-    def set(cls, context: "ExtContext") -> None:
+    def set(cls, context: "PipesContext") -> None:
         cls._instance = context
 
     @classmethod
-    def get(cls) -> "ExtContext":
+    def get(cls) -> "PipesContext":
         if cls._instance is None:
             raise Exception(
                 "ExtContext has not been initialized. You must call `init_dagster_ext()`."
@@ -671,7 +673,7 @@ class ExtContext:
 
     def __init__(
         self,
-        data: ExtContextData,
+        data: PipesContextData,
         message_channel: ExtMessageWriterChannel,
     ) -> None:
         self._data = data
@@ -679,8 +681,12 @@ class ExtContext:
         self._materialized_assets: set[str] = set()
 
     def _write_message(self, method: str, params: Optional[Mapping[str, Any]] = None) -> None:
-        message = ExtMessage(
-            {EXT_PROTOCOL_VERSION_FIELD: EXT_PROTOCOL_VERSION, "method": method, "params": params}
+        message = PipesMessage(
+            {
+                PIPES_PROTOCOL_VERSION_FIELD: PIPES_PROTOCOL_VERSION,
+                "method": method,
+                "params": params,
+            }
         )
         self._message_channel.write_message(message)
 
@@ -704,7 +710,7 @@ class ExtContext:
         return asset_keys
 
     @property
-    def provenance(self) -> Optional[ExtDataProvenance]:
+    def provenance(self) -> Optional[PipesDataProvenance]:
         provenance_by_asset_key = _assert_defined_asset_property(
             self._data["provenance_by_asset_key"], "provenance"
         )
@@ -712,7 +718,7 @@ class ExtContext:
         return next(iter(provenance_by_asset_key.values()))
 
     @property
-    def provenance_by_asset_key(self) -> Mapping[str, Optional[ExtDataProvenance]]:
+    def provenance_by_asset_key(self) -> Mapping[str, Optional[PipesDataProvenance]]:
         provenance_by_asset_key = _assert_defined_asset_property(
             self._data["provenance_by_asset_key"], "provenance_by_asset_key"
         )
@@ -745,14 +751,14 @@ class ExtContext:
         return partition_key
 
     @property
-    def partition_key_range(self) -> Optional["ExtPartitionKeyRange"]:
+    def partition_key_range(self) -> Optional["PipesPartitionKeyRange"]:
         partition_key_range = _assert_defined_partition_property(
             self._data["partition_key_range"], "partition_key_range"
         )
         return partition_key_range
 
     @property
-    def partition_time_window(self) -> Optional["ExtTimeWindow"]:
+    def partition_time_window(self) -> Optional["PipesTimeWindow"]:
         # None is a valid value for partition_time_window, but we check that a partition key range
         # is defined.
         _assert_defined_partition_property(
@@ -783,7 +789,7 @@ class ExtContext:
 
     def report_asset_materialization(
         self,
-        metadata: Optional[Mapping[str, Union[ExtMetadataRawValue, ExtMetadataValue]]] = None,
+        metadata: Optional[Mapping[str, Union[PipesMetadataRawValue, PipesMetadataValue]]] = None,
         data_version: Optional[str] = None,
         asset_key: Optional[str] = None,
     ):
@@ -791,7 +797,7 @@ class ExtContext:
             self._data, asset_key, "report_asset_materialization"
         )
         if asset_key in self._materialized_assets:
-            raise DagsterExtError(
+            raise DagsterPipesError(
                 f"Calling `report_asset_materialization` with asset key `{asset_key}` is undefined."
                 " Asset has already been materialized, so no additional data can be reported"
                 " for it."
@@ -814,8 +820,8 @@ class ExtContext:
         self,
         check_name: str,
         success: bool,
-        severity: ExtAssetCheckSeverity = "ERROR",
-        metadata: Optional[Mapping[str, Union[ExtMetadataRawValue, ExtMetadataValue]]] = None,
+        severity: PipesAssetCheckSeverity = "ERROR",
+        metadata: Optional[Mapping[str, Union[PipesMetadataRawValue, PipesMetadataValue]]] = None,
         asset_key: Optional[str] = None,
     ) -> None:
         asset_key = _resolve_optionally_passed_asset_key(

--- a/python_modules/dagster-pipes/dagster_pipes_tests/test_context.py
+++ b/python_modules/dagster-pipes/dagster_pipes_tests/test_context.py
@@ -2,15 +2,15 @@ from unittest.mock import MagicMock
 
 import pytest
 from dagster_pipes import (
-    DagsterExtError,
-    ExtContext,
-    ExtContextData,
-    ExtDataProvenance,
-    ExtPartitionKeyRange,
-    ExtTimeWindow,
+    DagsterPipesError,
+    PipesContext,
+    PipesContextData,
+    PipesDataProvenance,
+    PipesPartitionKeyRange,
+    PipesTimeWindow,
 )
 
-TEST_EXT_CONTEXT_DEFAULTS = ExtContextData(
+TEST_EXT_CONTEXT_DEFAULTS = PipesContextData(
     asset_keys=None,
     code_version_by_asset_key=None,
     provenance_by_asset_key=None,
@@ -26,25 +26,25 @@ TEST_EXT_CONTEXT_DEFAULTS = ExtContextData(
 
 def _make_external_execution_context(**kwargs):
     kwargs = {**TEST_EXT_CONTEXT_DEFAULTS, **kwargs}
-    return ExtContext(
-        data=ExtContextData(**kwargs),
+    return PipesContext(
+        data=PipesContextData(**kwargs),
         message_channel=MagicMock(),
     )
 
 
 def _assert_undefined(context, key) -> None:
-    with pytest.raises(DagsterExtError, match=f"`{key}` is undefined"):
+    with pytest.raises(DagsterPipesError, match=f"`{key}` is undefined"):
         getattr(context, key)
 
 
 def _assert_unknown_asset_key(context, method, *args, **kwargs) -> None:
-    with pytest.raises(DagsterExtError, match="Invalid asset key"):
+    with pytest.raises(DagsterPipesError, match="Invalid asset key"):
         getattr(context, method)(*args, **kwargs)
 
 
 def _assert_undefined_asset_key(context, method, *args, **kwargs) -> None:
     with pytest.raises(
-        DagsterExtError, match=f"Calling `{method}` without passing an asset key is undefined"
+        DagsterPipesError, match=f"Calling `{method}` without passing an asset key is undefined"
     ):
         getattr(context, method)(*args, **kwargs)
 
@@ -62,7 +62,7 @@ def test_no_asset_context():
 
 
 def test_single_asset_context():
-    foo_provenance = ExtDataProvenance(
+    foo_provenance = PipesDataProvenance(
         code_version="alpha", input_data_versions={"bar": "baz"}, is_user_provided=False
     )
 
@@ -101,7 +101,7 @@ def test_single_asset_context():
 
 
 def test_multi_asset_context():
-    foo_provenance = ExtDataProvenance(
+    foo_provenance = PipesDataProvenance(
         code_version="alpha", input_data_versions={"bar": "baz"}, is_user_provided=False
     )
     bar_provenance = None
@@ -139,7 +139,7 @@ def test_no_partition_context():
 
 
 def test_single_partition_context():
-    partition_key_range = ExtPartitionKeyRange(start="foo", end="foo")
+    partition_key_range = PipesPartitionKeyRange(start="foo", end="foo")
 
     context = _make_external_execution_context(
         partition_key="foo",
@@ -154,8 +154,8 @@ def test_single_partition_context():
 
 
 def test_multiple_partition_context():
-    partition_key_range = ExtPartitionKeyRange(start="2023-01-01", end="2023-01-02")
-    time_window = ExtTimeWindow(start="2023-01-01", end="2023-01-02")
+    partition_key_range = PipesPartitionKeyRange(start="2023-01-01", end="2023-01-02")
+    time_window = PipesTimeWindow(start="2023-01-01", end="2023-01-02")
 
     context = _make_external_execution_context(
         partition_key=None,
@@ -173,12 +173,12 @@ def test_extras_context():
     context = _make_external_execution_context(extras={"foo": "bar"})
 
     assert context.get_extra("foo") == "bar"
-    with pytest.raises(DagsterExtError, match="Extra `bar` is undefined"):
+    with pytest.raises(DagsterPipesError, match="Extra `bar` is undefined"):
         context.get_extra("bar")
 
 
 def test_report_twice_materialized():
     context = _make_external_execution_context(asset_keys=["foo"])
-    with pytest.raises(DagsterExtError, match="already been materialized"):
+    with pytest.raises(DagsterPipesError, match="already been materialized"):
         context.report_asset_materialization(asset_key="foo")
         context.report_asset_materialization(asset_key="foo")

--- a/python_modules/dagster-test/dagster_test/toys/external_execution/__init__.py
+++ b/python_modules/dagster-test/dagster_test/toys/external_execution/__init__.py
@@ -3,7 +3,7 @@ import sys
 
 from dagster import AssetExecutionContext, Config, Definitions, asset
 from dagster._core.pipes.subprocess import (
-    ExtSubprocess,
+    PipedSubprocess,
 )
 from pydantic import Field
 
@@ -32,13 +32,13 @@ class NumberConfig(Config):
 
 
 @asset
-def number_x(context: AssetExecutionContext, ext: ExtSubprocess, config: NumberConfig) -> None:
+def number_x(context: AssetExecutionContext, ext: PipedSubprocess, config: NumberConfig) -> None:
     extras = {**get_common_extras(context), "multiplier": config.multiplier}
     ext.run(command_for_asset("number_x"), context=context, extras=extras)
 
 
 @asset
-def number_y(context: AssetExecutionContext, ext: ExtSubprocess, config: NumberConfig):
+def number_y(context: AssetExecutionContext, ext: PipedSubprocess, config: NumberConfig):
     ext.run(
         command_for_asset("number_y"),
         context=context,
@@ -48,11 +48,11 @@ def number_y(context: AssetExecutionContext, ext: ExtSubprocess, config: NumberC
 
 
 @asset(deps=[number_x, number_y])
-def number_sum(context: AssetExecutionContext, ext: ExtSubprocess) -> None:
+def number_sum(context: AssetExecutionContext, ext: PipedSubprocess) -> None:
     ext.run(command_for_asset("number_sum"), context=context, extras=get_common_extras(context))
 
 
-ext = ExtSubprocess(
+ext = PipedSubprocess(
     env=get_env(),
 )
 

--- a/python_modules/dagster-test/dagster_test/toys/external_execution/__init__.py
+++ b/python_modules/dagster-test/dagster_test/toys/external_execution/__init__.py
@@ -3,7 +3,7 @@ import sys
 
 from dagster import AssetExecutionContext, Config, Definitions, asset
 from dagster._core.pipes.subprocess import (
-    PipedSubprocess,
+    PipesSubprocess,
 )
 from pydantic import Field
 
@@ -32,13 +32,13 @@ class NumberConfig(Config):
 
 
 @asset
-def number_x(context: AssetExecutionContext, ext: PipedSubprocess, config: NumberConfig) -> None:
+def number_x(context: AssetExecutionContext, ext: PipesSubprocess, config: NumberConfig) -> None:
     extras = {**get_common_extras(context), "multiplier": config.multiplier}
     ext.run(command_for_asset("number_x"), context=context, extras=extras)
 
 
 @asset
-def number_y(context: AssetExecutionContext, ext: PipedSubprocess, config: NumberConfig):
+def number_y(context: AssetExecutionContext, ext: PipesSubprocess, config: NumberConfig):
     ext.run(
         command_for_asset("number_y"),
         context=context,
@@ -48,11 +48,11 @@ def number_y(context: AssetExecutionContext, ext: PipedSubprocess, config: Numbe
 
 
 @asset(deps=[number_x, number_y])
-def number_sum(context: AssetExecutionContext, ext: PipedSubprocess) -> None:
+def number_sum(context: AssetExecutionContext, ext: PipesSubprocess) -> None:
     ext.run(command_for_asset("number_sum"), context=context, extras=get_common_extras(context))
 
 
-ext = PipedSubprocess(
+ext = PipesSubprocess(
     env=get_env(),
 )
 

--- a/python_modules/dagster-test/dagster_test/toys/external_execution/numbers_example/number_sum.py
+++ b/python_modules/dagster-test/dagster_test/toys/external_execution/numbers_example/number_sum.py
@@ -1,8 +1,8 @@
-from dagster_pipes import init_dagster_ext
+from dagster_pipes import init_dagster_pipes
 
 from .util import compute_data_version, load_asset_value, store_asset_value
 
-context = init_dagster_ext()
+context = init_dagster_pipes()
 storage_root = context.get_extra("storage_root")
 number_y = load_asset_value("number_y", storage_root)
 number_x = load_asset_value("number_x", storage_root)

--- a/python_modules/dagster-test/dagster_test/toys/external_execution/numbers_example/number_x.py
+++ b/python_modules/dagster-test/dagster_test/toys/external_execution/numbers_example/number_x.py
@@ -1,8 +1,8 @@
-from dagster_pipes import init_dagster_ext
+from dagster_pipes import init_dagster_pipes
 
 from .util import compute_data_version, store_asset_value
 
-context = init_dagster_ext()
+context = init_dagster_pipes()
 storage_root = context.get_extra("storage_root")
 
 multiplier = context.get_extra("multiplier")

--- a/python_modules/dagster-test/dagster_test/toys/external_execution/numbers_example/number_y.py
+++ b/python_modules/dagster-test/dagster_test/toys/external_execution/numbers_example/number_y.py
@@ -1,10 +1,10 @@
 import os
 
-from dagster_pipes import init_dagster_ext
+from dagster_pipes import init_dagster_pipes
 
 from .util import compute_data_version, store_asset_value
 
-context = init_dagster_ext()
+context = init_dagster_pipes()
 storage_root = context.get_extra("storage_root")
 
 value = int(os.environ["NUMBER_Y"])

--- a/python_modules/dagster/dagster/_core/pipes/client.py
+++ b/python_modules/dagster/dagster/_core/pipes/client.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from .context import ExtMessageHandler, ExtResult
 
 
-class PipedProcessClient(ABC):
+class PipesClient(ABC):
     @abstractmethod
     def run(
         self,
@@ -24,7 +24,7 @@ class PipedProcessClient(ABC):
     ) -> Iterator["ExtResult"]: ...
 
 
-class PipedProcessContextInjector(ABC):
+class PipesContextInjector(ABC):
     @abstractmethod
     @contextmanager
     def inject_context(self, context_data: "PipesContextData") -> Iterator[PipesParams]: ...

--- a/python_modules/dagster/dagster/_core/pipes/client.py
+++ b/python_modules/dagster/dagster/_core/pipes/client.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from .context import ExtMessageHandler, ExtResult
 
 
-class ExtClient(ABC):
+class PipedProcessClient(ABC):
     @abstractmethod
     def run(
         self,
@@ -24,7 +24,7 @@ class ExtClient(ABC):
     ) -> Iterator["ExtResult"]: ...
 
 
-class ExtContextInjector(ABC):
+class PipedProcessContextInjector(ABC):
     @abstractmethod
     @contextmanager
     def inject_context(self, context_data: "PipesContextData") -> Iterator[PipesParams]: ...

--- a/python_modules/dagster/dagster/_core/pipes/client.py
+++ b/python_modules/dagster/dagster/_core/pipes/client.py
@@ -3,9 +3,9 @@ from contextlib import contextmanager
 from typing import TYPE_CHECKING, Iterator, Optional
 
 from dagster_pipes import (
-    ExtContextData,
-    ExtExtras,
-    ExtParams,
+    PipesContextData,
+    PipesExtras,
+    PipesParams,
 )
 
 from dagster._core.execution.context.compute import OpExecutionContext
@@ -20,17 +20,17 @@ class ExtClient(ABC):
         self,
         *,
         context: OpExecutionContext,
-        extras: Optional[ExtExtras] = None,
+        extras: Optional[PipesExtras] = None,
     ) -> Iterator["ExtResult"]: ...
 
 
 class ExtContextInjector(ABC):
     @abstractmethod
     @contextmanager
-    def inject_context(self, context_data: "ExtContextData") -> Iterator[ExtParams]: ...
+    def inject_context(self, context_data: "PipesContextData") -> Iterator[PipesParams]: ...
 
 
 class ExtMessageReader(ABC):
     @abstractmethod
     @contextmanager
-    def read_messages(self, handler: "ExtMessageHandler") -> Iterator[ExtParams]: ...
+    def read_messages(self, handler: "ExtMessageHandler") -> Iterator[PipesParams]: ...

--- a/python_modules/dagster/dagster/_core/pipes/context.py
+++ b/python_modules/dagster/dagster/_core/pipes/context.py
@@ -1,7 +1,7 @@
 from contextlib import contextmanager
 from dataclasses import dataclass
 from queue import Queue
-from typing import Any, Iterator, Mapping, Optional, Set, Union
+from typing import Any, Dict, Iterator, Mapping, Optional, Set, Union
 
 from dagster_pipes import (
     DAGSTER_PIPES_ENV_KEYS,
@@ -164,13 +164,13 @@ def _ext_params_as_env_vars(
 
 
 @dataclass
-class ExtOrchestrationContext:
+class PipesSession:
     context_data: PipesContextData
     message_handler: ExtMessageHandler
     context_injector_params: PipesParams
     message_reader_params: PipesParams
 
-    def get_external_process_env_vars(self):
+    def get_piped_process_env_vars(self) -> Dict[str, str]:
         return {
             DAGSTER_PIPES_ENV_KEYS[IS_DAGSTER_PIPES_PROCESS]: encode_env_var(True),
             **_ext_params_as_env_vars(

--- a/python_modules/dagster/dagster/_core/pipes/context.py
+++ b/python_modules/dagster/dagster/_core/pipes/context.py
@@ -4,17 +4,17 @@ from queue import Queue
 from typing import Any, Iterator, Mapping, Optional, Set, Union
 
 from dagster_pipes import (
-    DAGSTER_EXT_ENV_KEYS,
-    EXT_METADATA_TYPE_INFER,
-    IS_DAGSTER_EXT_PROCESS_ENV_VAR,
-    ExtContextData,
-    ExtDataProvenance,
-    ExtExtras,
-    ExtMessage,
-    ExtMetadataType,
-    ExtMetadataValue,
-    ExtParams,
-    ExtTimeWindow,
+    DAGSTER_PIPED_ENV_KEYS,
+    IS_DAGSTER_PIPED_PROCESS_ENV_VAR,
+    PIPEABLE_METADATA_TYPE_INFER,
+    PipesContextData,
+    PipesDataProvenance,
+    PipesExtras,
+    PipesMessage,
+    PipesMetadataType,
+    PipesMetadataValue,
+    PipesParams,
+    PipesTimeWindow,
     encode_env_var,
 )
 from typing_extensions import TypeAlias
@@ -44,7 +44,7 @@ class ExtMessageHandler:
         self._unmaterialized_assets: Set[AssetKey] = set(context.selected_asset_keys)
 
     @contextmanager
-    def handle_messages(self, message_reader: ExtMessageReader) -> Iterator[ExtParams]:
+    def handle_messages(self, message_reader: ExtMessageReader) -> Iterator[PipesParams]:
         with message_reader.read_messages(self) as params:
             yield params
         for key in self._unmaterialized_assets:
@@ -55,14 +55,16 @@ class ExtMessageHandler:
             yield self._result_queue.get()
 
     def _resolve_metadata(
-        self, metadata: Mapping[str, ExtMetadataValue]
+        self, metadata: Mapping[str, PipesMetadataValue]
     ) -> Mapping[str, MetadataValue]:
         return {
             k: self._resolve_metadata_value(v["raw_value"], v["type"]) for k, v in metadata.items()
         }
 
-    def _resolve_metadata_value(self, value: Any, metadata_type: ExtMetadataType) -> MetadataValue:
-        if metadata_type == EXT_METADATA_TYPE_INFER:
+    def _resolve_metadata_value(
+        self, value: Any, metadata_type: PipesMetadataType
+    ) -> MetadataValue:
+        if metadata_type == PIPEABLE_METADATA_TYPE_INFER:
             return normalize_metadata_value(value)
         elif metadata_type == "text":
             return MetadataValue.text(value)
@@ -94,7 +96,7 @@ class ExtMessageHandler:
             check.failed(f"Unexpected metadata type {metadata_type}")
 
     # Type ignores because we currently validate in individual handlers
-    def handle_message(self, message: ExtMessage) -> None:
+    def handle_message(self, message: PipesMessage) -> None:
         if message["method"] == "report_asset_materialization":
             self._handle_report_asset_materialization(**message["params"])  # type: ignore
         elif message["method"] == "report_asset_check":
@@ -105,7 +107,7 @@ class ExtMessageHandler:
     def _handle_report_asset_materialization(
         self,
         asset_key: str,
-        metadata: Optional[Mapping[str, ExtMetadataValue]],
+        metadata: Optional[Mapping[str, PipesMetadataValue]],
         data_version: Optional[str],
     ) -> None:
         check.str_param(asset_key, "asset_key")
@@ -128,7 +130,7 @@ class ExtMessageHandler:
         check_name: str,
         success: bool,
         severity: str,
-        metadata: Mapping[str, ExtMetadataValue],
+        metadata: Mapping[str, PipesMetadataValue],
     ) -> None:
         check.str_param(asset_key, "asset_key")
         check.str_param(check_name, "check_name")
@@ -153,24 +155,24 @@ class ExtMessageHandler:
 
 
 def _ext_params_as_env_vars(
-    context_injector_params: ExtParams, message_reader_params: ExtParams
+    context_injector_params: PipesParams, message_reader_params: PipesParams
 ) -> Mapping[str, str]:
     return {
-        DAGSTER_EXT_ENV_KEYS["context"]: encode_env_var(context_injector_params),
-        DAGSTER_EXT_ENV_KEYS["messages"]: encode_env_var(message_reader_params),
+        DAGSTER_PIPED_ENV_KEYS["context"]: encode_env_var(context_injector_params),
+        DAGSTER_PIPED_ENV_KEYS["messages"]: encode_env_var(message_reader_params),
     }
 
 
 @dataclass
 class ExtOrchestrationContext:
-    context_data: ExtContextData
+    context_data: PipesContextData
     message_handler: ExtMessageHandler
-    context_injector_params: ExtParams
-    message_reader_params: ExtParams
+    context_injector_params: PipesParams
+    message_reader_params: PipesParams
 
     def get_external_process_env_vars(self):
         return {
-            DAGSTER_EXT_ENV_KEYS[IS_DAGSTER_EXT_PROCESS_ENV_VAR]: encode_env_var(True),
+            DAGSTER_PIPED_ENV_KEYS[IS_DAGSTER_PIPED_PROCESS_ENV_VAR]: encode_env_var(True),
             **_ext_params_as_env_vars(
                 context_injector_params=self.context_injector_params,
                 message_reader_params=self.message_reader_params,
@@ -183,8 +185,8 @@ class ExtOrchestrationContext:
 
 def build_external_execution_context_data(
     context: OpExecutionContext,
-    extras: Optional[ExtExtras],
-) -> "ExtContextData":
+    extras: Optional[PipesExtras],
+) -> "PipesContextData":
     asset_keys = (
         [_convert_asset_key(key) for key in sorted(context.selected_asset_keys)]
         if context.has_assets_def
@@ -209,7 +211,7 @@ def build_external_execution_context_data(
     partition_key = context.partition_key if context.has_partition_key else None
     partition_time_window = context.partition_time_window if context.has_partition_key else None
     partition_key_range = context.partition_key_range if context.has_partition_key else None
-    return ExtContextData(
+    return PipesContextData(
         asset_keys=asset_keys,
         code_version_by_asset_key=code_version_by_asset_key,
         provenance_by_asset_key=provenance_by_asset_key,
@@ -233,11 +235,11 @@ def _convert_asset_key(asset_key: AssetKey) -> str:
 
 def _convert_data_provenance(
     provenance: Optional[DataProvenance],
-) -> Optional["ExtDataProvenance"]:
+) -> Optional["PipesDataProvenance"]:
     return (
         None
         if provenance is None
-        else ExtDataProvenance(
+        else PipesDataProvenance(
             code_version=provenance.code_version,
             input_data_versions={
                 _convert_asset_key(k): v.value for k, v in provenance.input_data_versions.items()
@@ -249,8 +251,8 @@ def _convert_data_provenance(
 
 def _convert_time_window(
     time_window: TimeWindow,
-) -> "ExtTimeWindow":
-    return ExtTimeWindow(
+) -> "PipesTimeWindow":
+    return PipesTimeWindow(
         start=time_window.start.isoformat(),
         end=time_window.end.isoformat(),
     )
@@ -258,8 +260,8 @@ def _convert_time_window(
 
 def _convert_partition_key_range(
     partition_key_range: PartitionKeyRange,
-) -> "ExtTimeWindow":
-    return ExtTimeWindow(
+) -> "PipesTimeWindow":
+    return PipesTimeWindow(
         start=partition_key_range.start,
         end=partition_key_range.end,
     )

--- a/python_modules/dagster/dagster/_core/pipes/context.py
+++ b/python_modules/dagster/dagster/_core/pipes/context.py
@@ -4,9 +4,9 @@ from queue import Queue
 from typing import Any, Iterator, Mapping, Optional, Set, Union
 
 from dagster_pipes import (
-    DAGSTER_PIPED_ENV_KEYS,
-    IS_DAGSTER_PIPED_PROCESS_ENV_VAR,
-    PIPEABLE_METADATA_TYPE_INFER,
+    DAGSTER_PIPES_ENV_KEYS,
+    IS_DAGSTER_PIPES_PROCESS,
+    PIPES_METADATA_TYPE_INFER,
     PipesContextData,
     PipesDataProvenance,
     PipesExtras,
@@ -64,7 +64,7 @@ class ExtMessageHandler:
     def _resolve_metadata_value(
         self, value: Any, metadata_type: PipesMetadataType
     ) -> MetadataValue:
-        if metadata_type == PIPEABLE_METADATA_TYPE_INFER:
+        if metadata_type == PIPES_METADATA_TYPE_INFER:
             return normalize_metadata_value(value)
         elif metadata_type == "text":
             return MetadataValue.text(value)
@@ -158,8 +158,8 @@ def _ext_params_as_env_vars(
     context_injector_params: PipesParams, message_reader_params: PipesParams
 ) -> Mapping[str, str]:
     return {
-        DAGSTER_PIPED_ENV_KEYS["context"]: encode_env_var(context_injector_params),
-        DAGSTER_PIPED_ENV_KEYS["messages"]: encode_env_var(message_reader_params),
+        DAGSTER_PIPES_ENV_KEYS["context"]: encode_env_var(context_injector_params),
+        DAGSTER_PIPES_ENV_KEYS["messages"]: encode_env_var(message_reader_params),
     }
 
 
@@ -172,7 +172,7 @@ class ExtOrchestrationContext:
 
     def get_external_process_env_vars(self):
         return {
-            DAGSTER_PIPED_ENV_KEYS[IS_DAGSTER_PIPED_PROCESS_ENV_VAR]: encode_env_var(True),
+            DAGSTER_PIPES_ENV_KEYS[IS_DAGSTER_PIPES_PROCESS]: encode_env_var(True),
             **_ext_params_as_env_vars(
                 context_injector_params=self.context_injector_params,
                 message_reader_params=self.message_reader_params,

--- a/python_modules/dagster/dagster/_core/pipes/subprocess.py
+++ b/python_modules/dagster/dagster/_core/pipes/subprocess.py
@@ -9,8 +9,8 @@ from dagster._core.errors import DagsterExternalExecutionError
 from dagster._core.execution.context.compute import OpExecutionContext
 from dagster._core.pipes.client import (
     ExtMessageReader,
-    PipedProcessClient,
-    PipedProcessContextInjector,
+    PipesClient,
+    PipesContextInjector,
 )
 from dagster._core.pipes.context import ExtResult
 from dagster._core.pipes.utils import (
@@ -20,7 +20,7 @@ from dagster._core.pipes.utils import (
 )
 
 
-class _PipedSubprocess(PipedProcessClient):
+class _PipedSubprocess(PipesClient):
     """A pipes client that runs a subprocess with the given command and environment.
 
     By default parameters are injected via environment variables. And then context is passed via
@@ -29,15 +29,15 @@ class _PipedSubprocess(PipedProcessClient):
     Args:
         env (Optional[Mapping[str, str]]): An optional dict of environment variables to pass to the subprocess.
         cwd (Optional[str]): Working directory in which to launch the subprocess command.
-        context_injector (Optional[PipedProcessContextInjector]): An context injector to use to inject context into the subprocess. Defaults to ExtTempFileContextInjector.
-        message_reader (Optional[PipedProcessContextInjector]): An context injector to use to read messages from  the subprocess. Defaults to ExtTempFileMessageReader.
+        context_injector (Optional[PipesContextInjector]): An context injector to use to inject context into the subprocess. Defaults to ExtTempFileContextInjector.
+        message_reader (Optional[PipesContextInjector]): An context injector to use to read messages from  the subprocess. Defaults to ExtTempFileMessageReader.
     """
 
     def __init__(
         self,
         env: Optional[Mapping[str, str]] = None,
         cwd: Optional[str] = None,
-        context_injector: Optional[PipedProcessContextInjector] = None,
+        context_injector: Optional[PipesContextInjector] = None,
         message_reader: Optional[ExtMessageReader] = None,
     ):
         self.env = check.opt_mapping_param(env, "env", key_type=str, value_type=str)
@@ -46,7 +46,7 @@ class _PipedSubprocess(PipedProcessClient):
             check.opt_inst_param(
                 context_injector,
                 "context_injector",
-                PipedProcessContextInjector,
+                PipesContextInjector,
             )
             or ExtTempFileContextInjector()
         )

--- a/python_modules/dagster/dagster/_core/pipes/subprocess.py
+++ b/python_modules/dagster/dagster/_core/pipes/subprocess.py
@@ -20,7 +20,7 @@ from dagster._core.pipes.utils import (
 )
 
 
-class _PipedSubprocess(PipesClient):
+class _PipesSubprocess(PipesClient):
     """A pipes client that runs a subprocess with the given command and environment.
 
     By default parameters are injected via environment variables. And then context is passed via
@@ -93,4 +93,4 @@ class _PipedSubprocess(PipesClient):
         yield from pipes_session.get_results()
 
 
-PipedSubprocess = ResourceParam[_PipedSubprocess]
+PipesSubprocess = ResourceParam[_PipesSubprocess]

--- a/python_modules/dagster/dagster/_core/pipes/subprocess.py
+++ b/python_modules/dagster/dagster/_core/pipes/subprocess.py
@@ -8,9 +8,9 @@ from dagster._core.definitions.resource_annotation import ResourceParam
 from dagster._core.errors import DagsterExternalExecutionError
 from dagster._core.execution.context.compute import OpExecutionContext
 from dagster._core.pipes.client import (
-    ExtClient,
-    ExtContextInjector,
     ExtMessageReader,
+    PipedProcessClient,
+    PipedProcessContextInjector,
 )
 from dagster._core.pipes.context import ExtResult
 from dagster._core.pipes.utils import (
@@ -20,8 +20,8 @@ from dagster._core.pipes.utils import (
 )
 
 
-class _ExtSubprocess(ExtClient):
-    """An ext client that runs a subprocess with the given command and environment.
+class _PipedSubprocess(PipedProcessClient):
+    """A pipes client that runs a subprocess with the given command and environment.
 
     By default parameters are injected via environment variables. And then context is passed via
     a temp file, and structured messages are read from from a temp file.
@@ -29,15 +29,15 @@ class _ExtSubprocess(ExtClient):
     Args:
         env (Optional[Mapping[str, str]]): An optional dict of environment variables to pass to the subprocess.
         cwd (Optional[str]): Working directory in which to launch the subprocess command.
-        context_injector (Optional[ExtContextInjector]): An context injector to use to inject context into the subprocess. Defaults to ExtTempFileContextInjector.
-        message_reader (Optional[ExtContextInjector]): An context injector to use to read messages from  the subprocess. Defaults to ExtTempFileMessageReader.
+        context_injector (Optional[PipedProcessContextInjector]): An context injector to use to inject context into the subprocess. Defaults to ExtTempFileContextInjector.
+        message_reader (Optional[PipedProcessContextInjector]): An context injector to use to read messages from  the subprocess. Defaults to ExtTempFileMessageReader.
     """
 
     def __init__(
         self,
         env: Optional[Mapping[str, str]] = None,
         cwd: Optional[str] = None,
-        context_injector: Optional[ExtContextInjector] = None,
+        context_injector: Optional[PipedProcessContextInjector] = None,
         message_reader: Optional[ExtMessageReader] = None,
     ):
         self.env = check.opt_mapping_param(env, "env", key_type=str, value_type=str)
@@ -46,7 +46,7 @@ class _ExtSubprocess(ExtClient):
             check.opt_inst_param(
                 context_injector,
                 "context_injector",
-                ExtContextInjector,
+                PipedProcessContextInjector,
             )
             or ExtTempFileContextInjector()
         )
@@ -93,4 +93,4 @@ class _ExtSubprocess(ExtClient):
         yield from pipes_session.get_results()
 
 
-ExtSubprocess = ResourceParam[_ExtSubprocess]
+PipedSubprocess = ResourceParam[_PipedSubprocess]

--- a/python_modules/dagster/dagster/_core/pipes/subprocess.py
+++ b/python_modules/dagster/dagster/_core/pipes/subprocess.py
@@ -16,7 +16,7 @@ from dagster._core.pipes.context import ExtResult
 from dagster._core.pipes.utils import (
     ExtTempFileContextInjector,
     ExtTempFileMessageReader,
-    ext_protocol,
+    pipes_protocol,
 )
 
 
@@ -68,29 +68,29 @@ class _ExtSubprocess(ExtClient):
         env: Optional[Mapping[str, str]] = None,
         cwd: Optional[str] = None,
     ) -> Iterator[ExtResult]:
-        with ext_protocol(
+        with pipes_protocol(
             context=context,
             context_injector=self.context_injector,
             message_reader=self.message_reader,
             extras=extras,
-        ) as ext_context:
+        ) as pipes_session:
             process = Popen(
                 command,
                 cwd=cwd or self.cwd,
                 env={
-                    **ext_context.get_external_process_env_vars(),
+                    **pipes_session.get_piped_process_env_vars(),
                     **self.env,
                     **(env or {}),
                 },
             )
             while process.poll() is None:
-                yield from ext_context.get_results()
+                yield from pipes_session.get_results()
 
             if process.returncode != 0:
                 raise DagsterExternalExecutionError(
                     f"External execution process failed with code {process.returncode}"
                 )
-        yield from ext_context.get_results()
+        yield from pipes_session.get_results()
 
 
 ExtSubprocess = ResourceParam[_ExtSubprocess]

--- a/python_modules/dagster/dagster/_core/pipes/subprocess.py
+++ b/python_modules/dagster/dagster/_core/pipes/subprocess.py
@@ -1,7 +1,7 @@
 from subprocess import Popen
 from typing import Iterator, Mapping, Optional, Sequence, Union
 
-from dagster_pipes import ExtExtras
+from dagster_pipes import PipesExtras
 
 from dagster import _check as check
 from dagster._core.definitions.resource_annotation import ResourceParam
@@ -64,7 +64,7 @@ class _ExtSubprocess(ExtClient):
         command: Union[str, Sequence[str]],
         *,
         context: OpExecutionContext,
-        extras: Optional[ExtExtras] = None,
+        extras: Optional[PipesExtras] = None,
         env: Optional[Mapping[str, str]] = None,
         cwd: Optional[str] = None,
     ) -> Iterator[ExtResult]:

--- a/python_modules/dagster/dagster/_core/pipes/utils.py
+++ b/python_modules/dagster/dagster/_core/pipes/utils.py
@@ -24,7 +24,7 @@ from dagster import (
 )
 from dagster._core.pipes.client import (
     ExtMessageReader,
-    PipedProcessContextInjector,
+    PipesContextInjector,
 )
 from dagster._core.pipes.context import (
     ExtMessageHandler,
@@ -37,7 +37,7 @@ _CONTEXT_INJECTOR_FILENAME = "context"
 _MESSAGE_READER_FILENAME = "messages"
 
 
-class ExtFileContextInjector(PipedProcessContextInjector):
+class ExtFileContextInjector(PipesContextInjector):
     def __init__(self, path: str):
         self._path = check.str_param(path, "path")
 
@@ -52,7 +52,7 @@ class ExtFileContextInjector(PipedProcessContextInjector):
                 os.remove(self._path)
 
 
-class ExtTempFileContextInjector(PipedProcessContextInjector):
+class ExtTempFileContextInjector(PipesContextInjector):
     @contextmanager
     def inject_context(self, context: "PipesContextData") -> Iterator[PipesParams]:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -62,7 +62,7 @@ class ExtTempFileContextInjector(PipedProcessContextInjector):
                 yield params
 
 
-class ExtEnvContextInjector(PipedProcessContextInjector):
+class ExtEnvContextInjector(PipesContextInjector):
     @contextmanager
     def inject_context(
         self,
@@ -194,7 +194,7 @@ _FAIL_TO_YIELD_ERROR_MESSAGE = (
 @contextmanager
 def pipes_protocol(
     context: OpExecutionContext,
-    context_injector: PipedProcessContextInjector,
+    context_injector: PipesContextInjector,
     message_reader: ExtMessageReader,
     extras: Optional[PipesExtras] = None,
 ) -> Iterator[PipesSession]:

--- a/python_modules/dagster/dagster/_core/pipes/utils.py
+++ b/python_modules/dagster/dagster/_core/pipes/utils.py
@@ -10,12 +10,12 @@ from threading import Event, Thread
 from typing import Iterator, Optional
 
 from dagster_pipes import (
-    EXT_PROTOCOL_VERSION_FIELD,
-    ExtContextData,
-    ExtDefaultContextLoader,
+    PIPES_PROTOCOL_VERSION_FIELD,
+    DefaultPipesContextLoader,
     ExtDefaultMessageWriter,
-    ExtExtras,
-    ExtParams,
+    PipesContextData,
+    PipesExtras,
+    PipesParams,
 )
 
 from dagster import (
@@ -42,11 +42,11 @@ class ExtFileContextInjector(ExtContextInjector):
         self._path = check.str_param(path, "path")
 
     @contextmanager
-    def inject_context(self, context_data: "ExtContextData") -> Iterator[ExtParams]:
+    def inject_context(self, context_data: "PipesContextData") -> Iterator[PipesParams]:
         with open(self._path, "w") as input_stream:
             json.dump(context_data, input_stream)
         try:
-            yield {ExtDefaultContextLoader.FILE_PATH_KEY: self._path}
+            yield {DefaultPipesContextLoader.FILE_PATH_KEY: self._path}
         finally:
             if os.path.exists(self._path):
                 os.remove(self._path)
@@ -54,7 +54,7 @@ class ExtFileContextInjector(ExtContextInjector):
 
 class ExtTempFileContextInjector(ExtContextInjector):
     @contextmanager
-    def inject_context(self, context: "ExtContextData") -> Iterator[ExtParams]:
+    def inject_context(self, context: "PipesContextData") -> Iterator[PipesParams]:
         with tempfile.TemporaryDirectory() as tempdir:
             with ExtFileContextInjector(
                 os.path.join(tempdir, _CONTEXT_INJECTOR_FILENAME)
@@ -66,9 +66,9 @@ class ExtEnvContextInjector(ExtContextInjector):
     @contextmanager
     def inject_context(
         self,
-        context_data: "ExtContextData",
-    ) -> Iterator[ExtParams]:
-        yield {ExtDefaultContextLoader.DIRECT_KEY: context_data}
+        context_data: "PipesContextData",
+    ) -> Iterator[PipesParams]:
+        yield {DefaultPipesContextLoader.DIRECT_KEY: context_data}
 
 
 class ExtFileMessageReader(ExtMessageReader):
@@ -79,7 +79,7 @@ class ExtFileMessageReader(ExtMessageReader):
     def read_messages(
         self,
         handler: "ExtMessageHandler",
-    ) -> Iterator[ExtParams]:
+    ) -> Iterator[PipesParams]:
         is_task_complete = Event()
         thread = None
         try:
@@ -107,7 +107,7 @@ class ExtTempFileMessageReader(ExtMessageReader):
     def read_messages(
         self,
         handler: "ExtMessageHandler",
-    ) -> Iterator[ExtParams]:
+    ) -> Iterator[PipesParams]:
         with tempfile.TemporaryDirectory() as tempdir:
             with ExtFileMessageReader(
                 os.path.join(tempdir, _MESSAGE_READER_FILENAME)
@@ -127,7 +127,7 @@ class ExtBlobStoreMessageReader(ExtMessageReader):
     def read_messages(
         self,
         handler: "ExtMessageHandler",
-    ) -> Iterator[ExtParams]:
+    ) -> Iterator[PipesParams]:
         with self.get_params() as params:
             is_task_complete = Event()
             thread = None
@@ -150,13 +150,13 @@ class ExtBlobStoreMessageReader(ExtMessageReader):
 
     @abstractmethod
     @contextmanager
-    def get_params(self) -> Iterator[ExtParams]: ...
+    def get_params(self) -> Iterator[PipesParams]: ...
 
     @abstractmethod
-    def download_messages_chunk(self, index: int, params: ExtParams) -> Optional[str]: ...
+    def download_messages_chunk(self, index: int, params: PipesParams) -> Optional[str]: ...
 
     def _reader_thread(
-        self, handler: "ExtMessageHandler", params: ExtParams, is_task_complete: Event
+        self, handler: "ExtMessageHandler", params: PipesParams, is_task_complete: Event
     ) -> None:
         start_or_last_download = datetime.datetime.now()
         while True:
@@ -178,7 +178,7 @@ def extract_message_or_forward_to_stdout(handler: "ExtMessageHandler", log_line:
     # exceptions as control flow, you love to see it
     try:
         message = json.loads(log_line)
-        if EXT_PROTOCOL_VERSION_FIELD in message.keys():
+        if PIPES_PROTOCOL_VERSION_FIELD in message.keys():
             handler.handle_message(message)
     except Exception:
         # move non-message logs in to stdout for compute log capture
@@ -196,7 +196,7 @@ def ext_protocol(
     context: OpExecutionContext,
     context_injector: ExtContextInjector,
     message_reader: ExtMessageReader,
-    extras: Optional[ExtExtras] = None,
+    extras: Optional[PipesExtras] = None,
 ) -> Iterator[ExtOrchestrationContext]:
     """Enter the context managed context injector and message reader that power the EXT protocol and receive the environment variables
     that need to be provided to the external process.

--- a/python_modules/dagster/dagster/_core/pipes/utils.py
+++ b/python_modules/dagster/dagster/_core/pipes/utils.py
@@ -23,8 +23,8 @@ from dagster import (
     _check as check,
 )
 from dagster._core.pipes.client import (
-    ExtContextInjector,
     ExtMessageReader,
+    PipedProcessContextInjector,
 )
 from dagster._core.pipes.context import (
     ExtMessageHandler,
@@ -37,7 +37,7 @@ _CONTEXT_INJECTOR_FILENAME = "context"
 _MESSAGE_READER_FILENAME = "messages"
 
 
-class ExtFileContextInjector(ExtContextInjector):
+class ExtFileContextInjector(PipedProcessContextInjector):
     def __init__(self, path: str):
         self._path = check.str_param(path, "path")
 
@@ -52,7 +52,7 @@ class ExtFileContextInjector(ExtContextInjector):
                 os.remove(self._path)
 
 
-class ExtTempFileContextInjector(ExtContextInjector):
+class ExtTempFileContextInjector(PipedProcessContextInjector):
     @contextmanager
     def inject_context(self, context: "PipesContextData") -> Iterator[PipesParams]:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -62,7 +62,7 @@ class ExtTempFileContextInjector(ExtContextInjector):
                 yield params
 
 
-class ExtEnvContextInjector(ExtContextInjector):
+class ExtEnvContextInjector(PipedProcessContextInjector):
     @contextmanager
     def inject_context(
         self,
@@ -194,7 +194,7 @@ _FAIL_TO_YIELD_ERROR_MESSAGE = (
 @contextmanager
 def pipes_protocol(
     context: OpExecutionContext,
-    context_injector: ExtContextInjector,
+    context_injector: PipedProcessContextInjector,
     message_reader: ExtMessageReader,
     extras: Optional[PipesExtras] = None,
 ) -> Iterator[PipesSession]:

--- a/python_modules/dagster/dagster/_core/pipes/utils.py
+++ b/python_modules/dagster/dagster/_core/pipes/utils.py
@@ -28,7 +28,7 @@ from dagster._core.pipes.client import (
 )
 from dagster._core.pipes.context import (
     ExtMessageHandler,
-    ExtOrchestrationContext,
+    PipesSession,
     build_external_execution_context_data,
 )
 from dagster._utils import tail_file
@@ -186,18 +186,18 @@ def extract_message_or_forward_to_stdout(handler: "ExtMessageHandler", log_line:
 
 
 _FAIL_TO_YIELD_ERROR_MESSAGE = (
-    "Did you forget to `yield from ext_context.get_results()`? `get_results` should be called once"
-    " after the `ext_protocol` block has exited to yield any remaining buffered results."
+    "Did you forget to `yield from pipes_session.get_results()`? `get_results` should be called"
+    " once after the `pipes_protocol` block has exited to yield any remaining buffered results."
 )
 
 
 @contextmanager
-def ext_protocol(
+def pipes_protocol(
     context: OpExecutionContext,
     context_injector: ExtContextInjector,
     message_reader: ExtMessageReader,
     extras: Optional[PipesExtras] = None,
-) -> Iterator[ExtOrchestrationContext]:
+) -> Iterator[PipesSession]:
     """Enter the context managed context injector and message reader that power the EXT protocol and receive the environment variables
     that need to be provided to the external process.
     """
@@ -208,7 +208,7 @@ def ext_protocol(
     with context_injector.inject_context(
         context_data
     ) as ci_params, message_handler.handle_messages(message_reader) as mr_params:
-        yield ExtOrchestrationContext(
+        yield PipesSession(
             context_data=context_data,
             message_handler=message_handler,
             context_injector_params=ci_params,

--- a/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_subprocess.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_subprocess.py
@@ -75,9 +75,9 @@ def external_script() -> Iterator[str]:
         import time
 
         from dagster_pipes import (
-            ExtContext,
             ExtS3MessageWriter,
-            init_dagster_ext,
+            PipesContext,
+            init_dagster_pipes,
         )
 
         if os.getenv("MESSAGE_READER_SPEC") == "user/s3":
@@ -90,8 +90,8 @@ def external_script() -> Iterator[str]:
         else:
             message_writer = None  # use default
 
-        init_dagster_ext(message_writer=message_writer)
-        context = ExtContext.get()
+        init_dagster_pipes(message_writer=message_writer)
+        context = PipesContext.get()
         context.log("hello world")
         time.sleep(0.1)  # sleep to make sure that we encompass multiple intervals for blob store IO
         context.report_asset_materialization(
@@ -198,9 +198,9 @@ def test_ext_subprocess(
 
 def test_ext_multi_asset():
     def script_fn():
-        from dagster_pipes import init_dagster_ext
+        from dagster_pipes import init_dagster_pipes
 
-        context = init_dagster_ext()
+        context = init_dagster_pipes()
         context.report_asset_materialization(
             {"foo_meta": "ok"}, data_version="alpha", asset_key="foo"
         )
@@ -227,9 +227,9 @@ def test_ext_multi_asset():
 
 def test_ext_typed_metadata():
     def script_fn():
-        from dagster_pipes import init_dagster_ext
+        from dagster_pipes import init_dagster_pipes
 
-        context = init_dagster_ext()
+        context = init_dagster_pipes()
         context.report_asset_materialization(
             metadata={
                 "infer_meta": "bar",
@@ -307,9 +307,9 @@ def test_ext_asset_failed():
 
 def test_ext_asset_invocation():
     def script_fn():
-        from dagster_pipes import init_dagster_ext
+        from dagster_pipes import init_dagster_pipes
 
-        context = init_dagster_ext()
+        context = init_dagster_pipes()
         context.log("hello world")
 
     @asset
@@ -327,15 +327,15 @@ PATH_WITH_NONEXISTENT_DIR = "/tmp/does-not-exist/foo"
 def test_ext_no_orchestration():
     def script_fn():
         from dagster_pipes import (
-            ExtContext,
-            init_dagster_ext,
-            is_dagster_ext_process,
+            PipesContext,
+            init_dagster_pipes,
+            is_dagster_pipes_process,
         )
 
-        assert not is_dagster_ext_process()
+        assert not is_dagster_pipes_process()
 
-        init_dagster_ext()
-        context = ExtContext.get()
+        init_dagster_pipes()
+        context = PipesContext.get()
         context.log("hello world")
         context.report_asset_materialization(
             metadata={"bar": context.get_extra("bar")},

--- a/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_subprocess.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_subprocess.py
@@ -37,7 +37,7 @@ from dagster._core.execution.context.compute import AssetExecutionContext, OpExe
 from dagster._core.execution.context.invocation import build_asset_context
 from dagster._core.instance_for_test import instance_for_test
 from dagster._core.pipes.subprocess import (
-    PipedSubprocess,
+    PipesSubprocess,
 )
 from dagster._core.pipes.utils import (
     ExtEnvContextInjector,
@@ -159,7 +159,7 @@ def test_ext_subprocess(
         assert False, "Unreachable"
 
     @asset(check_specs=[AssetCheckSpec(name="foo_check", asset=AssetKey(["foo"]))])
-    def foo(context: AssetExecutionContext, ext: PipedSubprocess):
+    def foo(context: AssetExecutionContext, ext: PipesSubprocess):
         extras = {"bar": "baz"}
         cmd = [_PYTHON_EXECUTABLE, external_script]
         yield from ext.run(
@@ -172,7 +172,7 @@ def test_ext_subprocess(
             },
         )
 
-    resource = PipedSubprocess(context_injector=context_injector, message_reader=message_reader)
+    resource = PipesSubprocess(context_injector=context_injector, message_reader=message_reader)
 
     with instance_for_test() as instance:
         materialize([foo], instance=instance, resources={"ext": resource})
@@ -207,13 +207,13 @@ def test_ext_multi_asset():
         context.report_asset_materialization(data_version="alpha", asset_key="bar")
 
     @multi_asset(specs=[AssetSpec("foo"), AssetSpec("bar")])
-    def foo_bar(context: AssetExecutionContext, ext: PipedSubprocess):
+    def foo_bar(context: AssetExecutionContext, ext: PipesSubprocess):
         with temp_script(script_fn) as script_path:
             cmd = [_PYTHON_EXECUTABLE, script_path]
             yield from ext.run(cmd, context=context)
 
     with instance_for_test() as instance:
-        materialize([foo_bar], instance=instance, resources={"ext": PipedSubprocess()})
+        materialize([foo_bar], instance=instance, resources={"ext": PipesSubprocess()})
         foo_mat = instance.get_latest_materialization_event(AssetKey(["foo"]))
         assert foo_mat and foo_mat.asset_materialization
         assert foo_mat.asset_materialization.metadata["foo_meta"].value == "ok"
@@ -249,7 +249,7 @@ def test_ext_typed_metadata():
         )
 
     @asset
-    def foo(context: AssetExecutionContext, ext: PipedSubprocess):
+    def foo(context: AssetExecutionContext, ext: PipesSubprocess):
         with temp_script(script_fn) as script_path:
             cmd = [_PYTHON_EXECUTABLE, script_path]
             yield from ext.run(cmd, context=context)
@@ -258,7 +258,7 @@ def test_ext_typed_metadata():
         materialize(
             [foo],
             instance=instance,
-            resources={"ext": PipedSubprocess()},
+            resources={"ext": PipesSubprocess()},
         )
         mat = instance.get_latest_materialization_event(foo.key)
         assert mat and mat.asset_materialization
@@ -296,13 +296,13 @@ def test_ext_asset_failed():
         raise Exception("foo")
 
     @asset
-    def foo(context: AssetExecutionContext, ext: PipedSubprocess):
+    def foo(context: AssetExecutionContext, ext: PipesSubprocess):
         with temp_script(script_fn) as script_path:
             cmd = [_PYTHON_EXECUTABLE, script_path]
             yield from ext.run(cmd, context=context)
 
     with pytest.raises(DagsterExternalExecutionError):
-        materialize([foo], resources={"ext": PipedSubprocess()})
+        materialize([foo], resources={"ext": PipesSubprocess()})
 
 
 def test_ext_asset_invocation():
@@ -313,12 +313,12 @@ def test_ext_asset_invocation():
         context.log("hello world")
 
     @asset
-    def foo(context: AssetExecutionContext, ext: PipedSubprocess):
+    def foo(context: AssetExecutionContext, ext: PipesSubprocess):
         with temp_script(script_fn) as script_path:
             cmd = [_PYTHON_EXECUTABLE, script_path]
             ext.run(cmd, context=context)
 
-    foo(context=build_asset_context(), ext=PipedSubprocess())
+    foo(context=build_asset_context(), ext=PipesSubprocess())
 
 
 PATH_WITH_NONEXISTENT_DIR = "/tmp/does-not-exist/foo"

--- a/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_subprocess.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_subprocess.py
@@ -37,7 +37,7 @@ from dagster._core.execution.context.compute import AssetExecutionContext, OpExe
 from dagster._core.execution.context.invocation import build_asset_context
 from dagster._core.instance_for_test import instance_for_test
 from dagster._core.pipes.subprocess import (
-    ExtSubprocess,
+    PipedSubprocess,
 )
 from dagster._core.pipes.utils import (
     ExtEnvContextInjector,
@@ -159,7 +159,7 @@ def test_ext_subprocess(
         assert False, "Unreachable"
 
     @asset(check_specs=[AssetCheckSpec(name="foo_check", asset=AssetKey(["foo"]))])
-    def foo(context: AssetExecutionContext, ext: ExtSubprocess):
+    def foo(context: AssetExecutionContext, ext: PipedSubprocess):
         extras = {"bar": "baz"}
         cmd = [_PYTHON_EXECUTABLE, external_script]
         yield from ext.run(
@@ -172,7 +172,7 @@ def test_ext_subprocess(
             },
         )
 
-    resource = ExtSubprocess(context_injector=context_injector, message_reader=message_reader)
+    resource = PipedSubprocess(context_injector=context_injector, message_reader=message_reader)
 
     with instance_for_test() as instance:
         materialize([foo], instance=instance, resources={"ext": resource})
@@ -207,13 +207,13 @@ def test_ext_multi_asset():
         context.report_asset_materialization(data_version="alpha", asset_key="bar")
 
     @multi_asset(specs=[AssetSpec("foo"), AssetSpec("bar")])
-    def foo_bar(context: AssetExecutionContext, ext: ExtSubprocess):
+    def foo_bar(context: AssetExecutionContext, ext: PipedSubprocess):
         with temp_script(script_fn) as script_path:
             cmd = [_PYTHON_EXECUTABLE, script_path]
             yield from ext.run(cmd, context=context)
 
     with instance_for_test() as instance:
-        materialize([foo_bar], instance=instance, resources={"ext": ExtSubprocess()})
+        materialize([foo_bar], instance=instance, resources={"ext": PipedSubprocess()})
         foo_mat = instance.get_latest_materialization_event(AssetKey(["foo"]))
         assert foo_mat and foo_mat.asset_materialization
         assert foo_mat.asset_materialization.metadata["foo_meta"].value == "ok"
@@ -249,7 +249,7 @@ def test_ext_typed_metadata():
         )
 
     @asset
-    def foo(context: AssetExecutionContext, ext: ExtSubprocess):
+    def foo(context: AssetExecutionContext, ext: PipedSubprocess):
         with temp_script(script_fn) as script_path:
             cmd = [_PYTHON_EXECUTABLE, script_path]
             yield from ext.run(cmd, context=context)
@@ -258,7 +258,7 @@ def test_ext_typed_metadata():
         materialize(
             [foo],
             instance=instance,
-            resources={"ext": ExtSubprocess()},
+            resources={"ext": PipedSubprocess()},
         )
         mat = instance.get_latest_materialization_event(foo.key)
         assert mat and mat.asset_materialization
@@ -296,13 +296,13 @@ def test_ext_asset_failed():
         raise Exception("foo")
 
     @asset
-    def foo(context: AssetExecutionContext, ext: ExtSubprocess):
+    def foo(context: AssetExecutionContext, ext: PipedSubprocess):
         with temp_script(script_fn) as script_path:
             cmd = [_PYTHON_EXECUTABLE, script_path]
             yield from ext.run(cmd, context=context)
 
     with pytest.raises(DagsterExternalExecutionError):
-        materialize([foo], resources={"ext": ExtSubprocess()})
+        materialize([foo], resources={"ext": PipedSubprocess()})
 
 
 def test_ext_asset_invocation():
@@ -313,12 +313,12 @@ def test_ext_asset_invocation():
         context.log("hello world")
 
     @asset
-    def foo(context: AssetExecutionContext, ext: ExtSubprocess):
+    def foo(context: AssetExecutionContext, ext: PipedSubprocess):
         with temp_script(script_fn) as script_path:
             cmd = [_PYTHON_EXECUTABLE, script_path]
             ext.run(cmd, context=context)
 
-    foo(context=build_asset_context(), ext=ExtSubprocess())
+    foo(context=build_asset_context(), ext=PipedSubprocess())
 
 
 PATH_WITH_NONEXISTENT_DIR = "/tmp/does-not-exist/foo"

--- a/python_modules/libraries/dagster-aws/dagster_aws/pipes.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/pipes.py
@@ -7,7 +7,7 @@ import boto3
 import dagster._check as check
 from botocore.exceptions import ClientError
 from dagster._core.pipes.client import (
-    ExtParams,
+    PipesParams,
 )
 from dagster._core.pipes.utils import ExtBlobStoreMessageReader
 
@@ -20,10 +20,10 @@ class ExtS3MessageReader(ExtBlobStoreMessageReader):
         self.client = client
 
     @contextmanager
-    def get_params(self) -> Iterator[ExtParams]:
+    def get_params(self) -> Iterator[PipesParams]:
         yield {"bucket": self.bucket, "key_prefix": self.key_prefix}
 
-    def download_messages_chunk(self, index: int, params: ExtParams) -> Optional[str]:
+    def download_messages_chunk(self, index: int, params: PipesParams) -> Optional[str]:
         key = f"{self.key_prefix}/{index}.json"
         try:
             obj = self.client.get_object(Bucket=self.bucket, Key=key)

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
@@ -15,7 +15,7 @@ from dagster._core.pipes.client import ExtClient, ExtContextInjector, ExtMessage
 from dagster._core.pipes.context import ExtResult
 from dagster._core.pipes.utils import (
     ExtBlobStoreMessageReader,
-    ext_protocol,
+    pipes_protocol,
 )
 from dagster_pipes import (
     PipesContextData,
@@ -79,17 +79,17 @@ class _ExtDatabricks(ExtClient):
             submit_args (Optional[Mapping[str, str]]): Additional keyword arguments that will be
                 forwarded as-is to `WorkspaceClient.jobs.submit`.
         """
-        with ext_protocol(
+        with pipes_protocol(
             context=context,
             extras=extras,
             context_injector=self.context_injector,
             message_reader=self.message_reader,
-        ) as ext_context:
+        ) as pipes_session:
             submit_task_dict = task.as_dict()
             submit_task_dict["new_cluster"]["spark_env_vars"] = {
                 **submit_task_dict["new_cluster"].get("spark_env_vars", {}),
                 **(self.env or {}),
-                **ext_context.get_external_process_env_vars(),
+                **pipes_session.get_piped_process_env_vars(),
             }
             task = jobs.SubmitTask.from_dict(submit_task_dict)
             run_id = self.client.jobs.submit(
@@ -116,9 +116,9 @@ class _ExtDatabricks(ExtClient):
                     raise DagsterExternalExecutionError(
                         f"Error running Databricks job: {run.state.state_message}"
                     )
-                yield from ext_context.get_results()
+                yield from pipes_session.get_results()
                 time.sleep(5)
-        yield from ext_context.get_results()
+        yield from pipes_session.get_results()
 
 
 ExtDatabricks = ResourceParam[_ExtDatabricks]

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
@@ -11,7 +11,11 @@ import dagster._check as check
 from dagster._core.definitions.resource_annotation import ResourceParam
 from dagster._core.errors import DagsterExternalExecutionError
 from dagster._core.execution.context.compute import OpExecutionContext
-from dagster._core.pipes.client import ExtClient, ExtContextInjector, ExtMessageReader
+from dagster._core.pipes.client import (
+    ExtMessageReader,
+    PipedProcessClient,
+    PipedProcessContextInjector,
+)
 from dagster._core.pipes.context import ExtResult
 from dagster._core.pipes.utils import (
     ExtBlobStoreMessageReader,
@@ -27,7 +31,7 @@ from databricks.sdk.service import files, jobs
 from pydantic import Field
 
 
-class _ExtDatabricks(ExtClient):
+class _ExtDatabricks(PipedProcessClient):
     """Ext client for databricks.
 
     Args:
@@ -44,7 +48,7 @@ class _ExtDatabricks(ExtClient):
         self,
         client: WorkspaceClient,
         env: Optional[Mapping[str, str]] = None,
-        context_injector: Optional[ExtContextInjector] = None,
+        context_injector: Optional[PipedProcessContextInjector] = None,
         message_reader: Optional[ExtMessageReader] = None,
     ):
         self.client = client
@@ -52,7 +56,7 @@ class _ExtDatabricks(ExtClient):
         self.context_injector = check.opt_inst_param(
             context_injector,
             "context_injector",
-            ExtContextInjector,
+            PipedProcessContextInjector,
         ) or ExtDbfsContextInjector(client=self.client)
         self.message_reader = check.opt_inst_param(
             message_reader,
@@ -137,7 +141,7 @@ def dbfs_tempdir(dbfs_client: files.DbfsAPI) -> Iterator[str]:
         dbfs_client.delete(tempdir, recursive=True)
 
 
-class ExtDbfsContextInjector(ExtContextInjector):
+class ExtDbfsContextInjector(PipedProcessContextInjector):
     def __init__(self, *, client: WorkspaceClient):
         super().__init__()
         self.dbfs_client = files.DbfsAPI(client.api_client)

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
@@ -18,9 +18,9 @@ from dagster._core.pipes.utils import (
     ext_protocol,
 )
 from dagster_pipes import (
-    ExtContextData,
-    ExtExtras,
-    ExtParams,
+    PipesContextData,
+    PipesExtras,
+    PipesParams,
 )
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.service import files, jobs
@@ -65,7 +65,7 @@ class _ExtDatabricks(ExtClient):
         task: jobs.SubmitTask,
         *,
         context: OpExecutionContext,
-        extras: Optional[ExtExtras] = None,
+        extras: Optional[PipesExtras] = None,
         submit_args: Optional[Mapping[str, str]] = None,
     ) -> Iterator[ExtResult]:
         """Run a Databricks job with the EXT protocol.
@@ -143,7 +143,7 @@ class ExtDbfsContextInjector(ExtContextInjector):
         self.dbfs_client = files.DbfsAPI(client.api_client)
 
     @contextmanager
-    def inject_context(self, context: "ExtContextData") -> Iterator[ExtParams]:
+    def inject_context(self, context: "PipesContextData") -> Iterator[PipesParams]:
         with dbfs_tempdir(self.dbfs_client) as tempdir:
             path = os.path.join(tempdir, _CONTEXT_FILENAME)
             contents = base64.b64encode(json.dumps(context).encode("utf-8")).decode("utf-8")
@@ -157,11 +157,11 @@ class ExtDbfsMessageReader(ExtBlobStoreMessageReader):
         self.dbfs_client = files.DbfsAPI(client.api_client)
 
     @contextmanager
-    def get_params(self) -> Iterator[ExtParams]:
+    def get_params(self) -> Iterator[PipesParams]:
         with dbfs_tempdir(self.dbfs_client) as tempdir:
             yield {"path": tempdir}
 
-    def download_messages_chunk(self, index: int, params: ExtParams) -> Optional[str]:
+    def download_messages_chunk(self, index: int, params: PipesParams) -> Optional[str]:
         message_path = os.path.join(params["path"], f"{index}.json")
         try:
             raw_message = self.dbfs_client.read(message_path)

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
@@ -13,8 +13,8 @@ from dagster._core.errors import DagsterExternalExecutionError
 from dagster._core.execution.context.compute import OpExecutionContext
 from dagster._core.pipes.client import (
     ExtMessageReader,
-    PipedProcessClient,
-    PipedProcessContextInjector,
+    PipesClient,
+    PipesContextInjector,
 )
 from dagster._core.pipes.context import ExtResult
 from dagster._core.pipes.utils import (
@@ -31,7 +31,7 @@ from databricks.sdk.service import files, jobs
 from pydantic import Field
 
 
-class _ExtDatabricks(PipedProcessClient):
+class _ExtDatabricks(PipesClient):
     """Ext client for databricks.
 
     Args:
@@ -48,7 +48,7 @@ class _ExtDatabricks(PipedProcessClient):
         self,
         client: WorkspaceClient,
         env: Optional[Mapping[str, str]] = None,
-        context_injector: Optional[PipedProcessContextInjector] = None,
+        context_injector: Optional[PipesContextInjector] = None,
         message_reader: Optional[ExtMessageReader] = None,
     ):
         self.client = client
@@ -56,7 +56,7 @@ class _ExtDatabricks(PipedProcessClient):
         self.context_injector = check.opt_inst_param(
             context_injector,
             "context_injector",
-            PipedProcessContextInjector,
+            PipesContextInjector,
         ) or ExtDbfsContextInjector(client=self.client)
         self.message_reader = check.opt_inst_param(
             message_reader,
@@ -141,7 +141,7 @@ def dbfs_tempdir(dbfs_client: files.DbfsAPI) -> Iterator[str]:
         dbfs_client.delete(tempdir, recursive=True)
 
 
-class ExtDbfsContextInjector(PipedProcessContextInjector):
+class ExtDbfsContextInjector(PipesContextInjector):
     def __init__(self, *, client: WorkspaceClient):
         super().__init__()
         self.dbfs_client = files.DbfsAPI(client.api_client)

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_external_asset.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_external_asset.py
@@ -16,10 +16,14 @@ IS_BUILDKITE = os.getenv("BUILDKITE") is not None
 
 
 def script_fn():
-    from dagster_pipes import ExtDbfsContextLoader, ExtDbfsMessageWriter, init_dagster_ext
+    from dagster_pipes import (
+        DbfsPipesContextLoader,
+        ExtDbfsMessageWriter,
+        init_dagster_pipes,
+    )
 
-    context = init_dagster_ext(
-        context_loader=ExtDbfsContextLoader(), message_writer=ExtDbfsMessageWriter()
+    context = init_dagster_pipes(
+        context_loader=DbfsPipesContextLoader(), message_writer=ExtDbfsMessageWriter()
     )
 
     multiplier = context.get_extra("multiplier")

--- a/python_modules/libraries/dagster-docker/dagster_docker/pipes.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/pipes.py
@@ -8,9 +8,9 @@ from dagster import (
     _check as check,
 )
 from dagster._core.pipes.client import (
-    ExtClient,
-    ExtContextInjector,
     ExtMessageReader,
+    PipedProcessClient,
+    PipedProcessContextInjector,
 )
 from dagster._core.pipes.context import (
     ExtMessageHandler,
@@ -49,7 +49,7 @@ class DockerLogsMessageReader(ExtMessageReader):
             extract_message_or_forward_to_stdout(handler, log_line)
 
 
-class _ExtDocker(ExtClient):
+class _ExtDocker(PipedProcessClient):
     """An ext protocol compliant resource for launching docker containers.
 
     By default context is injected via environment variables and messages are parsed out of the
@@ -58,15 +58,15 @@ class _ExtDocker(ExtClient):
     Args:
         env (Optional[Mapping[str, str]]): An optional dict of environment variables to pass to the subprocess.
         register (Optional[Mapping[str, str]]): An optional dict of registry credentials to login the docker client.
-        context_injector (Optional[ExtContextInjector]): An context injector to use to inject context into the docker container process. Defaults to ExtEnvContextInjector.
-        message_reader (Optional[ExtContextInjector]): An context injector to use to read messages from the docker container process. Defaults to DockerLogsMessageReader.
+        context_injector (Optional[PipedProcessContextInjector]): An context injector to use to inject context into the docker container process. Defaults to ExtEnvContextInjector.
+        message_reader (Optional[PipedProcessContextInjector]): An context injector to use to read messages from the docker container process. Defaults to DockerLogsMessageReader.
     """
 
     def __init__(
         self,
         env: Optional[Mapping[str, str]] = None,
         registry: Optional[Mapping[str, str]] = None,
-        context_injector: Optional[ExtContextInjector] = None,
+        context_injector: Optional[PipedProcessContextInjector] = None,
         message_reader: Optional[ExtMessageReader] = None,
     ):
         self.env = check.opt_mapping_param(env, "env", key_type=str, value_type=str)
@@ -75,7 +75,7 @@ class _ExtDocker(ExtClient):
             check.opt_inst_param(
                 context_injector,
                 "context_injector",
-                ExtContextInjector,
+                PipedProcessContextInjector,
             )
             or ExtEnvContextInjector()
         )
@@ -113,7 +113,7 @@ class _ExtDocker(ExtClient):
                 Arguments to be forwarded to docker client containers.create.
             extras (Optional[PipesExtras]):
                 Extra values to pass along as part of the ext protocol.
-            context_injector (Optional[ExtContextInjector]):
+            context_injector (Optional[PipedProcessContextInjector]):
                 Override the default ext protocol context injection.
             message_Reader (Optional[ExtMessageReader]):
                 Override the default ext protocol message reader.

--- a/python_modules/libraries/dagster-docker/dagster_docker/pipes.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/pipes.py
@@ -9,8 +9,8 @@ from dagster import (
 )
 from dagster._core.pipes.client import (
     ExtMessageReader,
-    PipedProcessClient,
-    PipedProcessContextInjector,
+    PipesClient,
+    PipesContextInjector,
 )
 from dagster._core.pipes.context import (
     ExtMessageHandler,
@@ -49,7 +49,7 @@ class DockerLogsMessageReader(ExtMessageReader):
             extract_message_or_forward_to_stdout(handler, log_line)
 
 
-class _ExtDocker(PipedProcessClient):
+class _ExtDocker(PipesClient):
     """An ext protocol compliant resource for launching docker containers.
 
     By default context is injected via environment variables and messages are parsed out of the
@@ -58,15 +58,15 @@ class _ExtDocker(PipedProcessClient):
     Args:
         env (Optional[Mapping[str, str]]): An optional dict of environment variables to pass to the subprocess.
         register (Optional[Mapping[str, str]]): An optional dict of registry credentials to login the docker client.
-        context_injector (Optional[PipedProcessContextInjector]): An context injector to use to inject context into the docker container process. Defaults to ExtEnvContextInjector.
-        message_reader (Optional[PipedProcessContextInjector]): An context injector to use to read messages from the docker container process. Defaults to DockerLogsMessageReader.
+        context_injector (Optional[PipesContextInjector]): An context injector to use to inject context into the docker container process. Defaults to ExtEnvContextInjector.
+        message_reader (Optional[PipesContextInjector]): An context injector to use to read messages from the docker container process. Defaults to DockerLogsMessageReader.
     """
 
     def __init__(
         self,
         env: Optional[Mapping[str, str]] = None,
         registry: Optional[Mapping[str, str]] = None,
-        context_injector: Optional[PipedProcessContextInjector] = None,
+        context_injector: Optional[PipesContextInjector] = None,
         message_reader: Optional[ExtMessageReader] = None,
     ):
         self.env = check.opt_mapping_param(env, "env", key_type=str, value_type=str)
@@ -75,7 +75,7 @@ class _ExtDocker(PipedProcessClient):
             check.opt_inst_param(
                 context_injector,
                 "context_injector",
-                PipedProcessContextInjector,
+                PipesContextInjector,
             )
             or ExtEnvContextInjector()
         )
@@ -113,7 +113,7 @@ class _ExtDocker(PipedProcessClient):
                 Arguments to be forwarded to docker client containers.create.
             extras (Optional[PipesExtras]):
                 Extra values to pass along as part of the ext protocol.
-            context_injector (Optional[PipedProcessContextInjector]):
+            context_injector (Optional[PipesContextInjector]):
                 Override the default ext protocol context injection.
             message_Reader (Optional[ExtMessageReader]):
                 Override the default ext protocol message reader.

--- a/python_modules/libraries/dagster-docker/dagster_docker/pipes.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/pipes.py
@@ -22,10 +22,10 @@ from dagster._core.pipes.utils import (
     extract_message_or_forward_to_stdout,
 )
 from dagster_pipes import (
-    DagsterExtError,
+    DagsterPipesError,
     ExtDefaultMessageWriter,
-    ExtExtras,
-    ExtParams,
+    PipesExtras,
+    PipesParams,
 )
 
 
@@ -34,7 +34,7 @@ class DockerLogsMessageReader(ExtMessageReader):
     def read_messages(
         self,
         handler: ExtMessageHandler,
-    ) -> Iterator[ExtParams]:
+    ) -> Iterator[PipesParams]:
         self._handler = handler
         try:
             yield {ExtDefaultMessageWriter.STDIO_KEY: ExtDefaultMessageWriter.STDERR}
@@ -94,7 +94,7 @@ class _ExtDocker(ExtClient):
         env: Optional[Mapping[str, str]] = None,
         registry: Optional[Mapping[str, str]] = None,
         container_kwargs: Optional[Mapping[str, Any]] = None,
-        extras: Optional[ExtExtras] = None,
+        extras: Optional[PipesExtras] = None,
     ) -> Iterator[ExtResult]:
         """Create a docker container and run it to completion, enriched with the ext protocol.
 
@@ -111,7 +111,7 @@ class _ExtDocker(ExtClient):
                 with docker client login.
             container_kwargs (Optional[Mapping[str, Any]]:
                 Arguments to be forwarded to docker client containers.create.
-            extras (Optional[ExtExtras]):
+            extras (Optional[PipesExtras]):
                 Extra values to pass along as part of the ext protocol.
             context_injector (Optional[ExtContextInjector]):
                 Override the default ext protocol context injection.
@@ -160,7 +160,7 @@ class _ExtDocker(ExtClient):
 
                 result = container.wait()
                 if result["StatusCode"] != 0:
-                    raise DagsterExtError(f"Container exited with non-zero status code: {result}")
+                    raise DagsterPipesError(f"Container exited with non-zero status code: {result}")
             finally:
                 container.stop()
         return ext_context.get_results()

--- a/python_modules/libraries/dagster-docker/dagster_docker/pipes.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/pipes.py
@@ -18,8 +18,8 @@ from dagster._core.pipes.context import (
 )
 from dagster._core.pipes.utils import (
     ExtEnvContextInjector,
-    ext_protocol,
     extract_message_or_forward_to_stdout,
+    pipes_protocol,
 )
 from dagster_pipes import (
     DagsterPipesError,
@@ -118,12 +118,12 @@ class _ExtDocker(ExtClient):
             message_Reader (Optional[ExtMessageReader]):
                 Override the default ext protocol message reader.
         """
-        with ext_protocol(
+        with pipes_protocol(
             context=context,
             context_injector=self.context_injector,
             message_reader=self.message_reader,
             extras=extras,
-        ) as ext_context:
+        ) as pipes_session:
             client = docker.client.from_env()
             registry = registry or self.registry
             if registry:
@@ -139,7 +139,7 @@ class _ExtDocker(ExtClient):
                     image=image,
                     command=command,
                     env=env,
-                    ext_protocol_env=ext_context.get_external_process_env_vars(),
+                    pipes_protocol_env=pipes_session.get_piped_process_env_vars(),
                     container_kwargs=container_kwargs,
                 )
             except docker.errors.ImageNotFound:
@@ -149,7 +149,7 @@ class _ExtDocker(ExtClient):
                     image=image,
                     command=command,
                     env=env,
-                    ext_protocol_env=ext_context.get_external_process_env_vars(),
+                    pipes_protocol_env=pipes_session.get_piped_process_env_vars(),
                     container_kwargs=container_kwargs,
                 )
 
@@ -163,7 +163,7 @@ class _ExtDocker(ExtClient):
                     raise DagsterPipesError(f"Container exited with non-zero status code: {result}")
             finally:
                 container.stop()
-        return ext_context.get_results()
+        return pipes_session.get_results()
 
     def _create_container(
         self,
@@ -172,7 +172,7 @@ class _ExtDocker(ExtClient):
         command: Union[str, Sequence[str]],
         env: Optional[Mapping[str, str]],
         container_kwargs: Optional[Mapping[str, Any]],
-        ext_protocol_env: Mapping[str, str],
+        pipes_protocol_env: Mapping[str, str],
     ):
         kwargs = dict(container_kwargs or {})
         kwargs_env = kwargs.pop("environment", {})
@@ -181,7 +181,7 @@ class _ExtDocker(ExtClient):
             command=command,
             detach=True,
             environment={
-                **ext_protocol_env,
+                **pipes_protocol_env,
                 **(self.env or {}),
                 **(env or {}),
                 **kwargs_env,

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
@@ -22,8 +22,8 @@ from dagster._core.pipes.context import (
 )
 from dagster._core.pipes.utils import (
     ExtEnvContextInjector,
-    ext_protocol,
     extract_message_or_forward_to_stdout,
+    pipes_protocol,
 )
 from dagster_pipes import (
     ExtDefaultMessageWriter,
@@ -154,12 +154,12 @@ class _ExtK8sPod(ExtClient):
         """
         client = DagsterKubernetesClient.production_client()
 
-        with ext_protocol(
+        with pipes_protocol(
             context=context,
             extras=extras,
             context_injector=self.context_injector,
             message_reader=self.message_reader,
-        ) as ext_context:
+        ) as pipes_session:
             namespace = namespace or "default"
             pod_name = get_pod_name(context.run_id, context.op.name)
             pod_body = build_pod_body(
@@ -167,7 +167,7 @@ class _ExtK8sPod(ExtClient):
                 image=image,
                 command=command,
                 env_vars={
-                    **ext_context.get_external_process_env_vars(),
+                    **pipes_session.get_piped_process_env_vars(),
                     **(self.env or {}),
                     **(env or {}),
                 },
@@ -197,7 +197,7 @@ class _ExtK8sPod(ExtClient):
                     )
             finally:
                 client.core_api.delete_namespaced_pod(pod_name, namespace)
-        return ext_context.get_results()
+        return pipes_session.get_results()
 
 
 def build_pod_body(

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
@@ -14,7 +14,7 @@ from dagster._core.pipes.client import (
     ExtClient,
     ExtContextInjector,
     ExtMessageReader,
-    ExtParams,
+    PipesParams,
 )
 from dagster._core.pipes.context import (
     ExtMessageHandler,
@@ -27,7 +27,7 @@ from dagster._core.pipes.utils import (
 )
 from dagster_pipes import (
     ExtDefaultMessageWriter,
-    ExtExtras,
+    PipesExtras,
 )
 
 from dagster_k8s.utils import get_common_labels
@@ -50,7 +50,7 @@ class K8sPodLogsMessageReader(ExtMessageReader):
     def read_messages(
         self,
         handler: ExtMessageHandler,
-    ) -> Iterator[ExtParams]:
+    ) -> Iterator[PipesParams]:
         self._handler = handler
         try:
             yield {ExtDefaultMessageWriter.STDIO_KEY: ExtDefaultMessageWriter.STDERR}
@@ -123,7 +123,7 @@ class _ExtK8sPod(ExtClient):
         env: Optional[Mapping[str, str]] = None,
         base_pod_meta: Optional[Mapping[str, Any]] = None,
         base_pod_spec: Optional[Mapping[str, Any]] = None,
-        extras: Optional[ExtExtras] = None,
+        extras: Optional[PipesExtras] = None,
     ) -> Iterator[ExtResult]:
         """Publish a kubernetes pod and wait for it to complete, enriched with the ext protocol.
 
@@ -145,7 +145,7 @@ class _ExtK8sPod(ExtClient):
                 Raw k8s config for the k8s pod's pod spec
                 (https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec).
                 Keys can either snake_case or camelCase.
-            extras (Optional[ExtExtras]):
+            extras (Optional[PipesExtras]):
                 Extra values to pass along as part of the ext protocol.
             context_injector (Optional[ExtContextInjector]):
                 Override the default ext protocol context injection.

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
@@ -12,8 +12,8 @@ from dagster._core.definitions.resource_annotation import ResourceParam
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.pipes.client import (
     ExtMessageReader,
-    PipedProcessClient,
-    PipedProcessContextInjector,
+    PipesClient,
+    PipesContextInjector,
     PipesParams,
 )
 from dagster._core.pipes.context import (
@@ -77,7 +77,7 @@ class K8sPodLogsMessageReader(ExtMessageReader):
                 extract_message_or_forward_to_stdout(handler, log_line)
 
 
-class _ExtK8sPod(PipedProcessClient):
+class _ExtK8sPod(PipesClient):
     """An ext protocol compliant resource for launching kubernetes pods.
 
     By default context is injected via environment variables and messages are parsed out of
@@ -88,14 +88,14 @@ class _ExtK8sPod(PipedProcessClient):
 
     Args:
         env (Optional[Mapping[str, str]]): An optional dict of environment variables to pass to the subprocess.
-        context_injector (Optional[PipedProcessContextInjector]): An context injector to use to inject context into the k8s container process. Defaults to ExtEnvContextInjector.
-        message_reader (Optional[PipedProcessContextInjector]): An context injector to use to read messages from the k8s container process. Defaults to K8sPodLogsMessageReader.
+        context_injector (Optional[PipesContextInjector]): An context injector to use to inject context into the k8s container process. Defaults to ExtEnvContextInjector.
+        message_reader (Optional[PipesContextInjector]): An context injector to use to read messages from the k8s container process. Defaults to K8sPodLogsMessageReader.
     """
 
     def __init__(
         self,
         env: Optional[Mapping[str, str]] = None,
-        context_injector: Optional[PipedProcessContextInjector] = None,
+        context_injector: Optional[PipesContextInjector] = None,
         message_reader: Optional[ExtMessageReader] = None,
     ):
         self.env = check.opt_mapping_param(env, "env", key_type=str, value_type=str)
@@ -103,7 +103,7 @@ class _ExtK8sPod(PipedProcessClient):
             check.opt_inst_param(
                 context_injector,
                 "context_injector",
-                PipedProcessContextInjector,
+                PipesContextInjector,
             )
             or ExtEnvContextInjector()
         )
@@ -147,7 +147,7 @@ class _ExtK8sPod(PipedProcessClient):
                 Keys can either snake_case or camelCase.
             extras (Optional[PipesExtras]):
                 Extra values to pass along as part of the ext protocol.
-            context_injector (Optional[PipedProcessContextInjector]):
+            context_injector (Optional[PipesContextInjector]):
                 Override the default ext protocol context injection.
             message_Reader (Optional[ExtMessageReader]):
                 Override the default ext protocol message reader.

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
@@ -11,9 +11,9 @@ from dagster import (
 from dagster._core.definitions.resource_annotation import ResourceParam
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.pipes.client import (
-    ExtClient,
-    ExtContextInjector,
     ExtMessageReader,
+    PipedProcessClient,
+    PipedProcessContextInjector,
     PipesParams,
 )
 from dagster._core.pipes.context import (
@@ -77,7 +77,7 @@ class K8sPodLogsMessageReader(ExtMessageReader):
                 extract_message_or_forward_to_stdout(handler, log_line)
 
 
-class _ExtK8sPod(ExtClient):
+class _ExtK8sPod(PipedProcessClient):
     """An ext protocol compliant resource for launching kubernetes pods.
 
     By default context is injected via environment variables and messages are parsed out of
@@ -88,14 +88,14 @@ class _ExtK8sPod(ExtClient):
 
     Args:
         env (Optional[Mapping[str, str]]): An optional dict of environment variables to pass to the subprocess.
-        context_injector (Optional[ExtContextInjector]): An context injector to use to inject context into the k8s container process. Defaults to ExtEnvContextInjector.
-        message_reader (Optional[ExtContextInjector]): An context injector to use to read messages from the k8s container process. Defaults to K8sPodLogsMessageReader.
+        context_injector (Optional[PipedProcessContextInjector]): An context injector to use to inject context into the k8s container process. Defaults to ExtEnvContextInjector.
+        message_reader (Optional[PipedProcessContextInjector]): An context injector to use to read messages from the k8s container process. Defaults to K8sPodLogsMessageReader.
     """
 
     def __init__(
         self,
         env: Optional[Mapping[str, str]] = None,
-        context_injector: Optional[ExtContextInjector] = None,
+        context_injector: Optional[PipedProcessContextInjector] = None,
         message_reader: Optional[ExtMessageReader] = None,
     ):
         self.env = check.opt_mapping_param(env, "env", key_type=str, value_type=str)
@@ -103,7 +103,7 @@ class _ExtK8sPod(ExtClient):
             check.opt_inst_param(
                 context_injector,
                 "context_injector",
-                ExtContextInjector,
+                PipedProcessContextInjector,
             )
             or ExtEnvContextInjector()
         )
@@ -147,7 +147,7 @@ class _ExtK8sPod(ExtClient):
                 Keys can either snake_case or camelCase.
             extras (Optional[PipesExtras]):
                 Extra values to pass along as part of the ext protocol.
-            context_injector (Optional[ExtContextInjector]):
+            context_injector (Optional[PipedProcessContextInjector]):
                 Override the default ext protocol context injection.
             message_Reader (Optional[ExtMessageReader]):
                 Override the default ext protocol message reader.


### PR DESCRIPTION
## Summary & Motivation

Renaming the core classes in `dagster._core.pipes`.

Instead of `ExtSubprocess` we have `PipesSubprocess`. 

Renames:

* `ExtContextInjector` --> `PipesContextInjector`
* `ExtClient` -> `PipesClient`

## How I Tested These Changes

BK
