### PR TITLE
Store run requests on the AMP tick, use to source information about asset materializations

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -2381,6 +2381,10 @@ type InstigationTick {
   logKey: [String!]
   logEvents: InstigationEventConnection!
   dynamicPartitionsRequestResults: [DynamicPartitionsRequestResult!]!
+  endTimestamp: Float
+  requestedAssetKeys: [AssetKey!]!
+  requestedAssetMaterializationCount: Int!
+  autoMaterializeAssetEvaluationId: Int
 }
 
 type InstigationEventConnection {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -1524,13 +1524,17 @@ export enum InstigationStatus {
 
 export type InstigationTick = {
   __typename: 'InstigationTick';
+  autoMaterializeAssetEvaluationId: Maybe<Scalars['Int']>;
   cursor: Maybe<Scalars['String']>;
   dynamicPartitionsRequestResults: Array<DynamicPartitionsRequestResult>;
+  endTimestamp: Maybe<Scalars['Float']>;
   error: Maybe<PythonError>;
   id: Scalars['ID'];
   logEvents: InstigationEventConnection;
   logKey: Maybe<Array<Scalars['String']>>;
   originRunIds: Array<Scalars['String']>;
+  requestedAssetKeys: Array<AssetKey>;
+  requestedAssetMaterializationCount: Scalars['Int'];
   runIds: Array<Scalars['String']>;
   runKeys: Array<Scalars['String']>;
   runs: Array<Run>;
@@ -7176,11 +7180,17 @@ export const buildInstigationTick = (
   relationshipsToOmit.add('InstigationTick');
   return {
     __typename: 'InstigationTick',
+    autoMaterializeAssetEvaluationId:
+      overrides && overrides.hasOwnProperty('autoMaterializeAssetEvaluationId')
+        ? overrides.autoMaterializeAssetEvaluationId!
+        : 5375,
     cursor: overrides && overrides.hasOwnProperty('cursor') ? overrides.cursor! : 'voluptatem',
     dynamicPartitionsRequestResults:
       overrides && overrides.hasOwnProperty('dynamicPartitionsRequestResults')
         ? overrides.dynamicPartitionsRequestResults!
         : [],
+    endTimestamp:
+      overrides && overrides.hasOwnProperty('endTimestamp') ? overrides.endTimestamp! : 8.87,
     error:
       overrides && overrides.hasOwnProperty('error')
         ? overrides.error!
@@ -7200,6 +7210,14 @@ export const buildInstigationTick = (
     logKey: overrides && overrides.hasOwnProperty('logKey') ? overrides.logKey! : [],
     originRunIds:
       overrides && overrides.hasOwnProperty('originRunIds') ? overrides.originRunIds! : [],
+    requestedAssetKeys:
+      overrides && overrides.hasOwnProperty('requestedAssetKeys')
+        ? overrides.requestedAssetKeys!
+        : [],
+    requestedAssetMaterializationCount:
+      overrides && overrides.hasOwnProperty('requestedAssetMaterializationCount')
+        ? overrides.requestedAssetMaterializationCount!
+        : 412,
     runIds: overrides && overrides.hasOwnProperty('runIds') ? overrides.runIds! : [],
     runKeys: overrides && overrides.hasOwnProperty('runKeys') ? overrides.runKeys! : [],
     runs: overrides && overrides.hasOwnProperty('runs') ? overrides.runs! : [],

--- a/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
@@ -238,6 +238,10 @@ class GrapheneInstigationTick(graphene.ObjectType):
     logKey = graphene.List(graphene.NonNull(graphene.String))
     logEvents = graphene.Field(graphene.NonNull(GrapheneInstigationEventConnection))
     dynamicPartitionsRequestResults = non_null_list(GrapheneDynamicPartitionsRequestResult)
+    endTimestamp = graphene.Field(graphene.Float)
+    requestedAssetKeys = non_null_list(GrapheneAssetKey)
+    requestedAssetMaterializationCount = graphene.NonNull(graphene.Int)
+    autoMaterializeAssetEvaluationId = graphene.Field(graphene.Int)
 
     class Meta:
         name = "InstigationTick"
@@ -255,6 +259,8 @@ class GrapheneInstigationTick(graphene.ObjectType):
             originRunIds=tick.origin_run_ids,
             cursor=tick.cursor,
             logKey=tick.log_key,
+            endTimestamp=tick.end_timestamp,
+            autoMaterializeAssetEvaluationId=tick.tick_data.auto_materialize_evaluation_id,
         )
 
     def resolve_id(self, _):
@@ -283,6 +289,14 @@ class GrapheneInstigationTick(graphene.ObjectType):
             GrapheneDynamicPartitionsRequestResult(request_result)
             for request_result in self._tick.dynamic_partitions_request_results
         ]
+
+    def resolve_requestedAssetKeys(self, _):
+        return [
+            GrapheneAssetKey(path=asset_key.path) for asset_key in self._tick.requested_asset_keys
+        ]
+
+    def resolve_requestedAssetMaterializationCount(self, _):
+        return self._tick.requested_asset_materialization_count
 
 
 class GrapheneDryRunInstigationTick(graphene.ObjectType):

--- a/python_modules/dagster/dagster/_core/scheduler/instigation.py
+++ b/python_modules/dagster/dagster/_core/scheduler/instigation.py
@@ -1,10 +1,12 @@
 from enum import Enum
-from typing import Any, List, NamedTuple, Optional, Sequence, Union
+from typing import AbstractSet, Any, List, NamedTuple, Optional, Sequence, Union
 
 from typing_extensions import TypeAlias
 
 import dagster._check as check
+from dagster._core.definitions import RunRequest
 from dagster._core.definitions.auto_materialize_rule import AutoMaterializeAssetEvaluation
+from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
 
 # re-export
 from dagster._core.definitions.run_request import (
@@ -273,6 +275,9 @@ class InstigatorTick(NamedTuple("_InstigatorTick", [("tick_id", int), ("tick_dat
         check.inst_param(status, "status", TickStatus)
         return self._replace(tick_data=self.tick_data.with_status(status, **kwargs))
 
+    def with_run_requests(self, run_requests: Sequence[RunRequest]) -> "InstigatorTick":
+        return self._replace(tick_data=self.tick_data.with_run_requests(run_requests))
+
     def with_reason(self, skip_reason: str) -> "InstigatorTick":
         check.opt_str_param(skip_reason, "skip_reason")
         return self._replace(tick_data=self.tick_data.with_reason(skip_reason))
@@ -318,6 +323,10 @@ class InstigatorTick(NamedTuple("_InstigatorTick", [("tick_id", int), ("tick_dat
     @property
     def timestamp(self) -> float:
         return self.tick_data.timestamp
+
+    @property
+    def end_timestamp(self) -> Optional[float]:
+        return self.tick_data.end_timestamp
 
     @property
     def status(self) -> TickStatus:
@@ -377,6 +386,30 @@ class InstigatorTick(NamedTuple("_InstigatorTick", [("tick_id", int), ("tick_dat
     ) -> Sequence[DynamicPartitionsRequestResult]:
         return self.tick_data.dynamic_partitions_request_results
 
+    @property
+    def requested_asset_materialization_count(self) -> int:
+        check.invariant(
+            self.tick_data.instigator_type == InstigatorType.AUTO_MATERIALIZE,
+            "Only auto-materialize ticks set requested_asset_materialization_count",
+        )
+        asset_partitions = set()
+        for run_request in self.tick_data.run_requests or []:
+            for asset_key in run_request.asset_selection or []:
+                asset_partitions.add(AssetKeyPartitionKey(asset_key, run_request.partition_key))
+        return len(asset_partitions)
+
+    @property
+    def requested_asset_keys(self) -> AbstractSet[AssetKey]:
+        check.invariant(
+            self.tick_data.instigator_type == InstigatorType.AUTO_MATERIALIZE,
+            "Only auto-materialize ticks set requested_asset_keys",
+        )
+        asset_keys = set()
+        for run_request in self.tick_data.run_requests or []:
+            for asset_key in run_request.asset_selection or []:
+                asset_keys.add(asset_key)
+        return asset_keys
+
 
 @whitelist_for_serdes(
     old_storage_names={"JobTickData"},
@@ -409,6 +442,8 @@ class TickData(
                 Sequence[DynamicPartitionsRequestResult],
             ),
             ("end_timestamp", Optional[float]),  # Time the tick finished
+            ("run_requests", Optional[Sequence[RunRequest]]),  # run requests created by the tick
+            ("auto_materialize_evaluation_id", Optional[int]),
         ],
     )
 ):
@@ -454,6 +489,8 @@ class TickData(
             Sequence[DynamicPartitionsRequestResult]
         ] = None,
         end_timestamp: Optional[float] = None,
+        run_requests: Optional[Sequence[RunRequest]] = None,
+        auto_materialize_evaluation_id: Optional[int] = None,
     ):
         _validate_tick_args(instigator_type, status, run_ids, error, skip_reason)
         check.opt_list_param(log_key, "log_key", of_type=str)
@@ -479,6 +516,8 @@ class TickData(
                 of_type=DynamicPartitionsRequestResult,
             ),
             end_timestamp=end_timestamp,
+            run_requests=check.opt_sequence_param(run_requests, "run_requests"),
+            auto_materialize_evaluation_id=auto_materialize_evaluation_id,
         )
 
     def with_status(
@@ -525,6 +564,16 @@ class TickData(
                         if (run_key and run_key not in self.run_keys)
                         else self.run_keys
                     ),
+                },
+            )
+        )
+
+    def with_run_requests(self, run_requests: Sequence[RunRequest]) -> "TickData":
+        return TickData(
+            **merge_dicts(
+                self._asdict(),
+                {
+                    "run_requests": run_requests,
                 },
             )
         )


### PR DESCRIPTION
Summary:
Two reasons to do this:
- allows us to determine the set of asset keys and AssetKeyPartitionKey materializations that were materialized by the tick
- in the future, we can use this for idempotency. What i'm imagining is:
  - AMP tick evaluation produces a list of run requests
  - We reserve run IDs for each of them and store the (run_id, run request) tuples on the tick
  - we then go through them one-by-one, create the actual run with that run ID and submit it to the queue

Then if we fail partway through, we can check to see if any of the reserved run IDs already exist to enforce idempotency.

## Summary & Motivation

## How I Tested These Changes
