### PR TITLE
[pipes] add docstrings, @experimental markers, top-level exports

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -473,6 +473,25 @@ from dagster._core.instance import DagsterInstance as DagsterInstance
 from dagster._core.instance_for_test import instance_for_test as instance_for_test
 from dagster._core.launcher.default_run_launcher import DefaultRunLauncher as DefaultRunLauncher
 from dagster._core.log_manager import DagsterLogManager as DagsterLogManager
+from dagster._core.pipes.client import (
+    PipesClient as PipesClient,
+    PipesContextInjector as PipesContextInjector,
+    PipesMessageReader as PipesMessageReader,
+)
+from dagster._core.pipes.context import (
+    PipesMessageHandler as PipesMessageHandler,
+    PipesSession as PipesSession,
+)
+from dagster._core.pipes.subprocess import PipesSubprocessClient as PipesSubprocessClient
+from dagster._core.pipes.utils import (
+    PipesBlobStoreMessageReader as PipesBlobStoreMessageReader,
+    PipesEnvContextInjector as PipesEnvContextInjector,
+    PipesFileContextInjector as PipesFileContextInjector,
+    PipesFileMessageReader as PipesFileMessageReader,
+    PipesTempFileContextInjector as PipesTempFileContextInjector,
+    PipesTempFileMessageReader as PipesTempFileMessageReader,
+    open_pipes_session as open_pipes_session,
+)
 from dagster._core.run_coordinator.queued_run_coordinator import (
     QueuedRunCoordinator as QueuedRunCoordinator,
     SubmitRunContext as SubmitRunContext,

--- a/python_modules/dagster/dagster/_core/pipes/client.py
+++ b/python_modules/dagster/dagster/_core/pipes/client.py
@@ -8,29 +8,75 @@ from dagster_pipes import (
     PipesParams,
 )
 
+from dagster._annotations import experimental, public
 from dagster._core.execution.context.compute import OpExecutionContext
 
 if TYPE_CHECKING:
     from .context import PipesExecutionResult, PipesMessageHandler
 
 
+@experimental
 class PipesClient(ABC):
+    """Pipes client base class.
+
+    Pipes clients for specific external environments should subclass this.
+    """
+
+    @public
     @abstractmethod
     def run(
         self,
         *,
         context: OpExecutionContext,
         extras: Optional[PipesExtras] = None,
-    ) -> Iterator["PipesExecutionResult"]: ...
+    ) -> Iterator["PipesExecutionResult"]:
+        """Run a command in the external environment.
+
+        Args:
+            context (OpExecutionContext): The context from the executing op/asset.
+            extras (Optional[PipesExtras]): Arbitrary data to pass to the external environment.
+
+        Yields:
+            PipesExecutionResult: Results reported by the external process.
+        """
 
 
+@experimental
 class PipesContextInjector(ABC):
     @abstractmethod
     @contextmanager
-    def inject_context(self, context_data: "PipesContextData") -> Iterator[PipesParams]: ...
+    def inject_context(self, context_data: "PipesContextData") -> Iterator[PipesParams]:
+        """A `@contextmanager` that injects context data into the external process.
+
+        This method should write the context data to a location accessible to the external
+        process. It should yield parameters that the external process can use to locate and load the
+        context data.
+
+        Args:
+            context_data (PipesContextData): The context data to inject.
+
+        Yields:
+            PipesParams: A JSON-serializable dict of parameters to be used used by the external
+                process to locate and load the injected context data.
+        """
 
 
+@experimental
 class PipesMessageReader(ABC):
     @abstractmethod
     @contextmanager
-    def read_messages(self, handler: "PipesMessageHandler") -> Iterator[PipesParams]: ...
+    def read_messages(self, handler: "PipesMessageHandler") -> Iterator[PipesParams]:
+        """A `@contextmanager` that reads messages reported by an external process.
+
+        This method should start a thread to continuously read messages from some location
+        accessible to the external process. It should yield parameters that the external process
+        can use to direct its message output.
+
+        Args:
+            handler (PipesMessageHandler): The message handler to use to process messages read from
+                the external process.
+
+        Yields:
+            PipesParams: A dict of parameters that can be used by the external process to determine
+                where to write messages.
+        """

