### PR TITLE
Change run status sensors to track cursors via storage ids instead of timestamps

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -410,9 +410,12 @@ from dagster._core.errors import (
     raise_execution_interrupts as raise_execution_interrupts,
 )
 from dagster._core.event_api import (
+    AssetRecordsFilter as AssetRecordsFilter,
     EventLogRecord as EventLogRecord,
     EventRecordsFilter as EventRecordsFilter,
+    EventRecordsResult as EventRecordsResult,
     RunShardedEventsCursor as RunShardedEventsCursor,
+    RunStatusChangeEventFilter as RunStatusChangeEventFilter,
 )
 from dagster._core.events import (
     DagsterEvent as DagsterEvent,

--- a/python_modules/dagster/dagster/_core/event_api.py
+++ b/python_modules/dagster/dagster/_core/event_api.py
@@ -1,5 +1,7 @@
+import base64
 from datetime import datetime
-from typing import Callable, Mapping, NamedTuple, Optional, Sequence, Union
+from enum import Enum
+from typing import Callable, Literal, Mapping, NamedTuple, Optional, Sequence, Tuple, Union
 
 from typing_extensions import TypeAlias
 
@@ -7,11 +9,58 @@ import dagster._check as check
 from dagster._annotations import PublicAttr
 from dagster._core.definitions.events import AssetKey, AssetMaterialization, AssetObservation
 from dagster._core.errors import DagsterInvalidInvocationError
-from dagster._core.events import DagsterEventType
+from dagster._core.events import EVENT_TYPE_TO_PIPELINE_RUN_STATUS, DagsterEventType
 from dagster._core.events.log import EventLogEntry
 from dagster._serdes import whitelist_for_serdes
+from dagster._seven import json
 
 EventHandlerFn: TypeAlias = Callable[[EventLogEntry, str], None]
+
+
+class EventLogCursorType(Enum):
+    OFFSET = "OFFSET"
+    STORAGE_ID = "STORAGE_ID"
+
+
+class EventLogCursor(NamedTuple):
+    """Representation of an event record cursor, keeping track of the log query state."""
+
+    cursor_type: EventLogCursorType
+    value: int
+
+    def is_offset_cursor(self) -> bool:
+        return self.cursor_type == EventLogCursorType.OFFSET
+
+    def is_id_cursor(self) -> bool:
+        return self.cursor_type == EventLogCursorType.STORAGE_ID
+
+    def offset(self) -> int:
+        check.invariant(self.cursor_type == EventLogCursorType.OFFSET)
+        return max(0, int(self.value))
+
+    def storage_id(self) -> int:
+        check.invariant(self.cursor_type == EventLogCursorType.STORAGE_ID)
+        return int(self.value)
+
+    def __str__(self) -> str:
+        return self.to_string()
+
+    def to_string(self) -> str:
+        raw = json.dumps({"type": self.cursor_type.value, "value": self.value})
+        return base64.b64encode(bytes(raw, encoding="utf-8")).decode("utf-8")
+
+    @staticmethod
+    def parse(cursor_str: str) -> "EventLogCursor":
+        raw = json.loads(base64.b64decode(cursor_str).decode("utf-8"))
+        return EventLogCursor(EventLogCursorType(raw["type"]), raw["value"])
+
+    @staticmethod
+    def from_offset(offset: int) -> "EventLogCursor":
+        return EventLogCursor(EventLogCursorType.OFFSET, offset)
+
+    @staticmethod
+    def from_storage_id(storage_id: int) -> "EventLogCursor":
+        return EventLogCursor(EventLogCursorType.STORAGE_ID, storage_id)
 
 
 class RunShardedEventsCursor(NamedTuple):
@@ -22,6 +71,24 @@ class RunShardedEventsCursor(NamedTuple):
 
     id: int
     run_updated_after: datetime
+
+
+RunStatusChangeEventType: TypeAlias = Literal[
+    DagsterEventType.RUN_START,
+    DagsterEventType.RUN_SUCCESS,
+    DagsterEventType.RUN_FAILURE,
+    DagsterEventType.RUN_ENQUEUED,
+    DagsterEventType.RUN_STARTING,
+    DagsterEventType.RUN_CANCELING,
+    DagsterEventType.RUN_CANCELED,
+]
+AssetEventType: TypeAlias = Literal[
+    DagsterEventType.ASSET_MATERIALIZATION,
+    DagsterEventType.ASSET_OBSERVATION,
+    DagsterEventType.ASSET_MATERIALIZATION_PLANNED,
+]
+
+EventCursor: TypeAlias = Union[int, RunShardedEventsCursor]
 
 
 @whitelist_for_serdes
@@ -68,6 +135,16 @@ class EventLogRecord(NamedTuple):
         return self.event_log_entry.asset_observation
 
 
+class EventRecordsResult(NamedTuple):
+    """Return value for a query fetching event records from the instance.  Contains a list of event
+    records, a cursor string, and a boolean indicating whether there are more records to fetch.
+    """
+
+    records: Sequence[EventLogRecord]
+    cursor: str
+    has_more: bool
+
+
 @whitelist_for_serdes
 class EventRecordsFilter(
     NamedTuple(
@@ -76,8 +153,8 @@ class EventRecordsFilter(
             ("event_type", DagsterEventType),
             ("asset_key", Optional[AssetKey]),
             ("asset_partitions", Optional[Sequence[str]]),
-            ("after_cursor", Optional[Union[int, RunShardedEventsCursor]]),
-            ("before_cursor", Optional[Union[int, RunShardedEventsCursor]]),
+            ("after_cursor", Optional[EventCursor]),
+            ("before_cursor", Optional[EventCursor]),
             ("after_timestamp", Optional[float]),
             ("before_timestamp", Optional[float]),
             ("storage_ids", Optional[Sequence[int]]),
@@ -94,11 +171,11 @@ class EventRecordsFilter(
         asset_partitions (Optional[List[str]]): Filter parameter such that only asset
             events with a partition value matching one of the provided values.  Only
             valid when the `asset_key` parameter is provided.
-        after_cursor (Optional[Union[int, RunShardedEventsCursor]]): Filter parameter such that only
+        after_cursor (Optional[EventCursor]): Filter parameter such that only
             records with storage_id greater than the provided value are returned. Using a
             run-sharded events cursor will result in a significant performance gain when run against
             a SqliteEventLogStorage implementation (which is run-sharded)
-        before_cursor (Optional[Union[int, RunShardedEventsCursor]]): Filter parameter such that
+        before_cursor (Optional[EventCursor]): Filter parameter such that
             records with storage_id less than the provided value are returned. Using a run-sharded
             events cursor will result in a significant performance gain when run against
             a SqliteEventLogStorage implementation (which is run-sharded)
@@ -113,8 +190,8 @@ class EventRecordsFilter(
         event_type: DagsterEventType,
         asset_key: Optional[AssetKey] = None,
         asset_partitions: Optional[Sequence[str]] = None,
-        after_cursor: Optional[Union[int, RunShardedEventsCursor]] = None,
-        before_cursor: Optional[Union[int, RunShardedEventsCursor]] = None,
+        after_cursor: Optional[EventCursor] = None,
+        before_cursor: Optional[EventCursor] = None,
         after_timestamp: Optional[float] = None,
         before_timestamp: Optional[float] = None,
         storage_ids: Optional[Sequence[int]] = None,
@@ -145,4 +222,143 @@ class EventRecordsFilter(
             before_timestamp=check.opt_float_param(before_timestamp, "before_timestamp"),
             storage_ids=check.opt_nullable_sequence_param(storage_ids, "storage_ids", of_type=int),
             tags=check.opt_mapping_param(tags, "tags", key_type=str),
+        )
+
+    @staticmethod
+    def get_cursor_params(
+        cursor: Optional[str] = None, ascending: bool = False
+    ) -> Tuple[Optional[int], Optional[int]]:
+        if not cursor:
+            return None, None
+
+        cursor_obj = EventLogCursor.parse(cursor)
+        if not cursor_obj.is_id_cursor():
+            check.failed(f"Invalid cursor for fetching event records: {cursor}")
+        after_cursor = cursor_obj.storage_id() if ascending else None
+        before_cursor = cursor_obj.storage_id() if not ascending else None
+        return before_cursor, after_cursor
+
+
+@whitelist_for_serdes
+class AssetRecordsFilter(
+    NamedTuple(
+        "_AssetRecordsFilter",
+        [
+            ("asset_key", PublicAttr[Optional[AssetKey]]),
+            ("asset_partitions", PublicAttr[Optional[Sequence[str]]]),
+            ("after_timestamp", PublicAttr[Optional[float]]),
+            ("before_timestamp", PublicAttr[Optional[float]]),
+            ("storage_ids", PublicAttr[Optional[Sequence[int]]]),
+            ("tags", PublicAttr[Optional[Mapping[str, Union[str, Sequence[str]]]]]),
+        ],
+    )
+):
+    """Defines a set of filter fields for fetching a set of asset event records.
+
+    Args:
+        asset_key (Optional[AssetKey]): Asset key for which to get asset event entries / records.
+        asset_partitions (Optional[List[str]]): Filter parameter such that only asset
+            events with a partition value matching one of the provided values are returned.  Only
+            valid when the `asset_key` parameter is provided.
+        after_timestamp (Optional[float]): Filter parameter such that only event records for
+            events with timestamp greater than the provided value are returned.
+        before_timestamp (Optional[float]): Filter parameter such that only event records for
+            events with timestamp less than the provided value are returned.
+        storage_ids (Optional[Sequence[int]]): Filter parameter such that only event records for
+            the given storage ids are returned.
+        tags (Optional[Mapping[str, Union[str, Sequence[str]]]]): Filter parameter such that only
+            events with the given event tags are returned
+    """
+
+    def __new__(
+        cls,
+        asset_key: Optional[AssetKey] = None,
+        asset_partitions: Optional[Sequence[str]] = None,
+        after_timestamp: Optional[float] = None,
+        before_timestamp: Optional[float] = None,
+        storage_ids: Optional[Sequence[int]] = None,
+        tags: Optional[Mapping[str, Union[str, Sequence[str]]]] = None,
+    ):
+        return super(AssetRecordsFilter, cls).__new__(
+            cls,
+            asset_key=check.opt_inst_param(asset_key, "asset_key", AssetKey),
+            asset_partitions=check.opt_nullable_sequence_param(
+                asset_partitions, "asset_partitions", of_type=str
+            ),
+            after_timestamp=check.opt_float_param(after_timestamp, "after_timestamp"),
+            before_timestamp=check.opt_float_param(before_timestamp, "before_timestamp"),
+            storage_ids=check.opt_nullable_sequence_param(storage_ids, "storage_ids", of_type=int),
+            tags=check.opt_nullable_mapping_param(tags, "tags", key_type=str),
+        )
+
+    def to_event_records_filter(
+        self, event_type: AssetEventType, cursor: Optional[str] = None, ascending: bool = False
+    ) -> EventRecordsFilter:
+        before_cursor, after_cursor = EventRecordsFilter.get_cursor_params(cursor, ascending)
+        return EventRecordsFilter(
+            event_type=event_type,
+            asset_key=self.asset_key,
+            asset_partitions=self.asset_partitions,
+            after_cursor=after_cursor,
+            before_cursor=before_cursor,
+            after_timestamp=self.after_timestamp,
+            before_timestamp=self.before_timestamp,
+            storage_ids=self.storage_ids,
+            tags=self.tags,
+        )
+
+
+@whitelist_for_serdes
+class RunStatusChangeEventFilter(
+    NamedTuple(
+        "_RunStatusChangeEventFilter",
+        [
+            ("event_type", PublicAttr[RunStatusChangeEventType]),
+            ("after_timestamp", PublicAttr[Optional[float]]),
+            ("before_timestamp", PublicAttr[Optional[float]]),
+            ("storage_ids", PublicAttr[Optional[Sequence[int]]]),
+        ],
+    )
+):
+    """Defines a set of filter fields for fetching a set of asset event records.
+
+    Args:
+        event_type (DagsterEventType): Filter argument for dagster event type
+        after_timestamp (Optional[float]): Filter parameter such that only event records for
+            events with timestamp greater than the provided value are returned.
+        before_timestamp (Optional[float]): Filter parameter such that only event records for
+            events with timestamp less than the provided value are returned.
+        storage_ids (Optional[Sequence[int]]): Filter parameter such that only event records for
+            the given storage ids are returned.
+    """
+
+    def __new__(
+        cls,
+        event_type: RunStatusChangeEventType,
+        after_timestamp: Optional[float] = None,
+        before_timestamp: Optional[float] = None,
+        storage_ids: Optional[Sequence[int]] = None,
+    ):
+        if event_type not in EVENT_TYPE_TO_PIPELINE_RUN_STATUS:
+            check.failed("Invalid event type for run status change event filter")
+
+        return super(RunStatusChangeEventFilter, cls).__new__(
+            cls,
+            event_type=check.inst_param(event_type, "event_type", DagsterEventType),
+            after_timestamp=check.opt_float_param(after_timestamp, "after_timestamp"),
+            before_timestamp=check.opt_float_param(before_timestamp, "before_timestamp"),
+            storage_ids=check.opt_nullable_sequence_param(storage_ids, "storage_ids", of_type=int),
+        )
+
+    def to_event_records_filter(
+        self, cursor: Optional[str] = None, ascending: bool = False
+    ) -> EventRecordsFilter:
+        before_cursor, after_cursor = EventRecordsFilter.get_cursor_params(cursor, ascending)
+        return EventRecordsFilter(
+            event_type=self.event_type,
+            after_cursor=after_cursor,
+            before_cursor=before_cursor,
+            after_timestamp=self.after_timestamp,
+            before_timestamp=self.before_timestamp,
+            storage_ids=self.storage_ids,
         )

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -111,7 +111,11 @@ if TYPE_CHECKING:
         RepositoryLoadData,
     )
     from dagster._core.definitions.run_request import InstigatorType
-    from dagster._core.event_api import EventHandlerFn
+    from dagster._core.event_api import (
+        AssetRecordsFilter,
+        EventHandlerFn,
+        RunStatusChangeEventFilter,
+    )
     from dagster._core.events import (
         AssetMaterialization,
         DagsterEvent,
@@ -151,6 +155,7 @@ if TYPE_CHECKING:
         EventLogConnection,
         EventLogRecord,
         EventRecordsFilter,
+        EventRecordsResult,
     )
     from dagster._core.storage.partition_status_cache import (
         AssetPartitionStatus,
@@ -1904,6 +1909,108 @@ class DagsterInstance(DynamicPartitionsStore):
 
     @public
     @traced
+    def get_materialization_records(
+        self,
+        records_filter: Optional[Union[AssetKey, "AssetRecordsFilter"]] = None,
+        limit: int = 10000,
+        cursor: Optional[str] = None,
+        ascending: bool = False,
+    ) -> "EventRecordsResult":
+        """Return a list of materialization records stored in the event log storage.
+
+        Args:
+            records_filter (Optional[Union[AssetKey, AssetRecordsFilter]]): the filter by which to
+                filter event records.
+            limit (int): Number of results to get. Defaults to 10000.
+            cursor (Optional[str]): Cursor to use for pagination. Defaults to None.
+            ascending (Optional[bool]): Sort the result in ascending order if True, descending
+                otherwise. Defaults to descending.
+
+        Returns:
+            EventRecordsResult: Object containing a list of event log records and a cursor string
+        """
+        return self._event_storage.get_materialization_records(
+            records_filter, limit, cursor, ascending
+        )
+
+    @public
+    @traced
+    def get_planned_materialization_records(
+        self,
+        records_filter: Optional[Union[AssetKey, "AssetRecordsFilter"]] = None,
+        limit: int = 10000,
+        cursor: Optional[str] = None,
+        ascending: bool = False,
+    ) -> "EventRecordsResult":
+        """Return a list of planned materialization records stored in the event log storage.
+
+        Args:
+            records_filter (Optional[Union[AssetKey, AssetRecordsFilter]]): the filter by which to
+                filter event records.
+            limit (int): Number of results to get. Defaults to 10000.
+            cursor (Optional[str]): Cursor to use for pagination. Defaults to None.
+            ascending (Optional[bool]): Sort the result in ascending order if True, descending
+                otherwise. Defaults to descending.
+
+        Returns:
+            EventRecordsResult: Object containing a list of event log records and a cursor string
+        """
+        return self._event_storage.get_planned_materialization_records(
+            records_filter, limit, cursor, ascending
+        )
+
+    @public
+    @traced
+    def get_observation_records(
+        self,
+        records_filter: Optional[Union[AssetKey, "AssetRecordsFilter"]] = None,
+        limit: int = 10000,
+        cursor: Optional[str] = None,
+        ascending: bool = False,
+    ) -> "EventRecordsResult":
+        """Return a list of observation records stored in the event log storage.
+
+        Args:
+            records_filter (Optional[Union[AssetKey, AssetRecordsFilter]]): the filter by which to
+                filter event records.
+            limit (int): Number of results to get. Defaults to 10000.
+            cursor (Optional[str]): Cursor to use for pagination. Defaults to None.
+            ascending (Optional[bool]): Sort the result in ascending order if True, descending
+                otherwise. Defaults to descending.
+
+        Returns:
+            EventRecordsResult: Object containing a list of event log records and a cursor string
+        """
+        return self._event_storage.get_observation_records(records_filter, limit, cursor, ascending)
+
+    @public
+    @traced
+    def get_run_status_change_event_records(
+        self,
+        records_filter: Union["DagsterEventType", "RunStatusChangeEventFilter"],
+        limit: int = 10000,
+        cursor: Optional[str] = None,
+        ascending: bool = False,
+    ) -> "EventRecordsResult":
+        """Return a list of run_status_event records stored in the event log storage.
+
+        Args:
+            records_filter (Optional[Union[DagsterEventType, RunStatusChangeEventFilter]]): the
+                filter by which to filter event records.
+            limit (int): Number of results to get. Defaults to 10000.
+            cursor (Optional[str]): Cursor to use for pagination. Defaults to None.
+            ascending (Optional[bool]): Sort the result in ascending order if True, descending
+                otherwise. Defaults to descending.
+
+        Returns:
+            EventRecordsResult: Object containing a list of event log records and a cursor string
+        """
+        return self._event_storage.get_run_status_change_event_records(
+            records_filter, limit, cursor, ascending
+        )
+
+    @public
+    @traced
     def get_status_by_partition(
         self,
         asset_key: AssetKey,
@@ -2777,8 +2884,8 @@ class DagsterInstance(DynamicPartitionsStore):
         before_cursor: Optional[int] = None,
         after_cursor: Optional[int] = None,
     ) -> Optional["EventLogRecord"]:
-        from dagster._core.event_api import EventRecordsFilter
         from dagster._core.events import DagsterEventType
+        from dagster._core.storage.event_log.base import EventRecordsFilter
 
         # When we cant don't know whether the requested key corresponds to a source or regular
         # asset, we need to retrieve both the latest observation and materialization for all assets.

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -1,6 +1,4 @@
-import base64
 from abc import ABC, abstractmethod
-from enum import Enum
 from typing import (
     TYPE_CHECKING,
     Iterable,
@@ -16,7 +14,15 @@ from typing import (
 import dagster._check as check
 from dagster._core.assets import AssetDetails
 from dagster._core.definitions.events import AssetKey
-from dagster._core.event_api import EventHandlerFn, EventLogRecord, EventRecordsFilter
+from dagster._core.event_api import (
+    AssetRecordsFilter,
+    EventHandlerFn,
+    EventLogCursor,
+    EventLogRecord,
+    EventRecordsFilter,
+    EventRecordsResult,
+    RunStatusChangeEventFilter,
+)
 from dagster._core.events import DagsterEventType
 from dagster._core.execution.stats import (
     RunStepKeyStatsSnapshot,
@@ -27,7 +33,6 @@ from dagster._core.instance import MayHaveInstanceWeakref, T_DagsterInstance
 from dagster._core.storage.asset_check_execution_record import AssetCheckExecutionRecord
 from dagster._core.storage.dagster_run import DagsterRunStatsSnapshot
 from dagster._core.storage.sql import AlembicVersion
-from dagster._seven import json
 from dagster._utils import PrintFn
 from dagster._utils.concurrency import ConcurrencyClaimStatus, ConcurrencyKeyInfo
 
@@ -40,52 +45,6 @@ class EventLogConnection(NamedTuple):
     records: Sequence[EventLogRecord]
     cursor: str
     has_more: bool
-
-
-class EventLogCursorType(Enum):
-    OFFSET = "OFFSET"
-    STORAGE_ID = "STORAGE_ID"
-
-
-class EventLogCursor(NamedTuple):
-    """Representation of an event record cursor, keeping track of the log query state."""
-
-    cursor_type: EventLogCursorType
-    value: int
-
-    def is_offset_cursor(self) -> bool:
-        return self.cursor_type == EventLogCursorType.OFFSET
-
-    def is_id_cursor(self) -> bool:
-        return self.cursor_type == EventLogCursorType.STORAGE_ID
-
-    def offset(self) -> int:
-        check.invariant(self.cursor_type == EventLogCursorType.OFFSET)
-        return max(0, int(self.value))
-
-    def storage_id(self) -> int:
-        check.invariant(self.cursor_type == EventLogCursorType.STORAGE_ID)
-        return int(self.value)
-
-    def __str__(self) -> str:
-        return self.to_string()
-
-    def to_string(self) -> str:
-        raw = json.dumps({"type": self.cursor_type.value, "value": self.value})
-        return base64.b64encode(bytes(raw, encoding="utf-8")).decode("utf-8")
-
-    @staticmethod
-    def parse(cursor_str: str) -> "EventLogCursor":
-        raw = json.loads(base64.b64decode(cursor_str).decode("utf-8"))
-        return EventLogCursor(EventLogCursorType(raw["type"]), raw["value"])
-
-    @staticmethod
-    def from_offset(offset: int) -> "EventLogCursor":
-        return EventLogCursor(EventLogCursorType.OFFSET, offset)
-
-    @staticmethod
-    def from_storage_id(storage_id: int) -> "EventLogCursor":
-        return EventLogCursor(EventLogCursorType.STORAGE_ID, storage_id)
 
 
 class AssetEntry(
@@ -508,4 +467,44 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         is set and include_planned is True, the returned Sequence will include executions that are planned
         but do not have a target materialization yet (since we don't set the target until the check is executed).
         """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_materialization_records(
+        self,
+        records_filter: Optional[Union[AssetKey, AssetRecordsFilter]] = None,
+        limit: int = 10000,
+        cursor: Optional[str] = None,
+        ascending: bool = False,
+    ) -> EventRecordsResult:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_observation_records(
+        self,
+        records_filter: Optional[Union[AssetKey, AssetRecordsFilter]] = None,
+        limit: Optional[int] = None,
+        cursor: Optional[str] = None,
+        ascending: bool = False,
+    ) -> EventRecordsResult:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_planned_materialization_records(
+        self,
+        records_filter: Optional[Union[AssetKey, AssetRecordsFilter]] = None,
+        limit: Optional[int] = None,
+        cursor: Optional[str] = None,
+        ascending: bool = False,
+    ) -> EventRecordsResult:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_run_status_change_event_records(
+        self,
+        records_filter: Union[DagsterEventType, RunStatusChangeEventFilter],
+        limit: Optional[int] = None,
+        cursor: Optional[str] = None,
+        ascending: bool = False,
+    ) -> EventRecordsResult:
         raise NotImplementedError()

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -38,8 +38,18 @@ from dagster._core.errors import (
     DagsterInvalidInvocationError,
     DagsterInvariantViolationError,
 )
-from dagster._core.event_api import RunShardedEventsCursor
-from dagster._core.events import ASSET_CHECK_EVENTS, ASSET_EVENTS, MARKER_EVENTS, DagsterEventType
+from dagster._core.event_api import (
+    EventRecordsResult,
+    RunShardedEventsCursor,
+    RunStatusChangeEventFilter,
+)
+from dagster._core.events import (
+    ASSET_CHECK_EVENTS,
+    ASSET_EVENTS,
+    EVENT_TYPE_TO_PIPELINE_RUN_STATUS,
+    MARKER_EVENTS,
+    DagsterEventType,
+)
 from dagster._core.events.log import EventLogEntry
 from dagster._core.execution.stats import RunStepKeyStatsSnapshot, build_run_step_stats_from_events
 from dagster._core.storage.asset_check_execution_record import (
@@ -74,6 +84,7 @@ from ..dagster_run import DagsterRunStatsSnapshot
 from .base import (
     AssetEntry,
     AssetRecord,
+    AssetRecordsFilter,
     EventLogConnection,
     EventLogCursor,
     EventLogRecord,
@@ -897,6 +908,16 @@ class SqlEventLogStorage(EventLogStorage):
         limit: Optional[int] = None,
         ascending: bool = False,
     ) -> Sequence[EventLogRecord]:
+        return self._get_event_records(
+            event_records_filter=event_records_filter, limit=limit, ascending=ascending
+        )
+
+    def _get_event_records(
+        self,
+        event_records_filter: EventRecordsFilter,
+        limit: Optional[int] = None,
+        ascending: bool = False,
+    ) -> Sequence[EventLogRecord]:
         """Returns a list of (record_id, record)."""
         check.inst_param(event_records_filter, "event_records_filter", EventRecordsFilter)
         check.opt_int_param(limit, "limit")
@@ -976,6 +997,145 @@ class SqlEventLogStorage(EventLogStorage):
     @property
     def supports_intersect(self) -> bool:
         return True
+
+    def _get_event_records_result(
+        self,
+        event_records_filter: EventRecordsFilter,
+        limit: int,
+        cursor: Optional[str],
+        ascending: bool,
+    ):
+        records = self._get_event_records(
+            event_records_filter=event_records_filter,
+            limit=limit,
+            ascending=ascending,
+        )
+        if records:
+            new_cursor = EventLogCursor.from_storage_id(records[-1].storage_id).to_string()
+        elif cursor:
+            new_cursor = cursor
+        else:
+            new_cursor = EventLogCursor.from_storage_id(-1).to_string()
+        has_more = len(records) == limit
+        return EventRecordsResult(records, cursor=new_cursor, has_more=has_more)
+
+    def get_materialization_records(
+        self,
+        records_filter: Optional[Union[AssetKey, AssetRecordsFilter]] = None,
+        limit: int = 10000,
+        cursor: Optional[str] = None,
+        ascending: bool = False,
+    ) -> EventRecordsResult:
+        if isinstance(records_filter, AssetRecordsFilter):
+            event_records_filter = records_filter.to_event_records_filter(
+                event_type=DagsterEventType.ASSET_MATERIALIZATION,
+                cursor=cursor,
+                ascending=ascending,
+            )
+        else:
+            before_cursor, after_cursor = EventRecordsFilter.get_cursor_params(cursor, ascending)
+            if isinstance(records_filter, AssetKey):
+                event_records_filter = EventRecordsFilter(
+                    event_type=DagsterEventType.ASSET_MATERIALIZATION,
+                    asset_key=records_filter,
+                    before_cursor=before_cursor,
+                    after_cursor=after_cursor,
+                )
+            else:
+                event_records_filter = EventRecordsFilter(
+                    event_type=DagsterEventType.ASSET_MATERIALIZATION,
+                    before_cursor=before_cursor,
+                    after_cursor=after_cursor,
+                )
+
+        return self._get_event_records_result(event_records_filter, limit, cursor, ascending)
+
+    def get_observation_records(
+        self,
+        records_filter: Optional[Union[AssetKey, AssetRecordsFilter]] = None,
+        limit: int = 10000,
+        cursor: Optional[str] = None,
+        ascending: bool = False,
+    ) -> EventRecordsResult:
+        if isinstance(records_filter, AssetRecordsFilter):
+            event_records_filter = records_filter.to_event_records_filter(
+                event_type=DagsterEventType.ASSET_OBSERVATION,
+                cursor=cursor,
+                ascending=ascending,
+            )
+        else:
+            before_cursor, after_cursor = EventRecordsFilter.get_cursor_params(cursor, ascending)
+            if isinstance(records_filter, AssetKey):
+                event_records_filter = EventRecordsFilter(
+                    event_type=DagsterEventType.ASSET_OBSERVATION,
+                    asset_key=records_filter,
+                    before_cursor=before_cursor,
+                    after_cursor=after_cursor,
+                )
+            else:
+                event_records_filter = EventRecordsFilter(
+                    event_type=DagsterEventType.ASSET_OBSERVATION,
+                    before_cursor=before_cursor,
+                    after_cursor=after_cursor,
+                )
+
+        return self._get_event_records_result(event_records_filter, limit, cursor, ascending)
+
+    def get_planned_materialization_records(
+        self,
+        records_filter: Optional[Union[AssetKey, AssetRecordsFilter]] = None,
+        limit: int = 10000,
+        cursor: Optional[str] = None,
+        ascending: bool = False,
+    ) -> EventRecordsResult:
+        if isinstance(records_filter, AssetRecordsFilter):
+            event_records_filter = records_filter.to_event_records_filter(
+                event_type=DagsterEventType.ASSET_MATERIALIZATION_PLANNED,
+                cursor=cursor,
+                ascending=ascending,
+            )
+        else:
+            before_cursor, after_cursor = EventRecordsFilter.get_cursor_params(cursor, ascending)
+            if isinstance(records_filter, AssetKey):
+                event_records_filter = EventRecordsFilter(
+                    event_type=DagsterEventType.ASSET_MATERIALIZATION_PLANNED,
+                    asset_key=records_filter,
+                    before_cursor=before_cursor,
+                    after_cursor=after_cursor,
+                )
+            else:
+                event_records_filter = EventRecordsFilter(
+                    event_type=DagsterEventType.ASSET_MATERIALIZATION_PLANNED,
+                    before_cursor=before_cursor,
+                    after_cursor=after_cursor,
+                )
+        return self._get_event_records_result(event_records_filter, limit, cursor, ascending)
+
+    def get_run_status_change_event_records(
+        self,
+        records_filter: Union[DagsterEventType, RunStatusChangeEventFilter],
+        limit: int = 10000,
+        cursor: Optional[str] = None,
+        ascending: bool = False,
+    ) -> EventRecordsResult:
+        event_type = (
+            records_filter
+            if isinstance(records_filter, DagsterEventType)
+            else records_filter.event_type
+        )
+        if event_type not in EVENT_TYPE_TO_PIPELINE_RUN_STATUS:
+            expected = ", ".join(EVENT_TYPE_TO_PIPELINE_RUN_STATUS.keys())
+            check.failed(f"Expected one of {expected}, received {event_type.value}")
+
+        before_cursor, after_cursor = EventRecordsFilter.get_cursor_params(cursor, ascending)
+        event_records_filter = (
+            records_filter.to_event_records_filter(cursor, ascending)
+            if isinstance(records_filter, RunStatusChangeEventFilter)
+            else EventRecordsFilter(
+                event_type, before_cursor=before_cursor, after_cursor=after_cursor
+            )
+        )
+        return self._get_event_records_result(event_records_filter, limit, cursor, ascending)
 
     def get_logs_for_all_runs_by_log_id(
         self,

--- a/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
@@ -25,7 +25,7 @@ from dagster._config.config_schema import UserConfigSchema
 from dagster._core.definitions.events import AssetKey
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.event_api import EventHandlerFn
-from dagster._core.events import ASSET_CHECK_EVENTS, ASSET_EVENTS
+from dagster._core.events import ASSET_CHECK_EVENTS, ASSET_EVENTS, EVENT_TYPE_TO_PIPELINE_RUN_STATUS
 from dagster._core.events.log import EventLogEntry
 from dagster._core.storage.dagster_run import DagsterRunStatus, RunsFilter
 from dagster._core.storage.event_log.base import EventLogCursor, EventLogRecord, EventRecordsFilter
@@ -263,6 +263,11 @@ class SqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
         if event.is_dagster_event and event.dagster_event_type in ASSET_CHECK_EVENTS:
             self.store_asset_check_event(event, None)
 
+        if event.is_dagster_event and event.dagster_event_type in EVENT_TYPE_TO_PIPELINE_RUN_STATUS:
+            # should mirror run status change events in the index shard
+            with self.index_connection() as conn:
+                result = conn.execute(insert_event_statement)
+
     def get_event_records(
         self,
         event_records_filter: EventRecordsFilter,
@@ -280,8 +285,8 @@ class SqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
 
         is_asset_query = event_records_filter and event_records_filter.event_type in ASSET_EVENTS
         if is_asset_query:
-            # asset materializations, observations and materialization planned events
-            # get mirrored into the index shard, so no custom run shard-aware cursor logic needed
+            # asset materializations, observations and materialization planned events get mirrored
+            # into the index shard, so no custom run shard-aware cursor logic needed
             return super(SqliteEventLogStorage, self).get_event_records(
                 event_records_filter=event_records_filter, limit=limit, ascending=ascending
             )

--- a/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
@@ -8,7 +8,7 @@ import threading
 import time
 from collections import defaultdict
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, ContextManager, Iterable, Iterator, Optional, Sequence
+from typing import TYPE_CHECKING, Any, ContextManager, Iterator, Optional, Sequence, Union
 
 import sqlalchemy as db
 import sqlalchemy.exc as db_exc
@@ -24,8 +24,13 @@ from dagster._config import StringSource
 from dagster._config.config_schema import UserConfigSchema
 from dagster._core.definitions.events import AssetKey
 from dagster._core.errors import DagsterInvariantViolationError
-from dagster._core.event_api import EventHandlerFn
-from dagster._core.events import ASSET_CHECK_EVENTS, ASSET_EVENTS, EVENT_TYPE_TO_PIPELINE_RUN_STATUS
+from dagster._core.event_api import EventHandlerFn, EventRecordsResult, RunStatusChangeEventFilter
+from dagster._core.events import (
+    ASSET_CHECK_EVENTS,
+    ASSET_EVENTS,
+    EVENT_TYPE_TO_PIPELINE_RUN_STATUS,
+    DagsterEventType,
+)
 from dagster._core.events.log import EventLogEntry
 from dagster._core.storage.dagster_run import DagsterRunStatus, RunsFilter
 from dagster._core.storage.event_log.base import EventLogCursor, EventLogRecord, EventRecordsFilter
@@ -266,14 +271,14 @@ class SqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
         if event.is_dagster_event and event.dagster_event_type in EVENT_TYPE_TO_PIPELINE_RUN_STATUS:
             # should mirror run status change events in the index shard
             with self.index_connection() as conn:
-                result = conn.execute(insert_event_statement)
+                conn.execute(insert_event_statement)
 
     def get_event_records(
         self,
         event_records_filter: EventRecordsFilter,
         limit: Optional[int] = None,
         ascending: bool = False,
-    ) -> Iterable[EventLogRecord]:
+    ) -> Sequence[EventLogRecord]:
         """Overridden method to enable cross-run event queries in sqlite.
 
         The record id in sqlite does not auto increment cross runs, so instead of fetching events
@@ -285,12 +290,22 @@ class SqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
 
         is_asset_query = event_records_filter and event_records_filter.event_type in ASSET_EVENTS
         if is_asset_query:
-            # asset materializations, observations and materialization planned events get mirrored
-            # into the index shard, so no custom run shard-aware cursor logic needed
+            # asset materializations, observations and materialization planned events
+            # get mirrored into the index shard, so no custom run shard-aware cursor logic needed
             return super(SqliteEventLogStorage, self).get_event_records(
                 event_records_filter=event_records_filter, limit=limit, ascending=ascending
             )
 
+        return self._get_run_sharded_event_records(
+            event_records_filter=event_records_filter, limit=limit, ascending=ascending
+        )
+
+    def _get_run_sharded_event_records(
+        self,
+        event_records_filter: EventRecordsFilter,
+        limit: Optional[int] = None,
+        ascending: bool = False,
+    ) -> Sequence[EventLogRecord]:
         query = db_select([SqlEventLogStorageTable.c.id, SqlEventLogStorageTable.c.event])
         if event_records_filter.asset_key:
             asset_details = next(iter(self._get_assets_details([event_records_filter.asset_key])))
@@ -358,6 +373,50 @@ class SqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
                 break
 
         return event_records[:limit]
+
+    def get_run_status_change_event_records(
+        self,
+        records_filter: Union[DagsterEventType, RunStatusChangeEventFilter],
+        limit: int = 10000,
+        cursor: Optional[str] = None,
+        ascending: bool = False,
+    ) -> EventRecordsResult:
+        # custom implementation of the run status change event query to only read from the index
+        # shard instead of from the run shards.  This bypasses the default Sqlite implementation of
+        # the deprecated _get_event_records method, which reads from the run shards, opting for the
+        # super implementation instead, which reads from the index shard
+        event_type = (
+            records_filter
+            if isinstance(records_filter, DagsterEventType)
+            else records_filter.event_type
+        )
+        if event_type not in EVENT_TYPE_TO_PIPELINE_RUN_STATUS:
+            expected = ", ".join(EVENT_TYPE_TO_PIPELINE_RUN_STATUS.keys())
+            check.failed(f"Expected one of {expected}, received {event_type.value}")
+
+        before_cursor, after_cursor = EventRecordsFilter.get_cursor_params(cursor, ascending)
+        event_records_filter = (
+            records_filter.to_event_records_filter(cursor, ascending)
+            if isinstance(records_filter, RunStatusChangeEventFilter)
+            else EventRecordsFilter(
+                event_type, before_cursor=before_cursor, after_cursor=after_cursor
+            )
+        )
+
+        # bypass the run-sharded cursor logic... any caller of this run status change specific
+        # method should be reading from the index shard, which as of 1.5.0 contains mirrored run
+        # status change events
+        records = super(SqliteEventLogStorage, self).get_event_records(
+            event_records_filter=event_records_filter, limit=limit, ascending=ascending
+        )
+        if records:
+            new_cursor = EventLogCursor.from_storage_id(records[-1].storage_id).to_string()
+        elif cursor:
+            new_cursor = cursor
+        else:
+            new_cursor = EventLogCursor.from_storage_id(-1).to_string()
+        has_more = len(records) == limit
+        return EventRecordsResult(records, cursor=new_cursor, has_more=has_more)
 
     def supports_event_consumer_queries(self) -> bool:
         return False

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -376,6 +376,9 @@ class LegacyEventLogStorage(EventLogStorage, ConfigurableClass):
     def _instance(self) -> Optional["DagsterInstance"]:
         return self._storage._instance  # noqa: SLF001
 
+    def index_connection(self):
+        return self._storage.event_log_storage.index_connection()
+
     def register_instance(self, instance: "DagsterInstance") -> None:
         if not self._storage.has_instance:
             self._storage.register_instance(instance)

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -30,12 +30,14 @@ from .event_log.base import (
     EventLogRecord,
     EventLogStorage,
     EventRecordsFilter,
+    EventRecordsResult,
 )
 from .runs.base import RunStorage
 from .schedules.base import ScheduleStorage
 
 if TYPE_CHECKING:
     from dagster._core.definitions.run_request import InstigatorType
+    from dagster._core.event_api import AssetRecordsFilter, RunStatusChangeEventFilter
     from dagster._core.events import DagsterEvent, DagsterEventType
     from dagster._core.events.log import EventLogEntry
     from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
@@ -449,6 +451,50 @@ class LegacyEventLogStorage(EventLogStorage, ConfigurableClass):
         # annotation is wrong.
         return self._storage.event_log_storage.get_event_records(
             event_records_filter, limit, ascending  # type: ignore
+        )
+
+    def get_materialization_records(
+        self,
+        filters: Optional[Union[AssetKey, "AssetRecordsFilter"]] = None,
+        limit: int = 10000,
+        cursor: Optional[str] = None,
+        ascending: bool = False,
+    ) -> EventRecordsResult:
+        return self._storage.event_log_storage.get_materialization_records(
+            filters, limit, cursor, ascending
+        )
+
+    def get_observation_records(
+        self,
+        filters: Optional[Union[AssetKey, "AssetRecordsFilter"]] = None,
+        limit: int = 10000,
+        cursor: Optional[str] = None,
+        ascending: bool = False,
+    ) -> EventRecordsResult:
+        return self._storage.event_log_storage.get_observation_records(
+            filters, limit, cursor, ascending
+        )
+
+    def get_planned_materialization_records(
+        self,
+        filters: Optional[Union[AssetKey, "AssetRecordsFilter"]] = None,
+        limit: int = 10000,
+        cursor: Optional[str] = None,
+        ascending: bool = False,
+    ) -> EventRecordsResult:
+        return self._storage.event_log_storage.get_planned_materialization_records(
+            filters, limit, cursor, ascending
+        )
+
+    def get_run_status_change_event_records(
+        self,
+        filters: Union["DagsterEventType", "RunStatusChangeEventFilter"],
+        limit: int = 10000,
+        cursor: Optional[str] = None,
+        ascending: bool = False,
+    ) -> EventRecordsResult:
+        return self._storage.event_log_storage.get_run_status_change_event_records(
+            filters, limit, cursor, ascending
         )
 
     def get_asset_records(

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
@@ -964,8 +964,8 @@ def test_partitions_multi_asset_sensor_context():
         assert sensor_data.run_requests[0].tags["dagster/partition"] == "2022-08-01"
         assert (
             ctx.cursor
-            == '{"AssetKey([\'daily_partitions_asset\'])": ["2022-08-01", 3, {}],'
-            ' "AssetKey([\'daily_partitions_asset_2\'])": ["2022-08-01", 4, {}]}'
+            == '{"AssetKey([\'daily_partitions_asset\'])": ["2022-08-01", 4, {}],'
+            ' "AssetKey([\'daily_partitions_asset_2\'])": ["2022-08-01", 5, {}]}'
         )
 
 

--- a/python_modules/dagster/dagster_tests/execution_tests/test_data_versions.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_data_versions.py
@@ -979,7 +979,7 @@ def test_legacy_data_version_tags():
         assert extract_data_provenance_from_entry(record.event_log_entry) == DataProvenance(
             code_version="1",
             input_data_versions={AssetKey(["foo"]): DataVersion("alpha")},
-            input_storage_ids={AssetKey(["foo"]): 3},
+            input_storage_ids={AssetKey(["foo"]): 4},
             is_user_provided=True,
         )
 

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -48,6 +48,7 @@ from dagster._core.definitions.multi_dimensional_partitions import MultiPartitio
 from dagster._core.definitions.unresolved_asset_job_definition import define_asset_job
 from dagster._core.errors import DagsterInvalidInvocationError
 from dagster._core.events import (
+    EVENT_TYPE_TO_PIPELINE_RUN_STATUS,
     AssetMaterializationPlannedData,
     AssetObservationData,
     DagsterEvent,
@@ -77,6 +78,7 @@ from dagster._core.storage.event_log.migration import (
     EVENT_LOG_DATA_MIGRATIONS,
     migrate_asset_key_data,
 )
+from dagster._core.storage.event_log.schema import SqlEventLogStorageTable
 from dagster._core.storage.event_log.sqlite.sqlite_event_log import SqliteEventLogStorage
 from dagster._core.storage.partition_status_cache import AssetStatusCacheValue
 from dagster._core.test_utils import create_run_for_test, instance_for_test
@@ -1495,6 +1497,20 @@ class TestEventLogStorage:
                         after_cursor=0,
                     ),
                 )
+
+            # check that events were double-written to the index shard
+            with storage.index_connection() as conn:
+                run_status_change_events = conn.execute(
+                    db.select([SqlEventLogStorageTable.c.id]).where(
+                        SqlEventLogStorageTable.c.dagster_event_type.in_(
+                            [
+                                event_type.value
+                                for event_type in EVENT_TYPE_TO_PIPELINE_RUN_STATUS.keys()
+                            ]
+                        )
+                    )
+                ).fetchall()
+                assert len(run_status_change_events) == 6
 
     # .watch() is async, there's a small chance they don't run before the asserts
     @pytest.mark.flaky(reruns=1)

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -47,6 +47,7 @@ from dagster._core.definitions.job_base import InMemoryJob
 from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionKey
 from dagster._core.definitions.unresolved_asset_job_definition import define_asset_job
 from dagster._core.errors import DagsterInvalidInvocationError
+from dagster._core.event_api import EventLogCursor, EventRecordsResult
 from dagster._core.events import (
     EVENT_TYPE_TO_PIPELINE_RUN_STATUS,
     AssetMaterializationPlannedData,
@@ -1014,6 +1015,7 @@ class TestEventLogStorage:
 
             assert asset_key in set(storage.all_asset_keys())
 
+            # legacy API
             records = storage.get_event_records(
                 EventRecordsFilter(
                     event_type=DagsterEventType.ASSET_MATERIALIZATION,
@@ -1024,6 +1026,14 @@ class TestEventLogStorage:
             record = records[0]
             assert isinstance(record, EventLogRecord)
             assert record.event_log_entry.dagster_event.asset_key == asset_key
+
+            # new API
+            result = storage.get_materialization_records(asset_key)
+            assert isinstance(result, EventRecordsResult)
+            assert len(result.records) == 1
+            record = result.records[0]
+            assert record.event_log_entry.dagster_event.asset_key == asset_key
+            assert result.cursor == EventLogCursor.from_storage_id(record.storage_id).to_string()
 
     def test_asset_materialization_null_key_fails(self):
         with pytest.raises(check.CheckError):
@@ -1361,6 +1371,71 @@ class TestEventLogStorage:
                     limit=2,
                 )
             ] == [record.storage_id for record in all_success_events[:2][::-1]]
+
+            assert set(_event_types([r.event_log_entry for r in all_success_events])) == {
+                DagsterEventType.RUN_SUCCESS
+            }
+
+    def test_get_run_status_change_events(self, storage, instance):
+        asset_key = AssetKey(["path", "to", "asset_one"])
+
+        @op
+        def materialize_one(_):
+            yield AssetMaterialization(
+                asset_key=asset_key,
+                metadata={
+                    "text": "hello",
+                    "json": {"hello": "world"},
+                    "one_float": 1.0,
+                    "one_int": 1,
+                },
+            )
+            yield Output(1)
+
+        def _ops():
+            materialize_one()
+
+        def _store_run_events(run_id):
+            events, _ = _synthesize_events(_ops, run_id=run_id)
+            for event in events:
+                storage.store_event(event)
+
+        # store events for three runs
+        [run_id_1, run_id_2, run_id_3] = [
+            make_new_run_id(),
+            make_new_run_id(),
+            make_new_run_id(),
+        ]
+
+        with create_and_delete_test_runs(instance, [run_id_1, run_id_2, run_id_3]):
+            _store_run_events(run_id_1)
+            _store_run_events(run_id_2)
+            _store_run_events(run_id_3)
+
+            all_success_events = storage.get_run_status_change_event_records(
+                DagsterEventType.RUN_SUCCESS
+            ).records
+            assert len(all_success_events) == 3
+            assert all_success_events[0].storage_id > all_success_events[2].storage_id
+            assert (
+                len(
+                    storage.get_run_status_change_event_records(
+                        DagsterEventType.RUN_SUCCESS,
+                        cursor=str(
+                            EventLogCursor.from_storage_id(all_success_events[1].storage_id)
+                        ),
+                    ).records
+                )
+                == 1
+            )
+            assert [
+                i.storage_id
+                for i in storage.get_run_status_change_event_records(
+                    DagsterEventType.RUN_SUCCESS,
+                    ascending=True,
+                    limit=2,
+                ).records
+            ] == [record.storage_id for record in all_success_events[::-1][:2]]
 
             assert set(_event_types([r.event_log_entry for r in all_success_events])) == {
                 DagsterEventType.RUN_SUCCESS
@@ -2688,6 +2763,7 @@ class TestEventLogStorage:
             for event in events_one:
                 storage.store_event(event)
 
+            # legacy API
             records = storage.get_event_records(
                 EventRecordsFilter(
                     event_type=DagsterEventType.ASSET_OBSERVATION,
@@ -2696,6 +2772,49 @@ class TestEventLogStorage:
             )
 
             assert len(records) == 1
+
+            # new API
+            result = storage.get_observation_records(a)
+            assert isinstance(result, EventRecordsResult)
+            assert len(result.records) == 1
+            record = result.records[0]
+            assert record.event_log_entry.dagster_event.asset_key == a
+            assert result.cursor == EventLogCursor.from_storage_id(record.storage_id).to_string()
+
+    def test_get_planned_materialization(self, storage, test_run_id):
+        a = AssetKey(["key_a"])
+
+        storage.store_event(
+            EventLogEntry(
+                error_info=None,
+                level="debug",
+                user_message="",
+                run_id=test_run_id,
+                timestamp=time.time(),
+                dagster_event=DagsterEvent(
+                    DagsterEventType.ASSET_MATERIALIZATION_PLANNED.value,
+                    "nonce",
+                    event_specific_data=AssetMaterializationPlannedData(a, "foo"),
+                ),
+            )
+        )
+
+        # legacy API
+        records = storage.get_event_records(
+            EventRecordsFilter(
+                event_type=DagsterEventType.ASSET_MATERIALIZATION_PLANNED,
+                asset_key=a,
+            )
+        )
+        assert len(records) == 1
+
+        # new API
+        result = storage.get_planned_materialization_records(a)
+        assert isinstance(result, EventRecordsResult)
+        assert len(result.records) == 1
+        record = result.records[0]
+        assert record.event_log_entry.dagster_event.asset_key == a
+        assert result.cursor == EventLogCursor.from_storage_id(record.storage_id).to_string()
 
     def test_asset_key_exists_on_observation(self, storage, instance):
         key = AssetKey("hello")

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -81,6 +81,7 @@ from dagster._core.storage.event_log.migration import (
 from dagster._core.storage.event_log.schema import SqlEventLogStorageTable
 from dagster._core.storage.event_log.sqlite.sqlite_event_log import SqliteEventLogStorage
 from dagster._core.storage.partition_status_cache import AssetStatusCacheValue
+from dagster._core.storage.sqlalchemy_compat import db_select
 from dagster._core.test_utils import create_run_for_test, instance_for_test
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._core.utils import make_new_run_id
@@ -1501,7 +1502,7 @@ class TestEventLogStorage:
             # check that events were double-written to the index shard
             with storage.index_connection() as conn:
                 run_status_change_events = conn.execute(
-                    db.select([SqlEventLogStorageTable.c.id]).where(
+                    db_select([SqlEventLogStorageTable.c.id]).where(
                         SqlEventLogStorageTable.c.dagster_event_type.in_(
                             [
                                 event_type.value


### PR DESCRIPTION
## Summary & Motivation
This is a breaking change in `1.5.0`... run status sensors on Sqlite are switching from timestamp-based cursors to storage id based cursors.  This should help with performance changes, but the initial ticks post-upgrade might miss some runs due to clock skew.

## How I Tested These Changes
BK