### PR TITLE
break up auto-materialize toys between lazy and eager

### DIFF
--- a/python_modules/dagster-test/dagster_test/toys/auto_materializing/lazy_repo_1.py
+++ b/python_modules/dagster-test/dagster_test/toys/auto_materializing/lazy_repo_1.py
@@ -1,0 +1,33 @@
+from dagster import AutoMaterializePolicy, DailyPartitionsDefinition, asset, repository
+
+daily_partitions_def = DailyPartitionsDefinition(start_date="2023-02-01")
+
+
+@asset(auto_materialize_policy=AutoMaterializePolicy.lazy())
+def lazy_upstream():
+    return 1
+
+
+@asset(auto_materialize_policy=AutoMaterializePolicy.lazy())
+def lazy_downstream_1(lazy_upstream):
+    return lazy_upstream + 1
+
+
+@asset(auto_materialize_policy=AutoMaterializePolicy.lazy(), partitions_def=daily_partitions_def)
+def lazy_upstream_partitioned():
+    return 1
+
+
+@asset(auto_materialize_policy=AutoMaterializePolicy.lazy(), partitions_def=daily_partitions_def)
+def lazy_downstream_1_partitioned(lazy_upstream_partitioned):
+    return lazy_upstream_partitioned + 1
+
+
+@repository
+def lazy_auto_materialize_repo_1():
+    return [
+        lazy_upstream,
+        lazy_downstream_1,
+        lazy_upstream_partitioned,
+        lazy_downstream_1_partitioned,
+    ]

--- a/python_modules/dagster-test/dagster_test/toys/auto_materializing/lazy_repo_2.py
+++ b/python_modules/dagster-test/dagster_test/toys/auto_materializing/lazy_repo_2.py
@@ -1,0 +1,72 @@
+from dagster import (
+    AssetKey,
+    AutoMaterializePolicy,
+    DailyPartitionsDefinition,
+    SourceAsset,
+    asset,
+    repository,
+)
+from dagster._core.definitions.freshness_policy import FreshnessPolicy
+
+### Non partitioned ###
+
+lazy_downstream_1_source = SourceAsset(AssetKey(["lazy_downstream_1"]))
+
+
+@asset(auto_materialize_policy=AutoMaterializePolicy.lazy())
+def lazy_downstream_2(lazy_downstream_1):
+    return lazy_downstream_1 + 2
+
+
+@asset(auto_materialize_policy=AutoMaterializePolicy.lazy())
+def lazy_downstream_3(lazy_downstream_1):
+    return lazy_downstream_1 + 3
+
+
+@asset(
+    auto_materialize_policy=AutoMaterializePolicy.lazy(),
+    freshness_policy=FreshnessPolicy(maximum_lag_minutes=1440),
+)
+def lazy_downstream_4(lazy_downstream_2, lazy_downstream_3):
+    return lazy_downstream_2 + lazy_downstream_3
+
+
+### Partitioned ###
+
+daily_partitions_def = DailyPartitionsDefinition(start_date="2023-02-01")
+
+
+lazy_downstream_1_source_partitioned = SourceAsset(AssetKey(["lazy_downstream_1_partitioned"]))
+
+
+@asset(partitions_def=daily_partitions_def, auto_materialize_policy=AutoMaterializePolicy.lazy())
+def lazy_downstream_2_partitioned(lazy_downstream_1_partitioned):
+    return lazy_downstream_1_partitioned + 2
+
+
+@asset(partitions_def=daily_partitions_def, auto_materialize_policy=AutoMaterializePolicy.lazy())
+def lazy_downstream_3_partitioned(lazy_downstream_1_partitioned):
+    return lazy_downstream_1_partitioned + 3
+
+
+@asset(
+    partitions_def=daily_partitions_def,
+    auto_materialize_policy=AutoMaterializePolicy.lazy(),
+    freshness_policy=FreshnessPolicy(maximum_lag_minutes=1440),
+)
+def lazy_downstream_4_partitioned(lazy_downstream_2_partitioned, lazy_downstream_3_partitioned):
+    return lazy_downstream_2_partitioned + lazy_downstream_3_partitioned
+
+
+@repository
+def lazy_auto_materialize_repo_2():
+    return [
+        lazy_downstream_2,
+        lazy_downstream_3,
+        lazy_downstream_1_source,
+        lazy_downstream_4,
+        lazy_downstream_2_partitioned,
+        lazy_downstream_3_partitioned,
+        lazy_downstream_1_source_partitioned,
+        lazy_downstream_4_partitioned,
+    ]

--- a/python_modules/dagster-test/dagster_test/toys/auto_materializing/repo_1.py
+++ b/python_modules/dagster-test/dagster_test/toys/auto_materializing/repo_1.py
@@ -1,7 +1,8 @@
 from dagster import AutoMaterializePolicy, DailyPartitionsDefinition, asset, repository
 
-
 ### Non partitioned ##
+
+
 @asset(auto_materialize_policy=AutoMaterializePolicy.eager())
 def eager_upstream():
     return 3
@@ -17,18 +18,7 @@ def eager_downstream_1(eager_downstream_0_point_5):
     return eager_downstream_0_point_5 + 1
 
 
