### PR TITLE
Disable partitionStatusCounts resolver for asset backfills

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -295,6 +295,12 @@ class GraphenePartitionBackfill(graphene.ObjectType):
     def resolve_partitionStatusCounts(
         self, graphene_info: ResolveInfo
     ) -> Sequence["GraphenePartitionStatusCounts"]:
+        # This resolver is only enabled for job backfills, since it assumes a unique run per
+        # partition key (which is not true for asset backfills). Asset backfills should rely on
+        # the assetBackfillData resolver instead.
+        if self._backfill_job.is_asset_backfill:
+            return []
+
         partition_run_data = self._get_partition_run_data(graphene_info)
         return partition_status_counts_from_run_partition_data(
             partition_run_data,


### PR DESCRIPTION
This PR disables the `partitionStatusCounts` resolver for asset backfills, returning a null value when the targeted backfill is an asset backfill.

This resolver assumes a unique run per partition, and returns the run status per partition to display in a progress bar. However, for asset backfills, this frequently doesn't apply:
- Asset backfills can kick off multiple runs for the same partition key (i.e. a weekly partitions def downstream of a daily partitions def)
- Asset backfills can target different partitions per asset, which doesn't display well in a condensed progress bar (and currently raises an error)

We'll need to rethink how asset backfill statuses should be displayed, but early thinking is displaying counts by status. For asset backfills we can rely on the `assetBackfillData` resolver for this information.
