### PR TITLE
RFC: Add get_materialize_result to PipesClientCompletedInvocation

### DIFF
--- a/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/pure_assets_dsl/assets_dsl.py
+++ b/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/pure_assets_dsl/assets_dsl.py
@@ -3,7 +3,7 @@ import shutil
 from typing import Any, Dict, List
 
 import yaml
-from dagster import AssetsDefinition
+from dagster import AssetsDefinition, MaterializeResult
 from dagster._core.execution.context.compute import AssetExecutionContext
 from dagster._utils import file_relative_path
 
@@ -40,15 +40,15 @@ def from_asset_entries(asset_entries: Dict[str, Any]) -> List[AssetsDefinition]:
         def _assets_def(
             context: AssetExecutionContext,
             pipes_subprocess_client: PipesSubprocessClient,
-        ):
+        ) -> MaterializeResult:
             # instead of querying a dummy client, do your real data processing here
 
             python_executable = shutil.which("python")
             assert python_executable is not None
-            pipes_subprocess_client.run(
+            return pipes_subprocess_client.run(
                 command=[python_executable, file_relative_path(__file__, "sql_script.py"), sql],
                 context=context,
-            ).get_results()
+            ).get_materialize_result()
 
         assets_defs.append(_assets_def)
 

--- a/examples/experimental/assets_yaml_dsl/assets_yaml_dsl_tests/test_assets_dsl.py
+++ b/examples/experimental/assets_yaml_dsl/assets_yaml_dsl_tests/test_assets_dsl.py
@@ -3,8 +3,8 @@ from typing import List
 import yaml
 from assets_yaml_dsl.pure_assets_dsl.assets_dsl import from_asset_entries
 from dagster import AssetsDefinition
+from dagster._core.definitions import materialize
 from dagster._core.definitions.events import AssetKey
-from dagster._core.execution.context.invocation import build_asset_context
 from dagster._core.pipes.subprocess import PipesSubprocessClient
 
 
@@ -69,7 +69,10 @@ assets:
     assert assets_defs
     assert len(assets_defs) == 1
     assets_def = assets_defs[0]
-    assets_def(context=build_asset_context(), pipes_subprocess_client=PipesSubprocessClient())
+
+    materialize(
+        assets=[assets_def], resources=dict(pipes_subprocess_client=PipesSubprocessClient())
+    )
 
 
 def test_basic_group() -> None:

