### PR TITLE
[auto-materialize][1/n] Keep track of the set of skipped asset partitions in the cursor

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_auto_materialize_asset_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_auto_materialize_asset_evaluations.py
@@ -745,7 +745,7 @@ class TestAutoMaterializeAssetEvaluations(ExecutingGraphQLContextTestMatrix):
 
     def _test_current_evaluation_id(self, graphql_context: WorkspaceRequestContext):
         graphql_context.instance.daemon_cursor_storage.set_cursor_values(
-            {CURSOR_KEY: AssetDaemonCursor.empty().serialize()}
+            {CURSOR_KEY: AssetDaemonCursor.empty().serialize(graphql_context.instance)}
         )
 
         results = execute_dagster_graphql(

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -1,4 +1,5 @@
 import datetime
+import functools
 import itertools
 import logging
 from collections import defaultdict
@@ -19,6 +20,7 @@ from typing import (
 )
 
 import pendulum
+from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 
 import dagster._check as check
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
@@ -288,6 +290,7 @@ class AssetDaemonContext:
         AutoMaterializeAssetEvaluation,
         AbstractSet[AssetKeyPartitionKey],
         AbstractSet[AssetKeyPartitionKey],
+        AbstractSet[AssetKeyPartitionKey],
     ]:
         """Evaluates the auto materialize policy of a given asset key.
 
@@ -304,6 +307,7 @@ class AssetDaemonContext:
             - An AutoMaterializeAssetEvaluation object representing serializable information about
                 this evaluation.
             - The set of AssetKeyPartitionKeys that should be materialized.
+            - The set of AssetKeyPartitionKeys that should be skipped.
             - The set of AssetKeyPartitionKeys that should be discarded.
         """
         auto_materialize_policy = check.not_none(
@@ -428,8 +432,33 @@ class AssetDaemonContext:
                 dynamic_partitions_store=self.instance_queryer,
             ),
             to_materialize,
+            to_skip,
             to_discard,
         )
