### PR TITLE
Fix cache key for asset graph

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
@@ -61,7 +61,7 @@ const _assetLayoutCacheKey = (graphData: GraphData) => {
   return JSON.stringify({
     downstream: recreateObjectWithKeysSorted(graphData.downstream),
     upstream: recreateObjectWithKeysSorted(graphData.upstream),
-    nodes: Object.keys(graphData).sort(),
+    nodes: Object.keys(graphData.nodes).sort(),
   });
 };
 


### PR DESCRIPTION
## Summary & Motivation

We should be using the node IDs as part of the cache key, not the keys of GraphData (which would be the same for every graph)

## How I Tested These Changes

Locally checked that two graphs with no upstream/downstreams had different graphs