### PR TITLE
[ui] Use location-based feature flag on partitions dialog

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -56,6 +56,7 @@ import {DimensionRangeWizard} from '../partitions/DimensionRangeWizard';
 import {assembleIntoSpans, stringForSpan} from '../partitions/SpanRepresentation';
 import {DagsterTag} from '../runs/RunTag';
 import {testId} from '../testing/testId';
+import {useFeatureFlagForCodeLocation} from '../workspace/WorkspaceContext';
 import {RepoAddress} from '../workspace/types';
 
 import {partitionCountString} from './AssetNodePartitionCounts';
@@ -148,6 +149,11 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
 
   const [previewCount, setPreviewCount] = React.useState(0);
   const morePreviewsCount = partitionedAssets.length - previewCount;
+
+  const showSingleRunBackfillToggle = useFeatureFlagForCodeLocation(
+    repoAddress.location,
+    'SHOW_SINGLE_RUN_BACKFILL_TOGGLE',
+  );
 
   const [lastRefresh, setLastRefresh] = React.useState(Date.now());
 
@@ -586,40 +592,42 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
                 disabled={launchWithRangesAsTags}
                 onChange={() => setMissingFailedOnly(!missingFailedOnly)}
               />
-              <RadioContainer>
-                <Subheading>Launch as...</Subheading>
-                <Radio
-                  data-testid={testId('ranges-as-tags-true-radio')}
-                  checked={canLaunchWithRangesAsTags && launchWithRangesAsTags}
-                  disabled={!canLaunchWithRangesAsTags}
-                  onChange={() => setLaunchWithRangesAsTags(!launchWithRangesAsTags)}
-                >
-                  <Box flex={{direction: 'row', alignItems: 'center', gap: 8}}>
-                    <span>Single run</span>
-                    <Tooltip
-                      targetTagName="div"
-                      position="top-left"
-                      content={
-                        <div style={{maxWidth: 300}}>
-                          This option requires that your assets are written to operate on a
-                          partition key range via context.asset_partition_key_range_for_output or
-                          context.asset_partitions_time_window_for_output.
-                        </div>
-                      }
-                    >
-                      <Icon name="info" color={Colors.Gray500} />
-                    </Tooltip>
-                  </Box>
-                </Radio>
-                <Radio
-                  data-testid={testId('ranges-as-tags-false-radio')}
-                  checked={!canLaunchWithRangesAsTags || !launchWithRangesAsTags}
-                  disabled={!canLaunchWithRangesAsTags}
-                  onChange={() => setLaunchWithRangesAsTags(!launchWithRangesAsTags)}
-                >
-                  Multiple runs (One per selected partition)
-                </Radio>
-              </RadioContainer>
+              {showSingleRunBackfillToggle ? (
+                <RadioContainer>
+                  <Subheading>Launch as...</Subheading>
+                  <Radio
+                    data-testid={testId('ranges-as-tags-true-radio')}
+                    checked={canLaunchWithRangesAsTags && launchWithRangesAsTags}
+                    disabled={!canLaunchWithRangesAsTags}
+                    onChange={() => setLaunchWithRangesAsTags(!launchWithRangesAsTags)}
+                  >
+                    <Box flex={{direction: 'row', alignItems: 'center', gap: 8}}>
+                      <span>Single run</span>
+                      <Tooltip
+                        targetTagName="div"
+                        position="top-left"
+                        content={
+                          <div style={{maxWidth: 300}}>
+                            This option requires that your assets are written to operate on a
+                            partition key range via context.asset_partition_key_range_for_output or
+                            context.asset_partitions_time_window_for_output.
+                          </div>
+                        }
+                      >
+                        <Icon name="info" color={Colors.Gray500} />
+                      </Tooltip>
+                    </Box>
+                  </Radio>
+                  <Radio
+                    data-testid={testId('ranges-as-tags-false-radio')}
+                    checked={!canLaunchWithRangesAsTags || !launchWithRangesAsTags}
+                    disabled={!canLaunchWithRangesAsTags}
+                    onChange={() => setLaunchWithRangesAsTags(!launchWithRangesAsTags)}
+                  >
+                    Multiple runs (One per selected partition)
+                  </Radio>
+                </RadioContainer>
+              ) : null}
             </Box>
           )}
         </ToggleableSection>

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext.tsx
@@ -77,6 +77,10 @@ export const ROOT_WORKSPACE_QUERY = gql`
       ...WorkspaceDisplayMetadata
     }
     updatedTimestamp
+    featureFlags {
+      name
+      enabled
+    }
     locationOrLoadError {
       ... on RepositoryLocation {
         id
@@ -367,6 +371,27 @@ export const useActivePipelineForName = (pipelineName: string, snapshotId?: stri
     return match.repository.pipelines.find((pipeline) => pipeline.name === pipelineName) || null;
   }
   return null;
+};
+
+export const getFeatureFlagForCodeLocation = (
+  locationEntries: WorkspaceLocationNodeFragment[],
+  locationName: string,
+  flagName: string,
+) => {
+  const matchingLocation = locationEntries.find(({id}) => id === locationName);
+  if (matchingLocation) {
+    const {featureFlags} = matchingLocation;
+    const matchingFlag = featureFlags.find(({name}) => name === flagName);
+    if (matchingFlag) {
+      return matchingFlag.enabled;
+    }
+  }
+  return false;
+};
+
+export const useFeatureFlagForCodeLocation = (locationName: string, flagName: string) => {
+  const {locationEntries} = useWorkspaceState();
+  return getFeatureFlagForCodeLocation(locationEntries, locationName, flagName);
 };
 
 export const isThisThingAJob = (repo: DagsterRepoOption | null, pipelineOrJobName: string) => {

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/__tests__/getFeatureFlagForCodeLocation.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/__tests__/getFeatureFlagForCodeLocation.test.tsx
@@ -1,0 +1,43 @@
+import {buildFeatureFlag, buildWorkspaceLocationEntry} from '../../graphql/types';
+import {getFeatureFlagForCodeLocation} from '../WorkspaceContext';
+import {WorkspaceLocationNodeFragment} from '../types/WorkspaceContext.types';
+
+describe('getFeatureFlagForCodeLocation', () => {
+  const locationEntries: WorkspaceLocationNodeFragment[] = [
+    buildWorkspaceLocationEntry({
+      id: 'foo',
+      featureFlags: [
+        buildFeatureFlag({
+          name: 'LOREM',
+          enabled: false,
+        }),
+        buildFeatureFlag({
+          name: 'IPSUM',
+          enabled: true,
+        }),
+      ],
+    }),
+  ];
+
+  it('returns true for an enabled flag in a matching code location', () => {
+    expect(getFeatureFlagForCodeLocation(locationEntries, 'foo', 'IPSUM')).toBe(true);
+  });
+
+  it('returns false for a disabled flag in a matching code location', () => {
+    expect(getFeatureFlagForCodeLocation(locationEntries, 'foo', 'LOREM')).toBe(false);
+  });
+
+  it('returns false for a flag that cannot be found in a matching code location', () => {
+    expect(getFeatureFlagForCodeLocation(locationEntries, 'foo', 'FAKE_FLAG')).toBe(false);
+  });
+
+  it('returns false for an existing flag that cannot be found in an unknown code location', () => {
+    expect(getFeatureFlagForCodeLocation(locationEntries, 'FAKE_LOCATION', 'IPSUM')).toBe(false);
+  });
+
+  it('returns false for an unknown flag in an unknown code location', () => {
+    expect(getFeatureFlagForCodeLocation(locationEntries, 'FAKE_LOCATION', 'FAKE_FLAG')).toBe(
+      false,
+    );
+  });
+});

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/types/WorkspaceContext.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/types/WorkspaceContext.types.ts
@@ -27,6 +27,7 @@ export type RootWorkspaceQuery = {
           loadStatus: Types.RepositoryLocationLoadStatus;
           updatedTimestamp: number;
           displayMetadata: Array<{__typename: 'RepositoryMetadata'; key: string; value: string}>;
+          featureFlags: Array<{__typename: 'FeatureFlag'; name: string; enabled: boolean}>;
           locationOrLoadError:
             | {
                 __typename: 'PythonError';
@@ -125,6 +126,7 @@ export type WorkspaceLocationNodeFragment = {
   loadStatus: Types.RepositoryLocationLoadStatus;
   updatedTimestamp: number;
   displayMetadata: Array<{__typename: 'RepositoryMetadata'; key: string; value: string}>;
+  featureFlags: Array<{__typename: 'FeatureFlag'; name: string; enabled: boolean}>;
   locationOrLoadError:
     | {
         __typename: 'PythonError';


### PR DESCRIPTION
## Summary & Motivation

Add a feature flag utility to read flags from location entries, use it to gate the `SHOW_SINGLE_RUN_BACKFILL_TOGGLE` UI in the materialization partition dialog.

<img width="758" alt="Screenshot 2023-10-04 at 5 41 44 PM" src="https://github.com/dagster-io/dagster/assets/2823852/4f51346d-ff95-4af4-be10-95d07a4918d9">

## How I Tested These Changes

Jest to verify flag checking.

View http://localhost:3000/locations/partitioned_assets_repository@dagster_test.toys.repo/asset-groups/default/lineage/hourly_asset1, materialize. Verify that the radio container is not rendered.

Force the flag utility hook to return true, verify that the radio container is rendered.