-@asset(auto_materialize_policy=AutoMaterializePolicy.lazy())
-def lazy_upstream():
-    return 1
-
-
-@asset(auto_materialize_policy=AutoMaterializePolicy.lazy())
-def lazy_downstream_1(lazy_upstream):
-    return lazy_upstream + 1
-
-
 ### Partitioned ##
-
 
 daily_partitions_def = DailyPartitionsDefinition(start_date="2023-02-01")
 
@@ -52,27 +42,13 @@ def eager_downstream_1_partitioned(eager_upstream_partitioned):
     return eager_upstream_partitioned + 1
 
 
-@asset(auto_materialize_policy=AutoMaterializePolicy.lazy(), partitions_def=daily_partitions_def)
-def lazy_upstream_partitioned():
-    return 1
-
-
-@asset(auto_materialize_policy=AutoMaterializePolicy.lazy(), partitions_def=daily_partitions_def)
-def lazy_downstream_1_partitioned(lazy_upstream_partitioned):
-    return lazy_upstream_partitioned + 1
-
-
 @repository
 def auto_materialize_repo_1():
     return [
         eager_upstream,
         eager_downstream_0_point_5,
         eager_downstream_1,
-        lazy_upstream,
-        lazy_downstream_1,
         eager_upstream_partitioned,
         eager_downstream_1_partitioned,
-        lazy_upstream_partitioned,
-        lazy_downstream_1_partitioned,
         eager_downstream_0_point_5_partitioned,
     ]

--- a/python_modules/dagster-test/dagster_test/toys/auto_materializing/repo_2.py
+++ b/python_modules/dagster-test/dagster_test/toys/auto_materializing/repo_2.py
@@ -6,7 +6,6 @@ from dagster import (
     asset,
     repository,
 )
-from dagster._core.definitions.freshness_policy import FreshnessPolicy
 
 eager_downstream_1_source = SourceAsset(AssetKey(["eager_downstream_1"]))
 
@@ -26,27 +25,6 @@ def eager_downstream_3(eager_downstream_1):
 @asset(auto_materialize_policy=AutoMaterializePolicy.eager())
 def eager_downstream_4(eager_downstream_2, eager_downstream_3):
     return eager_downstream_2 + eager_downstream_3
-
-
-lazy_downstream_1_source = SourceAsset(AssetKey(["lazy_downstream_1"]))
-
-
-@asset(auto_materialize_policy=AutoMaterializePolicy.lazy())
-def lazy_downstream_2(lazy_downstream_1):
-    return lazy_downstream_1 + 2
-
-
-@asset(auto_materialize_policy=AutoMaterializePolicy.lazy())
-def lazy_downstream_3(lazy_downstream_1):
-    return lazy_downstream_1 + 3
-
-
-@asset(
-    auto_materialize_policy=AutoMaterializePolicy.lazy(),
-    freshness_policy=FreshnessPolicy(maximum_lag_minutes=1440),
-)
-def lazy_downstream_4(lazy_downstream_2, lazy_downstream_3):
-    return lazy_downstream_2 + lazy_downstream_3
 
 
 ### Partitioned ###
@@ -73,28 +51,6 @@ def eager_downstream_4_partitioned(eager_downstream_2_partitioned, eager_downstr
     return eager_downstream_2_partitioned + eager_downstream_3_partitioned
 
 
-lazy_downstream_1_source_partitioned = SourceAsset(AssetKey(["lazy_downstream_1_partitioned"]))
-
-
-@asset(partitions_def=daily_partitions_def, auto_materialize_policy=AutoMaterializePolicy.lazy())
-def lazy_downstream_2_partitioned(lazy_downstream_1_partitioned):
-    return lazy_downstream_1_partitioned + 2
-
-
-@asset(partitions_def=daily_partitions_def, auto_materialize_policy=AutoMaterializePolicy.lazy())
-def lazy_downstream_3_partitioned(lazy_downstream_1_partitioned):
-    return lazy_downstream_1_partitioned + 3
-
-
-@asset(
-    partitions_def=daily_partitions_def,
-    auto_materialize_policy=AutoMaterializePolicy.lazy(),
-    freshness_policy=FreshnessPolicy(maximum_lag_minutes=1440),
-)
-def lazy_downstream_4_partitioned(lazy_downstream_2_partitioned, lazy_downstream_3_partitioned):
-    return lazy_downstream_2_partitioned + lazy_downstream_3_partitioned
-
-
 @repository
 def auto_materialize_repo_2():
     return [
@@ -102,16 +58,8 @@ def auto_materialize_repo_2():
         eager_downstream_3,
         eager_downstream_1_source,
         eager_downstream_4,
-        lazy_downstream_2,
-        lazy_downstream_3,
-        lazy_downstream_1_source,
-        lazy_downstream_4,
         eager_downstream_2_partitioned,
         eager_downstream_3_partitioned,
         eager_downstream_1_source_partitioned,
         eager_downstream_4_partitioned,
-        lazy_downstream_2_partitioned,
-        lazy_downstream_3_partitioned,
-        lazy_downstream_1_source_partitioned,
-        lazy_downstream_4_partitioned,
     ]


### PR DESCRIPTION
## Summary & Motivation

I often find myself wanting to play around with eager auto-materialize, but the lazy assets are distracting. This moves them to a different repo where they're out of the way.

## How I Tested These Changes
