### PR TITLE
[Asset graph] Simplify layout cache

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/package.json
+++ b/js_modules/dagster-ui/packages/ui-core/package.json
@@ -51,6 +51,7 @@
     "fuse.js": "^6.4.2",
     "graphql": "^16.8.1",
     "highlight.js": "11.6.0",
+    "idb-lru-cache": "^0.1.0",
     "lodash": "^4.17.15",
     "lru-cache": "^6.0.0",
     "moment": "^2.29.4",

--- a/js_modules/dagster-ui/packages/ui-core/src/app/Util.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/Util.tsx
@@ -1,3 +1,4 @@
+import {cache} from 'idb-lru-cache';
 import memoize from 'lodash/memoize';
 import LRU from 'lru-cache';
 
@@ -148,71 +149,31 @@ export function asyncMemoize<T, R, U extends (arg: T, ...rest: any[]) => Promise
   }) as any;
 }
 
-export function indexedDBAsyncMemoize<
-  T,
-  R,
-  U extends (cacheKey: string, versionKey: string, arg: T, ...rest: any[]) => Promise<R>,
->(fn: U, hashFn?: (arg: T, ...rest: any[]) => any): U {
-  return (async (cacheKey: string, versionKey: string, arg: T, ...rest: any[]) => {
-    const dbName = 'IndexedDBAsyncMemoizeDB';
-    const storeName = 'memoizedValues';
+export function indexedDBAsyncMemoize<T, R, U extends (arg: T, ...rest: any[]) => Promise<R>>(
+  fn: U,
+  hashFn?: (arg: T, ...rest: any[]) => any,
+): U {
+  const lru = cache<string, R>({
+    dbName: 'indexDBAsyncMemoizeDB',
+    maxCount: 50,
+  });
+  return (async (arg: T, ...rest: any[]) => {
     const hashKey = hashFn ? hashFn(arg, ...rest) : arg;
 
     return new Promise<R>(async (resolve) => {
-      async function computeAndStoreLayout() {
-        const result = await fn(cacheKey, versionKey, arg, ...rest);
-        // Resolve the promise before storing the result in IndexedDB
-        resolve(result);
-
-        const request = indexedDB.open(dbName);
-        request.onsuccess = () => {
-          const db = request.result;
-          const transaction = db.transaction([storeName], 'readwrite');
-          const store = transaction.objectStore(storeName);
-          const key = cacheKey;
-          const data = {
-            version: versionKey,
-            [hashKey]: result,
-          };
-          store.put(data, key);
-        };
+      if (await lru.has(hashKey)) {
+        const {value} = await lru.get(hashKey);
+        resolve(value);
+        return;
       }
 
-      try {
-        const request = indexedDB.open(dbName);
-        request.onerror = () => {
-          computeAndStoreLayout();
-        };
-        request.onsuccess = () => {
-          const db = request.result;
-          const transaction = db.transaction([storeName], 'readwrite');
-          const store = transaction.objectStore(storeName);
-
-          const key = cacheKey;
-          const requestGet = store.get(key);
-          requestGet.onerror = function () {
-            computeAndStoreLayout();
-          };
-          requestGet.onsuccess = () => {
-            const cachedData = requestGet.result;
-            if (cachedData && cachedData.version === versionKey && cachedData[hashKey]) {
-              resolve(cachedData[hashKey]);
-            } else {
-              computeAndStoreLayout();
-            }
-          };
-        };
-
-        request.onupgradeneeded = function () {
-          const db = request.result;
-          if (!db.objectStoreNames.contains(storeName)) {
-            db.createObjectStore(storeName);
-          }
-          computeAndStoreLayout();
-        };
-      } catch (error) {
-        computeAndStoreLayout();
-      }
+      const result = await fn(arg, ...rest);
+      // Resolve the promise before storing the result in IndexedDB
+      resolve(result);
+      await lru.set(hashKey, result, {
+        // Some day in the year 2050...
+        expiry: new Date(9 ** 13),
+      });
     });
   }) as any;
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -13,7 +13,6 @@ import pickBy from 'lodash/pickBy';
 import uniq from 'lodash/uniq';
 import without from 'lodash/without';
 import React from 'react';
-import {useHistory} from 'react-router-dom';
 import styled from 'styled-components';
 
 import {useFeatureFlags} from '../app/Flags';
@@ -36,7 +35,7 @@ import {
   LargeDAGNotice,
   LoadingNotice,
 } from '../pipelines/GraphNotices';
-import {ExplorerPath, normalizePathnameForCacheKey} from '../pipelines/PipelinePathUtils';
+import {ExplorerPath} from '../pipelines/PipelinePathUtils';
 import {GraphQueryInput} from '../ui/GraphQueryInput';
 import {Loading} from '../ui/Loading';
 
@@ -137,14 +136,7 @@ const AssetGraphExplorerWithData: React.FC<WithDataProps> = ({
   allAssetKeys,
 }) => {
   const findAssetLocation = useFindAssetLocation();
-  const pathname = useHistory().location.pathname;
-  const {layout, loading, async} = useAssetLayout(
-    assetGraphData,
-    // Use the pathname as part of the key so that different deployments don't invalidate each other's cached layout
-    // Remove the slash at the end in the key so that the same layout is used for both `/path` and `/path/`
-    `explorer:${normalizePathnameForCacheKey(pathname)}`,
-    fullAssetGraphData,
-  );
+  const {layout, loading, async} = useAssetLayout(assetGraphData);
   const viewportEl = React.useRef<SVGViewport>();
   const {flagHorizontalDAGs, flagDAGSidebar} = useFeatureFlags();
 

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
@@ -358,8 +358,8 @@ export const AssetGraphExplorerSidebar = React.memo(
                           selectNode(e, id);
                         }}
                         selectThisNode={(e) => {
-                          selectNode(e, node.id);
                           setSelectedNode(node);
+                          selectNode(e, node.id);
                         }}
                         explorerPath={explorerPath}
                         onChangeExplorerPath={onChangeExplorerPath}

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
@@ -274,7 +274,11 @@ export const AssetGraphExplorerSidebar = React.memo(
           smoothScroll: true,
         });
       }
-    }, [indexOfLastSelectedNode, rowVirtualizer]);
+      // Only scroll if the rootNodes changes or the selected node changes
+      // otherwise opening/closing nodes will cause us to scroll again because the index changes
+      // if we toggle a node above the selected node
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [selectedNode, rootNodes, rowVirtualizer]);
 
     return (
       <div style={{display: 'grid', gridTemplateRows: 'auto auto minmax(0, 1fr)', height: '100%'}}>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeLineageGraph.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeLineageGraph.tsx
@@ -28,10 +28,9 @@ export const AssetNodeLineageGraph: React.FC<{
 
   const [highlighted, setHighlighted] = React.useState<string | null>(null);
 
-  const basePath = useHistory().location.pathname;
   // Use the pathname as part of the key so that different deployments don't invalidate each other's cached layout
   // and so that different assets dont invalidate each others layout
-  const {layout, loading} = useAssetLayout(assetGraphData, `node-lineage:${basePath}`);
+  const {layout, loading} = useAssetLayout(assetGraphData);
   const viewportEl = React.useRef<SVGViewport>();
   const history = useHistory();
 

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelinePathUtils.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelinePathUtils.tsx
@@ -24,12 +24,6 @@ export function explorerPathToString(path: ExplorerPath) {
   return `${root}/${path.opNames.map(encodeURIComponent).join('/')}`;
 }
 
-export function normalizePathnameForCacheKey(pathname: string) {
-  const _path = pathname.endsWith('/') ? pathname.slice(0, pathname.length - 1) : pathname;
-  // Remove the op query string
-  return _path.split('~')[0];
-}
-
 export function explorerPathFromString(path: string): ExplorerPath {
   const rootAndOps = path.split('/');
   const root = rootAndOps[0]!;

--- a/js_modules/dagster-ui/yarn.lock
+++ b/js_modules/dagster-ui/yarn.lock
@@ -2575,6 +2575,7 @@ __metadata:
     graphql-config: ^4.5.0
     graphql-tag: ^2.10.1
     highlight.js: 11.6.0
+    idb-lru-cache: ^0.1.0
     identity-obj-proxy: ^3.0.0
     jest: ^29.4
     jest-canvas-mock: ^2.4.0
@@ -16064,6 +16065,15 @@ __metadata:
   peerDependencies:
     postcss: ^8.1.0
   checksum: 5c324d283552b1269cfc13a503aaaa172a280f914e5b81544f3803bc6f06a3b585fb79f66f7c771a2c052db7982c18bf92d001e3b47282e3abbbb4c4cc488d68
+  languageName: node
+  linkType: hard
+
+"idb-lru-cache@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "idb-lru-cache@npm:0.1.0"
+  dependencies:
+    idb: ^7.0.1
+  checksum: e2f046b52f5f63a2c2c2abcd22eb0f12ad5450e6756a9e49a674fa9d31ae6a0a9e91a54dbc4e83d9e914c49b37f62b8950a60f996e841479d195652a08dd058a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary & Motivation
Use a simpler caching strategy: an LRU cache in IndexDB. This might mean we have stale layouts we might never see again in there but it also means we might have less duplicate caches. It greatly reduces the caching logic and eliminates the need to track graph versions for invalidating old data.

## How I Tested These Changes

locally