--- a/python_modules/dagster/dagster/_core/definitions/events.py
+++ b/python_modules/dagster/dagster/_core/definitions/events.py
@@ -19,7 +19,7 @@ from typing import (
 import dagster._check as check
 import dagster._seven as seven
 from dagster._annotations import PublicAttr, deprecated, experimental_param, public
-from dagster._core.definitions.data_version import DATA_VERSION_TAG, DataVersion
+from dagster._core.definitions.data_version import DataVersion
 from dagster._core.storage.tags import MULTIDIMENSIONAL_PARTITION_PREFIX, SYSTEM_TAG_PREFIX
 from dagster._serdes import whitelist_for_serdes
 from dagster._serdes.serdes import NamedTupleSerializer
@@ -616,21 +616,6 @@ class AssetMaterialization(
             description=description,
             metadata={"path": MetadataValue.path(path)},
         )
-
-    def get_data_version(self) -> Optional[str]:
-        if not self.tags:
-            return None
-
-        version_value = self.tags.get(DATA_VERSION_TAG)
-
-        if version_value is None:
-            return None
-
-        if not isinstance(version_value, str):
-            # be defensive in case bad values come from underlying storage
-            return None
-
-        return version_value
 
 
 @deprecated(

--- a/python_modules/dagster/dagster/_core/definitions/events.py
+++ b/python_modules/dagster/dagster/_core/definitions/events.py
@@ -19,7 +19,7 @@ from typing import (
 import dagster._check as check
 import dagster._seven as seven
 from dagster._annotations import PublicAttr, deprecated, experimental_param, public
-from dagster._core.definitions.data_version import DataVersion
+from dagster._core.definitions.data_version import DATA_VERSION_TAG, DataVersion
 from dagster._core.storage.tags import MULTIDIMENSIONAL_PARTITION_PREFIX, SYSTEM_TAG_PREFIX
 from dagster._serdes import whitelist_for_serdes
 from dagster._serdes.serdes import NamedTupleSerializer
@@ -616,6 +616,21 @@ class AssetMaterialization(
             description=description,
             metadata={"path": MetadataValue.path(path)},
         )
+
+    def get_data_version(self) -> Optional[str]:
+        if not self.tags:
+            return None
+
+        version_value = self.tags.get(DATA_VERSION_TAG)
+
+        if version_value is None:
+            return None
+
+        if not isinstance(version_value, str):
+            # be defensive in case bad values come from underlying storage
+            return None
+
+        return version_value
 
 
 @deprecated(

--- a/python_modules/dagster/dagster/_core/pipes/client.py
+++ b/python_modules/dagster/dagster/_core/pipes/client.py
@@ -62,7 +62,6 @@ class PipesClientCompletedInvocation:
             for check_result in self._results
             if isinstance(check_result, AssetCheckResult)
         ]
-        # import code; code.interact(local=locals())
 
         check.invariant(
             len(mat_results) == 1,
@@ -77,8 +76,6 @@ class PipesClientCompletedInvocation:
                     "Check result specified an asset key that is not part of the returned"
                     " materialization. If this was deliberate, use get_results() instead.",
                 )
-
-        # data_version_str = mat_result.get_data_version()
 
         if check_results:
             return mat_result._replace(

--- a/python_modules/dagster/dagster/_core/pipes/client.py
+++ b/python_modules/dagster/dagster/_core/pipes/client.py
@@ -64,6 +64,9 @@ class PipesClientCompletedInvocation:
         ]
 
         check.invariant(
+            len(mat_results) > 0, "No materialization results received. Internal error?"
+        )
+        check.invariant(
             len(mat_results) == 1,
             "Multiple materialize results returned. If this was deliberate, use get_results()"
             " instead.",

--- a/python_modules/dagster/dagster/_core/pipes/client.py
+++ b/python_modules/dagster/dagster/_core/pipes/client.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Iterator, Optional, Sequence
+from typing import TYPE_CHECKING, Iterator, List, Optional, Sequence
 
 from dagster_pipes import (
     PipesContextData,
@@ -8,7 +8,10 @@ from dagster_pipes import (
     PipesParams,
 )
 
+from dagster import _check as check
 from dagster._annotations import experimental, public
+from dagster._core.definitions.asset_check_result import AssetCheckResult
+from dagster._core.definitions.result import MaterializeResult
 from dagster._core.execution.context.compute import OpExecutionContext
 
 if TYPE_CHECKING:
@@ -49,6 +52,40 @@ class PipesClientCompletedInvocation:
 
     def get_results(self) -> Sequence["PipesExecutionResult"]:
         return tuple(self._results)
+
+    def get_materialize_result(self) -> MaterializeResult:
+        mat_results: List[MaterializeResult] = [
+            mat_result for mat_result in self._results if isinstance(mat_result, MaterializeResult)
+        ]
+        check_results: List[AssetCheckResult] = [
+            check_result
+            for check_result in self._results
+            if isinstance(check_result, AssetCheckResult)
+        ]
+        # import code; code.interact(local=locals())
+
+        check.invariant(
+            len(mat_results) == 1,
+            "Multiple materialize results returned. If this was deliberate, use get_results()"
+            " instead.",
+        )
+        mat_result = next(iter(mat_results))
+        for check_result in check_results:
+            if check_result.asset_key:
+                check.invariant(
+                    mat_result.asset_key == check_result.asset_key,
+                    "Check result specified an asset key that is not part of the returned"
+                    " materialization. If this was deliberate, use get_results() instead.",
+                )
+
+        # data_version_str = mat_result.get_data_version()
+
+        if check_results:
+            return mat_result._replace(
+                check_results=[*(mat_result.check_results or []), *check_results]
+            )
+        else:
+            return mat_result
 
 
 @experimental

--- a/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/in_process_client.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/in_process_client.py
@@ -1,0 +1,126 @@
+from contextlib import contextmanager
+from typing import Callable, Iterator, List, Optional
+
+from dagster import (
+    ResourceParam,
+    _check as check,
+)
+from dagster._annotations import public
+from dagster._core.execution.context.compute import OpExecutionContext
+from dagster._core.pipes.client import (
+    PipesClient,
+    PipesClientCompletedInvocation,
+    PipesContextInjector,
+    PipesMessageReader,
+)
+from dagster._core.pipes.context import build_external_execution_context_data
+from dagster._core.pipes.utils import PipesMessageHandler, open_pipes_session
+from dagster_pipes import (
+    PipesContext,
+    PipesContextData,
+    PipesContextLoader,
+    PipesExtras,
+    PipesMessage,
+    PipesMessageWriter,
+    PipesMessageWriterChannel,
+    PipesParams,
+    PipesParamsLoader,
+    open_dagster_pipes_context,
+)
+
+
+class InProcessPipesContextLoader(PipesContextLoader):
+    def __init__(self, pipes_context_data: PipesContextData):
+        self.pipes_context_data = pipes_context_data
+
+    @contextmanager
+    def load_context(self, params: PipesParams) -> Iterator[PipesContextData]:
+        yield self.pipes_context_data
+
+
+class InProcessPipesMessageWriteChannel(PipesMessageWriterChannel):
+    def __init__(self) -> None:
+        self.messages: List[PipesMessage] = []
+
+    def write_message(self, message: PipesMessage) -> None:
+        self.messages.append(message)
+
+
+class InProcessPipesMessageWriter(PipesMessageWriter):
+    def __init__(self) -> None:
+        self._write_channel = InProcessPipesMessageWriteChannel()
+        check.inst(self._write_channel, InProcessPipesMessageWriteChannel)
+
+    @property
+    def write_channel(self) -> InProcessPipesMessageWriteChannel:
+        return self._write_channel
+
+    @contextmanager
+    def open(self, params: PipesParams) -> Iterator[InProcessPipesMessageWriteChannel]:
+        yield self._write_channel
+
+
+class InProcessPipesParamLoader(PipesParamsLoader):
+    def load_context_params(self) -> PipesParams:
+        return {}
+
+    def load_messages_params(self) -> PipesParams:
+        return {}
+
+
+class InProcessContextInjector(PipesContextInjector):
+    @contextmanager
+    def inject_context(self, context_data: "PipesContextData") -> Iterator[PipesParams]:
+        yield {}
+
+
+class InProcessMessageReader(PipesMessageReader):
+    def __init__(
+        self,
+        message_writer: InProcessPipesMessageWriter,
+        fn: Callable[[PipesContext], None],
+        pipes_context: PipesContext,
+    ) -> None:
+        self.message_writer = message_writer
+        self.fn = fn
+        self.pipes_context = pipes_context
+
+    @contextmanager
+    def read_messages(self, handler: "PipesMessageHandler") -> Iterator[PipesParams]:
+        yield {}
+        # instead of doing something like polling a thread, we just sychronously call the function and handle all messagse
+        self.fn(self.pipes_context)
+        for pipes_message in self.message_writer.write_channel.messages:
+            handler.handle_message(pipes_message)
+
+
+class _InProcessPipesClient(PipesClient):
+    @public
+    def run(
+        self,
+        *,
+        context: OpExecutionContext,
+        fn: Callable[[PipesContext], None],
+        extras: Optional[PipesExtras] = None,
+    ) -> PipesClientCompletedInvocation:
+        pipes_context_data = build_external_execution_context_data(context=context, extras=extras)
+        pipes_context_loader = InProcessPipesContextLoader(pipes_context_data)
+        pipes_message_writer = InProcessPipesMessageWriter()
+        with open_dagster_pipes_context(
+            context_loader=pipes_context_loader,
+            message_writer=pipes_message_writer,
+            params_loader=InProcessPipesParamLoader(),
+        ) as pipes_context:
+            with open_pipes_session(
+                context=context,
+                context_injector=InProcessContextInjector(),
+                message_reader=InProcessMessageReader(
+                    pipes_message_writer, fn=fn, pipes_context=pipes_context
+                ),
+            ) as session:
+                pass
+
+        return PipesClientCompletedInvocation(list(session.get_results()))
+
+
+InProcessPipesClient = ResourceParam[_InProcessPipesClient]

--- a/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_inprocess.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_inprocess.py
@@ -1,0 +1,47 @@
+from dagster import (
+    Definitions,
+    MaterializeResult,
+    TextMetadataValue,
+    asset,
+)
+from dagster_pipes import (
+    PipesContext,
+)
+
+from .in_process_client import (
+    InProcessPipesClient,
+    InProcessPipesMessageWriteChannel,
+    InProcessPipesMessageWriter,
+)
+
+
+def test_inprocess_writer_init() -> None:
+    assert InProcessPipesMessageWriteChannel()
+    writer = InProcessPipesMessageWriter()
+    assert isinstance(writer.write_channel, InProcessPipesMessageWriteChannel)
+
+
+def test_basic_in_process() -> None:
+    called = {}
+
+    def _impl(context: PipesContext):
+        context.report_asset_materialization(metadata={"test_key": "test_value"})
+        called["impl"] = True
+
+    @asset
+    def an_asset(context, inprocess_client: InProcessPipesClient) -> MaterializeResult:
+        completed_invocation = inprocess_client.run(context=context, fn=_impl)
+        materialize_result = completed_invocation.get_materialize_result()
+        called["orch"] = True
+        assert materialize_result.asset_key
+        assert materialize_result.asset_key.to_user_string() == "an_asset"
+        assert materialize_result.metadata
+        assert isinstance(materialize_result.metadata["test_key"], TextMetadataValue)
+        assert materialize_result.metadata["test_key"].value == "test_value"
+        return materialize_result
+
+    defs = Definitions(assets=[an_asset], resources={"inprocess_client": InProcessPipesClient()})
+    exec_result = defs.get_implicit_global_asset_job_def().execute_in_process()
+    assert exec_result.success
+    assert called["impl"]
+    assert called["orch"]


### PR DESCRIPTION
## Summary & Motivation

We did a late-breaking change to add `PipesClientCompletedInvocation` in #16898. This builds on that and provides an ergonomic API for the common case where you are invoking a pipes process that executes a single asset. This allows the user to type the `@asset` with `MaterializeResult`, which is extremely clear relative to `Iterable[MaterializeResult, AssetCheckResult]`, which no one ever does in practice.

It is possible that this fails at runtime if the user emits multiple asset materializations or check results that do not correspond to the single asset materialization. However the error message and remediation is relatively clear.

## How I Tested These Changes

BK