### PR TITLE
[ui] Do not request partitionStatusCounts for asset backfills

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillActionsMenu.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillActionsMenu.tsx
@@ -61,11 +61,11 @@ export function backfillCanCancelRuns(
 
 export const BackfillActionsMenu = ({
   backfill,
-  counts,
+  canCancelRuns,
   refetch,
 }: {
   backfill: BackfillActionsBackfillFragment;
-  counts: {[runStatus: string]: number} | null;
+  canCancelRuns: boolean;
   refetch: () => void;
 }) => {
   const history = useHistory();
@@ -116,7 +116,6 @@ export const BackfillActionsMenu = ({
   };
 
   const canCancelSubmission = backfillCanCancelSubmission(backfill);
-  const canCancelRuns = backfillCanCancelRuns(backfill, counts);
 
   return (
     <>

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillPage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillPage.tsx
@@ -303,9 +303,7 @@ export const BackfillPage = () => {
               <BackfillActionsMenu
                 backfill={backfill}
                 refetch={queryResult.refetch}
-                counts={Object.fromEntries(
-                  backfill.partitionStatusCounts.map((e) => [e.runStatus, e.count]),
-                )}
+                canCancelRuns={backfill.status === BulkActionStatus.REQUESTED}
               />
             ) : null}
           </Box>
@@ -398,10 +396,6 @@ export const BACKFILL_DETAILS_QUERY = gql`
 
     error {
       ...PythonErrorFragment
-    }
-    partitionStatusCounts {
-      runStatus
-      count
     }
     assetBackfillData {
       rootAssetTargetedRanges {

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillRow.tsx
@@ -23,7 +23,7 @@ import {buildRepoAddress} from '../../workspace/buildRepoAddress';
 import {repoAddressAsHumanString} from '../../workspace/repoAddressAsString';
 import {workspacePathFromAddress, workspacePipelinePath} from '../../workspace/workspacePath';
 
-import {BackfillActionsMenu} from './BackfillActionsMenu';
+import {BackfillActionsMenu, backfillCanCancelRuns} from './BackfillActionsMenu';
 import {BackfillStatusTagForPage} from './BackfillStatusTagForPage';
 import {
   PartitionStatusesForBackfillFragment,
@@ -68,7 +68,8 @@ export const BackfillRow = ({
     },
   );
 
-  const statusUnsupported = backfill.numPartitions === null || backfill.partitionNames === null;
+  const statusUnsupported =
+    backfill.numPartitions === null || backfill.partitionNames === null || backfill.isAssetBackfill;
 
   // Note: We switch queries based on how many partitions there are to display,
   // because the detail is nice for small backfills but breaks for 100k+ partitions.
@@ -156,7 +157,11 @@ export const BackfillRow = ({
         )}
       </td>
       <td>
-        <BackfillActionsMenu backfill={backfill} counts={counts} refetch={refetch} />
+        <BackfillActionsMenu
+          backfill={backfill}
+          canCancelRuns={backfillCanCancelRuns(backfill, counts)}
+          refetch={refetch}
+        />
       </td>
     </tr>
   );

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/types/BackfillPage.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/types/BackfillPage.types.ts
@@ -32,11 +32,6 @@ export type BackfillStatusesByAssetQuery = {
             error: {__typename: 'PythonError'; message: string; stack: Array<string>};
           }>;
         } | null;
-        partitionStatusCounts: Array<{
-          __typename: 'PartitionStatusCounts';
-          runStatus: Types.RunStatus;
-          count: number;
-        }>;
         assetBackfillData: {
           __typename: 'AssetBackfillData';
           rootAssetTargetedPartitions: Array<string> | null;
@@ -108,11 +103,6 @@ export type PartitionBackfillFragment = {
       error: {__typename: 'PythonError'; message: string; stack: Array<string>};
     }>;
   } | null;
-  partitionStatusCounts: Array<{
-    __typename: 'PartitionStatusCounts';
-    runStatus: Types.RunStatus;
-    count: number;
-  }>;
   assetBackfillData: {
     __typename: 'AssetBackfillData';
     rootAssetTargetedPartitions: Array<string> | null;


### PR DESCRIPTION
## Summary & Motivation

- On the backfills page, this reverts to the old behavior -- no "run status" is shown for asset backfills. I think in the very near future we can use the asset-specific backfill data resolver to get better info to show here, but we need to determine what we want to show.

- On the backfill details page, rather than fetching `partitionStatusCounts` just to decide whether to show the "Cancel" option, we instead show Cancel whenever the backfill is in a REQUESTED state (the only non-final state other than cancelling)


Before:
<img width="1394" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/51c9e500-d8fe-4bd0-bd46-53ecc31e78af">

After:
<img width="1399" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/a45da112-1c42-4e56-8fac-a8999febff02">


## How I Tested These Changes

I tested these changes manually with my local instance which has a lot of backfills of assets / non-assets