### PR TITLE
[ui] Small CSS nits to asset graph

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -604,7 +604,7 @@ const TopbarWrapper = styled.div`
   grid-template-columns: auto auto 1fr auto auto auto auto;
   gap: 12px;
   align-items: center;
-  padding: 12px 15px;
+  padding: 12px;
   border-bottom: 1px solid ${Colors.KeylineGray};
   ${TextInputContainer} {
     width: 100%;

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -8,6 +8,7 @@ import {
   Icon,
   Tooltip,
   TextInputContainer,
+  Box,
 } from '@dagster-io/ui-components';
 import pickBy from 'lodash/pickBy';
 import uniq from 'lodash/uniq';
@@ -442,14 +443,18 @@ const AssetGraphExplorerWithData: React.FC<WithDataProps> = ({
               </Tooltip>
             )}
             <div>{fetchOptionFilters}</div>
-            <GraphQueryInput
-              type="asset_graph"
-              items={graphQueryItems}
-              value={explorerPath.opsQuery}
-              placeholder="Type an asset subset…"
-              onChange={(opsQuery) => onChangeExplorerPath({...explorerPath, opsQuery}, 'replace')}
-              popoverPosition="bottom-left"
-            />
+            <GraphQueryInputFlexWrap>
+              <GraphQueryInput
+                type="asset_graph"
+                items={graphQueryItems}
+                value={explorerPath.opsQuery}
+                placeholder="Type an asset subset…"
+                onChange={(opsQuery) =>
+                  onChangeExplorerPath({...explorerPath, opsQuery}, 'replace')
+                }
+                popoverPosition="bottom-left"
+              />
+            </GraphQueryInputFlexWrap>
             <Button
               onClick={() => {
                 onChangeExplorerPath({...explorerPath, opsQuery: ''}, 'push');
@@ -605,11 +610,15 @@ const TopbarWrapper = styled.div`
   align-items: center;
   padding: 12px;
   border-bottom: 1px solid ${Colors.KeylineGray};
