### PR TITLE
Fix negative asset backfill counts caused by reexecution

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -990,6 +990,13 @@ class PartitionsSubset(ABC, Generic[T_str]):
             set(self.get_partition_keys()).difference(set(other.get_partition_keys()))
         )
 
+    def __and__(self, other: "PartitionsSubset") -> "PartitionsSubset[T_str]":
+        if self is other:
+            return self
+        return self.partitions_def.empty_subset().with_partition_keys(
+            set(self.get_partition_keys()) & set(other.get_partition_keys())
+        )
+
     @abstractmethod
     def serialize(self) -> str: ...
 

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -249,16 +249,21 @@ class AssetBackfillData(NamedTuple):
                 failed_subset = self.failed_and_downstream_subset.get_partitions_subset(asset_key)
                 requested_subset = self.requested_subset.get_partitions_subset(asset_key)
 
+                # The failed subset includes partitions that failed and their downstream partitions.
+                # The downstream partitions are not included in the requested subset, so we determine
+                # the in progress subset by subtracting partitions that are failed and requested.
+                requested_and_failed_subset = failed_subset & requested_subset
+                in_progress_subset = requested_subset - (
+                    requested_and_failed_subset | materialized_subset
+                )
+
                 return PartitionedAssetBackfillStatus(
                     asset_key,
                     len(self.target_subset.get_partitions_subset(asset_key)),
                     {
                         AssetBackfillStatus.MATERIALIZED: len(materialized_subset),
                         AssetBackfillStatus.FAILED: len(failed_subset - materialized_subset),
-                        AssetBackfillStatus.IN_PROGRESS: len(requested_subset) - (
-                            len((failed_subset & requested_subset) - materialized_subset)
-                            + len(materialized_subset)
-                        ),
+                        AssetBackfillStatus.IN_PROGRESS: len(in_progress_subset),
                     },
                 )
             else:

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
@@ -30,6 +30,7 @@ from dagster import (
     StaticPartitionsDefinition,
     WeeklyPartitionsDefinition,
     asset,
+    materialize,
 )
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
@@ -851,6 +852,64 @@ def test_asset_backfill_status_counts():
     assert counts[2].partitions_counts_by_status[AssetBackfillStatus.FAILED] == 1
     assert counts[2].partitions_counts_by_status[AssetBackfillStatus.IN_PROGRESS] == 0
     assert counts[2].num_targeted_partitions == 1
+
+
+def test_asset_backfill_status_counts_with_reexecution():
+    @asset(partitions_def=DailyPartitionsDefinition("2023-01-01"), key="upstream")
+    def upstream_fail():
+        raise Exception("noo")
+
+    @asset(partitions_def=DailyPartitionsDefinition("2023-01-01"), key="upstream")
+    def upstream_success():
+        pass
+
+    assets_by_repo_name = {
+        "repo": [
+            upstream_fail,
+        ]
+    }
+    asset_graph = get_asset_graph(assets_by_repo_name)
+    instance = DagsterInstance.ephemeral()
+
+    backfill_data = AssetBackfillData.from_asset_partitions(
+        partition_names=["2023-01-01"],
+        asset_graph=asset_graph,
+        asset_selection=[
+            upstream_fail.key,
+        ],
+        dynamic_partitions_store=MagicMock(),
+        all_partitions=False,
+        backfill_start_time=pendulum.now("UTC"),
+    )
+
+    backfill_data = _single_backfill_iteration(
+        "fake_id", backfill_data, asset_graph, instance, assets_by_repo_name
+    )
+    backfill_data = _single_backfill_iteration(
+        "fake_id", backfill_data, asset_graph, instance, assets_by_repo_name
+    )
+
+    counts = backfill_data.get_backfill_status_per_asset_key()
+    assert counts[0].asset_key == upstream_fail.key
+    assert counts[0].partitions_counts_by_status[AssetBackfillStatus.MATERIALIZED] == 0
+    assert counts[0].partitions_counts_by_status[AssetBackfillStatus.FAILED] == 1
+    assert counts[0].partitions_counts_by_status[AssetBackfillStatus.IN_PROGRESS] == 0
+
+    materialize(
+        [upstream_success],
+        instance=instance,
+        partition_key="2023-01-01",
+        tags={BACKFILL_ID_TAG: "fake_id"},
+    )
+
+    backfill_data = _single_backfill_iteration(
+        "fake_id", backfill_data, asset_graph, instance, assets_by_repo_name
+    )
+    counts = backfill_data.get_backfill_status_per_asset_key()
+    assert counts[0].asset_key == upstream_fail.key
+    assert counts[0].partitions_counts_by_status[AssetBackfillStatus.MATERIALIZED] == 1
+    assert counts[0].partitions_counts_by_status[AssetBackfillStatus.FAILED] == 0
+    assert counts[0].partitions_counts_by_status[AssetBackfillStatus.IN_PROGRESS] == 0
 
 
 def test_asset_backfill_selects_only_existent_partitions():


### PR DESCRIPTION
Users reported seeing negative asset backfill counts, which was caused by:
- Kicking off backfill runs that failed
- Before the backfill completed, they successfully manually reexecuted the failed runs. This caused the re-executed partitions to be considered as both materialized and failed.

This PR amends the counts to remove partitions from the "failed" counts if they are also materialized. 

There can be an edge case where a partition originally succeeds, but fails when manually re-executed. In this case, it will display as successful, but I think this is expected behavior.