### PR TITLE
feat(dbt): allow explicit specification `target_path` when invoking dbt

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -622,6 +622,7 @@ class DbtCliResource(ConfigurableResource):
         manifest: Optional[DbtManifestParam] = None,
         dagster_dbt_translator: Optional[DagsterDbtTranslator] = None,
         context: Optional[OpExecutionContext] = None,
+        target_path: Optional[Path] = None,
     ) -> DbtCliInvocation:
         """Create a subprocess to execute a dbt CLI command.
 
@@ -636,6 +637,9 @@ class DbtCliResource(ConfigurableResource):
                 provided to the context argument, then the dagster_dbt_translator provided to
                 `@dbt_assets` will be used.
             context (Optional[OpExecutionContext]): The execution context from within `@dbt_assets`.
+            target_path (Optional[Path]): An explicit path to a target folder to use to store and
+                retrieve dbt artifacts when running a dbt CLI command. If not provided, a unique
+                target path will be generated.
 
         Returns:
             DbtCliInvocation: A invocation instance that can be used to retrieve the output of the
@@ -744,7 +748,7 @@ class DbtCliResource(ConfigurableResource):
                     dbt_macro_args = {"key": "value"}
                     dbt.cli(["run-operation", "my-macro", json.dumps(dbt_macro_args)]).wait()
         """
-        target_path = self._get_unique_target_path(context=context)
+        target_path = target_path or self._get_unique_target_path(context=context)
         env = {
             **os.environ.copy(),
             # Run dbt with unbuffered output.

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resources_v2.py
@@ -135,8 +135,25 @@ def test_dbt_cli_get_artifact() -> None:
     assert manifest_json_1 != manifest_json_2
 
 
+def test_dbt_cli_target_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("DBT_TARGET_PATH", os.fspath(tmp_path))
+    dbt = DbtCliResource(project_dir=TEST_PROJECT_DIR)
+
+    dbt_cli_invocation_1 = dbt.cli(["compile"]).wait()
+    manifest_st_mtime_1 = dbt_cli_invocation_1.target_path.joinpath("manifest.json").stat().st_mtime
+
+    dbt_cli_invocation_2 = dbt.cli(["compile"], target_path=dbt_cli_invocation_1.target_path).wait()
+    manifest_st_mtime_2 = dbt_cli_invocation_2.target_path.joinpath("manifest.json").stat().st_mtime
+
+    # The target path should be the same for both invocations
+    assert dbt_cli_invocation_1.target_path == dbt_cli_invocation_2.target_path
+
+    # Which results in the manifest.json being overwritten
+    assert manifest_st_mtime_1 != manifest_st_mtime_2
+
+
 @pytest.mark.parametrize("target_path", [Path("tmp"), Path("/tmp")])
-def test_dbt_cli_target_path(monkeypatch: pytest.MonkeyPatch, target_path: Path) -> None:
+def test_dbt_cli_target_path_env_var(monkeypatch: pytest.MonkeyPatch, target_path: Path) -> None:
     dbt = DbtCliResource(project_dir=TEST_PROJECT_DIR)
     expected_target_path = (
         target_path if target_path.is_absolute() else Path(TEST_PROJECT_DIR).joinpath(target_path)


### PR DESCRIPTION
## Summary & Motivation
Resolves https://github.com/dagster-io/dagster/issues/15293.

Here, we allow the user to explicitly set the target path of their dbt invocations. This is useful for commands (e.g. selection) that need the target path to be pre-populated with previous artifacts.

## How I Tested These Changes
pytest