-  ${TextInputContainer} {
-    width: 100%;
-  }
-  > :nth-child(2) {
-    flex: 1;
+`;
+
+const GraphQueryInputFlexWrap = styled.div`
+  flex: 1;
+
+  > ${Box} {
+    ${TextInputContainer} {
+      width: 100%;
+    }
     > * {
       display: block;
       width: 100%;

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -429,10 +429,8 @@ const AssetGraphExplorerWithData: React.FC<WithDataProps> = ({
             </OptionsOverlay>
           )}
 
-          <TopbarWrapper>
-            {showSidebar || !flagDAGSidebar ? (
-              <div />
-            ) : (
+          <TopbarWrapper style={{paddingLeft: showSidebar || !flagDAGSidebar ? 12 : 24}}>
+            {showSidebar || !flagDAGSidebar ? undefined : (
               <Tooltip content="Show sidebar">
                 <Button
                   icon={<Icon name="panel_show_left" />}

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -599,9 +599,8 @@ const TopbarWrapper = styled.div`
   top: 0;
   left: 0;
   right: 0;
-  display: grid;
+  display: flex;
   background: white;
-  grid-template-columns: auto auto 1fr auto auto auto auto;
   gap: 12px;
   align-items: center;
   padding: 12px;
@@ -609,7 +608,8 @@ const TopbarWrapper = styled.div`
   ${TextInputContainer} {
     width: 100%;
   }
-  > :nth-child(3) {
+  > :nth-child(2) {
+    flex: 1;
     > * {
       display: block;
       width: 100%;

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/layout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/layout.ts
@@ -54,7 +54,7 @@ export const layoutAssetGraph = (
           marginx: MARGIN,
           marginy: MARGIN,
           nodesep: -10,
-          edgesep: 10,
+          edgesep: 90,
           ranksep: 60,
         }
       : {

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Node.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Node.tsx
@@ -104,6 +104,9 @@ export const Node = ({
 
   const {onClick, loading, launchpadElement} = useMaterializationAction();
 
+  const showArrow =
+    !isAssetNode || (viewType === 'tree' && downstream.filter((id) => graphData.nodes[id]).length);
+
   return (
     <>
       {launchpadElement}
@@ -117,22 +120,23 @@ export const Node = ({
       />
       <Box ref={elementRef} onClick={selectThisNode} padding={{left: 8}}>
         <BoxWrapper level={level}>
-          <Box padding={{right: 12}} flex={{direction: 'row', gap: 2, alignItems: 'center'}}>
-            {!isAssetNode ||
-            (viewType === 'tree' && downstream.filter((id) => graphData.nodes[id]).length) ? (
+          <Box padding={{right: 12}} flex={{direction: 'row', alignItems: 'center'}}>
+            {showArrow ? (
               <div
                 onClick={(e) => {
                   e.stopPropagation();
                   toggleOpen();
                 }}
-                style={{cursor: 'pointer'}}
+                style={{cursor: 'pointer', width: 18}}
               >
                 <Icon
                   name="arrow_drop_down"
                   style={{transform: isOpen ? 'rotate(0deg)' : 'rotate(-90deg)'}}
                 />
               </div>
-            ) : null}
+            ) : (
+              <div style={{width: 18}} />
+            )}
             <GrayOnHoverBox
               flex={{
                 direction: 'row',
@@ -321,7 +325,7 @@ const BoxWrapper = ({level, children}: {level: number; children: React.ReactNode
         <Box
           padding={{left: 8}}
           margin={{left: 8}}
-          border={{side: 'left', width: 1, color: Colors.KeylineGray}}
+          border={i < level - 1 ? {side: 'left', width: 1, color: Colors.KeylineGray} : undefined}
           style={{position: 'relative'}}
         >
           {sofar}

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
@@ -80,7 +80,7 @@ export const AssetGraphExplorerSidebar = React.memo(
       null | {id: string; path: string} | {id: string}
     >(null);
 
-    const [viewType, setViewType] = React.useState<'tree' | 'group'>('tree');
+    const [viewType, setViewType] = React.useState<'tree' | 'group'>('group');
 
     const rootNodes = React.useMemo(
       () =>
@@ -306,6 +306,7 @@ export const AssetGraphExplorerSidebar = React.memo(
             gridTemplateColumns: '1fr auto',
             gap: '6px',
             padding: '12px 24px',
+            paddingRight: 12,
             borderBottom: `1px solid ${Colors.KeylineGray}`,
           }}
         >
@@ -313,8 +314,8 @@ export const AssetGraphExplorerSidebar = React.memo(
             <ButtonGroup
               activeItems={new Set([viewType])}
               buttons={[
-                {id: 'tree', label: 'Tree view', icon: 'gantt_flat'},
                 {id: 'group', label: 'Group view', icon: 'asset_group'},
+                {id: 'tree', label: 'Tree view', icon: 'gantt_flat'},
               ]}
               onClick={(id: 'tree' | 'group') => {
                 setViewType(id);
@@ -325,7 +326,7 @@ export const AssetGraphExplorerSidebar = React.memo(
             <Button icon={<Icon name="panel_show_right" />} onClick={hideSidebar} />
           </Tooltip>
         </div>
-        <Box padding={{vertical: 8, horizontal: 24}}>
+        <Box padding={{vertical: 8, left: 24, right: 12}}>
           <SearchFilter
             values={React.useMemo(() => {
               return allAssetKeys.map((key) => ({


### PR DESCRIPTION
## Summary & Motivation

We talked about a few of these on the design call yesterday -- 

I switched Group View to be the default on the left sidebar.

I tightened the right padding on the input and toolbar so that the highlighted node aligns with the edge of the box and the spacing matches the spacing of "Filters" on the other side of the panel divider

<img width="561" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/7551b8a4-88b2-4651-b179-361318ad6a3f">

I tightened the spacing from 15px to our normal 12px on the asset graph header so that this Materialize button doesn't indent slightly more when you switch from the catalog to the global graph:
<img width="403" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/f2050e5f-3251-4eeb-bb3c-3b530ed1cebd">

I added a spacer when the disclosure triangle isn't present, and removed the left-most vertical border which was always there:

Before:
<img width="384" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/23607eca-ab7f-4b11-9775-ff9aca74d9fb">

After:
<img width="378" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/daf78989-19e8-4576-8311-3f1ff231d35e">


<img width="1728" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/db2b5a61-2cc6-4ab6-a174-5ffa886bd3ae">


