### PR TITLE
Add a query for querying asset evaluations by evaluation ID

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -742,6 +742,13 @@ class LegacyScheduleStorage(ScheduleStorage, ConfigurableClass):
             asset_key, limit, cursor
         )
 
+    def get_auto_materialize_evaluations_for_evaluation_id(
+        self, evaluation_id: int
+    ) -> Sequence["AutoMaterializeAssetEvaluationRecord"]:
+        return self._storage.schedule_storage.get_auto_materialize_evaluations_for_evaluation_id(
+            evaluation_id
+        )
+
     def purge_asset_evaluations(self, before: float):
         return self._storage.schedule_storage.purge_asset_evaluations(before)
 

--- a/python_modules/dagster/dagster/_core/storage/schedules/base.py
+++ b/python_modules/dagster/dagster/_core/storage/schedules/base.py
@@ -162,6 +162,16 @@ class ScheduleStorage(abc.ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         """
 
     @abc.abstractmethod
+    def get_auto_materialize_evaluations_for_evaluation_id(
+        self, evaluation_id: int
+    ) -> Sequence[AutoMaterializeAssetEvaluationRecord]:
+        """Get all policy evaluations for a given evaluation ID.
+
+        Args:
+            evaluation_id (int): The evaluation ID to query.
+        """
+
+    @abc.abstractmethod
     def purge_asset_evaluations(self, before: float) -> None:
         """Wipe evaluations before a certain timestamp.
 

--- a/python_modules/dagster/dagster/_core/storage/schedules/sql_schedule_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/schedules/sql_schedule_storage.py
@@ -509,6 +509,22 @@ class SqlScheduleStorage(ScheduleStorage):
             rows = db_fetch_mappings(conn, query)
             return [AutoMaterializeAssetEvaluationRecord.from_db_row(row) for row in rows]
 
+    def get_auto_materialize_evaluations_for_evaluation_id(
+        self, evaluation_id: int
+    ) -> Sequence[AutoMaterializeAssetEvaluationRecord]:
+        with self.connect() as conn:
+            query = db_select(
+                [
+                    AssetDaemonAssetEvaluationsTable.c.id,
+                    AssetDaemonAssetEvaluationsTable.c.asset_evaluation_body,
+                    AssetDaemonAssetEvaluationsTable.c.evaluation_id,
+                    AssetDaemonAssetEvaluationsTable.c.create_timestamp,
+                ]
+            ).where(AssetDaemonAssetEvaluationsTable.c.evaluation_id == evaluation_id)
+
+            rows = db_fetch_mappings(conn, query)
+            return [AutoMaterializeAssetEvaluationRecord.from_db_row(row) for row in rows]
+
     def purge_asset_evaluations(self, before: float):
         check.float_param(before, "before")
 

--- a/python_modules/dagster/dagster/_utils/test/schedule_storage.py
+++ b/python_modules/dagster/dagster/_utils/test/schedule_storage.py
@@ -729,6 +729,17 @@ class TestScheduleStorage:
         assert res[0].evaluation_id == 10
         assert res[0].evaluation.num_requested == 1
 
+        res = storage.get_auto_materialize_evaluations_for_evaluation_id(evaluation_id=10)
+
+        assert len(res) == 2
+        assert res[0].evaluation.asset_key == AssetKey("asset_one")
+        assert res[0].evaluation_id == 10
+        assert res[0].evaluation.num_requested == 0
+
+        assert res[1].evaluation.asset_key == AssetKey("asset_two")
+        assert res[1].evaluation_id == 10
+        assert res[1].evaluation.num_requested == 1
+
         storage.add_auto_materialize_asset_evaluations(
             evaluation_id=11,
             asset_evaluations=[


### PR DESCRIPTION
Summary:
This will power the table view where we show what happened to each asset for each evaluation Id. Left out a cursor for now because this query has an index and is limited to the size of the asset graph, but I think to have efficient limiting and cursoring we would need an index by both evaluation ID + id.

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes
