### PR TITLE
[pipes] test renames ext -> pipes

### DIFF
--- a/integration_tests/test_suites/k8s-test-suite/tests/test_pipes.py
+++ b/integration_tests/test_suites/k8s-test-suite/tests/test_pipes.py
@@ -18,15 +18,15 @@ from dagster_test.test_project import (
 
 
 @pytest.mark.default
-def test_pipes_k8s_client(namespace, cluster_provider):
+def test_pipes_client(namespace, cluster_provider):
     docker_image = get_test_project_docker_image()
 
     @asset
     def number_y(
         context: AssetExecutionContext,
-        pipes_k8s_client: PipesK8sClient,
+        pipes_client: PipesK8sClient,
     ):
-        return pipes_k8s_client.run(
+        return pipes_client.run(
             context=context,
             namespace=namespace,
             image=docker_image,
@@ -46,7 +46,7 @@ def test_pipes_k8s_client(namespace, cluster_provider):
 
     result = materialize(
         [number_y],
-        resources={"pipes_k8s_client": PipesK8sClient()},
+        resources={"pipes_client": PipesK8sClient()},
         raise_on_error=False,
     )
     assert result.success
@@ -114,7 +114,7 @@ class PipesConfigMapContextInjector(PipesContextInjector):
 
 
 @pytest.mark.default
-def test_pipes_k8s_client_file_inject(namespace, cluster_provider):
+def test_pipes_client_file_inject(namespace, cluster_provider):
     # a convoluted test to
     # - vet base_pod_spec works for setting volumes & mounts
     # - preserve file injection via config map code
@@ -127,7 +127,7 @@ def test_pipes_k8s_client_file_inject(namespace, cluster_provider):
     @asset
     def number_y(
         context: AssetExecutionContext,
-        pipes_k8s_client: PipesK8sClient,
+        pipes_client: PipesK8sClient,
     ):
         pod_spec = injector.build_pod_spec(
             image=docker_image,
@@ -138,7 +138,7 @@ def test_pipes_k8s_client_file_inject(namespace, cluster_provider):
             ],
         )
 
-        return pipes_k8s_client.run(
+        return pipes_client.run(
             context=context,
             namespace=namespace,
             extras={
@@ -153,7 +153,7 @@ def test_pipes_k8s_client_file_inject(namespace, cluster_provider):
 
     result = materialize(
         [number_y],
-        resources={"pipes_k8s_client": PipesK8sClient(context_injector=injector)},
+        resources={"pipes_client": PipesK8sClient(context_injector=injector)},
         raise_on_error=False,
     )
     assert result.success
@@ -162,7 +162,7 @@ def test_pipes_k8s_client_file_inject(namespace, cluster_provider):
     assert mats[0].metadata["is_even"].value is True
 
 
-def test_use_excute_k8s_job(namespace, cluster_provider):
+def test_use_execute_k8s_job(namespace, cluster_provider):
     docker_image = get_test_project_docker_image()
 
     @asset
@@ -201,7 +201,7 @@ def test_use_excute_k8s_job(namespace, cluster_provider):
 
     result = materialize(
         [number_y_job],
-        resources={"pipes_k8s_client": PipesK8sClient()},
+        resources={"pipes_client": PipesK8sClient()},
         raise_on_error=False,
     )
     assert result.success

--- a/python_modules/dagster-pipes/dagster_pipes_tests/test_context.py
+++ b/python_modules/dagster-pipes/dagster_pipes_tests/test_context.py
@@ -13,7 +13,7 @@ from dagster_pipes import (
     PipesTimeWindow,
 )
 
-TEST_EXT_CONTEXT_DEFAULTS = PipesContextData(
+TEST_PIPES_CONTEXT_DEFAULTS = PipesContextData(
     asset_keys=None,
     code_version_by_asset_key=None,
     provenance_by_asset_key=None,
@@ -28,7 +28,7 @@ TEST_EXT_CONTEXT_DEFAULTS = PipesContextData(
 
 
 def _make_external_execution_context(**kwargs):
-    kwargs = {**TEST_EXT_CONTEXT_DEFAULTS, **kwargs}
+    kwargs = {**TEST_PIPES_CONTEXT_DEFAULTS, **kwargs}
     return PipesContext(
         data=PipesContextData(**kwargs),
         message_channel=MagicMock(),

--- a/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_subprocess.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_subprocess.py
@@ -136,7 +136,7 @@ def s3_client() -> Iterator[boto3.client]:
         ("user/env", "user/file"),
     ],
 )
-def test_ext_subprocess(
+def test_pipes_subprocess(
     capsys, tmpdir, external_script, s3_client, context_injector_spec, message_reader_spec
 ):
     if context_injector_spec == "default":
@@ -198,7 +198,7 @@ def test_ext_subprocess(
         assert asset_check_executions[0].status == AssetCheckExecutionRecordStatus.SUCCEEDED
 
 
-def test_ext_subprocess_client_no_return():
+def test_pipes_subprocess_client_no_return():
     def script_fn():
         from dagster_pipes import init_dagster_pipes
 
@@ -223,7 +223,7 @@ def test_ext_subprocess_client_no_return():
         materialize([foo], resources={"client": client})
 
 
-def test_ext_multi_asset():
+def test_pipes_multi_asset():
     def script_fn():
         from dagster_pipes import init_dagster_pipes
 
@@ -256,7 +256,7 @@ def test_ext_multi_asset():
         assert bar_mat.asset_materialization.tags[DATA_VERSION_TAG] == "alpha"
 
 
-def test_ext_dynamic_partitions():
+def test_pipes_dynamic_partitions():
     def script_fn():
         pass
 
@@ -279,7 +279,7 @@ def test_ext_dynamic_partitions():
         assert foo_mat.asset_materialization.partition == "bar"
 
 
-def test_ext_typed_metadata():
+def test_pipes_typed_metadata():
     def script_fn():
         from dagster_pipes import init_dagster_pipes
 
@@ -345,7 +345,7 @@ def test_ext_typed_metadata():
         assert metadata["null_meta"].value is None
 
 
-def test_ext_asset_failed():
+def test_pipes_asset_failed():
     def script_fn():
         raise Exception("foo")
 
@@ -359,7 +359,7 @@ def test_ext_asset_failed():
         materialize([foo], resources={"pipes_subprocess_client": PipesSubprocessClient()})
 
 
-def test_ext_asset_invocation():
+def test_pipes_asset_invocation():
     def script_fn():
         from dagster_pipes import init_dagster_pipes
 
@@ -378,7 +378,7 @@ def test_ext_asset_invocation():
 PATH_WITH_NONEXISTENT_DIR = "/tmp/does-not-exist/foo"
 
 
-def test_ext_no_orchestration():
+def test_pipes_no_orchestration():
     def script_fn():
         from dagster_pipes import (
             PipesContext,
@@ -407,7 +407,7 @@ def test_ext_no_orchestration():
         )
 
 
-def test_ext_no_client(external_script):
+def test_pipes_no_client(external_script):
     @asset(check_specs=[AssetCheckSpec(name="foo_check", asset=AssetKey(["subproc_run"]))])
     def subproc_run(context: AssetExecutionContext):
         extras = {"bar": "baz"}
@@ -445,7 +445,7 @@ def test_ext_no_client(external_script):
         assert asset_check_executions[0].status == AssetCheckExecutionRecordStatus.SUCCEEDED
 
 
-def test_ext_no_client_no_yield():
+def test_pipes_no_client_no_yield():
     def script_fn():
         pass
 

--- a/python_modules/libraries/dagster-docker/dagster_docker_tests/test_pipes.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker_tests/test_pipes.py
@@ -29,9 +29,9 @@ def test_default():
     @asset
     def number_x(
         context: AssetExecutionContext,
-        pipes_docker_client: PipesDockerClient,
+        pipes_client: PipesDockerClient,
     ):
-        return pipes_docker_client.run(
+        return pipes_client.run(
             image=docker_image,
             command=[
                 "python",
@@ -45,7 +45,7 @@ def test_default():
 
     result = materialize(
         [number_x],
-        resources={"pipes_docker_client": PipesDockerClient(**ext_config)},
+        resources={"pipes_client": PipesDockerClient(**ext_config)},
         raise_on_error=False,
     )
     assert result.success
@@ -69,7 +69,7 @@ def test_file_io():
         @asset
         def number_x(
             context: AssetExecutionContext,
-            pipes_docker_client: PipesDockerClient,
+            pipes_client: PipesDockerClient,
         ):
             instance_storage = context.instance.storage_directory()
             host_storage = os.path.join(instance_storage, "number_example")
@@ -88,7 +88,7 @@ def test_file_io():
                 },
             }
 
-            return pipes_docker_client.run(
+            return pipes_client.run(
                 image=docker_image,
                 command=[
                     "python",
@@ -107,7 +107,7 @@ def test_file_io():
         result = materialize(
             [number_x],
             resources={
-                "pipes_docker_client": PipesDockerClient(
+                "pipes_client": PipesDockerClient(
                     context_injector=PipesFileContextInjector(os.path.join(tempdir, "context")),
                 )
             },


### PR DESCRIPTION
## Summary & Motivation

Rename some test funcs and standardize on use of `pipes_client` for the client resource.

## How I Tested These Changes

Existing test suite.