### PR TITLE
[Asset graph] Revamp top bar

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -431,6 +431,7 @@ const AssetGraphExplorerWithData: React.FC<WithDataProps> = ({
           <TopbarWrapper>
             <div>{fetchOptionFilters}</div>
             <GraphQueryInput
+              type="asset_graph"
               items={graphQueryItems}
               value={explorerPath.opsQuery}
               placeholder="Type an asset subset…"

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -1,5 +1,4 @@
 import {
-  Box,
   Checkbox,
   Colors,
   NonIdealState,

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -8,6 +8,7 @@ import {
   Button,
   Icon,
   Tooltip,
+  TextInputContainer,
 } from '@dagster-io/ui-components';
 import pickBy from 'lodash/pickBy';
 import uniq from 'lodash/uniq';
@@ -427,27 +428,40 @@ const AssetGraphExplorerWithData: React.FC<WithDataProps> = ({
             </OptionsOverlay>
           )}
 
-          <Box style={{position: 'absolute', right: 12, top: 8}}>
-            <Box flex={{alignItems: 'center', gap: 12}}>
-              <AssetLiveDataRefresh />
-              <LaunchAssetObservationButton
-                preferredJobName={explorerPath.pipelineName}
-                scope={
-                  selectedDefinitions.length
-                    ? {selected: selectedDefinitions.filter((a) => a.isObservable)}
-                    : {all: allDefinitionsForMaterialize.filter((a) => a.isObservable)}
-                }
-              />
-              <LaunchAssetExecutionButton
-                preferredJobName={explorerPath.pipelineName}
-                scope={
-                  selectedDefinitions.length
-                    ? {selected: selectedDefinitions}
-                    : {all: allDefinitionsForMaterialize}
-                }
-              />
-            </Box>
-          </Box>
+          <TopbarWrapper>
+            <div>{fetchOptionFilters}</div>
+            <GraphQueryInput
+              items={graphQueryItems}
+              value={explorerPath.opsQuery}
+              placeholder="Type an asset subset…"
+              onChange={(opsQuery) => onChangeExplorerPath({...explorerPath, opsQuery}, 'replace')}
+              popoverPosition="bottom-left"
+            />
+            <Button
+              onClick={() => {
+                onChangeExplorerPath({...explorerPath, opsQuery: ''}, 'push');
+              }}
+            >
+              Clear query
+            </Button>
+            <AssetLiveDataRefresh />
+            <LaunchAssetObservationButton
+              preferredJobName={explorerPath.pipelineName}
+              scope={
+                selectedDefinitions.length
+                  ? {selected: selectedDefinitions.filter((a) => a.isObservable)}
+                  : {all: allDefinitionsForMaterialize.filter((a) => a.isObservable)}
+              }
+            />
+            <LaunchAssetExecutionButton
+              preferredJobName={explorerPath.pipelineName}
+              scope={
+                selectedDefinitions.length
+                  ? {selected: selectedDefinitions}
+                  : {all: allDefinitionsForMaterialize}
+              }
+            />
+          </TopbarWrapper>
           <QueryOverlay>
             {showSidebar || !flagDAGSidebar ? null : (
               <Tooltip content="Show sidebar">
@@ -459,16 +473,6 @@ const AssetGraphExplorerWithData: React.FC<WithDataProps> = ({
                 />
               </Tooltip>
             )}
-            {fetchOptionFilters}
-
-            <GraphQueryInput
-              width={fetchOptionFilters ? '16vw' : undefined}
-              items={graphQueryItems}
-              value={explorerPath.opsQuery}
-              placeholder="Type an asset subset…"
-              onChange={(opsQuery) => onChangeExplorerPath({...explorerPath, opsQuery}, 'replace')}
-              popoverPosition="bottom-left"
-            />
           </QueryOverlay>
         </ErrorBoundary>
       }
@@ -588,3 +592,26 @@ const assetKeyTokensInRange = (
 
   return uniq(ledToTarget);
 };
+
+const TopbarWrapper = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  display: grid;
+  background: white;
+  grid-template-columns: auto 1fr auto auto auto auto;
+  gap: 12px;
+  align-items: center;
+  padding: 12px 15px;
+  border-bottom: 1px solid ${Colors.KeylineGray};
+  ${TextInputContainer} {
+    width: 100%;
+  }
+  > :nth-child(2) {
+    > * {
+      display: block;
+      width: 100%;
+    }
+  }
+`;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetObservationButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetObservationButton.tsx
@@ -43,7 +43,7 @@ export const LaunchAssetObservationButton: React.FC<{
 
   const scopeAssets = 'selected' in scope ? scope.selected : scope.all;
   if (!scopeAssets.length) {
-    return <span />;
+    return <></>;
   }
 
   const count = scopeAssets.length > 1 ? ` (${scopeAssets.length})` : '';

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/GraphQueryInput.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/GraphQueryInput.tsx
@@ -39,6 +39,7 @@ interface GraphQueryInputProps {
   popoverPosition?: PopoverPosition;
   className?: string;
   disabled?: boolean;
+  type?: 'asset_graph';
 
   linkToPreview?: {
     repoName: string;
@@ -325,7 +326,7 @@ export const GraphQueryInput = React.memo(
               disabled={props.disabled}
               value={pendingValue}
               icon="op_selector"
-              rightElement={<InfoIconDialog />}
+              rightElement={props.type === 'asset_graph' ? <InfoIconDialog /> : undefined}
               strokeColor={intentToStrokeColor(props.intent)}
               autoFocus={props.autoFocus}
               placeholder={placeholderTextForItems(props.placeholder, props.items)}

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/GraphQueryInput.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/GraphQueryInput.tsx
@@ -11,6 +11,11 @@ import {
   Popover,
   TextInput,
   Tooltip,
+  Dialog,
+  DialogFooter,
+  DialogBody,
+  Table,
+  Tag,
 } from '@dagster-io/ui-components';
 import isEqual from 'lodash/isEqual';
 import uniq from 'lodash/uniq';
@@ -320,6 +325,7 @@ export const GraphQueryInput = React.memo(
               disabled={props.disabled}
               value={pendingValue}
               icon="op_selector"
+              rightElement={<InfoIconDialog />}
               strokeColor={intentToStrokeColor(props.intent)}
               autoFocus={props.autoFocus}
               placeholder={placeholderTextForItems(props.placeholder, props.items)}
@@ -422,6 +428,116 @@ export const GraphQueryInput = React.memo(
     prevProps.value === nextProps.value &&
     isEqual(prevProps.presets, nextProps.presets),
 );
+
+const InfoIconDialog = () => {
+  const [isOpen, setIsOpen] = React.useState(false);
+  return (
+    <>
+      <Dialog
+        isOpen={isOpen}
+        title="Query filter tips"
+        onClose={() => setIsOpen(false)}
+        style={{width: '743px', maxWidth: '80%'}}
+      >
+        <DialogBody>
+          <Box flex={{direction: 'column', gap: 10}}>
+            <div>Create custom filter queries to fine tune which assets appear in the graph.</div>
+            <CustomTable>
+              <thead>
+                <tr>
+                  <th>Query</th>
+                  <th>Description</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>
+                    <Tag>*</Tag>
+                  </td>
+                  <td>Render the entire lineage graph</td>
+                </tr>
+                <tr>
+                  <td>
+                    <Tag>*"my_asset"</Tag>
+                  </td>
+                  <td>Render the entire upstream lineage of my_asset</td>
+                </tr>
+                <tr>
+                  <td>
+                    <Tag>++"my_asset"</Tag>
+                  </td>
+                  <td>Render two layers upstream of my_asset</td>
+                </tr>
+                <tr>
+                  <td>
+                    <Tag>"my_asset"*</Tag>
+                  </td>
+                  <td>Render one layer upstream of my_asset</td>
+                </tr>
+                <tr>
+                  <td>
+                    <Tag>"my_asset"+</Tag>
+                  </td>
+                  <td>Render the entire downstream lineage of my_asset</td>
+                </tr>
+                <tr>
+                  <td>
+                    <Tag>"my_asset"++</Tag>
+                  </td>
+                  <td>Render two layers downstream of my_asset</td>
+                </tr>
+                <tr>
+                  <td>
+                    <Tag>+"my_asset"+</Tag>
+                  </td>
+                  <td>Render one layer upstream and downstream of my_asset</td>
+                </tr>
+                <tr>
+                  <td>
+                    <Tag>"my_asset" AND "another"</Tag>
+                  </td>
+                  <td>Render two disjointed lineage segments</td>
+                </tr>
+              </tbody>
+            </CustomTable>
+          </Box>
+        </DialogBody>
+        <DialogFooter topBorder>
+          <Button onClick={() => setIsOpen(false)} intent="primary">
+            Close
+          </Button>
+        </DialogFooter>
+      </Dialog>
+      <div
+        style={{cursor: 'pointer'}}
+        onClick={() => {
+          setIsOpen(true);
+        }}
+      >
+        <Icon name="info" />
+      </div>
+    </>
+  );
+};
+
+const CustomTable = styled(Table)`
+  border-left: none;
+
+  &&& tr {
+    &:last-child td {
+      box-shadow: inset 1px 1px 0 rgba(233, 232, 232, 1) !important;
+    }
+    &:last-child td:first-child,
+    td:first-child,
+    th:first-child {
+      vertical-align: middle;
+      box-shadow: inset 0 1px 0 ${Colors.KeylineGray} !important;
+    }
+  }
+  border: 1px solid ${Colors.KeylineGray};
+  border-top: none;
+  margin-bottom: 12px;
+`;
 
 const OpInfoWrap = styled.div`
   width: 350px;

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/GraphQueryInput.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/GraphQueryInput.tsx
@@ -459,43 +459,43 @@ const InfoIconDialog = () => {
                 </tr>
                 <tr>
                   <td>
-                    <Tag>*"my_asset"</Tag>
+                    <Tag>*&quot;my_asset&quot;</Tag>
                   </td>
                   <td>Render the entire upstream lineage of my_asset</td>
                 </tr>
                 <tr>
                   <td>
-                    <Tag>++"my_asset"</Tag>
+                    <Tag>++&quot;my_asset&quot;</Tag>
                   </td>
                   <td>Render two layers upstream of my_asset</td>
                 </tr>
                 <tr>
                   <td>
-                    <Tag>"my_asset"*</Tag>
+                    <Tag>&quot;my_asset&quot;*</Tag>
                   </td>
                   <td>Render one layer upstream of my_asset</td>
                 </tr>
                 <tr>
                   <td>
-                    <Tag>"my_asset"+</Tag>
+                    <Tag>&quot;my_asset&quot;+</Tag>
                   </td>
                   <td>Render the entire downstream lineage of my_asset</td>
                 </tr>
                 <tr>
                   <td>
-                    <Tag>"my_asset"++</Tag>
+                    <Tag>&quot;my_asset&quot;++</Tag>
                   </td>
                   <td>Render two layers downstream of my_asset</td>
                 </tr>
                 <tr>
                   <td>
-                    <Tag>+"my_asset"+</Tag>
+                    <Tag>+&quot;my_asset&quot;+</Tag>
                   </td>
                   <td>Render one layer upstream and downstream of my_asset</td>
                 </tr>
                 <tr>
                   <td>
-                    <Tag>"my_asset" AND "another"</Tag>
+                    <Tag>&quot;my_asset&quot; AND &quot;another&quot;</Tag>
                   </td>
                   <td>Render two disjointed lineage segments</td>
                 </tr>


### PR DESCRIPTION
## Summary & Motivation

Requests from Josh:

- [x]  Can we fix the alignment of the Selection box query row? Right now it does not align with the items in the sidebar (designs below)
    - [x]  Put all items into a toolbar that matches the sidebar header
    - [x]  Stretch the query input to fill space
    - [x]  Add an info icon action that opens a dialog (see designs)
    - [x]  Add a “Clear query” action to make it easier to reset this field

## How I Tested These Changes
locally:
<img width="1496" alt="Screenshot 2023-09-29 at 2 57 04 AM" src="https://github.com/dagster-io/dagster/assets/2286579/ff368fcf-f47e-42f7-80ab-64beec16ea98">
<img width="1496" alt="Screenshot 2023-09-29 at 2 46 53 AM" src="https://github.com/dagster-io/dagster/assets/2286579/e5f0f945-bbc1-4782-a9d7-75fef52fd7a2">
<img width="869" alt="Screenshot 2023-09-29 at 2 46 44 AM" src="https://github.com/dagster-io/dagster/assets/2286579/54f352ea-ba8a-4ab8-908c-b0841bea2aec">

