### PR TITLE
fix asset check key backcompat with step output props

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/plan/outputs.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/outputs.py
@@ -18,7 +18,7 @@ from .handle import UnresolvedStepHandle
 from .objects import TypeCheckData
 
 
-@whitelist_for_serdes
+@whitelist_for_serdes(storage_field_names={"asset_check_key": "asset_check_handle"})
 class StepOutputProperties(
     NamedTuple(
         "_StepOutputProperties",

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/__snapshots__/test_execution_plan.ambr
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/__snapshots__/test_execution_plan.ambr
@@ -36,7 +36,7 @@
             "name": "result",
             "properties": {
               "__class__": "StepOutputProperties",
-              "asset_check_key": null,
+              "asset_check_handle": null,
               "asset_key": null,
               "is_asset": false,
               "is_asset_partitioned": false,
@@ -108,7 +108,7 @@
             "name": "result",
             "properties": {
               "__class__": "StepOutputProperties",
-              "asset_check_key": null,
+              "asset_check_handle": null,
               "asset_key": null,
               "is_asset": false,
               "is_asset_partitioned": false,
@@ -176,7 +176,7 @@
             "name": "result",
             "properties": {
               "__class__": "StepOutputProperties",
-              "asset_check_key": null,
+              "asset_check_handle": null,
               "asset_key": null,
               "is_asset": false,
               "is_asset_partitioned": false,
@@ -255,7 +255,7 @@
             "name": "result",
             "properties": {
               "__class__": "StepOutputProperties",
-              "asset_check_key": null,
+              "asset_check_handle": null,
               "asset_key": null,
               "is_asset": false,
               "is_asset_partitioned": false,
@@ -389,7 +389,7 @@
             "name": "result",
             "properties": {
               "__class__": "StepOutputProperties",
-              "asset_check_key": null,
+              "asset_check_handle": null,
               "asset_key": null,
               "is_asset": false,
               "is_asset_partitioned": false,
@@ -461,7 +461,7 @@
             "name": "result",
             "properties": {
               "__class__": "StepOutputProperties",
-              "asset_check_key": null,
+              "asset_check_handle": null,
               "asset_key": null,
               "is_asset": false,
               "is_asset_partitioned": false,
@@ -511,7 +511,7 @@
             "name": "out_num",
             "properties": {
               "__class__": "StepOutputProperties",
-              "asset_check_key": null,
+              "asset_check_handle": null,
               "asset_key": null,
               "is_asset": false,
               "is_asset_partitioned": false,
@@ -591,7 +591,7 @@
             "name": "result",
             "properties": {
               "__class__": "StepOutputProperties",
-              "asset_check_key": null,
+              "asset_check_handle": null,
               "asset_key": null,
               "is_asset": false,
               "is_asset_partitioned": false,
@@ -641,7 +641,7 @@
             "name": "out_num",
             "properties": {
               "__class__": "StepOutputProperties",
-              "asset_check_key": null,
+              "asset_check_handle": null,
               "asset_key": null,
               "is_asset": false,
               "is_asset_partitioned": false,


### PR DESCRIPTION
Without this, checks won't work if user code <1.5 and host process >=1.5. It's tempting to not fix, because we're making the breaking `passed` change anyway. But that one is only an issue once you update user code- this would would break any cloud users as soon as we pushed the host cloud