### PR TITLE
Add get_materialize_result to PipesClientCompletedInvocation and PipesSession

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/result.py
+++ b/python_modules/dagster/dagster/_core/definitions/result.py
@@ -51,10 +51,9 @@ class MaterializeResult(
                 "metadata",
                 key_type=str,
             ),
-            check_results=check.opt_nullable_sequence_param(
+            check_results=check.opt_sequence_param(
                 check_results, "check_results", of_type=AssetCheckResult
-            )
-            or [],
+            ),
             data_version=check.opt_inst_param(data_version, "data_version", DataVersion),
         )
 

--- a/python_modules/dagster/dagster/_core/definitions/result.py
+++ b/python_modules/dagster/dagster/_core/definitions/result.py
@@ -19,7 +19,7 @@ class MaterializeResult(
         [
             ("asset_key", PublicAttr[Optional[AssetKey]]),
             ("metadata", PublicAttr[Optional[MetadataUserInput]]),
-            ("check_results", PublicAttr[Optional[Sequence[AssetCheckResult]]]),
+            ("check_results", PublicAttr[Sequence[AssetCheckResult]]),
             ("data_version", PublicAttr[Optional[DataVersion]]),
         ],
     )
@@ -53,6 +53,14 @@ class MaterializeResult(
             ),
             check_results=check.opt_nullable_sequence_param(
                 check_results, "check_results", of_type=AssetCheckResult
-            ),
+            )
+            or [],
             data_version=check.opt_inst_param(data_version, "data_version", DataVersion),
         )
+
+    def check_result_named(self, check_name: str) -> AssetCheckResult:
+        for check_result in self.check_results:
+            if check_result.check_name == check_name:
+                return check_result
+
+        check.failed(f"Could not find check result named {check_name}")

--- a/python_modules/dagster/dagster/_core/pipes/client.py
+++ b/python_modules/dagster/dagster/_core/pipes/client.py
@@ -1,17 +1,14 @@
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Iterator, List, Optional, Sequence
+from typing import TYPE_CHECKING, Iterator, Optional, Sequence
 
 from dagster_pipes import (
-    DagsterPipesError,
     PipesContextData,
     PipesExtras,
     PipesParams,
 )
 
-from dagster import _check as check
 from dagster._annotations import experimental, public
-from dagster._core.definitions.asset_check_result import AssetCheckResult
 from dagster._core.definitions.result import MaterializeResult
 from dagster._core.execution.context.compute import OpExecutionContext
 
@@ -58,40 +55,9 @@ class PipesClientCompletedInvocation:
         return tuple(self._results)
 
     def get_materialize_result(self) -> MaterializeResult:
-        mat_results: List[MaterializeResult] = [
-            mat_result for mat_result in self._results if isinstance(mat_result, MaterializeResult)
-        ]
-        check_results: List[AssetCheckResult] = [
-            check_result
-            for check_result in self._results
-            if isinstance(check_result, AssetCheckResult)
-        ]
+        from .context import materialize_result_from_pipes_results
 
-        check.invariant(
-            len(mat_results) > 0, "No materialization results received. Internal error?"
-        )
-        if len(mat_results) > 1:
-            raise DagsterPipesError(
-                "Multiple materialize results returned with asset keys"
-                f" {sorted([check.not_none(mr.asset_key).to_user_string() for mr in mat_results])}."
-                " If you are materializing multiple assets in a pipes invocation, use"
-                " get_results() instead.",
-            )
-        mat_result = next(iter(mat_results))
-        for check_result in check_results:
-            if check_result.asset_key:
-                check.invariant(
-                    mat_result.asset_key == check_result.asset_key,
-                    "Check result specified an asset key that is not part of the returned"
-                    " materialization. If this was deliberate, use get_results() instead.",
-                )
-
-        if check_results:
-            return mat_result._replace(
-                check_results=[*(mat_result.check_results or []), *check_results]
-            )
-        else:
-            return mat_result
+        return materialize_result_from_pipes_results(self.get_results())
 
 
 @experimental

--- a/python_modules/dagster/dagster/_core/pipes/client.py
+++ b/python_modules/dagster/dagster/_core/pipes/client.py
@@ -57,9 +57,24 @@ class PipesClientCompletedInvocation:
         self._results = results
 
     def get_results(self) -> Sequence["PipesExecutionResult"]:
