### PR TITLE
[AssetLiveDataProvider] Fix listening to in progress runs

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetLiveDataProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetLiveDataProvider.tsx
@@ -193,7 +193,7 @@ export const AssetLiveDataProvider = ({children}: {children: React.ReactNode}) =
   React.useEffect(() => {
     const assetKeyTokens = new Set(allObservedKeys.map(tokenForAssetKey));
     const dataForObservedKeys = allObservedKeys
-      .map((key) => cache[tokenForAssetKey(key)])
+      .map((key) => cache[JSON.stringify(key.path)])
       .filter((n) => n) as LiveDataForNode[];
 
     const assetStepKeys = new Set(dataForObservedKeys.flatMap((n) => n.opNames));


### PR DESCRIPTION
## Summary & Motivation

Fixes a bug where updating asset node data automatically when a Run completes wouldn't happen

## How I Tested These Changes
Loaded the asset-graph, materialized an asset and saw that the data update immediately once the run completed