### PR TITLE
Show progress through asset graph in AMP log messages

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -453,12 +453,25 @@ class AssetDaemonContext:
         to_discard: Set[AssetKeyPartitionKey] = set()
         expected_data_time_mapping: Dict[AssetKey, Optional[datetime.datetime]] = defaultdict()
         visited_multi_asset_keys = set()
+
+        num_checked_assets = 0
+
+        num_target_asset_keys = len(self.target_asset_keys)
+
         for asset_key in itertools.chain(*self.asset_graph.toposort_asset_keys()):
             # an asset may have already been visited if it was part of a non-subsettable multi-asset
-            if asset_key not in self.target_asset_keys or asset_key in visited_multi_asset_keys:
+            if asset_key not in self.target_asset_keys:
                 continue
 
-            self._logger.debug(f"Evaluating asset {asset_key.to_user_string()}")
+            num_checked_assets = num_checked_assets + 1
+            self._logger.debug(
+                "Evaluating asset"
+                f" {asset_key.to_user_string()} ({num_checked_assets}/{num_target_asset_keys})"
+            )
+
+            if asset_key in visited_multi_asset_keys:
+                self._logger.debug(f"Asset {asset_key.to_user_string()} already visited")
+                continue
 
             (evaluation, to_materialize_for_asset, to_discard_for_asset) = self.evaluate_asset(
                 asset_key, will_materialize_mapping, expected_data_time_mapping


### PR DESCRIPTION
Summary:
Small quality of life improvement when reading logs so that you can tell how much progress it's made through a long tick.

Test Plan:
Run a dry run script, view log output

## Summary & Motivation

## How I Tested These Changes
