### PR TITLE
[Asset graph] Make zooming in / zooming out of large graph buttery smooth

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -621,13 +621,13 @@ function filterEdges(
 ) {
   if (allowGroupsOnlyZoomLevel && scale < GROUPS_ONLY_SCALE) {
     return edges.filter((e) => {
-      const fromAsset = graphData.nodes[e.fromId]!;
-      const toAsset = graphData.nodes[e.toId]!;
+      const fromAsset = graphData.nodes[e.fromId];
+      const toAsset = graphData.nodes[e.toId];
       // If the assets are in the same asset group then filter out the edge
       return (
-        fromAsset.definition.groupName !== toAsset.definition.groupName ||
-        fromAsset.definition.repository.id !== toAsset.definition.repository.id ||
-        fromAsset.definition.repository.location.id !== toAsset.definition.repository.location.id
+        fromAsset?.definition.groupName !== toAsset?.definition.groupName ||
+        fromAsset?.definition.repository.id !== toAsset?.definition.repository.id ||
+        fromAsset?.definition.repository.location.id !== toAsset?.definition.repository.location.id
       );
     });
   }


### PR DESCRIPTION
## Summary & Motivation

Filtering out edges that are within a group when we're only showing the group node because they're not visible (they're hidden behind the group node). Not rendering these hidden edges significantly improves the performance of zooming in and out.

## How I Tested These Changes

Locally 