### PR TITLE
[auto-materialize][perf] Prefetch asset records for source assets as well

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -115,11 +115,7 @@ class AssetDaemonContext:
 
         # fetch some data in advance to batch some queries
         self.instance_queryer.prefetch_asset_records(
-            [
-                key
-                for key in self.target_asset_keys_and_parents
-                if not self.asset_graph.is_source(key)
-            ]
+            [key for key in self.target_asset_keys_and_parents]
         )
 
     @property

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -152,9 +152,7 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
         return asset_key in self._asset_record_cache
 
     def get_asset_record(self, asset_key: AssetKey) -> Optional["AssetRecord"]:
-        if asset_key not in self.asset_graph.materializable_asset_keys:
-            return None
-        elif asset_key not in self._asset_record_cache:
+        if asset_key not in self._asset_record_cache:
             self._asset_record_cache[asset_key] = next(
                 iter(self.instance.get_asset_records([asset_key])), None
             )

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -152,7 +152,9 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
         return asset_key in self._asset_record_cache
 
     def get_asset_record(self, asset_key: AssetKey) -> Optional["AssetRecord"]:
-        if asset_key not in self._asset_record_cache:
+        if asset_key not in self.asset_graph.materializable_asset_keys:
+            return None
+        elif asset_key not in self._asset_record_cache:
             self._asset_record_cache[asset_key] = next(
                 iter(self.instance.get_asset_records([asset_key])), None
             )


### PR DESCRIPTION
## Summary & Motivation

Source assets have asset records, so we should prefetch these as well. Significantly reduces the time for the test to run (on my machine: 11.7s -> 5.5s)

## How I Tested These Changes
