### PR TITLE
[Asset-graph] Make cache key deterministic

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
@@ -36,10 +36,32 @@ const asyncGetFullOpLayout = asyncMemoize((ops: ILayoutOp[], opts: LayoutOpGraph
 const _assetLayoutCacheKey = (graphData: GraphData) => {
   // Note: The "show secondary edges" toggle means that we need a cache key that incorporates
   // both the displayed nodes and the displayed edges.
+
+  // Make the cache key deterministic by alphabetically sorting all of the keys since the order
+  // of the keys is not guaranteed to be consistent even when the graph hasn't changed.
+
+  function recreateObjectWithKeysSorted(obj: Record<string, Record<string, boolean>>) {
+    const newObj: Record<string, Record<string, boolean>> = {};
+    Object.keys(obj)
+      .sort()
+      .forEach((key) => {
+        newObj[key] = Object.keys(obj[key]!)
+          .sort()
+          .reduce(
+            (acc, k) => {
+              acc[k] = obj[key]![k]!;
+              return acc;
+            },
+            {} as Record<string, boolean>,
+          );
+      });
+    return newObj;
+  }
+
   return JSON.stringify({
-    downstream: graphData.downstream,
-    upstream: graphData.upstream,
-    nodes: Object.keys(graphData),
+    downstream: recreateObjectWithKeysSorted(graphData.downstream),
+    upstream: recreateObjectWithKeysSorted(graphData.upstream),
+    nodes: Object.keys(graphData).sort(),
   });
 };
 


### PR DESCRIPTION
## Summary & Motivation
Noticed that the cache key we use isn't created in a deterministic way, not sure exactly why (specualation: could be the order from the database for the assetKeys from the workspace query isn't deterministic). Let's make it deterministic by sorting the keys.

## How I Tested These Changes

locally reloaded the page a few times and made sure we always use the cache. Also restarted the webserver