### PR TITLE
[Asset graph] Usability improvements

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/components/PageHeader.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/PageHeader.tsx
@@ -13,17 +13,21 @@ interface Props {
   metadata?: React.ReactNode;
   right?: React.ReactNode;
   tabs?: React.ReactNode;
+  paddingBelowTitle?: number;
 }
 
 export const PageHeader = (props: Props) => {
-  const {title, tags, right, tabs} = props;
+  const {title, tags, right, tabs, paddingBelowTitle = 16} = props;
   return (
     <PageHeaderContainer
       background={Colors.Gray50}
       padding={{top: 16, left: 24, right: 12}}
       border="bottom"
     >
-      <Box flex={{direction: 'row', justifyContent: 'space-between'}} padding={{bottom: 16}}>
+      <Box
+        flex={{direction: 'row', justifyContent: 'space-between'}}
+        padding={{bottom: paddingBelowTitle as any}}
+      >
         <Box flex={{direction: 'row', alignItems: 'flex-start', gap: 12, wrap: 'wrap'}}>
           {title}
           {tags}

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -311,100 +311,102 @@ const AssetGraphExplorerWithData: React.FC<WithDataProps> = ({
           {loading || !layout ? (
             <LoadingNotice async={async} nodeType="asset" />
           ) : (
-            <SVGViewport
-              ref={(r) => (viewportEl.current = r || undefined)}
-              defaultZoom={flagHorizontalDAGs ? 'zoom-to-fit-width' : 'zoom-to-fit'}
-              interactor={SVGViewport.Interactors.PanAndZoom}
-              graphWidth={layout.width}
-              graphHeight={layout.height}
-              graphHasNoMinimumZoom={allowGroupsOnlyZoomLevel}
-              onClick={onClickBackground}
-              onArrowKeyDown={onArrowKeyDown}
-              onDoubleClick={(e) => {
-                viewportEl.current?.autocenter(true);
-                e.stopPropagation();
-              }}
-              maxZoom={DEFAULT_MAX_ZOOM}
-              maxAutocenterZoom={1.0}
-            >
-              {({scale}, viewportRect) => (
-                <SVGContainer width={layout.width} height={layout.height}>
-                  <AssetEdges
-                    viewportRect={viewportRect}
-                    selected={selectedGraphNodes.map((n) => n.id)}
-                    highlighted={highlighted}
-                    edges={layout.edges}
-                    strokeWidth={allowGroupsOnlyZoomLevel ? Math.max(4, 3 / scale) : 4}
-                    baseColor={
-                      allowGroupsOnlyZoomLevel && scale < GROUPS_ONLY_SCALE
-                        ? Colors.Gray400
-                        : Colors.KeylineGray
-                    }
-                  />
-
-                  {Object.values(layout.groups)
-                    .filter((node) => !isNodeOffscreen(node.bounds, viewportRect))
-                    .sort((a, b) => a.id.length - b.id.length)
-                    .map((group) => (
-                      <foreignObject
-                        key={group.id}
-                        {...group.bounds}
-                        onDoubleClick={(e) => {
-                          if (!viewportEl.current) {
-                            return;
-                          }
-                          const targetScale = viewportEl.current.scaleForSVGBounds(
-                            group.bounds.width,
-                            group.bounds.height,
-                          );
-                          viewportEl.current.zoomToSVGBox(group.bounds, true, targetScale * 0.9);
-                          e.stopPropagation();
-                        }}
-                      >
-                        <AssetGroupNode group={group} scale={scale} />
-                      </foreignObject>
-                    ))}
-
-                  {Object.values(layout.nodes)
-                    .filter((node) => !isNodeOffscreen(node.bounds, viewportRect))
-                    .map(({id, bounds}) => {
-                      const graphNode = assetGraphData.nodes[id]!;
-                      const path = JSON.parse(id);
-                      if (allowGroupsOnlyZoomLevel && scale < GROUPS_ONLY_SCALE) {
-                        return;
+            <div style={{cursor: 'grab'}}>
+              <SVGViewport
+                ref={(r) => (viewportEl.current = r || undefined)}
+                defaultZoom={flagHorizontalDAGs ? 'zoom-to-fit-width' : 'zoom-to-fit'}
+                interactor={SVGViewport.Interactors.PanAndZoom}
+                graphWidth={layout.width}
+                graphHeight={layout.height}
+                graphHasNoMinimumZoom={allowGroupsOnlyZoomLevel}
+                onClick={onClickBackground}
+                onArrowKeyDown={onArrowKeyDown}
+                onDoubleClick={(e) => {
+                  viewportEl.current?.autocenter(true);
+                  e.stopPropagation();
+                }}
+                maxZoom={DEFAULT_MAX_ZOOM}
+                maxAutocenterZoom={1.0}
+              >
+                {({scale}, viewportRect) => (
+                  <SVGContainer width={layout.width} height={layout.height}>
+                    <AssetEdges
+                      viewportRect={viewportRect}
+                      selected={selectedGraphNodes.map((n) => n.id)}
+                      highlighted={highlighted}
+                      edges={layout.edges}
+                      strokeWidth={allowGroupsOnlyZoomLevel ? Math.max(4, 3 / scale) : 4}
+                      baseColor={
+                        allowGroupsOnlyZoomLevel && scale < GROUPS_ONLY_SCALE
+                          ? Colors.Gray400
+                          : Colors.KeylineGray
                       }
-                      return (
+                    />
+
+                    {Object.values(layout.groups)
+                      .filter((node) => !isNodeOffscreen(node.bounds, viewportRect))
+                      .sort((a, b) => a.id.length - b.id.length)
+                      .map((group) => (
                         <foreignObject
-                          {...bounds}
-                          key={id}
-                          onMouseEnter={() => setHighlighted(id)}
-                          onMouseLeave={() => setHighlighted(null)}
-                          onClick={(e) => onSelectNode(e, {path}, graphNode)}
+                          key={group.id}
+                          {...group.bounds}
                           onDoubleClick={(e) => {
-                            viewportEl.current?.zoomToSVGBox(bounds, true, 1.2);
+                            if (!viewportEl.current) {
+                              return;
+                            }
+                            const targetScale = viewportEl.current.scaleForSVGBounds(
+                              group.bounds.width,
+                              group.bounds.height,
+                            );
+                            viewportEl.current.zoomToSVGBox(group.bounds, true, targetScale * 0.9);
                             e.stopPropagation();
                           }}
-                          style={{overflow: 'visible'}}
                         >
-                          {!graphNode ? (
-                            <AssetNodeLink assetKey={{path}} />
-                          ) : scale < MINIMAL_SCALE ? (
-                            <AssetNodeMinimal
-                              definition={graphNode.definition}
-                              selected={selectedGraphNodes.includes(graphNode)}
-                            />
-                          ) : (
-                            <AssetNode
-                              definition={graphNode.definition}
-                              selected={selectedGraphNodes.includes(graphNode)}
-                            />
-                          )}
+                          <AssetGroupNode group={group} scale={scale} />
                         </foreignObject>
-                      );
-                    })}
-                </SVGContainer>
-              )}
-            </SVGViewport>
+                      ))}
+
+                    {Object.values(layout.nodes)
+                      .filter((node) => !isNodeOffscreen(node.bounds, viewportRect))
+                      .map(({id, bounds}) => {
+                        const graphNode = assetGraphData.nodes[id]!;
+                        const path = JSON.parse(id);
+                        if (allowGroupsOnlyZoomLevel && scale < GROUPS_ONLY_SCALE) {
+                          return;
+                        }
+                        return (
+                          <foreignObject
+                            {...bounds}
+                            key={id}
+                            onMouseEnter={() => setHighlighted(id)}
+                            onMouseLeave={() => setHighlighted(null)}
+                            onClick={(e) => onSelectNode(e, {path}, graphNode)}
+                            onDoubleClick={(e) => {
+                              viewportEl.current?.zoomToSVGBox(bounds, true, 1.2);
+                              e.stopPropagation();
+                            }}
+                            style={{overflow: 'visible'}}
+                          >
+                            {!graphNode ? (
+                              <AssetNodeLink assetKey={{path}} />
+                            ) : scale < MINIMAL_SCALE ? (
+                              <AssetNodeMinimal
+                                definition={graphNode.definition}
+                                selected={selectedGraphNodes.includes(graphNode)}
+                              />
+                            ) : (
+                              <AssetNode
+                                definition={graphNode.definition}
+                                selected={selectedGraphNodes.includes(graphNode)}
+                              />
+                            )}
+                          </foreignObject>
+                        );
+                      })}
+                  </SVGContainer>
+                )}
+              </SVGViewport>
+            </div>
           )}
           {setOptions && (
             <OptionsOverlay>

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -311,102 +311,100 @@ const AssetGraphExplorerWithData: React.FC<WithDataProps> = ({
           {loading || !layout ? (
             <LoadingNotice async={async} nodeType="asset" />
           ) : (
-            <div style={{cursor: 'grab'}}>
-              <SVGViewport
-                ref={(r) => (viewportEl.current = r || undefined)}
-                defaultZoom={flagHorizontalDAGs ? 'zoom-to-fit-width' : 'zoom-to-fit'}
-                interactor={SVGViewport.Interactors.PanAndZoom}
-                graphWidth={layout.width}
-                graphHeight={layout.height}
-                graphHasNoMinimumZoom={allowGroupsOnlyZoomLevel}
-                onClick={onClickBackground}
-                onArrowKeyDown={onArrowKeyDown}
-                onDoubleClick={(e) => {
-                  viewportEl.current?.autocenter(true);
-                  e.stopPropagation();
-                }}
-                maxZoom={DEFAULT_MAX_ZOOM}
-                maxAutocenterZoom={1.0}
-              >
-                {({scale}, viewportRect) => (
-                  <SVGContainer width={layout.width} height={layout.height}>
-                    <AssetEdges
-                      viewportRect={viewportRect}
-                      selected={selectedGraphNodes.map((n) => n.id)}
-                      highlighted={highlighted}
-                      edges={layout.edges}
-                      strokeWidth={allowGroupsOnlyZoomLevel ? Math.max(4, 3 / scale) : 4}
-                      baseColor={
-                        allowGroupsOnlyZoomLevel && scale < GROUPS_ONLY_SCALE
-                          ? Colors.Gray400
-                          : Colors.KeylineGray
-                      }
-                    />
+            <SVGViewport
+              ref={(r) => (viewportEl.current = r || undefined)}
+              defaultZoom={flagHorizontalDAGs ? 'zoom-to-fit-width' : 'zoom-to-fit'}
+              interactor={SVGViewport.Interactors.PanAndZoom}
+              graphWidth={layout.width}
+              graphHeight={layout.height}
+              graphHasNoMinimumZoom={allowGroupsOnlyZoomLevel}
+              onClick={onClickBackground}
+              onArrowKeyDown={onArrowKeyDown}
+              onDoubleClick={(e) => {
+                viewportEl.current?.autocenter(true);
+                e.stopPropagation();
+              }}
+              maxZoom={DEFAULT_MAX_ZOOM}
+              maxAutocenterZoom={1.0}
+            >
+              {({scale}, viewportRect) => (
+                <SVGContainer width={layout.width} height={layout.height}>
+                  <AssetEdges
+                    viewportRect={viewportRect}
+                    selected={selectedGraphNodes.map((n) => n.id)}
+                    highlighted={highlighted}
+                    edges={layout.edges}
+                    strokeWidth={allowGroupsOnlyZoomLevel ? Math.max(4, 3 / scale) : 4}
+                    baseColor={
+                      allowGroupsOnlyZoomLevel && scale < GROUPS_ONLY_SCALE
+                        ? Colors.Gray400
+                        : Colors.KeylineGray
+                    }
+                  />
 
-                    {Object.values(layout.groups)
-                      .filter((node) => !isNodeOffscreen(node.bounds, viewportRect))
-                      .sort((a, b) => a.id.length - b.id.length)
-                      .map((group) => (
+                  {Object.values(layout.groups)
+                    .filter((node) => !isNodeOffscreen(node.bounds, viewportRect))
+                    .sort((a, b) => a.id.length - b.id.length)
+                    .map((group) => (
+                      <foreignObject
+                        key={group.id}
+                        {...group.bounds}
+                        onDoubleClick={(e) => {
+                          if (!viewportEl.current) {
+                            return;
+                          }
+                          const targetScale = viewportEl.current.scaleForSVGBounds(
+                            group.bounds.width,
+                            group.bounds.height,
+                          );
+                          viewportEl.current.zoomToSVGBox(group.bounds, true, targetScale * 0.9);
+                          e.stopPropagation();
+                        }}
+                      >
+                        <AssetGroupNode group={group} scale={scale} />
+                      </foreignObject>
+                    ))}
+
+                  {Object.values(layout.nodes)
+                    .filter((node) => !isNodeOffscreen(node.bounds, viewportRect))
+                    .map(({id, bounds}) => {
+                      const graphNode = assetGraphData.nodes[id]!;
+                      const path = JSON.parse(id);
+                      if (allowGroupsOnlyZoomLevel && scale < GROUPS_ONLY_SCALE) {
+                        return;
+                      }
+                      return (
                         <foreignObject
-                          key={group.id}
-                          {...group.bounds}
+                          {...bounds}
+                          key={id}
+                          onMouseEnter={() => setHighlighted(id)}
+                          onMouseLeave={() => setHighlighted(null)}
+                          onClick={(e) => onSelectNode(e, {path}, graphNode)}
                           onDoubleClick={(e) => {
-                            if (!viewportEl.current) {
-                              return;
-                            }
-                            const targetScale = viewportEl.current.scaleForSVGBounds(
-                              group.bounds.width,
-                              group.bounds.height,
-                            );
-                            viewportEl.current.zoomToSVGBox(group.bounds, true, targetScale * 0.9);
+                            viewportEl.current?.zoomToSVGBox(bounds, true, 1.2);
                             e.stopPropagation();
                           }}
+                          style={{overflow: 'visible'}}
                         >
-                          <AssetGroupNode group={group} scale={scale} />
+                          {!graphNode ? (
+                            <AssetNodeLink assetKey={{path}} />
+                          ) : scale < MINIMAL_SCALE ? (
+                            <AssetNodeMinimal
+                              definition={graphNode.definition}
+                              selected={selectedGraphNodes.includes(graphNode)}
+                            />
+                          ) : (
+                            <AssetNode
+                              definition={graphNode.definition}
+                              selected={selectedGraphNodes.includes(graphNode)}
+                            />
+                          )}
                         </foreignObject>
-                      ))}
-
-                    {Object.values(layout.nodes)
-                      .filter((node) => !isNodeOffscreen(node.bounds, viewportRect))
-                      .map(({id, bounds}) => {
-                        const graphNode = assetGraphData.nodes[id]!;
-                        const path = JSON.parse(id);
-                        if (allowGroupsOnlyZoomLevel && scale < GROUPS_ONLY_SCALE) {
-                          return;
-                        }
-                        return (
-                          <foreignObject
-                            {...bounds}
-                            key={id}
-                            onMouseEnter={() => setHighlighted(id)}
-                            onMouseLeave={() => setHighlighted(null)}
-                            onClick={(e) => onSelectNode(e, {path}, graphNode)}
-                            onDoubleClick={(e) => {
-                              viewportEl.current?.zoomToSVGBox(bounds, true, 1.2);
-                              e.stopPropagation();
-                            }}
-                            style={{overflow: 'visible'}}
-                          >
-                            {!graphNode ? (
-                              <AssetNodeLink assetKey={{path}} />
-                            ) : scale < MINIMAL_SCALE ? (
-                              <AssetNodeMinimal
-                                definition={graphNode.definition}
-                                selected={selectedGraphNodes.includes(graphNode)}
-                              />
-                            ) : (
-                              <AssetNode
-                                definition={graphNode.definition}
-                                selected={selectedGraphNodes.includes(graphNode)}
-                              />
-                            )}
-                          </foreignObject>
-                        );
-                      })}
-                  </SVGContainer>
-                )}
-              </SVGViewport>
-            </div>
+                      );
+                    })}
+                </SVGContainer>
+              )}
+            </SVGViewport>
           )}
           {setOptions && (
             <OptionsOverlay>

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode.tsx
@@ -286,7 +286,7 @@ const AssetInsetForHoverEffect = styled.div`
 
 const AssetNodeContainer = styled.div<{$selected: boolean}>`
   user-select: none;
-  cursor: default;
+  cursor: pointer;
   padding: 4px;
 `;
 

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Node.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Node.tsx
@@ -50,7 +50,7 @@ export const Node = ({
   isSelected: boolean;
   explorerPath: ExplorerPath;
   onChangeExplorerPath: (path: ExplorerPath, mode: 'replace' | 'push') => void;
-  viewType: 'tree' | 'folder';
+  viewType: 'tree' | 'group';
 }) => {
   const isGroupNode = 'groupName' in node;
   const isLocationNode = 'locationName' in node;

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/SearchFilter.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/SearchFilter.tsx
@@ -14,7 +14,7 @@ export const SearchFilter = <T,>({
     <SuggestWrapper {...containerProps}>
       <Suggest<(typeof values)[0]>
         key="asset-graph-explorer-search-bar"
-        inputProps={{placeholder: 'Search', style: {width: `min(100%, ${viewport.width}px)`}}}
+        inputProps={{placeholder: 'Jump to…', style: {width: `min(100%, ${viewport.width}px)`}}}
         items={values}
         inputValueRenderer={(item) => item.label}
         itemPredicate={(query, item) =>

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
@@ -310,7 +310,7 @@ export const AssetGraphExplorerSidebar = React.memo(
               activeItems={new Set([viewType])}
               buttons={[
                 {id: 'tree', label: 'Tree view', icon: 'gantt_flat'},
-                {id: 'group', label: 'Group view', icon: 'folder_open'},
+                {id: 'group', label: 'Group view', icon: 'asset_group'},
               ]}
               onClick={(id: 'tree' | 'group') => {
                 setViewType(id);

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
@@ -80,7 +80,7 @@ export const AssetGraphExplorerSidebar = React.memo(
       null | {id: string; path: string} | {id: string}
     >(null);
 
-    const [viewType, setViewType] = React.useState<'tree' | 'folder'>('tree');
+    const [viewType, setViewType] = React.useState<'tree' | 'group'>('tree');
 
     const rootNodes = React.useMemo(
       () =>
@@ -120,7 +120,7 @@ export const AssetGraphExplorerSidebar = React.memo(
       return treeNodes;
     }, [graphData.downstream, graphData.nodes, openNodes, rootNodes]);
 
-    const folderNodes = React.useMemo(() => {
+    const {folderNodes, codeLocationNodes} = React.useMemo(() => {
       const folderNodes: FolderNodeType[] = [];
 
       // Map of Code Locations -> Groups -> Assets
@@ -174,7 +174,7 @@ export const AssetGraphExplorerSidebar = React.memo(
         }
       });
 
-      return folderNodes;
+      return {folderNodes, codeLocationNodes};
     }, [graphData.nodes, openNodes]);
 
     const renderedNodes = viewType === 'tree' ? treeNodes : folderNodes;
@@ -192,9 +192,27 @@ export const AssetGraphExplorerSidebar = React.memo(
     const items = rowVirtualizer.getVirtualItems();
 
     React.useLayoutEffect(() => {
+      if (renderedNodes.length === 1 && viewType === 'group') {
+        // If there's a single code location and a single group in it then just open them
+        setOpenNodes((prevOpenNodes) => {
+          const nextOpenNodes = new Set(prevOpenNodes);
+          const locations = Object.keys(codeLocationNodes);
+          if (locations.length === 1) {
+            const location = codeLocationNodes[locations[0]!]!;
+            nextOpenNodes.add(location.locationName);
+            const groups = Object.keys(location.groups);
+            if (groups.length === 1) {
+              nextOpenNodes.add(
+                location.locationName + ':' + location.groups[groups[0]!]!.groupName,
+              );
+            }
+          }
+          return nextOpenNodes;
+        });
+      }
       if (lastSelectedNode) {
         setOpenNodes((prevOpenNodes) => {
-          if (viewType === 'folder') {
+          if (viewType === 'group') {
             const nextOpenNodes = new Set(prevOpenNodes);
             const assetNode = graphData.nodes[lastSelectedNode.id];
             if (assetNode) {
@@ -292,9 +310,9 @@ export const AssetGraphExplorerSidebar = React.memo(
               activeItems={new Set([viewType])}
               buttons={[
                 {id: 'tree', label: 'Tree view', icon: 'gantt_flat'},
-                {id: 'folder', label: 'Folder view', icon: 'folder_open'},
+                {id: 'group', label: 'Group view', icon: 'folder_open'},
               ]}
-              onClick={(id: 'tree' | 'folder') => {
+              onClick={(id: 'tree' | 'group') => {
                 setViewType(id);
               }}
             />

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetGroupRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetGroupRoot.tsx
@@ -84,11 +84,8 @@ export const AssetGroupRoot: React.FC<{repoAddress: RepoAddress; tab: 'lineage' 
     <Page style={{display: 'flex', flexDirection: 'column', paddingBottom: 0}}>
       <PageHeader
         title={<Heading>{groupName}</Heading>}
-        right={
-          <div style={{marginBottom: -8}}>
-            <ReloadAllButton label="Reload definitions" />
-          </div>
-        }
+        right={<ReloadAllButton label="Reload definitions" />}
+        paddingBelowTitle={0}
         tags={<AssetGroupTags groupSelector={groupSelector} repoAddress={repoAddress} />}
         tabs={
           <Box

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsGroupsGlobalGraphRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsGroupsGlobalGraphRoot.tsx
@@ -94,11 +94,8 @@ export const AssetsGroupsGlobalGraphRoot: React.FC = () => {
     <Page style={{display: 'flex', flexDirection: 'column', paddingBottom: 0}}>
       <PageHeader
         title={<Heading>Global Asset Lineage</Heading>}
-        right={
-          <div style={{marginBottom: -8}}>
-            <ReloadAllButton label="Reload definitions" />
-          </div>
-        }
+        paddingBelowTitle={0}
+        right={<ReloadAllButton label="Reload definitions" />}
       />
       <AssetGraphExplorer
         fetchOptions={fetchOptions}

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/SVGViewport.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/SVGViewport.tsx
@@ -39,6 +39,7 @@ interface SVGViewportState {
   y: number;
   scale: number;
   minScale: number;
+  isClickHeld: boolean;
 }
 
 interface Point {
@@ -94,6 +95,7 @@ const PanAndZoomInteractor: SVGViewportInteractor = {
       lastY = offset.y;
     };
 
+    viewport.setState({isClickHeld: true});
     const onCancelClick = (e: MouseEvent) => {
       // If you press, drag, and release the mouse we don't want it to trigger a click
       // beneath your cursor. onClick's within the DAG should only fire if you did not
@@ -104,6 +106,7 @@ const PanAndZoomInteractor: SVGViewportInteractor = {
       }
     };
     const onUp = () => {
+      viewport.setState({isClickHeld: false});
       document.removeEventListener('mousemove', onMove);
       document.removeEventListener('mouseup', onUp);
       setTimeout(() => {
@@ -299,6 +302,7 @@ export class SVGViewport extends React.Component<SVGViewportProps, SVGViewportSt
     y: 0,
     scale: DETAIL_ZOOM,
     minScale: 0,
+    isClickHeld: false,
   };
 
   resizeObserver: any | undefined;
@@ -587,7 +591,7 @@ export class SVGViewport extends React.Component<SVGViewportProps, SVGViewportSt
 
   render() {
     const {children, onClick, interactor} = this.props;
-    const {x, y, scale} = this.state;
+    const {x, y, scale, isClickHeld} = this.state;
     const dotsize = Math.max(7, 30 * scale);
 
     return (
@@ -596,6 +600,7 @@ export class SVGViewport extends React.Component<SVGViewportProps, SVGViewportSt
         style={Object.assign({}, SVGViewportStyles, {
           backgroundPosition: `${x}px ${y}px`,
           backgroundSize: `${dotsize}px`,
+          ...(isClickHeld ? {cursor: 'grabbing'} : {}),
         })}
         onMouseDown={(e) => interactor.onMouseDown(this, e)}
         onDoubleClick={this.onDoubleClick}
@@ -630,6 +635,7 @@ const SVGViewportStyles: React.CSSProperties = {
   userSelect: 'none',
   outline: 'none',
   background: `url("data:image/svg+xml;utf8,<svg width='30px' height='30px' viewBox='0 0 80 80' xmlns='http://www.w3.org/2000/svg'><circle fill='rgba(236, 236, 236, 1)' cx='5' cy='5' r='5' /></svg>") repeat`,
+  cursor: 'grab',
 };
 
 const ZoomSliderContainer = styled.div`

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/SVGViewport.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/SVGViewport.tsx
@@ -600,7 +600,7 @@ export class SVGViewport extends React.Component<SVGViewportProps, SVGViewportSt
         style={Object.assign({}, SVGViewportStyles, {
           backgroundPosition: `${x}px ${y}px`,
           backgroundSize: `${dotsize}px`,
-          ...(isClickHeld ? {cursor: 'grabbing'} : {}),
+          cursor: isClickHeld ? 'grabbing' : 'grab',
         })}
         onMouseDown={(e) => interactor.onMouseDown(this, e)}
         onDoubleClick={this.onDoubleClick}
@@ -635,7 +635,6 @@ const SVGViewportStyles: React.CSSProperties = {
   userSelect: 'none',
   outline: 'none',
   background: `url("data:image/svg+xml;utf8,<svg width='30px' height='30px' viewBox='0 0 80 80' xmlns='http://www.w3.org/2000/svg'><circle fill='rgba(236, 236, 236, 1)' cx='5' cy='5' r='5' /></svg>") repeat`,
-  cursor: 'grab',
 };
 
 const ZoomSliderContainer = styled.div`


### PR DESCRIPTION
## Summary & Motivation

Requests from josh:

- [x]  Can we rename “Folder view” to “Group view” and use the asset group icon
- [x]  On an asset group page is it possible to auto expand the list of asset in the group/folder view? Or maybe this should always just be a list if there is only one group?
- [x]  Can we change the default cursor on the graph to be `cursor: grab` and `cursor: grabbing` on drag? Hovering over an asset should change it to `cursor: pointer`
- [x]  Fix the alignment of the reload definitions button
- [x]  change the placeholder text here from “Search” to “Jump to…”


## How I Tested These Changes
locally