### PR TITLE
[dagster-pipes] fix issue with pipes + non-time-partitioned assets

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -1813,14 +1813,13 @@ def fetch_flattened_time_window_ranges(
 
 
 def has_one_dimension_time_window_partitioning(
-    partitions_def: PartitionsDefinition,
+    partitions_def: Optional[PartitionsDefinition],
 ) -> bool:
     from .multi_dimensional_partitions import MultiPartitionsDefinition
 
     if isinstance(partitions_def, TimeWindowPartitionsDefinition):
         return True
-
-    if isinstance(partitions_def, MultiPartitionsDefinition):
+    elif isinstance(partitions_def, MultiPartitionsDefinition):
         time_window_dims = [
             dim
             for dim in partitions_def.partitions_defs

--- a/python_modules/dagster/dagster/_core/pipes/context.py
+++ b/python_modules/dagster/dagster/_core/pipes/context.py
@@ -28,7 +28,10 @@ from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.metadata import MetadataValue, normalize_metadata_value
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
 from dagster._core.definitions.result import MaterializeResult
-from dagster._core.definitions.time_window_partitions import TimeWindow
+from dagster._core.definitions.time_window_partitions import (
+    TimeWindow,
+    has_one_dimension_time_window_partitioning,
+)
 from dagster._core.execution.context.compute import OpExecutionContext
 from dagster._core.execution.context.invocation import BoundOpExecutionContext
 from dagster._core.pipes.client import PipesMessageReader
@@ -266,8 +269,15 @@ def build_external_execution_context_data(
         else None
     )
     partition_key = context.partition_key if context.has_partition_key else None
-    partition_time_window = context.partition_time_window if context.has_partition_key else None
     partition_key_range = context.partition_key_range if context.has_partition_key else None
+    partition_time_window = (
+        context.partition_time_window
+        if context.has_partition_key
+        and has_one_dimension_time_window_partitioning(
+            context.get_step_execution_context().partitions_def
+        )
+        else None
+    )
     return PipesContextData(
         asset_keys=asset_keys,
         code_version_by_asset_key=code_version_by_asset_key,


### PR DESCRIPTION
## Summary & Motivation

Previously, if you attempted to use pipes with any non-time-partitioned asset (i.e. static or dynamic), you'd get an error when building the context, as `context.partition_time_window` would raise an error.

This PR makes sure we only call that in cases where it will not raise an error. A bit gross that we have to dig into the step execution context to get the partitions_def, but it is what it is.

## How I Tested These Changes

The new unit test failed before this change, passes now.
