### PR TITLE
RFC: Stopping the yield typing madness with StreamingExecutionResult

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/op_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_definition.py
@@ -30,6 +30,7 @@ from dagster._core.definitions.resource_requirement import (
     OutputManagerRequirement,
     ResourceRequirement,
 )
+from dagster._core.definitions.result import StreamingExecutionResult
 from dagster._core.errors import (
     DagsterInvalidDefinitionError,
     DagsterInvalidInvocationError,
@@ -455,9 +456,6 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
         return direct_invocation_result(self, *args, **kwargs)
 
 
-from dagster._core.definitions.result import StreamingExecutionResult
-
-
 def _resolve_output_defs_from_outs(
     compute_fn: Union[Callable[..., Any], "DecoratedOpFunction"],
     outs: Optional[Mapping[str, Out]],
@@ -488,8 +486,6 @@ def _resolve_output_defs_from_outs(
 
     # Introspection on type annotations is experimental, so checking
     # metaclass is the best we can do.
-
-    # import code; code.interact(local=locals())
 
     if annotation != inspect.Parameter.empty and annotation == StreamingExecutionResult:
         pass

--- a/python_modules/dagster/dagster/_core/definitions/output.py
+++ b/python_modules/dagster/dagster/_core/definitions/output.py
@@ -17,6 +17,7 @@ from dagster._core.definitions.metadata import (
 )
 from dagster._core.errors import DagsterError, DagsterInvalidDefinitionError
 from dagster._core.types.dagster_type import (
+    Any as DagsterAny,
     DagsterType,
     is_dynamic_output_annotation,
     resolve_dagster_type,
@@ -403,7 +404,7 @@ class Out(
 
     def to_definition(
         self,
-        annotation_type: type,
+        annotation_type: Optional[type],
         name: Optional[str],
         description: Optional[str],
         code_version: Optional[str],
@@ -411,7 +412,7 @@ class Out(
         dagster_type = (
             self.dagster_type
             if self.dagster_type is not NoValueSentinel
-            else _checked_inferred_type(annotation_type)
+            else _checked_inferred_type(annotation_type) if annotation_type else DagsterAny
         )
 
         klass = OutputDefinition if not self.is_dynamic else DynamicOutputDefinition

--- a/python_modules/dagster/dagster/_core/definitions/result.py
+++ b/python_modules/dagster/dagster/_core/definitions/result.py
@@ -1,4 +1,4 @@
-from typing import NamedTuple, Optional, Sequence
+from typing import Iterator, NamedTuple, Optional, Sequence, Union
 
 import dagster._check as check
 from dagster._annotations import PublicAttr, experimental
@@ -56,3 +56,12 @@ class MaterializeResult(
             ),
             data_version=check.opt_inst_param(data_version, "data_version", DataVersion),
         )
+
+
+from dataclasses import dataclass
+
+
+@dataclass
+class StreamingExecutionResult:
+    def __init__(self, result_iter: Iterator[Union[MaterializeResult, AssetCheckResult]]):
+        self.result_iter = result_iter

--- a/python_modules/dagster/dagster/_core/definitions/result.py
+++ b/python_modules/dagster/dagster/_core/definitions/result.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import Iterator, NamedTuple, Optional, Sequence, Union
 
 import dagster._check as check
@@ -56,9 +57,6 @@ class MaterializeResult(
             ),
             data_version=check.opt_inst_param(data_version, "data_version", DataVersion),
         )
-
-
-from dataclasses import dataclass
 
 
 @dataclass

--- a/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
@@ -30,7 +30,7 @@ from dagster._core.definitions import (
 from dagster._core.definitions.decorators.op_decorator import DecoratedOpFunction
 from dagster._core.definitions.input import InputDefinition
 from dagster._core.definitions.op_definition import OpDefinition
-from dagster._core.definitions.result import MaterializeResult
+from dagster._core.definitions.result import MaterializeResult, StreamingExecutionResult
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.types.dagster_type import DagsterTypeKind, is_generic_output_annotation
 from dagster._utils import is_named_tuple_instance
@@ -244,6 +244,8 @@ def _check_output_object_name(
 def validate_and_coerce_op_result_to_iterator(
     result: Any, context: OpExecutionContext, output_defs: Sequence[OutputDefinition]
 ) -> Iterator[Any]:
+    result = result.result_iter if isinstance(result, StreamingExecutionResult) else result
+
     if inspect.isgenerator(result):
         # this happens when a user explicitly returns a generator in the op
         for event in result:

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -1736,18 +1736,19 @@ def test_return_materialization_multi_asset_streaming():
     #
     # yield successful
     #
-    def _iter():
-        yield MaterializeResult(
-            asset_key="one",
-            metadata={"one": 1},
-        )
-        yield MaterializeResult(
-            asset_key="two",
-            metadata={"two": 2},
-        )
 
     @multi_asset(outs={"one": AssetOut(), "two": AssetOut()})
     def multi() -> StreamingExecutionResult:
+        def _iter():
+            yield MaterializeResult(
+                asset_key="one",
+                metadata={"one": 1},
+            )
+            yield MaterializeResult(
+                asset_key="two",
+                metadata={"two": 2},
+            )
+
         return StreamingExecutionResult(_iter())
 
     mats = _exec_asset(multi)


### PR DESCRIPTION
## Summary & Motivation

One of the most frustrating things IMO programming in Dagster is the overreliance on `yield` for common use cases, and then the corresponding challenges in correctly typing that.

This proposes a new class `StreamingExecutionResult`, that seeks to remedy that.

The idea is that instead directly yielding from the `@asset` (or similar) decorator you instead return a `StreamingExecutionResult` that contains.

Unfortunately in python the ergonomics of lambda functions are inferior to a language like javascript, so this does require the creation of another function with a made up name.

However in exchange for that I think you get much better devex overall.

Before:

```python

    @multi_asset(outs={"one": AssetOut(), "two": AssetOut()})
    def multi():
        yield MaterializeResult(
            asset_key="one",
            metadata={"one": 1},
        )
        yield MaterializeResult(
            asset_key="two",
            metadata={"two": 2},
        )
```

you can instead:

```python


    @multi_asset(outs={"one": AssetOut(), "two": AssetOut()})
    def multi() -> StreamingExecutionResult:
        def _iter():
            yield MaterializeResult(
                asset_key="one",
                metadata={"one": 1},
            )
            yield MaterializeResult(
                asset_key="two",
                metadata={"two": 2},
            )
        return StreamingExecutionResult(_iter())
```

While adding `_iter` is slightly annoying, overall I think this is much more explict.

Name is up for debate since this can also consume lists of results, not just generators, so it is therefore not necessarily streaming. `StreamableExecutionResult` is an alternative name.

This leaves us in a world where we can type 100% of dagster assets and asset checks with either `MaterializeResult`, `AssetCheckResult` or `StreamableExecutionResult`. We can also add an `ExecutionResult` alias for the union of `MaterializeResult`, `AssetCheckResult` then add the inevitable `ObservationResult` or anything else in the future.

I think this is way more clear than direct yielding.

## How I Tested These Changes