+
+    @functools.cached_property
+    def skipped_asset_graph_subset(self) -> AssetGraphSubset:
+        subset = self.cursor.skipped_asset_graph_subset or AssetGraphSubset(self.asset_graph)
+        # factor out any asset partitions which have been materialized since last tick
+        for asset_key in self.target_asset_keys:
+            partitions_def = self.asset_graph.get_partitions_def(asset_key)
+            new_asset_partitions = self.instance_queryer.get_asset_partitions_updated_after_cursor(
+                asset_key=asset_key,
+                asset_partitions=None,
+                after_cursor=self.latest_storage_id,
+                respect_materialization_data_versions=False,
+            )
+            subset -= {
+                ap
+                for ap in new_asset_partitions
+                if partitions_def is None
+                # ignore partitions which are invalid
+                or (
+                    ap.partition_key is not None
+                    and partitions_def.has_partition_key(ap.partition_key)
+                )
+            }
+        return subset
 
     def get_auto_materialize_asset_evaluations(
         self,
@@ -437,6 +466,7 @@ class AssetDaemonContext:
         Mapping[AssetKey, AutoMaterializeAssetEvaluation],
         AbstractSet[AssetKeyPartitionKey],
         AbstractSet[AssetKeyPartitionKey],
+        AssetGraphSubset,
     ]:
         """Returns a mapping from asset key to the AutoMaterializeAssetEvaluation for that key, as
         well as a set of all asset partitions that should be materialized this tick.
@@ -450,8 +480,9 @@ class AssetDaemonContext:
         visited_multi_asset_keys = set()
 
         num_checked_assets = 0
-
         num_target_asset_keys = len(self.target_asset_keys)
+
+        skipped_asset_graph_subset = self.skipped_asset_graph_subset
 
         for asset_key in itertools.chain(*self.asset_graph.toposort_asset_keys()):
             # an asset may have already been visited if it was part of a non-subsettable multi-asset
@@ -468,9 +499,12 @@ class AssetDaemonContext:
                 self._logger.debug(f"Asset {asset_key.to_user_string()} already visited")
                 continue
 
-            (evaluation, to_materialize_for_asset, to_discard_for_asset) = self.evaluate_asset(
-                asset_key, will_materialize_mapping, expected_data_time_mapping
-            )
+            (
+                evaluation,
+                to_materialize_for_asset,
+                to_skip_for_asset,
+                to_discard_for_asset,
+            ) = self.evaluate_asset(asset_key, will_materialize_mapping, expected_data_time_mapping)
 
             log_fn = (
                 self._logger.info
@@ -494,6 +528,11 @@ class AssetDaemonContext:
             evaluations_by_key[asset_key] = evaluation
             will_materialize_mapping[asset_key] = to_materialize_for_asset
             to_discard.update(to_discard_for_asset)
+
+            # update set of asset partitions which are currently in the "skipped" state
+            skipped_asset_graph_subset |= to_skip_for_asset
+            skipped_asset_graph_subset -= to_materialize_for_asset | to_discard_for_asset
+
             expected_data_time = get_expected_data_time_for_asset_key(
                 self.asset_graph,
                 asset_key,
@@ -515,20 +554,39 @@ class AssetDaemonContext:
                     if auto_materialize_policy is None:
                         check.failed(f"Expected auto materialize policy on asset {asset_key}")
 
+                    to_materialize_for_neighbor = {
+                        ap._replace(asset_key=neighbor_key) for ap in to_materialize_for_asset
+                    }
+                    to_skip_for_neighbor = {
+                        ap._replace(asset_key=neighbor_key) for ap in to_skip_for_asset
+                    }
+                    to_discard_for_neighbor = {
+                        ap._replace(asset_key=neighbor_key) for ap in to_discard_for_asset
+                    }
+
                     evaluations_by_key[neighbor_key] = evaluation._replace(
                         asset_key=neighbor_key,
                         rule_snapshots=auto_materialize_policy.rule_snapshots,  # Neighbors can have different rule snapshots
                     )
-                    will_materialize_mapping[neighbor_key] = {
-                        ap._replace(asset_key=neighbor_key) for ap in to_materialize_for_asset
-                    }
-                    to_discard.update(
-                        {ap._replace(asset_key=neighbor_key) for ap in to_discard_for_asset}
+                    will_materialize_mapping[neighbor_key] = to_materialize_for_neighbor
+                    to_discard.update(to_discard_for_neighbor)
+
+                    # update set of asset partitions which are currently in the "skipped" state
+                    skipped_asset_graph_subset |= to_skip_for_neighbor
+                    skipped_asset_graph_subset -= (
+                        to_materialize_for_neighbor | to_discard_for_neighbor
                     )
+
                     expected_data_time_mapping[neighbor_key] = expected_data_time
                     visited_multi_asset_keys.add(neighbor_key)
 
-        return evaluations_by_key, set().union(*will_materialize_mapping.values()), to_discard
+        to_materialize = set().union(*will_materialize_mapping.values())
+        return (
+            evaluations_by_key,
+            to_materialize,
+            to_discard,
+            skipped_asset_graph_subset,
+        )
 
     def evaluate(
         self,
@@ -545,7 +603,9 @@ class AssetDaemonContext:
             else []
         )
 
-        evaluations, to_materialize, to_discard = self.get_auto_materialize_asset_evaluations()
+        evaluations, to_materialize, to_discard, skipped_asset_graph_subset = (
+            self.get_auto_materialize_asset_evaluations()
+        )
 
         run_requests = [
             *build_run_requests(
@@ -577,6 +637,7 @@ class AssetDaemonContext:
                     for asset_key in cast(Sequence[AssetKey], run_request.asset_selection)
                 ],
                 observe_request_timestamp=observe_request_timestamp,
+                skipped_asset_graph_subset=skipped_asset_graph_subset,
             ),
             # only record evaluations where something happened
             [

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -20,9 +20,9 @@ from typing import (
 )
 
 import pendulum
-from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 
 import dagster._check as check
+from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.definitions.data_time import CachingDataTimeResolver
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -436,53 +436,29 @@ class AssetDaemonContext:
             to_discard,
         )
 
-    @functools.cached_property
-    def skipped_asset_graph_subset(self) -> AssetGraphSubset:
-        subset = self.cursor.skipped_asset_graph_subset or AssetGraphSubset(self.asset_graph)
-        # factor out any asset partitions which have been materialized since last tick
-        for asset_key in self.target_asset_keys:
-            partitions_def = self.asset_graph.get_partitions_def(asset_key)
-            new_asset_partitions = self.instance_queryer.get_asset_partitions_updated_after_cursor(
-                asset_key=asset_key,
-                asset_partitions=None,
-                after_cursor=self.latest_storage_id,
-                respect_materialization_data_versions=False,
-            )
-            subset -= {
-                ap
-                for ap in new_asset_partitions
-                if partitions_def is None
-                # ignore partitions which are invalid
-                or (
-                    ap.partition_key is not None
-                    and partitions_def.has_partition_key(ap.partition_key)
-                )
-            }
-        return subset
-
     def get_auto_materialize_asset_evaluations(
         self,
     ) -> Tuple[
         Mapping[AssetKey, AutoMaterializeAssetEvaluation],
         AbstractSet[AssetKeyPartitionKey],
         AbstractSet[AssetKeyPartitionKey],
-        AssetGraphSubset,
+        AbstractSet[AssetKeyPartitionKey],
     ]:
         """Returns a mapping from asset key to the AutoMaterializeAssetEvaluation for that key, as
