### PR TITLE
[Asset-graph] Fix cache check logic

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphData.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphData.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 
 import {filterByQuery, GraphQueryItem} from '../app/GraphQueryImpl';
 import {AssetKey} from '../assets/types';
-import {asyncIsAssetLayoutCached} from '../graph/asyncGraphLayout';
+import {asyncGetFullAssetLayoutIndexDB} from '../graph/asyncGraphLayout';
 import {AssetGroupSelector, PipelineSelector} from '../graphql/types';
 
 import {ASSET_NODE_FRAGMENT} from './AssetNode';
@@ -123,7 +123,7 @@ export function useAssetGraphData(opsQuery: string, options: AssetGraphFetchScop
           removeEdgesToHiddenAssets(fullAssetGraphData, repoFilteredNodes);
         }
         if (fullAssetGraphData) {
-          const isCached = await asyncIsAssetLayoutCached(fullAssetGraphData);
+          const isCached = await asyncGetFullAssetLayoutIndexDB.isCached(fullAssetGraphData);
           if (isCached) {
             setAssetGraphDataMaybeCached(fullAssetGraphData);
             setIsCached(true);

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
@@ -82,8 +82,7 @@ const asyncGetFullAssetLayoutIndexDB = indexedDBAsyncMemoize(
 );
 
 export function asyncIsAssetLayoutCached(graphData: GraphData) {
-  const key = _assetLayoutCacheKey(graphData);
-  return asyncGetFullAssetLayoutIndexDB.isCached(key);
+  return asyncGetFullAssetLayoutIndexDB.isCached(graphData);
 }
 
 const asyncGetFullAssetLayout = asyncMemoize(

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
@@ -67,7 +67,7 @@ const _assetLayoutCacheKey = (graphData: GraphData) => {
 
 const getFullAssetLayout = memoize(layoutAssetGraph, _assetLayoutCacheKey);
 
-const asyncGetFullAssetLayoutIndexDB = indexedDBAsyncMemoize(
+export const asyncGetFullAssetLayoutIndexDB = indexedDBAsyncMemoize(
   (graphData: GraphData, opts: LayoutAssetGraphOptions) => {
     return new Promise<AssetGraphLayout>((resolve) => {
       const worker = new Worker(new URL('../workers/dagre_layout.worker', import.meta.url));
@@ -80,10 +80,6 @@ const asyncGetFullAssetLayoutIndexDB = indexedDBAsyncMemoize(
   },
   _assetLayoutCacheKey,
 );
-
-export function asyncIsAssetLayoutCached(graphData: GraphData) {
-  return asyncGetFullAssetLayoutIndexDB.isCached(graphData);
-}
 
 const asyncGetFullAssetLayout = asyncMemoize(
   (graphData: GraphData, opts: LayoutAssetGraphOptions) => {


### PR DESCRIPTION
## Summary & Motivation

We started hashing the graph data to to cutdown the size of our keys in indexdb and forgot to update the logic that checks if something is in the cache to use that same logic. This updates that logic.

## How I Tested These Changes

Load the asset graph locally