### PR TITLE
[pipes] init_dagster_pipes -> open_dagster_pipes context manager

### DIFF
--- a/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/domain_specific_dsl/user_scripts/fetch_the_tickers.py
+++ b/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/domain_specific_dsl/user_scripts/fetch_the_tickers.py
@@ -1,5 +1,4 @@
-from dagster_pipes import init_dagster_pipes
+from dagster_pipes import open_dagster_pipes
 
-context = init_dagster_pipes()
-
-context.log.info(f"Got tickers: {context.extras['tickers']}")
+with open_dagster_pipes() as context:
+    context.log.info(f"Got tickers: {context.extras['tickers']}")

--- a/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/pure_assets_dsl/sql_script.py
+++ b/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/pure_assets_dsl/sql_script.py
@@ -1,6 +1,6 @@
 import sys
 
-from dagster_pipes import init_dagster_pipes
+from dagster_pipes import open_dagster_pipes
 
 
 class SomeSqlClient:
@@ -11,9 +11,8 @@ class SomeSqlClient:
 if __name__ == "__main__":
     sql = sys.argv[1]
 
-    context = init_dagster_pipes()
-
-    client = SomeSqlClient()
-    client.query(sql)
-    context.report_asset_materialization(metadata={"sql": sql})
-    context.log.info(f"Ran {sql}")
+    with open_dagster_pipes() as context:
+        client = SomeSqlClient()
+        client.query(sql)
+        context.report_asset_materialization(metadata={"sql": sql})
+        context.log.info(f"Ran {sql}")

--- a/python_modules/dagster-pipes/dagster_pipes_tests/test_context.py
+++ b/python_modules/dagster-pipes/dagster_pipes_tests/test_context.py
@@ -1,3 +1,5 @@
+from contextlib import contextmanager
+from typing import Iterator
 from unittest.mock import MagicMock
 
 import pytest
@@ -7,8 +9,10 @@ from dagster_pipes import (
     DagsterPipesError,
     PipesContext,
     PipesContextData,
+    PipesContextLoader,
     PipesDataProvenance,
     PipesMessage,
+    PipesParams,
     PipesPartitionKeyRange,
     PipesTimeWindow,
 )
@@ -27,11 +31,21 @@ TEST_PIPES_CONTEXT_DEFAULTS = PipesContextData(
 )
 
 
+class _DirectContextLoader(PipesContextLoader):
+    def __init__(self, context_data: PipesContextData):
+        self._context_data = context_data
+
+    @contextmanager
+    def load_context(self, params: PipesParams) -> Iterator[PipesContextData]:
+        yield self._context_data
+
+
 def _make_external_execution_context(**kwargs):
     kwargs = {**TEST_PIPES_CONTEXT_DEFAULTS, **kwargs}
     return PipesContext(
-        data=PipesContextData(**kwargs),
-        message_channel=MagicMock(),
+        params_loader=MagicMock(),
+        context_loader=_DirectContextLoader(PipesContextData(**kwargs)),
+        message_writer=MagicMock(),
     )
 
 
@@ -219,3 +233,19 @@ def test_log():
     context._message_channel.write_message.assert_called_with(  # noqa: SLF001
         _make_pipes_message(method="log", params={"level": "DEBUG", "message": "foo"})
     )
+
+
+def test_message_after_close():
+    context = _make_external_execution_context(asset_keys=["foo"])
+    context.close()
+    with pytest.raises(
+        DagsterPipesError, match="Cannot send message after pipes context is closed"
+    ):
+        context.log.info("foo")
+
+
+def test_multiple_close():
+    context = _make_external_execution_context(asset_keys=["foo"])
+    # `close` is idempotent, multiple calls should not raise an error
+    context.close()
+    context.close()

--- a/python_modules/dagster-test/dagster_test/toys/external_execution/numbers_example/number_sum.py
+++ b/python_modules/dagster-test/dagster_test/toys/external_execution/numbers_example/number_sum.py
@@ -1,13 +1,13 @@
-from dagster_pipes import init_dagster_pipes
+from dagster_pipes import open_dagster_pipes
 
 from .util import compute_data_version, load_asset_value, store_asset_value
 
-context = init_dagster_pipes()
-storage_root = context.get_extra("storage_root")
-number_y = load_asset_value("number_y", storage_root)
-number_x = load_asset_value("number_x", storage_root)
-value = number_x + number_y
-store_asset_value("number_sum", storage_root, value)
+with open_dagster_pipes() as context:
+    storage_root = context.get_extra("storage_root")
+    number_y = load_asset_value("number_y", storage_root)
+    number_x = load_asset_value("number_x", storage_root)
+    value = number_x + number_y
+    store_asset_value("number_sum", storage_root, value)
 
