### PR TITLE
[ui] Materializations: Sort copies

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/ParentUpdatedLink.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/ParentUpdatedLink.tsx
@@ -28,11 +28,11 @@ export const ParentUpdatedLink = ({updatedAssetKeys, willUpdateAssetKeys}: Props
 
   const filteredAssetKeys: AssetKeyDetail[] = React.useMemo(() => {
     return [
-      ...filteredUpdatedAssetKeys.sort(sortAssetKeys).map((assetKey) => ({
+      ...[...filteredUpdatedAssetKeys].sort(sortAssetKeys).map((assetKey) => ({
         assetKey,
         detailType: AssetDetailType.Updated,
       })),
-      ...filteredWillUpdateAssetKeys.sort(sortAssetKeys).map((assetKey) => ({
+      ...[...filteredWillUpdateAssetKeys].sort(sortAssetKeys).map((assetKey) => ({
         assetKey,
         detailType: AssetDetailType.WillUpdate,
       })),


### PR DESCRIPTION
## Summary & Motivation

A runtime error is occurring when trying to sort arrays of asset keys. The arrays are frozen. Sort copies instead of original arrays.

## How I Tested These Changes

I don't have a repro, so let's test it live in a scenario where it would repro.
