### PR TITLE
[Asset-graph] Chunk requests using new useAssetLiveData hook +  Virtualization 

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/components/RefreshableCountdown.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/RefreshableCountdown.tsx
@@ -9,7 +9,7 @@ import {secondsToCountdownTime} from './secondsToCountdownTime';
 
 interface Props {
   refreshing: boolean;
-  seconds: number;
+  seconds?: number;
   onRefresh: () => void;
   dataDescription?: string;
 }
@@ -21,7 +21,11 @@ export const RefreshableCountdown = (props: Props) => {
       <span
         style={{color: Colors.Gray400, fontVariantNumeric: 'tabular-nums', whiteSpace: 'nowrap'}}
       >
-        {refreshing ? `Refreshing ${dataDescription}…` : secondsToCountdownTime(seconds)}
+        {refreshing
+          ? `Refreshing ${dataDescription}…`
+          : seconds === undefined
+          ? null
+          : secondsToCountdownTime(seconds)}
       </span>
       <Tooltip content={<span style={{whiteSpace: 'nowrap'}}>Refresh now</span>} position="top">
         <RefreshButton onClick={onRefresh}>

--- a/js_modules/dagster-ui/packages/ui-core/.storybook/main.js
+++ b/js_modules/dagster-ui/packages/ui-core/.storybook/main.js
@@ -56,6 +56,10 @@ const config = {
   docs: {
     autodocs: true,
   },
+  env: (config) => ({
+    ...config,
+    STORYBOOK: true,
+  }),
 };
 
 export default config;

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetLiveDataProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetLiveDataProvider.tsx
@@ -1,31 +1,30 @@
 import {ApolloClient, useApolloClient} from '@apollo/client';
+import uniq from 'lodash/uniq';
 import React from 'react';
 
-import {assertUnreachable} from '../app/Util';
-import {LiveDataForNode, buildLiveDataForNode} from '../asset-graph/Utils';
+import {observeAssetEventsInRuns} from '../asset-graph/AssetRunLogObserver';
+import {LiveDataForNode, buildLiveDataForNode, tokenForAssetKey} from '../asset-graph/Utils';
 import {
   AssetGraphLiveQuery,
   AssetGraphLiveQueryVariables,
-  AssetLatestInfoFragment,
   AssetNodeLiveFragment,
 } from '../asset-graph/types/useLiveDataForAssetKeys.types';
-import {
-  ASSETS_GRAPH_LIVE_QUERY,
-  ASSET_LATEST_INFO_FRAGMENT,
-  ASSET_NODE_LIVE_FRAGMENT,
-} from '../asset-graph/useLiveDataForAssetKeys';
+import {ASSETS_GRAPH_LIVE_QUERY} from '../asset-graph/useLiveDataForAssetKeys';
 import {AssetKeyInput} from '../graphql/types';
 import {isDocumentVisible, useDocumentVisibility} from '../hooks/useDocumentVisibility';
+import {useDidLaunchEvent} from '../runs/RunUtils';
 
 const _assetKeyListeners: Record<string, Array<DataForNodeListener>> = {};
+let providerListener = (_key: string, _data: LiveDataForNode) => {};
+const _cache: Record<string, LiveDataForNode> = {};
 
 /*
  * Note: This hook may return partial data since it will fetch assets in chunks/batches.
  */
 export function useAssetsLiveData(assetKeys: AssetKeyInput[]) {
-  const [data, setData] = React.useState<Record<string, LiveDataForNode | null>>({});
+  const [data, setData] = React.useState<Record<string, LiveDataForNode>>({});
+  const [isRefreshing, setIsRefreshing] = React.useState(false);
 
-  const client = useApolloClient();
   const setNeedsImmediateFetch = React.useContext(AssetLiveDataContext).setNeedsImmediateFetch;
 
   React.useEffect(() => {
@@ -35,34 +34,36 @@ export function useAssetsLiveData(assetKeys: AssetKeyInput[]) {
       });
     };
     assetKeys.forEach((key) => {
-      _subscribeToAssetKey(client, key, setDataSingle, setNeedsImmediateFetch);
+      _subscribeToAssetKey(key, setDataSingle, setNeedsImmediateFetch);
     });
     return () => {
       assetKeys.forEach((key) => {
         _unsubscribeToAssetKey(key, setDataSingle);
       });
     };
-  }, [assetKeys, client, setNeedsImmediateFetch]);
+  }, [assetKeys, setNeedsImmediateFetch]);
 
-  return data;
-}
-
-function _getAssetFromCache(client: ApolloClient<any>, uniqueId: string) {
-  const cachedAssetData = client.readFragment<AssetNodeLiveFragment>({
-    fragment: ASSET_NODE_LIVE_FRAGMENT,
-    fragmentName: 'AssetNodeLiveFragment',
-    id: `assetNodeLiveFragment-${uniqueId}`,
-  });
-  const cachedLatestInfo = client.readFragment<AssetLatestInfoFragment>({
-    fragment: ASSET_LATEST_INFO_FRAGMENT,
-    fragmentName: 'AssetLatestInfoFragment',
-    id: `assetLatestInfoFragment-${uniqueId}`,
-  });
-  if (cachedAssetData && cachedLatestInfo) {
-    return {cachedAssetData, cachedLatestInfo};
-  } else {
-    return null;
-  }
+  return {
+    liveDataByNode: data,
+    refresh: React.useCallback(() => {
+      _resetLastFetchedOrRequested(assetKeys);
+      setNeedsImmediateFetch();
+      setIsRefreshing(true);
+    }, [setNeedsImmediateFetch, assetKeys]),
+    refreshing: React.useMemo(() => {
+      for (const key of assetKeys) {
+        const stringKey = JSON.stringify(key.path);
+        if (!lastFetchedOrRequested[stringKey]?.fetched) {
+          return true;
+        }
+      }
+      setTimeout(() => {
+        setIsRefreshing(false);
+      });
+      return false;
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [assetKeys, data, isRefreshing]),
+  };
 }
 
 async function _queryAssetKeys(client: ApolloClient<any>, assetKeys: AssetKeyInput[]) {
@@ -73,24 +74,18 @@ async function _queryAssetKeys(client: ApolloClient<any>, assetKeys: AssetKeyInp
       assetKeys,
     },
   });
+  const nodesByKey: Record<string, AssetNodeLiveFragment> = {};
+  const liveDataByKey: Record<string, LiveDataForNode> = {};
   data.assetNodes.forEach((assetNode) => {
-    _assetKeyToUniqueId[JSON.stringify(assetNode.assetKey.path)] = assetNode.id;
-    client.writeFragment({
-      fragment: ASSET_NODE_LIVE_FRAGMENT,
-      fragmentName: 'AssetNodeLiveFragment',
-      id: `assetNodeLiveFragment-${assetNode.id}`,
-      data: assetNode,
-    });
+    const id = JSON.stringify(assetNode.assetKey.path);
+    nodesByKey[id] = assetNode;
   });
   data.assetsLatestInfo.forEach((assetLatestInfo) => {
-    _assetKeyToUniqueId[JSON.stringify(assetLatestInfo.assetKey.path)] = assetLatestInfo.id;
-    client.writeFragment({
-      fragment: ASSET_LATEST_INFO_FRAGMENT,
-      fragmentName: 'AssetLatestInfoFragment',
-      id: `assetLatestInfoFragment-${assetLatestInfo.id}`,
-      data: assetLatestInfo,
-    });
+    const id = JSON.stringify(assetLatestInfo.assetKey.path);
+    liveDataByKey[id] = buildLiveDataForNode(nodesByKey[id]!, assetLatestInfo);
   });
+  Object.assign(_cache, liveDataByKey);
+  return liveDataByKey;
 }
 
 // How many assets to fetch at once
@@ -100,14 +95,18 @@ export const BATCH_SIZE = 50;
 const BATCHING_INTERVAL = 250;
 
 export const SUBSCRIPTION_IDLE_POLL_RATE = 30 * 1000;
-// const SUBSCRIPTION_MAX_POLL_RATE = 2 * 1000;
+const SUBSCRIPTION_MAX_POLL_RATE = 2 * 1000;
 
 type DataForNodeListener = (stringKey: string, data: LiveDataForNode) => void;
 
 const AssetLiveDataContext = React.createContext<{
   setNeedsImmediateFetch: () => void;
+  onSubscribed: () => void;
+  onUnsubscribed: () => void;
 }>({
   setNeedsImmediateFetch: () => {},
+  onSubscribed: () => {},
+  onUnsubscribed: () => {},
 });
 
 // Map of asset keys to their last fetched time and last requested time
@@ -116,16 +115,18 @@ const lastFetchedOrRequested: Record<
   {fetched: number; requested?: undefined} | {requested: number; fetched?: undefined} | null
 > = {};
 
-export const _testOnly_resetLastFetchedOrRequested = () => {
-  if (typeof jest !== 'undefined') {
-    Object.keys(lastFetchedOrRequested).forEach((key) => {
+export const _resetLastFetchedOrRequested = (keys?: AssetKeyInput[]) => {
+  (keys?.map((key) => JSON.stringify(key.path)) ?? Object.keys(lastFetchedOrRequested)).forEach(
+    (key) => {
       delete lastFetchedOrRequested[key];
-    });
-  }
+    },
+  );
 };
 
 export const AssetLiveDataProvider = ({children}: {children: React.ReactNode}) => {
   const [needsImmediateFetch, setNeedsImmediateFetch] = React.useState<boolean>(false);
+  const [allObservedKeys, setAllObservedKeys] = React.useState<AssetKeyInput[]>([]);
+  const [cache, setCache] = React.useState<Record<string, LiveDataForNode>>({});
 
   const client = useApolloClient();
 
@@ -159,12 +160,64 @@ export const AssetLiveDataProvider = ({children}: {children: React.ReactNode}) =
     };
   }, [client, needsImmediateFetch]);
 
