### PR TITLE
revert AssetCheckKey backcompat serdes

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_check_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_spec.py
@@ -28,7 +28,7 @@ class AssetCheckSeverity(Enum):
 
 
 @experimental
-@whitelist_for_serdes(storage_name="AssetCheckHandle")
+@whitelist_for_serdes(old_storage_names={"AssetCheckHandle"})
 class AssetCheckKey(NamedTuple):
     """Check names are expected to be unique per-asset. Thus, this combination of asset key and
     check name uniquely identifies an asset check within a deployment.

--- a/python_modules/dagster/dagster/_core/execution/plan/outputs.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/outputs.py
@@ -18,7 +18,7 @@ from .handle import UnresolvedStepHandle
 from .objects import TypeCheckData
 
 
-@whitelist_for_serdes(storage_field_names={"asset_check_key": "asset_check_handle"})
+@whitelist_for_serdes
 class StepOutputProperties(
     NamedTuple(
         "_StepOutputProperties",

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/__snapshots__/test_execution_plan.ambr
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/__snapshots__/test_execution_plan.ambr
@@ -36,7 +36,7 @@
             "name": "result",
             "properties": {
               "__class__": "StepOutputProperties",
-              "asset_check_handle": null,
+              "asset_check_key": null,
               "asset_key": null,
               "is_asset": false,
               "is_asset_partitioned": false,
@@ -108,7 +108,7 @@
             "name": "result",
             "properties": {
               "__class__": "StepOutputProperties",
-              "asset_check_handle": null,
+              "asset_check_key": null,
               "asset_key": null,
               "is_asset": false,
               "is_asset_partitioned": false,
@@ -176,7 +176,7 @@
             "name": "result",
             "properties": {
               "__class__": "StepOutputProperties",
-              "asset_check_handle": null,
+              "asset_check_key": null,
               "asset_key": null,
               "is_asset": false,
               "is_asset_partitioned": false,
@@ -255,7 +255,7 @@
             "name": "result",
             "properties": {
               "__class__": "StepOutputProperties",
-              "asset_check_handle": null,
+              "asset_check_key": null,
               "asset_key": null,
               "is_asset": false,
               "is_asset_partitioned": false,
@@ -389,7 +389,7 @@
             "name": "result",
             "properties": {
               "__class__": "StepOutputProperties",
-              "asset_check_handle": null,
+              "asset_check_key": null,
               "asset_key": null,
               "is_asset": false,
               "is_asset_partitioned": false,
@@ -461,7 +461,7 @@
             "name": "result",
             "properties": {
               "__class__": "StepOutputProperties",
-              "asset_check_handle": null,
+              "asset_check_key": null,
               "asset_key": null,
               "is_asset": false,
               "is_asset_partitioned": false,
@@ -511,7 +511,7 @@
             "name": "out_num",
             "properties": {
               "__class__": "StepOutputProperties",
-              "asset_check_handle": null,
+              "asset_check_key": null,
               "asset_key": null,
               "is_asset": false,
               "is_asset_partitioned": false,
@@ -591,7 +591,7 @@
             "name": "result",
             "properties": {
               "__class__": "StepOutputProperties",
-              "asset_check_handle": null,
+              "asset_check_key": null,
               "asset_key": null,
               "is_asset": false,
               "is_asset_partitioned": false,
@@ -641,7 +641,7 @@
             "name": "out_num",
             "properties": {
               "__class__": "StepOutputProperties",
-              "asset_check_handle": null,
+              "asset_check_key": null,
               "asset_key": null,
               "is_asset": false,
               "is_asset_partitioned": false,


### PR DESCRIPTION
https://dagsterlabs.slack.com/archives/C05KFG9TETB/p1695924264975479

For the 1.5 release, we've decided to make the internal AssetCheckHandle -> AssetCheckKey rename breaking.

If we don't do this, we'd need to have backcompat handling for deserialization of AssetCheckKeys forever (or drop support for checks on 1.5.0). This is undesirable because AssetCheckKey is a public api.

```python
@whitelist_for_serdes(old_storage_names={"AssetCheckHandle"})
class AssetCheckKey(NamedTuple):
```

---

The implication of this change is that any checks running on dagster 1.4 won't work with dagster cloud, or dagster-ui + daemon on 1.5.