### PR TITLE
feat(dbt): implement subsetting to execute dbt tests

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -303,7 +303,7 @@ def get_manifest_and_translator_from_dbt_assets(
     check.invariant(len(dbt_assets) == 1, "Exactly one dbt AssetsDefinition is required")
     dbt_assets_def = dbt_assets[0]
     metadata_by_key = dbt_assets_def.metadata_by_key or {}
-    first_asset_key = next(iter(dbt_assets_def.keys))
+    first_asset_key = next(iter(dbt_assets_def.metadata_by_key.keys()))
     first_metadata = metadata_by_key.get(first_asset_key, {})
     manifest_wrapper: Optional["DbtManifestWrapper"] = first_metadata.get(MANIFEST_METADATA_KEY)
     if manifest_wrapper is None:


### PR DESCRIPTION
## Summary & Motivation
Add the ability to select individual dbt tests when subsetting the execution of a dbt project.

Now that users can explicitly select for both tests and models, we should disable dbt's indirect selection: https://docs.getdbt.com/reference/node-selection/test-selection-examples?indirect-selection-mode=empty#indirect-selection.

dbt's indirect selection basically controls whether tests are automatically run when a dbt model is built. Previously, in the case for `dbt build`, all tests associated with a dbt model would be run if the model is materialized. Now, we only run the tests that were explicitly selected and are available in the asset definition's context.

## How I Tested These Changes
local, pytest