### PR TITLE
direct invocation for assets returning MaterializeResult

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/op_invocation.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_invocation.py
@@ -27,6 +27,7 @@ from .events import (
     Output,
 )
 from .output import DynamicOutputDefinition
+from .result import MaterializeResult
 
 if TYPE_CHECKING:
     from ..execution.context.invocation import BoundOpExecutionContext
@@ -390,7 +391,7 @@ def _type_check_output_wrapper(
             for event in gen:
                 if isinstance(
                     event,
-                    (AssetMaterialization, AssetObservation, ExpectationResult),
+                    (AssetMaterialization, AssetObservation, ExpectationResult, MaterializeResult),
                 ):
                     yield event
                 else:
@@ -439,6 +440,8 @@ def _type_check_function_output(
 
     output_defs_by_name = {output_def.name: output_def for output_def in op_def.output_defs}
     for event in validate_and_coerce_op_result_to_iterator(result, context, op_def.output_defs):
+        if isinstance(event, MaterializeResult):
+            continue
         _type_check_output(output_defs_by_name[event.output_name], event, context)
     return result
 

--- a/python_modules/dagster/dagster/_core/definitions/op_invocation.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_invocation.py
@@ -391,7 +391,7 @@ def _type_check_output_wrapper(
             for event in gen:
                 if isinstance(
                     event,
-                    (AssetMaterialization, AssetObservation, ExpectationResult, MaterializeResult),
+                    (AssetMaterialization, AssetObservation, ExpectationResult),
                 ):
                     yield event
                 else:

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -1,7 +1,7 @@
 import ast
 import datetime
 import tempfile
-from typing import Sequence, Tuple
+from typing import Sequence
 
 import pytest
 from dagster import (
@@ -1844,52 +1844,6 @@ def test_return_materialization_multi_asset():
         ),
     ):
         _exec_asset(ret_list)
-
-
-def test_materialize_result_output_typing():
-    # Test that the return annotation MaterializeResult is interpreted as a Nothing type, since we
-    # coerce returned MaterializeResults to Output(None)
-
-    class TestingIOManager(IOManager):
-        def handle_output(self, context, obj):
-            assert context.dagster_type.is_nothing
-            return None
-
-        def load_input(self, context):
-            return 1
-
-    @asset
-    def asset_with_type_annotation() -> MaterializeResult:
-        return MaterializeResult(metadata={"foo": "bar"})
-
-    assert materialize(
-        [asset_with_type_annotation], resources={"io_manager": TestingIOManager()}
-    ).success
-
-    @multi_asset(outs={"one": AssetOut(), "two": AssetOut()})
-    def multi_asset_with_outs_and_type_annotation() -> Tuple[MaterializeResult, MaterializeResult]:
-        return MaterializeResult(asset_key="one"), MaterializeResult(asset_key="two")
-
-    assert materialize(
-        [multi_asset_with_outs_and_type_annotation], resources={"io_manager": TestingIOManager()}
-    ).success
-
-    @multi_asset(specs=[AssetSpec("one"), AssetSpec("two")])
-    def multi_asset_with_specs_and_type_annotation() -> Tuple[MaterializeResult, MaterializeResult]:
-        return MaterializeResult(asset_key="one"), MaterializeResult(asset_key="two")
-
-    assert materialize(
-        [multi_asset_with_specs_and_type_annotation], resources={"io_manager": TestingIOManager()}
-    ).success
-
-    @multi_asset(specs=[AssetSpec("one"), AssetSpec("two")])
-    def multi_asset_with_specs_and_no_type_annotation():
-        return MaterializeResult(asset_key="one"), MaterializeResult(asset_key="two")
-
-    assert materialize(
-        [multi_asset_with_specs_and_no_type_annotation],
-        resources={"io_manager": TestingIOManager()},
-    ).success
 
 
 def test_multi_asset_no_out():

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_materialize_result.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_materialize_result.py
@@ -1,0 +1,175 @@
+from typing import Tuple
+
+import pytest
+from dagster import (
+    AssetCheckResult,
+    AssetCheckSpec,
+    AssetExecutionContext,
+    AssetKey,
+    AssetOut,
+    AssetSpec,
+    DagsterInvariantViolationError,
+    IOManager,
+    MaterializeResult,
+    asset,
+    instance_for_test,
+    materialize,
+    multi_asset,
+)
+from dagster._core.storage.asset_check_execution_record import AssetCheckExecutionRecordStatus
+
+
+def test_materialize_result_asset():
+    @asset
+    def ret_untyped(context: AssetExecutionContext):
+        return MaterializeResult(
+            metadata={"one": 1},
+        )
+
+    result = materialize([ret_untyped])
+    assert result.success
+    mats = result.asset_materializations_for_node(ret_untyped.node_def.name)
+    assert len(mats) == 1, mats
+    assert "one" in mats[0].metadata
+    assert mats[0].tags
+
+    # key mismatch
+    @asset
+    def ret_mismatch(context: AssetExecutionContext):
+        return MaterializeResult(
+            asset_key="random",
+            metadata={"one": 1},
+        )
+
+    with pytest.raises(
+        DagsterInvariantViolationError,
+        match="Asset key random not found in AssetsDefinition",
+    ):
+        materialize(ret_mismatch)
+
+
+def test_return_materialization_with_asset_checks():
+    with instance_for_test() as instance:
+
+        @asset(check_specs=[AssetCheckSpec(name="foo_check", asset=AssetKey("ret_checks"))])
+        def ret_checks(context: AssetExecutionContext):
+            return MaterializeResult(
+                check_results=[
+                    AssetCheckResult(check_name="foo_check", metadata={"one": 1}, passed=True)
+                ]
+            )
+
+        materialize([ret_checks], instance=instance)
+        asset_check_executions = instance.event_log_storage.get_asset_check_executions(
+            asset_key=ret_checks.key,
+            check_name="foo_check",
+            limit=1,
+        )
+        assert len(asset_check_executions) == 1
+        assert asset_check_executions[0].status == AssetCheckExecutionRecordStatus.SUCCEEDED
+
+
+def test_materialize_result_output_typing():
+    # Test that the return annotation MaterializeResult is interpreted as a Nothing type, since we
+    # coerce returned MaterializeResults to Output(None)
+
+    class TestingIOManager(IOManager):
+        def handle_output(self, context, obj):
+            assert context.dagster_type.is_nothing
+            return None
+
+        def load_input(self, context):
+            return 1
+
+    @asset
+    def asset_with_type_annotation() -> MaterializeResult:
+        return MaterializeResult(metadata={"foo": "bar"})
+
+    assert materialize(
+        [asset_with_type_annotation], resources={"io_manager": TestingIOManager()}
+    ).success
+
+    @multi_asset(outs={"one": AssetOut(), "two": AssetOut()})
+    def multi_asset_with_outs_and_type_annotation() -> Tuple[MaterializeResult, MaterializeResult]:
+        return MaterializeResult(asset_key="one"), MaterializeResult(asset_key="two")
+
+    assert materialize(
+        [multi_asset_with_outs_and_type_annotation], resources={"io_manager": TestingIOManager()}
+    ).success
+
+    @multi_asset(specs=[AssetSpec("one"), AssetSpec("two")])
+    def multi_asset_with_specs_and_type_annotation() -> Tuple[MaterializeResult, MaterializeResult]:
+        return MaterializeResult(asset_key="one"), MaterializeResult(asset_key="two")
+
+    assert materialize(
+        [multi_asset_with_specs_and_type_annotation], resources={"io_manager": TestingIOManager()}
+    ).success
+
+    @multi_asset(specs=[AssetSpec("one"), AssetSpec("two")])
+    def multi_asset_with_specs_and_no_type_annotation():
+        return MaterializeResult(asset_key="one"), MaterializeResult(asset_key="two")
+
+    assert materialize(
+        [multi_asset_with_specs_and_no_type_annotation],
+        resources={"io_manager": TestingIOManager()},
+    ).success
+
+
+def test_direct_invocation_materialize_result():
+    @asset
+    def my_asset() -> MaterializeResult:
+        return MaterializeResult(metadata={"foo": "bar"})
+
+    res = my_asset()
+    assert res.metadata["foo"] == "bar"
+
+    # @asset
+    # def generator_asset() -> Generator[MaterializeResult, None, None]:
+    #     yield MaterializeResult(metadata={"foo": "bar"})
+
+    # res = list(generator_asset())
+    # assert res[0].metadata["foo"] == "bar"
+
+    @multi_asset(specs=[AssetSpec("one"), AssetSpec("two")])
+    def specs_multi_asset():
+        return MaterializeResult(asset_key="one", metadata={"foo": "bar"}), MaterializeResult(
+            asset_key="two", metadata={"baz": "qux"}
+        )
+
+    res = specs_multi_asset()
+    assert res[0].metadata["foo"] == "bar"
+    assert res[1].metadata["baz"] == "qux"
+
+    # @multi_asset(
+    #     specs=[AssetSpec("one"), AssetSpec("two")]
+    # )
+    # def generator_specs_multi_asset():
+    #     yield MaterializeResult(asset_key="one", metadata={"foo": "bar"})
+    #     yield MaterializeResult(asset_key="two", metadata={"baz": "qux"})
+
+    # res = list(generator_specs_multi_asset())
+    # assert res[0].metadata["foo"] == "bar"
+    # assert res[1].metadata["baz"] == "qux"
+
+    @multi_asset(outs={"one": AssetOut(), "two": AssetOut()})
+    def outs_multi_asset():
+        return MaterializeResult(asset_key="one", metadata={"foo": "bar"}), MaterializeResult(
+            asset_key="two", metadata={"baz": "qux"}
+        )
+
+    res = outs_multi_asset()
+    assert res[0].metadata["foo"] == "bar"
+    assert res[1].metadata["baz"] == "qux"
+
+    # @multi_asset(
+    #     outs={"one": AssetOut(), "two": AssetOut()}
+    # )
+    # def generator_outs_multi_asset():
+    #     yield MaterializeResult(asset_key="one", metadata={"foo": "bar"})
+    #     yield MaterializeResult(asset_key="two", metadata={"baz": "qux"})
+
+    # res = list(generator_outs_multi_asset())
+    # assert res[0].metadata["foo"] == "bar"
+    # assert res[1].metadata["baz"] == "qux"
+
+    # need to test generator cases too see _type_check_output_wrapper for all cases


### PR DESCRIPTION
## Summary & Motivation
* moves the tests for `MaterializeResult` to one place so we can see them all together
* adds special casing for `MaterializeResult` for direct invocation when `MaterializeResult` is returned

Does not fix direct invocation when `MaterializeResult` is `yielded`. We'll need to solve this another way, either by interpreting `Generator[MaterializeResult]` type hints as `nothing` or by special casing `MaterializeResult` in the generator direct invocation paths so that we mark the corresponding expected Output as seen 


A note on `AssetCheckResult`:
We see similar errors for direct invocation for assets that yield `AssetCheckResult`s as when yielding `MaterializationResult`s. However, returning a single `AssetCheckResult` isn't allowed

```python
@asset(check_specs=[AssetCheckSpec("check1", asset="asset1")])
    def asset1():
        return AssetCheckResult(passed=True)
```

so we are not special casing this behavior to allow direct invocation to work

## How I Tested These Changes
