### PR TITLE
Fix bug where selecting a partition clears the launchpad and typing in the config clears the partition

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/ExecutionSessionStorage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/ExecutionSessionStorage.tsx
@@ -2,6 +2,7 @@ import memoize from 'lodash/memoize';
 import * as React from 'react';
 
 import {AssetKeyInput} from '../graphql/types';
+import {useSetStateUpdateCallback} from '../hooks/useSetStateUpdateCallback';
 import {getJSONForKey, useStateWithStorage} from '../hooks/useStateWithStorage';
 import {
   LaunchpadSessionPartitionSetsFragment,
@@ -125,7 +126,7 @@ export function applyCreateSession(
   };
 }
 
-type StorageHook = [IStorageData, (data: IStorageData) => void];
+type StorageHook = [IStorageData, (data: React.SetStateAction<IStorageData>) => void];
 
 const buildValidator =
   (initial: Partial<IExecutionSession> = {}) =>
@@ -164,7 +165,10 @@ export function useExecutionSessionStorage(
   );
 
   const [state, setState] = useStateWithStorage(key, validator);
-  const wrappedSetState = writeLaunchpadSessionToStorage(setState);
+  const wrappedSetState = useSetStateUpdateCallback(
+    state,
+    writeLaunchpadSessionToStorage(setState),
+  );
 
   return [state, wrappedSetState];
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/ConfigEditorConfigPicker.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/ConfigEditorConfigPicker.tsx
@@ -309,7 +309,7 @@ const ConfigEditorPartitionPicker: React.FC<ConfigEditorPartitionPickerProps> = 
           </Button>
         ) : null}
         <CreatePartitionDialog
-          key={showCreatePartition ? '1' : '0'}
+          key={showCreatePartition ? 'showCreatePartition::1' : 'showCreatePartition::0'}
           isOpen={showCreatePartition}
           partitionDefinitionName={partitionDefinitionName}
           repoAddress={repoAddress}

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/ConfigEditorConfigPicker.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/ConfigEditorConfigPicker.tsx
@@ -280,7 +280,6 @@ const ConfigEditorPartitionPicker: React.FC<ConfigEditorPartitionPickerProps> = 
     return (
       <>
         <Suggest<Partition>
-          key={selected ? selected.name : 'none'}
           defaultSelectedItem={selected}
           items={partitions}
           inputProps={inputProps}
@@ -309,7 +308,7 @@ const ConfigEditorPartitionPicker: React.FC<ConfigEditorPartitionPickerProps> = 
           </Button>
         ) : null}
         <CreatePartitionDialog
-          key={showCreatePartition ? 'showCreatePartition::1' : 'showCreatePartition::0'}
+          key={showCreatePartition ? '1' : '0'}
           isOpen={showCreatePartition}
           partitionDefinitionName={partitionDefinitionName}
           repoAddress={repoAddress}

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/ConfigEditorConfigPicker.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/ConfigEditorConfigPicker.tsx
@@ -273,9 +273,14 @@ const ConfigEditorPartitionPicker: React.FC<ConfigEditorPartitionPickerProps> = 
       });
     }
 
+    // Note: We don't want this Suggest to be a fully "controlled" React component.
+    // Keeping it's state is annoyign and we only want to update our data model on
+    // selection change. However, we need to set an initial value (defaultSelectedItem)
+    // and ensure it is re-applied to the internal state when it changes (via `key` below).
     return (
       <>
         <Suggest<Partition>
+          key={selected ? selected.name : 'none'}
           defaultSelectedItem={selected}
           items={partitions}
           inputProps={inputProps}
@@ -303,21 +308,24 @@ const ConfigEditorPartitionPicker: React.FC<ConfigEditorPartitionPickerProps> = 
             Add new partition
           </Button>
         ) : null}
-        <CreatePartitionDialog
-          key={showCreatePartition ? '1' : '0'}
-          isOpen={showCreatePartition}
-          partitionDefinitionName={partitionDefinitionName}
-          repoAddress={repoAddress}
-          close={() => {
-            setShowCreatePartition(false);
-          }}
-          refetch={async () => {
-            await refetch();
-          }}
-          onCreated={(partitionName) => {
-            onSelect(repositorySelector, partitionSetName, partitionName);
-          }}
-        />
+        {/* Wrapper div to avoid any key conflicts with the key on the Suggestion component */}
+        <div>
+          <CreatePartitionDialog
+            key={showCreatePartition ? '1' : '0'}
+            isOpen={showCreatePartition}
+            partitionDefinitionName={partitionDefinitionName}
+            repoAddress={repoAddress}
+            close={() => {
+              setShowCreatePartition(false);
+            }}
+            refetch={async () => {
+              await refetch();
+            }}
+            onCreated={(partitionName) => {
+              onSelect(repositorySelector, partitionSetName, partitionName);
+            }}
+          />
+        </div>
       </>
     );
   },

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/ConfigEditorConfigPicker.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/ConfigEditorConfigPicker.tsx
@@ -273,10 +273,6 @@ const ConfigEditorPartitionPicker: React.FC<ConfigEditorPartitionPickerProps> = 
       });
     }
 
