### PR TITLE
Rename get_pipes_env_vars to get_bootstrap_env_vars. Refactor to call generalized get_bootstrap_params

### DIFF
--- a/integration_tests/test_suites/k8s-test-suite/tests/test_external_asset.py
+++ b/integration_tests/test_suites/k8s-test-suite/tests/test_external_asset.py
@@ -191,7 +191,7 @@ def test_use_excute_k8s_job(namespace, cluster_provider):
                     for k, v in {
                         "PYTHONPATH": "/dagster_test/toys/external_execution/",
                         "NUMBER_Y": "2",
-                        **pipes_session.get_pipes_env_vars(),
+                        **pipes_session.get_pipes_bootstrap_env_vars(),
                     }.items()
                 ],
                 k8s_job_name=job_name,

--- a/integration_tests/test_suites/k8s-test-suite/tests/test_external_asset.py
+++ b/integration_tests/test_suites/k8s-test-suite/tests/test_external_asset.py
@@ -191,7 +191,7 @@ def test_use_excute_k8s_job(namespace, cluster_provider):
                     for k, v in {
                         "PYTHONPATH": "/dagster_test/toys/external_execution/",
                         "NUMBER_Y": "2",
-                        **pipes_session.get_pipes_bootstrap_env_vars(),
+                        **pipes_session.get_bootstrap_env_vars(),
                     }.items()
                 ],
                 k8s_job_name=job_name,

--- a/python_modules/dagster-pipes/dagster_pipes/__init__.py
+++ b/python_modules/dagster-pipes/dagster_pipes/__init__.py
@@ -60,7 +60,7 @@ def _param_name_to_env_key(key: str) -> str:
 
 IS_DAGSTER_PIPES_PROCESS = "IS_DAGSTER_PIPED_PROCESS"
 
