### PR TITLE
[WIP] Allow AutoMaterializeRules to stay true for multiple ticks in a row

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_auto_materialize_asset_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_auto_materialize_asset_evaluations.py
@@ -567,7 +567,7 @@ class TestAutoMaterializeAssetEvaluations(ExecutingGraphQLContextTestMatrix):
 
     def _test_current_evaluation_id(self, graphql_context: WorkspaceRequestContext):
         graphql_context.instance.daemon_cursor_storage.set_cursor_values(
-            {CURSOR_KEY: AssetDaemonCursor.empty().serialize()}
+            {CURSOR_KEY: AssetDaemonCursor.empty().serialize(graphql_context.instance)}
         )
 
         results = execute_dagster_graphql(

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -648,6 +648,7 @@ class AssetDaemonContext:
                 ],
                 observe_request_timestamp=observe_request_timestamp,
                 skipped_asset_graph_subset=skipped_asset_graph_subset,
+                evaluations=list(evaluations.values()),
                 instance_queryer=self.instance_queryer,
             ),
             [
@@ -656,6 +657,9 @@ class AssetDaemonContext:
                 # only record evaluations where something happened
                 if sum([evaluation.num_requested, evaluation.num_skipped, evaluation.num_discarded])
                 > 0
+                and not evaluation.equivalent_to_stored_evaluation(
+                    self.cursor.latest_evaluation_by_asset_key.get(evaluation.asset_key)
+                )
             ],
         )
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -456,7 +456,7 @@ class AssetDaemonContext:
     def skipped_asset_graph_subset(self) -> AssetGraphSubset:
         subset = self.cursor.skipped_asset_graph_subset or AssetGraphSubset(self.asset_graph)
         # factor out any asset partitions which have been materialized since last tick
