### PR TITLE
required_assets_and_checks_by_key on InternalAssetGraph

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/external_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/external_asset_graph.py
@@ -20,7 +20,7 @@ from dagster._core.host_representation.handle import RepositoryHandle
 from dagster._core.selector.subset_selector import DependencyGraph
 from dagster._core.workspace.workspace import IWorkspace
 
-from .asset_graph import AssetGraph
+from .asset_graph import AssetGraph, AssetKeyOrCheckKey
 from .backfill_policy import BackfillPolicy
 from .events import AssetKey
 from .freshness_policy import FreshnessPolicy
@@ -62,6 +62,7 @@ class ExternalAssetGraph(AssetGraph):
             code_versions_by_key=code_versions_by_key,
             is_observable_by_key=is_observable_by_key,
             auto_observe_interval_minutes_by_key=auto_observe_interval_minutes_by_key,
+            required_assets_and_checks_by_key={},
         )
         self._repo_handles_by_key = repo_handles_by_key
         self._materialization_job_names_by_key = job_names_by_key
@@ -300,3 +301,6 @@ class ExternalAssetGraph(AssetGraph):
                 asset_key
             )
         return list(asset_keys_by_repo.values())
+
+    def get_required_asset_and_check_keys(self, key: AssetKeyOrCheckKey):
+        raise NotImplementedError()

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
@@ -23,8 +23,10 @@ from dagster import (
     op,
     repository,
 )
+from dagster._core.definitions.asset_check_spec import AssetCheckSpec
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
+from dagster._core.definitions.decorators.asset_check_decorator import asset_check
 from dagster._core.definitions.events import AssetKeyPartitionKey
 from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
 from dagster._core.definitions.partition import PartitionsDefinition, PartitionsSubset
@@ -669,3 +671,62 @@ def test_asset_graph_partial_deserialization(asset_graph_from_assets):
         },
         non_partitioned_asset_keys={AssetKey("unpartitioned2")},
     )
+
+
+def test_required_assets_and_checks_by_key_check_decorator():
+    @asset
+    def asset0(): ...
+
+    @asset_check(asset=asset0)
+    def check0(): ...
+
+    asset_graph = AssetGraph.from_assets([asset0], asset_checks=[check0])
+    assert asset_graph.get_required_asset_and_check_keys(asset0.key) == set()
+    assert asset_graph.get_required_asset_and_check_keys(check0.spec.key) == set()
+
+
+def test_required_assets_and_checks_by_key_asset_decorator():
+    foo_check = AssetCheckSpec(name="foo", asset="asset0")
+    bar_check = AssetCheckSpec(name="bar", asset="asset0")
+
+    @asset(check_specs=[foo_check, bar_check])
+    def asset0(): ...
+
+    @asset_check(asset=asset0)
+    def check0(): ...
+
+    asset_graph = AssetGraph.from_assets([asset0], asset_checks=[check0])
+
+    grouped_keys = [asset0.key, foo_check.key, bar_check.key]
+    for key in grouped_keys:
+        assert asset_graph.get_required_asset_and_check_keys(key) == set(grouped_keys)
+
+    assert asset_graph.get_required_asset_and_check_keys(check0.spec.key) == set()
+
+
+def test_required_assets_and_checks_by_key_multi_asset():
+    foo_check = AssetCheckSpec(name="foo", asset="asset0")
+    bar_check = AssetCheckSpec(name="bar", asset="asset1")
+
+    @multi_asset(
+        outs={"asset0": AssetOut(), "asset1": AssetOut()}, check_specs=[foo_check, bar_check]
+    )
+    def asset_fn(): ...
+
+    biz_check = AssetCheckSpec(name="bar", asset="subsettable_asset0")
+
+    @multi_asset(
+        outs={"subsettable_asset0": AssetOut(), "subsettable_asset1": AssetOut()},
+        check_specs=[biz_check],
+        can_subset=True,
+    )
+    def subsettable_asset_fn(): ...
+
+    asset_graph = AssetGraph.from_assets([asset_fn, subsettable_asset_fn])
+
+    grouped_keys = [AssetKey(["asset0"]), AssetKey(["asset1"]), foo_check.key, bar_check.key]
+    for key in grouped_keys:
+        assert asset_graph.get_required_asset_and_check_keys(key) == set(grouped_keys)
+
+    for key in [AssetKey(["subsettable_asset0"]), AssetKey(["subsettable_asset1"]), biz_check.key]:
+        assert asset_graph.get_required_asset_and_check_keys(key) == set()


### PR DESCRIPTION
Rework of https://github.com/dagster-io/dagster/pull/16711

We want a `canExecuteIndividually` resolver on asset checks, in order to disable the 'execute' button if it's just going to error. We'll support that with `asset_graph.get_required_asset_and_check_keys(check_key) > 0`.

The next diff will add atomic_execution_units to ExternalAssetCheck, and implement this on ExternalAssetGraph. We don't actually need this implementation on InternalAssetGraph currently, but I think it's good for consistency?