-context.log.info(f"{context.asset_key}: {number_x} + {number_y} = {value}")
-context.report_asset_materialization(data_version=compute_data_version(value))
+    context.log.info(f"{context.asset_key}: {number_x} + {number_y} = {value}")
+    context.report_asset_materialization(data_version=compute_data_version(value))

--- a/python_modules/dagster-test/dagster_test/toys/external_execution/numbers_example/number_x.py
+++ b/python_modules/dagster-test/dagster_test/toys/external_execution/numbers_example/number_x.py
@@ -1,13 +1,13 @@
-from dagster_pipes import init_dagster_pipes
+from dagster_pipes import open_dagster_pipes
 
 from .util import compute_data_version, store_asset_value
 
-context = init_dagster_pipes()
-storage_root = context.get_extra("storage_root")
+with open_dagster_pipes() as context:
+    storage_root = context.get_extra("storage_root")
 
-multiplier = context.get_extra("multiplier")
-value = 2 * multiplier
-store_asset_value("number_x", storage_root, value)
+    multiplier = context.get_extra("multiplier")
+    value = 2 * multiplier
+    store_asset_value("number_x", storage_root, value)
 
-context.log.info(f"{context.asset_key}: {2} * {multiplier} = {value}")
-context.report_asset_materialization(data_version=compute_data_version(value))
+    context.log.info(f"{context.asset_key}: {2} * {multiplier} = {value}")
+    context.report_asset_materialization(data_version=compute_data_version(value))

--- a/python_modules/dagster-test/dagster_test/toys/external_execution/numbers_example/number_y.py
+++ b/python_modules/dagster-test/dagster_test/toys/external_execution/numbers_example/number_y.py
@@ -1,17 +1,17 @@
 import os
 
-from dagster_pipes import init_dagster_pipes
+from dagster_pipes import open_dagster_pipes
 
 from .util import compute_data_version, store_asset_value
 
-context = init_dagster_pipes()
-storage_root = context.get_extra("storage_root")
+with open_dagster_pipes() as context:
+    storage_root = context.get_extra("storage_root")
 
-value = int(os.environ["NUMBER_Y"])
-store_asset_value("number_y", storage_root, value)
+    value = int(os.environ["NUMBER_Y"])
+    store_asset_value("number_y", storage_root, value)
 
-context.log.info(f"{context.asset_key}: {value} read from $NUMBER_Y environment variable.")
-context.report_asset_materialization(
-    metadata={"is_even": value % 2 == 0},
-    data_version=compute_data_version(value),
-)
+    context.log.info(f"{context.asset_key}: {value} read from $NUMBER_Y environment variable.")
+    context.report_asset_materialization(
+        metadata={"is_even": value % 2 == 0},
+        data_version=compute_data_version(value),
+    )

--- a/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_subprocess.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_subprocess.py
@@ -76,9 +76,8 @@ def external_script() -> Iterator[str]:
         import time
 
         from dagster_pipes import (
-            PipesContext,
             PipesS3MessageWriter,
-            init_dagster_pipes,
+            open_dagster_pipes,
         )
 
         if os.getenv("MESSAGE_READER_SPEC") == "user/s3":
@@ -91,23 +90,24 @@ def external_script() -> Iterator[str]:
         else:
             message_writer = None  # use default
 
-        init_dagster_pipes(message_writer=message_writer)
-        context = PipesContext.get()
-        context.log.info("hello world")
-        time.sleep(0.1)  # sleep to make sure that we encompass multiple intervals for blob store IO
-        context.report_asset_materialization(
-            metadata={"bar": {"raw_value": context.get_extra("bar"), "type": "md"}},
-            data_version="alpha",
-        )
-        context.report_asset_check(
-            "foo_check",
-            passed=True,
-            severity="WARN",
-            metadata={
-                "meta_1": 1,
-                "meta_2": {"raw_value": "foo", "type": "text"},
-            },
-        )
+        with open_dagster_pipes(message_writer=message_writer) as context:
+            context.log.info("hello world")
+            time.sleep(
+                0.1
+            )  # sleep to make sure that we encompass multiple intervals for blob store IO
+            context.report_asset_materialization(
+                metadata={"bar": {"raw_value": context.get_extra("bar"), "type": "md"}},
+                data_version="alpha",
+            )
+            context.report_asset_check(
+                "foo_check",
+                passed=True,
+                severity="WARN",
+                metadata={
+                    "meta_1": 1,
+                    "meta_2": {"raw_value": "foo", "type": "text"},
+                },
+            )
 
     with temp_script(script_fn) as script_path:
         yield script_path
