### PR TITLE
[ez][Asset graph] revert padding change

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/components/PageHeader.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/PageHeader.tsx
@@ -13,21 +13,17 @@ interface Props {
   metadata?: React.ReactNode;
   right?: React.ReactNode;
   tabs?: React.ReactNode;
-  paddingBelowTitle?: number;
 }
 
 export const PageHeader = (props: Props) => {
-  const {title, tags, right, tabs, paddingBelowTitle = 16} = props;
+  const {title, tags, right, tabs} = props;
   return (
     <PageHeaderContainer
       background={Colors.Gray50}
       padding={{top: 16, left: 24, right: 12}}
       border="bottom"
     >
-      <Box
-        flex={{direction: 'row', justifyContent: 'space-between'}}
-        padding={{bottom: paddingBelowTitle as any}}
-      >
+      <Box flex={{direction: 'row', justifyContent: 'space-between'}} padding={{bottom: 16}}>
         <Box flex={{direction: 'row', alignItems: 'flex-start', gap: 12, wrap: 'wrap'}}>
           {title}
           {tags}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetGroupRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetGroupRoot.tsx
@@ -85,7 +85,6 @@ export const AssetGroupRoot: React.FC<{repoAddress: RepoAddress; tab: 'lineage' 
       <PageHeader
         title={<Heading>{groupName}</Heading>}
         right={<ReloadAllButton label="Reload definitions" />}
-        paddingBelowTitle={0}
         tags={<AssetGroupTags groupSelector={groupSelector} repoAddress={repoAddress} />}
         tabs={
           <Box

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsGroupsGlobalGraphRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsGroupsGlobalGraphRoot.tsx
@@ -94,7 +94,6 @@ export const AssetsGroupsGlobalGraphRoot: React.FC = () => {
     <Page style={{display: 'flex', flexDirection: 'column', paddingBottom: 0}}>
       <PageHeader
         title={<Heading>Global Asset Lineage</Heading>}
-        paddingBelowTitle={0}
         right={<ReloadAllButton label="Reload definitions" />}
       />
       <AssetGraphExplorer


### PR DESCRIPTION
## Summary & Motivation

Reverting a padding change I made that tried to solve one problem but created another. I solved the original problem in a separate PR.

before:
<img width="1491" alt="Screenshot 2023-10-02 at 8 37 19 AM" src="https://github.com/dagster-io/dagster/assets/2286579/3218bb3c-2f89-4c3e-91c1-b09149c98f94">


after:
<img width="1492" alt="Screenshot 2023-10-02 at 8 36 44 AM" src="https://github.com/dagster-io/dagster/assets/2286579/2d693866-be7c-4ea1-9f2f-0c7eb605fd90">

## How I Tested These Changes