-        for asset_key in self.asset_graph.all_asset_keys:
+        for asset_key in self.target_asset_keys:
             partitions_def = self.asset_graph.get_partitions_def(asset_key)
             new_asset_partitions = self.instance_queryer.get_asset_partitions_updated_after_cursor(
                 asset_key=asset_key,

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -455,15 +455,7 @@ class AssetDaemonContext:
     @functools.cached_property
     def skipped_asset_graph_subset(self) -> AssetGraphSubset:
         subset = self.cursor.skipped_asset_graph_subset or AssetGraphSubset(self.asset_graph)
-        # factor out any asset partitions which have been materialized since last tick
-        for asset_key in self.asset_graph.all_asset_keys:
-            new_asset_partitions = self.instance_queryer.get_asset_partitions_updated_after_cursor(
-                asset_key=asset_key,
-                asset_partitions=None,
-                after_cursor=self.latest_storage_id,
-                respect_materialization_data_versions=False,
-            )
-            subset -= new_asset_partitions
+        # TODO: factor out any asset partitions which have been materialized since last tick
         return subset
 
     def get_auto_materialize_asset_evaluations(

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -455,7 +455,15 @@ class AssetDaemonContext:
     @functools.cached_property
     def skipped_asset_graph_subset(self) -> AssetGraphSubset:
         subset = self.cursor.skipped_asset_graph_subset or AssetGraphSubset(self.asset_graph)
-        # TODO: factor out any asset partitions which have been materialized since last tick
+        # factor out any asset partitions which have been materialized since last tick
+        for asset_key in self.asset_graph.all_asset_keys:
+            new_asset_partitions = self.instance_queryer.get_asset_partitions_updated_after_cursor(
+                asset_key=asset_key,
+                asset_partitions=None,
+                after_cursor=self.latest_storage_id,
+                respect_materialization_data_versions=False,
+            )
+            subset -= new_asset_partitions
         return subset
 
     def get_auto_materialize_asset_evaluations(

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
@@ -15,13 +15,16 @@ from typing import (
 )
 
 import dagster._check as check
+from dagster import deserialize_value
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
+from dagster._core.definitions.auto_materialize_rule import AutoMaterializeAssetEvaluation
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
 from dagster._core.definitions.time_window_partitions import (
     TimeWindowPartitionsDefinition,
     TimeWindowPartitionsSubset,
 )
 from dagster._core.instance import DynamicPartitionsStore
+from dagster._serdes.serdes import serialize_value
 from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
 
 from .asset_graph import AssetGraph
@@ -56,6 +59,7 @@ class AssetDaemonCursor(NamedTuple):
     evaluation_id: int
     last_observe_request_timestamp_by_asset_key: Mapping[AssetKey, float]
     skipped_asset_graph_subset: Optional[AssetGraphSubset]
+    latest_evaluation_by_asset_key: Mapping[AssetKey, AutoMaterializeAssetEvaluation]
 
     def was_previously_handled(self, asset_key: AssetKey) -> bool:
         return asset_key in self.handled_root_asset_keys
@@ -90,6 +94,7 @@ class AssetDaemonCursor(NamedTuple):
         newly_observe_requested_asset_keys: Sequence[AssetKey],
         observe_request_timestamp: float,
         skipped_asset_graph_subset: AssetGraphSubset,
+        evaluations: Sequence[AutoMaterializeAssetEvaluation],
         instance_queryer: CachingInstanceQueryer,
     ) -> "AssetDaemonCursor":
         """Returns a cursor that represents this cursor plus the updates that have happened within the
@@ -142,6 +147,10 @@ class AssetDaemonCursor(NamedTuple):
                 observe_request_timestamp
             )
 
+        result_latest_evaluation_by_asset_key = {**self.latest_evaluation_by_asset_key}
+        for evaluation in evaluations:
+            result_latest_evaluation_by_asset_key[evaluation.asset_key] = evaluation
+
         if latest_storage_id and self.latest_storage_id:
             check.invariant(
                 latest_storage_id >= self.latest_storage_id,
@@ -155,6 +164,7 @@ class AssetDaemonCursor(NamedTuple):
             evaluation_id=evaluation_id,
             last_observe_request_timestamp_by_asset_key=result_last_observe_request_timestamp_by_asset_key,
             skipped_asset_graph_subset=skipped_asset_graph_subset,
+            latest_evaluation_by_asset_key=result_latest_evaluation_by_asset_key,
         )
 
     @classmethod
@@ -166,6 +176,7 @@ class AssetDaemonCursor(NamedTuple):
             evaluation_id=0,
             last_observe_request_timestamp_by_asset_key={},
             skipped_asset_graph_subset=None,
+            latest_evaluation_by_asset_key={},
         )
 
     @classmethod
@@ -183,6 +194,7 @@ class AssetDaemonCursor(NamedTuple):
             evaluation_id = data[3] if len(data) == 4 else 0
             serialized_last_observe_request_timestamp_by_asset_key = {}
             serialized_skipped_asset_graph_subset = None
+            serialized_latest_evaluation_by_asset_key = {}
         else:
             latest_storage_id = data["latest_storage_id"]
             serialized_handled_root_asset_keys = data["handled_root_asset_keys"]
@@ -194,6 +206,9 @@ class AssetDaemonCursor(NamedTuple):
                 "last_observe_request_timestamp_by_asset_key", {}
             )
             serialized_skipped_asset_graph_subset = data.get("skipped_asset_graph_subset")
+            serialized_latest_evaluation_by_asset_key = data.get(
+                "latest_evaluation_by_asset_key", {}
+            )
 
         handled_root_partitions_by_asset_key = {}
         for (
@@ -227,6 +242,15 @@ class AssetDaemonCursor(NamedTuple):
             except:
                 subset = partitions_def.empty_subset()
             handled_root_partitions_by_asset_key[key] = subset
+
+        latest_evaluation_by_asset_key = {}
+        for key_str, serialized_evaluation in serialized_latest_evaluation_by_asset_key.items():
+            key = AssetKey.from_user_string(key_str)
+            evaluation = deserialize_value(serialized_evaluation)
+            if not isinstance(evaluation, AutoMaterializeAssetEvaluation):
+                continue
+            latest_evaluation_by_asset_key[key] = evaluation
+
         return cls(
             latest_storage_id=latest_storage_id,
             handled_root_asset_keys={
@@ -247,6 +271,7 @@ class AssetDaemonCursor(NamedTuple):
                 if serialized_skipped_asset_graph_subset
                 else None
             ),
+            latest_evaluation_by_asset_key=latest_evaluation_by_asset_key,
         )
 
     @classmethod
@@ -282,6 +307,10 @@ class AssetDaemonCursor(NamedTuple):
                     if self.skipped_asset_graph_subset
                     else None
                 ),
+                "latest_evaluation_by_asset_key": {
+                    key.to_user_string(): serialize_value(evaluation)
+                    for key, evaluation in self.latest_evaluation_by_asset_key.items()
+                },
             }
         )
         return serialized

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
@@ -59,7 +59,7 @@ class AssetDaemonCursor(NamedTuple):
     handled_root_partitions_by_asset_key: Mapping[AssetKey, PartitionsSubset]
     evaluation_id: int
     last_observe_request_timestamp_by_asset_key: Mapping[AssetKey, float]
-    serialized_unhandled_asset_graph_subset: Optional[Mapping[str, Any]]
+    serialized_skipped_asset_graph_subset: Optional[Mapping[str, Any]]
 
     def was_previously_handled(self, asset_key: AssetKey) -> bool:
         return asset_key in self.handled_root_asset_keys
@@ -93,7 +93,7 @@ class AssetDaemonCursor(NamedTuple):
         asset_graph: AssetGraph,
         newly_observe_requested_asset_keys: Sequence[AssetKey],
         observe_request_timestamp: float,
-        unhandled_asset_graph_subset: AssetGraphSubset,
+        skipped_asset_graph_subset: AssetGraphSubset,
         instance_queryer: CachingInstanceQueryer,
     ) -> "AssetDaemonCursor":
         """Returns a cursor that represents this cursor plus the updates that have happened within the
@@ -158,7 +158,7 @@ class AssetDaemonCursor(NamedTuple):
             handled_root_partitions_by_asset_key=result_handled_root_partitions_by_asset_key,
             evaluation_id=evaluation_id,
             last_observe_request_timestamp_by_asset_key=result_last_observe_request_timestamp_by_asset_key,
-            serialized_unhandled_asset_graph_subset=unhandled_asset_graph_subset.to_storage_dict(
+            serialized_skipped_asset_graph_subset=skipped_asset_graph_subset.to_storage_dict(
                 instance_queryer
             ),
         )
@@ -171,7 +171,7 @@ class AssetDaemonCursor(NamedTuple):
             handled_root_asset_keys=set(),
             evaluation_id=0,
             last_observe_request_timestamp_by_asset_key={},
-            serialized_unhandled_asset_graph_subset=None,
+            serialized_skipped_asset_graph_subset=None,
         )
 
     @classmethod
@@ -188,7 +188,7 @@ class AssetDaemonCursor(NamedTuple):
 
             evaluation_id = data[3] if len(data) == 4 else 0
             serialized_last_observe_request_timestamp_by_asset_key = {}
-            serialized_unhandled_asset_graph_subset = None
+            serialized_skipped_asset_graph_subset = None
         else:
             latest_storage_id = data["latest_storage_id"]
             serialized_handled_root_asset_keys = data["handled_root_asset_keys"]
@@ -199,7 +199,7 @@ class AssetDaemonCursor(NamedTuple):
             serialized_last_observe_request_timestamp_by_asset_key = data.get(
                 "last_observe_request_timestamp_by_asset_key", {}
             )
-            serialized_unhandled_asset_graph_subset = data.get("unhandled_asset_graph_subset")
+            serialized_skipped_asset_graph_subset = data.get("skipped_asset_graph_subset")
 
         handled_root_partitions_by_asset_key = {}
         for (
@@ -244,7 +244,7 @@ class AssetDaemonCursor(NamedTuple):
                 AssetKey.from_user_string(key_str): timestamp
                 for key_str, timestamp in serialized_last_observe_request_timestamp_by_asset_key.items()
             },
-            serialized_unhandled_asset_graph_subset=serialized_unhandled_asset_graph_subset,
+            serialized_skipped_asset_graph_subset=serialized_skipped_asset_graph_subset,
         )
 
     @classmethod
