### PR TITLE
[ui] Materializations: Minor spacing/interaction tweaks

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/CollapsibleSection.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/CollapsibleSection.tsx
@@ -20,7 +20,7 @@ export const CollapsibleSection = ({header, details, headerRightSide, children}:
             grow: 1,
           }}
         >
-          <Box flex={{direction: 'row', alignItems: 'center', gap: 4, grow: 1}}>
+          <Box flex={{direction: 'row', alignItems: 'center', gap: 8, grow: 1}}>
             <Subheading>{header}</Subheading>
             {details ? (
               <Tooltip content={details} placement="top">
@@ -47,17 +47,19 @@ export const Collapsible = ({
   const [isCollapsed, setIsCollapsed] = React.useState(false);
   return (
     <Box flex={{direction: 'column'}} border="bottom">
-      <Box
-        flex={{direction: 'row', alignItems: 'center'}}
-        padding={{vertical: 8, horizontal: 16}}
-        border="bottom"
-      >
-        <Icon
-          name="arrow_drop_down"
-          style={{transform: isCollapsed ? 'rotate(-90deg)' : 'rotate(0deg)'}}
-        />
-        <SectionHeader onClick={() => setIsCollapsed(!isCollapsed)}>{header}</SectionHeader>
-      </Box>
+      <SectionHeader onClick={() => setIsCollapsed(!isCollapsed)}>
+        <Box
+          flex={{direction: 'row', alignItems: 'center', gap: 6}}
+          padding={{vertical: 8, horizontal: 12}}
+          border="bottom"
+        >
+          <Icon
+            name="arrow_drop_down"
+            style={{transform: isCollapsed ? 'rotate(-90deg)' : 'rotate(0deg)'}}
+          />
+          <div>{header}</div>
+        </Box>
+      </SectionHeader>
       {isCollapsed ? null : children}
     </Box>
   );


### PR DESCRIPTION
## Summary & Motivation

A minor spacing/alignment tweak on the asset materizalitions middle panel. Also make the entire collapsible header clickable.

Before:

<img width="853" alt="Screenshot 2023-10-05 at 10 32 34 AM" src="https://github.com/dagster-io/dagster/assets/2823852/6c29f079-0957-4ade-af92-baef6a8f9fd8">

After:

<img width="857" alt="Screenshot 2023-10-05 at 10 30 07 AM" src="https://github.com/dagster-io/dagster/assets/2823852/ff07148c-b92e-4f4b-9fa1-233a443b7a51">

## How I Tested These Changes

View http://localhost:3000/assets/eager_downstream_1?view=auto-materialize-history&evaluation=1, verify spacing and interaction.
