### PR TITLE
[gql] Add user tag to reported runless event

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/__init__.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/__init__.py
@@ -1,7 +1,7 @@
 import asyncio
 import os
 import sys
-from typing import TYPE_CHECKING, Any, AsyncIterator, Optional, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, Any, AsyncIterator, Mapping, Optional, Sequence, Tuple, Union
 
 # re-exports
 import dagster._check as check
@@ -383,14 +383,15 @@ def create_asset_event(
     asset_key: AssetKey,
     partition_key: Optional[str],
     description: Optional[str],
+    tags: Optional[Mapping[str, str]],
 ) -> Union[AssetMaterialization, AssetObservation]:
     if event_type == DagsterEventType.ASSET_MATERIALIZATION:
         return AssetMaterialization(
-            asset_key=asset_key, partition=partition_key, description=description
+            asset_key=asset_key, partition=partition_key, description=description, tags=tags
         )
     elif event_type == DagsterEventType.ASSET_OBSERVATION:
         return AssetObservation(
-            asset_key=asset_key, partition=partition_key, description=description
+            asset_key=asset_key, partition=partition_key, description=description, tags=tags
         )
     else:
         check.failed(f"Unexpected event type {event_type}")
@@ -402,6 +403,7 @@ def report_runless_asset_events(
     asset_key: AssetKey,
     partition_keys: Optional[Sequence[str]] = None,
     description: Optional[str] = None,
+    tags: Optional[Mapping[str, str]] = None,
 ) -> "GrapheneReportRunlessAssetEventsSuccess":
     from ...schema.roots.mutation import GrapheneReportRunlessAssetEventsSuccess
 