-    // Note: We don't want this Suggest to be a fully "controlled" React component.
-    // Keeping it's state is annoyign and we only want to update our data model on
-    // selection change. However, we need to set an initial value (defaultSelectedItem)
-    // and ensure it is re-applied to the internal state when it changes (via `key` below).
     return (
       <>
         <Suggest<Partition>

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadSession.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadSession.tsx
@@ -80,7 +80,7 @@ type Preset = ConfigEditorPipelinePresetFragment;
 
 interface LaunchpadSessionProps {
   session: IExecutionSession;
-  onSave: (changes: IExecutionSessionChanges) => void;
+  onSave: (changes: React.SetStateAction<IExecutionSessionChanges>) => void;
   launchpadType: LaunchpadType;
   pipeline: LaunchpadSessionPipelineFragment;
   partitionSets: LaunchpadSessionPartitionSetsFragment;
@@ -166,7 +166,7 @@ const LaunchpadSession: React.FC<LaunchpadSessionProps> = (props) => {
   const {
     launchpadType,
     session: currentSession,
-    onSave,
+    onSave: onSaveSession,
     partitionSets,
     pipeline,
     repoAddress,
@@ -212,10 +212,6 @@ const LaunchpadSession: React.FC<LaunchpadSessionProps> = (props) => {
       mounted.current = false;
     };
   });
-
-  const onSaveSession = (changes: IExecutionSessionChanges) => {
-    onSave(changes);
-  };
 
   const onConfigChange = (config: any) => {
     onSaveSession({
@@ -487,7 +483,12 @@ const LaunchpadSession: React.FC<LaunchpadSessionProps> = (props) => {
           body: <PythonErrorInfo error={partition.runConfigOrError} />,
         });
       } else {
-        runConfigYaml = partition.runConfigOrError.yaml;
+        runConfigYaml = yaml.stringify(
+          merge(
+            yaml.parse(sanitizeConfigYamlString(partition.runConfigOrError.yaml)),
+            yaml.parse(sanitizeConfigYamlString(currentSession.runConfigYaml)),
+          ),
+        );
       }
 
       const solidSelection = sessionSolidSelection || partition.solidSelection;

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadSetupFromRunRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadSetupFromRunRoot.tsx
@@ -101,7 +101,7 @@ const LaunchpadSetupFromRunAllowedRoot: React.FC<Props> = (props) => {
         newSession.solidSelection = [solidSelection];
       }
 
-      onSave(applyCreateSession(storageData, newSession));
+      onSave((storageData) => applyCreateSession(storageData, newSession));
     }
   }, [run, storageData, onSave]);
 

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadSetupRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadSetupRoot.tsx
@@ -43,7 +43,7 @@ const LaunchpadSetupAllowedRoot: React.FC<Props> = (props) => {
 
   useJobTitle(explorerPath, isJob);
 
-  const [data, onSave] = useExecutionSessionStorage(repoAddress, pipelineName);
+  const [_, onSave] = useExecutionSessionStorage(repoAddress, pipelineName);
   const queryString = qs.parse(window.location.search, {ignoreQueryPrefix: true});
 
   React.useEffect(() => {
@@ -78,7 +78,7 @@ const LaunchpadSetupAllowedRoot: React.FC<Props> = (props) => {
         newSession.assetSelection = queryString.assetSelection as any;
       }
 
-      onSave(applyCreateSession(data, newSession));
+      onSave((data) => applyCreateSession(data, newSession));
     }
   });
 

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadStoredSessionsContainer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadStoredSessionsContainer.tsx
@@ -8,6 +8,7 @@ import {
   useInitialDataForMode,
 } from '../app/ExecutionSessionStorage';
 import {useFeatureFlags} from '../app/Flags';
+import {useSetStateUpdateCallback} from '../hooks/useSetStateUpdateCallback';
 import {RepoAddress} from '../workspace/types';
 
 import LaunchpadSession from './LaunchpadSession';
