### PR TITLE
[AssetLiveDataProvider] Add retry logic in case of network error

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetLiveDataProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetLiveDataProvider.tsx
@@ -313,6 +313,14 @@ async function _batchedQueryAssets(
     };
   });
   onUpdatingOrUpdated();
+
+  function doNextFetch() {
+    isFetching = false;
+    const nextAssets = _determineAssetsToFetch();
+    if (nextAssets.length) {
+      _batchedQueryAssets(nextAssets, client, setData, onUpdatingOrUpdated);
+    }
+  }
   try {
     const data = await _queryAssetKeys(client, assetKeys);
     const fetchedTime = Date.now();
@@ -323,24 +331,11 @@ async function _batchedQueryAssets(
     });
     setData(data);
     onUpdatingOrUpdated();
-    isFetching = false;
-    const nextAssets = _determineAssetsToFetch();
-    if (nextAssets.length) {
-      _batchedQueryAssets(nextAssets, client, setData, onUpdatingOrUpdated);
-    }
+    doNextFetch();
   } catch (e) {
     console.error(e);
     // Retry fetching in 5 seconds if theres a network error
-    setTimeout(() => {
-      assetKeys.forEach((key) => {
-        delete lastFetchedOrRequested[tokenForAssetKey(key)];
-        isFetching = false;
-        const nextAssets = _determineAssetsToFetch();
-        if (nextAssets.length) {
-          _batchedQueryAssets(nextAssets, client, setData, onUpdatingOrUpdated);
-        }
-      });
-    }, 5000);
+    setTimeout(doNextFetch, 5000);
   }
 }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetLiveDataProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetLiveDataProvider.tsx
@@ -82,7 +82,6 @@ export function useAssetsLiveData(assetKeys: AssetKeyInput[]) {
 }
 
 async function _queryAssetKeys(client: ApolloClient<any>, assetKeys: AssetKeyInput[]) {
-  console.log({assetKeys});
   const {data} = await client.query<AssetGraphLiveQuery, AssetGraphLiveQueryVariables>({
     query: ASSETS_GRAPH_LIVE_QUERY,
     fetchPolicy: 'network-only',


### PR DESCRIPTION
## Summary & Motivation

Currently if a network error occurs, AssetLiveDataProvider ends up in a broken state where it no longer fetches even after the network is reconnected. This PR adds retry logic so that after 5 seconds it attempts to query data again.

## How I Tested These Changes

Load the asset graph see data load,
Kill the dagster webserver
Scroll down the sidebar and see that data doesn't load anymore
Restart the dagster webserver
See that data starts coming in again automatically.