-DAGSTER_PIPES_ENV_KEYS = {
+DAGSTER_PIPES_BOOTSTRAP_PARAM_NAMES = {
     k: _param_name_to_env_key(k) for k in (IS_DAGSTER_PIPES_PROCESS, "context", "messages")
 }
 

--- a/python_modules/dagster/dagster/_core/pipes/context.py
+++ b/python_modules/dagster/dagster/_core/pipes/context.py
@@ -177,7 +177,7 @@ class PipesSession:
     on a `PipesSession` object.
 
     During the session, an external process should be started and the parameters injected into its
-    environment. The typical way to do this is to call :py:meth:`PipesSession.get_pipes_bootstrap_env_vars`
+    environment. The typical way to do this is to call :py:meth:`PipesSession.get_bootstrap_env_vars`
     and pass the result as environment variables.
 
     During execution, results (e.g. asset materializations) are reported by the external process and
@@ -203,7 +203,7 @@ class PipesSession:
     message_reader_params: PipesParams
 
     @public
-    def get_pipes_bootstrap_env_vars(self) -> Dict[str, str]:
+    def get_bootstrap_env_vars(self) -> Dict[str, str]:
         """Encode context injector and message reader params as environment variables.
 
         Passing environment variables is the typical way to expose the pipes I/O parameters
@@ -215,13 +215,13 @@ class PipesSession:
         """
         return {
             param_name: encode_env_var(param_value)
-            for param_name, param_value in self.get_pipes_bootstrap_params().items()
+            for param_name, param_value in self.get_bootstrap_params().items()
         }
 
     @public
-    def get_pipes_bootstrap_params(self) -> Dict[str, Any]:
+    def get_bootstrap_params(self) -> Dict[str, Any]:
         """Get the params necessary to bootstrap a launched pipes process. These parameters are typically
-        are as environment variable. See `get_pipes_bootstrap_env_vars`. It is the context injector's
+        are as environment variable. See `get_bootstrap_env_vars`. It is the context injector's
         responsibility to decide how to pass these parameters to the external environment.
 
         Returns:

--- a/python_modules/dagster/dagster/_core/pipes/context.py
+++ b/python_modules/dagster/dagster/_core/pipes/context.py
@@ -4,7 +4,7 @@ from queue import Queue
 from typing import Any, Dict, Iterator, Mapping, Optional, Set, Union
 
 from dagster_pipes import (
-    DAGSTER_PIPES_ENV_KEYS,
+    DAGSTER_PIPES_BOOTSTRAP_PARAM_NAMES,
     IS_DAGSTER_PIPES_PROCESS,
     PIPES_METADATA_TYPE_INFER,
     PipesContextData,
@@ -165,15 +165,6 @@ class PipesMessageHandler:
         self._context.log.log(level, message)
 
 
-def _ext_params_as_env_vars(
-    context_injector_params: PipesParams, message_reader_params: PipesParams
-) -> Mapping[str, str]:
-    return {
-        DAGSTER_PIPES_ENV_KEYS["context"]: encode_env_var(context_injector_params),
-        DAGSTER_PIPES_ENV_KEYS["messages"]: encode_env_var(message_reader_params),
-    }
-
-
 @experimental
 @dataclass
 class PipesSession:
@@ -186,7 +177,7 @@ class PipesSession:
     on a `PipesSession` object.
 
     During the session, an external process should be started and the parameters injected into its
-    environment. The typical way to do this is to call :py:meth:`PipesSession.get_pipes_env_vars`
+    environment. The typical way to do this is to call :py:meth:`PipesSession.get_pipes_bootstrap_env_vars`
     and pass the result as environment variables.
 
     During execution, results (e.g. asset materializations) are reported by the external process and
@@ -212,7 +203,7 @@ class PipesSession:
     message_reader_params: PipesParams
 
     @public
-    def get_pipes_env_vars(self) -> Dict[str, str]:
+    def get_pipes_bootstrap_env_vars(self) -> Dict[str, str]:
         """Encode context injector and message reader params as environment variables.
 
         Passing environment variables is the typical way to expose the pipes I/O parameters
@@ -220,14 +211,27 @@ class PipesSession:
 
         Returns:
             Mapping[str, str]: Environment variables to pass to the external process. The values are
-            base-64-encoded and compressed with gzip.
+            serialized as json, compressed with gzip, and then base-64-encoded.
         """
         return {
-            DAGSTER_PIPES_ENV_KEYS[IS_DAGSTER_PIPES_PROCESS]: encode_env_var(True),
-            **_ext_params_as_env_vars(
-                context_injector_params=self.context_injector_params,
-                message_reader_params=self.message_reader_params,
-            ),
+            param_name: encode_env_var(param_value)
+            for param_name, param_value in self.get_pipes_bootstrap_params().items()
+        }
+
+    @public
+    def get_pipes_bootstrap_params(self) -> Dict[str, Any]:
+        """Get the params necessary to bootstrap a launched pipes process. These parameters are typically
+        are as environment variable. See `get_pipes_bootstrap_env_vars`. It is the context injector's
+        responsibility to decide how to pass these parameters to the external environment.
+
+        Returns:
+            Mapping[str, str]: Parameters to pass to the external process and their corresponding
+            values that must be passed by the context injector.
+        """
+        return {
+            DAGSTER_PIPES_BOOTSTRAP_PARAM_NAMES[IS_DAGSTER_PIPES_PROCESS]: True,
+            DAGSTER_PIPES_BOOTSTRAP_PARAM_NAMES["context"]: self.context_injector_params,
+            DAGSTER_PIPES_BOOTSTRAP_PARAM_NAMES["messages"]: self.message_reader_params,
         }
 
     @public

--- a/python_modules/dagster/dagster/_core/pipes/subprocess.py
+++ b/python_modules/dagster/dagster/_core/pipes/subprocess.py
@@ -97,7 +97,7 @@ class _PipesSubprocess(PipesClient):
                 command,
                 cwd=cwd or self.cwd,
                 env={
-                    **pipes_session.get_pipes_bootstrap_env_vars(),
+                    **pipes_session.get_bootstrap_env_vars(),
                     **self.env,
                     **(env or {}),
                 },

--- a/python_modules/dagster/dagster/_core/pipes/subprocess.py
+++ b/python_modules/dagster/dagster/_core/pipes/subprocess.py
@@ -97,7 +97,7 @@ class _PipesSubprocess(PipesClient):
                 command,
                 cwd=cwd or self.cwd,
                 env={
-                    **pipes_session.get_pipes_env_vars(),
+                    **pipes_session.get_pipes_bootstrap_env_vars(),
                     **self.env,
                     **(env or {}),
                 },

--- a/python_modules/dagster/dagster/_core/pipes/utils.py
+++ b/python_modules/dagster/dagster/_core/pipes/utils.py
@@ -352,7 +352,7 @@ def open_pipes_session(
             ) as pipes_session:
                 subprocess.Popen(
                     ["/bin/python", "/path/to/script.py"],
-                    env={**pipes_session.get_pipes_env_vars()}
+                    env={**pipes_session.get_pipes_bootstrap_env_vars()}
                 )
                 while process.poll() is None:
                     yield from pipes_session.get_results()

--- a/python_modules/dagster/dagster/_core/pipes/utils.py
+++ b/python_modules/dagster/dagster/_core/pipes/utils.py
@@ -352,7 +352,7 @@ def open_pipes_session(
             ) as pipes_session:
                 subprocess.Popen(
                     ["/bin/python", "/path/to/script.py"],
-                    env={**pipes_session.get_pipes_bootstrap_env_vars()}
+                    env={**pipes_session.get_bootstrap_env_vars()}
                 )
                 while process.poll() is None:
                     yield from pipes_session.get_results()

--- a/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_subprocess.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_subprocess.py
@@ -420,7 +420,7 @@ def test_ext_no_client(external_script):
             PipesTempFileMessageReader(),
             extras=extras,
         ) as pipes_session:
-            subprocess.run(cmd, env=pipes_session.get_pipes_env_vars(), check=False)
+            subprocess.run(cmd, env=pipes_session.get_pipes_bootstrap_env_vars(), check=False)
         yield from pipes_session.get_results()
 
     with instance_for_test() as instance:
@@ -457,7 +457,7 @@ def test_ext_no_client_no_yield():
                 PipesTempFileMessageReader(),
             ) as pipes_session:
                 cmd = [_PYTHON_EXECUTABLE, external_script]
-                subprocess.run(cmd, env=pipes_session.get_pipes_env_vars(), check=False)
+                subprocess.run(cmd, env=pipes_session.get_pipes_bootstrap_env_vars(), check=False)
 
     with pytest.raises(
         DagsterInvariantViolationError,

--- a/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_subprocess.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_subprocess.py
@@ -420,7 +420,7 @@ def test_ext_no_client(external_script):
             PipesTempFileMessageReader(),
             extras=extras,
         ) as pipes_session:
-            subprocess.run(cmd, env=pipes_session.get_pipes_bootstrap_env_vars(), check=False)
+            subprocess.run(cmd, env=pipes_session.get_bootstrap_env_vars(), check=False)
         yield from pipes_session.get_results()
 
     with instance_for_test() as instance:
@@ -457,7 +457,7 @@ def test_ext_no_client_no_yield():
                 PipesTempFileMessageReader(),
             ) as pipes_session:
                 cmd = [_PYTHON_EXECUTABLE, external_script]
-                subprocess.run(cmd, env=pipes_session.get_pipes_bootstrap_env_vars(), check=False)
+                subprocess.run(cmd, env=pipes_session.get_bootstrap_env_vars(), check=False)
 
     with pytest.raises(
         DagsterInvariantViolationError,

--- a/python_modules/libraries/dagster-databricks/README.md
+++ b/python_modules/libraries/dagster-databricks/README.md
@@ -163,7 +163,7 @@ def databricks_asset(context: AssetExecutionContext):
         # `pipes_session`. Yield them all after Databricks execution is finished.
 
         # Dict[str, str] with environment variables containing Pipes comms info.
-        env_vars = pipes_session.get_pipes_env_vars()
+        env_vars = pipes_session.get_pipes_bootstrap_env_vars()
 
         # Some function that handles launching/monitoring of the Databricks job.
         # It must ensure that the `env_vars` are set on the executing cluster.
@@ -175,7 +175,7 @@ def databricks_asset(context: AssetExecutionContext):
         # pipes_session.get_results()` as often as you like. `get_results` returns
         # an iterator that your custom code can `yield from` to forward the
         # results back to the materialize function. Note you will need to extract
-        # the env vars by calling `pipes_session.get_pipes_env_vars()`,
+        # the env vars by calling `pipes_session.get_pipes_bootstrap_env_vars()`,
         # and launch the Databricks job in the same way as with (1).
 
         # The function should return an `Iterator[MaterializeResult]`.

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
@@ -107,7 +107,7 @@ class _PipesDatabricksClient(PipesClient):
             submit_task_dict["new_cluster"]["spark_env_vars"] = {
                 **submit_task_dict["new_cluster"].get("spark_env_vars", {}),
                 **(self.env or {}),
-                **pipes_session.get_pipes_env_vars(),
+                **pipes_session.get_pipes_bootstrap_env_vars(),
             }
             task = jobs.SubmitTask.from_dict(submit_task_dict)
             run_id = self.client.jobs.submit(

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
@@ -107,7 +107,7 @@ class _PipesDatabricksClient(PipesClient):
             submit_task_dict["new_cluster"]["spark_env_vars"] = {
                 **submit_task_dict["new_cluster"].get("spark_env_vars", {}),
                 **(self.env or {}),
-                **pipes_session.get_pipes_bootstrap_env_vars(),
+                **pipes_session.get_bootstrap_env_vars(),
             }
             task = jobs.SubmitTask.from_dict(submit_task_dict)
             run_id = self.client.jobs.submit(

--- a/python_modules/libraries/dagster-docker/dagster_docker/pipes.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/pipes.py
@@ -150,7 +150,7 @@ class _PipesDockerClient(PipesClient):
                     image=image,
                     command=command,
                     env=env,
-                    open_pipes_session_env=pipes_session.get_pipes_env_vars(),
+                    open_pipes_session_env=pipes_session.get_pipes_bootstrap_env_vars(),
                     container_kwargs=container_kwargs,
                 )
             except docker.errors.ImageNotFound:
@@ -160,7 +160,7 @@ class _PipesDockerClient(PipesClient):
                     image=image,
                     command=command,
                     env=env,
-                    open_pipes_session_env=pipes_session.get_pipes_env_vars(),
+                    open_pipes_session_env=pipes_session.get_pipes_bootstrap_env_vars(),
                     container_kwargs=container_kwargs,
                 )
 

--- a/python_modules/libraries/dagster-docker/dagster_docker/pipes.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/pipes.py
@@ -150,7 +150,7 @@ class _PipesDockerClient(PipesClient):
                     image=image,
                     command=command,
                     env=env,
-                    open_pipes_session_env=pipes_session.get_pipes_bootstrap_env_vars(),
+                    open_pipes_session_env=pipes_session.get_bootstrap_env_vars(),
                     container_kwargs=container_kwargs,
                 )
             except docker.errors.ImageNotFound:
@@ -160,7 +160,7 @@ class _PipesDockerClient(PipesClient):
                     image=image,
                     command=command,
                     env=env,
-                    open_pipes_session_env=pipes_session.get_pipes_bootstrap_env_vars(),
+                    open_pipes_session_env=pipes_session.get_bootstrap_env_vars(),
                     container_kwargs=container_kwargs,
                 )
 

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
@@ -179,7 +179,7 @@ class _PipesK8sClient(PipesClient):
                 image=image,
                 command=command,
                 env_vars={
-                    **pipes_session.get_pipes_bootstrap_env_vars(),
+                    **pipes_session.get_bootstrap_env_vars(),
                     **(self.env or {}),
                     **(env or {}),
                 },

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
@@ -179,7 +179,7 @@ class _PipesK8sClient(PipesClient):
                 image=image,
                 command=command,
                 env_vars={
-                    **pipes_session.get_pipes_env_vars(),
+                    **pipes_session.get_pipes_bootstrap_env_vars(),
                     **(self.env or {}),
                     **(env or {}),
                 },


### PR DESCRIPTION
## Summary & Motivation

This is both a refactor and a change in terminology. I'm in the process of writing the launch post on Pipes, and describing the initial parameter process as "bootstrapping" has been very helpful.

Furthermore, I also want to make it clear that while environment variables are the most common way to pass bootstrapping parameters, it is not the only way. The decision about how to bootstrap is the responsibility of a particular context injector, not a hardcoded behavior in the system.

The code level is feels good to separate the encoding process from setting up the logical parameter dictionary as well.

## How I Tested These Changes