-        well as a set of all asset partitions that should be materialized this tick.
+        well as sets of all asset partitions that should be materialized, skipped, and discarded
+        this tick.
         """
         evaluations_by_key: Dict[AssetKey, AutoMaterializeAssetEvaluation] = {}
         will_materialize_mapping: Dict[AssetKey, AbstractSet[AssetKeyPartitionKey]] = defaultdict(
             set
         )
+        to_skip: Set[AssetKeyPartitionKey] = set()
         to_discard: Set[AssetKeyPartitionKey] = set()
         expected_data_time_mapping: Dict[AssetKey, Optional[datetime.datetime]] = defaultdict()
         visited_multi_asset_keys = set()
 
         num_checked_assets = 0
         num_target_asset_keys = len(self.target_asset_keys)
-
-        skipped_asset_graph_subset = self.skipped_asset_graph_subset
 
         for asset_key in itertools.chain(*self.asset_graph.toposort_asset_keys()):
             # an asset may have already been visited if it was part of a non-subsettable multi-asset
@@ -527,11 +503,8 @@ class AssetDaemonContext:
 
             evaluations_by_key[asset_key] = evaluation
             will_materialize_mapping[asset_key] = to_materialize_for_asset
+            to_skip.update(to_skip_for_asset)
             to_discard.update(to_discard_for_asset)
-
-            # update set of asset partitions which are currently in the "skipped" state
-            skipped_asset_graph_subset |= to_skip_for_asset
-            skipped_asset_graph_subset -= to_materialize_for_asset | to_discard_for_asset
 
             expected_data_time = get_expected_data_time_for_asset_key(
                 self.asset_graph,
@@ -569,28 +542,18 @@ class AssetDaemonContext:
                         rule_snapshots=auto_materialize_policy.rule_snapshots,  # Neighbors can have different rule snapshots
                     )
                     will_materialize_mapping[neighbor_key] = to_materialize_for_neighbor
+                    to_skip.update(to_skip_for_neighbor)
                     to_discard.update(to_discard_for_neighbor)
-
-                    # update set of asset partitions which are currently in the "skipped" state
-                    skipped_asset_graph_subset |= to_skip_for_neighbor
-                    skipped_asset_graph_subset -= (
-                        to_materialize_for_neighbor | to_discard_for_neighbor
-                    )
 
                     expected_data_time_mapping[neighbor_key] = expected_data_time
                     visited_multi_asset_keys.add(neighbor_key)
 
         to_materialize = set().union(*will_materialize_mapping.values())
-        return (
-            evaluations_by_key,
-            to_materialize,
-            to_discard,
-            skipped_asset_graph_subset,
-        )
+        return (evaluations_by_key, to_materialize, to_skip, to_discard)
 
     def evaluate(
         self,
-    ) -> Tuple[Sequence[RunRequest], AssetDaemonCursor, Sequence[AutoMaterializeAssetEvaluation],]:
+    ) -> Tuple[Sequence[RunRequest], AssetDaemonCursor, Sequence[AutoMaterializeAssetEvaluation]]:
         observe_request_timestamp = pendulum.now().timestamp()
         auto_observe_run_requests = (
             get_auto_observe_run_requests(
@@ -603,7 +566,7 @@ class AssetDaemonContext:
             else []
         )
 
-        evaluations, to_materialize, to_discard, skipped_asset_graph_subset = (
+        evaluations, to_materialize, to_skip, to_discard = (
             self.get_auto_materialize_asset_evaluations()
         )
 
@@ -637,7 +600,9 @@ class AssetDaemonContext:
                     for asset_key in cast(Sequence[AssetKey], run_request.asset_selection)
                 ],
                 observe_request_timestamp=observe_request_timestamp,
-                skipped_asset_graph_subset=skipped_asset_graph_subset,
+                skipped_on_last_tick_subset=AssetGraphSubset.from_asset_partition_set(
+                    to_skip, self.asset_graph
+                ),
             ),
             # only record evaluations where something happened
             [

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -1,5 +1,4 @@
 import datetime
-import functools
 import itertools
 import logging
 from collections import defaultdict

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
@@ -54,7 +54,7 @@ class AssetDaemonCursor(NamedTuple):
     handled_root_partitions_by_asset_key: Mapping[AssetKey, PartitionsSubset]
     evaluation_id: int
     last_observe_request_timestamp_by_asset_key: Mapping[AssetKey, float]
-    skipped_asset_graph_subset: Optional[AssetGraphSubset]
+    skipped_on_last_tick_subset: Optional[AssetGraphSubset]
 
     def was_previously_handled(self, asset_key: AssetKey) -> bool:
         return asset_key in self.handled_root_asset_keys
@@ -88,7 +88,7 @@ class AssetDaemonCursor(NamedTuple):
         asset_graph: AssetGraph,
         newly_observe_requested_asset_keys: Sequence[AssetKey],
         observe_request_timestamp: float,
-        skipped_asset_graph_subset: AssetGraphSubset,
+        skipped_on_last_tick_subset: AssetGraphSubset,
     ) -> "AssetDaemonCursor":
         """Returns a cursor that represents this cursor plus the updates that have happened within the
         tick.
