### PR TITLE
Filter asset keys as the storage level in get_asset_records

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -1275,15 +1275,23 @@ class SqlEventLogStorage(EventLogStorage):
             columns.append(AssetKeyTable.c.wipe_timestamp)
 
         query = db_select(columns).order_by(AssetKeyTable.c.asset_key.asc())
+        if asset_keys:
+            ... 
+
         query = self._apply_asset_filter_to_query(query, asset_keys, prefix, limit, cursor)
 
         if self.has_secondary_index(ASSET_KEY_INDEX_COLS):
+
             query = query.where(
                 db.or_(
                     AssetKeyTable.c.wipe_timestamp.is_(None),
                     AssetKeyTable.c.last_materialization_timestamp > AssetKeyTable.c.wipe_timestamp,
                 )
             )
+
+            if asset_keys:            
+                query.filter(AssetKeyTable.c.asset_key.in_(list(ak.to_string() for ak in asset_keys)))
+
             with self.index_connection() as conn:
                 rows = db_fetch_mappings(conn, query)
 

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -1275,13 +1275,10 @@ class SqlEventLogStorage(EventLogStorage):
             columns.append(AssetKeyTable.c.wipe_timestamp)
 
         query = db_select(columns).order_by(AssetKeyTable.c.asset_key.asc())
-        if asset_keys:
-            ... 
 
         query = self._apply_asset_filter_to_query(query, asset_keys, prefix, limit, cursor)
 
         if self.has_secondary_index(ASSET_KEY_INDEX_COLS):
-
             query = query.where(
                 db.or_(
                     AssetKeyTable.c.wipe_timestamp.is_(None),
@@ -1289,8 +1286,10 @@ class SqlEventLogStorage(EventLogStorage):
                 )
             )
 
-            if asset_keys:            
-                query.filter(AssetKeyTable.c.asset_key.in_(list(ak.to_string() for ak in asset_keys)))
+            if asset_keys:
+                query.filter(
+                    AssetKeyTable.c.asset_key.in_(list(ak.to_string() for ak in asset_keys))
+                )
 
             with self.index_connection() as conn:
                 rows = db_fetch_mappings(conn, query)


### PR DESCRIPTION
## Summary & Motivation

With the changes to our frontend to asset fetching on demand and filtered, we are going to be doing more requests that have filtered applied. This is good. However our backends need to respect it to get the full benefit.

In `SqlEventLogStorage.get_asset_records()` we were fetching all asset records, even if `asset_keys` was set. This PR fixes that, pushing down asset key filtering down to the database, reducing the rows fetched from N to 1.

## How I Tested These Changes

1. Confirmed that single asset keys were being fetched while browsing asset catalog.
2. Profiled before change

3. Profiled after change