--- a/python_modules/dagster/dagster/_core/pipes/context.py
+++ b/python_modules/dagster/dagster/_core/pipes/context.py
@@ -20,6 +20,7 @@ from dagster_pipes import (
 from typing_extensions import TypeAlias
 
 import dagster._check as check
+from dagster._annotations import experimental, public
 from dagster._core.definitions.asset_check_result import AssetCheckResult
 from dagster._core.definitions.asset_check_spec import AssetCheckSeverity
 from dagster._core.definitions.data_version import DataProvenance, DataVersion
@@ -35,7 +36,14 @@ from dagster._core.pipes.client import PipesMessageReader
 PipesExecutionResult: TypeAlias = Union[MaterializeResult, AssetCheckResult]
 
 
+@experimental
 class PipesMessageHandler:
+    """Class to process :py:obj:`PipesMessage` objects received from a pipes process.
+
+    Args:
+        context (OpExecutionContext): The context for the executing op/asset.
+    """
+
     def __init__(self, context: OpExecutionContext) -> None:
         self._context = context
         # Queue is thread-safe
@@ -163,14 +171,54 @@ def _ext_params_as_env_vars(
     }
 
 
+@experimental
 @dataclass
 class PipesSession:
+    """Object representing a pipes session.
+
+    A pipes session is defined by a pair of :py:class:`PipesContextInjector` and
+    :py:class:`PipesMessageReader` objects. At the opening of the session, the context injector
+    writes context data to an externally accessible location, and the message reader starts
+    monitoring an externally accessible location. These locations are encoded in parameters stored
+    on a `PipesSession` object.
+
+    During the session, an external process should be started and the parameters injected into its
+    environment. The typical way to do this is to call :py:meth:`PipesSession.get_pipes_env_vars`
+    and pass the result as environment variables.
+
+    During execution, results (e.g. asset materializations) are reported by the external process and
+    buffered on the `PipesSession` object. The buffer can periodically be cleared and yielded to
+    Dagster machinery by calling `yield from PipesSession.get_results()`.
+
+    When the external process exits, the session can be closed. Closing consists of handling any
+    unprocessed messages written by the external process and cleaning up any resources used for
+    context injection and message reading.
+
+    Args:
+        context_data (PipesContextData): The context for the executing op/asset.
+        message_handler (PipesMessageHandler): The message handler to use for processing messages
+        context_injector_params (PipesParams): Parameters yielded by the context injector,
+            indicating the location from which the external process should load context data.
+        message_reader_params (PipesParams): Parameters yielded by the message reader, indicating
+            the location to which the external process should write messages.
+    """
+
     context_data: PipesContextData
     message_handler: PipesMessageHandler
     context_injector_params: PipesParams
     message_reader_params: PipesParams
 
+    @public
     def get_pipes_env_vars(self) -> Dict[str, str]:
+        """Encode context injector and message reader params as environment variables.
+
+        Passing environment variables is the typical way to expose the pipes I/O parameters
+        to a pipes process.
+
+        Returns:
+            Mapping[str, str]: Environment variables to pass to the external process. The values are
+                base-64-encoded and compressed with gzip.
+        """
         return {
             DAGSTER_PIPES_ENV_KEYS[IS_DAGSTER_PIPES_PROCESS]: encode_env_var(True),
             **_ext_params_as_env_vars(
@@ -179,7 +227,16 @@ class PipesSession:
             ),
         }
 
+    @public
     def get_results(self) -> Iterator[PipesExecutionResult]:
+        """Iterator over buffered :py:class:`PipesExecutionResult` objects received from the
+        external process.
+
+        When this is called it clears the results buffer.
+
+        Yields:
+            ExtResult: Result reported by external process.
+        """
         yield from self.message_handler.clear_result_queue()
 
 

--- a/python_modules/dagster/dagster/_core/pipes/utils.py
+++ b/python_modules/dagster/dagster/_core/pipes/utils.py
@@ -22,6 +22,7 @@ from dagster import (
     OpExecutionContext,
     _check as check,
 )
+from dagster._annotations import experimental
 from dagster._core.pipes.client import (
     PipesContextInjector,
     PipesMessageReader,
@@ -37,12 +38,31 @@ _CONTEXT_INJECTOR_FILENAME = "context"
 _MESSAGE_READER_FILENAME = "messages"
 
 
+@experimental
 class PipesFileContextInjector(PipesContextInjector):
+    """Context injector that injects context data into the external process by writing it to a
+    specified file.
+
+    Args:
+        path (str): The path of a file to which to write context data. The file will be deleted on
+            close of the pipes session.
+    """
+
     def __init__(self, path: str):
         self._path = check.str_param(path, "path")
 
     @contextmanager
     def inject_context(self, context_data: "PipesContextData") -> Iterator[PipesParams]:
+        """Inject context to external environment by writing it to a file as JSON and exposing the
+        path to the file.
+
+        Args:
+            context_data (PipesContextData): The context data to inject.
+
+        Yields:
+            PipesParams: A dict of parameters that can be used by the external process to locate and
+                load the injected context data.
+        """
         with open(self._path, "w") as input_stream:
             json.dump(context_data, input_stream)
         try:
@@ -52,9 +72,24 @@ class PipesFileContextInjector(PipesContextInjector):
                 os.remove(self._path)
 
 
+@experimental
 class PipesTempFileContextInjector(PipesContextInjector):
+    """Context injector that injects context data into the external process by writing it to an
+    automatically-generated temporary file.
+    """
+
     @contextmanager
     def inject_context(self, context: "PipesContextData") -> Iterator[PipesParams]:
+        """Inject context to external environment by writing it to an automatically-generated
+        temporary file as JSON and exposing the path to the file.
+
+        Args:
+            context_data (PipesContextData): The context data to inject.
+
+        Yields:
+            PipesParams: A dict of parameters that can be used by the external process to locate and
+                load the injected context data.
+        """
         with tempfile.TemporaryDirectory() as tempdir:
             with PipesFileContextInjector(
                 os.path.join(tempdir, _CONTEXT_INJECTOR_FILENAME)
@@ -63,15 +98,35 @@ class PipesTempFileContextInjector(PipesContextInjector):
 
 
 class PipesEnvContextInjector(PipesContextInjector):
+    """Context injector that injects context data into the external process by injecting it directly into the external process environment."""
+
     @contextmanager
     def inject_context(
         self,
         context_data: "PipesContextData",
     ) -> Iterator[PipesParams]:
+        """Inject context to external environment by embedding directly in the parameters that will
+        be passed to the external process (typically as environment variables).
+
+        Args:
+            context_data (PipesContextData): The context data to inject.
+
+        Yields:
+            PipesParams: A dict of parameters that can be used by the external process to locate and
+                load the injected context data.
+        """
         yield {DefaultPipesContextLoader.DIRECT_KEY: context_data}
 
 
+@experimental
 class PipesFileMessageReader(PipesMessageReader):
+    """Message reader that reads messages by tailing a specified file.
+
+    Args:
+        path (str): The path of the file to which messages will be written. The file will be deleted
+            on close of the pipes session.
+    """
+
     def __init__(self, path: str):
         self._path = check.str_param(path, "path")
 
@@ -80,6 +135,16 @@ class PipesFileMessageReader(PipesMessageReader):
         self,
         handler: "PipesMessageHandler",
     ) -> Iterator[PipesParams]:
+        """Set up a thread to read streaming messages from teh external process by tailing the
+        target file.
+
+        Args:
+            handler (PipesMessageHandler): object to process incoming messages
+
+        Yields:
+            PipesParams: A dict of parameters that specifies where a pipes process should write
+                pipes protocol messages.
+        """
         is_task_complete = Event()
         thread = None
         try:
@@ -102,12 +167,25 @@ class PipesFileMessageReader(PipesMessageReader):
             handler.handle_message(message)
 
 
+@experimental
 class PipesTempFileMessageReader(PipesMessageReader):
+    """Message reader that reads messages by tailing an automatically-generated temporary file."""
+
     @contextmanager
     def read_messages(
         self,
         handler: "PipesMessageHandler",
     ) -> Iterator[PipesParams]:
+        """Set up a thread to read streaming messages from the external process by an
+        automatically-generated temporary file.
+
+        Args:
+            handler (PipesMessageHandler): object to process incoming messages
+
+        Yields:
+            PipesParams: A dict of parameters that specifies where a pipes process should write
+                pipes protocol messages.
+        """
         with tempfile.TemporaryDirectory() as tempdir:
             with PipesFileMessageReader(
                 os.path.join(tempdir, _MESSAGE_READER_FILENAME)
@@ -116,6 +194,22 @@ class PipesTempFileMessageReader(PipesMessageReader):
 
 
 class PipesBlobStoreMessageReader(PipesMessageReader):
+    """Message reader that reads a sequence of message chunks written by an external process into a
+    blob store such as S3, Azure blob storage, or GCS.
+
+    The reader maintains a counter, starting at 1, that is synchronized with a message writer in
+    some pipes process. The reader starts a thread that periodically attempts to read a chunk
+    indexed by the counter at some location expected to be written by the pipes process. The chunk
+    should be a file with each line corresponding to a JSON-encoded pipes message. When a chunk is
+    successfully read, the messages are processed and the counter is incremented. The
+    :py:class:`PipesBlobStoreMessageWriter` on the other end is expected to similarly increment a
+    counter (starting from 1) on successful write, keeping counters on the read and write end in
+    sync.
+
+    Args:
+        interval (float): interval in seconds between attempts to download a chunk
+    """
+
     interval: float
     counter: int
 
@@ -128,6 +222,16 @@ class PipesBlobStoreMessageReader(PipesMessageReader):
         self,
         handler: "PipesMessageHandler",
     ) -> Iterator[PipesParams]:
+        """Set up a thread to read streaming messages by periodically reading message chunks from a
+        target location.
+
+        Args:
+            handler (PipesMessageHandler): object to process incoming messages
+
+        Yields:
+            PipesParams: A dict of parameters that specifies where a pipes process should write
+                pipes protocol message chunks.
+        """
         with self.get_params() as params:
             is_task_complete = Event()
             thread = None
@@ -150,7 +254,13 @@ class PipesBlobStoreMessageReader(PipesMessageReader):
 
     @abstractmethod
     @contextmanager
-    def get_params(self) -> Iterator[PipesParams]: ...
+    def get_params(self) -> Iterator[PipesParams]:
+        """Yield a set of parameters to be passed to a message writer in a pipes process.
+
+        Yields:
+            PipesParams: A dict of parameters that specifies where a pipes process should write
+                pipes protocol message chunks.
+        """
 
     @abstractmethod
     def download_messages_chunk(self, index: int, params: PipesParams) -> Optional[str]: ...
@@ -191,6 +301,7 @@ _FAIL_TO_YIELD_ERROR_MESSAGE = (
 )
 
 
+@experimental
 @contextmanager
 def open_pipes_session(
     context: OpExecutionContext,
@@ -198,10 +309,53 @@ def open_pipes_session(
     message_reader: PipesMessageReader,
     extras: Optional[PipesExtras] = None,
 ) -> Iterator[PipesSession]:
-    """Enter the context managed context injector and message reader that power the EXT protocol and receive the environment variables
-    that need to be provided to the external process.
+    """Context manager that opens and closes a pipes session.
+
+    This context manager should be used to wrap the launch of an external process using the pipe
+    protocol to report results back to Dagster. The yielded :py:class:`PipesSession` should be used
+    to (a) obtain the environment variables that need to be provided to the external process; (b)
+    access results streamed back from the external process.
+
+    This method is an alternative to :py:class:`PipesClient` subclasses for users who want more
+    control over how pipes processes are launched. When using `open_pipes_session`, it is the user's
+    responsibility to inject the message reader and context injector parameters available on the
+    yielded `PipesSession` and pass them to the appropriate API when launching the external process.
+    Typically these parameters should be set as environment variables.
+
+
+    Args:
+        context (OpExecutionContext): The context for the current op/asset execution.
+        context_injector (PipesContextInjector): The context injector to use to inject context into the external process.
+        message_reader (PipesMessageReader): The message reader to use to read messages from the external process.
+        extras (Optional[PipesExtras]): Optional extras to pass to the external process via the injected context.
+
+    Yields:
+        PipesSession: Interface for interacting with the external process.
+
+    .. code-block:: python
+
+        import subprocess
+        from dagster import ext_protocol
+
+        extras = {"foo": "bar"}
+
+        @asset
+        def ext_asset(context: OpExecutionContext):
+            with open_pipes_session(
+                context=context,
+                extras={"foo": "bar"},
+                context_injector=ExtTempFileContextInjector(),
+                message_reader=ExtTempFileMessageReader(),
+            ) as pipes_session:
+                subprocess.Popen(
+                    ["/bin/python", "/path/to/script.py"],
+                    env={**pipes_session.get_pipes_env_vars()}
+                )
+                while process.poll() is None:
+                    yield from pipes_session.get_results()
+
+            yield from pipes_session.get_results()
     """
-    # This will trigger an error if expected outputs are not yielded
     context.set_requires_typed_event_stream(error_message=_FAIL_TO_YIELD_ERROR_MESSAGE)
     context_data = build_external_execution_context_data(context, extras)
     message_handler = PipesMessageHandler(context)

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/__init__.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/__init__.py
@@ -28,7 +28,6 @@ from .pipes import (
     PipesDatabricksClient as PipesDatabricksClient,
     PipesDbfsContextInjector as PipesDbfsContextInjector,
     PipesDbfsMessageReader as PipesDbfsMessageReader,
-    dbfs_tempdir as dbfs_tempdir,
 )
 from .resources import (
     DatabricksClientResource as DatabricksClientResource,

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
@@ -8,6 +8,7 @@ from contextlib import contextmanager
 from typing import Iterator, Mapping, Optional
 
 import dagster._check as check
+from dagster._annotations import experimental
 from dagster._core.definitions.resource_annotation import ResourceParam
 from dagster._core.errors import DagsterExternalExecutionError
 from dagster._core.execution.context.compute import OpExecutionContext
@@ -31,12 +32,18 @@ from databricks.sdk.service import files, jobs
 from pydantic import Field
 
 
+@experimental
 class _PipesDatabricksClient(PipesClient):
-    """Ext client for databricks.
+    """Pipes client for databricks.
 
     Args:
-        client (WorkspaceClient): A databricks workspace client.
-        env (Optional[Mapping[str,str]]: An optional dict of environment variables to pass to the databricks job.
+        client (WorkspaceClient): A databricks `WorkspaceClient` object.
+        env (Optional[Mapping[str,str]]: An optional dict of environment variables to pass to the
+            databricks job.
+        context_injector (Optional[PipesContextInjector]): A context injector to use to inject
+            context into the k8s container process. Defaults to :py:class:`PipesDbfsContextInjector`.
+        message_reader (Optional[PipesMessageReader]): A message reader to use to read messages
+            from the databricks job. Defaults to :py:class:`PipesDbfsMessageReader`.
     """
 
     env: Optional[Mapping[str, str]] = Field(
@@ -72,7 +79,7 @@ class _PipesDatabricksClient(PipesClient):
         extras: Optional[PipesExtras] = None,
         submit_args: Optional[Mapping[str, str]] = None,
     ) -> Iterator[PipesExecutionResult]:
-        """Run a Databricks job with the EXT protocol.
+        """Run a Databricks job with the pipes protocol.
 
         Args:
             task (databricks.sdk.service.jobs.SubmitTask): Specification of the databricks
@@ -80,8 +87,14 @@ class _PipesDatabricksClient(PipesClient):
                 `spark_env_vars` key of the `new_cluster` field (if there is an existing dictionary
                 here, the EXT environment variables will be merged in). Everything else will be
                 passed unaltered under the `tasks` arg to `WorkspaceClient.jobs.submit`.
+            context (OpExecutionContext): The context from the executing op or asset.
+            extras (Optional[PipesExtras]): An optional dict of extra parameters to pass to the
+                subprocess.
             submit_args (Optional[Mapping[str, str]]): Additional keyword arguments that will be
                 forwarded as-is to `WorkspaceClient.jobs.submit`.
+
+        Yields:
+            PipesExecutionResult: Results reported by the external process.
         """
         with open_pipes_session(
             context=context,
@@ -141,13 +154,30 @@ def dbfs_tempdir(dbfs_client: files.DbfsAPI) -> Iterator[str]:
         dbfs_client.delete(tempdir, recursive=True)
 
 
+@experimental
 class PipesDbfsContextInjector(PipesContextInjector):
+    """A context injector that injects context into a Databricks job by writing a JSON file to DBFS.
+
+    Args:
+        client (WorkspaceClient): A databricks `WorkspaceClient` object.
+    """
+
     def __init__(self, *, client: WorkspaceClient):
         super().__init__()
         self.dbfs_client = files.DbfsAPI(client.api_client)
 
     @contextmanager
     def inject_context(self, context: "PipesContextData") -> Iterator[PipesParams]:
+        """Inject context to external environment by writing it to an automatically-generated
+        DBFS temporary file as JSON and exposing the path to the file.
+
+        Args:
+            context_data (PipesContextData): The context data to inject.
+
+        Yields:
+            PipesParams: A dict of parameters that can be used by the external process to locate and
+                load the injected context data.
+        """
         with dbfs_tempdir(self.dbfs_client) as tempdir:
             path = os.path.join(tempdir, _CONTEXT_FILENAME)
             contents = base64.b64encode(json.dumps(context).encode("utf-8")).decode("utf-8")
@@ -155,7 +185,16 @@ class PipesDbfsContextInjector(PipesContextInjector):
             yield {"path": path}
 
 
+@experimental
 class PipesDbfsMessageReader(PipesBlobStoreMessageReader):
+    """Message reader that reads messages by periodically reading message chunks from an
+    automatically-generated temporary directory on DBFS.
+
+    Args:
+        interval (float): interval in seconds between attempts to download a chunk
+        client (WorkspaceClient): A databricks `WorkspaceClient` object.
+    """
+
     def __init__(self, *, interval: int = 10, client: WorkspaceClient):
         super().__init__(interval=interval)
         self.dbfs_client = files.DbfsAPI(client.api_client)

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_external_asset.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_external_asset.py
@@ -8,7 +8,7 @@ from typing import Any, Callable, Iterator
 import pytest
 from dagster import AssetExecutionContext, asset, materialize
 from dagster._core.errors import DagsterExternalExecutionError
-from dagster_databricks import PipesDatabricksClient, dbfs_tempdir
+from dagster_databricks.pipes import PipesDatabricksClient, dbfs_tempdir
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.service import files, jobs
 

--- a/python_modules/libraries/dagster-docker/dagster_docker/__init__.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/__init__.py
@@ -6,6 +6,10 @@ from .ops import (
     docker_container_op as docker_container_op,
     execute_docker_container as execute_docker_container,
 )
+from .pipes import (
+    PipesDockerClient as PipesDockerClient,
+    PipesDockerLogsMessageReader as PipesDockerLogsMessageReader,
+)
 from .version import __version__
 
 DagsterLibraryRegistry.register("dagster-docker", __version__)

--- a/python_modules/libraries/dagster-docker/dagster_docker/pipes.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/pipes.py
@@ -7,6 +7,7 @@ from dagster import (
     ResourceParam,
     _check as check,
 )
+from dagster._annotations import experimental
 from dagster._core.pipes.client import (
     PipesClient,
     PipesContextInjector,
@@ -29,7 +30,8 @@ from dagster_pipes import (
 )
 
 
-class DockerLogsMessageReader(PipesMessageReader):
+@experimental
+class PipesDockerLogsMessageReader(PipesMessageReader):
     @contextmanager
     def read_messages(
         self,
@@ -49,17 +51,22 @@ class DockerLogsMessageReader(PipesMessageReader):
             extract_message_or_forward_to_stdout(handler, log_line)
 
 
+@experimental
 class _PipesDockerClient(PipesClient):
-    """An ext protocol compliant resource for launching docker containers.
+    """A pipes client that runs external processes in docker containers.
 
-        By default context is injected via environment variables and messages are parsed out of the
-        log stream and other logs are forwarded to stdout of the orchestration process.
+    By default context is injected via environment variables and messages are parsed out of the
+    log stream, with other logs forwarded to stdout of the orchestration process.
 
     Args:
-        env (Optional[Mapping[str, str]]): An optional dict of environment variables to pass to the subprocess.
-        register (Optional[Mapping[str, str]]): An optional dict of registry credentials to login the docker client.
-        context_injector (Optional[PipesContextInjector]): An context injector to use to inject context into the docker container process. Defaults to PipesEnvContextInjector.
-        message_reader (Optional[PipesContextInjector]): An context injector to use to read messages from the docker container process. Defaults to DockerLogsMessageReader.
+        env (Optional[Mapping[str, str]]): An optional dict of environment variables to pass to the
+            container.
+        register (Optional[Mapping[str, str]]): An optional dict of registry credentials to login to
+            the docker client.
+        context_injector (Optional[PipesContextInjector]): A context injector to use to inject
+            context into the docker container process. Defaults to :py:class:`PipesEnvContextInjector`.
+        message_reader (Optional[PipesContextInjector]): A message reader to use to read messages
+            from the docker container process. Defaults to :py:class:`DockerLogsMessageReader`.
     """
 
     def __init__(
@@ -82,7 +89,7 @@ class _PipesDockerClient(PipesClient):
 
         self.message_reader = (
             check.opt_inst_param(message_reader, "message_reader", PipesMessageReader)
-            or DockerLogsMessageReader()
+            or PipesDockerLogsMessageReader()
         )
 
     def run(
@@ -96,7 +103,7 @@ class _PipesDockerClient(PipesClient):
         container_kwargs: Optional[Mapping[str, Any]] = None,
         extras: Optional[PipesExtras] = None,
     ) -> Iterator[PipesExecutionResult]:
-        """Create a docker container and run it to completion, enriched with the ext protocol.
+        """Create a docker container and run it to completion, enriched with the pipes protocol.
 
         Args:
             image (str):
@@ -117,6 +124,9 @@ class _PipesDockerClient(PipesClient):
                 Override the default ext protocol context injection.
             message_Reader (Optional[PipesMessageReader]):
                 Override the default ext protocol message reader.
+
+        Yields:
+            PipesExecutionResult: Results reported by the external process.
         """
         with open_pipes_session(
             context=context,
@@ -155,7 +165,7 @@ class _PipesDockerClient(PipesClient):
 
             result = container.start()
             try:
-                if isinstance(self.message_reader, DockerLogsMessageReader):
+                if isinstance(self.message_reader, PipesDockerLogsMessageReader):
                     self.message_reader.consume_docker_logs(container)
 
                 result = container.wait()

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/__init__.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/__init__.py
@@ -10,6 +10,10 @@ from .ops import (
     execute_k8s_job as execute_k8s_job,
     k8s_job_op as k8s_job_op,
 )
+from .pipes import (
+    PipesK8sClient as PipesK8sClient,
+    PipesK8sPodLogsMessageReader as PipesK8sPodLogsMessageReader,
+)
 from .version import __version__ as __version__
 
 DagsterLibraryRegistry.register("dagster-k8s", __version__)


### PR DESCRIPTION
## Summary & Motivation

See title.

This is only on the orchestration end, `dagster-pipes` still needs a little polish here.

## How I Tested These Changes

Existing test suite.