@@ -152,7 +152,7 @@ class AssetDaemonCursor(NamedTuple):
             handled_root_partitions_by_asset_key=result_handled_root_partitions_by_asset_key,
             evaluation_id=evaluation_id,
             last_observe_request_timestamp_by_asset_key=result_last_observe_request_timestamp_by_asset_key,
-            skipped_asset_graph_subset=skipped_asset_graph_subset,
+            skipped_on_last_tick_subset=skipped_on_last_tick_subset,
         )
 
     @classmethod
@@ -163,7 +163,7 @@ class AssetDaemonCursor(NamedTuple):
             handled_root_asset_keys=set(),
             evaluation_id=0,
             last_observe_request_timestamp_by_asset_key={},
-            skipped_asset_graph_subset=None,
+            skipped_on_last_tick_subset=None,
         )
 
     @classmethod
@@ -180,7 +180,7 @@ class AssetDaemonCursor(NamedTuple):
 
             evaluation_id = data[3] if len(data) == 4 else 0
             serialized_last_observe_request_timestamp_by_asset_key = {}
-            serialized_skipped_asset_graph_subset = {}
+            serialized_skipped_on_last_tick_subset = {}
         else:
             latest_storage_id = data["latest_storage_id"]
             serialized_handled_root_asset_keys = data["handled_root_asset_keys"]
@@ -191,7 +191,7 @@ class AssetDaemonCursor(NamedTuple):
             serialized_last_observe_request_timestamp_by_asset_key = data.get(
                 "last_observe_request_timestamp_by_asset_key", {}
             )
-            serialized_skipped_asset_graph_subset = data.get("skipped_asset_graph_subset", {})
+            serialized_skipped_on_last_tick_subset = data.get("skipped_on_last_tick_subset", {})
 
         handled_root_partitions_by_asset_key = {}
         for (
@@ -236,13 +236,13 @@ class AssetDaemonCursor(NamedTuple):
                 AssetKey.from_user_string(key_str): timestamp
                 for key_str, timestamp in serialized_last_observe_request_timestamp_by_asset_key.items()
             },
-            skipped_asset_graph_subset=(
+            skipped_on_last_tick_subset=(
                 AssetGraphSubset.from_storage_dict(
-                    serialized_skipped_asset_graph_subset,
+                    serialized_skipped_on_last_tick_subset,
                     asset_graph=asset_graph,
                     allow_partial=True,
                 )
-                if serialized_skipped_asset_graph_subset
+                if serialized_skipped_on_last_tick_subset
                 else None
             ),
         )
