### PR TITLE
PipesSubprocess --> PipesSubprocessClient

### DIFF
--- a/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/__init__.py
+++ b/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/__init__.py
@@ -1,10 +1,10 @@
 from dagster import Definitions
-from dagster._core.pipes.subprocess import PipesSubprocess
+from dagster._core.pipes.subprocess import PipesSubprocessClient
 
 from .domain_specific_dsl.stocks_dsl import get_stocks_dsl_example_defs
 from .pure_assets_dsl.assets_dsl import get_asset_dsl_example_defs
 
 defs = Definitions(
     assets=get_asset_dsl_example_defs() + get_stocks_dsl_example_defs(),
-    resources={"subprocess_resource": PipesSubprocess()},
+    resources={"pipes_subprocess_client": PipesSubprocessClient()},
 )

--- a/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/domain_specific_dsl/stocks_dsl.py
+++ b/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/domain_specific_dsl/stocks_dsl.py
@@ -12,7 +12,7 @@ except ImportError:
 
 from dagster import AssetKey, AssetsDefinition, asset, file_relative_path, multi_asset
 from dagster._core.definitions.asset_spec import AssetSpec
-from dagster._core.pipes.subprocess import PipesSubprocess
+from dagster._core.pipes.subprocess import PipesSubprocessClient
 
 
 def load_yaml(relative_path: str) -> Dict[str, Any]:
@@ -86,11 +86,13 @@ def assets_defs_from_stock_assets(stock_assets: StockAssets) -> List[AssetsDefin
     ticker_specs = [spec_for_stock_info(stock_info) for stock_info in stock_assets.stock_infos]
 
     @multi_asset(specs=ticker_specs)
-    def fetch_the_tickers(context: AssetExecutionContext, subprocess_resource: PipesSubprocess):
+    def fetch_the_tickers(
+        context: AssetExecutionContext, pipes_subprocess_client: PipesSubprocessClient
+    ):
         python_executable = shutil.which("python")
         assert python_executable is not None
         script_path = file_relative_path(__file__, "user_scripts/fetch_the_tickers.py")
-        subprocess_resource.run(
+        pipes_subprocess_client.run(
             command=[python_executable, script_path], context=context, extras={"tickers": tickers}
         )
 

--- a/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/pure_assets_dsl/assets_dsl.py
+++ b/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/pure_assets_dsl/assets_dsl.py
@@ -13,7 +13,7 @@ except ImportError:
     from yaml import Loader
 
 from dagster import AssetKey, asset
-from dagster._core.pipes.subprocess import PipesSubprocess
+from dagster._core.pipes.subprocess import PipesSubprocessClient
 
 
 def load_yaml(relative_path) -> Dict[str, Any]:
@@ -39,13 +39,13 @@ def from_asset_entries(asset_entries: Dict[str, Any]) -> List[AssetsDefinition]:
         @asset(key=asset_key, deps=deps, description=description, group_name=group_name)
         def _assets_def(
             context: AssetExecutionContext,
-            subprocess_resource: PipesSubprocess,
+            pipes_subprocess_client: PipesSubprocessClient,
         ) -> None:
             # instead of querying a dummy client, do your real data processing here
 
             python_executable = shutil.which("python")
             assert python_executable is not None
-            subprocess_resource.run(
+            pipes_subprocess_client.run(
                 command=[python_executable, file_relative_path(__file__, "sql_script.py"), sql],
                 context=context,
             )

--- a/examples/experimental/assets_yaml_dsl/assets_yaml_dsl_tests/test_assets_dsl.py
+++ b/examples/experimental/assets_yaml_dsl/assets_yaml_dsl_tests/test_assets_dsl.py
@@ -5,7 +5,7 @@ from assets_yaml_dsl.pure_assets_dsl.assets_dsl import from_asset_entries
 from dagster import AssetsDefinition
 from dagster._core.definitions.events import AssetKey
 from dagster._core.execution.context.invocation import build_asset_context
-from dagster._core.pipes.subprocess import PipesSubprocess
+from dagster._core.pipes.subprocess import PipesSubprocessClient
 
 
 def assets_defs_from_yaml(yaml_string) -> List[AssetsDefinition]:
@@ -69,7 +69,7 @@ assets:
     assert assets_defs
     assert len(assets_defs) == 1
     assets_def = assets_defs[0]
-    assets_def(context=build_asset_context(), subprocess_resource=PipesSubprocess())
+    assets_def(context=build_asset_context(), pipes_subprocess_client=PipesSubprocessClient())
 
 
 def test_basic_group() -> None:

--- a/examples/experimental/assets_yaml_dsl/assets_yaml_dsl_tests/test_stocks_dsl.py
+++ b/examples/experimental/assets_yaml_dsl/assets_yaml_dsl_tests/test_stocks_dsl.py
@@ -18,7 +18,7 @@ import yaml
 from assets_yaml_dsl.domain_specific_dsl.stocks_dsl import assets_defs_from_stock_assets
 from dagster import AssetKey
 from dagster._core.definitions import materialize
-from dagster._core.pipes.subprocess import PipesSubprocess
+from dagster._core.pipes.subprocess import PipesSubprocessClient
 from examples.experimental.assets_yaml_dsl.assets_yaml_dsl.domain_specific_dsl.stocks_dsl import (
     build_stock_assets_object,
 )
@@ -55,5 +55,5 @@ def test_materialize_stocks_dsl():
     stock_assets = build_stock_assets_object(stocks_dsl_document)
     assets_defs = assets_defs_from_stock_assets(stock_assets)
     assert materialize(
-        assets=assets_defs, resources={"subprocess_resource": PipesSubprocess()}
+        assets=assets_defs, resources={"pipes_subprocess_client": PipesSubprocessClient()}
     ).success

--- a/python_modules/dagster/dagster/_core/pipes/subprocess.py
+++ b/python_modules/dagster/dagster/_core/pipes/subprocess.py
@@ -93,4 +93,4 @@ class _PipesSubprocess(PipesClient):
         yield from pipes_session.get_results()
 
 
-PipesSubprocess = ResourceParam[_PipesSubprocess]
+PipesSubprocessClient = ResourceParam[_PipesSubprocess]


### PR DESCRIPTION
## Summary & Motivation

Renaming `PipesSubprocess` to `PipesSubprocessClient` in line with the naming conventions of the other `PipesClient` classes. Flagged prior PR and followed up on here.

## How I Tested These Changes
