### PR TITLE
[Asset graph] Don't cover top toolbar when loading layout

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/GraphNotices.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/GraphNotices.tsx
@@ -84,7 +84,7 @@ export const LoadingNotice: React.FC<{async: boolean; nodeType: 'asset' | 'op'}>
 const LoadingContainer = styled.div`
   background-color: ${Colors.White};
   position: absolute;
-  top: 0;
+  top: 57px;
   bottom: 0;
   left: 0;
   right: 0;


### PR DESCRIPTION
## Summary & Motivation

before: When you type "*" in the op query input and hit enter it disappears and doesn't let you change your op query until it's done layouting.
after: Now you can change your mind and type something else without waiting for the layout to complete.

## How I Tested These Changes

locally I tested both the asset graph and the ops graph for jobs:

assets:
<img width="1491" alt="Screenshot 2023-10-03 at 9 47 33 AM" src="https://github.com/dagster-io/dagster/assets/2286579/a0fc9dc4-40d4-4b3d-ab49-21a09f2574c9">

jobs:
<img width="1204" alt="Screenshot 2023-10-03 at 9 47 48 AM" src="https://github.com/dagster-io/dagster/assets/2286579/190072bf-e879-40b8-bc11-5e798549c31c">

