### PR TITLE
[dagster-azure] Override make_directory from UPathIOManager in PickledObjectADLS2IOManager

### DIFF
--- a/python_modules/libraries/dagster-azure/dagster_azure/adls2/io_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/adls2/io_manager.py
@@ -62,6 +62,10 @@ class PickledObjectADLS2IOManager(UPathIOManager):
         with self._acquire_lease(file_client, is_rm=True) as lease:
             file_client.delete_file(lease=lease, recursive=True)
 
+    def make_directory(self, path: UPath) -> None:
+        # It is not necessary to create directories in S3
+        return None
+    
     def path_exists(self, path: UPath) -> bool:
         try:
             self.file_system_client.get_file_client(str(path)).get_file_properties()


### PR DESCRIPTION
## Summary & Motivation

The `PickledObjectADLS2IOManager` in `dagster-azure` doesn't override the `make_directory` function from its base class `UPathIOManager`. This becomes an issue when dealing with Azure Blob Storage as a file system, as it doesn't support direct directory creation. Even though the inputs and outputs are being stored and read correctly, when saving outputs, a local folder is generated. This could potentially cause problems with permissions, especially when running in a Kubernetes environment, where creating a folder locally poses issues.

## How I Tested These Changes

Pipeline with adls2_io_manager was executed. Newly implemented method was called instead of base class.  