@@ -410,11 +412,11 @@ def report_runless_asset_events(
     if partition_keys is not None:
         for partition_key in partition_keys:
             instance.report_runless_asset_event(
-                create_asset_event(event_type, asset_key, partition_key, description)
+                create_asset_event(event_type, asset_key, partition_key, description, tags)
             )
     else:
         instance.report_runless_asset_event(
-            create_asset_event(event_type, asset_key, None, description)
+            create_asset_event(event_type, asset_key, None, description, tags)
         )
 
     return GrapheneReportRunlessAssetEventsSuccess(assetKey=asset_key)

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/mutation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/mutation.py
@@ -717,7 +717,7 @@ class GrapheneReportRunlessAssetEventsMutation(graphene.Mutation):
         partition_keys = eventParams.get("partitionKeys", None)
         description = eventParams.get("description", None)
 
-        viewer_tags = {**graphene_info.context.get_viewer_tags()}
+        reporting_user_tags = {**graphene_info.context.get_reporting_user_tags()}
 
         return report_runless_asset_events(
             graphene_info,
@@ -725,7 +725,7 @@ class GrapheneReportRunlessAssetEventsMutation(graphene.Mutation):
             asset_key=asset_key,
             partition_keys=partition_keys,
             description=description,
-            tags=viewer_tags,
+            tags=reporting_user_tags,
         )
 
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/mutation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/mutation.py
@@ -717,12 +717,15 @@ class GrapheneReportRunlessAssetEventsMutation(graphene.Mutation):
         partition_keys = eventParams.get("partitionKeys", None)
         description = eventParams.get("description", None)
 
+        viewer_tags = {**graphene_info.context.get_viewer_tags()}
+
         return report_runless_asset_events(
             graphene_info,
             event_type=event_type,
             asset_key=asset_key,
             partition_keys=partition_keys,
             description=description,
+            tags=viewer_tags,
         )
 
 

--- a/python_modules/dagster/dagster/_core/definitions/events.py
+++ b/python_modules/dagster/dagster/_core/definitions/events.py
@@ -21,11 +21,6 @@ import dagster._seven as seven
 from dagster._annotations import PublicAttr, deprecated, experimental_param, public
 from dagster._core.definitions.data_version import DATA_VERSION_TAG, DataVersion
 from dagster._core.storage.tags import MULTIDIMENSIONAL_PARTITION_PREFIX, SYSTEM_TAG_PREFIX
-from dagster._core.definitions.data_version import DataVersion
-from dagster._core.storage.tags import (
-    MULTIDIMENSIONAL_PARTITION_PREFIX,
-    is_system_tag,
-)
 from dagster._serdes import whitelist_for_serdes
 from dagster._serdes.serdes import NamedTupleSerializer
 
@@ -463,7 +458,7 @@ class AssetObservation(
             asset_key = AssetKey(asset_key)
 
         tags = check.opt_mapping_param(tags, "tags", key_type=str, value_type=str)
-        if any([not is_system_tag(tag) for tag in tags or {}]):
+        if any([not tag.startswith(SYSTEM_TAG_PREFIX) for tag in tags or {}]):
             check.failed(
                 "Users should not pass values into the tags argument for AssetMaterializations. "
                 "The tags argument is reserved for system-populated tags."
@@ -567,7 +562,7 @@ class AssetMaterialization(
             asset_key = AssetKey(asset_key)
 
         check.opt_mapping_param(tags, "tags", key_type=str, value_type=str)
-        invalid_tags = [tag for tag in tags or {} if not is_system_tag(tag)]
+        invalid_tags = [tag for tag in tags or {} if not tag.startswith(SYSTEM_TAG_PREFIX)]
         if len(invalid_tags) > 0:
             check.failed(
                 f"Invalid tags: {tags} Users should not pass values into the tags argument for"

--- a/python_modules/dagster/dagster/_core/definitions/events.py
+++ b/python_modules/dagster/dagster/_core/definitions/events.py
@@ -21,6 +21,11 @@ import dagster._seven as seven
 from dagster._annotations import PublicAttr, deprecated, experimental_param, public
 from dagster._core.definitions.data_version import DATA_VERSION_TAG, DataVersion
 from dagster._core.storage.tags import MULTIDIMENSIONAL_PARTITION_PREFIX, SYSTEM_TAG_PREFIX
+from dagster._core.definitions.data_version import DataVersion
+from dagster._core.storage.tags import (
+    MULTIDIMENSIONAL_PARTITION_PREFIX,
+    is_system_tag,
+)
 from dagster._serdes import whitelist_for_serdes
 from dagster._serdes.serdes import NamedTupleSerializer
 
@@ -458,7 +463,7 @@ class AssetObservation(
             asset_key = AssetKey(asset_key)
 
         tags = check.opt_mapping_param(tags, "tags", key_type=str, value_type=str)
-        if any([not tag.startswith(SYSTEM_TAG_PREFIX) for tag in tags or {}]):
+        if any([not is_system_tag(tag) for tag in tags or {}]):
             check.failed(
                 "Users should not pass values into the tags argument for AssetMaterializations. "
                 "The tags argument is reserved for system-populated tags."
@@ -562,7 +567,7 @@ class AssetMaterialization(
             asset_key = AssetKey(asset_key)
 
         check.opt_mapping_param(tags, "tags", key_type=str, value_type=str)
-        invalid_tags = [tag for tag in tags or {} if not tag.startswith(SYSTEM_TAG_PREFIX)]
+        invalid_tags = [tag for tag in tags or {} if not is_system_tag(tag)]
         if len(invalid_tags) > 0:
             check.failed(
                 f"Invalid tags: {tags} Users should not pass values into the tags argument for"

--- a/python_modules/dagster/dagster/_core/storage/tags.py
+++ b/python_modules/dagster/dagster/_core/storage/tags.py
@@ -109,3 +109,7 @@ def check_reserved_tags(tags):
                 not tag.startswith(SYSTEM_TAG_PREFIX),
                 desc=f"Attempted to set tag with reserved system prefix: {tag}",
             )
+
+
+def is_system_tag(tag):
+    return tag.startswith(SYSTEM_TAG_PREFIX) or tag.startswith(HIDDEN_TAG_PREFIX) or tag == USER_TAG

--- a/python_modules/dagster/dagster/_core/storage/tags.py
+++ b/python_modules/dagster/dagster/_core/storage/tags.py
@@ -63,9 +63,11 @@ AUTO_OBSERVE_TAG = f"{SYSTEM_TAG_PREFIX}auto_observe"
 RUN_WORKER_ID_TAG = f"{HIDDEN_TAG_PREFIX}run_worker"
 GLOBAL_CONCURRENCY_TAG = f"{SYSTEM_TAG_PREFIX}concurrency_key"
 
-# In cloud, we tag runs with the email of the user who triggered the run
-# This is used to display the user in the UI
+# This tag is used to tag runs and backfills with the email of the creator.
 USER_TAG = "user"
+
+# This tag is used to tag runless asset events reported via the UI with the email of the reporting user.
+REPORTING_USER_TAG = f"{SYSTEM_TAG_PREFIX}reporting_user"
 
 RUN_ISOLATION_TAG = f"{SYSTEM_TAG_PREFIX}isolation"
 
@@ -109,7 +111,3 @@ def check_reserved_tags(tags):
                 not tag.startswith(SYSTEM_TAG_PREFIX),
                 desc=f"Attempted to set tag with reserved system prefix: {tag}",
             )
-
-
-def is_system_tag(tag: str) -> bool:
-    return tag.startswith(SYSTEM_TAG_PREFIX) or tag.startswith(HIDDEN_TAG_PREFIX) or tag == USER_TAG

--- a/python_modules/dagster/dagster/_core/storage/tags.py
+++ b/python_modules/dagster/dagster/_core/storage/tags.py
@@ -111,5 +111,5 @@ def check_reserved_tags(tags):
             )
 
 
-def is_system_tag(tag):
+def is_system_tag(tag: str) -> bool:
     return tag.startswith(SYSTEM_TAG_PREFIX) or tag.startswith(HIDDEN_TAG_PREFIX) or tag == USER_TAG

--- a/python_modules/dagster/dagster/_core/workspace/context.py
+++ b/python_modules/dagster/dagster/_core/workspace/context.py
@@ -139,6 +139,9 @@ class BaseWorkspaceRequestContext(IWorkspace):
     def get_viewer_tags(self) -> Dict[str, str]:
         return {}
 
+    def get_reporting_user_tags(self) -> Dict[str, str]:
+        return {}
+
     def get_code_location(self, location_name: str) -> CodeLocation:
         location_entry = self.get_location_entry(location_name)
         if not location_entry:


### PR DESCRIPTION
This PR tags runless events reported via graphQL with a tag corresponding to the cloud user. This enables displaying which user reported a specific event.

Prior, the user tag was only used on runs. This PR is the first place where we will begin storing the user tag on events.

Test added in internal: https://github.com/dagster-io/internal/pull/7122