@@ -275,9 +275,9 @@ class AssetDaemonCursor(NamedTuple):
                     key.to_user_string(): timestamp
                     for key, timestamp in self.last_observe_request_timestamp_by_asset_key.items()
                 },
-                "skipped_asset_graph_subset": (
-                    self.skipped_asset_graph_subset.to_storage_dict(dynamic_partitions_store)
-                    if self.skipped_asset_graph_subset
+                "skipped_on_last_tick_subset": (
+                    self.skipped_on_last_tick_subset.to_storage_dict(dynamic_partitions_store)
+                    if self.skipped_on_last_tick_subset
                     else None
                 ),
             }

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
@@ -3,7 +3,6 @@ import itertools
 import json
 from collections import defaultdict
 from typing import (
-    TYPE_CHECKING,
     AbstractSet,
     Dict,
     Iterable,
@@ -14,28 +13,21 @@ from typing import (
     Set,
     cast,
 )
-from dagster import deserialize_value
-from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
-from dagster._core.definitions.auto_materialize_rule import AutoMaterializeAssetEvaluation
 
 import dagster._check as check
+from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
 from dagster._core.definitions.time_window_partitions import (
     TimeWindowPartitionsDefinition,
     TimeWindowPartitionsSubset,
 )
 from dagster._core.instance import DynamicPartitionsStore
-from dagster._serdes.serdes import serialize_value
-from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
 
 from .asset_graph import AssetGraph
 from .partition import (
     PartitionsDefinition,
     PartitionsSubset,
 )
-
-if TYPE_CHECKING:
-    from dagster._core.instance import DynamicPartitionsStore
 
 
 class AssetDaemonCursor(NamedTuple):

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
@@ -44,7 +44,7 @@ class AssetGraphSubset:
         return self.partitions_subsets_by_asset_key.keys() | self._non_partitioned_asset_keys
 
     @property
-    def num_partitions_and_non_partitioned_assets(self):
+    def num_partitions_and_non_partitioned_assets(self) -> int:
         return len(self._non_partitioned_asset_keys) + sum(
             len(subset) for subset in self._partitions_subsets_by_asset_key.values()
         )
@@ -182,10 +182,10 @@ class AssetGraphSubset:
         partitions_by_asset_key = defaultdict(set)
         non_partitioned_asset_keys = set()
         for asset_key, partition_key in asset_partitions_set:
-            if partition_key is not None:
-                partitions_by_asset_key[asset_key].add(partition_key)
-            else:
+            if not asset_graph.is_partitioned(asset_key):
                 non_partitioned_asset_keys.add(asset_key)
+            elif partition_key is not None:
+                partitions_by_asset_key[asset_key].add(partition_key)
 
         return AssetGraphSubset(
             partitions_subsets_by_asset_key={

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -232,7 +232,7 @@ class AssetDaemon(IntervalDaemon):
         with AutoMaterializeLaunchContext(
             tick, instance, self._logger, tick_retention_settings
         ) as tick_context:
-            run_requests, new_cursor, evaluations = AssetDaemonContext(
+            asset_daemon_context = AssetDaemonContext(
                 asset_graph=asset_graph,
                 target_asset_keys=target_asset_keys,
                 instance=instance,
@@ -244,7 +244,8 @@ class AssetDaemon(IntervalDaemon):
                 auto_observe=True,
                 respect_materialization_data_versions=instance.auto_materialize_respect_materialization_data_versions,
                 logger=self._logger,
-            ).evaluate()
+            )
+            run_requests, new_cursor, evaluations = asset_daemon_context.evaluate()
 
             self._logger.info(
                 f"Tick produced {len(run_requests)} run{'s' if len(run_requests) != 1 else ''} and"
@@ -314,7 +315,9 @@ class AssetDaemon(IntervalDaemon):
                             run_ids=evaluation.run_ids | {run.run_id}
                         )
 
-            instance.daemon_cursor_storage.set_cursor_values({CURSOR_KEY: new_cursor.serialize()})
+            instance.daemon_cursor_storage.set_cursor_values(
+                {CURSOR_KEY: new_cursor.serialize(asset_daemon_context.instance_queryer)}
+            )
             tick_context.update_state(
                 TickStatus.SUCCESS if len(run_requests) > 0 else TickStatus.SKIPPED,
             )

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
@@ -165,7 +165,6 @@ class AssetReconciliationScenario(
             ("requires_respect_materialization_data_versions", bool),
             ("supports_with_external_asset_graph", bool),
             ("expected_error_message", Optional[str]),
-            ("expected_skipped_subset", Optional[AbstractSet[AssetKeyPartitionKey]]),
         ],
     )
 ):
@@ -189,7 +188,6 @@ class AssetReconciliationScenario(
         requires_respect_materialization_data_versions: bool = False,
         supports_with_external_asset_graph: bool = True,
         expected_error_message: Optional[str] = None,
-        expected_skipped_subset: Optional[AbstractSet[AssetKeyPartitionKey]] = None,
     ) -> "AssetReconciliationScenario":
         # For scenarios with no auto-materialize policies, we infer auto-materialize policies
         # and add them to the assets.
@@ -227,7 +225,6 @@ class AssetReconciliationScenario(
             requires_respect_materialization_data_versions=requires_respect_materialization_data_versions,
             supports_with_external_asset_graph=supports_with_external_asset_graph,
             expected_error_message=expected_error_message,
-            expected_skipped_subset=expected_skipped_subset,
         )
 
     def _get_code_location_origin(
@@ -246,13 +243,6 @@ class AssetReconciliationScenario(
                 + (f"_{location_name}" if location_name else ""),
             ),
             location_name=location_name or "test_location",
-        )
-
-    @property
-    def expected_skipped_asset_graph_subset(self) -> AssetGraphSubset:
-        return AssetGraphSubset.from_asset_partition_set(
-            self.expected_skipped_subset or set(),
-            AssetGraph.from_assets(self.assets or []),
         )
 
     def do_sensor_scenario(

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/auto_materialize_policy_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/auto_materialize_policy_scenarios.py
@@ -819,14 +819,10 @@ auto_materialize_policy_scenarios = {
             unevaluated_runs=[run(["A"])],
             # C must wait for B to be materialized
             expected_run_requests=[],
-            # C is skipped because B is not materialized
-            expected_skipped_subset={AssetKeyPartitionKey(AssetKey("C"))},
         ),
         unevaluated_runs=[run(["B"])],
         # can now run C because the skip rule is no longer true
         expected_run_requests=[run_request(["C"])],
-        # C is no longer skipped
-        expected_skipped_subset=set(),
     ),
     "skipped_subset_partitioned": AssetReconciliationScenario(
         assets=partitioned_vee,
@@ -840,19 +836,10 @@ auto_materialize_policy_scenarios = {
             ],
             # C must wait for B to be materialized
             expected_run_requests=[],
-            # C is skipped because B is not materialized
-            expected_skipped_subset={
-                AssetKeyPartitionKey(AssetKey("C"), partition_key="a"),
-                AssetKeyPartitionKey(AssetKey("C"), partition_key="b"),
-            },
         ),
         unevaluated_runs=[run(["B"], partition_key="a")],
         # can now run C[a] because the skip rule is no longer true
         expected_run_requests=[run_request(["C"], partition_key="a")],
-        # C[a] is no longer skipped
-        expected_skipped_subset={
-            AssetKeyPartitionKey(AssetKey("C"), partition_key="b"),
-        },
     ),
     "skipped_subset_partitioned2": AssetReconciliationScenario(
         assets=partitioned_vee,
@@ -866,20 +853,11 @@ auto_materialize_policy_scenarios = {
             ],
             # C must wait for B to be materialized
             expected_run_requests=[],
-            # C is skipped because B is not materialized
-            expected_skipped_subset={
-                AssetKeyPartitionKey(AssetKey("C"), partition_key="a"),
-                AssetKeyPartitionKey(AssetKey("C"), partition_key="b"),
-            },
         ),
         # manually run C
         unevaluated_runs=[
             run(["C"], partition_key="a"),
         ],
         expected_run_requests=[],
