### PR TITLE
[pipes] open/close control messages

### DIFF
--- a/python_modules/dagster-pipes/dagster_pipes/__init__.py
+++ b/python_modules/dagster-pipes/dagster_pipes/__init__.py
@@ -88,6 +88,10 @@ class PipesMessage(TypedDict):
     params: Optional[Mapping[str, Any]]
 
 
+PIPES_OPENED_MESSAGE: PipesMessage = _make_message("opened", None)
+PIPES_CLOSED_MESSAGE: PipesMessage = _make_message("closed", None)
+
+
 ###### PIPES CONTEXT
 
 
@@ -893,6 +897,7 @@ class PipesContext:
         self._io_stack = ExitStack()
         self._data = self._io_stack.enter_context(context_loader.load_context(context_params))
         self._message_channel = self._io_stack.enter_context(message_writer.open(messages_params))
+        self._message_channel.write_message(PIPES_OPENED_MESSAGE)
         self._logger = _PipesLogger(self)
         self._materialized_assets: Set[str] = set()
         self._closed: bool = False
@@ -909,6 +914,7 @@ class PipesContext:
         idempotent-- subsequent calls after the first have no effect.
         """
         if not self._closed:
+            self._message_channel.write_message(PIPES_CLOSED_MESSAGE)
             self._io_stack.close()
             self._closed = True
 

--- a/python_modules/dagster/dagster/_core/pipes/client.py
+++ b/python_modules/dagster/dagster/_core/pipes/client.py
@@ -73,6 +73,10 @@ class PipesContextInjector(ABC):
             process to locate and load the injected context data.
         """
 
+    @abstractmethod
+    def no_messages_debug_text(self) -> str:
+        """A message to be displayed when no messages are received from the external process to aid with debugging."""
+
 
 @experimental
 class PipesMessageReader(ABC):
@@ -93,3 +97,7 @@ class PipesMessageReader(ABC):
             PipesParams: A dict of parameters that can be used by the external process to determine
             where to write messages.
         """
+
+    @abstractmethod
+    def no_messages_debug_text(self) -> str:
+        """A message to be displayed when no messages are received from the external process to aid with debugging."""

--- a/python_modules/dagster/dagster/_core/pipes/context.py
+++ b/python_modules/dagster/dagster/_core/pipes/context.py
@@ -32,6 +32,7 @@ from dagster._core.definitions.time_window_partitions import (
     TimeWindow,
     has_one_dimension_time_window_partitioning,
 )
+from dagster._core.errors import DagsterPipesExecutionError
 from dagster._core.execution.context.compute import OpExecutionContext
 from dagster._core.execution.context.invocation import BoundOpExecutionContext
 from dagster._core.pipes.client import PipesMessageReader
@@ -53,6 +54,7 @@ class PipesMessageHandler:
         self._result_queue: Queue[PipesExecutionResult] = Queue()
         # Only read by the main thread after all messages are handled, so no need for a lock
         self._unmaterialized_assets: Set[AssetKey] = set(context.selected_asset_keys)
+        self._closed = False
 
     @contextmanager
     def handle_messages(self, message_reader: PipesMessageReader) -> Iterator[PipesParams]:
@@ -64,6 +66,10 @@ class PipesMessageHandler:
     def clear_result_queue(self) -> Iterator[PipesExecutionResult]:
         while not self._result_queue.empty():
             yield self._result_queue.get()
+
+    @property
+    def is_closed(self) -> bool:
+        return self._closed
 
     def _resolve_metadata(
         self, metadata: Mapping[str, PipesMetadataValue]
@@ -108,12 +114,29 @@ class PipesMessageHandler:
 
     # Type ignores because we currently validate in individual handlers
     def handle_message(self, message: PipesMessage) -> None:
-        if message["method"] == "report_asset_materialization":
+        if self._closed:
+            raise DagsterPipesExecutionError(
+                f"Received message after pipes session closed: `{message}`"
+            )
+        if message["method"] == "opened":
+            self._handle_opened()
+        elif message["method"] == "closed":
+            self._handle_closed()
+        elif message["method"] == "report_asset_materialization":
             self._handle_report_asset_materialization(**message["params"])  # type: ignore
         elif message["method"] == "report_asset_check":
             self._handle_report_asset_check(**message["params"])  # type: ignore
         elif message["method"] == "log":
             self._handle_log(**message["params"])  # type: ignore
+        else:
+            raise DagsterPipesExecutionError(f"Unknown message method: {message['method']}")
+
+    def _handle_opened(self) -> None:
+        self._context.log.info("Opened pipes connection.")
+
+    def _handle_closed(self) -> None:
+        self._closed = True
+        self._context.log.info("Closed pipes connection.")
 
     def _handle_report_asset_materialization(
         self,

--- a/python_modules/dagster/dagster/_core/pipes/utils.py
+++ b/python_modules/dagster/dagster/_core/pipes/utils.py
@@ -23,6 +23,7 @@ from dagster import (
     _check as check,
 )
 from dagster._annotations import experimental
+from dagster._core.errors import DagsterPipesExecutionError
 from dagster._core.pipes.client import (
     PipesContextInjector,
     PipesMessageReader,
@@ -370,4 +371,11 @@ def open_pipes_session(
             message_handler=message_handler,
             context_injector_params=ci_params,
             message_reader_params=mr_params,
+        )
+    if not message_handler.is_closed:
+        raise DagsterPipesExecutionError(
+            "Pipes session was not closed. This means messages buffered in the external process may"
+            " have been discarded without being delivered. To close a pipes session, either use"
+            " `open_dagster_pipes` as a context manager or explicitly call `PipesContext.close()`"
+            " in the external process."
         )

--- a/python_modules/dagster/dagster/_core/pipes/utils.py
+++ b/python_modules/dagster/dagster/_core/pipes/utils.py
@@ -23,7 +23,6 @@ from dagster import (
     _check as check,
 )
 from dagster._annotations import experimental
-from dagster._core.errors import DagsterPipesExecutionError
 from dagster._core.pipes.client import (
     PipesContextInjector,
     PipesMessageReader,
@@ -72,6 +71,9 @@ class PipesFileContextInjector(PipesContextInjector):
             if os.path.exists(self._path):
                 os.remove(self._path)
 
+    def no_messages_debug_text(self) -> str:
+        return "Attempted to inject context via file {self._path}"
+
 
 @experimental
 class PipesTempFileContextInjector(PipesContextInjector):
@@ -97,6 +99,9 @@ class PipesTempFileContextInjector(PipesContextInjector):
             ).inject_context(context) as params:
                 yield params
 
+    def no_messages_debug_text(self) -> str:
+        return "Attempted to inject context via a temporary file."
+
 
 class PipesEnvContextInjector(PipesContextInjector):
     """Context injector that injects context data into the external process by injecting it directly into the external process environment."""
@@ -117,6 +122,9 @@ class PipesEnvContextInjector(PipesContextInjector):
             load the injected context data.
         """
         yield {PipesDefaultContextLoader.DIRECT_KEY: context_data}
