### PR TITLE
[Asset graph] Simplify layout cache

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/package.json
+++ b/js_modules/dagster-ui/packages/ui-core/package.json
@@ -51,6 +51,7 @@
     "fuse.js": "^6.4.2",
     "graphql": "^16.8.1",
     "highlight.js": "11.6.0",
+    "idb-lru-cache": "^0.1.0",
     "lodash": "^4.17.15",
     "lru-cache": "^6.0.0",
     "moment": "^2.29.4",

--- a/js_modules/dagster-ui/packages/ui-core/src/app/Util.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/Util.tsx
@@ -1,3 +1,4 @@
+import {cache} from 'idb-lru-cache';
 import memoize from 'lodash/memoize';
 import LRU from 'lru-cache';
 
@@ -148,71 +149,31 @@ export function asyncMemoize<T, R, U extends (arg: T, ...rest: any[]) => Promise
   }) as any;
 }
 
-export function indexedDBAsyncMemoize<
-  T,
-  R,
-  U extends (cacheKey: string, versionKey: string, arg: T, ...rest: any[]) => Promise<R>,
->(fn: U, hashFn?: (arg: T, ...rest: any[]) => any): U {
-  return (async (cacheKey: string, versionKey: string, arg: T, ...rest: any[]) => {
-    const dbName = 'IndexedDBAsyncMemoizeDB';
-    const storeName = 'memoizedValues';
+export function indexedDBAsyncMemoize<T, R, U extends (arg: T, ...rest: any[]) => Promise<R>>(
+  fn: U,
+  hashFn?: (arg: T, ...rest: any[]) => any,
+): U {
+  const lru = cache<string, R>({
+    dbName: 'indexDBAsyncMemoizeDB',
+    maxCount: 50,
+  });
+  return (async (arg: T, ...rest: any[]) => {
     const hashKey = hashFn ? hashFn(arg, ...rest) : arg;
 
     return new Promise<R>(async (resolve) => {
-      async function computeAndStoreLayout() {
-        const result = await fn(cacheKey, versionKey, arg, ...rest);
-        // Resolve the promise before storing the result in IndexedDB
-        resolve(result);
-
-        const request = indexedDB.open(dbName);
-        request.onsuccess = () => {
-          const db = request.result;
-          const transaction = db.transaction([storeName], 'readwrite');
-          const store = transaction.objectStore(storeName);
-          const key = cacheKey;
-          const data = {
-            version: versionKey,
-            [hashKey]: result,
-          };
-          store.put(data, key);
-        };
+      if (await lru.has(hashKey)) {
+        const {value} = await lru.get(hashKey);
+        resolve(value);
+        return;
       }
 
-      try {
-        const request = indexedDB.open(dbName);
-        request.onerror = () => {
-          computeAndStoreLayout();
-        };
-        request.onsuccess = () => {
-          const db = request.result;
-          const transaction = db.transaction([storeName], 'readwrite');
-          const store = transaction.objectStore(storeName);
-
-          const key = cacheKey;
-          const requestGet = store.get(key);
-          requestGet.onerror = function () {
-            computeAndStoreLayout();
-          };
-          requestGet.onsuccess = () => {
-            const cachedData = requestGet.result;
-            if (cachedData && cachedData.version === versionKey && cachedData[hashKey]) {
-              resolve(cachedData[hashKey]);
-            } else {
-              computeAndStoreLayout();
-            }
-          };
-        };
-
-        request.onupgradeneeded = function () {
-          const db = request.result;
-          if (!db.objectStoreNames.contains(storeName)) {
-            db.createObjectStore(storeName);
-          }
-          computeAndStoreLayout();
-        };
-      } catch (error) {
-        computeAndStoreLayout();
-      }
+      const result = await fn(arg, ...rest);
+      // Resolve the promise before storing the result in IndexedDB
+      resolve(result);
+      await lru.set(hashKey, result, {
+        // Some day in the year 2050...
+        expiry: new Date(9 ** 13),
+      });
     });
   }) as any;
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetLiveDataProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetLiveDataProvider.tsx
@@ -312,10 +312,7 @@ function _determineAssetsToFetch() {
   const assetsToFetch: AssetKeyInput[] = [];
   const assetsWithoutData: AssetKeyInput[] = [];
   const allKeys = Object.keys(_assetKeyListeners);
-  while (
-    allKeys.length &&
-    (assetsToFetch.length < BATCH_SIZE || assetsWithoutData.length < BATCH_SIZE)
-  ) {
+  while (allKeys.length && assetsWithoutData.length < BATCH_SIZE) {
     const key = allKeys.shift()!;
     const isRequested = !!lastFetchedOrRequested[key]?.requested;
     if (isRequested) {

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetLiveDataProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetLiveDataProvider.tsx
@@ -100,7 +100,7 @@ async function _queryAssetKeys(client: ApolloClient<any>, assetKeys: AssetKeyInp
 }
 
 // How many assets to fetch at once
-export const BATCH_SIZE = 50;
+export const BATCH_SIZE = 10;
 
 // Milliseconds we wait until sending a batched query
 const BATCHING_INTERVAL = 250;
@@ -312,7 +312,10 @@ function _determineAssetsToFetch() {
   const assetsToFetch: AssetKeyInput[] = [];
   const assetsWithoutData: AssetKeyInput[] = [];
   const allKeys = Object.keys(_assetKeyListeners);
-  while (allKeys.length && (assetsToFetch.length < BATCH_SIZE || assetsWithoutData.length < 50)) {
+  while (
+    allKeys.length &&
+    (assetsToFetch.length < BATCH_SIZE || assetsWithoutData.length < BATCH_SIZE)
+  ) {
     const key = allKeys.shift()!;
     const isRequested = !!lastFetchedOrRequested[key]?.requested;
     if (isRequested) {
@@ -330,7 +333,7 @@ function _determineAssetsToFetch() {
   }
 
   // Prioritize fetching assets for which there is no data in the cache
-  return assetsWithoutData.concat(assetsToFetch).slice(0, 50);
+  return assetsWithoutData.concat(assetsToFetch).slice(0, BATCH_SIZE);
 }
 
 function fetchData(client: ApolloClient<any>) {

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -13,7 +13,6 @@ import pickBy from 'lodash/pickBy';
 import uniq from 'lodash/uniq';
 import without from 'lodash/without';
 import React from 'react';
-import {useHistory} from 'react-router-dom';
 import styled from 'styled-components';
 
 import {useFeatureFlags} from '../app/Flags';
@@ -36,7 +35,7 @@ import {
   LargeDAGNotice,
   LoadingNotice,
 } from '../pipelines/GraphNotices';
-import {ExplorerPath, normalizePathnameForCacheKey} from '../pipelines/PipelinePathUtils';
+import {ExplorerPath} from '../pipelines/PipelinePathUtils';
 import {GraphQueryInput} from '../ui/GraphQueryInput';
 import {Loading} from '../ui/Loading';
 
@@ -137,14 +136,7 @@ const AssetGraphExplorerWithData: React.FC<WithDataProps> = ({
   allAssetKeys,
 }) => {
   const findAssetLocation = useFindAssetLocation();
-  const pathname = useHistory().location.pathname;
-  const {layout, loading, async} = useAssetLayout(
-    assetGraphData,
-    // Use the pathname as part of the key so that different deployments don't invalidate each other's cached layout
-    // Remove the slash at the end in the key so that the same layout is used for both `/path` and `/path/`
-    `explorer:${normalizePathnameForCacheKey(pathname)}`,
-    fullAssetGraphData,
-  );
+  const {layout, loading, async} = useAssetLayout(assetGraphData);
   const viewportEl = React.useRef<SVGViewport>();
   const {flagHorizontalDAGs, flagDAGSidebar} = useFeatureFlags();
 

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Node.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Node.tsx
@@ -123,6 +123,7 @@ export const Node = ({
               <div
                 onClick={(e) => {
                   e.stopPropagation();
+                  console.log('toggling open');
                   toggleOpen();
                 }}
                 style={{cursor: 'pointer'}}

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Node.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Node.tsx
@@ -25,6 +25,8 @@ import {GraphData, GraphNode, tokenForAssetKey} from '../Utils';
 
 import {FolderNodeNonAssetType, getDisplayName} from './util';
 
+import {getDisplayName} from './util';
+
 export const Node = ({
   graphData,
   node,

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Node.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Node.tsx
@@ -25,8 +25,6 @@ import {GraphData, GraphNode, tokenForAssetKey} from '../Utils';
 
 import {FolderNodeNonAssetType, getDisplayName} from './util';
 
-import {getDisplayName} from './util';
-
 export const Node = ({
   graphData,
   node,

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Node.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Node.tsx
@@ -22,7 +22,7 @@ import {
 import {useMaterializationAction} from '../../assets/LaunchAssetExecutionButton';
 import {ExplorerPath} from '../../pipelines/PipelinePathUtils';
 import {VirtualizedItemListForDialog} from '../../ui/VirtualizedItemListForDialog';
-import {buildAssetNodeStatusContent} from '../AssetNodeStatusContent';
+import {buildAssetNodeStatusContent, StatusCase} from '../AssetNodeStatusContent';
 import {GraphData, GraphNode, tokenForAssetKey} from '../Utils';
 
 import {FolderNodeNonAssetType, StatusCaseDot, getDisplayName} from './util';
@@ -354,7 +354,7 @@ const GrayOnHoverBox = styled(Box)`
 function StatusDot({node}: {node: GraphNode}) {
   const liveData = useAssetLiveData(node.assetKey);
   if (!liveData) {
-    return <div />;
+    return <StatusCaseDot statusCase={StatusCase.LOADING} />;
   }
   const status = buildAssetNodeStatusContent({
     assetKey: node.assetKey,

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Node.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Node.tsx
@@ -13,6 +13,7 @@ import React from 'react';
 import styled from 'styled-components';
 
 import {showSharedToaster} from '../../app/DomUtils';
+import {useAssetLiveData} from '../../asset-data/AssetLiveDataProvider';
 import {
   AssetKeysDialog,
   AssetKeysDialogEmptyState,
@@ -21,9 +22,10 @@ import {
 import {useMaterializationAction} from '../../assets/LaunchAssetExecutionButton';
 import {ExplorerPath} from '../../pipelines/PipelinePathUtils';
 import {VirtualizedItemListForDialog} from '../../ui/VirtualizedItemListForDialog';
+import {buildAssetNodeStatusContent} from '../AssetNodeStatusContent';
 import {GraphData, GraphNode, tokenForAssetKey} from '../Utils';
 
-import {FolderNodeNonAssetType, getDisplayName} from './util';
+import {FolderNodeNonAssetType, StatusCaseDot, getDisplayName} from './util';
 
 export const Node = ({
   graphData,
@@ -107,6 +109,7 @@ export const Node = ({
       {launchpadElement}
       <UpstreamDownstreamDialog
         title="Parent assets"
+        graphData={graphData}
         assetKeys={upstream}
         isOpen={showParents}
         setIsOpen={setShowParents}
@@ -149,11 +152,12 @@ export const Node = ({
               <div
                 style={{
                   display: 'grid',
-                  gridTemplateColumns:
-                    isGroupNode || isLocationNode ? 'auto minmax(0, 1fr)' : 'minmax(0, 1fr)',
+                  gridTemplateColumns: 'auto minmax(0, 1fr)',
                   gap: '6px',
+                  alignItems: 'center',
                 }}
               >
+                {isAssetNode ? <StatusDot node={node} /> : null}
                 {isGroupNode ? <Icon name="asset_group" /> : null}
                 {isLocationNode ? <Icon name="folder_open" /> : null}
                 <MiddleTruncate text={displayName} />
@@ -232,12 +236,14 @@ export const Node = ({
 
 const UpstreamDownstreamDialog = ({
   title,
+  graphData,
   assetKeys,
   isOpen,
   setIsOpen,
   selectNode,
 }: {
   title: string;
+  graphData: GraphData;
   assetKeys: string[];
   isOpen: boolean;
   setIsOpen: (isOpen: boolean) => void;
@@ -281,10 +287,16 @@ const UpstreamDownstreamDialog = ({
               itemBorders={false}
               renderItem={(assetId) => {
                 const path = JSON.parse(assetId);
+                const node = graphData.nodes[assetId];
                 return (
                   <MenuItem
                     icon="asset"
-                    text={path[path.length - 1]}
+                    text={
+                      <Box flex={{direction: 'row', alignItems: 'center', gap: 4}}>
+                        {node ? <StatusDot node={node} /> : null}
+                        <span>{path[path.length - 1]}</span>
+                      </Box>
+                    }
                     key={assetId}
                     onClick={(e) => {
                       selectNode(e, assetId);
@@ -338,3 +350,17 @@ const GrayOnHoverBox = styled(Box)`
     visibility: hidden;
   }
 `;
+
+function StatusDot({node}: {node: GraphNode}) {
+  const liveData = useAssetLiveData(node.assetKey);
+  if (!liveData) {
+    return <div />;
+  }
+  const status = buildAssetNodeStatusContent({
+    assetKey: node.assetKey,
+    definition: node.definition,
+    liveData,
+    expanded: true,
+  });
+  return <StatusCaseDot statusCase={status.case} />;
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
@@ -59,7 +59,9 @@ export const AssetGraphExplorerSidebar = React.memo(
       if (!assetGraphData.nodes[id]) {
         try {
           const path = JSON.parse(id);
-          const nextOpsQuery = `\"${tokenForAssetKey({path})}\"`;
+          const nextOpsQuery = explorerPath.opsQuery.trim()
+            ? `\"${tokenForAssetKey({path})}\"`
+            : '*';
           onChangeExplorerPath(
             {
               ...explorerPath,

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
@@ -271,6 +271,7 @@ export const AssetGraphExplorerSidebar = React.memo(
       if (indexOfLastSelectedNode !== -1) {
         rowVirtualizer.scrollToIndex(indexOfLastSelectedNode, {
           align: 'center',
+          smoothScroll: true,
         });
       }
     }, [indexOfLastSelectedNode, rowVirtualizer]);
@@ -342,7 +343,6 @@ export const AssetGraphExplorerSidebar = React.memo(
                             : selectedNode?.id === node.id
                         }
                         toggleOpen={() => {
-                          setSelectedNode(node);
                           setOpenNodes((nodes) => {
                             const openNodes = new Set(nodes);
                             const isOpen = openNodes.has(nodePathKey(node));

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
@@ -269,7 +269,9 @@ export const AssetGraphExplorerSidebar = React.memo(
 
     React.useLayoutEffect(() => {
       if (indexOfLastSelectedNode !== -1) {
-        rowVirtualizer.scrollToIndex(indexOfLastSelectedNode);
+        rowVirtualizer.scrollToIndex(indexOfLastSelectedNode, {
+          align: 'center',
+        });
       }
     }, [indexOfLastSelectedNode, rowVirtualizer]);
 

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/util.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/util.ts
@@ -1,9 +1,0 @@
-import {GraphNode} from '../Utils';
-
-export function nodeId(node: {path: string; id: string} | {id: string}) {
-  return 'path' in node ? node.path : node.id;
-}
-
-export function getDisplayName(node: GraphNode) {
-  return node.assetKey.path[node.assetKey.path.length - 1]!;
-}

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/util.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/util.ts
@@ -1,3 +1,5 @@
+import {GraphNode} from '../Utils';
+
 export function nodeId(node: {path: string; id: string} | {id: string}) {
   return 'path' in node ? node.path : node.id;
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/util.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/util.ts
@@ -1,0 +1,7 @@
+export function nodeId(node: {path: string; id: string} | {id: string}) {
+  return 'path' in node ? node.path : node.id;
+}
+
+export function getDisplayName(node: GraphNode) {
+  return node.assetKey.path[node.assetKey.path.length - 1]!;
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/util.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/util.tsx
@@ -1,5 +1,6 @@
 import {Colors, Spinner, Tooltip} from '@dagster-io/ui-components';
 import React from 'react';
+import styled, {keyframes} from 'styled-components';
 
 import {StatusCase} from '../AssetNodeStatusContent';
 import {GraphNode} from '../Utils';
@@ -52,15 +53,23 @@ export function StatusCaseDot({statusCase}: {statusCase: StatusCase}) {
 
   switch (type) {
     case 'loading':
-      return <div />;
+      return (
+        <LoadingDot
+          style={{
+            width: '10px',
+            height: '10px',
+            borderRadius: '50%',
+          }}
+        />
+      );
     case 'missing':
       return (
         <Tooltip content="Missing" position="top">
           <div
             style={{
-              backgroundColor: Colors.Gray200,
-              width: '10px',
-              height: '10px',
+              width: '12px',
+              height: '12px',
+              border: `2px solid ${Colors.Gray500}`,
               borderRadius: '50%',
             }}
           />
@@ -94,3 +103,21 @@ export function StatusCaseDot({statusCase}: {statusCase: StatusCase}) {
       );
   }
 }
+
+const pulse = keyframes`
+  from {
+    background-color: ${Colors.Gray100}
+  }
+
+  50% {
+    background-color: ${Colors.Gray300}
+  }
+
+  to {
+    background-color: ${Colors.Gray100}
+  }
+`;
+
+const LoadingDot = styled.div`
+  animation: ${pulse} 1s ease-out infinite;
+`;

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/util.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/util.tsx
@@ -51,6 +51,8 @@ export function StatusCaseDot({statusCase}: {statusCase: StatusCase}) {
   }, [statusCase]);
 
   switch (type) {
+    case 'loading':
+      return <div />;
     case 'missing':
       return (
         <Tooltip content="Missing" position="top">

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/util.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/util.tsx
@@ -1,3 +1,7 @@
+import {Colors, Spinner, Tooltip} from '@dagster-io/ui-components';
+import React from 'react';
+
+import {StatusCase} from '../AssetNodeStatusContent';
 import {GraphNode} from '../Utils';
 
 export type FolderNodeNonAssetType =
@@ -14,4 +18,77 @@ export function nodePathKey(node: {path: string; id: string} | {id: string}) {
 
 export function getDisplayName(node: GraphNode) {
   return node.assetKey.path[node.assetKey.path.length - 1]!;
+}
+
+export function StatusCaseDot({statusCase}: {statusCase: StatusCase}) {
+  const type = React.useMemo(() => {
+    switch (statusCase) {
+      case StatusCase.LOADING:
+        return 'loading' as const;
+      case StatusCase.SOURCE_OBSERVING:
+        return 'inprogress' as const;
+      case StatusCase.SOURCE_OBSERVED:
+        return 'successful' as const;
+      case StatusCase.SOURCE_NEVER_OBSERVED:
+        return 'missing' as const;
+      case StatusCase.SOURCE_NO_STATE:
+        return 'missing' as const;
+      case StatusCase.MATERIALIZING:
+        return 'inprogress' as const;
+      case StatusCase.LATE_OR_FAILED:
+        return 'failed' as const;
+      case StatusCase.NEVER_MATERIALIZED:
+        return 'missing' as const;
+      case StatusCase.MATERIALIZED:
+        return 'successful' as const;
+      case StatusCase.PARTITIONS_FAILED:
+        return 'failed' as const;
+      case StatusCase.PARTITIONS_MISSING:
+        return 'missing' as const;
+      case StatusCase.PARTITIONS_MATERIALIZED:
+        return 'successful' as const;
+    }
+  }, [statusCase]);
+
+  switch (type) {
+    case 'missing':
+      return (
+        <Tooltip content="Missing" position="top">
+          <div
+            style={{
+              backgroundColor: Colors.Gray200,
+              width: '10px',
+              height: '10px',
+              borderRadius: '50%',
+            }}
+          />
+        </Tooltip>
+      );
+    case 'failed':
+      return (
+        <Tooltip content="Failed" position="top">
+          <div
+            style={{
+              backgroundColor: Colors.Red500,
+              width: '10px',
+              height: '10px',
+              borderRadius: '50%',
+            }}
+          />
+        </Tooltip>
+      );
+    case 'inprogress':
+      return <Spinner purpose="body-text" />;
+    case 'successful':
+      return (
+        <div
+          style={{
+            backgroundColor: Colors.Green500,
+            width: '10px',
+            height: '10px',
+            borderRadius: '50%',
+          }}
+        />
+      );
+  }
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeLineageGraph.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeLineageGraph.tsx
@@ -28,10 +28,9 @@ export const AssetNodeLineageGraph: React.FC<{
 
   const [highlighted, setHighlighted] = React.useState<string | null>(null);
 
-  const basePath = useHistory().location.pathname;
   // Use the pathname as part of the key so that different deployments don't invalidate each other's cached layout
   // and so that different assets dont invalidate each others layout
-  const {layout, loading} = useAssetLayout(assetGraphData, `node-lineage:${basePath}`);
+  const {layout, loading} = useAssetLayout(assetGraphData);
   const viewportEl = React.useRef<SVGViewport>();
   const history = useHistory();
 

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelinePathUtils.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelinePathUtils.tsx
@@ -24,12 +24,6 @@ export function explorerPathToString(path: ExplorerPath) {
   return `${root}/${path.opNames.map(encodeURIComponent).join('/')}`;
 }
 
-export function normalizePathnameForCacheKey(pathname: string) {
-  const _path = pathname.endsWith('/') ? pathname.slice(0, pathname.length - 1) : pathname;
-  // Remove the op query string
-  return _path.split('~')[0];
-}
-
 export function explorerPathFromString(path: string): ExplorerPath {
   const rootAndOps = path.split('/');
   const root = rootAndOps[0]!;

--- a/js_modules/dagster-ui/yarn.lock
+++ b/js_modules/dagster-ui/yarn.lock
@@ -2575,6 +2575,7 @@ __metadata:
     graphql-config: ^4.5.0
     graphql-tag: ^2.10.1
     highlight.js: 11.6.0
+    idb-lru-cache: ^0.1.0
     identity-obj-proxy: ^3.0.0
     jest: ^29.4
     jest-canvas-mock: ^2.4.0
@@ -16064,6 +16065,15 @@ __metadata:
   peerDependencies:
     postcss: ^8.1.0
   checksum: 5c324d283552b1269cfc13a503aaaa172a280f914e5b81544f3803bc6f06a3b585fb79f66f7c771a2c052db7982c18bf92d001e3b47282e3abbbb4c4cc488d68
+  languageName: node
+  linkType: hard
+
+"idb-lru-cache@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "idb-lru-cache@npm:0.1.0"
+  dependencies:
+    idb: ^7.0.1
+  checksum: e2f046b52f5f63a2c2c2abcd22eb0f12ad5450e6756a9e49a674fa9d31ae6a0a9e91a54dbc4e83d9e914c49b37f62b8950a60f996e841479d195652a08dd058a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary & Motivation
 Use a simpler caching strategy: an LRU cache in IndexDB. This might mean we have stale layouts we might never see again in there but it also means we might have less duplicate caches. It greatly reduces the caching logic and eliminates the need to track graph versions for invalidating old data.


## How I Tested These Changes

Locally loaded the asset graph a few times