@@ -42,11 +43,14 @@ export const LaunchpadStoredSessionsContainer = (props: Props) => {
     onSave(applyCreateSession(data, initialDataForMode));
   };
 
-  const onSaveSession = (changes: IExecutionSessionChanges) => {
-    onSave(applyChangesToSession(data, data.current, changes));
-  };
-
   const currentSession = data.sessions[data.current]!;
+
+  const onSaveSession = useSetStateUpdateCallback<IExecutionSessionChanges>(
+    currentSession,
+    (changes: IExecutionSessionChanges) => {
+      onSave(applyChangesToSession(data, data.current, changes));
+    },
+  );
 
   return (
     <>

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadStoredSessionsContainer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadStoredSessionsContainer.tsx
@@ -40,7 +40,7 @@ export const LaunchpadStoredSessionsContainer = (props: Props) => {
   const [data, onSave] = useExecutionSessionStorage(repoAddress, pipeline.name, initialDataForMode);
 
   const onCreateSession = () => {
-    onSave(applyCreateSession(data, initialDataForMode));
+    onSave((data) => applyCreateSession(data, initialDataForMode));
   };
 
   const currentSession = data.sessions[data.current]!;
@@ -48,7 +48,7 @@ export const LaunchpadStoredSessionsContainer = (props: Props) => {
   const onSaveSession = useSetStateUpdateCallback<IExecutionSessionChanges>(
     currentSession,
     (changes: IExecutionSessionChanges) => {
-      onSave(applyChangesToSession(data, data.current, changes));
+      onSave((data) => applyChangesToSession(data, data.current, changes));
     },
   );
 

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadTabs.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadTabs.tsx
@@ -87,7 +87,7 @@ const REMOVE_ALL_THRESHOLD = 3;
 interface LaunchpadTabsProps {
   data: IStorageData;
   onCreate: () => void;
-  onSave: (data: IStorageData) => void;
+  onSave: (data: React.SetStateAction<IStorageData>) => void;
 }
 
 export const LaunchpadTabs = (props: LaunchpadTabsProps) => {
@@ -120,12 +120,13 @@ export const LaunchpadTabs = (props: LaunchpadTabsProps) => {
       description: 'All configuration tabs will be discarded.',
     });
 
-    let updatedData = data;
-    sessionKeys.forEach((keyToRemove) => {
-      updatedData = applyRemoveSession(updatedData, keyToRemove);
+    onSave((data) => {
+      let updatedData = data;
+      sessionKeys.forEach((keyToRemove) => {
+        updatedData = applyRemoveSession(updatedData, keyToRemove);
+      });
+      return updatedData;
     });
-
-    onSave(updatedData);
   };
 
   return (

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadTransientSessionContainer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadTransientSessionContainer.tsx
@@ -7,6 +7,7 @@ import {
   useInitialDataForMode,
 } from '../app/ExecutionSessionStorage';
 import {useFeatureFlags} from '../app/Flags';
+import {useSetStateUpdateCallback} from '../hooks/useSetStateUpdateCallback';
 import {RepoAddress} from '../workspace/types';
 
 import LaunchpadSession from './LaunchpadSession';
@@ -45,10 +46,12 @@ export const LaunchpadTransientSessionContainer = (props: Props) => {
 
   const [session, setSession] = React.useState<IExecutionSession>(initialSessionComplete);
 
-  const onSaveSession = (changes: IExecutionSessionChanges) => {
-    const newSession = {...session, ...changes};
-    setSession(newSession);
-  };
+  const onSaveSession = useSetStateUpdateCallback<IExecutionSessionChanges>(
+    session,
+    (changes: IExecutionSessionChanges) => {
+      setSession((session) => ({...session, ...changes}));
+    },
+  );
 
   return (
     <LaunchpadSession


### PR DESCRIPTION
## Summary & Motivation

As titled fixes those issues.

The issue causing typing to clear the partition:
Multiple saveSessions being batched together where the second call has no idea about changes the first one made. To solve that I made the onSave use React.SetStateAction which allows callers to make sure they're modifying up to date data rather than the data they were last rendered with.
^I believe this is due to the automatic batching in React 18 (https://blog.bitsrc.io/automatic-batching-in-react-18-what-you-should-know-d50141dc096e?gi=d591c60a9986) which we started using due to the next.js change

The causing adding a partition to clear the config:
We weren't merging the default partition config with what was in the launchpad

## How I Tested These Changes
Locally in the launchpad confirmed both issues are fixed