+  React.useEffect(() => {
+    providerListener = (key, data) => {
+      setCache((cache) => {
+        return {...cache, [key]: data};
+      });
+    };
+  }, []);
+
+  useDidLaunchEvent(() => {
+    _resetLastFetchedOrRequested();
+    setNeedsImmediateFetch(true);
+  }, SUBSCRIPTION_MAX_POLL_RATE);
+
+  React.useEffect(() => {
+    const assetKeyTokens = new Set(allObservedKeys.map(tokenForAssetKey));
+    const dataForObservedKeys = allObservedKeys
+      .map((key) => cache[tokenForAssetKey(key)])
+      .filter((n) => n) as LiveDataForNode[];
+
+    const assetStepKeys = new Set(dataForObservedKeys.flatMap((n) => n.opNames));
+
+    const runInProgressId = uniq(
+      dataForObservedKeys.flatMap((p) => [
+        ...p.unstartedRunIds,
+        ...p.inProgressRunIds,
+        ...p.assetChecks
+          .map((c) => c.executionForLatestMaterialization)
+          .filter(Boolean)
+          .map((e) => e!.runId),
+      ]),
+    ).sort();
+
+    const unobserve = observeAssetEventsInRuns(runInProgressId, (events) => {
+      if (
+        events.some(
+          (e) =>
+            (e.assetKey && assetKeyTokens.has(tokenForAssetKey(e.assetKey))) ||
+            (e.stepKey && assetStepKeys.has(e.stepKey)),
+        )
+      ) {
+        _resetLastFetchedOrRequested();
+      }
+    });
+    return unobserve;
+  }, [allObservedKeys, cache]);
+
   return (
     <AssetLiveDataContext.Provider
       value={React.useMemo(
         () => ({
           setNeedsImmediateFetch: () => {
             setNeedsImmediateFetch(true);
+          },
+          onSubscribed: () => {
+            setAllObservedKeys(getAllAssetKeysWithListeners());
+          },
+          onUnsubscribed: () => {
+            setAllObservedKeys(getAllAssetKeysWithListeners());
           },
         }),
         [],
@@ -193,27 +246,7 @@ async function _batchedQueryAssets(
       requested: requestTime,
     };
   });
-  await _queryAssetKeys(client, assetKeys);
-  const data: Record<string, LiveDataForNode> = {};
-  assetKeys.forEach((key) => {
-    const stringKey = JSON.stringify(key.path);
-    const uniqueId = _assetKeyToUniqueId[stringKey];
-    if (!uniqueId) {
-      assertUnreachable(
-        `Expected uniqueID for assetKey to be known after fetching it's data: ${stringKey}` as never,
-      );
-      return;
-    }
-    const cachedData = _getAssetFromCache(client, uniqueId)!;
-    if (cachedData) {
-      const {cachedAssetData, cachedLatestInfo} = cachedData;
-      data[stringKey] = buildLiveDataForNode(cachedAssetData, cachedLatestInfo);
-    } else {
-      assertUnreachable(
-        ('Apollo failed to populate cache for asset key: ' + JSON.stringify(key.path)) as never,
-      );
-    }
-  });
+  const data = await _queryAssetKeys(client, assetKeys);
   const fetchedTime = Date.now();
   assetKeys.forEach((key) => {
     lastFetchedOrRequested[JSON.stringify(key.path)] = {
@@ -229,7 +262,6 @@ async function _batchedQueryAssets(
 }
 
 function _subscribeToAssetKey(
-  client: ApolloClient<any>,
   assetKey: AssetKeyInput,
   setData: DataForNodeListener,
   setNeedsImmediateFetch: () => void,
@@ -237,11 +269,9 @@ function _subscribeToAssetKey(
   const stringKey = JSON.stringify(assetKey.path);
   _assetKeyListeners[stringKey] = _assetKeyListeners[stringKey] || [];
   _assetKeyListeners[stringKey]!.push(setData);
-  const uniqueId = _assetKeyToUniqueId[stringKey];
-  const cachedData = uniqueId ? _getAssetFromCache(client, uniqueId) : null;
+  const cachedData = _cache[stringKey];
   if (cachedData) {
-    const {cachedAssetData, cachedLatestInfo} = cachedData;
-    setData(stringKey, buildLiveDataForNode(cachedAssetData, cachedLatestInfo));
+    setData(stringKey, cachedData);
   } else {
     setNeedsImmediateFetch();
   }
@@ -290,6 +320,7 @@ function fetchData(client: ApolloClient<any>) {
   _batchedQueryAssets(_determineAssetsToFetch(), client, (data) => {
     Object.entries(data).forEach(([key, assetData]) => {
       const listeners = _assetKeyListeners[key];
+      providerListener(key, assetData);
       if (!listeners) {
         return;
       }
@@ -300,5 +331,6 @@ function fetchData(client: ApolloClient<any>) {
   });
 }
 
-// Map of AssetKeyInput to its unique asset ID. We won't know until we query because the backend implementation depends on the repository location and name.
-const _assetKeyToUniqueId: Record<string, string> = {};
+function getAllAssetKeysWithListeners(): AssetKeyInput[] {
+  return Object.keys(_assetKeyListeners).map((key) => JSON.parse(key));
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetLiveDataProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetLiveDataProvider.tsx
@@ -18,9 +18,6 @@ const _assetKeyListeners: Record<string, Array<DataForNodeListener>> = {};
 let providerListener = (_key: string, _data: LiveDataForNode) => {};
 const _cache: Record<string, LiveDataForNode> = {};
 
-/*
- * Note: This hook may return partial data since it will fetch assets in chunks/batches.
- */
 export function useAssetsLiveData(assetKeys: AssetKeyInput[]) {
   const [data, setData] = React.useState<Record<string, LiveDataForNode>>({});
   const [isRefreshing, setIsRefreshing] = React.useState(false);

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetLiveDataProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetLiveDataProvider.tsx
@@ -25,7 +25,8 @@ export function useAssetsLiveData(assetKeys: AssetKeyInput[]) {
   const [data, setData] = React.useState<Record<string, LiveDataForNode>>({});
   const [isRefreshing, setIsRefreshing] = React.useState(false);
 
-  const setNeedsImmediateFetch = React.useContext(AssetLiveDataContext).setNeedsImmediateFetch;
+  const {setNeedsImmediateFetch, onSubscribed, onUnsubscribed} =
+    React.useContext(AssetLiveDataContext);
 
   React.useEffect(() => {
     const setDataSingle = (stringKey: string, assetData: LiveDataForNode) => {
@@ -36,12 +37,14 @@ export function useAssetsLiveData(assetKeys: AssetKeyInput[]) {
     assetKeys.forEach((key) => {
       _subscribeToAssetKey(key, setDataSingle, setNeedsImmediateFetch);
     });
+    onSubscribed();
     return () => {
       assetKeys.forEach((key) => {
         _unsubscribeToAssetKey(key, setDataSingle);
       });
+      onUnsubscribed();
     };
-  }, [assetKeys, setNeedsImmediateFetch]);
+  }, [assetKeys, onSubscribed, onUnsubscribed, setNeedsImmediateFetch]);
 
   return {
     liveDataByNode: data,

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetLiveDataProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetLiveDataProvider.tsx
@@ -335,5 +335,5 @@ function fetchData(client: ApolloClient<any>) {
 }
 
 function getAllAssetKeysWithListeners(): AssetKeyInput[] {
-  return Object.keys(_assetKeyListeners).map((key) => JSON.parse(key));
+  return Object.keys(_assetKeyListeners).map((key) => ({path: JSON.parse(key)}));
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/__tests__/AssetLiveDataProvider.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/__tests__/AssetLiveDataProvider.test.tsx
@@ -4,19 +4,8 @@ import {MockedProvider, MockedResponse} from '@apollo/client/testing';
 import {render, act, waitFor} from '@testing-library/react';
 import React from 'react';
 
-import {
-  AssetGraphLiveQuery,
-  AssetGraphLiveQueryVariables,
-} from '../../asset-graph/types/useLiveDataForAssetKeys.types';
-import {ASSETS_GRAPH_LIVE_QUERY} from '../../asset-graph/useLiveDataForAssetKeys';
-import {
-  AssetKey,
-  AssetKeyInput,
-  buildAssetKey,
-  buildAssetLatestInfo,
-  buildAssetNode,
-} from '../../graphql/types';
-import {buildQueryMock, getMockResultFn} from '../../testing/mocking';
+import {AssetKey, AssetKeyInput, buildAssetKey} from '../../graphql/types';
+import {getMockResultFn} from '../../testing/mocking';
 import {
   AssetLiveDataProvider,
   SUBSCRIPTION_IDLE_POLL_RATE,
@@ -24,26 +13,10 @@ import {
   useAssetsLiveData,
 } from '../AssetLiveDataProvider';
 
+import {buildMockedAssetGraphLiveQuery} from './util';
+
 Object.defineProperty(document, 'visibilityState', {value: 'visible', writable: true});
 Object.defineProperty(document, 'hidden', {value: false, writable: true});
-
-function buildMockedQuery(assetKeys: AssetKeyInput[]) {
-  return buildQueryMock<AssetGraphLiveQuery, AssetGraphLiveQueryVariables>({
-    query: ASSETS_GRAPH_LIVE_QUERY,
-    variables: {
-      // strip __typename
-      assetKeys: assetKeys.map((assetKey) => ({path: assetKey.path})),
-    },
-    data: {
-      assetNodes: assetKeys.map((assetKey) =>
-        buildAssetNode({assetKey: buildAssetKey(assetKey), id: JSON.stringify(assetKey)}),
-      ),
-      assetsLatestInfo: assetKeys.map((assetKey) =>
-        buildAssetLatestInfo({assetKey: buildAssetKey(assetKey), id: JSON.stringify(assetKey)}),
-      ),
-    },
-  });
-}
 
 afterEach(() => {
   _resetLastFetchedOrRequested();
@@ -83,8 +56,8 @@ function Test({
 describe('AssetLiveDataProvider', () => {
   it('provides asset data and uses cache if recently fetched', async () => {
     const assetKeys = [buildAssetKey({path: ['key1']})];
-    const mockedQuery = buildMockedQuery(assetKeys);
-    const mockedQuery2 = buildMockedQuery(assetKeys);
+    const mockedQuery = buildMockedAssetGraphLiveQuery(assetKeys);
+    const mockedQuery2 = buildMockedAssetGraphLiveQuery(assetKeys);
 
     const resultFn = getMockResultFn(mockedQuery);
     const resultFn2 = getMockResultFn(mockedQuery2);
@@ -141,8 +114,8 @@ describe('AssetLiveDataProvider', () => {
 
   it('obeys document visibility', async () => {
     const assetKeys = [buildAssetKey({path: ['key1']})];
-    const mockedQuery = buildMockedQuery(assetKeys);
-    const mockedQuery2 = buildMockedQuery(assetKeys);
+    const mockedQuery = buildMockedAssetGraphLiveQuery(assetKeys);
+    const mockedQuery2 = buildMockedAssetGraphLiveQuery(assetKeys);
 
     const resultFn = getMockResultFn(mockedQuery);
     const resultFn2 = getMockResultFn(mockedQuery2);
@@ -219,8 +192,8 @@ describe('AssetLiveDataProvider', () => {
     const chunk1 = assetKeys.slice(0, 50);
     const chunk2 = assetKeys.slice(50, 100);
 
-    const mockedQuery = buildMockedQuery(chunk1);
-    const mockedQuery2 = buildMockedQuery(chunk2);
+    const mockedQuery = buildMockedAssetGraphLiveQuery(chunk1);
+    const mockedQuery2 = buildMockedAssetGraphLiveQuery(chunk2);
 
     const resultFn = getMockResultFn(mockedQuery);
     const resultFn2 = getMockResultFn(mockedQuery2);
@@ -265,8 +238,8 @@ describe('AssetLiveDataProvider', () => {
     const hook2Keys = assetKeys.slice(33, 66);
     const hook3Keys = assetKeys.slice(66, 100);
 
-    const mockedQuery = buildMockedQuery(chunk1);
-    const mockedQuery2 = buildMockedQuery(chunk2);
+    const mockedQuery = buildMockedAssetGraphLiveQuery(chunk1);
+    const mockedQuery2 = buildMockedAssetGraphLiveQuery(chunk2);
 
     const resultFn = getMockResultFn(mockedQuery);
     const resultFn2 = getMockResultFn(mockedQuery2);
@@ -324,9 +297,9 @@ describe('AssetLiveDataProvider', () => {
 
     secondPrioritizedFetchKeys.push(...fetch1Keys);
 
-    const mockedQuery = buildMockedQuery(fetch1Keys);
-    const mockedQuery2 = buildMockedQuery(firstPrioritizedFetchKeys);
-    const mockedQuery3 = buildMockedQuery(secondPrioritizedFetchKeys);
+    const mockedQuery = buildMockedAssetGraphLiveQuery(fetch1Keys);
+    const mockedQuery2 = buildMockedAssetGraphLiveQuery(firstPrioritizedFetchKeys);
+    const mockedQuery3 = buildMockedAssetGraphLiveQuery(secondPrioritizedFetchKeys);
 
     const resultFn = getMockResultFn(mockedQuery);
     const resultFn2 = getMockResultFn(mockedQuery2);

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/__tests__/AssetLiveDataProvider.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/__tests__/AssetLiveDataProvider.test.tsx
@@ -20,7 +20,7 @@ import {buildQueryMock, getMockResultFn} from '../../testing/mocking';
 import {
   AssetLiveDataProvider,
   SUBSCRIPTION_IDLE_POLL_RATE,
-  _testOnly_resetLastFetchedOrRequested,
+  _resetLastFetchedOrRequested,
   useAssetsLiveData,
 } from '../AssetLiveDataProvider';
 
@@ -46,7 +46,7 @@ function buildMockedQuery(assetKeys: AssetKeyInput[]) {
 }
 
 afterEach(() => {
-  _testOnly_resetLastFetchedOrRequested();
+  _resetLastFetchedOrRequested();
 });
 
 function Test({

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/__tests__/util.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/__tests__/util.ts
@@ -1,0 +1,30 @@
+import {
+  AssetGraphLiveQuery,
+  AssetGraphLiveQueryVariables,
+} from '../../asset-graph/types/useLiveDataForAssetKeys.types';
+import {ASSETS_GRAPH_LIVE_QUERY} from '../../asset-graph/useLiveDataForAssetKeys';
+import {
+  AssetKeyInput,
+  buildAssetNode,
+  buildAssetKey,
+  buildAssetLatestInfo,
+} from '../../graphql/types';
+import {buildQueryMock} from '../../testing/mocking';
+
+export function buildMockedAssetGraphLiveQuery(assetKeys: AssetKeyInput[]) {
+  return buildQueryMock<AssetGraphLiveQuery, AssetGraphLiveQueryVariables>({
+    query: ASSETS_GRAPH_LIVE_QUERY,
+    variables: {
+      // strip __typename
+      assetKeys: assetKeys.map((assetKey) => ({path: assetKey.path})),
+    },
+    data: {
+      assetNodes: assetKeys.map((assetKey) =>
+        buildAssetNode({assetKey: buildAssetKey(assetKey), id: JSON.stringify(assetKey)}),
+      ),
+      assetsLatestInfo: assetKeys.map((assetKey) =>
+        buildAssetLatestInfo({assetKey: buildAssetKey(assetKey), id: JSON.stringify(assetKey)}),
+      ),
+    },
+  });
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetEdges.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetEdges.tsx
@@ -13,18 +13,27 @@ export const AssetEdges: React.FC<{
 }> = ({edges, highlighted, strokeWidth = 4, baseColor = Colors.KeylineGray, viewportRect}) => {
   // Note: we render the highlighted edges twice, but it's so that the first item with
   // all the edges in it can remain memoized.
+
+  const intersectedEdges = edges.filter((edge) => doesViewportContainEdge(edge, viewportRect));
+  const visibleToFromEdges = intersectedEdges.filter(
+    (edge) =>
+      doesViewportContainPoint(edge.from, viewportRect) ||
+      doesViewportContainPoint(edge.to, viewportRect),
+  );
   return (
     <React.Fragment>
       <AssetEdgeSet
         color={baseColor}
-        edges={edges}
+        edges={intersectedEdges.length > 50 ? visibleToFromEdges : intersectedEdges}
         strokeWidth={strokeWidth}
         viewportRect={viewportRect}
       />
       <AssetEdgeSet
         viewportRect={viewportRect}
         color={Colors.Blue500}
-        edges={edges.filter(({fromId, toId}) => highlighted === fromId || highlighted === toId)}
+        edges={intersectedEdges.filter(
+          ({fromId, toId}) => highlighted === fromId || highlighted === toId,
+        )}
         strokeWidth={strokeWidth}
       />
     </React.Fragment>
@@ -36,7 +45,7 @@ const AssetEdgeSet: React.FC<{
   color: string;
   strokeWidth: number;
   viewportRect: {top: number; left: number; right: number; bottom: number};
-}> = React.memo(({edges, color, strokeWidth, viewportRect}) => (
+}> = React.memo(({edges, color, strokeWidth}) => (
   <>
     <defs>
       <marker
@@ -51,24 +60,43 @@ const AssetEdgeSet: React.FC<{
         <path d="M 0 0 L 8 5 L 0 10 z" fill={color} />
       </marker>
     </defs>
-    {edges
-      .filter(
-        (edge) =>
-          doesViewportContainPoint(edge.from, viewportRect) ||
-          doesViewportContainPoint(edge.to, viewportRect),
-      )
-      .map((edge, idx) => (
-        <path
-          key={idx}
-          d={buildSVGPath({source: edge.from, target: edge.to})}
-          stroke={color}
-          strokeWidth={strokeWidth}
-          fill="none"
-          markerEnd={`url(#arrow${btoa(color)})`}
-        />
-      ))}
+    {edges.map((edge, idx) => (
+      <path
+        key={idx}
+        d={buildSVGPath({source: edge.from, target: edge.to})}
+        stroke={color}
+        strokeWidth={strokeWidth}
+        fill="none"
+        markerEnd={`url(#arrow${btoa(color)})`}
+      />
+    ))}
   </>
 ));
+
+//https://stackoverflow.com/a/20925869/1162881
+function doesViewportContainEdge(
+  edge: {from: {x: number; y: number}; to: {x: number; y: number}},
+  viewportRect: {top: number; left: number; right: number; bottom: number},
+) {
+  return (
+    isOverlapping1D(
+      Math.max(edge.from.x, edge.to.x),
+      Math.max(viewportRect.left, viewportRect.right),
+      Math.min(edge.from.x, edge.to.x),
+      Math.min(viewportRect.left, viewportRect.right),
+    ) &&
+    isOverlapping1D(
+      Math.max(edge.from.y, edge.to.y),
+      Math.max(viewportRect.top, viewportRect.bottom),
+      Math.min(edge.from.y, edge.to.y),
+      Math.min(viewportRect.top, viewportRect.bottom),
+    )
+  );
+}
+
+function isOverlapping1D(xmax1: number, xmax2: number, xmin1: number, xmin2: number) {
+  return xmax1 >= xmin2 && xmax2 >= xmin1;
+}
 
 function doesViewportContainPoint(
   point: {x: number; y: number},

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -585,9 +585,3 @@ const assetKeyTokensInRange = (
 
   return uniq(ledToTarget);
 };
-
-function normalizePathnameForCacheKey(pathname: string) {
-  const _path = pathname.endsWith('/') ? pathname.slice(0, pathname.length - 1) : pathname;
-  // Remove the op query string
-  return _path.split('~')[0];
-}

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -585,3 +585,9 @@ const assetKeyTokensInRange = (
 
   return uniq(ledToTarget);
 };
+
+function normalizePathnameForCacheKey(pathname: string) {
+  const _path = pathname.endsWith('/') ? pathname.slice(0, pathname.length - 1) : pathname;
+  // Remove the op query string
+  return _path.split('~')[0];
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorerSidebar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorerSidebar.tsx
@@ -486,7 +486,7 @@ const Node = ({
         }}
         selectNode={selectNode}
       />
-      <Box ref={elementRef} onClick={selectThisNode}>
+      <Box ref={elementRef} onClick={selectThisNode} padding={{left: 8}}>
         <BoxWrapper level={level}>
           <Box padding={{right: 12}} flex={{direction: 'row', gap: 2, alignItems: 'center'}}>
             {!isAssetNode ||
@@ -560,7 +560,7 @@ const Node = ({
                           }}
                         />
                         {upstream.length || downstream.length ? <MenuDivider /> : null}
-                        {upstream.length > 1 ? (
+                        {upstream.length ? (
                           <MenuItem
                             text={`View parents (${upstream.length})`}
                             icon="list"
@@ -654,7 +654,8 @@ const BoxWrapper = ({level, children}: {level: number; children: React.ReactNode
         <Box
           padding={{left: 8}}
           margin={{left: 8}}
-          border={i > 0 ? {side: 'left', width: 1, color: Colors.KeylineGray} : undefined}
+          border={{side: 'left', width: 1, color: Colors.KeylineGray}}
+          style={{position: 'relative'}}
         >
           {sofar}
         </Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode.tsx
@@ -7,7 +7,7 @@ import {Link} from 'react-router-dom';
 import styled, {CSSObject} from 'styled-components';
 
 import {withMiddleTruncation} from '../app/Util';
-import {useAssetsLiveData} from '../asset-data/AssetLiveDataProvider';
+import {useAssetLiveData} from '../asset-data/AssetLiveDataProvider';
 import {PartitionCountTags} from '../assets/AssetNodePartitionCounts';
 import {StaleReasonsTags} from '../assets/Stale';
 import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
@@ -28,10 +28,7 @@ export const AssetNode: React.FC<{
   const displayName = definition.assetKey.path[definition.assetKey.path.length - 1]!;
   const isSource = definition.isSource;
 
-  const {liveDataByNode} = useAssetsLiveData(
-    React.useMemo(() => [definition.assetKey], [definition]),
-  );
-  const liveData = liveDataByNode[JSON.stringify(definition.assetKey.path)];
+  const liveData = useAssetLiveData(definition.assetKey);
   return (
     <AssetInsetForHoverEffect>
       <AssetTopTags definition={definition} liveData={liveData} />
@@ -213,10 +210,7 @@ export const AssetNodeMinimal: React.FC<{
   definition: AssetNodeFragment;
 }> = ({selected, definition}) => {
   const {isSource, assetKey} = definition;
-  const {liveDataByNode} = useAssetsLiveData(
-    React.useMemo(() => [definition.assetKey], [definition]),
-  );
-  const liveData = liveDataByNode[JSON.stringify(assetKey.path)];
+  const liveData = useAssetLiveData(assetKey);
   const {border, background} = buildAssetNodeStatusContent({assetKey, definition, liveData});
   const displayName = assetKey.path[assetKey.path.length - 1]!;
 

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode.tsx
@@ -7,6 +7,7 @@ import {Link} from 'react-router-dom';
 import styled, {CSSObject} from 'styled-components';
 
 import {withMiddleTruncation} from '../app/Util';
+import {useAssetsLiveData} from '../asset-data/AssetLiveDataProvider';
 import {PartitionCountTags} from '../assets/AssetNodePartitionCounts';
 import {StaleReasonsTags} from '../assets/Stale';
 import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
@@ -22,12 +23,15 @@ import {AssetNodeFragment} from './types/AssetNode.types';
 
 export const AssetNode: React.FC<{
   definition: AssetNodeFragment;
-  liveData?: LiveDataForNode;
   selected: boolean;
-}> = React.memo(({definition, selected, liveData}) => {
+}> = React.memo(({definition, selected}) => {
   const displayName = definition.assetKey.path[definition.assetKey.path.length - 1]!;
   const isSource = definition.isSource;
 
+  const {liveDataByNode} = useAssetsLiveData(
+    React.useMemo(() => [definition.assetKey], [definition]),
+  );
+  const liveData = liveDataByNode[JSON.stringify(definition.assetKey.path)];
   return (
     <AssetInsetForHoverEffect>
       <AssetTopTags definition={definition} liveData={liveData} />
@@ -206,10 +210,13 @@ const AssetNodeChecksRow: React.FC<{
 
 export const AssetNodeMinimal: React.FC<{
   selected: boolean;
-  liveData?: LiveDataForNode;
   definition: AssetNodeFragment;
-}> = ({selected, definition, liveData}) => {
+}> = ({selected, definition}) => {
   const {isSource, assetKey} = definition;
+  const {liveDataByNode} = useAssetsLiveData(
+    React.useMemo(() => [definition.assetKey], [definition]),
+  );
+  const liveData = liveDataByNode[JSON.stringify(assetKey.path)];
   const {border, background} = buildAssetNodeStatusContent({assetKey, definition, liveData});
   const displayName = assetKey.path[assetKey.path.length - 1]!;
 

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/SidebarAssetInfo.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/SidebarAssetInfo.tsx
@@ -5,6 +5,7 @@ import {Link} from 'react-router-dom';
 import styled from 'styled-components';
 
 import {COMMON_COLLATOR} from '../app/Util';
+import {useAssetsLiveData} from '../asset-data/AssetLiveDataProvider';
 import {ASSET_NODE_CONFIG_FRAGMENT} from '../assets/AssetConfig';
 import {AssetDefinedInMultipleReposNotice} from '../assets/AssetDefinedInMultipleReposNotice';
 import {
@@ -34,21 +35,16 @@ import {buildRepoAddress} from '../workspace/buildRepoAddress';
 import {RepoAddress} from '../workspace/types';
 import {workspacePathFromAddress} from '../workspace/workspacePath';
 
-import {
-  LiveDataForNode,
-  displayNameForAssetKey,
-  GraphNode,
-  nodeDependsOnSelf,
-  stepKeyForAsset,
-} from './Utils';
+import {displayNameForAssetKey, GraphNode, nodeDependsOnSelf, stepKeyForAsset} from './Utils';
 import {SidebarAssetQuery, SidebarAssetQueryVariables} from './types/SidebarAssetInfo.types';
 import {AssetNodeForGraphQueryFragment} from './types/useAssetGraphData.types';
 
 export const SidebarAssetInfo: React.FC<{
   graphNode: GraphNode;
-  liveData?: LiveDataForNode;
-}> = ({graphNode, liveData}) => {
+}> = ({graphNode}) => {
   const {assetKey, definition} = graphNode;
+  const {liveDataByNode} = useAssetsLiveData(React.useMemo(() => [assetKey], [assetKey]));
+  const liveData = liveDataByNode[JSON.stringify(assetKey.path)];
   const partitionHealthRefreshHint = healthRefreshHintFromLiveData(liveData);
   const partitionHealthData = usePartitionHealthData(
     [assetKey],

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/SidebarAssetInfo.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/SidebarAssetInfo.tsx
@@ -5,7 +5,7 @@ import {Link} from 'react-router-dom';
 import styled from 'styled-components';
 
 import {COMMON_COLLATOR} from '../app/Util';
-import {useAssetsLiveData} from '../asset-data/AssetLiveDataProvider';
+import {useAssetLiveData} from '../asset-data/AssetLiveDataProvider';
 import {ASSET_NODE_CONFIG_FRAGMENT} from '../assets/AssetConfig';
 import {AssetDefinedInMultipleReposNotice} from '../assets/AssetDefinedInMultipleReposNotice';
 import {
@@ -43,8 +43,7 @@ export const SidebarAssetInfo: React.FC<{
   graphNode: GraphNode;
 }> = ({graphNode}) => {
   const {assetKey, definition} = graphNode;
-  const {liveDataByNode} = useAssetsLiveData(React.useMemo(() => [assetKey], [assetKey]));
-  const liveData = liveDataByNode[JSON.stringify(assetKey.path)];
+  const liveData = useAssetLiveData(assetKey);
   const partitionHealthRefreshHint = healthRefreshHintFromLiveData(liveData);
   const partitionHealthData = usePartitionHealthData(
     [assetKey],

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/Utils.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/Utils.tsx
@@ -148,6 +148,7 @@ export interface LiveDataForNode {
     numPartitions: number;
     numFailed: number;
   } | null;
+  opNames: string[];
 }
 
 export const MISSING_LIVE_DATA: LiveDataForNode = {
@@ -162,6 +163,7 @@ export const MISSING_LIVE_DATA: LiveDataForNode = {
   staleStatus: null,
   staleCauses: [],
   assetChecks: [],
+  opNames: [],
   stepKey: '',
 };
 
@@ -217,6 +219,7 @@ export const buildLiveDataForNode = (
     unstartedRunIds: assetLatestInfo?.unstartedRunIds || [],
     partitionStats: assetNode.partitionStats || null,
     runWhichFailedToMaterialize,
+    opNames: assetNode.opNames,
   };
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__fixtures__/AssetNode.fixtures.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__fixtures__/AssetNode.fixtures.ts
@@ -707,14 +707,14 @@ export const AssetNodeScenariosBase = [
     title: 'Materialized and Stale',
     liveData: LiveDataForNodeMaterializedAndStale,
     definition: AssetNodeFragmentBasic,
-    expectedText: ['Code version', 'Feb'],
+    expectedText: ['Upstream code version', 'Feb'],
   },
 
   {
     title: 'Materialized and Stale and Overdue',
     liveData: LiveDataForNodeMaterializedAndStaleAndOverdue,
     definition: AssetNodeFragmentBasic,
-    expectedText: ['Code version', 'Overdue', 'Feb'],
+    expectedText: ['Upstream code version', 'Overdue', 'Feb'],
   },
 
   {
@@ -771,8 +771,8 @@ export const AssetNodeScenariosSource = [
     definition: {
       ...AssetNodeFragmentSource,
       isObservable: false,
-      id: '["source_asset_not_observable"]',
-      assetKey: buildAssetKey({path: ['source_asset_not_observable']}),
+      id: '["source_asset_no"]',
+      assetKey: buildAssetKey({path: ['source_asset_no']}),
     },
     expectedText: [],
   },
@@ -784,8 +784,8 @@ export const AssetNodeScenariosSource = [
       ...AssetNodeFragmentSource,
       isObservable: false,
       description: null,
-      id: '["source_asset_not_observable_no_description"]',
-      assetKey: buildAssetKey({path: ['source_asset_not_observable_no_description']}),
+      id: '["source_asset_nono"]',
+      assetKey: buildAssetKey({path: ['source_asset_nono']}),
     },
     expectedText: [],
   },

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__fixtures__/AssetNode.fixtures.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__fixtures__/AssetNode.fixtures.ts
@@ -94,6 +94,7 @@ export const LiveDataForNodeRunStartedNotMaterializing: LiveDataForNode = {
   assetChecks: [],
   freshnessInfo: null,
   partitionStats: null,
+  opNames: [],
 };
 
 export const LiveDataForNodeRunStartedMaterializing: LiveDataForNode = {
@@ -109,6 +110,7 @@ export const LiveDataForNodeRunStartedMaterializing: LiveDataForNode = {
   assetChecks: [],
   freshnessInfo: null,
   partitionStats: null,
+  opNames: [],
 };
 
 export const LiveDataForNodeRunFailed: LiveDataForNode = {
@@ -129,6 +131,7 @@ export const LiveDataForNodeRunFailed: LiveDataForNode = {
   assetChecks: [],
   freshnessInfo: null,
   partitionStats: null,
+  opNames: [],
 };
 
 export const LiveDataForNodeNeverMaterialized: LiveDataForNode = {
@@ -144,6 +147,7 @@ export const LiveDataForNodeNeverMaterialized: LiveDataForNode = {
   assetChecks: [],
   freshnessInfo: null,
   partitionStats: null,
+  opNames: [],
 };
 
 export const LiveDataForNodeMaterialized: LiveDataForNode = {
@@ -163,6 +167,7 @@ export const LiveDataForNodeMaterialized: LiveDataForNode = {
   assetChecks: [],
   freshnessInfo: null,
   partitionStats: null,
+  opNames: [],
 };
 
 export const LiveDataForNodeMaterializedWithChecks: LiveDataForNode = {
@@ -233,6 +238,7 @@ export const LiveDataForNodeMaterializedWithChecks: LiveDataForNode = {
   ],
   freshnessInfo: null,
   partitionStats: null,
+  opNames: [],
 };
 
 export const LiveDataForNodeMaterializedWithChecksOk: LiveDataForNode = {
@@ -259,6 +265,7 @@ export const LiveDataForNodeMaterializedAndStale: LiveDataForNode = {
   assetChecks: [],
   freshnessInfo: null,
   partitionStats: null,
+  opNames: [],
 };
 
 export const LiveDataForNodeMaterializedAndStaleAndOverdue: LiveDataForNode = {
@@ -281,6 +288,7 @@ export const LiveDataForNodeMaterializedAndStaleAndOverdue: LiveDataForNode = {
     currentMinutesLate: 12,
   },
   partitionStats: null,
+  opNames: [],
 };
 
 export const LiveDataForNodeMaterializedAndStaleAndFresh: LiveDataForNode = {
@@ -303,6 +311,7 @@ export const LiveDataForNodeMaterializedAndStaleAndFresh: LiveDataForNode = {
     currentMinutesLate: 0,
   },
   partitionStats: null,
+  opNames: [],
 };
 
 export const LiveDataForNodeMaterializedAndFresh: LiveDataForNode = {
@@ -325,6 +334,7 @@ export const LiveDataForNodeMaterializedAndFresh: LiveDataForNode = {
     currentMinutesLate: 0,
   },
   partitionStats: null,
+  opNames: [],
 };
 
 export const LiveDataForNodeMaterializedAndOverdue: LiveDataForNode = {
@@ -347,6 +357,7 @@ export const LiveDataForNodeMaterializedAndOverdue: LiveDataForNode = {
     currentMinutesLate: 12,
   },
   partitionStats: null,
+  opNames: [],
 };
 
 export const LiveDataForNodeFailedAndOverdue: LiveDataForNode = {
@@ -370,6 +381,7 @@ export const LiveDataForNodeFailedAndOverdue: LiveDataForNode = {
     currentMinutesLate: 12,
   },
   partitionStats: null,
+  opNames: [],
 };
 
 export const LiveDataForNodeSourceNeverObserved: LiveDataForNode = {
@@ -386,6 +398,7 @@ export const LiveDataForNodeSourceNeverObserved: LiveDataForNode = {
   freshnessInfo: null,
 
   partitionStats: null,
+  opNames: [],
 };
 
 export const LiveDataForNodeSourceObservationRunning: LiveDataForNode = {
@@ -401,6 +414,7 @@ export const LiveDataForNodeSourceObservationRunning: LiveDataForNode = {
   assetChecks: [],
   freshnessInfo: null,
   partitionStats: null,
+  opNames: [],
 };
 export const LiveDataForNodeSourceObservedUpToDate: LiveDataForNode = {
   stepKey: 'source_asset',
@@ -412,6 +426,7 @@ export const LiveDataForNodeSourceObservedUpToDate: LiveDataForNode = {
     __typename: 'ObservationEvent',
     runId: 'ABCDEF',
     timestamp: TIMESTAMP,
+    opNames: [],
   },
   runWhichFailedToMaterialize: null,
   staleStatus: StaleStatus.FRESH,
@@ -444,6 +459,7 @@ export const LiveDataForNodePartitionedSomeMissing: LiveDataForNode = {
     numPartitions: 1500,
     numFailed: 0,
   },
+  opNames: [],
 };
 
 export const LiveDataForNodePartitionedSomeFailed: LiveDataForNode = {
@@ -468,6 +484,7 @@ export const LiveDataForNodePartitionedSomeFailed: LiveDataForNode = {
     numPartitions: 1500,
     numFailed: 849,
   },
+  opNames: [],
 };
 
 export const LiveDataForNodePartitionedNoneMissing: LiveDataForNode = {
@@ -492,6 +509,7 @@ export const LiveDataForNodePartitionedNoneMissing: LiveDataForNode = {
     numPartitions: 1500,
     numFailed: 0,
   },
+  opNames: [],
 };
 
 export const LiveDataForNodePartitionedNeverMaterialized: LiveDataForNode = {
@@ -512,6 +530,7 @@ export const LiveDataForNodePartitionedNeverMaterialized: LiveDataForNode = {
     numPartitions: 1500,
     numFailed: 0,
   },
+  opNames: [],
 };
 
 export const LiveDataForNodePartitionedMaterializing: LiveDataForNode = {
@@ -532,6 +551,7 @@ export const LiveDataForNodePartitionedMaterializing: LiveDataForNode = {
     numPartitions: 1500,
     numFailed: 0,
   },
+  opNames: [],
 };
 
 export const LiveDataForNodePartitionedStale: LiveDataForNode = {
@@ -556,6 +576,7 @@ export const LiveDataForNodePartitionedStale: LiveDataForNode = {
     numPartitions: 1500,
     numFailed: 0,
   },
+  opNames: [],
 };
 
 export const LiveDataForNodePartitionedOverdue: LiveDataForNode = {
@@ -583,6 +604,7 @@ export const LiveDataForNodePartitionedOverdue: LiveDataForNode = {
     numPartitions: 1500,
     numFailed: 0,
   },
+  opNames: [],
 };
 
 export const LiveDataForNodePartitionedFresh: LiveDataForNode = {
@@ -610,6 +632,7 @@ export const LiveDataForNodePartitionedFresh: LiveDataForNode = {
     numPartitions: 1500,
     numFailed: 0,
   },
+  opNames: [],
 };
 
 export const LiveDataForNodePartitionedLatestRunFailed: LiveDataForNode = {
@@ -635,6 +658,7 @@ export const LiveDataForNodePartitionedLatestRunFailed: LiveDataForNode = {
     numPartitions: 1500,
     numFailed: 1,
   },
+  opNames: [],
 };
 
 export const AssetNodeScenariosBase = [

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__fixtures__/AssetNode.fixtures.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__fixtures__/AssetNode.fixtures.ts
@@ -8,6 +8,7 @@ import {
   buildAssetCheckExecution,
   buildAssetCheckEvaluation,
   buildAssetCheck,
+  buildAssetKey,
 } from '../../graphql/types';
 import {LiveDataForNode} from '../Utils';
 import {AssetNodeFragment} from '../types/AssetNode.types';
@@ -75,14 +76,14 @@ export const AssetNodeFragmentSource: AssetNodeFragment = {
 
 export const AssetNodeFragmentPartitioned: AssetNodeFragment = {
   ...AssetNodeFragmentBasic,
-  assetKey: {__typename: 'AssetKey', path: ['asset1']},
+  assetKey: {__typename: 'AssetKey', path: ['asset_partioned']},
   description: 'This is a partitioned asset description',
-  id: '["asset1"]',
+  id: '["asset_partioned"]',
   isPartitioned: true,
 };
 
 export const LiveDataForNodeRunStartedNotMaterializing: LiveDataForNode = {
-  stepKey: 'asset1',
+  stepKey: 'asset2',
   unstartedRunIds: ['ABCDEF'],
   inProgressRunIds: [],
   lastMaterialization: null,
@@ -98,7 +99,7 @@ export const LiveDataForNodeRunStartedNotMaterializing: LiveDataForNode = {
 };
 
 export const LiveDataForNodeRunStartedMaterializing: LiveDataForNode = {
-  stepKey: 'asset1',
+  stepKey: 'asset3',
   unstartedRunIds: [],
   inProgressRunIds: ['ABCDEF'],
   lastMaterialization: null,
@@ -114,7 +115,7 @@ export const LiveDataForNodeRunStartedMaterializing: LiveDataForNode = {
 };
 
 export const LiveDataForNodeRunFailed: LiveDataForNode = {
-  stepKey: 'asset1',
+  stepKey: 'asset4',
   unstartedRunIds: [],
   inProgressRunIds: [],
   lastMaterialization: null,
@@ -135,7 +136,7 @@ export const LiveDataForNodeRunFailed: LiveDataForNode = {
 };
 
 export const LiveDataForNodeNeverMaterialized: LiveDataForNode = {
-  stepKey: 'asset1',
+  stepKey: 'asset5',
   unstartedRunIds: [],
   inProgressRunIds: [],
   lastMaterialization: null,
@@ -151,7 +152,7 @@ export const LiveDataForNodeNeverMaterialized: LiveDataForNode = {
 };
 
 export const LiveDataForNodeMaterialized: LiveDataForNode = {
-  stepKey: 'asset1',
+  stepKey: 'asset6',
   unstartedRunIds: [],
   inProgressRunIds: [],
   lastMaterialization: {
@@ -171,7 +172,7 @@ export const LiveDataForNodeMaterialized: LiveDataForNode = {
 };
 
 export const LiveDataForNodeMaterializedWithChecks: LiveDataForNode = {
-  stepKey: 'asset1',
+  stepKey: 'asset7',
   unstartedRunIds: [],
   inProgressRunIds: [],
   lastMaterialization: {
@@ -249,7 +250,7 @@ export const LiveDataForNodeMaterializedWithChecksOk: LiveDataForNode = {
 };
 
 export const LiveDataForNodeMaterializedAndStale: LiveDataForNode = {
-  stepKey: 'asset1',
+  stepKey: 'asset8',
   unstartedRunIds: [],
   inProgressRunIds: [],
   lastMaterialization: {
@@ -269,7 +270,7 @@ export const LiveDataForNodeMaterializedAndStale: LiveDataForNode = {
 };
 
 export const LiveDataForNodeMaterializedAndStaleAndOverdue: LiveDataForNode = {
-  stepKey: 'asset1',
+  stepKey: 'asset9',
   unstartedRunIds: [],
   inProgressRunIds: [],
   lastMaterialization: {
@@ -292,7 +293,7 @@ export const LiveDataForNodeMaterializedAndStaleAndOverdue: LiveDataForNode = {
 };
 
 export const LiveDataForNodeMaterializedAndStaleAndFresh: LiveDataForNode = {
-  stepKey: 'asset1',
+  stepKey: 'asset10',
   unstartedRunIds: [],
   inProgressRunIds: [],
   lastMaterialization: {
@@ -315,7 +316,7 @@ export const LiveDataForNodeMaterializedAndStaleAndFresh: LiveDataForNode = {
 };
 
 export const LiveDataForNodeMaterializedAndFresh: LiveDataForNode = {
-  stepKey: 'asset1',
+  stepKey: 'asset11',
   unstartedRunIds: [],
   inProgressRunIds: [],
   lastMaterialization: {
@@ -338,7 +339,7 @@ export const LiveDataForNodeMaterializedAndFresh: LiveDataForNode = {
 };
 
 export const LiveDataForNodeMaterializedAndOverdue: LiveDataForNode = {
-  stepKey: 'asset1',
+  stepKey: 'asset12',
   unstartedRunIds: [],
   inProgressRunIds: [],
   lastMaterialization: {
@@ -361,7 +362,7 @@ export const LiveDataForNodeMaterializedAndOverdue: LiveDataForNode = {
 };
 
 export const LiveDataForNodeFailedAndOverdue: LiveDataForNode = {
-  stepKey: 'asset1',
+  stepKey: 'asset13',
   unstartedRunIds: [],
   inProgressRunIds: [],
   lastMaterializationRunStatus: null,
@@ -385,7 +386,7 @@ export const LiveDataForNodeFailedAndOverdue: LiveDataForNode = {
 };
 
 export const LiveDataForNodeSourceNeverObserved: LiveDataForNode = {
-  stepKey: 'source_asset',
+  stepKey: 'source_asset2',
   unstartedRunIds: [],
   inProgressRunIds: [],
   lastMaterialization: null,
@@ -402,7 +403,7 @@ export const LiveDataForNodeSourceNeverObserved: LiveDataForNode = {
 };
 
 export const LiveDataForNodeSourceObservationRunning: LiveDataForNode = {
-  stepKey: 'source_asset',
+  stepKey: 'source_asset3',
   unstartedRunIds: [],
   inProgressRunIds: ['ABCDEF'],
   lastMaterialization: null,
@@ -417,7 +418,7 @@ export const LiveDataForNodeSourceObservationRunning: LiveDataForNode = {
   opNames: [],
 };
 export const LiveDataForNodeSourceObservedUpToDate: LiveDataForNode = {
-  stepKey: 'source_asset',
+  stepKey: 'source_asset4',
   unstartedRunIds: [],
   inProgressRunIds: [],
   lastMaterialization: null,
@@ -426,19 +427,18 @@ export const LiveDataForNodeSourceObservedUpToDate: LiveDataForNode = {
     __typename: 'ObservationEvent',
     runId: 'ABCDEF',
     timestamp: TIMESTAMP,
-    opNames: [],
   },
   runWhichFailedToMaterialize: null,
   staleStatus: StaleStatus.FRESH,
   staleCauses: [],
   assetChecks: [],
   freshnessInfo: null,
-
+  opNames: [],
   partitionStats: null,
 };
 
 export const LiveDataForNodePartitionedSomeMissing: LiveDataForNode = {
-  stepKey: 'partitioned_asset',
+  stepKey: 'partitioned_asset1',
   unstartedRunIds: [],
   inProgressRunIds: [],
   lastMaterialization: {
@@ -463,7 +463,7 @@ export const LiveDataForNodePartitionedSomeMissing: LiveDataForNode = {
 };
 
 export const LiveDataForNodePartitionedSomeFailed: LiveDataForNode = {
-  stepKey: 'partitioned_asset',
+  stepKey: 'partitioned_asset2',
   unstartedRunIds: [],
   inProgressRunIds: [],
   lastMaterialization: {
@@ -488,7 +488,7 @@ export const LiveDataForNodePartitionedSomeFailed: LiveDataForNode = {
 };
 
 export const LiveDataForNodePartitionedNoneMissing: LiveDataForNode = {
-  stepKey: 'partitioned_asset',
+  stepKey: 'partitioned_asset3',
   unstartedRunIds: [],
   inProgressRunIds: [],
   lastMaterialization: {
@@ -513,7 +513,7 @@ export const LiveDataForNodePartitionedNoneMissing: LiveDataForNode = {
 };
 
 export const LiveDataForNodePartitionedNeverMaterialized: LiveDataForNode = {
-  stepKey: 'asset1',
+  stepKey: 'asset20',
   unstartedRunIds: [],
   inProgressRunIds: [],
   lastMaterialization: null,
@@ -534,7 +534,7 @@ export const LiveDataForNodePartitionedNeverMaterialized: LiveDataForNode = {
 };
 
 export const LiveDataForNodePartitionedMaterializing: LiveDataForNode = {
-  stepKey: 'asset1',
+  stepKey: 'asset21',
   unstartedRunIds: ['LMAANO'],
   inProgressRunIds: ['ABCDEF', 'CDEFG', 'HIHKA'],
   lastMaterialization: null,
@@ -555,7 +555,7 @@ export const LiveDataForNodePartitionedMaterializing: LiveDataForNode = {
 };
 
 export const LiveDataForNodePartitionedStale: LiveDataForNode = {
-  stepKey: 'asset1',
+  stepKey: 'asset22',
   unstartedRunIds: [],
   inProgressRunIds: [],
   lastMaterialization: {
@@ -580,7 +580,7 @@ export const LiveDataForNodePartitionedStale: LiveDataForNode = {
 };
 
 export const LiveDataForNodePartitionedOverdue: LiveDataForNode = {
-  stepKey: 'asset1',
+  stepKey: 'asset23',
   unstartedRunIds: [],
   inProgressRunIds: [],
   lastMaterialization: {
@@ -608,7 +608,7 @@ export const LiveDataForNodePartitionedOverdue: LiveDataForNode = {
 };
 
 export const LiveDataForNodePartitionedFresh: LiveDataForNode = {
-  stepKey: 'asset1',
+  stepKey: 'asset24',
   unstartedRunIds: [],
   inProgressRunIds: [],
   lastMaterialization: {
@@ -636,7 +636,7 @@ export const LiveDataForNodePartitionedFresh: LiveDataForNode = {
 };
 
 export const LiveDataForNodePartitionedLatestRunFailed: LiveDataForNode = {
-  stepKey: 'asset1',
+  stepKey: 'asset25',
   unstartedRunIds: [],
   inProgressRunIds: [],
   lastMaterialization: null,
@@ -768,14 +768,25 @@ export const AssetNodeScenariosSource = [
   {
     title: 'Source Asset - Not Observable',
     liveData: undefined,
-    definition: {...AssetNodeFragmentSource, isObservable: false},
+    definition: {
+      ...AssetNodeFragmentSource,
+      isObservable: false,
+      id: '["source_asset_not_observable"]',
+      assetKey: buildAssetKey({path: ['source_asset_not_observable']}),
+    },
     expectedText: [],
   },
 
   {
     title: 'Source Asset - Not Observable, No Description',
     liveData: undefined,
-    definition: {...AssetNodeFragmentSource, isObservable: false, description: null},
+    definition: {
+      ...AssetNodeFragmentSource,
+      isObservable: false,
+      description: null,
+      id: '["source_asset_not_observable_no_description"]',
+      assetKey: buildAssetKey({path: ['source_asset_not_observable_no_description']}),
+    },
     expectedText: [],
   },
 

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__stories__/AssetNode.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__stories__/AssetNode.stories.tsx
@@ -1,7 +1,9 @@
 import {Box} from '@dagster-io/ui-components';
 import React from 'react';
 
+import {_setCacheEntryForTest} from '../../asset-data/AssetLiveDataProvider';
 import {KNOWN_TAGS} from '../../graph/OpTags';
+import {buildAssetKey} from '../../graphql/types';
 import {AssetNode, AssetNodeMinimal} from '../AssetNode';
 import {AssetNodeLink} from '../ForeignNode';
 import * as Mocks from '../__fixtures__/AssetNode.fixtures';
@@ -15,7 +17,19 @@ export default {
 
 export const LiveStates = () => {
   const caseWithLiveData = (scenario: (typeof Mocks.AssetNodeScenariosBase)[0]) => {
-    const dimensions = getAssetNodeDimensions(scenario.definition);
+    const definitionCopy = {
+      ...scenario.definition,
+      assetKey: {
+        ...scenario.definition.assetKey,
+        path: [],
+      },
+    };
+    definitionCopy.assetKey.path = scenario.liveData
+      ? [scenario.liveData.stepKey]
+      : JSON.parse(scenario.definition.id);
+
+    const dimensions = getAssetNodeDimensions(definitionCopy);
+    _setCacheEntryForTest(definitionCopy.assetKey, scenario.liveData);
     return (
       <Box flex={{direction: 'column', gap: 8, alignItems: 'flex-start'}}>
         <div
@@ -26,19 +40,11 @@ export const LiveStates = () => {
             overflowY: 'hidden',
           }}
         >
-          <AssetNode
-            definition={scenario.definition}
-            liveData={scenario.liveData}
-            selected={false}
-          />
+          <AssetNode definition={definitionCopy} selected={false} />
         </div>
         <div style={{position: 'relative', width: dimensions.width, height: 82}}>
           <div style={{position: 'absolute', width: dimensions.width, height: 82}}>
-            <AssetNodeMinimal
-              definition={scenario.definition}
-              liveData={scenario.liveData}
-              selected={false}
-            />
+            <AssetNodeMinimal definition={definitionCopy} selected={false} />
           </div>
         </div>
         <code>
@@ -79,6 +85,7 @@ export const PartnerTags = () => {
   const caseWithComputeKind = (computeKind: string) => {
     const def = {...Mocks.AssetNodeFragmentBasic, computeKind};
     const liveData = Mocks.LiveDataForNodeMaterialized;
+    _setCacheEntryForTest(buildAssetKey({path: [liveData.stepKey]}), liveData);
     const dimensions = getAssetNodeDimensions(def);
 
     return (
@@ -87,7 +94,7 @@ export const PartnerTags = () => {
         <div
           style={{position: 'relative', width: 280, height: dimensions.height, overflowY: 'hidden'}}
         >
-          <AssetNode definition={def} selected={false} liveData={liveData} />
+          <AssetNode definition={def} selected={false} />
         </div>
       </Box>
     );

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__stories__/SidebarAssetInfo.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__stories__/SidebarAssetInfo.stories.tsx
@@ -19,7 +19,6 @@ import {
 import {WorkspaceProvider} from '../../workspace/WorkspaceContext';
 import {SIDEBAR_ASSET_QUERY, SidebarAssetInfo} from '../SidebarAssetInfo';
 import {GraphNode} from '../Utils';
-import {LiveDataForNodeMaterializedWithChecks} from '../__fixtures__/AssetNode.fixtures';
 import {SidebarAssetQuery} from '../types/SidebarAssetInfo.types';
 
 // eslint-disable-next-line import/no-default-export
@@ -252,7 +251,7 @@ const TestContainer: React.FC<{
 export const AssetWithMaterializations = () => {
   return (
     <TestContainer>
-      <SidebarAssetInfo graphNode={buildGraphNodeMock({})} liveData={undefined} />
+      <SidebarAssetInfo graphNode={buildGraphNodeMock({})} />
     </TestContainer>
   );
 };
@@ -284,7 +283,7 @@ export const AssetWithPolicies = () => {
         }),
       ]}
     >
-      <SidebarAssetInfo graphNode={buildGraphNodeMock({})} liveData={undefined} />
+      <SidebarAssetInfo graphNode={buildGraphNodeMock({})} />
     </TestContainer>
   );
 };
@@ -292,10 +291,7 @@ export const AssetWithPolicies = () => {
 export const AssetWithGraphName = () => {
   return (
     <TestContainer>
-      <SidebarAssetInfo
-        graphNode={buildGraphNodeMock({graphName: 'op_graph'})}
-        liveData={undefined}
-      />
+      <SidebarAssetInfo graphNode={buildGraphNodeMock({graphName: 'op_graph'})} />
     </TestContainer>
   );
 };
@@ -303,10 +299,7 @@ export const AssetWithGraphName = () => {
 export const AssetWithAssetChecks = () => {
   return (
     <TestContainer>
-      <SidebarAssetInfo
-        graphNode={buildGraphNodeMock({})}
-        liveData={LiveDataForNodeMaterializedWithChecks}
-      />
+      <SidebarAssetInfo graphNode={buildGraphNodeMock({})} />
     </TestContainer>
   );
 };
@@ -314,10 +307,7 @@ export const AssetWithAssetChecks = () => {
 export const AssetWithDifferentOpName = () => {
   return (
     <TestContainer>
-      <SidebarAssetInfo
-        graphNode={buildGraphNodeMock({opNames: ['not_asset_name']})}
-        liveData={undefined}
-      />
+      <SidebarAssetInfo graphNode={buildGraphNodeMock({opNames: ['not_asset_name']})} />
     </TestContainer>
   );
 };
@@ -325,10 +315,7 @@ export const AssetWithDifferentOpName = () => {
 export const ObservableSourceAsset = () => {
   return (
     <TestContainer>
-      <SidebarAssetInfo
-        graphNode={buildGraphNodeMock({isObservable: true, isSource: true})}
-        liveData={undefined}
-      />
+      <SidebarAssetInfo graphNode={buildGraphNodeMock({isObservable: true, isSource: true})} />
     </TestContainer>
   );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__tests__/AssetNode.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__tests__/AssetNode.test.tsx
@@ -2,6 +2,7 @@ import {render, screen, waitFor} from '@testing-library/react';
 import * as React from 'react';
 import {MemoryRouter} from 'react-router-dom';
 
+import {_setCacheEntryForTest} from '../../asset-data/AssetLiveDataProvider';
 import {AssetNode} from '../AssetNode';
 import {
   AssetNodeScenariosBase,
@@ -18,14 +19,26 @@ const Scenarios = [
 describe('AssetNode', () => {
   Scenarios.forEach((scenario) =>
     it(`renders ${scenario.expectedText.join(',')} when ${scenario.title}`, async () => {
+      const definitionCopy = {
+        ...scenario.definition,
+        assetKey: {
+          ...scenario.definition.assetKey,
+          path: [],
+        },
+      };
+      definitionCopy.assetKey.path = scenario.liveData
+        ? [scenario.liveData.stepKey]
+        : JSON.parse(scenario.definition.id);
+      _setCacheEntryForTest(definitionCopy.assetKey, scenario.liveData);
+
       render(
         <MemoryRouter>
-          <AssetNode definition={scenario.definition} selected={false} />
+          <AssetNode definition={definitionCopy} selected={false} />
         </MemoryRouter>,
       );
 
       await waitFor(() => {
-        const assetKey = scenario.definition.assetKey;
+        const assetKey = definitionCopy.assetKey;
         const displayName = assetKey.path[assetKey.path.length - 1]!;
         expect(screen.getByText(displayName)).toBeVisible();
         for (const text of scenario.expectedText) {

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__tests__/AssetNode.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__tests__/AssetNode.test.tsx
@@ -20,11 +20,7 @@ describe('AssetNode', () => {
     it(`renders ${scenario.expectedText.join(',')} when ${scenario.title}`, async () => {
       render(
         <MemoryRouter>
-          <AssetNode
-            definition={scenario.definition}
-            liveData={scenario.liveData}
-            selected={false}
-          />
+          <AssetNode definition={scenario.definition} selected={false} />
         </MemoryRouter>,
       );
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeDefinition.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeDefinition.tsx
@@ -14,7 +14,7 @@ import {Link} from 'react-router-dom';
 
 import {COMMON_COLLATOR} from '../app/Util';
 import {ASSET_NODE_FRAGMENT} from '../asset-graph/AssetNode';
-import {isHiddenAssetGroupJob, LiveData, toGraphId} from '../asset-graph/Utils';
+import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
 import {AssetNodeForGraphQueryFragment} from '../asset-graph/types/useAssetGraphData.types';
 import {DagsterTypeSummary} from '../dagstertype/DagsterType';
 import {Description} from '../pipelines/Description';
@@ -46,11 +46,9 @@ export const AssetNodeDefinition: React.FC<{
   assetNode: AssetNodeDefinitionFragment;
   upstream: AssetNodeForGraphQueryFragment[] | null;
   downstream: AssetNodeForGraphQueryFragment[] | null;
-  liveDataByNode: LiveData;
   dependsOnSelf: boolean;
-}> = ({assetNode, upstream, downstream, liveDataByNode, dependsOnSelf}) => {
+}> = ({assetNode, upstream, downstream, dependsOnSelf}) => {
   const {assetMetadata, assetType} = metadataForAssetNode(assetNode);
-  const liveDataForNode = liveDataByNode[toGraphId(assetNode.assetKey)];
 
   const configType = assetNode.configField?.configType;
   const assetConfigSchema = configType && configType.key !== 'Any' ? configType : null;
@@ -109,11 +107,7 @@ export const AssetNodeDefinition: React.FC<{
                 <Body style={{flex: 1}}>
                   {freshnessPolicyDescription(assetNode.freshnessPolicy)}
                 </Body>
-                <OverdueTag
-                  liveData={liveDataForNode}
-                  policy={assetNode.freshnessPolicy}
-                  assetKey={assetNode.assetKey}
-                />
+                <OverdueTag policy={assetNode.freshnessPolicy} assetKey={assetNode.assetKey} />
               </Box>
             </>
           )}
@@ -149,7 +143,7 @@ export const AssetNodeDefinition: React.FC<{
             </Link>
           </Box>
           {dependsOnSelf && <DependsOnSelfBanner />}
-          <AssetNodeList items={upstream} liveDataByNode={liveDataByNode} />
+          <AssetNodeList items={upstream} />
           <Box
             padding={{vertical: 16, horizontal: 24}}
             border="top-and-bottom"
@@ -165,7 +159,7 @@ export const AssetNodeDefinition: React.FC<{
               </Box>
             </Link>
           </Box>
-          <AssetNodeList items={downstream} liveDataByNode={liveDataByNode} />
+          <AssetNodeList items={downstream} />
           {/** Ensures the line between the left and right columns goes to the bottom of the page */}
           <div style={{flex: 1}} />
         </Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeLineage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeLineage.tsx
@@ -90,12 +90,7 @@ export const AssetNodeLineage: React.FC<{
           Not all upstream/downstream assets shown. Increase the depth to show more.
         </DepthHidesAssetsNotice>
       )}
-      <AssetNodeLineageGraph
-        assetKey={assetKey}
-        liveDataByNode={liveDataByNode}
-        assetGraphData={assetGraphData}
-        params={params}
-      />
+      <AssetNodeLineageGraph assetKey={assetKey} assetGraphData={assetGraphData} params={params} />
     </Box>
   );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeLineageGraph.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeLineageGraph.tsx
@@ -8,7 +8,7 @@ import {MINIMAL_SCALE} from '../asset-graph/AssetGraphExplorer';
 import {AssetGroupNode} from '../asset-graph/AssetGroupNode';
 import {AssetNodeMinimal, AssetNode} from '../asset-graph/AssetNode';
 import {AssetNodeLink} from '../asset-graph/ForeignNode';
-import {GraphData, LiveData, toGraphId} from '../asset-graph/Utils';
+import {GraphData, toGraphId} from '../asset-graph/Utils';
 import {DEFAULT_MAX_ZOOM, SVGViewport} from '../graph/SVGViewport';
 import {useAssetLayout} from '../graph/asyncGraphLayout';
 import {AssetKeyInput} from '../graphql/types';
@@ -22,9 +22,8 @@ const LINEAGE_GRAPH_ZOOM_LEVEL = 'lineageGraphZoomLevel';
 export const AssetNodeLineageGraph: React.FC<{
   assetKey: AssetKeyInput;
   assetGraphData: GraphData;
-  liveDataByNode: LiveData;
   params: AssetViewParams;
-}> = ({assetKey, assetGraphData, liveDataByNode, params}) => {
+}> = ({assetKey, assetGraphData, params}) => {
   const assetGraphId = toGraphId(assetKey);
 
   const [highlighted, setHighlighted] = React.useState<string | null>(null);
@@ -70,10 +69,10 @@ export const AssetNodeLineageGraph: React.FC<{
       maxZoom={DEFAULT_MAX_ZOOM}
       maxAutocenterZoom={DEFAULT_MAX_ZOOM}
     >
-      {({scale}) => (
+      {({scale}, viewportRect) => (
         <SVGContainer width={layout.width} height={layout.height}>
           {viewportEl.current && <SVGSaveZoomLevel scale={scale} />}
-          <AssetEdges highlighted={highlighted} edges={layout.edges} />
+          <AssetEdges highlighted={highlighted} edges={layout.edges} viewportRect={viewportRect} />
 
           {Object.values(layout.groups)
             .sort((a, b) => a.id.length - b.id.length)
@@ -105,13 +104,11 @@ export const AssetNodeLineageGraph: React.FC<{
                 ) : scale < MINIMAL_SCALE ? (
                   <AssetNodeMinimal
                     definition={graphNode.definition}
-                    liveData={liveDataByNode[graphNode.id]}
                     selected={graphNode.id === assetGraphId}
                   />
                 ) : (
                   <AssetNode
                     definition={graphNode.definition}
-                    liveData={liveDataByNode[graphNode.id]}
                     selected={graphNode.id === assetGraphId}
                   />
                 )}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeList.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeList.tsx
@@ -4,15 +4,13 @@ import {useHistory} from 'react-router-dom';
 import styled from 'styled-components';
 
 import {AssetNode} from '../asset-graph/AssetNode';
-import {LiveData, toGraphId} from '../asset-graph/Utils';
 import {AssetNodeForGraphQueryFragment} from '../asset-graph/types/useAssetGraphData.types';
 
 import {assetDetailsPathForKey} from './assetDetailsPathForKey';
 
 export const AssetNodeList: React.FC<{
   items: AssetNodeForGraphQueryFragment[] | null;
-  liveDataByNode: LiveData;
-}> = ({items, liveDataByNode}) => {
+}> = ({items}) => {
   const history = useHistory();
 
   if (items === null) {
@@ -33,11 +31,7 @@ export const AssetNodeList: React.FC<{
             history.push(assetDetailsPathForKey(asset.assetKey, {view: 'definition'}));
           }}
         >
-          <AssetNode
-            definition={asset}
-            selected={false}
-            liveData={liveDataByNode[toGraphId(asset.assetKey)]}
-          />
+          <AssetNode definition={asset} selected={false} />
         </AssetNodeWrapper>
       ))}
     </Container>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetSidebarActivitySummary.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetSidebarActivitySummary.tsx
@@ -71,11 +71,7 @@ export const AssetSidebarActivitySummary: React.FC<Props> = ({
         <SidebarSection title="Freshness policy">
           <Box margin={{horizontal: 24, vertical: 12}} flex={{gap: 12, alignItems: 'flex-start'}}>
             <Body style={{flex: 1}}>{freshnessPolicyDescription(asset.freshnessPolicy)}</Body>
-            <OverdueTag
-              liveData={liveData}
-              policy={asset.freshnessPolicy}
-              assetKey={asset.assetKey}
-            />
+            <OverdueTag policy={asset.freshnessPolicy} assetKey={asset.assetKey} />
           </Box>
         </SidebarSection>
       )}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
@@ -118,7 +118,6 @@ export const AssetView = ({assetKey}: Props) => {
         upstream={upstream}
         downstream={downstream}
         dependsOnSelf={node ? nodeDependsOnSelf(node) : false}
-        liveDataByNode={liveDataByNode}
       />
     );
   };
@@ -487,11 +486,7 @@ const AssetViewPageHeaderTags: React.FC<{
       )}
       {definition && definition.autoMaterializePolicy && <AutomaterializeDaemonStatusTag />}
       {definition && definition.freshnessPolicy && (
-        <OverdueTag
-          liveData={liveData}
-          policy={definition.freshnessPolicy}
-          assetKey={definition.assetKey}
-        />
+        <OverdueTag policy={definition.freshnessPolicy} assetKey={definition.assetKey} />
       )}
       {definition && (
         <StaleReasonsTags

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/OverdueTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/OverdueTag.tsx
@@ -7,6 +7,7 @@ import React from 'react';
 
 import {Timestamp} from '../app/time/Timestamp';
 import {timestampToString} from '../app/time/timestampToString';
+import {useAssetLiveData} from '../asset-data/AssetLiveDataProvider';
 import {LiveDataForNode} from '../asset-graph/Utils';
 import {AssetKeyInput, FreshnessPolicy} from '../graphql/types';
 import {humanCronString} from '../schedules/humanCronString';
@@ -39,10 +40,11 @@ export const humanizedMinutesLateString = (minLate: number) =>
   dayjs.duration(minLate, 'minutes').humanize(false);
 
 export const OverdueTag: React.FC<{
-  liveData: LiveDataForNode | undefined;
   policy: Pick<FreshnessPolicy, 'cronSchedule' | 'cronScheduleTimezone' | 'maximumLagMinutes'>;
   assetKey: AssetKeyInput;
-}> = ({liveData, policy, assetKey}) => {
+}> = ({policy, assetKey}) => {
+  const liveData = useAssetLiveData(assetKey);
+
   if (!liveData?.freshnessInfo) {
     return null;
   }

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__stories__/AssetNodeDefinition.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__stories__/AssetNodeDefinition.stories.tsx
@@ -30,7 +30,6 @@ export const MinimalAsset = () => {
         dependsOnSelf={false}
         downstream={[]}
         upstream={[]}
-        liveDataByNode={{}}
         assetNode={
           buildAssetNode({
             description: null,
@@ -56,7 +55,6 @@ export const FullUseAsset = () => {
           buildAssetNode({assetKey: buildAssetKey({path: ['downstream_1']})}),
           buildAssetNode({assetKey: buildAssetKey({path: ['downstream_2']})}),
         ]}
-        liveDataByNode={{}}
         assetNode={
           buildAssetNode({
             description: `

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__stories__/OverdueTag.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__stories__/OverdueTag.stories.tsx
@@ -4,10 +4,6 @@ import React from 'react';
 
 import {createAppCache} from '../../app/AppCache';
 import {
-  LiveDataForNodeMaterialized,
-  LiveDataForNodeMaterializedAndOverdue,
-} from '../../asset-graph/__fixtures__/AssetNode.fixtures';
-import {
   AssetFreshnessInfo,
   FreshnessPolicy,
   buildAssetFreshnessInfo,
@@ -29,13 +25,13 @@ const TEST_LAG_MINUTES = 4 * 60 + 30;
 const TEST_TIME = Date.now();
 const LAST_MATERIALIZATION_TIME = TEST_TIME - 4 * 60 * 1000;
 
-const mockLiveData = {
-  ...LiveDataForNodeMaterializedAndOverdue,
-  lastMaterialization: {
-    ...LiveDataForNodeMaterializedAndOverdue.lastMaterialization!,
-    timestamp: `${LAST_MATERIALIZATION_TIME}`,
-  },
-};
+// const mockLiveData = {
+//   ...LiveDataForNodeMaterializedAndOverdue,
+//   lastMaterialization: {
+//     ...LiveDataForNodeMaterializedAndOverdue.lastMaterialization!,
+//     timestamp: `${LAST_MATERIALIZATION_TIME}`,
+//   },
+// };
 
 function buildOverduePopoverMock(
   policy: FreshnessPolicy,
@@ -105,11 +101,7 @@ export const OverdueCronSchedule = () => {
       mocks={[buildOverduePopoverMock(mockFreshnessPolicyCron, freshnessInfo)]}
     >
       <Box style={{width: 400}} flex={{gap: 8, alignItems: 'center'}}>
-        <OverdueTag
-          assetKey={{path: ['inp8']}}
-          liveData={{...mockLiveData, freshnessInfo}}
-          policy={mockFreshnessPolicyCron}
-        />
+        <OverdueTag assetKey={{path: ['inp8']}} policy={mockFreshnessPolicyCron} />
         Hover for details, times are relative to last cron tick (eg: earlier). Note: The relative
         materialization times in the modal are not mocked to align with the cron schedule tick.
       </Box>
@@ -136,11 +128,7 @@ export const OverdueNoSchedule = () => {
       mocks={[buildOverduePopoverMock(mockFreshnessPolicy, freshnessInfo)]}
     >
       <Box style={{width: 400}} flex={{gap: 8, alignItems: 'center'}}>
-        <OverdueTag
-          assetKey={{path: ['inp8']}}
-          liveData={{...mockLiveData, freshnessInfo}}
-          policy={mockFreshnessPolicy}
-        />
+        <OverdueTag assetKey={{path: ['inp8']}} policy={mockFreshnessPolicy} />
         {' Hover for details, times are relative to now (eg: "ago")'}
       </Box>
     </MockedProvider>
@@ -168,11 +156,7 @@ export const OverdueNoUpstreams = () => {
       mocks={[buildOverduePopoverMock(mockFreshnessPolicy, freshnessInfo, false)]}
     >
       <Box style={{width: 400}} flex={{gap: 8, alignItems: 'center'}}>
-        <OverdueTag
-          assetKey={{path: ['inp8']}}
-          liveData={{...mockLiveData, freshnessInfo}}
-          policy={mockFreshnessPolicy}
-        />
+        <OverdueTag assetKey={{path: ['inp8']}} policy={mockFreshnessPolicy} />
         {' Hover for details. "derived from upstream data" omitted from description.'}
       </Box>
     </MockedProvider>
@@ -186,19 +170,15 @@ export const NeverMaterialized = () => {
     maximumLagMinutes: 24 * 60,
     lastEvaluationTimestamp: `${TEST_TIME}`,
   });
-  const freshnessInfo = {
-    __typename: 'AssetFreshnessInfo' as const,
-    currentMinutesLate: null,
-    currentLagMinutes: null,
-  };
+  // const freshnessInfo = {
+  //   __typename: 'AssetFreshnessInfo' as const,
+  //   currentMinutesLate: null,
+  //   currentLagMinutes: null,
+  // };
 
   return (
     <MockedProvider cache={createAppCache()} mocks={[]}>
-      <OverdueTag
-        assetKey={{path: ['inp8']}}
-        policy={mockFreshnessPolicy}
-        liveData={{...mockLiveData, freshnessInfo}}
-      />
+      <OverdueTag assetKey={{path: ['inp8']}} policy={mockFreshnessPolicy} />
     </MockedProvider>
   );
 };
@@ -221,11 +201,7 @@ export const Fresh = () => {
       cache={createAppCache()}
       mocks={[buildOverduePopoverMock(mockFreshnessPolicyMet, freshnessInfo)]}
     >
-      <OverdueTag
-        assetKey={{path: ['inp8']}}
-        policy={mockFreshnessPolicyMet}
-        liveData={{...mockLiveData, freshnessInfo}}
-      />
+      <OverdueTag assetKey={{path: ['inp8']}} policy={mockFreshnessPolicyMet} />
     </MockedProvider>
   );
 };
@@ -239,11 +215,7 @@ export const NoFreshnessInfo = () => {
   });
   return (
     <MockedProvider cache={createAppCache()} mocks={[]}>
-      <OverdueTag
-        assetKey={{path: ['inp8']}}
-        liveData={LiveDataForNodeMaterialized}
-        policy={mockFreshnessPolicy}
-      />
+      <OverdueTag assetKey={{path: ['inp8']}} policy={mockFreshnessPolicy} />
     </MockedProvider>
   );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewAssetsRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewAssetsRoot.tsx
@@ -223,7 +223,7 @@ function VirtualRow({height, start, group}: RowProps) {
     [group.assets],
   );
 
-  const liveDataByNode = useAssetsLiveData(assetKeys);
+  const {liveDataByNode} = useAssetsLiveData(assetKeys);
 
   const statuses = React.useMemo(() => {
     type assetType = (typeof group)['assets'][0];


### PR DESCRIPTION
## Summary & Motivation

1. Update AssetLiveData to observe run events and refresh asset data
2. Update asset-graph to use useAssetLiveData so that it benefits from chunked asset loading

## How I Tested These Changes
1. Test using the refresh functionality provided useAssetLiveData
2. Test that the asset-graph data now loads in chunks
3. Test that asset data refreshes when launching a run and as events come in
4. Rely on existing jest tests for `useAssetLiveData` to make sure core functionality still works
https://www.loom.com/share/cfc67d92c87640d7aa04d0fda578707e