### PR TITLE
[pipes] few renames

### DIFF
--- a/python_modules/dagster-pipes/dagster_pipes/__init__.py
+++ b/python_modules/dagster-pipes/dagster_pipes/__init__.py
@@ -582,10 +582,10 @@ class PipesS3MessageWriter(PipesBlobStoreMessageWriter):
     def make_channel(
         self,
         params: PipesParams,
-    ) -> "PipesS3MessageChannel":
+    ) -> "PipesS3MessageWriterChannel":
         bucket = _assert_env_param_type(params, "bucket", str, self.__class__)
         key_prefix = _assert_opt_env_param_type(params, "key_prefix", str, self.__class__)
-        return PipesS3MessageChannel(
+        return PipesS3MessageWriterChannel(
             client=self._client,
             bucket=bucket,
             key_prefix=key_prefix,
@@ -593,7 +593,7 @@ class PipesS3MessageWriter(PipesBlobStoreMessageWriter):
         )
 
 
-class PipesS3MessageChannel(PipesBlobStoreMessageWriterChannel):
+class PipesS3MessageWriterChannel(PipesBlobStoreMessageWriterChannel):
     # client is a boto3.client("s3") object
     def __init__(
         self, client: Any, bucket: str, key_prefix: Optional[str], *, interval: float = 10

--- a/python_modules/dagster/dagster/_core/errors.py
+++ b/python_modules/dagster/dagster/_core/errors.py
@@ -672,5 +672,5 @@ class DagsterDefinitionChangedDeserializationError(DagsterError):
     """
 
 
-class DagsterExternalExecutionError(DagsterError):
+class DagsterPipesExecutionError(DagsterError):
     """Indicates that an error occurred during the execution of an external process."""

--- a/python_modules/dagster/dagster/_core/pipes/subprocess.py
+++ b/python_modules/dagster/dagster/_core/pipes/subprocess.py
@@ -6,7 +6,7 @@ from dagster_pipes import PipesExtras
 from dagster import _check as check
 from dagster._annotations import experimental, public
 from dagster._core.definitions.resource_annotation import ResourceParam
-from dagster._core.errors import DagsterExternalExecutionError
+from dagster._core.errors import DagsterPipesExecutionError
 from dagster._core.execution.context.compute import OpExecutionContext
 from dagster._core.pipes.client import (
     PipesClient,
@@ -105,7 +105,7 @@ class _PipesSubprocess(PipesClient):
                 yield from pipes_session.get_results()
 
             if process.returncode != 0:
-                raise DagsterExternalExecutionError(
+                raise DagsterPipesExecutionError(
                     f"External execution process failed with code {process.returncode}"
                 )
         yield from pipes_session.get_results()

--- a/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_subprocess.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_subprocess.py
@@ -33,7 +33,7 @@ from dagster._core.definitions.metadata import (
     UrlMetadataValue,
 )
 from dagster._core.definitions.partition import DynamicPartitionsDefinition
-from dagster._core.errors import DagsterExternalExecutionError, DagsterInvariantViolationError
+from dagster._core.errors import DagsterInvariantViolationError, DagsterPipesExecutionError
 from dagster._core.execution.context.compute import AssetExecutionContext, OpExecutionContext
 from dagster._core.execution.context.invocation import build_asset_context
 from dagster._core.instance_for_test import instance_for_test
@@ -331,7 +331,7 @@ def test_ext_asset_failed():
             cmd = [_PYTHON_EXECUTABLE, script_path]
             yield from pipes_subprocess_client.run(cmd, context=context)
 
-    with pytest.raises(DagsterExternalExecutionError):
+    with pytest.raises(DagsterPipesExecutionError):
         materialize([foo], resources={"pipes_subprocess_client": PipesSubprocessClient()})
 
 

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
@@ -10,7 +10,7 @@ from typing import Iterator, Mapping, Optional
 import dagster._check as check
 from dagster._annotations import experimental
 from dagster._core.definitions.resource_annotation import ResourceParam
-from dagster._core.errors import DagsterExternalExecutionError
+from dagster._core.errors import DagsterPipesExecutionError
 from dagster._core.execution.context.compute import OpExecutionContext
 from dagster._core.pipes.client import (
     PipesClient,
@@ -126,11 +126,11 @@ class _PipesDatabricksClient(PipesClient):
                     if run.state.result_state == jobs.RunResultState.SUCCESS:
                         break
                     else:
-                        raise DagsterExternalExecutionError(
+                        raise DagsterPipesExecutionError(
                             f"Error running Databricks job: {run.state.state_message}"
                         )
                 elif run.state.life_cycle_state == jobs.RunLifeCycleState.INTERNAL_ERROR:
-                    raise DagsterExternalExecutionError(
+                    raise DagsterPipesExecutionError(
                         f"Error running Databricks job: {run.state.state_message}"
                     )
                 yield from pipes_session.get_results()

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_pipes.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_pipes.py
@@ -7,7 +7,7 @@ from typing import Any, Callable, Iterator
 
 import pytest
 from dagster import AssetExecutionContext, asset, materialize
-from dagster._core.errors import DagsterExternalExecutionError
+from dagster._core.errors import DagsterPipesExecutionError
 from dagster_databricks.pipes import PipesDatabricksClient, dbfs_tempdir
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.service import files, jobs
@@ -113,7 +113,7 @@ def test_nonexistent_entry_point(client: WorkspaceClient):
         task = _make_submit_task("/fake/fake")
         pipes_databricks_client.run(task=task, context=context)
 
-    with pytest.raises(DagsterExternalExecutionError, match=r"Cannot read the python file"):
+    with pytest.raises(DagsterPipesExecutionError, match=r"Cannot read the python file"):
         materialize(
             [fake],
             resources={"pipes_databricks_client": PipesDatabricksClient(client)},


### PR DESCRIPTION
## Summary & Motivation

Two symbol renames:

- PipesS3MessageChannel -> PipesS3MessageWriterChannel
- DagsterExternalExecutionError -> DagsterPipesExecutionError

## How I Tested These Changes

Existing test suite.