### PR TITLE
feat(dbt-cloud): poll the cached compile run if it is ongoing

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/asset_defs.py
@@ -1,6 +1,7 @@
 import json
 import shlex
 from argparse import Namespace
+from contextlib import suppress
 from typing import (
     Any,
     Callable,
@@ -164,6 +165,10 @@ class DbtCloudCacheableAssetsDefinition(CacheableAssetsDefinition):
         return dbt_compile_options
 
     def _get_cached_compile_dbt_cloud_job_run(self, compile_run_id: int) -> Tuple[int, int]:
+        # If the compile run is ongoing, allow it a grace period of 10 minutes to finish.
+        with suppress(Exception):
+            self._dbt_cloud.poll_run(run_id=compile_run_id, poll_timeout=600)
+
         compile_run = self._dbt_cloud.get_run(
             run_id=compile_run_id, include_related=["trigger", "run_steps"]
         )


### PR DESCRIPTION
## Summary & Motivation
In cases where the cached run is ongoing and a schedule has triggered a run of a dbt Cloud job, allow the computation to proceed if the cached run successfully terminates within 10 minutes. 

## How I Tested These Changes
existing pytest