### PR TITLE
[pipes k8s] add kubeconfig options

### DIFF
--- a/integration_tests/test_suites/k8s-test-suite/tests/test_pipes.py
+++ b/integration_tests/test_suites/k8s-test-suite/tests/test_pipes.py
@@ -46,7 +46,12 @@ def test_pipes_client(namespace, cluster_provider):
 
     result = materialize(
         [number_y],
-        resources={"pipes_client": PipesK8sClient()},
+        resources={
+            "pipes_client": PipesK8sClient(
+                load_incluster_config=False,
+                kubeconfig_file=cluster_provider.kubeconfig_file,
+            )
+        },
         raise_on_error=False,
     )
     assert result.success
@@ -156,7 +161,13 @@ def test_pipes_client_file_inject(namespace, cluster_provider):
 
     result = materialize(
         [number_y],
-        resources={"pipes_client": PipesK8sClient(context_injector=injector)},
+        resources={
+            "pipes_client": PipesK8sClient(
+                context_injector=injector,
+                load_incluster_config=False,
+                kubeconfig_file=cluster_provider.kubeconfig_file,
+            )
+        },
         raise_on_error=False,
     )
     assert result.success
@@ -204,7 +215,12 @@ def test_use_execute_k8s_job(namespace, cluster_provider):
 
     result = materialize(
         [number_y_job],
-        resources={"pipes_client": PipesK8sClient()},
+        resources={
+            "pipes_client": PipesK8sClient(
+                load_incluster_config=False,
+                kubeconfig_file=cluster_provider.kubeconfig_file,
+            )
+        },
         raise_on_error=False,
     )
     assert result.success

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
@@ -1,3 +1,4 @@
+import os
 import random
 import string
 from contextlib import contextmanager
@@ -101,6 +102,17 @@ class _PipesK8sClient(PipesClient):
             context into the k8s container process. Defaults to :py:class:`PipesEnvContextInjector`.
         message_reader (Optional[PipesMessageReader]): A message reader to use to read messages
             from the k8s container process. Defaults to :py:class:`PipesK8sPodLogsMessageReader`.
+        load_incluster_config (Optional[bool]): Whether this client is expected to be running from inside
+            a kubernetes cluster and should load config using ``kubernetes.config.load_incluster_config``.
+            Otherwise ``kubernetes.config.load_kube_config`` is used with the kubeconfig_file argument.
+            Default: None
+        kubeconfig_file (Optional[str]): The value to pass as the config_file argument to
+            ``kubernetes.config.load_kube_config``.
+            Default: None.
+        kube_context (Optional[str]): The value to pass as the context argument to
+            ``kubernetes.config.load_kube_config``.
+            Default: None.
+
     """
 
     def __init__(
@@ -108,6 +120,9 @@ class _PipesK8sClient(PipesClient):
         env: Optional[Mapping[str, str]] = None,
         context_injector: Optional[PipesContextInjector] = None,
         message_reader: Optional[PipesMessageReader] = None,
+        load_incluster_config: Optional[bool] = None,
+        kubeconfig_file: Optional[str] = None,
+        kube_context: Optional[str] = None,
     ):
         self.env = check.opt_mapping_param(env, "env", key_type=str, value_type=str)
         self.context_injector = (
@@ -118,15 +133,49 @@ class _PipesK8sClient(PipesClient):
             )
             or PipesEnvContextInjector()
         )
-
         self.message_reader = (
             check.opt_inst_param(message_reader, "message_reader", PipesMessageReader)
             or PipesK8sPodLogsMessageReader()
         )
 
+        if load_incluster_config:
+            check.invariant(
+                self.kube_context is None and self.kubeconfig_file is None,
+                "kubeconfig_file and kube_context should not be set when load_incluster_config is"
+                " True ",
+            )
+
+        self.load_incluster_config = check.opt_bool_param(
+            load_incluster_config, "load_incluster_config"
+        )
+        self.kubeconfig_file = check.opt_str_param(kubeconfig_file, "kubeconfig_file")
+        self.kube_context = check.opt_str_param(kube_context, "kube_context")
+
     @classmethod
     def _is_dagster_maintained(cls) -> bool:
         return True
+
+    def _load_k8s_config(self):
+        # when nothing is specified
+        if (
+            self.load_incluster_config is None
+            and self.kubeconfig_file is None
+            and self.kube_context is None
+        ):
+            # check for env var that is always set by kubernetes and if present use in cluster
+            if os.getenv("KUBERNETES_SERVICE_HOST"):
+                kubernetes.config.load_incluster_config()
+            # otherwise do default load
+            else:
+                kubernetes.config.load_kube_config()
+
+        elif self.load_incluster_config:
+            kubernetes.config.load_incluster_config()
+        else:
+            kubernetes.config.load_kube_config(
+                config_file=self.kubeconfig_file,
+                context=self.kube_context,
+            )
 
     def run(
         self,
@@ -171,6 +220,7 @@ class _PipesK8sClient(PipesClient):
             PipesClientCompletedInvocation: Wrapper containing results reported by the external
                 process.
         """
+        self._load_k8s_config()
         client = DagsterKubernetesClient.production_client()
 
         with open_pipes_session(


### PR DESCRIPTION
Add the same options we have on our other kubernetes APIs to control how we laod the config.

I started with the same set-up we use elsewhere in dagster k8s but also
* added support for kube_context 
* changed the default from incluster=True to an env var check that decides whether to default in cluster or load config. 

## How I Tested These Changes

existing tests