### PR TITLE
[helm] Configurable postgres credential secret with username-password pair

### DIFF
--- a/docs/content/deployment/guides/kubernetes/customizing-your-deployment.mdx
+++ b/docs/content/deployment/guides/kubernetes/customizing-your-deployment.mdx
@@ -249,7 +249,7 @@ postgresql:
     port: 5432
 ```
 
-Supplying `.Values.postgresql.postgresqlPassword` will create a Kubernetes Secret with key `postgresql-password`, containing the encoded password. This secret is used to supply the Dagster infrastructure with an environment variable that's used when creating the storages for the Dagster instance.
+Supplying `.Values.postgresql.postgresqlUsername` and `.Values.postgresql.postgresqlPassword` will create a Kubernetes Secret with keys `postgresql-username` and `postgresql-password`, containing the encoded credentials. This secret is used to supply the Dagster infrastructure with environment variables that are used when creating the storages for the Dagster instance.
 
 If you use a secrets manager like [Vault](https://www.hashicorp.com/products/vault/kubernetes), it may be convenient to manage this Secret outside of the Dagster Helm chart. In this case, the generation of this Secret within the chart should be disabled, and `.Values.global.postgresqlSecretName` should be set to the name of the externally managed Secret.
 
@@ -258,6 +258,15 @@ global:
   postgresqlSecretName: "dagster-postgresql-secret"
 
 generatePostgresqlPasswordSecret: false
+```
+
+For situations where a database credential secret is created with keys other than `postgresql-username` and `postgresql-password`, these can be customized via the settings `global.postgresqlSecretUsernameKey` and `global.postgresqlSecretPasswordKey`. For example, the following configuration is compatible with the [Vault Database Secrets Backend](https://developer.hashicorp.com/vault/docs/secrets/databases):
+
+```yaml
+global:
+  postgresqlSecretName: dagster-postgresql-secret
+  postgresqlSecretUsernameKey: username
+  postgresqlSecretPasswordKey: password
 ```
 
 ---

--- a/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
@@ -49,11 +49,16 @@ spec:
           env:
             - name: DAGSTER_CURRENT_IMAGE
               value: {{ include "dagster.dagsterImage.name" (list $ $deployment.image) | quote }}
+            - name: DAGSTER_PG_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "dagsterUserDeployments.postgresql.secretName" $ }}
+                  key: {{ include "dagsterUserDeployments.postgresql.secretUsernameKey" $ }}
             - name: DAGSTER_PG_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "dagsterUserDeployments.postgresql.secretName" $ }}
-                  key: postgresql-password
+                  key: {{ include "dagsterUserDeployments.postgresql.secretPasswordKey" $ }}
             {{- $includeConfigInLaunchedRuns := $deployment.includeConfigInLaunchedRuns | default (dict "enabled" true) }}
             {{- if $includeConfigInLaunchedRuns.enabled }}
             {{- if $deployment.dagsterApiGrpcArgs }}

--- a/helm/dagster/charts/dagster-user-deployments/templates/helpers/_helpers.tpl
+++ b/helm/dagster/charts/dagster-user-deployments/templates/helpers/_helpers.tpl
@@ -79,6 +79,16 @@ Create the name of the service account to use
 {{- $global.postgresqlSecretName | default .Values.postgresqlSecretName }}
 {{- end -}}
 
+{{- define "dagsterUserDeployments.postgresql.secretUsernameKey" -}}
+{{- $global := .Values.global | default dict }}
+{{- $global.postgresqlSecretUsernameKey | default .Values.postgresqlSecretUsernameKey }}
+{{- end -}}
+
+{{- define "dagsterUserDeployments.postgresql.secretPasswordKey" -}}
+{{- $global := .Values.global | default dict }}
+{{- $global.postgresqlSecretPasswordKey | default .Values.postgresqlSecretPasswordKey }}
+{{- end -}}
+
 {{/*
 This environment shared across all User Code containers
 */}}