@@ -200,10 +200,10 @@ def test_pipes_subprocess(
 
 def test_pipes_subprocess_client_no_return():
     def script_fn():
-        from dagster_pipes import init_dagster_pipes
+        from dagster_pipes import open_dagster_pipes
 
-        context = init_dagster_pipes()
-        context.report_asset_materialization()
+        with open_dagster_pipes() as context:
+            context.report_asset_materialization()
 
     @asset
     def foo(context: OpExecutionContext, client: PipesSubprocessClient):
@@ -225,13 +225,13 @@ def test_pipes_subprocess_client_no_return():
 
 def test_pipes_multi_asset():
     def script_fn():
-        from dagster_pipes import init_dagster_pipes
+        from dagster_pipes import open_dagster_pipes
 
-        context = init_dagster_pipes()
-        context.report_asset_materialization(
-            {"foo_meta": "ok"}, data_version="alpha", asset_key="foo"
-        )
-        context.report_asset_materialization(data_version="alpha", asset_key="bar")
+        with open_dagster_pipes() as context:
+            context.report_asset_materialization(
+                {"foo_meta": "ok"}, data_version="alpha", asset_key="foo"
+            )
+            context.report_asset_materialization(data_version="alpha", asset_key="bar")
 
     @multi_asset(specs=[AssetSpec("foo"), AssetSpec("bar")])
     def foo_bar(context: AssetExecutionContext, pipes_subprocess_client: PipesSubprocessClient):
@@ -258,7 +258,10 @@ def test_pipes_multi_asset():
 
 def test_pipes_dynamic_partitions():
     def script_fn():
-        pass
+        from dagster_pipes import open_dagster_pipes
+
+        with open_dagster_pipes() as _:
+            pass
 
     @asset(partitions_def=DynamicPartitionsDefinition(name="blah"))
     def foo(context: AssetExecutionContext, pipes_subprocess_client: PipesSubprocessClient):
@@ -281,26 +284,26 @@ def test_pipes_dynamic_partitions():
 
 def test_pipes_typed_metadata():
     def script_fn():
-        from dagster_pipes import init_dagster_pipes
+        from dagster_pipes import open_dagster_pipes
 
-        context = init_dagster_pipes()
-        context.report_asset_materialization(
-            metadata={
-                "infer_meta": "bar",
-                "text_meta": {"raw_value": "bar", "type": "text"},
-                "url_meta": {"raw_value": "http://bar.com", "type": "url"},
-                "path_meta": {"raw_value": "/bar", "type": "path"},
-                "notebook_meta": {"raw_value": "/bar.ipynb", "type": "notebook"},
-                "json_meta": {"raw_value": ["bar"], "type": "json"},
-                "md_meta": {"raw_value": "bar", "type": "md"},
-                "float_meta": {"raw_value": 1.0, "type": "float"},
-                "int_meta": {"raw_value": 1, "type": "int"},
-                "bool_meta": {"raw_value": True, "type": "bool"},
-                "dagster_run_meta": {"raw_value": "foo", "type": "dagster_run"},
-                "asset_meta": {"raw_value": "bar/baz", "type": "asset"},
-                "null_meta": {"raw_value": None, "type": "null"},
-            }
-        )
+        with open_dagster_pipes() as context:
+            context.report_asset_materialization(
+                metadata={
+                    "infer_meta": "bar",
+                    "text_meta": {"raw_value": "bar", "type": "text"},
+                    "url_meta": {"raw_value": "http://bar.com", "type": "url"},
+                    "path_meta": {"raw_value": "/bar", "type": "path"},
+                    "notebook_meta": {"raw_value": "/bar.ipynb", "type": "notebook"},
+                    "json_meta": {"raw_value": ["bar"], "type": "json"},
+                    "md_meta": {"raw_value": "bar", "type": "md"},
+                    "float_meta": {"raw_value": 1.0, "type": "float"},
+                    "int_meta": {"raw_value": 1, "type": "int"},
+                    "bool_meta": {"raw_value": True, "type": "bool"},
+                    "dagster_run_meta": {"raw_value": "foo", "type": "dagster_run"},
+                    "asset_meta": {"raw_value": "bar/baz", "type": "asset"},
+                    "null_meta": {"raw_value": None, "type": "null"},
+                }
+            )
 
     @asset
     def foo(context: AssetExecutionContext, pipes_subprocess_client: PipesSubprocessClient):
@@ -361,10 +364,10 @@ def test_pipes_asset_failed():
 
 def test_pipes_asset_invocation():
     def script_fn():
-        from dagster_pipes import init_dagster_pipes
+        from dagster_pipes import open_dagster_pipes
 
-        context = init_dagster_pipes()
-        context.log.info("hello world")
+        with open_dagster_pipes() as context:
+            context.log.info("hello world")
 
     @asset
     def foo(context: AssetExecutionContext, pipes_subprocess_client: PipesSubprocessClient):
@@ -382,19 +385,19 @@ def test_pipes_no_orchestration():
     def script_fn():
         from dagster_pipes import (
             PipesContext,
-            init_dagster_pipes,
             is_dagster_pipes_process,
+            open_dagster_pipes,
         )
 
         assert not is_dagster_pipes_process()
 
-        init_dagster_pipes()
-        context = PipesContext.get()
-        context.log.info("hello world")
-        context.report_asset_materialization(
-            metadata={"bar": context.get_extra("bar")},
-            data_version="alpha",
-        )
+        with open_dagster_pipes() as _:
+            context = PipesContext.get()
+            context.log.info("hello world")
+            context.report_asset_materialization(
+                metadata={"bar": context.get_extra("bar")},
+                data_version="alpha",
+            )
 
     with temp_script(script_fn) as script_path:
         cmd = ["python", script_path]
@@ -447,7 +450,10 @@ def test_pipes_no_client(external_script):
 
 def test_pipes_no_client_no_yield():
     def script_fn():
-        pass
+        from dagster_pipes import open_dagster_pipes
+
+        with open_dagster_pipes() as _:
+            pass
 
     @asset
     def foo(context: OpExecutionContext):
@@ -469,3 +475,23 @@ def test_pipes_no_client_no_yield():
         ),
     ):
         materialize([foo])
