### PR TITLE
Add requestedAssetMaterializations to the tick graphql type

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -2391,6 +2391,7 @@ type InstigationTick {
   endTimestamp: Float
   requestedAssetKeys: [AssetKey!]!
   requestedAssetMaterializationCount: Int!
+  requestedMaterializationsForAssets: [RequestedMaterializationsForAsset!]!
   autoMaterializeAssetEvaluationId: Int
 }
 
@@ -2411,6 +2412,11 @@ type DynamicPartitionsRequestResult {
   partitionsDefName: String!
   type: DynamicPartitionsRequestType!
   skippedPartitionKeys: [String!]!
+}
+
+type RequestedMaterializationsForAsset {
+  assetKey: AssetKey!
+  partitionKeys: [String!]!
 }
 
 type ScheduleData {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -1551,6 +1551,7 @@ export type InstigationTick = {
   originRunIds: Array<Scalars['String']>;
   requestedAssetKeys: Array<AssetKey>;
   requestedAssetMaterializationCount: Scalars['Int'];
+  requestedMaterializationsForAssets: Array<RequestedMaterializationsForAsset>;
   runIds: Array<Scalars['String']>;
   runKeys: Array<Scalars['String']>;
   runs: Array<Run>;
@@ -3223,6 +3224,12 @@ export type RepositoryOrigin = {
 export type RepositorySelector = {
   repositoryLocationName: Scalars['String'];
   repositoryName: Scalars['String'];
+};
+
+export type RequestedMaterializationsForAsset = {
+  __typename: 'RequestedMaterializationsForAsset';
+  assetKey: AssetKey;
+  partitionKeys: Array<Scalars['String']>;
 };
 
 export type Resource = {
@@ -7271,6 +7278,10 @@ export const buildInstigationTick = (
       overrides && overrides.hasOwnProperty('requestedAssetMaterializationCount')
         ? overrides.requestedAssetMaterializationCount!
         : 412,
+    requestedMaterializationsForAssets:
+      overrides && overrides.hasOwnProperty('requestedMaterializationsForAssets')
+        ? overrides.requestedMaterializationsForAssets!
+        : [],
     runIds: overrides && overrides.hasOwnProperty('runIds') ? overrides.runIds! : [],
     runKeys: overrides && overrides.hasOwnProperty('runKeys') ? overrides.runKeys! : [],
     runs: overrides && overrides.hasOwnProperty('runs') ? overrides.runs! : [],
@@ -10342,6 +10353,25 @@ export const buildRepositorySelector = (
         : 'facere',
     repositoryName:
       overrides && overrides.hasOwnProperty('repositoryName') ? overrides.repositoryName! : 'ipsam',
+  };
+};
+
+export const buildRequestedMaterializationsForAsset = (
+  overrides?: Partial<RequestedMaterializationsForAsset>,
+  _relationshipsToOmit: Set<string> = new Set(),
+): {__typename: 'RequestedMaterializationsForAsset'} & RequestedMaterializationsForAsset => {
+  const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
+  relationshipsToOmit.add('RequestedMaterializationsForAsset');
+  return {
+    __typename: 'RequestedMaterializationsForAsset',
+    assetKey:
+      overrides && overrides.hasOwnProperty('assetKey')
+        ? overrides.assetKey!
+        : relationshipsToOmit.has('AssetKey')
+        ? ({} as AssetKey)
+        : buildAssetKey({}, relationshipsToOmit),
+    partitionKeys:
+      overrides && overrides.hasOwnProperty('partitionKeys') ? overrides.partitionKeys! : [],
   };
 };
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
@@ -224,6 +224,14 @@ class GrapheneDynamicPartitionsRequestResult(DynamicPartitionsRequestMixin, grap
         return self._dynamic_partitions_request_result.skipped_partitions
 
 
+class GrapheneRequestedMaterializationsForAsset(graphene.ObjectType):
+    assetKey = graphene.NonNull(GrapheneAssetKey)
+    partitionKeys = non_null_list(graphene.String)
+
+    class Meta:
+        name = "RequestedMaterializationsForAsset"
+
+
 class GrapheneInstigationTick(graphene.ObjectType):
     id = graphene.NonNull(graphene.ID)
     status = graphene.NonNull(GrapheneInstigationTickStatus)
@@ -241,6 +249,7 @@ class GrapheneInstigationTick(graphene.ObjectType):
     endTimestamp = graphene.Field(graphene.Float)
     requestedAssetKeys = non_null_list(GrapheneAssetKey)
     requestedAssetMaterializationCount = graphene.NonNull(graphene.Int)
+    requestedMaterializationsForAssets = non_null_list(GrapheneRequestedMaterializationsForAsset)
     autoMaterializeAssetEvaluationId = graphene.Field(graphene.Int)
 
     class Meta:
@@ -293,6 +302,14 @@ class GrapheneInstigationTick(graphene.ObjectType):
     def resolve_requestedAssetKeys(self, _):
         return [
             GrapheneAssetKey(path=asset_key.path) for asset_key in self._tick.requested_asset_keys
+        ]
+
+    def resolve_requestedMaterializationsForAssets(self, _):
+        return [
+            GrapheneRequestedMaterializationsForAsset(
+                assetKey=GrapheneAssetKey(path=asset_key.path), partitionKeys=list(partition_keys)
+            )
+            for asset_key, partition_keys in self._tick.requested_assets_and_partitions.items()
         ]
 
     def resolve_requestedAssetMaterializationCount(self, _):


### PR DESCRIPTION
Summary:
This is much simpler to query for when rendering the tick timeline and allows us to avoid a separate query to the evaluation table - no need to dig into specific rule evaluations or anything like that. (If we did want to show skips and discards, then we would need the rule output).

Added a new graphql type with an asset key and >=0 partition keys. If it's 0, it means the asset is unpartitioned (it being in the list means that it had to have something requested, so there's no ambiguous states there). If it's >=1, the specific partition keys are included on the object.

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes
