### PR TITLE
RFC: store run requests on the AMP tick

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
@@ -238,6 +238,7 @@ class GrapheneInstigationTick(graphene.ObjectType):
     logKey = graphene.List(graphene.NonNull(graphene.String))
     logEvents = graphene.Field(graphene.NonNull(GrapheneInstigationEventConnection))
     dynamicPartitionsRequestResults = non_null_list(GrapheneDynamicPartitionsRequestResult)
+    endTimestamp = graphene.Field(graphene.Float)
 
     class Meta:
         name = "InstigationTick"
@@ -255,6 +256,7 @@ class GrapheneInstigationTick(graphene.ObjectType):
             originRunIds=tick.origin_run_ids,
             cursor=tick.cursor,
             logKey=tick.log_key,
+            endTimestamp=tick.end_timestamp,
         )
 
     def resolve_id(self, _):

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -6,6 +6,7 @@ from typing import (
     Dict,
     List,
     Optional,
+    Sequence,
     Tuple,
     Type,
 )
@@ -103,6 +104,9 @@ class AutoMaterializeLaunchContext:
 
     def add_run_info(self, run_id=None):
         self._tick = self._tick.with_run_info(run_id)
+
+    def set_run_requests(self, run_requests: Sequence[RunRequest]):
+        self._tick = self._tick.with_run_requests(run_requests)
 
     def update_state(self, status: TickStatus, **kwargs: object):
         self._tick = self._tick.with_status(status=status, **kwargs)
@@ -277,6 +281,8 @@ class AssetDaemon(IntervalDaemon):
                         pipeline_and_execution_plan_cache,
                     )
                 )
+
+            tick_context.set_run_requests(run_requests=run_requests)
 
             # Now submit all runs to the queue
             for submit_job_input in submit_job_inputs:


### PR DESCRIPTION
Summary:
Two reasons to do this:
- allows us to determine the set of asset keys that were materialized by the tick
- in the future, we can use this for idempotency. What i'm imagining is:
  - AMP tick evaluation produces a list of run requests
  - We reserve run IDs for each of them and store the (run_id, run request) tuples on the tick
  - we then go through them one-by-one, create the actual run with that run ID and submit it to the queue

Then if we fail partway through, we can check to see if any of the reserved run IDs already exist to enforce idempotency. Hooray!

## Summary & Motivation

## How I Tested These Changes