-        # C[a] is no longer skipped because it was executed manually
-        expected_skipped_subset={
-            AssetKeyPartitionKey(AssetKey("C"), partition_key="b"),
-        },
     ),
 }

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/auto_materialize_policy_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/auto_materialize_policy_scenarios.py
@@ -14,7 +14,7 @@ from dagster._core.definitions.auto_materialize_rule import (
     ParentUpdatedRuleEvaluationData,
     WaitingOnAssetsRuleEvaluationData,
 )
-from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
+from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
 from dagster._seven.compat.pendulum import create_pendulum_time
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_cursor.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_cursor.py
@@ -3,6 +3,7 @@ import json
 from dagster import AssetKey, StaticPartitionsDefinition, asset
 from dagster._core.definitions.asset_daemon_cursor import AssetDaemonCursor
 from dagster._core.definitions.asset_graph import AssetGraph
+from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 
 partitions = StaticPartitionsDefinition(partition_keys=["a", "b", "c"])
 
@@ -28,6 +29,7 @@ def test_asset_reconciliation_cursor_evaluation_id_backcompat():
         {AssetKey("my_asset"): partitions.empty_subset().with_partition_keys(["a"])},
         0,
         {},
+        None,
     )
 
     c2 = c.with_updates(
@@ -38,15 +40,16 @@ def test_asset_reconciliation_cursor_evaluation_id_backcompat():
         {AssetKey("my_asset"): {"a"}},
         1,
         asset_graph,
-        {},
+        [],
         0,
+        AssetGraphSubset(asset_graph),
     )
 
