### PR TITLE
[pipes] Add context.log.<level> API

### DIFF
--- a/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/domain_specific_dsl/user_scripts/fetch_the_tickers.py
+++ b/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/domain_specific_dsl/user_scripts/fetch_the_tickers.py
@@ -2,4 +2,4 @@ from dagster_pipes import init_dagster_pipes
 
 context = init_dagster_pipes()
 
-context.log(f"Got tickers: {context.extras['tickers']}")
+context.log.info(f"Got tickers: {context.extras['tickers']}")

--- a/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/pure_assets_dsl/sql_script.py
+++ b/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/pure_assets_dsl/sql_script.py
@@ -16,4 +16,4 @@ if __name__ == "__main__":
     client = SomeSqlClient()
     client.query(sql)
     context.report_asset_materialization(metadata={"sql": sql})
-    context.log(f"Ran {sql}")
+    context.log.info(f"Ran {sql}")

--- a/python_modules/dagster-pipes/dagster_pipes/__init__.py
+++ b/python_modules/dagster-pipes/dagster_pipes/__init__.py
@@ -137,14 +137,6 @@ PipesMetadataType = Literal[
     "null",
 ]
 
-PipesLogLevel = Literal[
-    "CRITICAL",
-    "ERROR",
-    "WARNING",
-    "INFO",
-    "DEBUG",
-]
-
 # ########################
 # ##### UTIL
 # ########################
@@ -321,19 +313,6 @@ def _normalize_param_metadata(
     return new_metadata
 
 
-# _LOG_LEVELS = frozenset(PipesLogLevel.__annotations__.keys())
-# # copied from Dagster core
-# _LOG_LEVEL_ALIASES: Mapping[str, str] = {
-#     "FATAL", "CRITICAL",
-#     "WARN": "WARNING",
-# }
-
-# def _normalize_log_level(level: str) -> str:
-#     upcased_level = level.upper()
-#     normalized_level = _LOG_LEVEL_ALIASES.get(upcased_level, upcased_level)
-#     return _assert_param_value(level, _LOG_LEVELS, "log", "level")
-
-
 def _param_from_env_var(key: str) -> Any:
     raw_value = os.environ.get(_param_name_to_env_var(key))
     return decode_env_var(raw_value) if raw_value is not None else None
@@ -379,7 +358,7 @@ def _get_mock() -> "MagicMock":
     return MagicMock()
 
 
-class PipesLogger(logging.Logger):
+class _PipesLogger(logging.Logger):
     def __init__(self, context: "PipesContext") -> None:
         super().__init__(name="dagster-pipes")
         self.addHandler(_PipesLoggerHandler(context))
@@ -717,7 +696,7 @@ class PipesContext:
     ) -> None:
         self._data = data
         self._message_channel = message_channel
-        self._logger = PipesLogger(self)
+        self._logger = _PipesLogger(self)
         self._materialized_assets: set[str] = set()
 
     def _write_message(self, method: str, params: Optional[Mapping[str, Any]] = None) -> None:
@@ -888,9 +867,3 @@ class PipesContext:
     @property
     def log(self) -> logging.Logger:
         return self._logger
-
-    # def log(self, message: str, level: str = "info") -> None:
-    #     message = _assert_param_type(message, str, "log", "message")
-    #     normalized_level = _normalize_log_level(_assert_param_type(level, str, "log", "level"))
-    #     _assert_param_value(normalized_level, _LOG_LEVELS, "log", "level")
-    #     self._write_message("log", {"message": message, "level": level})

--- a/python_modules/dagster-test/dagster_test/toys/external_execution/numbers_example/number_sum.py
+++ b/python_modules/dagster-test/dagster_test/toys/external_execution/numbers_example/number_sum.py
@@ -9,5 +9,5 @@ number_x = load_asset_value("number_x", storage_root)
 value = number_x + number_y
 store_asset_value("number_sum", storage_root, value)
 
-context.log(f"{context.asset_key}: {number_x} + {number_y} = {value}")
+context.log.info(f"{context.asset_key}: {number_x} + {number_y} = {value}")
 context.report_asset_materialization(data_version=compute_data_version(value))

--- a/python_modules/dagster-test/dagster_test/toys/external_execution/numbers_example/number_x.py
+++ b/python_modules/dagster-test/dagster_test/toys/external_execution/numbers_example/number_x.py
@@ -9,5 +9,5 @@ multiplier = context.get_extra("multiplier")
 value = 2 * multiplier
 store_asset_value("number_x", storage_root, value)
 
-context.log(f"{context.asset_key}: {2} * {multiplier} = {value}")
+context.log.info(f"{context.asset_key}: {2} * {multiplier} = {value}")
 context.report_asset_materialization(data_version=compute_data_version(value))

--- a/python_modules/dagster-test/dagster_test/toys/external_execution/numbers_example/number_y.py
+++ b/python_modules/dagster-test/dagster_test/toys/external_execution/numbers_example/number_y.py
@@ -10,7 +10,7 @@ storage_root = context.get_extra("storage_root")
 value = int(os.environ["NUMBER_Y"])
 store_asset_value("number_y", storage_root, value)
 
-context.log(f"{context.asset_key}: {value} read from $NUMBER_Y environment variable.")
+context.log.info(f"{context.asset_key}: {value} read from $NUMBER_Y environment variable.")
 context.report_asset_materialization(
     metadata={"is_even": value % 2 == 0},
     data_version=compute_data_version(value),

--- a/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_subprocess.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_subprocess.py
@@ -92,7 +92,7 @@ def external_script() -> Iterator[str]:
 
         init_dagster_pipes(message_writer=message_writer)
         context = PipesContext.get()
-        context.log("hello world")
+        context.log.info("hello world")
         time.sleep(0.1)  # sleep to make sure that we encompass multiple intervals for blob store IO
         context.report_asset_materialization(
             metadata={"bar": {"raw_value": context.get_extra("bar"), "type": "md"}},

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_external_asset.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_external_asset.py
@@ -29,7 +29,7 @@ def script_fn():
     multiplier = context.get_extra("multiplier")
     value = 2 * multiplier
 
-    context.log(f"{context.asset_key}: {2} * {multiplier} = {value}")
+    context.log.info(f"{context.asset_key}: {2} * {multiplier} = {value}")
     context.report_asset_materialization(
         metadata={"value": value},
         data_version="alpha",


### PR DESCRIPTION
## Summary & Motivation

Replace existing `PipesContext.log(message=..., level=...)` API with `PipesContext.log.<level>(...)` API mirroring implementation on `OpExecutionContext`.

Implementation introduces custom (and private) `_PipesLogger` and `_PipesLoggerHandler` classes inheriting from stdlib `logging` classes.

## How I Tested These Changes

New unit tests.