### PR TITLE
[ui] Show edges of selected nodes in blue on the asset graph

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetEdges.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetEdges.tsx
@@ -6,11 +6,19 @@ import {AssetLayoutEdge} from './layout';
 
 export const AssetEdges: React.FC<{
   edges: AssetLayoutEdge[];
+  selected: string[] | null;
   highlighted: string | null;
   strokeWidth?: number;
   baseColor?: string;
   viewportRect: {top: number; left: number; right: number; bottom: number};
-}> = ({edges, highlighted, strokeWidth = 4, baseColor = Colors.KeylineGray, viewportRect}) => {
+}> = ({
+  edges,
+  selected,
+  highlighted,
+  strokeWidth = 4,
+  baseColor = Colors.KeylineGray,
+  viewportRect,
+}) => {
   // Note: we render the highlighted edges twice, but it's so that the first item with
   // all the edges in it can remain memoized.
 
@@ -29,12 +37,16 @@ export const AssetEdges: React.FC<{
         viewportRect={viewportRect}
       />
       <AssetEdgeSet
-        viewportRect={viewportRect}
         color={Colors.Blue500}
-        edges={intersectedEdges.filter(
-          ({fromId, toId}) => highlighted === fromId || highlighted === toId,
+        edges={edges.filter(
+          ({fromId, toId}) =>
+            selected?.includes(fromId) ||
+            selected?.includes(toId) ||
+            highlighted === fromId ||
+            highlighted === toId,
         )}
         strokeWidth={strokeWidth}
+        viewportRect={viewportRect}
       />
     </React.Fragment>
   );

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -331,6 +331,7 @@ const AssetGraphExplorerWithData: React.FC<WithDataProps> = ({
                 <SVGContainer width={layout.width} height={layout.height}>
                   <AssetEdges
                     viewportRect={viewportRect}
+                    selected={selectedGraphNodes.map((n) => n.id)}
                     highlighted={highlighted}
                     edges={layout.edges}
                     strokeWidth={allowGroupsOnlyZoomLevel ? Math.max(4, 3 / scale) : 4}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeLineageGraph.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeLineageGraph.tsx
@@ -72,7 +72,12 @@ export const AssetNodeLineageGraph: React.FC<{
       {({scale}, viewportRect) => (
         <SVGContainer width={layout.width} height={layout.height}>
           {viewportEl.current && <SVGSaveZoomLevel scale={scale} />}
-          <AssetEdges highlighted={highlighted} edges={layout.edges} viewportRect={viewportRect} />
+          <AssetEdges
+            selected={null}
+            highlighted={highlighted}
+            edges={layout.edges}
+            viewportRect={viewportRect}
+          />
 
           {Object.values(layout.groups)
             .sort((a, b) => a.id.length - b.id.length)


### PR DESCRIPTION
## Summary & Motivation

This is a small change we've been discussing in asset graph improvements threads:

When assets are selected, show their edges in blue (and do not hide them if they go offscreen) so that it's easier to follow the lines by panning around the graph.

<img width="1728" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/8b548ffd-1b76-4a73-a91f-907111a5b26e">

<img width="1022" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/ccb97a39-ba04-4568-b005-0a4c418630cd">

## How I Tested These Changes
Selecting / panning / zooming both asset and op graphs (they behave the same way) 
