### PR TITLE
Add assetKey field to evaluation record graphql type

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeMiddlePanel.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeMiddlePanel.tsx
@@ -3,11 +3,7 @@ import {Box, NonIdealState, Subheading} from '@dagster-io/ui-components';
 import * as React from 'react';
 
 import {ErrorWrapper} from '../../app/PythonErrorInfo';
-import {
-  AutoMaterializeAssetEvaluationRecord,
-  AutoMaterializeDecisionType,
-  AutoMaterializeRule,
-} from '../../graphql/types';
+import {AutoMaterializeDecisionType, AutoMaterializeRule} from '../../graphql/types';
 import {AssetKey} from '../types';
 
 import {AutomaterializeRequestedPartitionsLink} from './AutomaterializeRequestedPartitionsLink';
@@ -19,6 +15,7 @@ import {
   GetEvaluationsQuery,
   GetEvaluationsQueryVariables,
   RuleWithEvaluationsFragment,
+  AutoMaterializeEvaluationRecordItemFragment,
 } from './types/GetEvaluationsQuery.types';
 
 interface Props {
@@ -139,7 +136,7 @@ export const AutomaterializeMiddlePanelWithData = ({
   assetHasDefinedPartitions,
 }: {
   currentRules: AutoMaterializeRule[];
-  selectedEvaluation: NoConditionsMetEvaluation | AutoMaterializeAssetEvaluationRecord;
+  selectedEvaluation: NoConditionsMetEvaluation | AutoMaterializeEvaluationRecordItemFragment;
   assetHasDefinedPartitions: boolean;
 }) => {
   const runIds =

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -3217,6 +3217,7 @@ type AutoMaterializeAssetEvaluationRecord {
   timestamp: Float!
   runIds: [String!]!
   rules: [AutoMaterializeRule!]
+  assetKey: AssetKey!
 }
 
 type AutoMaterializeRuleWithRuleEvaluations {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -464,6 +464,7 @@ export type AutoMaterializeAssetEvaluationNeedsMigrationError = Error & {
 
 export type AutoMaterializeAssetEvaluationRecord = {
   __typename: 'AutoMaterializeAssetEvaluationRecord';
+  assetKey: AssetKey;
   evaluationId: Scalars['Int'];
   id: Scalars['ID'];
   numDiscarded: Scalars['Int'];
@@ -5208,6 +5209,12 @@ export const buildAutoMaterializeAssetEvaluationRecord = (
   relationshipsToOmit.add('AutoMaterializeAssetEvaluationRecord');
   return {
     __typename: 'AutoMaterializeAssetEvaluationRecord',
+    assetKey:
+      overrides && overrides.hasOwnProperty('assetKey')
+        ? overrides.assetKey!
+        : relationshipsToOmit.has('AssetKey')
+        ? ({} as AssetKey)
+        : buildAssetKey({}, relationshipsToOmit),
     evaluationId:
       overrides && overrides.hasOwnProperty('evaluationId') ? overrides.evaluationId! : 9286,
     id:

--- a/python_modules/dagster-graphql/dagster_graphql/schema/auto_materialize_asset_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/auto_materialize_asset_evaluations.py
@@ -182,6 +182,7 @@ class GrapheneAutoMaterializeAssetEvaluationRecord(graphene.ObjectType):
     timestamp = graphene.NonNull(graphene.Float)
     runIds = non_null_list(graphene.String)
     rules = graphene.Field(graphene.List(graphene.NonNull(GrapheneAutoMaterializeRule)))
+    assetKey = graphene.NonNull(GrapheneAssetKey)
 
     class Meta:
         name = "AutoMaterializeAssetEvaluationRecord"
@@ -210,6 +211,7 @@ class GrapheneAutoMaterializeAssetEvaluationRecord(graphene.ObjectType):
                 if record.evaluation.rule_snapshots is not None
                 else None  # Return None if no rules serialized in evaluation
             ),
+            assetKey=GrapheneAssetKey(path=record.asset_key.path),
         )
 
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_auto_materialize_asset_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_auto_materialize_asset_evaluations.py
@@ -214,6 +214,9 @@ query GetEvaluationsQuery($assetKey: AssetKeyInput!, $limit: Int!, $cursor: Stri
                     description
                     className
                 }
+                assetKey {
+                    path
+                }
             }
             currentEvaluationId
         }
@@ -267,6 +270,9 @@ query GetEvaluationsForEvaluationIdQuery($evaluationId: Int!) {
                     description
                     className
                 }
+                assetKey {
+                    path
+                }
             }
             currentEvaluationId
         }
@@ -308,6 +314,9 @@ class TestAutoMaterializeAssetEvaluations(ExecutingGraphQLContextTestMatrix):
         )
         assert len(results.data["autoMaterializeAssetEvaluationsOrError"]["records"]) == 1
         assert results.data["autoMaterializeAssetEvaluationsOrError"]["records"][0]["rules"] is None
+        assert results.data["autoMaterializeAssetEvaluationsOrError"]["records"][0]["assetKey"] == {
+            "path": ["asset_one"]
+        }
 
         results_asset_two = execute_dagster_graphql(
             graphql_context,


### PR DESCRIPTION
Summary:
so that a query that returns records for multiple assets knows which asset each is for.

Test Plan:

## Summary & Motivation

## How I Tested These Changes
