### PR TITLE
[pipes] opened/closed messages

### DIFF
--- a/integration_tests/test_suites/k8s-test-suite/tests/test_pipes.py
+++ b/integration_tests/test_suites/k8s-test-suite/tests/test_pipes.py
@@ -65,6 +65,9 @@ class PipesConfigMapContextInjector(PipesContextInjector):
         self._namespace = namespace
         self._cm_name = "dagster-pipes-cm"
 
+    def no_messages_debug_text(self) -> str:
+        return "Attempted to inject context via volume mounted config map."
+
     @contextmanager
     def inject_context(
         self,

--- a/python_modules/dagster-pipes/dagster_pipes/__init__.py
+++ b/python_modules/dagster-pipes/dagster_pipes/__init__.py
@@ -893,6 +893,7 @@ class PipesContext:
         self._io_stack = ExitStack()
         self._data = self._io_stack.enter_context(context_loader.load_context(context_params))
         self._message_channel = self._io_stack.enter_context(message_writer.open(messages_params))
+        self._message_channel.write_message(_make_message("opened", {}))
         self._logger = _PipesLogger(self)
         self._materialized_assets: Set[str] = set()
         self._closed: bool = False
@@ -909,6 +910,7 @@ class PipesContext:
         idempotent-- subsequent calls after the first have no effect.
         """
         if not self._closed:
+            self._message_channel.write_message(_make_message("closed", {}))
             self._io_stack.close()
             self._closed = True
 

--- a/python_modules/dagster/dagster/_core/pipes/client.py
+++ b/python_modules/dagster/dagster/_core/pipes/client.py
@@ -73,6 +73,14 @@ class PipesContextInjector(ABC):
             process to locate and load the injected context data.
         """
 
+    @abstractmethod
+    def no_messages_debug_text(self) -> str:
+        """A message to be displayed when no messages are received from the external process to aid with debugging.
+
+        Example: "Attempted to inject context using a magic portal. Expected PipesMagicPortalContextLoader to be
+        explicitly passed to open_dagster_pipes in the external process."
+        """
+
 
 @experimental
 class PipesMessageReader(ABC):
@@ -92,4 +100,13 @@ class PipesMessageReader(ABC):
         Yields:
             PipesParams: A dict of parameters that can be used by the external process to determine
             where to write messages.
+        """
+
+    @abstractmethod
+    def no_messages_debug_text(self) -> str:
+        """A message to be displayed when no messages are received from the external process to aid with
+        debugging.
+
+        Example: "Attempted to read messages using a magic portal. Expected PipesMagicPortalMessageWriter
+        to be explicitly passed to open_dagster_pipes in the external process."
         """

--- a/python_modules/libraries/dagster-aws/dagster_aws/pipes.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/pipes.py
@@ -30,3 +30,10 @@ class PipesS3MessageReader(PipesBlobStoreMessageReader):
             return obj["Body"].read().decode("utf-8")
         except ClientError:
             return None
+
+    def no_messages_debug_text(self) -> str:
+        return (
+            f"Attempted to read messages from S3 bucket {self.bucket}. Expected"
+            " PipesS3MessageWriter to be explicitly passed to open_dagster_pipes in the external"
+            " process."
+        )

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
@@ -184,6 +184,13 @@ class PipesDbfsContextInjector(PipesContextInjector):
             self.dbfs_client.put(path, contents=contents, overwrite=True)
             yield {"path": path}
 
+    def no_messages_debug_text(self) -> str:
+        return (
+            "Attempted to inject context via a temporary file in dbfs. Expected"
+            " PipesDbfsContextLoader to be explicitly passed to open_dagster_pipes in the external"
+            " process."
+        )
+
 
 @experimental
 class PipesDbfsMessageReader(PipesBlobStoreMessageReader):
@@ -217,3 +224,10 @@ class PipesDbfsMessageReader(PipesBlobStoreMessageReader):
         # status check showing a non-existent file.
         except IOError:
             return None
+
+    def no_messages_debug_text(self) -> str:
+        return (
+            "Attempted to read messages from a temporary file in dbfs. Expected"
+            " PipesDbfsMessageWriter to be explicitly passed to open_dagster_pipes in the external"
+            " process."
+        )

--- a/python_modules/libraries/dagster-docker/dagster_docker/pipes.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/pipes.py
@@ -50,6 +50,9 @@ class PipesDockerLogsMessageReader(PipesMessageReader):
         for log_line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
             extract_message_or_forward_to_stdout(handler, log_line)
 
+    def no_messages_debug_text(self) -> str:
+        return "Attempted to read messages by extracting them from docker logs directly."
+
 
 @experimental
 class _PipesDockerClient(PipesClient):

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
@@ -80,6 +80,9 @@ class PipesK8sPodLogsMessageReader(PipesMessageReader):
             for log_line in log_chunk.split("\n"):
                 extract_message_or_forward_to_stdout(handler, log_line)
 
+    def no_messages_debug_text(self) -> str:
+        return "Attempted to read messages by extracting them from kubernetes pod logs directly."
+
 
 @experimental
 class _PipesK8sClient(PipesClient):


### PR DESCRIPTION
Adds `opened` and `closed` control messages to the pipes protocol and leverages those to communicate to users
* when the pipes successfully opened 
* when the pipes did not get close correctly
* when no messages were received and some extra debug information to try to help 

To provide extra debug information, `no_messages_debug_text` was added to the orchestration side components to attempt to help. Notably components that expect specific non-default matching components to be used in the external side call that out. 


## How I Tested These Changes

updated tests