+
+
+def test_pipes_manual_close():
+    def script_fn():
+        from dagster_pipes import open_dagster_pipes
+
+        context = open_dagster_pipes()
+        context.report_asset_materialization(data_version="alpha")
+        context.close()
+
+    @asset
+    def foo(context: OpExecutionContext, pipes_client: PipesSubprocessClient):
+        with temp_script(script_fn) as script_path:
+            cmd = [_PYTHON_EXECUTABLE, script_path]
+            return pipes_client.run(command=cmd, context=context).get_results()
+
+    with instance_for_test() as instance:
+        materialize([foo], instance=instance, resources={"pipes_client": PipesSubprocessClient()})
+        mat = instance.get_latest_materialization_event(foo.key)
+        assert mat and mat.asset_materialization

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
@@ -208,7 +208,10 @@ class PipesDbfsMessageReader(PipesBlobStoreMessageReader):
         message_path = os.path.join(params["path"], f"{index}.json")
         try:
             raw_message = self.dbfs_client.read(message_path)
-            return raw_message.data
+
+            # Files written to dbfs using the Python IO interface used in PipesDbfsMessageWriter are
+            # base64-encoded.
+            return base64.b64decode(raw_message.data).decode("utf-8")
         # An error here is an expected result, since an IOError will be thrown if the next message
         # chunk doesn't yet exist. Swallowing the error here is equivalent to doing a no-op on a
         # status check showing a non-existent file.


### PR DESCRIPTION
## Summary & Motivation

* `init_dagster_pipes` -> `open_dagster_pipes`. Still just a function that returns a `PipesContext`.
    * The `PipesMessageChannel` now writes an `opened` message when it is created during `open_dagster_pipes`. On the orchestration end, this currently does nothing except for log a message.
    * `init_dagster_pipes` still defined, deprecated for removal in 1.5.3 (along with `atexit` automatic `close` registration)
* `PipesContext` gets `__enter__` and `__exit__` methods so that it can function as a context manager.
* The `__enter__` method does nothing except `return self`
* The `__exit__` method calls `self.close()`.
* `PipesContext.close()` sends a `closed` message and causes any further attempts to write a message to throw an error.
* The orchestration end throws an error on session exit if no `closed` has been received.
* Add additional "unknown message" conditional case in `PipesMessageHandler.handle_message`

## How I Tested These Changes

New unit tests.