@@ -275,7 +275,7 @@ class AssetDaemonCursor(NamedTuple):
                     key.to_user_string(): timestamp
                     for key, timestamp in self.last_observe_request_timestamp_by_asset_key.items()
                 },
-                "unhandled_asset_graph_subset": self.serialized_unhandled_asset_graph_subset,
+                "skipped_asset_graph_subset": self.serialized_skipped_asset_graph_subset,
             }
         )
         return serialized

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
@@ -3,9 +3,7 @@ import itertools
 import json
 from collections import defaultdict
 from typing import (
-    TYPE_CHECKING,
     AbstractSet,
-    Any,
     Dict,
     Iterable,
     Mapping,
@@ -23,6 +21,7 @@ from dagster._core.definitions.time_window_partitions import (
     TimeWindowPartitionsDefinition,
     TimeWindowPartitionsSubset,
 )
+from dagster._core.instance import DynamicPartitionsStore
 from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
 
 from .asset_graph import AssetGraph
@@ -30,9 +29,6 @@ from .partition import (
     PartitionsDefinition,
     PartitionsSubset,
 )
-
-if TYPE_CHECKING:
-    from dagster._core.instance import DynamicPartitionsStore
 
 
 class AssetDaemonCursor(NamedTuple):
@@ -262,7 +258,7 @@ class AssetDaemonCursor(NamedTuple):
         else:
             return data["evaluation_id"]
 
-    def serialize(self, instance_queryer: CachingInstanceQueryer) -> str:
+    def serialize(self, dynamic_partitions_store: DynamicPartitionsStore) -> str:
         serializable_handled_root_partitions_by_asset_key = {
             key.to_user_string(): subset.serialize()
             for key, subset in self.handled_root_partitions_by_asset_key.items()
@@ -282,7 +278,7 @@ class AssetDaemonCursor(NamedTuple):
                     for key, timestamp in self.last_observe_request_timestamp_by_asset_key.items()
                 },
                 "skipped_asset_graph_subset": (
-                    self.skipped_asset_graph_subset.to_storage_dict(instance_queryer)
+                    self.skipped_asset_graph_subset.to_storage_dict(dynamic_partitions_store)
                     if self.skipped_asset_graph_subset
                     else None
                 ),

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
@@ -116,11 +116,17 @@ class AssetGraphSubset:
         result_partition_subsets_by_asset_key = {**self.partitions_subsets_by_asset_key}
         result_non_partitioned_asset_keys = set(self._non_partitioned_asset_keys)
 
+        print("xxxxxxxxxx")
+        print(other)
         if not isinstance(other, AssetGraphSubset):
             other = AssetGraphSubset.from_asset_partition_set(other, self.asset_graph)
+        print(" ")
+        print(other)
 
         for asset_key in other.asset_keys:
             if asset_key in other.non_partitioned_asset_keys:
+                print(other)
+                print(self)
                 check.invariant(asset_key not in self.partitions_subsets_by_asset_key)
                 result_non_partitioned_asset_keys = oper(
                     result_non_partitioned_asset_keys, {asset_key}
@@ -182,10 +188,10 @@ class AssetGraphSubset:
         partitions_by_asset_key = defaultdict(set)
         non_partitioned_asset_keys = set()
         for asset_key, partition_key in asset_partitions_set:
-            if partition_key is not None:
-                partitions_by_asset_key[asset_key].add(partition_key)
-            else:
+            if not asset_graph.is_partitioned(asset_key):
                 non_partitioned_asset_keys.add(asset_key)
+            elif partition_key is not None:
+                partitions_by_asset_key[asset_key].add(partition_key)
 
         return AssetGraphSubset(
             partitions_subsets_by_asset_key={

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
@@ -116,17 +116,11 @@ class AssetGraphSubset:
         result_partition_subsets_by_asset_key = {**self.partitions_subsets_by_asset_key}
         result_non_partitioned_asset_keys = set(self._non_partitioned_asset_keys)
 
-        print("xxxxxxxxxx")
-        print(other)
         if not isinstance(other, AssetGraphSubset):
             other = AssetGraphSubset.from_asset_partition_set(other, self.asset_graph)
-        print(" ")
-        print(other)
 
         for asset_key in other.asset_keys:
             if asset_key in other.non_partitioned_asset_keys:
-                print(other)
-                print(self)
                 check.invariant(asset_key not in self.partitions_subsets_by_asset_key)
                 result_non_partitioned_asset_keys = oper(
                     result_non_partitioned_asset_keys, {asset_key}

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -499,20 +499,6 @@ class MaterializeOnMissingRule(AutoMaterializeRule, NamedTuple("_MaterializeOnMi
         return self._get_merged_results(context, asset_partitions_by_evaluation_data)
 
 
-def fun_function(x: Mapping[Optional[int], str]):
-    pass
-
-
-def call_function(foo: bool):
-    my_dictionary: Dict[Optional[int], str] = {1: "hello"}
-    fun_function(my_dictionary)
-
-
-def call_function2(foo: bool):
-    my_dictionary = {None: "hello", 1: "world"}
-    fun_function(my_dictionary)
-
-
 @whitelist_for_serdes
 class SkipOnParentOutdatedRule(AutoMaterializeRule, NamedTuple("_SkipOnParentOutdatedRule", [])):
     @property

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -220,11 +220,10 @@ class AutoMaterializeRule(ABC):
         self, context: RuleEvaluationContext
     ) -> RuleEvaluationResults:
         """Return the previous evaluation results for this rule, if any."""
-
         # this line ensures that if a materialize rule is "handled" (i.e. a materialization was
         # kicked off after it was discovered, or the asset was discarded), then we don't resurrect
         # the previous evaluation results
-        if context.cursor.is_unhandled(context.asset_key):
+        if context.asset_key in context.daemon_context.unhandled_asset_graph_subset:
             return []
 
         # here, we query the instance for the last recorded evaluation record
@@ -257,7 +256,7 @@ class AutoMaterializeRule(ABC):
                     for ap in asset_partitions
                     # only include asset partitions that are still unhandled from a previous tick
                     # and which do not have new evaluation data
-                    if ap in context.cursor.unhandled_asset_graph_subset
+                    if ap in context.daemon_context.unhandled_asset_graph_subset
                     and ap not in new_asset_partitions
                 },
             )

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -523,7 +523,7 @@ class SkipOnParentOutdatedRule(AutoMaterializeRule, NamedTuple("_SkipOnParentOut
             if asset_partitions_by_waiting_on_asset_keys
             else []
         )
-        return self._get_merged_results(context, results)
+        return None, results
 
 
 @whitelist_for_serdes

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -502,7 +502,12 @@ class SkipOnParentOutdatedRule(AutoMaterializeRule, NamedTuple("_SkipOnParentOut
     ) -> Tuple[Optional[AbstractSet[AssetKeyPartitionKey]], RuleEvaluationResults]:
         asset_partitions_by_waiting_on_asset_keys = defaultdict(set)
 
-        for candidate in context.candidates:
+        for candidate in {
+            *context.new_candidates,
+            *context.daemon_context.get_asset_partitions_with_newly_updated_parents_for_key(
+                context.asset_key
+            ),
+        }:
             outdated_ancestors = set()
             # find the root cause of why this asset partition's parents are outdated (if any)
             for parent in context.get_parents_that_will_not_be_materialized_on_current_tick(

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -502,12 +502,7 @@ class SkipOnParentOutdatedRule(AutoMaterializeRule, NamedTuple("_SkipOnParentOut
     ) -> Tuple[Optional[AbstractSet[AssetKeyPartitionKey]], RuleEvaluationResults]:
         asset_partitions_by_waiting_on_asset_keys = defaultdict(set)
 
-        for candidate in {
-            *context.new_candidates,
-            *context.daemon_context.get_asset_partitions_with_newly_updated_parents_for_key(
-                context.asset_key
-            ),
-        }:
+        for candidate in context.candidates:
             outdated_ancestors = set()
             # find the root cause of why this asset partition's parents are outdated (if any)
             for parent in context.get_parents_that_will_not_be_materialized_on_current_tick(

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -315,6 +315,8 @@ class AssetDaemon(IntervalDaemon):
             instance.daemon_cursor_storage.set_cursor_values(
                 {CURSOR_KEY: new_cursor.serialize(asset_daemon_context.instance_queryer)}
             )
+            print("NEW CURSOR")
+            print(new_cursor.serialize(asset_daemon_context.instance_queryer))
             tick_context.update_state(
                 TickStatus.SUCCESS if len(run_requests) > 0 else TickStatus.SKIPPED,
                 end_timestamp=tick_finish_timestamp,

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -145,7 +145,6 @@ class AutoMaterializeLaunchContext:
 
 class AssetDaemon(IntervalDaemon):
     def __init__(self, interval_seconds: int):
-        interval_seconds = 5
         super().__init__(interval_seconds=interval_seconds)
 
     @classmethod
@@ -315,8 +314,6 @@ class AssetDaemon(IntervalDaemon):
             instance.daemon_cursor_storage.set_cursor_values(
                 {CURSOR_KEY: new_cursor.serialize(asset_daemon_context.instance_queryer)}
             )
-            print("NEW CURSOR")
-            print(new_cursor.serialize(asset_daemon_context.instance_queryer))
             tick_context.update_state(
                 TickStatus.SUCCESS if len(run_requests) > 0 else TickStatus.SKIPPED,
                 end_timestamp=tick_finish_timestamp,

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -205,11 +205,6 @@ class AssetDaemon(IntervalDaemon):
         )
 
         raw_cursor = _get_raw_cursor(instance)
-        cursor = (
-            AssetDaemonCursor.from_serialized(raw_cursor, asset_graph)
-            if raw_cursor
-            else AssetDaemonCursor.empty()
-        )
 
         tick_retention_settings = instance.get_tick_retention_settings(
             InstigatorType.AUTO_MATERIALIZE
@@ -229,11 +224,11 @@ class AssetDaemon(IntervalDaemon):
         with AutoMaterializeLaunchContext(
             tick, instance, self._logger, tick_retention_settings
         ) as tick_context:
-            run_requests, new_cursor, evaluations = AssetDaemonContext(
+            new_raw_cursor, new_evaluation_id, run_requests, evaluations = AssetDaemonContext(
                 asset_graph=asset_graph,
                 target_asset_keys=target_asset_keys,
                 instance=instance,
-                cursor=cursor,
+                raw_cursor=raw_cursor,
                 materialize_run_tags={
                     AUTO_MATERIALIZE_TAG: "true",
                     **instance.auto_materialize_run_tags,
@@ -247,7 +242,7 @@ class AssetDaemon(IntervalDaemon):
             self._logger.info(
                 f"Tick produced {len(run_requests)} run{'s' if len(run_requests) != 1 else ''} and"
                 f" {len(evaluations)} asset evaluation{'s' if len(evaluations) != 1 else ''} for"
-                f" evaluation ID {new_cursor.evaluation_id}"
+                f" evaluation ID {new_evaluation_id}"
             )
 
             evaluations_by_asset_key = {
@@ -269,7 +264,7 @@ class AssetDaemon(IntervalDaemon):
                         run_request._replace(
                             tags={
                                 **run_request.tags,
-                                ASSET_EVALUATION_ID_TAG: str(new_cursor.evaluation_id),
+                                ASSET_EVALUATION_ID_TAG: str(new_evaluation_id),
                             }
                         ),
                         instance,
@@ -311,7 +306,7 @@ class AssetDaemon(IntervalDaemon):
 
             tick_finish_timestamp = pendulum.now("UTC").timestamp()
 
-            instance.daemon_cursor_storage.set_cursor_values({CURSOR_KEY: new_cursor.serialize()})
+            instance.daemon_cursor_storage.set_cursor_values({CURSOR_KEY: new_raw_cursor})
             tick_context.update_state(
                 TickStatus.SUCCESS if len(run_requests) > 0 else TickStatus.SKIPPED,
                 end_timestamp=tick_finish_timestamp,
@@ -321,7 +316,7 @@ class AssetDaemon(IntervalDaemon):
         # so that if the daemon crashes and doesn't update the cursor we don't try to write duplicates.
         if schedule_storage.supports_auto_materialize_asset_evaluations:
             schedule_storage.add_auto_materialize_asset_evaluations(
-                new_cursor.evaluation_id, list(evaluations_by_asset_key.values())
+                new_evaluation_id, list(evaluations_by_asset_key.values())
             )
             schedule_storage.purge_asset_evaluations(
                 before=pendulum.now("UTC").subtract(days=EVALUATIONS_TTL_DAYS).timestamp(),

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -145,6 +145,7 @@ class AutoMaterializeLaunchContext:
 
 class AssetDaemon(IntervalDaemon):
     def __init__(self, interval_seconds: int):
+        interval_seconds = 5
         super().__init__(interval_seconds=interval_seconds)
 
     @classmethod

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -45,7 +45,6 @@ from dagster._core.storage.tags import PARTITION_NAME_TAG
 from dagster._utils.cached_method import cached_method
 
 if TYPE_CHECKING:
-    from dagster._core.scheduler.instigation import AutoMaterializeAssetEvaluationRecord
     from dagster._core.storage.event_log import EventLogRecord
     from dagster._core.storage.event_log.base import AssetRecord
 
@@ -933,20 +932,3 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
                 self._outdated_ancestors_cache[current_partition] = outdated_ancestors
 
         return self._outdated_ancestors_cache[asset_partition]
-
-    @cached_method
-    def get_previous_asset_evaluation_record(
-        self, asset_key: AssetKey
-    ) -> Optional["AutoMaterializeAssetEvaluationRecord"]:
-        schedule_storage = self.instance.schedule_storage
-        if schedule_storage is None:
-            return None
-        evaluation_record = next(
-            iter(
-                schedule_storage.get_auto_materialize_asset_evaluations(
-                    asset_key=asset_key, limit=1
-                )
-            ),
-            None,
-        )
-        return evaluation_record

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -47,6 +47,7 @@ from dagster._utils.cached_method import cached_method
 if TYPE_CHECKING:
     from dagster._core.storage.event_log import EventLogRecord
     from dagster._core.storage.event_log.base import AssetRecord
+    from dagster._core.scheduler.instigation import AutoMaterializeAssetEvaluationRecord
 
 
 class CachingInstanceQueryer(DynamicPartitionsStore):
@@ -521,6 +522,10 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
     def has_dynamic_partition(self, partitions_def_name: str, partition_key: str) -> bool:
         return partition_key in self.get_dynamic_partitions(partitions_def_name)
 
+    ######################
+    # AUTO MATERIALIZATION
+    ######################
+
     def asset_partitions_with_newly_updated_parents_and_new_latest_storage_id(
         self,
         latest_storage_id: Optional[int],
@@ -663,10 +668,6 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
                 result_latest_storage_id = asset_latest_storage_id
 
         return (result_asset_partitions, result_latest_storage_id)
-
-    ####################
-    # RECONCILIATION
-    ####################
 
     def _asset_partitions_data_versions(
         self,
@@ -933,3 +934,20 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
                 self._outdated_ancestors_cache[current_partition] = outdated_ancestors
 
         return self._outdated_ancestors_cache[asset_partition]
+
+    @cached_method
+    def get_previous_asset_evaluation_record(
+        self, asset_key: AssetKey
+    ) -> Optional["AutoMaterializeAssetEvaluationRecord"]:
+        schedule_storage = self.instance.schedule_storage
+        if schedule_storage is None:
+            return None
+        evaluation_record = next(
+            iter(
+                schedule_storage.get_auto_materialize_asset_evaluations(
+                    asset_key=asset_key, limit=1
+                )
+            ),
+            None,
+        )
+        return evaluation_record

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -761,7 +761,6 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
             respect_materialization_data_versions (bool): If True, will use data versions to filter
                 out asset partitions which were materialized, but not have not had their data
                 versions changed since the given cursor.
-                NOTE: This boolean has been temporarily disabled
         """
         if not self.asset_partition_has_materialization_or_observation(
             AssetKeyPartitionKey(asset_key), after_cursor=after_cursor

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -45,9 +45,9 @@ from dagster._core.storage.tags import PARTITION_NAME_TAG
 from dagster._utils.cached_method import cached_method
 
 if TYPE_CHECKING:
+    from dagster._core.scheduler.instigation import AutoMaterializeAssetEvaluationRecord
     from dagster._core.storage.event_log import EventLogRecord
     from dagster._core.storage.event_log.base import AssetRecord
-    from dagster._core.scheduler.instigation import AutoMaterializeAssetEvaluationRecord
 
 
 class CachingInstanceQueryer(DynamicPartitionsStore):

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
@@ -165,6 +165,7 @@ class AssetReconciliationScenario(
             ("requires_respect_materialization_data_versions", bool),
             ("supports_with_external_asset_graph", bool),
             ("expected_error_message", Optional[str]),
+            ("expected_skipped_subset", Optional[AbstractSet[AssetKeyPartitionKey]]),
         ],
     )
 ):
@@ -188,6 +189,7 @@ class AssetReconciliationScenario(
         requires_respect_materialization_data_versions: bool = False,
         supports_with_external_asset_graph: bool = True,
         expected_error_message: Optional[str] = None,
+        expected_skipped_subset: Optional[AbstractSet[AssetKeyPartitionKey]] = None,
     ) -> "AssetReconciliationScenario":
         # For scenarios with no auto-materialize policies, we infer auto-materialize policies
         # and add them to the assets.
@@ -225,6 +227,7 @@ class AssetReconciliationScenario(
             requires_respect_materialization_data_versions=requires_respect_materialization_data_versions,
             supports_with_external_asset_graph=supports_with_external_asset_graph,
             expected_error_message=expected_error_message,
+            expected_skipped_subset=expected_skipped_subset,
         )
 
     def _get_code_location_origin(
@@ -243,6 +246,13 @@ class AssetReconciliationScenario(
                 + (f"_{location_name}" if location_name else ""),
             ),
             location_name=location_name or "test_location",
+        )
+
+    @property
+    def expected_skipped_asset_graph_subset(self) -> AssetGraphSubset:
+        return AssetGraphSubset.from_asset_partition_set(
+            self.expected_skipped_subset or set(),
+            AssetGraph.from_assets(self.assets or []),
         )
 
     def do_sensor_scenario(

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
@@ -341,7 +341,9 @@ class AssetReconciliationScenario(
                     )
 
                 # make sure we can deserialize it using the new asset graph
-                cursor = AssetDaemonCursor.from_serialized(cursor.serialize(), repo.asset_graph)
+                cursor = AssetDaemonCursor.from_serialized(
+                    cursor.serialize(instance), repo.asset_graph
+                )
 
             else:
                 cursor = AssetDaemonCursor.empty()

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
@@ -397,9 +397,7 @@ class AssetReconciliationScenario(
                     asset_graph = ExternalAssetGraph.from_workspace(workspace)
 
             target_asset_keys = (
-                self.asset_selection.resolve(asset_graph)
-                if self.asset_selection
-                else asset_graph.materializable_asset_keys
+                self.asset_selection.resolve(asset_graph) if self.asset_selection else None
             )
 
             run_requests, cursor, evaluations = AssetDaemonContext(

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_fast.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_fast.py
@@ -40,7 +40,7 @@ from .scenarios.scenarios import ASSET_RECONCILIATION_SCENARIOS
 )
 def test_reconciliation(scenario, respect_materialization_data_versions):
     instance = DagsterInstance.ephemeral()
-    run_requests, _, evaluations = scenario.do_sensor_scenario(
+    run_requests, cursor, evaluations = scenario.do_sensor_scenario(
         instance, respect_materialization_data_versions=respect_materialization_data_versions
     )
 
@@ -74,6 +74,18 @@ def test_reconciliation(scenario, respect_materialization_data_versions):
                 for evaluation_spec in scenario.expected_evaluations
             ]
         ) == _sorted_evaluations(evaluations)
+
+    if scenario.expected_skipped_subset is not None:
+        # the __eq__ method for AssetGraphSubset ends up checking for object equality between
+        # the underlying AssetGraphs, so we just compare the important bits.
+        assert (
+            cursor.skipped_asset_graph_subset.non_partitioned_asset_keys
+            == scenario.expected_skipped_asset_graph_subset.non_partitioned_asset_keys
+        )
+        assert (
+            cursor.skipped_asset_graph_subset.partitions_subsets_by_asset_key
+            == scenario.expected_skipped_asset_graph_subset.partitions_subsets_by_asset_key
+        )
 
     assert len(run_requests) == len(scenario.expected_run_requests), evaluations
 


### PR DESCRIPTION
## Summary & Motivation

The underlying semantics of auto materialize `MATERIALIZE` rules has historically been to *only* return things that have newly become true since the last tick.

In order for this to work, we need to ensure that the existing `SKIP` rules will never become false without a `MATERIALIZE` rule newly becoming true. Otherwise, you could have the following situations:

Tick 1: Both a `MATERIALIZE` and `SKIP` rule activate -> no materialization
Tick 2: `SKIP` rule becomes false

Now, on this tick, we will have "forgotten" that there's still a reason that we should materialize, leading to no materialization being fired.

This has been fine, as all of our existing `SKIP` rules relate to the materialization of assets, so we'd always have a relevant `MATERIALIZE` rule on tick 2. However, this won't always be the case.

This PR allows old tick information to be "resurrected" and merged with the newly true rules which are calculated on the given tick.

## How I Tested These Changes
