### PR TITLE
Add end_timestamp to all ticks

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
@@ -201,6 +201,7 @@ query SensorQuery($sensorSelector: SensorSelector!, $dayRange: Int, $dayOffset: 
         ticks(dayRange: $dayRange, dayOffset: $dayOffset) {
           id
           timestamp
+          endTimestamp
         }
       }
     }
@@ -952,6 +953,9 @@ def test_sensor_tick_range(graphql_context: WorkspaceRequestContext):
     )
     assert len(result.data["sensorOrError"]["sensorState"]["ticks"]) == 1
     assert result.data["sensorOrError"]["sensorState"]["ticks"][0]["timestamp"] == three.timestamp()
+    assert (
+        result.data["sensorOrError"]["sensorState"]["ticks"][0]["endTimestamp"] >= three.timestamp()
+    )
 
     result = execute_dagster_graphql(
         graphql_context,
@@ -960,6 +964,9 @@ def test_sensor_tick_range(graphql_context: WorkspaceRequestContext):
     )
     assert len(result.data["sensorOrError"]["sensorState"]["ticks"]) == 1
     assert result.data["sensorOrError"]["sensorState"]["ticks"][0]["timestamp"] == two.timestamp()
+    assert (
+        result.data["sensorOrError"]["sensorState"]["ticks"][0]["endTimestamp"] >= two.timestamp()
+    )
 
     result = execute_dagster_graphql(
         graphql_context,

--- a/python_modules/dagster/dagster/_core/scheduler/instigation.py
+++ b/python_modules/dagster/dagster/_core/scheduler/instigation.py
@@ -1,6 +1,7 @@
 from enum import Enum
 from typing import AbstractSet, Any, List, NamedTuple, Optional, Sequence, Union
 
+import pendulum
 from typing_extensions import TypeAlias
 
 import dagster._check as check
@@ -273,7 +274,10 @@ class InstigatorTick(NamedTuple("_InstigatorTick", [("tick_id", int), ("tick_dat
 
     def with_status(self, status: TickStatus, **kwargs: Any):
         check.inst_param(status, "status", TickStatus)
-        return self._replace(tick_data=self.tick_data.with_status(status, **kwargs))
+        end_timestamp = pendulum.now("UTC").timestamp() if status != TickStatus.STARTED else None
+        return self._replace(
+            tick_data=self.tick_data.with_status(status, end_timestamp=end_timestamp, **kwargs)
+        )
 
     def with_run_requests(self, run_requests: Sequence[RunRequest]) -> "InstigatorTick":
         return self._replace(tick_data=self.tick_data.with_run_requests(run_requests))

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -126,10 +126,7 @@ class AutoMaterializeLaunchContext:
         # Log the error if the failure wasn't an interrupt or the daemon generator stopping
         if exception_value and not isinstance(exception_value, GeneratorExit):
             error_data = serializable_error_info_from_exc_info(sys.exc_info())
-            tick_finish_timestamp = pendulum.now("UTC").timestamp()
-            self.update_state(
-                TickStatus.FAILURE, error=error_data, end_timestamp=tick_finish_timestamp
-            )
+            self.update_state(TickStatus.FAILURE, error=error_data)
 
         self._write()
 
@@ -317,12 +314,9 @@ class AssetDaemon(IntervalDaemon):
                             run_ids=evaluation.run_ids | {run.run_id}
                         )
 
-            tick_finish_timestamp = pendulum.now("UTC").timestamp()
-
             instance.daemon_cursor_storage.set_cursor_values({CURSOR_KEY: new_cursor.serialize()})
             tick_context.update_state(
                 TickStatus.SUCCESS if len(run_requests) > 0 else TickStatus.SKIPPED,
-                end_timestamp=tick_finish_timestamp,
             )
 
         # We enforce uniqueness per (asset key, evaluation id). Store the evaluations after the cursor,

--- a/python_modules/dagster/dagster/_utils/test/schedule_storage.py
+++ b/python_modules/dagster/dagster/_utils/test/schedule_storage.py
@@ -297,8 +297,14 @@ class TestScheduleStorage:
         current_time = time.time()
         tick = storage.create_tick(self.build_schedule_tick(current_time))
 
-        updated_tick = tick.with_status(TickStatus.SUCCESS).with_run_info(run_id="1234")
-        assert updated_tick.status == TickStatus.SUCCESS
+        assert not tick.end_timestamp
+
+        freeze_datetime = pendulum.now("UTC")
+
+        with pendulum.test(freeze_datetime):
+            updated_tick = tick.with_status(TickStatus.SUCCESS).with_run_info(run_id="1234")
+            assert updated_tick.status == TickStatus.SUCCESS
+            assert updated_tick.end_timestamp == freeze_datetime.timestamp()
 
         storage.update_tick(updated_tick)
 
@@ -316,9 +322,14 @@ class TestScheduleStorage:
 
         current_time = time.time()
         tick = storage.create_tick(self.build_schedule_tick(current_time))
+        assert not tick.end_timestamp
 
-        updated_tick = tick.with_status(TickStatus.SKIPPED)
-        assert updated_tick.status == TickStatus.SKIPPED
+        freeze_datetime = pendulum.now("UTC")
+
+        with pendulum.test(freeze_datetime):
+            updated_tick = tick.with_status(TickStatus.SKIPPED)
+            assert updated_tick.status == TickStatus.SKIPPED
+            assert updated_tick.end_timestamp == freeze_datetime.timestamp()
 
         storage.update_tick(updated_tick)
 
@@ -337,11 +348,15 @@ class TestScheduleStorage:
         current_time = time.time()
         tick = storage.create_tick(self.build_schedule_tick(current_time))
 
-        updated_tick = tick.with_status(
-            TickStatus.FAILURE,
-            error=SerializableErrorInfo(message="Error", stack=[], cls_name="TestError"),
-        )
-        assert updated_tick.status == TickStatus.FAILURE
+        freeze_datetime = pendulum.now("UTC")
+
+        with pendulum.test(freeze_datetime):
+            updated_tick = tick.with_status(
+                TickStatus.FAILURE,
+                error=SerializableErrorInfo(message="Error", stack=[], cls_name="TestError"),
+            )
+            assert updated_tick.status == TickStatus.FAILURE
+            assert updated_tick.end_timestamp == freeze_datetime.timestamp()
 
         storage.update_tick(updated_tick)
 


### PR DESCRIPTION
Summary:
Whenever a tick moves into a terminal state, set the end timestamp there, instead of just in the asset daemon.

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes
