### PR TITLE
make concurrency run list fit content

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceConcurrency.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceConcurrency.tsx
@@ -543,7 +543,7 @@ const ConcurrencyRunsDialog: React.FC<{
       isOpen={!!runIds && runIds.length > 0}
       title={title}
       onClose={onClose}
-      style={{width: '60%', minWidth: '400px'}}
+      style={{minWidth: '400px', maxWidth: 'calc(100% - 40px)', width: 'fit-content'}}
     >
       <Box padding={{vertical: 16}}>
         {!data ? (
@@ -551,10 +551,12 @@ const ConcurrencyRunsDialog: React.FC<{
             <Spinner purpose="section" />
           </Box>
         ) : data.pipelineRunsOrError.__typename === 'Runs' ? (
-          <RunTable
-            runs={data.pipelineRunsOrError.results}
-            additionalActionsForRun={freeSlotsActionMenuItem}
-          />
+          <div style={{overflow: 'auto'}}>
+            <RunTable
+              runs={data.pipelineRunsOrError.results}
+              additionalActionsForRun={freeSlotsActionMenuItem}
+            />
+          </div>
         ) : (
           <Box padding={{vertical: 64}}>
             <NonIdealState


### PR DESCRIPTION
## Summary & Motivation
We should make the concurrency run dialog fit the content... Previously was hard-coded to 60%.  Now it fits the content (within reason) and has a scrollable table area.

## How I Tested These Changes
https://github.com/dagster-io/dagster/assets/1040172/7c67e9aa-b5e1-4490-8072-2ba269c3c341