+        """Get the stream of results as a Sequence of a completed pipes
+        client invocation. For each "report" call in the external process,
+        one result object will be in the list.
+
+        Returns: Sequence[PipesExecutionResult]
+        """
         return tuple(self._results)
 
     def get_materialize_result(self) -> MaterializeResult:
+        """Get a single materialize result for a pipes invocation. This coalesces
+        the materialization result and any separately reported asset check results from
+        the external process.
+
+        This does not work on invocations that materialize multiple assets and will fail
+        in that case. For multiple assets use `get_results` instead to get the result stream.
+
+        Returns: MaterializeResult
+        """
         return materialize_result_from_pipes_results(self.get_results())
 
 

--- a/python_modules/dagster/dagster/_core/pipes/client.py
+++ b/python_modules/dagster/dagster/_core/pipes/client.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Iterator, Optional, Sequence
+from typing import TYPE_CHECKING, Iterator, List, Optional, Sequence
 
 from dagster_pipes import (
     PipesContextData,
@@ -8,7 +8,10 @@ from dagster_pipes import (
     PipesParams,
 )
 
+from dagster import _check as check
 from dagster._annotations import experimental, public
+from dagster._core.definitions.asset_check_result import AssetCheckResult
+from dagster._core.definitions.result import MaterializeResult
 from dagster._core.execution.context.compute import OpExecutionContext
 
 if TYPE_CHECKING:
@@ -52,6 +55,40 @@ class PipesClientCompletedInvocation:
 
     def get_results(self) -> Sequence["PipesExecutionResult"]:
         return tuple(self._results)
+
+    def get_materialize_result(self) -> MaterializeResult:
+        mat_results: List[MaterializeResult] = [
+            mat_result for mat_result in self._results if isinstance(mat_result, MaterializeResult)
+        ]
+        check_results: List[AssetCheckResult] = [
+            check_result
+            for check_result in self._results
+            if isinstance(check_result, AssetCheckResult)
+        ]
+
+        check.invariant(
+            len(mat_results) > 0, "No materialization results received. Internal error?"
+        )
+        check.invariant(
+            len(mat_results) == 1,
+            "Multiple materialize results returned. If this was deliberate, use get_results()"
+            " instead.",
+        )
+        mat_result = next(iter(mat_results))
+        for check_result in check_results:
+            if check_result.asset_key:
+                check.invariant(
+                    mat_result.asset_key == check_result.asset_key,
+                    "Check result specified an asset key that is not part of the returned"
+                    " materialization. If this was deliberate, use get_results() instead.",
+                )
+
+        if check_results:
+            return mat_result._replace(
+                check_results=[*(mat_result.check_results or []), *check_results]
+            )
+        else:
+            return mat_result
 
 
 @experimental

--- a/python_modules/dagster/dagster/_core/pipes/context.py
+++ b/python_modules/dagster/dagster/_core/pipes/context.py
@@ -1,12 +1,13 @@
 from contextlib import contextmanager
 from dataclasses import dataclass
 from queue import Queue
-from typing import Any, Dict, Iterator, Mapping, Optional, Set, Union
+from typing import Any, Dict, Iterator, List, Mapping, Optional, Set, Union
 
 from dagster_pipes import (
     DAGSTER_PIPES_BOOTSTRAP_PARAM_NAMES,
     IS_DAGSTER_PIPES_PROCESS,
     PIPES_METADATA_TYPE_INFER,
+    DagsterPipesError,
     PipesContextData,
     PipesDataProvenance,
     PipesExtras,
@@ -17,6 +18,7 @@ from dagster_pipes import (
     PipesTimeWindow,
     encode_env_var,
 )
+from git import Sequence
 from typing_extensions import TypeAlias
 
 import dagster._check as check
@@ -272,6 +274,45 @@ class PipesSession:
             ExtResult: Result reported by external process.
         """
         yield from self.message_handler.clear_result_queue()
+
+    @public
+    def get_materialize_result(self) -> MaterializeResult:
+        return materialize_result_from_pipes_results(list(self.get_results()))
+
+
+def materialize_result_from_pipes_results(
+    all_results: Sequence[PipesExecutionResult],
+) -> MaterializeResult:
+    mat_results: List[MaterializeResult] = [
+        mat_result for mat_result in all_results if isinstance(mat_result, MaterializeResult)
+    ]
+    check_results: List[AssetCheckResult] = [
+        check_result for check_result in all_results if isinstance(check_result, AssetCheckResult)
+    ]
+
+    check.invariant(len(mat_results) > 0, "No materialization results received. Internal error?")
+    if len(mat_results) > 1:
+        raise DagsterPipesError(
+            "Multiple materialize results returned with asset keys"
+            f" {sorted([check.not_none(mr.asset_key).to_user_string() for mr in mat_results])}."
+            " If you are materializing multiple assets in a pipes invocation, use"
+            " get_results() instead.",
+        )
+    mat_result = next(iter(mat_results))
+    for check_result in check_results:
+        if check_result.asset_key:
+            check.invariant(
+                mat_result.asset_key == check_result.asset_key,
+                "Check result specified an asset key that is not part of the returned"
+                " materialization. If this was deliberate, use get_results() instead.",
+            )
+
+    if check_results:
+        return mat_result._replace(
+            check_results=[*(mat_result.check_results or []), *check_results]
+        )
+    else:
+        return mat_result
 
 
 def build_external_execution_context_data(

--- a/python_modules/dagster/dagster/_core/pipes/context.py
+++ b/python_modules/dagster/dagster/_core/pipes/context.py
@@ -1,7 +1,7 @@
 from contextlib import contextmanager
 from dataclasses import dataclass
 from queue import Queue
-from typing import Any, Dict, Iterator, List, Mapping, Optional, Set, Union
+from typing import Any, Dict, Iterator, List, Mapping, Optional, Sequence, Set, Union
 
 from dagster_pipes import (
     DAGSTER_PIPES_BOOTSTRAP_PARAM_NAMES,
@@ -18,7 +18,6 @@ from dagster_pipes import (
     PipesTimeWindow,
     encode_env_var,
 )
-from git import Sequence
 from typing_extensions import TypeAlias
 
 import dagster._check as check

--- a/python_modules/dagster/dagster/_core/pipes/utils.py
+++ b/python_modules/dagster/dagster/_core/pipes/utils.py
@@ -314,8 +314,9 @@ _FAIL_TO_YIELD_ERROR_MESSAGE = (
     "Did you forget to `yield from pipes_session.get_results()` or `return"
     " <PipesClient>.run(...).get_results`? If using `open_pipes_session`,"
     " `pipes_session.get_results` should be called once after the `open_pipes_session` block has"
-    " exited to yield any remaining buffered results. If using `<PipesClient>.run`, you should"
-    " always return `<PipesClient>.run(...).get_results()`."
+    " exited to yield any remaining buffered results via `<PipesSession>.get_results()`."
+    " If using `<PipesClient>.run`, you should always return"
+    " `<PipesClient>.run(...).get_results()` or `<PipesClient>.run(...).get_materialize_result()`."
 )
 
 

--- a/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/in_process_client.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/in_process_client.py
@@ -22,7 +22,6 @@ from dagster_pipes import (
     PipesMessageWriterChannel,
     PipesParams,
     PipesParamsLoader,
-    open_dagster_pipes,
 )
 
 
@@ -106,7 +105,7 @@ class _InProcessPipesClient(PipesClient):
         pipes_context_data = build_external_execution_context_data(context=context, extras=extras)
         pipes_context_loader = InProcessPipesContextLoader(pipes_context_data)
         pipes_message_writer = InProcessPipesMessageWriter()
-        with open_dagster_pipes(
+        with PipesContext(  # construct PipesContext directly to avoid env var check in open_dagster_pipes
             context_loader=pipes_context_loader,
             message_writer=pipes_message_writer,
             params_loader=InProcessPipesParamLoader(),
@@ -115,7 +114,8 @@ class _InProcessPipesClient(PipesClient):
                 context=context,
                 context_injector=InProcessContextInjector(),
                 message_reader=InProcessMessageReader(
-                    pipes_message_writer, pipes_context=pipes_context
+                    pipes_message_writer,
+                    pipes_context=pipes_context,
                 ),
             ) as session:
                 fn(pipes_context)

--- a/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_in_process_client.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_in_process_client.py
@@ -19,7 +19,14 @@ from dagster_pipes import (
     PipesContext,
 )
 
-from .in_process_client import InProcessContextInjector, InProcessPipesClient
+from .in_process_client import (
+    InProcessContextInjector,
+    InProcessMessageReader,
+    InProcessPipesClient,
+    InProcessPipesContextLoader,
+    InProcessPipesMessageWriter,
+    InProcessPipesParamLoader,
+)
 
 
 def execute_asset_through_def(assets_def, resources) -> ExecuteInProcessResult:
@@ -188,14 +195,6 @@ def test_wrong_asset_check_name() -> None:
         in str(exc_info.value)
     )
     assert called["yes"]
-
-
-from .in_process_client import (
-    InProcessMessageReader,
-    InProcessPipesContextLoader,
-    InProcessPipesMessageWriter,
-    InProcessPipesParamLoader,
-)
 
 
 def test_open_pipes_session_get_materialize_result() -> None:

--- a/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_in_process_client.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_in_process_client.py
@@ -1,4 +1,3 @@
-from dagster._core.pipes.utils import open_pipes_session
 import pytest
 from dagster import (
     AssetCheckSpec,
@@ -11,8 +10,14 @@ from dagster import (
     multi_asset,
 )
 from dagster._core.definitions.asset_check_spec import AssetCheckSeverity
+from dagster._core.definitions.metadata import TextMetadataValue
 from dagster._core.errors import DagsterInvariantViolationError
-from dagster_pipes import DagsterPipesError, PipesContext
+from dagster._core.pipes.context import build_external_execution_context_data
+from dagster._core.pipes.utils import open_pipes_session
+from dagster_pipes import (
+    DagsterPipesError,
+    PipesContext,
+)
 
 from .in_process_client import InProcessContextInjector, InProcessPipesClient
 
@@ -183,3 +188,56 @@ def test_wrong_asset_check_name() -> None:
         in str(exc_info.value)
     )
     assert called["yes"]
+
+
+from .in_process_client import (
+    InProcessMessageReader,
+    InProcessPipesContextLoader,
+    InProcessPipesMessageWriter,
+    InProcessPipesParamLoader,
+)
+
+
+def test_open_pipes_session_get_materialize_result() -> None:
+    called = {}
+
+    def _impl(context: PipesContext):
+        context.report_asset_materialization(metadata={"some_key": "some_value"})
+        called["yes"] = True
+
+    @asset
+    def an_asset(context: AssetExecutionContext):
+        pipes_context_data = build_external_execution_context_data(context=context, extras={})
+        pipes_context_loader = InProcessPipesContextLoader(pipes_context_data)
+        pipes_message_writer = InProcessPipesMessageWriter()
+        with PipesContext(  # construct PipesContext directly to avoid env var check in open_dagster_pipes
+            context_loader=pipes_context_loader,
+            message_writer=pipes_message_writer,
+            params_loader=InProcessPipesParamLoader(),
+        ) as pipes_context:
+            with open_pipes_session(
+                context=context,
+                context_injector=InProcessContextInjector(),
+                message_reader=InProcessMessageReader(
+                    pipes_message_writer,
+                    pipes_context=pipes_context,
+                ),
+            ) as session:
+                _impl(pipes_context)
+
+            mat_result = session.get_materialize_result()
+            assert mat_result.asset_key
+            assert mat_result.asset_key.to_user_string() == "an_asset"
+            assert mat_result.metadata
+            assert isinstance(mat_result.metadata["some_key"], TextMetadataValue)
+            assert mat_result.metadata["some_key"].value == "some_value"
+            return mat_result
+
+    result = execute_asset_through_def(
+        an_asset, resources={"inprocess_client": InProcessPipesClient()}
+    )
+    assert called["yes"]
+    assert result.success
+    mat_events = result.get_asset_materialization_events()
+    assert len(mat_events) == 1
+    assert mat_events[0].materialization.metadata["some_key"].value == "some_value"

--- a/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_in_process_client.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_in_process_client.py
@@ -1,3 +1,4 @@
+from dagster._core.pipes.utils import open_pipes_session
 import pytest
 from dagster import (
     AssetCheckSpec,
@@ -13,7 +14,7 @@ from dagster._core.definitions.asset_check_spec import AssetCheckSeverity
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster_pipes import DagsterPipesError, PipesContext
 
-from .in_process_client import InProcessPipesClient
+from .in_process_client import InProcessContextInjector, InProcessPipesClient
 
 
 def execute_asset_through_def(assets_def, resources) -> ExecuteInProcessResult:

--- a/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_in_process_client.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_in_process_client.py
@@ -1,4 +1,6 @@
+from re import M
 from dagster import AssetExecutionContext, Definitions, ExecuteInProcessResult, asset
+from dagster._core.definitions.result import MaterializeResult
 from dagster_pipes import PipesContext
 
 from .in_process_client import InProcessPipesClient
@@ -22,6 +24,28 @@ def test_basic_materialization() -> None:
     @asset
     def an_asset(context: AssetExecutionContext, inprocess_client: InProcessPipesClient):
         return inprocess_client.run(context=context, fn=_impl).get_results()
+
+    result = execute_asset_through_def(
+        an_asset, resources={"inprocess_client": InProcessPipesClient()}
+    )
+    assert result.success
+    mat_events = result.get_asset_materialization_events()
+    assert len(mat_events) ==1
+    assert mat_events[0].materialization.metadata["some_key"].value == "some_value"
+    assert called["yes"]
+
+
+
+def test_get_materialize_result():
+    called = {}
+
+    def _impl(context: PipesContext):
+        context.report_asset_materialization(metadata={"some_key": "some_value"})
+        called["yes"] = True
+
+    @asset
+    def an_asset(context: AssetExecutionContext, inprocess_client: InProcessPipesClient) -> MaterializeResult:
+        return inprocess_client.run(context=context, fn=_impl).get_materialize_result()
 
     result = execute_asset_through_def(
         an_asset, resources={"inprocess_client": InProcessPipesClient()}

--- a/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_in_process_client.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_in_process_client.py
@@ -1,6 +1,10 @@
-from re import M
-from dagster import AssetExecutionContext, Definitions, ExecuteInProcessResult, asset
-from dagster._core.definitions.result import MaterializeResult
+from dagster import (
+    AssetExecutionContext,
+    Definitions,
+    ExecuteInProcessResult,
+    MaterializeResult,
+    asset,
+)
 from dagster_pipes import PipesContext
 
 from .in_process_client import InProcessPipesClient
@@ -28,12 +32,11 @@ def test_basic_materialization() -> None:
     result = execute_asset_through_def(
         an_asset, resources={"inprocess_client": InProcessPipesClient()}
     )
+    assert called["yes"]
     assert result.success
     mat_events = result.get_asset_materialization_events()
-    assert len(mat_events) ==1
+    assert len(mat_events) == 1
     assert mat_events[0].materialization.metadata["some_key"].value == "some_value"
-    assert called["yes"]
-
 
 
 def test_get_materialize_result():
@@ -44,11 +47,16 @@ def test_get_materialize_result():
         called["yes"] = True
 
     @asset
-    def an_asset(context: AssetExecutionContext, inprocess_client: InProcessPipesClient) -> MaterializeResult:
+    def an_asset(
+        context: AssetExecutionContext, inprocess_client: InProcessPipesClient
+    ) -> MaterializeResult:
         return inprocess_client.run(context=context, fn=_impl).get_materialize_result()
 
     result = execute_asset_through_def(
         an_asset, resources={"inprocess_client": InProcessPipesClient()}
     )
     assert result.success
+    mat_events = result.get_asset_materialization_events()
+    assert len(mat_events) == 1
+    assert mat_events[0].materialization.metadata["some_key"].value == "some_value"
     assert called["yes"]

--- a/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_in_process_client.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_in_process_client.py
@@ -129,6 +129,8 @@ def test_with_asset_checks() -> None:
             AssetCheckSpec(name="check_two", asset="an_asset"),
         ]
     )
+    # Bug in MaterializeResult type inference
+    # def an_asset(context: AssetExecutionContext, inprocess_client: InProcessPipesClient) -> MaterializeResult:
     def an_asset(context: AssetExecutionContext, inprocess_client: InProcessPipesClient):
         mat_result = inprocess_client.run(context=context, fn=_impl).get_materialize_result()
         assert len(mat_result.check_results) == 2


### PR DESCRIPTION
## Summary & Motivation

This adds `get_materialize_result` to `PipesClientCompletedInvocation` and `PipesSession`. For the common case that a pipes invocation creates a single asset, this is a simpler API that returns a single `MaterializeResult`. Then type signature of `@asset` can be simpler, just `MaterializeResult`. (in practice almost no one correctly annotates the streaming version of `@asset` at all)

I think we should with this API in all examples.

## How I Tested These Changes

BK
