### PR TITLE
s/PipesResult/PipesExecutionResult/g

### DIFF
--- a/python_modules/dagster/dagster/_core/pipes/client.py
+++ b/python_modules/dagster/dagster/_core/pipes/client.py
@@ -11,7 +11,7 @@ from dagster_pipes import (
 from dagster._core.execution.context.compute import OpExecutionContext
 
 if TYPE_CHECKING:
-    from .context import PipesMessageHandler, PipesResult
+    from .context import PipesExecutionResult, PipesMessageHandler
 
 
 class PipesClient(ABC):
@@ -21,7 +21,7 @@ class PipesClient(ABC):
         *,
         context: OpExecutionContext,
         extras: Optional[PipesExtras] = None,
-    ) -> Iterator["PipesResult"]: ...
+    ) -> Iterator["PipesExecutionResult"]: ...
 
 
 class PipesContextInjector(ABC):

--- a/python_modules/dagster/dagster/_core/pipes/context.py
+++ b/python_modules/dagster/dagster/_core/pipes/context.py
@@ -32,14 +32,14 @@ from dagster._core.execution.context.compute import OpExecutionContext
 from dagster._core.execution.context.invocation import BoundOpExecutionContext
 from dagster._core.pipes.client import PipesMessageReader
 
-PipesResult: TypeAlias = Union[MaterializeResult, AssetCheckResult]
+PipesExecutionResult: TypeAlias = Union[MaterializeResult, AssetCheckResult]
 
 
 class PipesMessageHandler:
     def __init__(self, context: OpExecutionContext) -> None:
         self._context = context
         # Queue is thread-safe
-        self._result_queue: Queue[PipesResult] = Queue()
+        self._result_queue: Queue[PipesExecutionResult] = Queue()
         # Only read by the main thread after all messages are handled, so no need for a lock
         self._unmaterialized_assets: Set[AssetKey] = set(context.selected_asset_keys)
 
@@ -50,7 +50,7 @@ class PipesMessageHandler:
         for key in self._unmaterialized_assets:
             self._result_queue.put(MaterializeResult(asset_key=key))
 
-    def clear_result_queue(self) -> Iterator[PipesResult]:
+    def clear_result_queue(self) -> Iterator[PipesExecutionResult]:
         while not self._result_queue.empty():
             yield self._result_queue.get()
 
@@ -179,7 +179,7 @@ class PipesSession:
             ),
         }
 
-    def get_results(self) -> Iterator[PipesResult]:
+    def get_results(self) -> Iterator[PipesExecutionResult]:
         yield from self.message_handler.clear_result_queue()
 
 

--- a/python_modules/dagster/dagster/_core/pipes/subprocess.py
+++ b/python_modules/dagster/dagster/_core/pipes/subprocess.py
@@ -12,7 +12,7 @@ from dagster._core.pipes.client import (
     PipesContextInjector,
     PipesMessageReader,
 )
-from dagster._core.pipes.context import PipesResult
+from dagster._core.pipes.context import PipesExecutionResult
 from dagster._core.pipes.utils import (
     PipesTempFileContextInjector,
     PipesTempFileMessageReader,
@@ -67,7 +67,7 @@ class _PipesSubprocess(PipesClient):
         extras: Optional[PipesExtras] = None,
         env: Optional[Mapping[str, str]] = None,
         cwd: Optional[str] = None,
-    ) -> Iterator[PipesResult]:
+    ) -> Iterator[PipesExecutionResult]:
         with open_pipes_session(
             context=context,
             context_injector=self.context_injector,

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
@@ -16,7 +16,7 @@ from dagster._core.pipes.client import (
     PipesContextInjector,
     PipesMessageReader,
 )
-from dagster._core.pipes.context import PipesResult
+from dagster._core.pipes.context import PipesExecutionResult
 from dagster._core.pipes.utils import (
     PipesBlobStoreMessageReader,
     open_pipes_session,
@@ -71,7 +71,7 @@ class _PipesDatabricksClient(PipesClient):
         context: OpExecutionContext,
         extras: Optional[PipesExtras] = None,
         submit_args: Optional[Mapping[str, str]] = None,
-    ) -> Iterator[PipesResult]:
+    ) -> Iterator[PipesExecutionResult]:
         """Run a Databricks job with the EXT protocol.
 
         Args:

--- a/python_modules/libraries/dagster-docker/dagster_docker/pipes.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/pipes.py
@@ -13,8 +13,8 @@ from dagster._core.pipes.client import (
     PipesMessageReader,
 )
 from dagster._core.pipes.context import (
+    PipesExecutionResult,
     PipesMessageHandler,
-    PipesResult,
 )
 from dagster._core.pipes.utils import (
     PipesEnvContextInjector,
@@ -95,7 +95,7 @@ class _PipesDockerClient(PipesClient):
         registry: Optional[Mapping[str, str]] = None,
         container_kwargs: Optional[Mapping[str, Any]] = None,
         extras: Optional[PipesExtras] = None,
-    ) -> Iterator[PipesResult]:
+    ) -> Iterator[PipesExecutionResult]:
         """Create a docker container and run it to completion, enriched with the ext protocol.
 
         Args:

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
@@ -17,8 +17,8 @@ from dagster._core.pipes.client import (
     PipesParams,
 )
 from dagster._core.pipes.context import (
+    PipesExecutionResult,
     PipesMessageHandler,
-    PipesResult,
 )
 from dagster._core.pipes.utils import (
     PipesEnvContextInjector,
@@ -124,7 +124,7 @@ class _PipesK8sClient(PipesClient):
         base_pod_meta: Optional[Mapping[str, Any]] = None,
         base_pod_spec: Optional[Mapping[str, Any]] = None,
         extras: Optional[PipesExtras] = None,
-    ) -> Iterator[PipesResult]:
+    ) -> Iterator[PipesExecutionResult]:
         """Publish a kubernetes pod and wait for it to complete, enriched with the ext protocol.
 
         Args:


### PR DESCRIPTION
## Summary & Motivation

Per our live discussion renaming `PipesResult` and `PipesExecutionResult`. We anticipate a similar name in dagster core for `Union[MaterializeResult, AssetCheckResult]` which is also likely include `ObservationResult` when we have external assets support active observation.

## How I Tested These Changes

BK
