### PR TITLE
Replace Next.js' static `assetPrefix` with `__webpack_public_path__` to support dynamic path prefix

### DIFF
--- a/js_modules/dagster-ui/package.json
+++ b/js_modules/dagster-ui/package.json
@@ -3,7 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "build": "yarn workspace @dagster-io/app-oss build && yarn post-build",
+    "build": "yarn workspace @dagster-io/app-oss build && yarn replace-asset-prefix && yarn post-build",
+    "replace-asset-prefix": "node ./packages/app-oss/replace-asset-prefix.js",
     "build-with-profiling": "yarn workspace @dagster-io/app-oss build --profile && yarn post-build",
     "post-build": "cd ../../python_modules/dagster-webserver/dagster_webserver && rm -rf webapp && mkdir -p webapp && cp -r ../../../js_modules/dagster-ui/packages/app-oss/build ./webapp/ && mkdir -p webapp/build/vendor && cp -r graphql-playground ./webapp/build/vendor && cp ../../../js_modules/dagster-ui/packages/app-oss/csp-header.txt ./webapp/build",
     "lint": "yarn workspace @dagster-io/app-oss lint && yarn workspace @dagster-io/ui-core lint && yarn workspace @dagster-io/ui-components lint",

--- a/js_modules/dagster-ui/packages/app-oss/replace-asset-prefix.js
+++ b/js_modules/dagster-ui/packages/app-oss/replace-asset-prefix.js
@@ -25,7 +25,7 @@ function processDirectory(directory) {
         '"BUILDTIME_ASSETPREFIX_REPLACE_ME',
         // if typeof window === "undefined" then we are inside a web worker
         // Grab the path from the location object
-        '(() => {if (typeof window === "undefined") {return self.location.pathname.split("_next")[0].slice(0, -1)} return self.__webpack_public_path__ || "";})() + "',
+        '(() => {if (typeof window === "undefined") {return self.location.pathname.split("/_next/")[0]} return self.__webpack_public_path__ || "";})() + "',
       );
     }
   }

--- a/js_modules/dagster-ui/packages/app-oss/replace-asset-prefix.js
+++ b/js_modules/dagster-ui/packages/app-oss/replace-asset-prefix.js
@@ -1,0 +1,34 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const fs = require('fs');
+const path = require('path');
+
+function replaceStringInFile(filePath, searchString, replacement) {
+  const fileContent = fs.readFileSync(filePath, 'utf8');
+  const replacedContent = fileContent.replace(new RegExp(searchString, 'g'), replacement);
+  fs.writeFileSync(filePath, replacedContent);
+}
+
+function processDirectory(directory) {
+  const files = fs.readdirSync(directory);
+
+  for (const file of files) {
+    const filePath = path.join(directory, file);
+
+    const isDirectory = fs.statSync(filePath).isDirectory();
+
+    if (isDirectory) {
+      // Recursively process subdirectories
+      processDirectory(filePath);
+    } else if (file.endsWith('.js')) {
+      replaceStringInFile(
+        filePath,
+        '"BUILDTIME_ASSETPREFIX_REPLACE_ME',
+        // if typeof window === "undefined" then we are inside a web worker
+        // Grab the path from the location object
+        '(() => {if (typeof window === "undefined") {return self.location.pathname.split("_next")[0].slice(0, -1)} return self.__webpack_public_path__ || "";})() + "',
+      );
+    }
+  }
+}
+
+processDirectory(__dirname + '/build/');

--- a/js_modules/dagster-ui/packages/app-oss/src/pages/_document.tsx
+++ b/js_modules/dagster-ui/packages/app-oss/src/pages/_document.tsx
@@ -16,6 +16,12 @@ export default function Document() {
       <Head nonce="NONCE-PLACEHOLDER">
         {/* Not sure if we need the following script */}
         <script
+          nonce="NONCE-PLACEHOLDER"
+          dangerouslySetInnerHTML={{
+            __html: 'window.__webpack_public_path__ = "__PATH_PREFIX__"',
+          }}
+        />
+        <script
           id="webpack-nonce-setter"
           nonce="NONCE-PLACEHOLDER"
           dangerouslySetInnerHTML={{__html: `__webpack_nonce__ = 'NONCE-PLACEHOLDER';`}}

--- a/js_modules/dagster-ui/packages/app-oss/src/pages/_document.tsx
+++ b/js_modules/dagster-ui/packages/app-oss/src/pages/_document.tsx
@@ -14,13 +14,13 @@ export default function Document() {
   return (
     <Html lang="en">
       <Head nonce="NONCE-PLACEHOLDER">
-        {/* Not sure if we need the following script */}
         <script
           nonce="NONCE-PLACEHOLDER"
           dangerouslySetInnerHTML={{
             __html: 'window.__webpack_public_path__ = "__PATH_PREFIX__"',
           }}
         />
+        {/* Not sure if we need the following script */}
         <script
           id="webpack-nonce-setter"
           nonce="NONCE-PLACEHOLDER"

--- a/python_modules/dagster-webserver/dagster_webserver/webserver.py
+++ b/python_modules/dagster-webserver/dagster_webserver/webserver.py
@@ -27,9 +27,7 @@ from starlette.responses import (
     JSONResponse,
     PlainTextResponse,
     RedirectResponse,
-    Response,
     StreamingResponse,
-    guess_type,
 )
 from starlette.routing import Mount, Route, WebSocketRoute
 from starlette.types import Message


### PR DESCRIPTION
## Summary & Motivation
This pr addresses a performance issue reported by a user: https://dagster.slack.com/archives/C01U954MEER/p1695936650103649

This is an alternative approach to https://github.com/dagster-io/dagster/pull/16941 that avoids needing to string replace javascript files at run time and instead replaces at buildtime using `__webpack_public_path__`.

This solution is pretty hacky for webworkers and may need tweaking in the future if we start SSRing more of the app. For workers we grab the path from the global location object.

## How I Tested These Changes

Built the app and ran `dagster-webserver -p 4444 --path-prefix=/test1235` and made sure the app still worked including webworkers.

This doesn't affect cloud or local development (I tested local development and it just ignores __webpack_public_path__).