+
+    def no_messages_debug_text(self) -> str:
+        return "Attempted to inject context directly, typically as an environment variable."
 
 
 @experimental
@@ -167,6 +175,9 @@ class PipesFileMessageReader(PipesMessageReader):
             message = json.loads(line)
             handler.handle_message(message)
 
+    def no_messages_debug_text(self) -> str:
+        return f"Attempted to read messages from file {self._path}."
+
 
 @experimental
 class PipesTempFileMessageReader(PipesMessageReader):
@@ -192,6 +203,9 @@ class PipesTempFileMessageReader(PipesMessageReader):
                 os.path.join(tempdir, _MESSAGE_READER_FILENAME)
             ).read_messages(handler) as params:
                 yield params
+
+    def no_messages_debug_text(self) -> str:
+        return "Attempted to read messages from a local temporary file."
 
 
 class PipesBlobStoreMessageReader(PipesMessageReader):
@@ -363,19 +377,29 @@ def open_pipes_session(
     context.set_requires_typed_event_stream(error_message=_FAIL_TO_YIELD_ERROR_MESSAGE)
     context_data = build_external_execution_context_data(context, extras)
     message_handler = PipesMessageHandler(context)
-    with context_injector.inject_context(
-        context_data
-    ) as ci_params, message_handler.handle_messages(message_reader) as mr_params:
-        yield PipesSession(
-            context_data=context_data,
-            message_handler=message_handler,
-            context_injector_params=ci_params,
-            message_reader_params=mr_params,
-        )
-    if not message_handler.is_closed:
-        raise DagsterPipesExecutionError(
-            "Pipes session was not closed. This means messages buffered in the external process may"
-            " have been discarded without being delivered. To close a pipes session, either use"
-            " `open_dagster_pipes` as a context manager or explicitly call `PipesContext.close()`"
-            " in the external process."
-        )
+    try:
+        with context_injector.inject_context(
+            context_data
+        ) as ci_params, message_handler.handle_messages(message_reader) as mr_params:
+            yield PipesSession(
+                context_data=context_data,
+                message_handler=message_handler,
+                context_injector_params=ci_params,
+                message_reader_params=mr_params,
+            )
+    finally:
+        if not message_handler.received_any_message:
+            context.log.warn(
+                " [pipes] did not receive any messages from external process. Check stdout /"
+                " stderr logs from the external process if"
+                f" possible.\n{context_injector.__class__.__name__}:"
+                f" {context_injector.no_messages_debug_text()}\n{message_reader.__class__.__name__}:"
+                f" {message_reader.no_messages_debug_text()}\n"
+            )
+        elif not message_handler.received_closed_message:
+            context.log.warn(
+                " [pipes] did not receive closed message from external process. Buffered messages"
+                " may have been discarded without being delivered. Use `open_dagster_pipes` as a"
+                " context manager or explicitly call `PipesContext.close()` in the external"
+                " process to ensure delivery in most cases."
+            )

--- a/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_subprocess.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_subprocess.py
@@ -495,3 +495,23 @@ def test_pipes_manual_close():
         materialize([foo], instance=instance, resources={"pipes_client": PipesSubprocessClient()})
         mat = instance.get_latest_materialization_event(foo.key)
         assert mat and mat.asset_materialization
+
+
+def test_pipes_no_close():
+    def script_fn():
+        from dagster_pipes import open_dagster_pipes
+
+        context = open_dagster_pipes()
+        context.report_asset_materialization(data_version="alpha")
+
+    @asset
+    def foo(context: OpExecutionContext, pipes_client: PipesSubprocessClient):
+        with temp_script(script_fn) as script_path:
+            cmd = [_PYTHON_EXECUTABLE, script_path]
+            return pipes_client.run(command=cmd, context=context).get_results()
+
+    with instance_for_test() as instance:
+        with pytest.raises(DagsterPipesExecutionError, match="Pipes session was not closed"):
+            materialize(
+                [foo], instance=instance, resources={"pipes_client": PipesSubprocessClient()}
+            )

--- a/python_modules/libraries/dagster-aws/dagster_aws/pipes.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/pipes.py
@@ -30,3 +30,10 @@ class PipesS3MessageReader(PipesBlobStoreMessageReader):
             return obj["Body"].read().decode("utf-8")
         except ClientError:
             return None
+
+    def no_messages_debug_text(self) -> str:
+        return (
+            f"Attempted to read messages from S3 bucket {self.bucket}. Expected"
+            " PipesS3MessageWriter to be explicitly passed to open_dagster_pipes in the external"
+            " process."
+        )

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
@@ -184,6 +184,13 @@ class PipesDbfsContextInjector(PipesContextInjector):
             self.dbfs_client.put(path, contents=contents, overwrite=True)
             yield {"path": path}
 
+    def no_messages_debug_text(self) -> str:
+        return (
+            "Attempted to inject context via a temporary file in dbfs. Expected"
+            " PipesDbfsContextLoader to be explicitly passed to open_dagster_pipes in the external"
+            " process."
+        )
+
 
 @experimental
 class PipesDbfsMessageReader(PipesBlobStoreMessageReader):
@@ -217,3 +224,10 @@ class PipesDbfsMessageReader(PipesBlobStoreMessageReader):
         # status check showing a non-existent file.
         except IOError:
             return None
+
+    def no_messages_debug_text(self) -> str:
+        return (
+            "Attempted to read messages from a temporary file in dbfs. Expected"
+            " PipesDbfsMessageWriter to be explicitly passed to open_dagster_pipes in the external"
+            " process."
+        )

--- a/python_modules/libraries/dagster-docker/dagster_docker/pipes.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/pipes.py
@@ -50,6 +50,9 @@ class PipesDockerLogsMessageReader(PipesMessageReader):
         for log_line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
             extract_message_or_forward_to_stdout(handler, log_line)
 
+    def no_messages_debug_text(self) -> str:
+        return "Attempted to read messages by extracting them from docker logs directly."
+
 
 @experimental
 class _PipesDockerClient(PipesClient):

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
@@ -80,6 +80,9 @@ class PipesK8sPodLogsMessageReader(PipesMessageReader):
             for log_line in log_chunk.split("\n"):
                 extract_message_or_forward_to_stdout(handler, log_line)
 
+    def no_messages_debug_text(self) -> str:
+        return "Attempted to read messages by extracting them from kubernetes pod logs directly."
+
 
 @experimental
 class _PipesK8sClient(PipesClient):


### PR DESCRIPTION
Adds `opened` and `closed` control messages to the pipes protocol and leverages those to communicate to users
* when the pipes successfully opened 
* when the pipes did not get close correctly
* when no messages were received and some extra debug information to try to help 

To provide extra debug information, `no_messages_debug_text` was added to the orchestration side components to attempt to help. Notably components that expect specific non-default matching components to be used in the external side call that out. 

## How I Tested These Changes