--- a/helm/dagster/charts/dagster-user-deployments/values.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/values.yaml
@@ -1,12 +1,16 @@
 ---
 global:
   postgresqlSecretName: ""
+  postgresqlSecretUsernameKey: ""
+  postgresqlSecretPasswordKey: ""
   dagsterHome: ""
   serviceAccountName: ""
   celeryConfigSecretName: ""
 
 dagsterHome: "/opt/dagster/dagster_home"
 postgresqlSecretName: "dagster-postgresql-secret"
+postgresqlSecretUsernameKey: "postgresql-username"
+postgresqlSecretPasswordKey: "postgresql-password"
 celeryConfigSecretName: "dagster-celery-config-secret"
 
 ####################################################################################################

--- a/helm/dagster/templates/deployment-daemon.yaml
+++ b/helm/dagster/templates/deployment-daemon.yaml
@@ -75,11 +75,16 @@ spec:
             "{{- template "dagster.dagsterDaemon.daemonCommand" . }}"
           ]
           env:
+            - name: DAGSTER_PG_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "dagster.postgresql.secretName" . | quote }}
+                  key: {{ .Values.global.postgresqlSecretUsernameKey | quote }}
             - name: DAGSTER_PG_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "dagster.postgresql.secretName" $ | quote }}
-                  key: postgresql-password
+                  name: {{ include "dagster.postgresql.secretName" . | quote }}
+                  key: {{ .Values.global.postgresqlSecretPasswordKey | quote }}
             - name: DAGSTER_DAEMON_HEARTBEAT_TOLERANCE
               value: "{{ .Values.dagsterDaemon.heartbeatTolerance }}"
             # This is a list by default, but for backcompat it can be a map. As a map it's written to the daemon-env

--- a/helm/dagster/templates/helpers/_deployment-webserver.tpl
+++ b/helm/dagster/templates/helpers/_deployment-webserver.tpl
@@ -77,7 +77,12 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "dagster.postgresql.secretName" . | quote }}
-                  key: postgresql-password
+                  key: {{ include "dagster.postgresql.secretPasswordKey" . | quote }}
+            - name: DAGSTER_PG_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "dagster.postgresql.secretName" . | quote }}
+                  key: {{ include "dagster.postgresql.secretUsernameKey" . | quote }}
             # This is a list by default, but for backcompat it can be a map. As
             # a map it's written to the webserver-env configmap.
             {{- if and ($_.Values.dagsterWebserver.env) (kindIs "slice" $_.Values.dagsterWebserver.env) }}

--- a/helm/dagster/templates/helpers/_deployment-webserver.tpl
+++ b/helm/dagster/templates/helpers/_deployment-webserver.tpl
@@ -73,16 +73,16 @@ spec:
             "{{ template "dagster.webserver.dagsterWebserverCommand" . }}"
           ]
           env:
-            - name: DAGSTER_PG_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "dagster.postgresql.secretName" . | quote }}
-                  key: {{ include "dagster.postgresql.secretPasswordKey" . | quote }}
             - name: DAGSTER_PG_USERNAME
               valueFrom:
                 secretKeyRef:
                   name: {{ include "dagster.postgresql.secretName" . | quote }}
-                  key: {{ include "dagster.postgresql.secretUsernameKey" . | quote }}
+                  key: {{ .Values.global.postgresqlSecretUsernameKey | quote }}
+            - name: DAGSTER_PG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "dagster.postgresql.secretName" . | quote }}
+                  key: {{ .Values.global.postgresqlSecretPasswordKey | quote }}
             # This is a list by default, but for backcompat it can be a map. As
             # a map it's written to the webserver-env configmap.
             {{- if and ($_.Values.dagsterWebserver.env) (kindIs "slice" $_.Values.dagsterWebserver.env) }}

--- a/helm/dagster/templates/helpers/instance/_postgresql.tpl
+++ b/helm/dagster/templates/helpers/instance/_postgresql.tpl
@@ -1,6 +1,7 @@
 {{- define "dagsterYaml.postgresql.config" }}
 postgres_db:
-  username: {{ .Values.postgresql.postgresqlUsername }}
+  username:
+    env: DAGSTER_PG_USERNAME
   password:
     env: DAGSTER_PG_PASSWORD
   hostname: {{ include "dagster.postgresql.host" . }}

--- a/helm/dagster/templates/job-instance-migrate.yaml
+++ b/helm/dagster/templates/job-instance-migrate.yaml
@@ -29,11 +29,16 @@ spec:
           command: ["dagster"]
           args: ["instance", "migrate"]
           env:
+            - name: DAGSTER_PG_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "dagster.postgresql.secretName" . | quote }}
+                  key: {{ .Values.global.postgresqlSecretUsernameKey | quote }}
             - name: DAGSTER_PG_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "dagster.postgresql.secretName" . | quote }}
-                  key: postgresql-password
+                  key: {{ .Values.global.postgresqlSecretPasswordKey | quote }}
           envFrom:
             - configMapRef:
                 name: {{ template "dagster.fullname" . }}-webserver-env

--- a/helm/dagster/templates/secret-postgres.yaml
+++ b/helm/dagster/templates/secret-postgres.yaml
@@ -11,6 +11,7 @@ metadata:
 type: Opaque
 data:
   {{- if not (empty .Values.postgresql) }}
-  postgresql-password: "{{ .Values.postgresql.postgresqlPassword | b64enc }}"
+  {{ .Values.global.postgresqlSecretUsernameKey }}: "{{ .Values.postgresql.postgresqlUsername | b64enc }}"
+  {{ .Values.global.postgresqlSecretPasswordKey }}: "{{ .Values.postgresql.postgresqlPassword | b64enc }}"
   {{- end }}
 {{ end }}

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -7,6 +7,8 @@
 ---
 global:
   postgresqlSecretName: "dagster-postgresql-secret"
+  postgresqlSecretUsernameKey: "postgresql-username"
+  postgresqlSecretPasswordKey: "postgresql-password"
   # The DAGSTER_HOME env var is set by default on all nodes from this value
   dagsterHome: "/opt/dagster/dagster_home"
 


### PR DESCRIPTION
## Summary & Motivation

Resolves https://github.com/dagster-io/dagster/issues/15023. Specifically, in [Customizing your Kubernetes Deployment](https://docs.dagster.io/deployment/guides/kubernetes/customizing-your-deployment), the following example is given:

> If you use a secrets manager like [Vault](https://www.hashicorp.com/products/vault/kubernetes), it may be convenient to manage this Secret outside of the Dagster Helm chart. In this case, the generation of this Secret within the chart should be disabled, and .Values.global.postgresqlSecretName should be set to the name of the externally managed Secret.

However, this only works in the case of a static username and manually created secret that matches the specific secret key that Dagster expects. This does not work well with dynamically generated credential scenarios. For example, the [Vault Database Secrets Engine](https://developer.hashicorp.com/vault/docs/secrets/databases) generates a dynamic username-password pair and stores them in the secret keys `username` and `password`.

This PR updates the Helm charts `dagster` and `dagster-user-deployments` to expect (or generate) a secret with both a username and password. By default, the keys are `postgresql-username` and `postgresql-password`, but these keys can be customized by changing `global.postgresqlSecretUsernameKey` and `global.postgresqlSecretPasswordKey`.

### Open questions before merging

- Can this be made backward compatible with existing manually created secrets that only contain `postgresql-password`?
- Should the default keys be changed to `username` and `password` to enable this to work out-of-the-box with Vault with fewer config changes?

## How I Tested These Changes

Packaged the Helm chart and deployed it on my private project via OCI, with the following `values.yaml` changes:

```yaml
global:
  postgresqlSecretName: dagster-postgresql-secret
  postgresqlSecretUsernameKey: username
  postgresqlSecretPasswordKey: password
generatePostgresqlPasswordSecret: false
```

Used the Vault Database Secrets Engine and [Vault Secrets Operator](https://developer.hashicorp.com/vault/docs/platform/k8s/vso) to automatically populate the secret.