### PR TITLE
fixes for direct invocation & MaterializeResult

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/op_invocation.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_invocation.py
@@ -5,6 +5,7 @@ from typing import (
     Dict,
     Mapping,
     NamedTuple,
+    Set,
     Tuple,
     TypeVar,
     Union,
@@ -20,13 +21,15 @@ from dagster._core.errors import (
 )
 
 from .events import (
+    AssetKey,
     AssetMaterialization,
     AssetObservation,
     DynamicOutput,
     ExpectationResult,
     Output,
 )
-from .output import DynamicOutputDefinition
+from .output import DynamicOutputDefinition, OutputDefinition
+from .result import MaterializeResult
 
 if TYPE_CHECKING:
     from ..execution.context.invocation import BoundOpExecutionContext
@@ -34,7 +37,6 @@ if TYPE_CHECKING:
     from .composition import PendingNodeInvocation
     from .decorators.op_decorator import DecoratedOpFunction
     from .op_definition import OpDefinition
-    from .output import OutputDefinition
 
 T = TypeVar("T")
 
@@ -324,6 +326,55 @@ def _resolve_inputs(
     return input_dict
 
 
+def _key_for_result(result: MaterializeResult, context: "BoundOpExecutionContext") -> AssetKey:
+    if result.asset_key:
+        return result.asset_key
+
+    if len(context.assets_def.keys) == 1:
+        return next(iter(context.assets_def.keys))
+
+    raise DagsterInvariantViolationError(
+        "Unable to resolve unset asset_key for MaterializeResult, set explicitly when constructing."
+    )
+
+
+def _handle_gen_event(
+    event: T,
+    op_def: "OpDefinition",
+    context: "BoundOpExecutionContext",
+    output_defs: Mapping[str, OutputDefinition],
+    outputs_seen: Set[str],
+) -> T:
+    if isinstance(
+        event,
+        (AssetMaterialization, AssetObservation, ExpectationResult),
+    ):
+        return event
+    elif isinstance(event, MaterializeResult):
+        asset_key = _key_for_result(event, context)
+        output_name = context.assets_def.get_output_name_for_asset_key(asset_key)
+        outputs_seen.add(output_name)
+        return event
+    else:
+        if not isinstance(event, (Output, DynamicOutput)):
+            raise DagsterInvariantViolationError(
+                f"When yielding outputs from a {op_def.node_type_str} generator,"
+                " they should be wrapped in an `Output` object."
+            )
+        else:
+            output_def = output_defs[event.output_name]
+            _type_check_output(output_def, event, context)
+            if output_def.name in outputs_seen and not isinstance(
+                output_def, DynamicOutputDefinition
+            ):
+                raise DagsterInvariantViolationError(
+                    f"Invocation of {op_def.node_type_str} '{context.alias}' yielded"
+                    f" an output '{output_def.name}' multiple times."
+                )
+            outputs_seen.add(output_def.name)
+        return event
+
+
 def _type_check_output_wrapper(
     op_def: "OpDefinition", result: Any, context: "BoundOpExecutionContext"
 ) -> Any:
@@ -341,35 +392,22 @@ def _type_check_output_wrapper(
             outputs_seen = set()
 
             async for event in async_gen:
-                if isinstance(
-                    event,
-                    (AssetMaterialization, AssetObservation, ExpectationResult),
-                ):
-                    yield event
-                else:
-                    if not isinstance(event, (Output, DynamicOutput)):
-                        raise DagsterInvariantViolationError(
-                            f"When yielding outputs from a {op_def.node_type_str} generator,"
-                            " they should be wrapped in an `Output` object."
-                        )
-                    else:
-                        output_def = output_defs[event.output_name]
-                        _type_check_output(output_def, event, context)
-                        if output_def.name in outputs_seen and not isinstance(
-                            output_def, DynamicOutputDefinition
-                        ):
-                            raise DagsterInvariantViolationError(
-                                f"Invocation of {op_def.node_type_str} '{context.alias}' yielded"
-                                f" an output '{output_def.name}' multiple times."
-                            )
-                        outputs_seen.add(output_def.name)
-                    yield event
+                yield _handle_gen_event(event, op_def, context, output_defs, outputs_seen)
+
             for output_def in op_def.output_defs:
-                if output_def.name not in outputs_seen and output_def.is_required:
-                    raise DagsterInvariantViolationError(
-                        f"Invocation of {op_def.node_type_str} '{context.alias}' did not return"
-                        f" an output for non-optional output '{output_def.name}'"
-                    )
+                if (
+                    output_def.name not in outputs_seen
+                    and output_def.is_required
+                    and not output_def.is_dynamic
+                ):
+                    if output_def.dagster_type.is_nothing:
+                        # implicitly yield None as we do in execute_step
+                        yield Output(output_name=output_def.name, value=None)
+                    else:
+                        raise DagsterInvariantViolationError(
+                            f"Invocation of {op_def.node_type_str} '{context.alias}' did not"
+                            f" return an output for non-optional output '{output_def.name}'"
+                        )
 
         return to_gen(result)
 
@@ -388,29 +426,8 @@ def _type_check_output_wrapper(
         def type_check_gen(gen):
             outputs_seen = set()
             for event in gen:
-                if isinstance(
-                    event,
-                    (AssetMaterialization, AssetObservation, ExpectationResult),
-                ):
-                    yield event
-                else:
-                    if not isinstance(event, (Output, DynamicOutput)):
-                        raise DagsterInvariantViolationError(
-                            f"When yielding outputs from a {op_def.node_type_str} generator,"
-                            " they should be wrapped in an `Output` object."
-                        )
-                    else:
-                        output_def = output_defs[event.output_name]
-                        output = _type_check_output(output_def, event, context)
-                        if output_def.name in outputs_seen and not isinstance(
-                            output_def, DynamicOutputDefinition
-                        ):
-                            raise DagsterInvariantViolationError(
-                                f"Invocation of {op_def.node_type_str} '{context.alias}' yielded"
-                                f" an output '{output_def.name}' multiple times."
-                            )
-                        outputs_seen.add(output_def.name)
-                    yield output
+                yield _handle_gen_event(event, op_def, context, output_defs, outputs_seen)
+
             for output_def in op_def.output_defs:
                 if (
                     output_def.name not in outputs_seen
@@ -439,13 +456,17 @@ def _type_check_function_output(
 
     output_defs_by_name = {output_def.name: output_def for output_def in op_def.output_defs}
     for event in validate_and_coerce_op_result_to_iterator(result, context, op_def.output_defs):
-        _type_check_output(output_defs_by_name[event.output_name], event, context)
+        if isinstance(event, (Output, DynamicOutput)):
+            _type_check_output(output_defs_by_name[event.output_name], event, context)
+
     return result
 
 
 def _type_check_output(
-    output_def: "OutputDefinition", output: T, context: "BoundOpExecutionContext"
-) -> T:
+    output_def: "OutputDefinition",
+    output: Union[Output, DynamicOutput],
+    context: "BoundOpExecutionContext",
+) -> None:
     """Validates and performs core type check on a provided output.
 
     Args:
@@ -457,36 +478,19 @@ def _type_check_output(
     from ..execution.plan.execute_step import do_type_check
 
     op_label = context.describe_op()
-
-    if isinstance(output, (Output, DynamicOutput)):
-        dagster_type = output_def.dagster_type
-        type_check = do_type_check(context.for_type(dagster_type), dagster_type, output.value)
-        if not type_check.success:
-            raise DagsterTypeCheckDidNotPass(
-                description=(
-                    f'Type check failed for {op_label} output "{output.output_name}" - '
-                    f'expected type "{dagster_type.display_name}". '
-                    f"Description: {type_check.description}"
-                ),
-                metadata=type_check.metadata,
-                dagster_type=dagster_type,
-            )
-
-        context.observe_output(
-            output_def.name, output.mapping_key if isinstance(output, DynamicOutput) else None
+    dagster_type = output_def.dagster_type
+    type_check = do_type_check(context.for_type(dagster_type), dagster_type, output.value)
+    if not type_check.success:
+        raise DagsterTypeCheckDidNotPass(
+            description=(
+                f'Type check failed for {op_label} output "{output.output_name}" - '
+                f'expected type "{dagster_type.display_name}". '
+                f"Description: {type_check.description}"
+            ),
+            metadata=type_check.metadata,
+            dagster_type=dagster_type,
         )
-        return output
-    else:
-        dagster_type = output_def.dagster_type
-        type_check = do_type_check(context.for_type(dagster_type), dagster_type, output)
-        if not type_check.success:
-            raise DagsterTypeCheckDidNotPass(
-                description=(
-                    f'Type check failed for {op_label} output "{output_def.name}" - '
-                    f'expected type "{dagster_type.display_name}". '
-                    f"Description: {type_check.description}"
-                ),
-                metadata=type_check.metadata,
-                dagster_type=dagster_type,
-            )
-        return output
+
+    context.observe_output(
+        output_def.name, output.mapping_key if isinstance(output, DynamicOutput) else None
+    )

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_materialize_result.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_materialize_result.py
@@ -279,10 +279,6 @@ def test_generator_return_type_annotation():
     materialize([generator_asset], resources={"io_manager": TestingIOManager()})
 
 
-@pytest.mark.skip(
-    "Direct invocation causes errors, unskip these tests once direct invocation path is fixed."
-    " https://github.com/dagster-io/dagster/issues/16921"
-)
 def test_direct_invocation_materialize_result():
     @asset
     def my_asset() -> MaterializeResult:
@@ -312,10 +308,6 @@ def test_direct_invocation_materialize_result():
     assert res[1].metadata["baz"] == "qux"
 
 
-@pytest.mark.skip(
-    "Direct invocation causes errors, unskip these tests once direct invocation path is fixed."
-    " https://github.com/dagster-io/dagster/issues/16921"
-)
 def test_direct_invocation_for_generators():
     @asset
     def generator_asset() -> Generator[MaterializeResult, None, None]:
@@ -355,10 +347,6 @@ def test_materialize_result_with_partitions():
     assert mats[0].metadata["key"].text == "red"
 
 
-@pytest.mark.skip(
-    "Direct invocation causes errors, unskip these tests once direct invocation path is fixed."
-    " https://github.com/dagster-io/dagster/issues/16921"
-)
 def test_materialize_result_with_partitions_direct_invocation():
     @asset(partitions_def=StaticPartitionsDefinition(["red", "blue", "yellow"]))
     def partitioned_asset(context: AssetExecutionContext) -> MaterializeResult:


### PR DESCRIPTION
updates the generator code paths in direct invocation to properly handle `MaterializeResult` 

## How I Tested These Changes

removed skips on existing test suite