### PR TITLE
[Dagster-webserver][oss] Serve files using FileResponse so they can be cached

### DIFF
--- a/python_modules/dagster-webserver/dagster_webserver/webserver.py
+++ b/python_modules/dagster-webserver/dagster_webserver/webserver.py
@@ -271,6 +271,8 @@ class DagsterWebserver(GraphQLServer, Generic[T_IWorkspaceProcessContext]):
                 full_path = os.path.join(subdir, file)
 
                 # Replace path.sep to make sure our routes use forward slashes on windows
+                # Note forward slashes are okay here because these are used for routing, not for
+                # file paths
                 mount_path = "/" + full_path[len(base_dir) :].replace(os.path.sep, "/")
                 # We only need to replace BUILDTIME_ASSETPREFIX_REPLACE_ME in javascript files
                 if self._uses_app_path_prefix and (

--- a/python_modules/dagster-webserver/dagster_webserver/webserver.py
+++ b/python_modules/dagster-webserver/dagster_webserver/webserver.py
@@ -1,9 +1,9 @@
 import gzip
 import io
-import uuid
 import os
-from typing import Generic, List, TypeVar
 import tempfile
+import uuid
+from typing import Generic, List, TypeVar
 
 import dagster._check as check
 from dagster import __version__ as dagster_version
@@ -28,9 +28,7 @@ from starlette.responses import (
     JSONResponse,
     PlainTextResponse,
     RedirectResponse,
-    Response,
     StreamingResponse,
-    guess_type,
 )
 from starlette.routing import Mount, Route, WebSocketRoute
 from starlette.types import Message
@@ -39,6 +37,7 @@ from .graphql import GraphQLServer
 from .version import __version__
 
 T_IWorkspaceProcessContext = TypeVar("T_IWorkspaceProcessContext", bound=IWorkspaceProcessContext)
+
 
 class DagsterWebserver(GraphQLServer, Generic[T_IWorkspaceProcessContext]):
     _process_context: T_IWorkspaceProcessContext


### PR DESCRIPTION
## Summary & Motivation

This pr addresses a performance issue reported by a user: https://dagster.slack.com/archives/C01U954MEER/p1695936650103649

While updating OSS to use Next.js to build the frontend we needed to update the file serving logic to string replace a special path string present in javascript in order to support the `--path-prefix` feature of dagster-webserver. The original logic ran this string replacement every time a javascript file was requested. Now: We run the string replacement the first time the file is requested and save it in a temporary directory. If the file already exists we just serve the file from the temporary directory using Starlette's FileResponse which sets the proper headers to enable browser caching.



## How I Tested These Changes

Relying on existing tests + tested it locally with `dagster-webserver -p 3333 --path-prefix=/test` 