### PR TITLE
interpret MaterializeResult return type annotation as Nothing

### DIFF
--- a/python_modules/dagster/dagster/_core/types/dagster_type.py
+++ b/python_modules/dagster/dagster/_core/types/dagster_type.py
@@ -873,6 +873,9 @@ def resolve_dagster_type(dagster_type: object) -> DagsterType:
         type_args = get_args(dynamic_out_annotation)
         dagster_type = type_args[0] if len(type_args) == 1 else Any
     elif dagster_type == MaterializeResult:
+        # convert MaterializeResult type annotation to Nothing until returning
+        # scalar values via MaterializeResult is supported
+        # https://github.com/dagster-io/dagster/issues/16887
         dagster_type = Nothing
 
     # Then, check to see if it is part of python's typing library

--- a/python_modules/dagster/dagster/_core/types/dagster_type.py
+++ b/python_modules/dagster/dagster/_core/types/dagster_type.py
@@ -840,6 +840,7 @@ def resolve_dagster_type(dagster_type: object) -> DagsterType:
     # circular dep
     from dagster._utils.typing_api import is_typing_type
 
+    from ..definitions.result import MaterializeResult
     from .primitive_mapping import (
         is_supported_runtime_python_builtin,
         remap_python_builtin_for_runtime,
@@ -871,6 +872,8 @@ def resolve_dagster_type(dagster_type: object) -> DagsterType:
         dynamic_out_annotation = get_args(dagster_type)[0]
         type_args = get_args(dynamic_out_annotation)
         dagster_type = type_args[0] if len(type_args) == 1 else Any
+    elif dagster_type == MaterializeResult:
+        dagster_type = Nothing
 
     # Then, check to see if it is part of python's typing library
     if is_typing_type(dagster_type):

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -1,7 +1,7 @@
 import ast
 import datetime
 import tempfile
-from typing import Sequence
+from typing import Sequence, Tuple
 
 import pytest
 from dagster import (
@@ -1844,6 +1844,52 @@ def test_return_materialization_multi_asset():
         ),
     ):
         _exec_asset(ret_list)
+
+
+def test_materialize_result_output_typing():
+    # Test that the return annotation MaterializeResult is interpreted as a Nothing type, since we
+    # coerce returned MaterializeResults to Output(None)
+
+    class TestingIOManager(IOManager):
+        def handle_output(self, context, obj):
+            assert context.dagster_type.is_nothing
+            return None
+
+        def load_input(self, context):
+            return 1
+
+    @asset
+    def asset_with_type_annotation() -> MaterializeResult:
+        return MaterializeResult(metadata={"foo": "bar"})
+
+    assert materialize(
+        [asset_with_type_annotation], resources={"io_manager": TestingIOManager()}
+    ).success
+
+    @multi_asset(outs={"one": AssetOut(), "two": AssetOut()})
+    def multi_asset_with_outs_and_type_annotation() -> Tuple[MaterializeResult, MaterializeResult]:
+        return MaterializeResult(asset_key="one"), MaterializeResult(asset_key="two")
+
+    assert materialize(
+        [multi_asset_with_outs_and_type_annotation], resources={"io_manager": TestingIOManager()}
+    ).success
+
+    @multi_asset(specs=[AssetSpec("one"), AssetSpec("two")])
+    def multi_asset_with_specs_and_type_annotation() -> Tuple[MaterializeResult, MaterializeResult]:
+        return MaterializeResult(asset_key="one"), MaterializeResult(asset_key="two")
+
+    assert materialize(
+        [multi_asset_with_specs_and_type_annotation], resources={"io_manager": TestingIOManager()}
+    ).success
+
+    @multi_asset(specs=[AssetSpec("one"), AssetSpec("two")])
+    def multi_asset_with_specs_and_no_type_annotation():
+        return MaterializeResult(asset_key="one"), MaterializeResult(asset_key="two")
+
+    assert materialize(
+        [multi_asset_with_specs_and_no_type_annotation],
+        resources={"io_manager": TestingIOManager()},
+    ).success
 
 
 def test_multi_asset_no_out():


### PR DESCRIPTION
## Summary & Motivation
Before if you wrote this asset 
```python
@asset 
def my_asset() -> MaterializeResult:
   return MaterializeResult(metadata={"foo":"bar"})
```
you would get a type error 
```
dagster._core.errors.DagsterTypeCheckDidNotPass: Type check failed for step output "result" - expected type "MaterializeResult". Description: Value of type <class 'NoneType'> failed type check for Dagster type MaterializeResult, expected value to be of Python type dagster._core.definitions.result.MaterializeResult.
```

This is because we coerce returned `MaterializeResult`s to `Output(None)` but we do not update the expected return type.

This PR interprets the return type annotation `MaterializeResult` as a `Nothing` return type annotation. This will also allow the IO managers to skip storing `MaterializeResult`


This PR does not address when no type annotation is given. The asset 
```python
@asset 
def my_asset():
   return MaterializeResult(metadata={"foo":"bar"})
```
will get the implied return type `Any`, which means the IO managers may try to store the `MaterializeResult` type. I think we can add special logic to skip IO manager invocation when the return value is a `MaterializeResult` but that will need to be explored in another PR 

## How I Tested These Changes
