### PR TITLE
[pipes] docker handle bytes logs

### DIFF
--- a/python_modules/libraries/dagster-docker/dagster_docker/pipes.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/pipes.py
@@ -48,7 +48,14 @@ class PipesDockerLogsMessageReader(PipesMessageReader):
             self._handler, "Can only consume logs within context manager scope."
         )
         for log_line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
-            extract_message_or_forward_to_stdout(handler, log_line)
+            if isinstance(log_line, bytes):
+                log_entry = log_line.decode("utf-8")
+            elif isinstance(log_line, str):
+                log_entry = log_line
+            else:
+                continue
+
+            extract_message_or_forward_to_stdout(handler, log_entry)
 
     def no_messages_debug_text(self) -> str:
         return "Attempted to read messages by extracting them from docker logs directly."

--- a/python_modules/libraries/dagster-docker/dagster_docker_tests/test_pipes.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker_tests/test_pipes.py
@@ -116,3 +116,48 @@ def test_file_io():
         assert result.success
         mats = result.asset_materializations_for_node(number_x.op.name)
         assert mats[0].metadata["path"]
+
+
+_print_script = """
+import sys
+import time
+
+sys.stdout.write('w1')
+print('p1')
+sys.stdout.write('w2')
+print('p2')
+"""
+
+
+@pytest.mark.integration
+def test_bytes_logs():
+    # docker_image = get_test_project_docker_image()
+
+    # ext_config = {}
+
+    # if IS_BUILDKITE:
+    #     ext_config["registry"] = get_buildkite_registry_config()
+    # else:
+    #     find_local_test_image(docker_image)
+
+    @asset
+    def bytes_logs(
+        context: AssetExecutionContext,
+    ):
+        c = PipesDockerClient()
+
+        return c.run(
+            context=context,
+            image="python:3.10-slim",
+            command=[
+                "python",
+                "-c",
+                _print_script,
+            ],
+        ).get_results()
+
+    result = materialize(
+        [bytes_logs],
+        raise_on_error=False,
+    )
+    assert result.success


### PR DESCRIPTION
the API docs dont make this clear but we found a repro where bytes instead of str were returned so handle it

## How I Tested These Changes

added test case