-    serdes_c2 = AssetDaemonCursor.from_serialized(c2.serialize(), asset_graph)
+    serdes_c2 = AssetDaemonCursor.from_serialized(c2.serialize(None), asset_graph)
     assert serdes_c2 == c2
     assert serdes_c2.evaluation_id == 1
 
-    assert AssetDaemonCursor.get_evaluation_id_from_serialized(c2.serialize()) == 1
+    assert AssetDaemonCursor.get_evaluation_id_from_serialized(c2.serialize(None)) == 1
 
 
 def test_asset_reconciliation_cursor_auto_observe_backcompat():

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_fast.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_fast.py
@@ -40,7 +40,7 @@ from .scenarios.scenarios import ASSET_RECONCILIATION_SCENARIOS
 )
 def test_reconciliation(scenario, respect_materialization_data_versions):
     instance = DagsterInstance.ephemeral()
-    run_requests, _, evaluations = scenario.do_sensor_scenario(
+    run_requests, cursor, evaluations = scenario.do_sensor_scenario(
         instance, respect_materialization_data_versions=respect_materialization_data_versions
     )
 
@@ -74,6 +74,18 @@ def test_reconciliation(scenario, respect_materialization_data_versions):
                 for evaluation_spec in scenario.expected_evaluations
             ]
         ) == _sorted_evaluations(evaluations)
+
+    if scenario.expected_skipped_subset is not None:
+        # the __eq__ method for AssetGraphSubset ends up checking for object equality between
+        # the underlying AssetGraphs, so we just compare the important bits.
+        assert (
+            cursor.skipped_asset_graph_subset.non_partitioned_asset_keys
+            == scenario.expected_skipped_asset_graph_subset.non_partitioned_asset_keys
+        )
+        assert (
+            cursor.skipped_asset_graph_subset.partitions_subsets_by_asset_key
+            == scenario.expected_skipped_asset_graph_subset.partitions_subsets_by_asset_key
+        )
 
     assert len(run_requests) == len(scenario.expected_run_requests), evaluations
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_fast.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_fast.py
@@ -75,18 +75,6 @@ def test_reconciliation(scenario, respect_materialization_data_versions):
             ]
         ) == _sorted_evaluations(evaluations)
 
-    if scenario.expected_skipped_subset is not None:
-        # the __eq__ method for AssetGraphSubset ends up checking for object equality between
-        # the underlying AssetGraphs, so we just compare the important bits.
-        assert (
-            cursor.skipped_asset_graph_subset.non_partitioned_asset_keys
-            == scenario.expected_skipped_asset_graph_subset.non_partitioned_asset_keys
-        )
-        assert (
-            cursor.skipped_asset_graph_subset.partitions_subsets_by_asset_key
-            == scenario.expected_skipped_asset_graph_subset.partitions_subsets_by_asset_key
-        )
-
     assert len(run_requests) == len(scenario.expected_run_requests), evaluations
 
     def sort_run_request_key_fn(run_request):


### PR DESCRIPTION
## Summary & Motivation

This is part of a larger stack with the goal of making the asset daemon capable of remembering rules which continue to be true for multiple ticks in a row.

This PR is fairly modest, and purely keeps track of the set of skipped asset partitions within the cursor, which will be critical for knowing which asset partitions have things which may have materialization rules which are still true.

## How I Tested These Changes
