### PR TITLE
Make PipesClient.run reflect the actual reality of its level of specficity

### DIFF
--- a/python_modules/dagster-test/dagster_test/toys/external_execution/__init__.py
+++ b/python_modules/dagster-test/dagster_test/toys/external_execution/__init__.py
@@ -38,7 +38,9 @@ def number_x(
     config: NumberConfig,
 ) -> None:
     extras = {**get_common_extras(context), "multiplier": config.multiplier}
-    pipes_subprocess_client.run(command_for_asset("number_x"), context=context, extras=extras)
+    pipes_subprocess_client.run(
+        command=command_for_asset("number_x"), context=context, extras=extras
+    )
 
 
 @asset
@@ -48,7 +50,7 @@ def number_y(
     config: NumberConfig,
 ):
     pipes_subprocess_client.run(
-        command_for_asset("number_y"),
+        command=command_for_asset("number_y"),
         context=context,
         extras=get_common_extras(context),
         env={"NUMBER_Y": "4"},
@@ -60,7 +62,7 @@ def number_sum(
     context: AssetExecutionContext, pipes_subprocess_client: PipesSubprocessClient
 ) -> None:
     pipes_subprocess_client.run(
-        command_for_asset("number_sum"), context=context, extras=get_common_extras(context)
+        command=command_for_asset("number_sum"), context=context, extras=get_common_extras(context)
     )
 
 

--- a/python_modules/dagster/dagster/_core/pipes/client.py
+++ b/python_modules/dagster/dagster/_core/pipes/client.py
@@ -32,7 +32,7 @@ class PipesClient(ABC):
         **kwargs,
     ) -> "PipesClientCompletedInvocation":
         """Synchronously execute an external process with the pipes protocol. Derived
-         clients must have context and extras arguments, but also can add arbitrary
+         clients must have `context` and `extras` arguments, but also can add arbitrary
          arguments that are appropriate for their own implementation.
 
         Args:

--- a/python_modules/dagster/dagster/_core/pipes/client.py
+++ b/python_modules/dagster/dagster/_core/pipes/client.py
@@ -31,7 +31,9 @@ class PipesClient(ABC):
         extras: Optional[PipesExtras] = None,
         **kwargs,
     ) -> "PipesClientCompletedInvocation":
-        """Synchronously execute an external process with the pipes protocol.
+        """Synchronously execute an external process with the pipes protocol. Derived
+         clients must have context and extras arguments, but also can add arbitrary
+         arguments that are appropriate for their own implementation.
 
         Args:
             context (OpExecutionContext): The context from the executing op/asset.

--- a/python_modules/dagster/dagster/_core/pipes/client.py
+++ b/python_modules/dagster/dagster/_core/pipes/client.py
@@ -29,6 +29,7 @@ class PipesClient(ABC):
         *,
         context: OpExecutionContext,
         extras: Optional[PipesExtras] = None,
+        **kwargs,
     ) -> "PipesClientCompletedInvocation":
         """Synchronously execute an external process with the pipes protocol.
 

--- a/python_modules/dagster/dagster/_core/pipes/subprocess.py
+++ b/python_modules/dagster/dagster/_core/pipes/subprocess.py
@@ -67,10 +67,10 @@ class _PipesSubprocess(PipesClient):
     @public
     def run(
         self,
-        command: Union[str, Sequence[str]],
         *,
         context: OpExecutionContext,
         extras: Optional[PipesExtras] = None,
+        command: Union[str, Sequence[str]],
         env: Optional[Mapping[str, str]] = None,
         cwd: Optional[str] = None,
     ) -> PipesClientCompletedInvocation:

--- a/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_subprocess.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_subprocess.py
@@ -164,7 +164,7 @@ def test_ext_subprocess(
         extras = {"bar": "baz"}
         cmd = [_PYTHON_EXECUTABLE, external_script]
         return ext.run(
-            cmd,
+            command=cmd,
             context=context,
             extras=extras,
             env={
@@ -238,7 +238,7 @@ def test_ext_multi_asset():
     def foo_bar(context: AssetExecutionContext, pipes_subprocess_client: PipesSubprocessClient):
         with temp_script(script_fn) as script_path:
             cmd = [_PYTHON_EXECUTABLE, script_path]
-            return pipes_subprocess_client.run(cmd, context=context).get_results()
+            return pipes_subprocess_client.run(command=cmd, context=context).get_results()
 
     with instance_for_test() as instance:
         materialize(
@@ -265,7 +265,7 @@ def test_ext_dynamic_partitions():
     def foo(context: AssetExecutionContext, pipes_subprocess_client: PipesSubprocessClient):
         with temp_script(script_fn) as script_path:
             cmd = [_PYTHON_EXECUTABLE, script_path]
-            return pipes_subprocess_client.run(cmd, context=context).get_results()
+            return pipes_subprocess_client.run(command=cmd, context=context).get_results()
 
     with instance_for_test() as instance:
         instance.add_dynamic_partitions("blah", ["bar"])
@@ -307,7 +307,7 @@ def test_ext_typed_metadata():
     def foo(context: AssetExecutionContext, pipes_subprocess_client: PipesSubprocessClient):
         with temp_script(script_fn) as script_path:
             cmd = [_PYTHON_EXECUTABLE, script_path]
-            return pipes_subprocess_client.run(cmd, context=context).get_results()
+            return pipes_subprocess_client.run(command=cmd, context=context).get_results()
 
     with instance_for_test() as instance:
         materialize(
@@ -354,7 +354,7 @@ def test_ext_asset_failed():
     def foo(context: AssetExecutionContext, pipes_subprocess_client: PipesSubprocessClient):
         with temp_script(script_fn) as script_path:
             cmd = [_PYTHON_EXECUTABLE, script_path]
-            return pipes_subprocess_client.run(cmd, context=context).get_results()
+            return pipes_subprocess_client.run(command=cmd, context=context).get_results()
 
     with pytest.raises(DagsterPipesExecutionError):
         materialize([foo], resources={"pipes_subprocess_client": PipesSubprocessClient()})
@@ -371,7 +371,7 @@ def test_ext_asset_invocation():
     def foo(context: AssetExecutionContext, pipes_subprocess_client: PipesSubprocessClient):
         with temp_script(script_fn) as script_path:
             cmd = [_PYTHON_EXECUTABLE, script_path]
-            yield from pipes_subprocess_client.run(cmd, context=context).get_results()
+            yield from pipes_subprocess_client.run(command=cmd, context=context).get_results()
 
     foo(context=build_asset_context(), pipes_subprocess_client=PipesSubprocessClient())
 

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
@@ -73,10 +73,10 @@ class _PipesDatabricksClient(PipesClient):
 
     def run(
         self,
-        task: jobs.SubmitTask,
         *,
         context: OpExecutionContext,
         extras: Optional[PipesExtras] = None,
+        task: jobs.SubmitTask,
         submit_args: Optional[Mapping[str, str]] = None,
     ) -> PipesClientCompletedInvocation:
         """Synchronously execute a Databricks job with the pipes protocol.

--- a/python_modules/libraries/dagster-docker/dagster_docker/pipes.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/pipes.py
@@ -96,12 +96,12 @@ class _PipesDockerClient(PipesClient):
         self,
         *,
         context: OpExecutionContext,
+        extras: Optional[PipesExtras] = None,
         image: str,
         command: Union[str, Sequence[str]],
         env: Optional[Mapping[str, str]] = None,
         registry: Optional[Mapping[str, str]] = None,
         container_kwargs: Optional[Mapping[str, Any]] = None,
-        extras: Optional[PipesExtras] = None,
     ) -> PipesClientCompletedInvocation:
         """Create a docker container and run it to completion, enriched with the pipes protocol.
 

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
@@ -125,13 +125,13 @@ class _PipesK8sClient(PipesClient):
         self,
         *,
         context: OpExecutionContext,
+        extras: Optional[PipesExtras] = None,
         image: Optional[str] = None,
         command: Optional[Union[str, Sequence[str]]] = None,
         namespace: Optional[str] = None,
         env: Optional[Mapping[str, str]] = None,
         base_pod_meta: Optional[Mapping[str, Any]] = None,
         base_pod_spec: Optional[Mapping[str, Any]] = None,
-        extras: Optional[PipesExtras] = None,
     ) -> PipesClientCompletedInvocation:
         """Publish a kubernetes pod and wait for it to complete, enriched with the pipes protocol.
 


### PR DESCRIPTION
## Summary & Motivation

`PipesClient.run` is has two required arguments, `context` and `extras`, but also subclasses require  arbitrary arguments appropriate to their subclass. This PR

* Makes the interface of run more accurately, showing that it takes an arbitrary set of kwargs
* Makes all subclasses have all arguments require kwargs, giving us the ability to add required arguments in the future.

This interface accurately reflects the contract we are enforcing.

## How I Tested These Changes

BK
