### PR TITLE
[auto-materialize][3/n] Recover previous materialization results and merge them

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -586,6 +586,9 @@ class AssetDaemonContext:
                 for evaluation in evaluations_by_asset_key.values()
                 if sum([evaluation.num_requested, evaluation.num_skipped, evaluation.num_discarded])
                 > 0
+                and not evaluation.equivalent_to_stored_evaluation(
+                    self.cursor.latest_evaluation_by_asset_key.get(evaluation.asset_key)
+                )
             ],
         )
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -334,7 +334,6 @@ class AssetDaemonContext:
             will_materialize_mapping=will_materialize_mapping,
             expected_data_time_mapping=expected_data_time_mapping,
             candidates=set(),
-            new_candidates=set(),
             daemon_context=self,
         )
 
@@ -357,9 +356,7 @@ class AssetDaemonContext:
                 to_materialize.update(asset_partitions)
             self._verbose_log_fn("Done evaluating materialize rule")
 
-        skip_context = materialize_context._replace(
-            candidates=to_materialize, new_candidates=new_candidates
-        )
+        skip_context = materialize_context._replace(candidates=to_materialize)
 
         for skip_rule in auto_materialize_policy.skip_rules:
             rule_snapshot = skip_rule.to_snapshot()
@@ -482,7 +479,6 @@ class AssetDaemonContext:
 
             evaluations_by_key[asset_key] = evaluation
             will_materialize_mapping[asset_key] = to_materialize_for_asset
-            to_skip.update(to_skip_for_asset)
             to_discard.update(to_discard_for_asset)
 
             expected_data_time = get_expected_data_time_for_asset_key(
@@ -518,7 +514,6 @@ class AssetDaemonContext:
                         rule_snapshots=auto_materialize_policy.rule_snapshots,  # Neighbors can have different rule snapshots
                     )
                     will_materialize_mapping[neighbor_key] = to_materialize_for_neighbor
-                    to_skip.update(to_skip_for_neighbor)
                     to_discard.update(to_discard_for_neighbor)
 
                     expected_data_time_mapping[neighbor_key] = expected_data_time

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -377,7 +377,6 @@ class AssetDaemonContext:
         to_materialize.difference_update(to_skip)
 
         # this is treated separately from other rules, for now
-        discard_context = dataclasses.replace(skip_context, candidates=to_materialize)
         if auto_materialize_policy.max_materializations_per_minute is not None:
             rule = DiscardOnMaxMaterializationsExceededRule(
                 limit=auto_materialize_policy.max_materializations_per_minute
@@ -386,7 +385,9 @@ class AssetDaemonContext:
 
             self._verbose_log_fn(f"Evaluating discard rule: {rule_snapshot}")
 
-            for evaluation_data, asset_partitions in rule.evaluate_for_asset(discard_context):
+            for evaluation_data, asset_partitions in rule.evaluate_for_asset(
+                dataclasses.replace(skip_context, candidates=to_materialize)
+            ):
                 all_results.append(
                     (
                         AutoMaterializeRuleEvaluation(

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -334,6 +334,7 @@ class AssetDaemonContext:
             will_materialize_mapping=will_materialize_mapping,
             expected_data_time_mapping=expected_data_time_mapping,
             candidates=set(),
+            new_candidates=set(),
             daemon_context=self,
         )
 
@@ -356,7 +357,9 @@ class AssetDaemonContext:
                 to_materialize.update(asset_partitions)
             self._verbose_log_fn("Done evaluating materialize rule")
 
-        skip_context = materialize_context._replace(candidates=to_materialize)
+        skip_context = materialize_context._replace(
+            candidates=to_materialize, new_candidates=new_candidates
+        )
 
         for skip_rule in auto_materialize_policy.skip_rules:
             rule_snapshot = skip_rule.to_snapshot()

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -575,13 +575,11 @@ class AssetDaemonContext:
                 observe_request_timestamp=observe_request_timestamp,
                 evaluations=list(evaluations_by_asset_key.values()),
             ),
-            # only record evaluations where something happened
+            # only record evaluations where something changed
             [
                 evaluation
                 for evaluation in evaluations_by_asset_key.values()
-                if sum([evaluation.num_requested, evaluation.num_skipped, evaluation.num_discarded])
-                > 0
-                and not evaluation.equivalent_to_stored_evaluation(
+                if not evaluation.equivalent_to_stored_evaluation(
                     self.cursor.latest_evaluation_by_asset_key.get(evaluation.asset_key)
                 )
             ],

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -1,3 +1,4 @@
+import dataclasses
 import datetime
 import itertools
 import logging
@@ -356,7 +357,7 @@ class AssetDaemonContext:
                 to_materialize.update(asset_partitions)
             self._verbose_log_fn("Done evaluating materialize rule")
 
-        skip_context = materialize_context._replace(candidates=to_materialize)
+        skip_context = dataclasses.replace(materialize_context, candidates=to_materialize)
 
         for skip_rule in auto_materialize_policy.skip_rules:
             rule_snapshot = skip_rule.to_snapshot()
@@ -376,6 +377,7 @@ class AssetDaemonContext:
         to_materialize.difference_update(to_skip)
 
         # this is treated separately from other rules, for now
+        discard_context = dataclasses.replace(skip_context, candidates=to_materialize)
         if auto_materialize_policy.max_materializations_per_minute is not None:
             rule = DiscardOnMaxMaterializationsExceededRule(
                 limit=auto_materialize_policy.max_materializations_per_minute
@@ -384,9 +386,7 @@ class AssetDaemonContext:
 
             self._verbose_log_fn(f"Evaluating discard rule: {rule_snapshot}")
 
-            for evaluation_data, asset_partitions in rule.evaluate_for_asset(
-                skip_context._replace(candidates=to_materialize)
-            ):
+            for evaluation_data, asset_partitions in rule.evaluate_for_asset(discard_context):
                 all_results.append(
                     (
                         AutoMaterializeRuleEvaluation(
@@ -580,7 +580,8 @@ class AssetDaemonContext:
                 evaluation
                 for evaluation in evaluations_by_asset_key.values()
                 if not evaluation.equivalent_to_stored_evaluation(
-                    self.cursor.latest_evaluation_by_asset_key.get(evaluation.asset_key)
+                    self.cursor.latest_evaluation_by_asset_key.get(evaluation.asset_key),
+                    self.asset_graph,
                 )
             ],
         )

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -479,6 +479,7 @@ class AssetDaemonContext:
 
             evaluations_by_key[asset_key] = evaluation
             will_materialize_mapping[asset_key] = to_materialize_for_asset
+            to_skip.update(to_skip_for_asset)
             to_discard.update(to_discard_for_asset)
 
             expected_data_time = get_expected_data_time_for_asset_key(
@@ -514,6 +515,7 @@ class AssetDaemonContext:
                         rule_snapshots=auto_materialize_policy.rule_snapshots,  # Neighbors can have different rule snapshots
                     )
                     will_materialize_mapping[neighbor_key] = to_materialize_for_neighbor
+                    to_skip.update(to_skip_for_neighbor)
                     to_discard.update(to_discard_for_neighbor)
 
                     expected_data_time_mapping[neighbor_key] = expected_data_time

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -139,7 +139,7 @@ class RuleEvaluationContext(NamedTuple):
         """The set of candidates on this tick which were not candidates on the previous tick."""
         return {c for c in self.candidates if c not in self.cursor.skipped_on_last_tick_subset}
 
-    def get_previous_tick_results(self, rule: "AutoMaterializeRule"):
+    def get_previous_tick_results(self, rule: "AutoMaterializeRule") -> "RuleEvaluationResults":
         """Returns the results that were calculated for a given rule on the previous tick."""
         previous_evaluation = self.cursor.latest_evaluation_by_asset_key.get(self.asset_key)
         if not previous_evaluation:
@@ -301,9 +301,13 @@ class AutoMaterializeRule(ABC):
                 previous tick should be included in the results of this tick.
         """
         asset_partitions_by_evaluation_data = defaultdict(set, asset_partitions_by_evaluation_data)
+        evaluated_asset_partitions = set().union(*asset_partitions_by_evaluation_data.values())
         for evaluation_data, asset_partitions in context.get_previous_tick_results(self):
             for ap in asset_partitions:
-                if should_include(ap):
+                # evaluated data from this tick takes precedence over data from the previous tick
+                if ap in evaluated_asset_partitions:
+                    continue
+                elif should_include(ap):
                     asset_partitions_by_evaluation_data[evaluation_data].add(ap)
 
         return list(asset_partitions_by_evaluation_data.items())
@@ -499,8 +503,7 @@ class MaterializeOnParentUpdatedRule(
         return self.add_evaluation_data_from_previous_tick(
             context,
             asset_partitions_by_evaluation_data,
-            should_include=lambda ap: ap not in has_or_will_update
-            and context.skipped_on_last_tick_and_not_materialized_since(ap),
+            should_include=lambda ap: context.skipped_on_last_tick_and_not_materialized_since(ap),
         )
 
 
@@ -544,8 +547,7 @@ class MaterializeOnMissingRule(AutoMaterializeRule, NamedTuple("_MaterializeOnMi
         return self.add_evaluation_data_from_previous_tick(
             context,
             asset_partitions_by_evaluation_data,
-            should_include=lambda ap: ap not in missing_asset_partitions
-            and context.skipped_on_last_tick_and_not_materialized_since(ap),
+            should_include=lambda ap: context.skipped_on_last_tick_and_not_materialized_since(ap),
         )
 
 

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -122,7 +122,7 @@ class AutoMaterializeRuleEvaluation(NamedTuple):
     evaluation_data: Optional[AutoMaterializeRuleEvaluationData]
 
 
-@dataclass
+@dataclass(frozen=True)
 class RuleEvaluationContext:
     asset_key: AssetKey
     cursor: "AssetDaemonCursor"

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -153,6 +153,17 @@ class RuleEvaluationContext:
             asset_graph=self.asset_graph
         )
 
+    @functools.cached_property
+    def previous_tick_evaluated_asset_partitions(
+        self,
+    ) -> AbstractSet[AssetKeyPartitionKey]:
+        """Returns the set of asset partitions that were skipped on the previous tick."""
+        if not self.previous_tick_evaluation:
+            return set()
+        return self.previous_tick_evaluation.get_evaluated_asset_partitions(
+            asset_graph=self.asset_graph
+        )
+
     def get_previous_tick_results(self, rule: "AutoMaterializeRule") -> "RuleEvaluationResults":
         """Returns the results that were calculated for a given rule on the previous tick."""
         if not self.previous_tick_evaluation:
@@ -161,13 +172,12 @@ class RuleEvaluationContext:
             rule_snapshot=rule.to_snapshot(), asset_graph=self.asset_graph
         )
 
-    def get_candidates_not_evaluated_on_previous_tick(
-        self, rule: "AutoMaterializeRule"
-    ) -> AbstractSet[AssetKeyPartitionKey]:
-        """Returns the set of candidates that do not have evaluation data from the previous tick."""
-        return self.candidates - set().union(
-            *[asset_partitions for _, asset_partitions in self.get_previous_tick_results(rule=rule)]
-        )
+    def get_candidates_not_evaluated_on_previous_tick(self) -> AbstractSet[AssetKeyPartitionKey]:
+        """Returns the set of candidates that were not evaluated by any rules on the previous tick.
+        Any asset partition that was evaluated by any rule on the previous tick must have been
+        evaluated by *all* skip rules.
+        """
+        return self.candidates - self.previous_tick_evaluated_asset_partitions
 
     def get_candidates_with_updated_or_will_update_parents(
         self,
@@ -590,7 +600,7 @@ class SkipOnParentOutdatedRule(AutoMaterializeRule, NamedTuple("_SkipOnParentOut
 
         # only need to evaluate net-new candidates and candidates whose parents have changed
         candidates_to_evaluate = (
-            context.get_candidates_not_evaluated_on_previous_tick(rule=self)
+            context.get_candidates_not_evaluated_on_previous_tick()
             | context.get_candidates_with_updated_or_will_update_parents()
         )
         for candidate in candidates_to_evaluate:
@@ -636,7 +646,7 @@ class SkipOnParentMissingRule(AutoMaterializeRule, NamedTuple("_SkipOnParentMiss
 
         # only need to evaluate net-new candidates and candidates whose parents have changed
         candidates_to_evaluate = (
-            context.get_candidates_not_evaluated_on_previous_tick(self)
+            context.get_candidates_not_evaluated_on_previous_tick()
             | context.get_candidates_with_updated_or_will_update_parents()
         )
         for candidate in candidates_to_evaluate:
@@ -703,7 +713,7 @@ class SkipOnNotAllParentsUpdatedRule(
 
         # only need to evaluate net-new candidates and candidates whose parents have changed
         candidates_to_evaluate = (
-            context.get_candidates_not_evaluated_on_previous_tick(self)
+            context.get_candidates_not_evaluated_on_previous_tick()
             | context.get_candidates_with_updated_or_will_update_parents()
         )
         for candidate in candidates_to_evaluate:
@@ -1007,13 +1017,22 @@ class AutoMaterializeAssetEvaluation(NamedTuple):
         to_materialize = self._get_asset_partitions_with_decision_type(
             AutoMaterializeDecisionType.MATERIALIZE, asset_graph
         )
-        # nothing can be discarded without being in to_materialize, so don't bother deserializing
         if not to_materialize:
             return set()
         to_skip = self._get_asset_partitions_with_decision_type(
             AutoMaterializeDecisionType.SKIP, asset_graph
         )
         return to_materialize - to_skip
+
+    def get_evaluated_asset_partitions(
+        self, asset_graph: AssetGraph
+    ) -> AbstractSet[AssetKeyPartitionKey]:
+        """Returns the set of asset partitions which were evaluated by any rule on this evaluation."""
+        # no asset partition can be evaluated by SKIP or DISCARD rules without having at least one
+        # materialize rule evaluation
+        return self._get_asset_partitions_with_decision_type(
+            AutoMaterializeDecisionType.MATERIALIZE, asset_graph
+        )
 
     def equivalent_to_stored_evaluation(
         self, stored_evaluation: Optional["AutoMaterializeAssetEvaluation"], asset_graph: AssetGraph

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -134,15 +134,29 @@ class RuleEvaluationContext(NamedTuple):
     def asset_graph(self) -> AssetGraph:
         return self.instance_queryer.asset_graph
 
-    def get_candidates_not_skipped_on_previous_tick(self) -> AbstractSet[AssetKeyPartitionKey]:
-        """Returns the set of candidate asset partitions which were not skipped on the previous
-        tick.
+    def get_previous_tick_results(self, rule: "AutoMaterializeRule") -> "RuleEvaluationResults":
+        """Returns the results that were calculated for a given rule on the previous tick."""
+        previous_evaluation = self.cursor.latest_evaluation_by_asset_key.get(self.asset_key)
+        if not previous_evaluation:
+            return []
+        return previous_evaluation.get_rule_evaluation_results(
+            rule_snapshot=rule.to_snapshot(), asset_graph=self.asset_graph
+        )
 
-        Many rules use the results from the previous tick, rather than re-calculating from scratch.
-        This function finds candidates for which this would not be possible, as the previous tick
-        did not calculate information for them.
-        """
-        return {c for c in self.candidates if c not in self.cursor.skipped_on_last_tick_subset}
+    def get_previous_tick_skipped_asset_partitions(self) -> AbstractSet[AssetKeyPartitionKey]:
+        """Returns the set of asset partitions that were skipped on the previous tick"""
+        previous_evaluation = self.cursor.latest_evaluation_by_asset_key.get(self.asset_key)
+        if not previous_evaluation:
+            return set()
+        return previous_evaluation.get_skipped_asset_partitions(self.asset_graph)
+
+    def get_candidates_not_evaluated_on_previous_tick(
+        self, rule: "AutoMaterializeRule"
+    ) -> AbstractSet[AssetKeyPartitionKey]:
+        """Returns the set of candidates that do not have evaluation data from the previous tick."""
+        return self.candidates - set().union(
+            *[asset_partitions for _, asset_partitions in self.get_previous_tick_results(rule=rule)]
+        )
 
     def get_candidates_with_updated_or_will_update_parents(
         self,
@@ -157,24 +171,9 @@ class RuleEvaluationContext(NamedTuple):
         will_update_parents = set(self.get_will_update_parent_mapping().keys())
         return self.candidates & (updated_parents | will_update_parents)
 
-    def get_previous_tick_results(self, rule: "AutoMaterializeRule") -> "RuleEvaluationResults":
-        """Returns the results that were calculated for a given rule on the previous tick."""
-        previous_evaluation = self.cursor.latest_evaluation_by_asset_key.get(self.asset_key)
-        if not previous_evaluation:
-            return []
-        return previous_evaluation.get_rule_evaluation_results(
-            rule_snapshot=rule.to_snapshot(), asset_graph=self.asset_graph
-        )
-
-    def skipped_on_last_tick_and_not_materialized_since(
-        self, asset_partition: AssetKeyPartitionKey
-    ) -> bool:
-        """Returns whether an asset partition was skipped on the last tick and has not been
-        materialized since that tick.
-        """
-        if asset_partition not in self.cursor.skipped_on_last_tick_subset:
-            return False
-        return not self.instance_queryer.asset_partition_has_materialization_or_observation(
+    def materialized_since_previous_tick(self, asset_partition: AssetKeyPartitionKey) -> bool:
+        """Returns whether an asset partition has been materialized since the last tick."""
+        return self.instance_queryer.asset_partition_has_materialization_or_observation(
             asset_partition, after_cursor=self.cursor.latest_storage_id
         )
 
@@ -307,10 +306,18 @@ class AutoMaterializeRule(ABC):
         """
         asset_partitions_by_evaluation_data = defaultdict(set, asset_partitions_by_evaluation_data)
         evaluated_asset_partitions = set().union(*asset_partitions_by_evaluation_data.values())
+        previous_tick_skipped_asset_partitions = (
+            context.get_previous_tick_skipped_asset_partitions()
+        )
         for evaluation_data, asset_partitions in context.get_previous_tick_results(self):
             for ap in asset_partitions:
-                # evaluated data from this tick takes precedence over data from the previous tick
-                if ap in evaluated_asset_partitions:
+                # evaluated data from this tick takes precedence over data from the previous tick,
+                # and we cannot use information from the previous tick if this asset partition was
+                # not skipped
+                if (
+                    ap in evaluated_asset_partitions
+                    or ap not in previous_tick_skipped_asset_partitions
+                ):
                     continue
                 elif should_use_past_data_fn(ap):
                     asset_partitions_by_evaluation_data[evaluation_data].add(ap)
@@ -508,9 +515,7 @@ class MaterializeOnParentUpdatedRule(
         return self.add_evaluation_data_from_previous_tick(
             context,
             asset_partitions_by_evaluation_data,
-            should_use_past_data_fn=lambda ap: context.skipped_on_last_tick_and_not_materialized_since(
-                ap
-            ),
+            should_use_past_data_fn=lambda ap: not context.materialized_since_previous_tick(ap),
         )
 
 
@@ -554,9 +559,8 @@ class MaterializeOnMissingRule(AutoMaterializeRule, NamedTuple("_MaterializeOnMi
         return self.add_evaluation_data_from_previous_tick(
             context,
             asset_partitions_by_evaluation_data,
-            should_use_past_data_fn=lambda ap: context.skipped_on_last_tick_and_not_materialized_since(
-                ap
-            ),
+            should_use_past_data_fn=lambda ap: ap not in missing_asset_partitions
+            and not context.materialized_since_previous_tick(ap),
         )
 
 
@@ -575,7 +579,7 @@ class SkipOnParentOutdatedRule(AutoMaterializeRule, NamedTuple("_SkipOnParentOut
 
         # only need to evaluate net-new candidates and candidates whose parents have changed
         candidates_to_evaluate = (
-            context.get_candidates_not_skipped_on_previous_tick()
+            context.get_candidates_not_evaluated_on_previous_tick(rule=self)
             | context.get_candidates_with_updated_or_will_update_parents()
         )
         for candidate in candidates_to_evaluate:
@@ -600,7 +604,7 @@ class SkipOnParentOutdatedRule(AutoMaterializeRule, NamedTuple("_SkipOnParentOut
             context,
             asset_partitions_by_evaluation_data,
             should_use_past_data_fn=lambda ap: ap not in candidates_to_evaluate
-            and context.skipped_on_last_tick_and_not_materialized_since(ap),
+            and not context.materialized_since_previous_tick(ap),
         )
 
 
@@ -622,7 +626,7 @@ class SkipOnParentMissingRule(AutoMaterializeRule, NamedTuple("_SkipOnParentMiss
 
         # only need to evaluate net-new candidates and candidates whose parents have changed
         candidates_to_evaluate = (
-            context.get_candidates_not_skipped_on_previous_tick()
+            context.get_candidates_not_evaluated_on_previous_tick(self)
             | context.get_candidates_with_updated_or_will_update_parents()
         )
         for candidate in candidates_to_evaluate:
@@ -648,7 +652,7 @@ class SkipOnParentMissingRule(AutoMaterializeRule, NamedTuple("_SkipOnParentMiss
             context,
             asset_partitions_by_evaluation_data,
             should_use_past_data_fn=lambda ap: ap not in candidates_to_evaluate
-            and context.skipped_on_last_tick_and_not_materialized_since(ap),
+            and not context.materialized_since_previous_tick(ap),
         )
 
 
@@ -690,7 +694,7 @@ class SkipOnNotAllParentsUpdatedRule(
 
         # only need to evaluate net-new candidates and candidates whose parents have changed
         candidates_to_evaluate = (
-            context.get_candidates_not_skipped_on_previous_tick()
+            context.get_candidates_not_evaluated_on_previous_tick(self)
             | context.get_candidates_with_updated_or_will_update_parents()
         )
         for candidate in candidates_to_evaluate:
@@ -746,7 +750,7 @@ class SkipOnNotAllParentsUpdatedRule(
             context,
             asset_partitions_by_evaluation_data,
             should_use_past_data_fn=lambda ap: ap not in candidates_to_evaluate
-            and context.skipped_on_last_tick_and_not_materialized_since(ap),
+            and not context.materialized_since_previous_tick(ap),
         )
 
 
@@ -962,6 +966,36 @@ class AutoMaterializeAssetEvaluation(NamedTuple):
                     )
                 )
         return results
+
+    def _get_asset_partitions_for_decision_type(
+        self, decision_type: AutoMaterializeDecisionType, asset_graph: AssetGraph
+    ) -> AbstractSet[AssetKeyPartitionKey]:
+        """Returns the set of asset partitions that had at least one evaluation with the given
+        decision type on this evaluation."""
+        asset_partitions = set()
+        for rule_snapshot in self.rule_snapshots or []:
+            if rule_snapshot.decision_type == decision_type:
+                asset_partitions.update(
+                    set().union(
+                        *[
+                            ap
+                            for _, ap in self.get_rule_evaluation_results(
+                                rule_snapshot, asset_graph
+                            )
+                        ]
+                    )
+                )
+        return asset_partitions
+
+    def get_skipped_asset_partitions(
+        self, asset_graph: AssetGraph
+    ) -> AbstractSet[AssetKeyPartitionKey]:
+        """Returns the set of asset partitions that were skipped in this evaluation."""
+        return self._get_asset_partitions_for_decision_type(
+            AutoMaterializeDecisionType.SKIP, asset_graph
+        ) - self._get_asset_partitions_for_decision_type(
+            AutoMaterializeDecisionType.DISCARD, asset_graph
+        )
 
     def equivalent_to_stored_evaluation(
         self, stored_evaluation: Optional["AutoMaterializeAssetEvaluation"]

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -614,8 +614,7 @@ class SkipOnParentOutdatedRule(AutoMaterializeRule, NamedTuple("_SkipOnParentOut
         return self.add_evaluation_data_from_previous_tick(
             context,
             asset_partitions_by_evaluation_data,
-            should_use_past_data_fn=lambda ap: ap not in candidates_to_evaluate
-            and not context.materialized_requested_or_discarded_since_previous_tick(ap),
+            should_use_past_data_fn=lambda ap: ap not in candidates_to_evaluate,
         )
 
 
@@ -662,8 +661,7 @@ class SkipOnParentMissingRule(AutoMaterializeRule, NamedTuple("_SkipOnParentMiss
         return self.add_evaluation_data_from_previous_tick(
             context,
             asset_partitions_by_evaluation_data,
-            should_use_past_data_fn=lambda ap: ap not in candidates_to_evaluate
-            and not context.materialized_requested_or_discarded_since_previous_tick(ap),
+            should_use_past_data_fn=lambda ap: ap not in candidates_to_evaluate,
         )
 
 
@@ -760,8 +758,7 @@ class SkipOnNotAllParentsUpdatedRule(
         return self.add_evaluation_data_from_previous_tick(
             context,
             asset_partitions_by_evaluation_data,
-            should_use_past_data_fn=lambda ap: ap not in candidates_to_evaluate
-            and not context.materialized_requested_or_discarded_since_previous_tick(ap),
+            should_use_past_data_fn=lambda ap: ap not in candidates_to_evaluate,
         )
 
 
@@ -1036,7 +1033,7 @@ class AutoMaterializeAssetEvaluation(NamedTuple):
             and stored_evaluation.num_requested == 0
             and stored_evaluation.num_discarded == 0
             and stored_evaluation.num_skipped == self.num_skipped
-            # ensure a stable comparison between the evaluation data
+            and len(sorted_results) == len(sorted_stored_results)
             and (
                 # first is a quick check for the equality of the string representations of the
                 # partition subsets

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -817,6 +817,45 @@ class SkipOnRequiredButNonexistentParentsRule(
 
 
 @whitelist_for_serdes
+class SkipOnBackfillInProgressRule(
+    AutoMaterializeRule,
+    NamedTuple("_SkipOnBackfillInProgressRule", [("all_partitions", bool)]),
+):
+    @property
+    def decision_type(self) -> AutoMaterializeDecisionType:
+        return AutoMaterializeDecisionType.SKIP
+
+    @property
+    def description(self) -> str:
+        if self.all_partitions:
+            return "part of an asset targeted by an in-progress backfill"
+        else:
+            return "targeted by an in-progress backfill"
+
+    def evaluate_for_asset(self, context: RuleEvaluationContext) -> RuleEvaluationResults:
+        backfill_in_progress_candidates: AbstractSet[AssetKeyPartitionKey] = set()
+        backfilling_subset = (
+            context.instance_queryer.get_active_backfill_target_asset_graph_subset()
+        )
+
+        if self.all_partitions:
+            backfill_in_progress_candidates = {
+                candidate
+                for candidate in context.candidates
+                if candidate.asset_key in backfilling_subset.asset_keys
+            }
+        else:
+            backfill_in_progress_candidates = {
+                candidate for candidate in context.candidates if candidate in backfilling_subset
+            }
+
+        if backfill_in_progress_candidates:
+            return [(None, backfill_in_progress_candidates)]
+
+        return []
+
+
+@whitelist_for_serdes
 class DiscardOnMaxMaterializationsExceededRule(
     AutoMaterializeRule, NamedTuple("_DiscardOnMaxMaterializationsExceededRule", [("limit", int)])
 ):
@@ -838,46 +877,6 @@ class DiscardOnMaxMaterializationsExceededRule(
         )
         if rate_limited_asset_partitions:
             return [(None, rate_limited_asset_partitions)]
-        return []
-
-
-@whitelist_for_serdes
-class SkipOnBackfillInProgressRule(
-    AutoMaterializeRule,
-    NamedTuple("_SkipOnBackfillInProgressRule", [("all_partitions", bool)]),
-):
-    @property
-    def decision_type(self) -> AutoMaterializeDecisionType:
-        return AutoMaterializeDecisionType.SKIP
-
-    @property
-    def description(self) -> str:
-        if self.all_partitions:
-            return "part of an asset targeted by an in-progress backfill"
-        else:
-            return "targeted by an in-progress backfill"
-
-    def evaluate_for_asset(self, context: RuleEvaluationContext) -> RuleEvaluationResults:
-        backfill_in_progress_candidates: AbstractSet[AssetKeyPartitionKey] = set()
-
-        backfilling_subset = (
-            context.instance_queryer.get_active_backfill_target_asset_graph_subset()
-        )
-
-        if self.all_partitions:
-            backfill_in_progress_candidates = {
-                candidate
-                for candidate in context.candidates
-                if candidate.asset_key in backfilling_subset.asset_keys
-            }
-        else:
-            backfill_in_progress_candidates = {
-                candidate for candidate in context.candidates if candidate in backfilling_subset
-            }
-
-        if backfill_in_progress_candidates:
-            return [(None, backfill_in_progress_candidates)]
-
         return []
 
 

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -5,6 +5,7 @@ from enum import Enum
 from typing import (
     TYPE_CHECKING,
     AbstractSet,
+    Callable,
     Dict,
     FrozenSet,
     Mapping,
@@ -127,12 +128,37 @@ class RuleEvaluationContext(NamedTuple):
     will_materialize_mapping: Mapping[AssetKey, AbstractSet[AssetKeyPartitionKey]]
     expected_data_time_mapping: Mapping[AssetKey, Optional[datetime.datetime]]
     candidates: AbstractSet[AssetKeyPartitionKey]
-    new_candidates: AbstractSet[AssetKeyPartitionKey]
     daemon_context: "AssetDaemonContext"
 
     @property
     def asset_graph(self) -> AssetGraph:
         return self.instance_queryer.asset_graph
+
+    @property
+    def new_candidates(self) -> AbstractSet[AssetKeyPartitionKey]:
+        """The set of candidates on this tick which were not candidates on the previous tick."""
+        return {c for c in self.candidates if c not in self.cursor.skipped_on_last_tick_subset}
+
+    def get_previous_tick_results(self, rule: "AutoMaterializeRule"):
+        """Returns the results that were calculated for a given rule on the previous tick."""
+        previous_evaluation = self.cursor.latest_evaluation_by_asset_key.get(self.asset_key)
+        if not previous_evaluation:
+            return []
+        return previous_evaluation.get_rule_evaluation_results(
+            rule_snapshot=rule.to_snapshot(), asset_graph=self.asset_graph
+        )
+
+    def skipped_on_last_tick_and_not_materialized_since(
+        self, asset_partition: AssetKeyPartitionKey
+    ) -> bool:
+        """Returns whether an asset partition was skipped on the last tick and has not been
+        materialized since that tick.
+        """
+        if asset_partition not in self.cursor.skipped_on_last_tick_subset:
+            return False
+        return not self.instance_queryer.asset_partition_has_materialization_or_observation(
+            asset_partition, after_cursor=self.cursor.latest_storage_id
+        )
 
     def materializable_in_same_run(self, child_key: AssetKey, parent_key: AssetKey) -> bool:
         """Returns whether a child asset can be materialized in the same run as a parent asset."""
@@ -257,52 +283,30 @@ class AutoMaterializeRule(ABC):
         """
         ...
 
-    def merge_with_past_results(
+    def add_evaluation_data_from_previous_tick(
         self,
         context: RuleEvaluationContext,
         asset_partitions_by_evaluation_data: Mapping[
-            Optional[AutoMaterializeRuleEvaluationData], AbstractSet[AssetKeyPartitionKey]
+            Optional[AutoMaterializeRuleEvaluationData], Set[AssetKeyPartitionKey]
         ],
-        evaluated_candidates: Optional[AbstractSet[AssetKeyPartitionKey]] = None,
-    ) -> RuleEvaluationResults:
-        """Merge the new results of an evaluation with any previous results which are still valid,
-        along with the set of asset partitions which have new evaluations.
+        should_include: Callable[[AssetKeyPartitionKey], bool],
+    ) -> "RuleEvaluationResults":
+        """Combines a given set of evaluation data with evaluation data from the previous tick.
+
+        Args:
+            context: The current RuleEvaluationContext.
+            asset_partitions_by_evaluation_data: A mapping from evaluation data to the set of asset
+                partitions that the rule applies to.
+            should_include: A function that returns whether a given asset partition from the
+                previous tick should be included in the results of this tick.
         """
-        # first, get the evaluation results for this rule from the previous tick
-        previous_evaluation = context.cursor.latest_evaluation_by_asset_key.get(context.asset_key)
-        previous_results = (
-            previous_evaluation.get_rule_evaluation_results(
-                rule_snapshot=self.to_snapshot(), asset_graph=context.asset_graph
-            )
-            if previous_evaluation
-            else []
-        )
-
-        # get the set of asset partitions that have a new evaluation this tick (this is unnecessary
-        # if evaluated_candidates is provided)
-        newly_evaluated_asset_partitions = set().union(
-            *asset_partitions_by_evaluation_data.values()
-        )
-
-        # now, carry forward any results from the previous tick that are still valid
-        merged_results = defaultdict(set)
-        for evaluation_data, asset_partitions in previous_results:
+        asset_partitions_by_evaluation_data = defaultdict(set, asset_partitions_by_evaluation_data)
+        for evaluation_data, asset_partitions in context.get_previous_tick_results(self):
             for ap in asset_partitions:
-                # ignore any stored information for asset partitions that were re-evaluated this
-                # tick or were not skipped on the previous tick
-                if (
-                    ap in (evaluated_candidates or set()) | newly_evaluated_asset_partitions
-                    or ap not in context.daemon_context.skipped_asset_graph_subset
-                ):
-                    continue
-                merged_results[evaluation_data].add(ap)
+                if should_include(ap):
+                    asset_partitions_by_evaluation_data[evaluation_data].add(ap)
 
-        # finally, add in the newly-calculated results
-        for evaluation_data, asset_partitions in asset_partitions_by_evaluation_data.items():
-            for ap in asset_partitions:
-                merged_results[evaluation_data].add(ap)
-
-        return list(merged_results.items())
+        return list(asset_partitions_by_evaluation_data.items())
 
     @abstractmethod
     def evaluate_for_asset(self, context: RuleEvaluationContext) -> RuleEvaluationResults:
@@ -455,10 +459,10 @@ class MaterializeOnParentUpdatedRule(
         """
         asset_partitions_by_evaluation_data = defaultdict(set)
 
-        # next, for each asset partition of this asset which has newly-updated parents, or
-        # has a parent that will update, create a ParentUpdatedRuleEvaluationData
         will_update_parents_by_asset_partition = context.get_will_update_parent_mapping()
 
+        # the set of asset partitions whose parents have been updated since last tick, or will be
+        # requested this tick.
         has_or_will_update = context.get_asset_partitions_with_updated_parents() | set(
             will_update_parents_by_asset_partition.keys()
         )
@@ -492,7 +496,12 @@ class MaterializeOnParentUpdatedRule(
                     )
                 ].add(asset_partition)
 
-        return self.merge_with_past_results(context, asset_partitions_by_evaluation_data)
+        return self.add_evaluation_data_from_previous_tick(
+            context,
+            asset_partitions_by_evaluation_data,
+            should_include=lambda ap: ap not in has_or_will_update
+            and context.skipped_on_last_tick_and_not_materialized_since(ap),
+        )
 
 
 @whitelist_for_serdes
@@ -510,7 +519,9 @@ class MaterializeOnMissingRule(AutoMaterializeRule, NamedTuple("_MaterializeOnMi
         previously discarded. Currently only applies to root asset partitions and asset partitions
         with updated parents.
         """
-        missing_asset_partitions = (
+        asset_partitions_by_evaluation_data = defaultdict(set)
+
+        missing_asset_partitions = set(
             context.daemon_context.get_never_handled_root_asset_partitions_for_key(
                 context.asset_key
             )
@@ -526,10 +537,16 @@ class MaterializeOnMissingRule(AutoMaterializeRule, NamedTuple("_MaterializeOnMi
                 candidate
             ):
                 missing_asset_partitions |= {candidate}
-        asset_partitions_by_evaluation_data: Dict[
-            Optional[AutoMaterializeRuleEvaluationData], AbstractSet[AssetKeyPartitionKey]
-        ] = ({None: missing_asset_partitions} if missing_asset_partitions else {})
-        return self.merge_with_past_results(context, asset_partitions_by_evaluation_data)
+
+        if missing_asset_partitions:
+            asset_partitions_by_evaluation_data[None] = missing_asset_partitions
+
+        return self.add_evaluation_data_from_previous_tick(
+            context,
+            asset_partitions_by_evaluation_data,
+            should_include=lambda ap: ap not in missing_asset_partitions
+            and context.skipped_on_last_tick_and_not_materialized_since(ap),
+        )
 
 
 @whitelist_for_serdes
@@ -566,10 +583,12 @@ class SkipOnParentOutdatedRule(AutoMaterializeRule, NamedTuple("_SkipOnParentOut
                 asset_partitions_by_evaluation_data[
                     WaitingOnAssetsRuleEvaluationData(frozenset(outdated_ancestors))
                 ].add(candidate)
-        return self.merge_with_past_results(
+
+        return self.add_evaluation_data_from_previous_tick(
             context,
             asset_partitions_by_evaluation_data,
-            evaluated_candidates=candidates_to_evaluate,
+            should_include=lambda ap: ap not in candidates_to_evaluate
+            and context.skipped_on_last_tick_and_not_materialized_since(ap),
         )
 
 
@@ -612,10 +631,11 @@ class SkipOnParentMissingRule(AutoMaterializeRule, NamedTuple("_SkipOnParentMiss
                     WaitingOnAssetsRuleEvaluationData(frozenset(missing_parent_asset_keys))
                 ].add(candidate)
 
-        return self.merge_with_past_results(
+        return self.add_evaluation_data_from_previous_tick(
             context,
             asset_partitions_by_evaluation_data,
-            evaluated_candidates=candidates_to_evaluate,
+            should_include=lambda ap: ap not in candidates_to_evaluate
+            and context.skipped_on_last_tick_and_not_materialized_since(ap),
         )
 
 
@@ -708,10 +728,11 @@ class SkipOnNotAllParentsUpdatedRule(
                     WaitingOnAssetsRuleEvaluationData(frozenset(non_updated_parent_keys))
                 ].add(candidate)
 
-        return self.merge_with_past_results(
+        return self.add_evaluation_data_from_previous_tick(
             context,
             asset_partitions_by_evaluation_data,
-            evaluated_candidates=candidates_to_evaluate,
+            should_include=lambda ap: ap not in candidates_to_evaluate
+            and context.skipped_on_last_tick_and_not_materialized_since(ap),
         )
 
 

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -146,7 +146,7 @@ class RuleEvaluationContext:
     def previous_tick_requested_or_discarded_asset_partitions(
         self,
     ) -> AbstractSet[AssetKeyPartitionKey]:
-        """Returns the set of asset partitions that were skipped on the previous tick."""
+        """Returns the set of asset partitions that were requested or discarded on the previous tick."""
         if not self.previous_tick_evaluation:
             return set()
         return self.previous_tick_evaluation.get_requested_or_discarded_asset_partitions(
@@ -326,7 +326,10 @@ class AutoMaterializeRule(ABC):
         ],
         should_use_past_data_fn: Callable[[AssetKeyPartitionKey], bool],
     ) -> "RuleEvaluationResults":
-        """Combines a given set of evaluation data with evaluation data from the previous tick.
+        """Combines a given set of evaluation data with evaluation data from the previous tick. The
+        returned value will include the union of the evaluation data contained within
+        `asset_partitions_by_evaluation_data` and the evaluation data calculated for asset
+        partitions on the previous tick for which `should_use_past_data_fn` evaluates to `True`.
 
         Args:
             context: The current RuleEvaluationContext.
@@ -889,6 +892,12 @@ class AutoMaterializeAssetEvaluation(NamedTuple):
             tuples, where the first element is the condition and the second element is the
             serialized subset of partitions that the condition applies to. If it's not partitioned,
             the second element will be None.
+        num_requested (int): The number of asset partitions that were requested to be materialized
+        num_skipped (int): The number of asset partitions that were skipped
+        num_discarded (int): The number of asset partitions that were discarded
+        run_ids (Set[str]): The set of run IDs created for this evaluation
+        rule_snapshots (Optional[Sequence[AutoMaterializeRuleSnapshot]]): The snapshots of the
+            rules on the policy at the time it was evaluated.
     """
 
     asset_key: AssetKey
@@ -953,17 +962,15 @@ class AutoMaterializeAssetEvaluation(NamedTuple):
                 rule_snapshots=auto_materialize_policy.rule_snapshots,
             )
 
-    def _deserialize_result(
+    def _deserialize_rule_evaluation_result(
         self,
-        serialized_result: Tuple[
-            AutoMaterializeRuleEvaluation, Optional[SerializedPartitionsSubset]
-        ],
+        rule_evaluation: AutoMaterializeRuleEvaluation,
+        serialized_subset: Optional[SerializedPartitionsSubset],
         asset_graph: AssetGraph,
     ) -> Optional[
         Tuple[Optional[AutoMaterializeRuleEvaluationData], AbstractSet[AssetKeyPartitionKey]]
     ]:
         partitions_def = asset_graph.get_partitions_def(self.asset_key)
-        rule_evaluation, serialized_subset = serialized_result
         if serialized_subset is None:
             if partitions_def is None:
                 return (rule_evaluation.evaluation_data, {AssetKeyPartitionKey(self.asset_key)})
@@ -985,11 +992,13 @@ class AutoMaterializeAssetEvaluation(NamedTuple):
     ) -> RuleEvaluationResults:
         """For a given rule snapshot, returns the calculated evaluations for that rule."""
         results = []
-        for serialized_result in self.partition_subsets_by_condition:
+        for rule_evaluation, serialized_subset in self.partition_subsets_by_condition:
             # filter for the same rule
-            if serialized_result[0].rule_snapshot != rule_snapshot:
+            if rule_evaluation.rule_snapshot != rule_snapshot:
                 continue
-            deserialized_result = self._deserialize_result(serialized_result, asset_graph)
+            deserialized_result = self._deserialize_rule_evaluation_result(
+                rule_evaluation, serialized_subset, asset_graph
+            )
             if deserialized_result:
                 results.append(deserialized_result)
         return results
@@ -999,10 +1008,12 @@ class AutoMaterializeAssetEvaluation(NamedTuple):
     ) -> AbstractSet[AssetKeyPartitionKey]:
         """Returns the set of asset partitions with a given decision type applied to them."""
         asset_partitions = set()
-        for serialized_result in self.partition_subsets_by_condition:
-            if serialized_result[0].rule_snapshot.decision_type != decision_type:
+        for rule_evaluation, serialized_subset in self.partition_subsets_by_condition:
+            if rule_evaluation.rule_snapshot.decision_type != decision_type:
                 continue
-            deserialized_result = self._deserialize_result(serialized_result, asset_graph)
+            deserialized_result = self._deserialize_rule_evaluation_result(
+                rule_evaluation, serialized_subset, asset_graph
+            )
             if deserialized_result is None:
                 continue
             asset_partitions.update(deserialized_result[1])
@@ -1046,7 +1057,8 @@ class AutoMaterializeAssetEvaluation(NamedTuple):
         sorted_results = sorted(self.partition_subsets_by_condition)
         sorted_stored_results = sorted(stored_evaluation.partition_subsets_by_condition)
         return (
-            set(self.rule_snapshots or []) == set(stored_evaluation.rule_snapshots or [])
+            self.asset_key == stored_evaluation.asset_key
+            and set(self.rule_snapshots or []) == set(stored_evaluation.rule_snapshots or [])
             # if num_requested / num_discarded > 0 on the stored evaluation, then something changed
             # in the global state on the previous tick
             and stored_evaluation.num_requested == 0
@@ -1059,8 +1071,14 @@ class AutoMaterializeAssetEvaluation(NamedTuple):
                 sorted_results == [tuple(x) for x in sorted_stored_results]
                 # however, not all identical partition subsets are serialized to the same string,
                 # so sometimes we need to deserialize the keys to be sure
-                or [self._deserialize_result(x, asset_graph) for x in sorted_results]
-                == [self._deserialize_result(x, asset_graph) for x in sorted_stored_results]
+                or [
+                    self._deserialize_rule_evaluation_result(re, ss, asset_graph)
+                    for re, ss in sorted_results
+                ]
+                == [
+                    self._deserialize_rule_evaluation_result(re, ss, asset_graph)
+                    for re, ss in sorted_stored_results
+                ]
             )
         )
 

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -157,7 +157,7 @@ class RuleEvaluationContext:
     def previous_tick_evaluated_asset_partitions(
         self,
     ) -> AbstractSet[AssetKeyPartitionKey]:
-        """Returns the set of asset partitions that were skipped on the previous tick."""
+        """Returns the set of asset partitions that were evaluated on the previous tick."""
         if not self.previous_tick_evaluation:
             return set()
         return self.previous_tick_evaluation.get_evaluated_asset_partitions(
@@ -172,8 +172,12 @@ class RuleEvaluationContext:
             rule_snapshot=rule.to_snapshot(), asset_graph=self.asset_graph
         )
 
-    def get_candidates_not_evaluated_on_previous_tick(self) -> AbstractSet[AssetKeyPartitionKey]:
-        """Returns the set of candidates that were not evaluated by any rules on the previous tick.
+    def get_candidates_not_evaluated_by_rule_on_previous_tick(
+        self,
+    ) -> AbstractSet[AssetKeyPartitionKey]:
+        """Returns the set of candidates that were not evaluated by the rule that is currently being
+        evaluated on the previous tick.
+
         Any asset partition that was evaluated by any rule on the previous tick must have been
         evaluated by *all* skip rules.
         """
@@ -600,7 +604,7 @@ class SkipOnParentOutdatedRule(AutoMaterializeRule, NamedTuple("_SkipOnParentOut
 
         # only need to evaluate net-new candidates and candidates whose parents have changed
         candidates_to_evaluate = (
-            context.get_candidates_not_evaluated_on_previous_tick()
+            context.get_candidates_not_evaluated_by_rule_on_previous_tick()
             | context.get_candidates_with_updated_or_will_update_parents()
         )
         for candidate in candidates_to_evaluate:
@@ -646,7 +650,7 @@ class SkipOnParentMissingRule(AutoMaterializeRule, NamedTuple("_SkipOnParentMiss
 
         # only need to evaluate net-new candidates and candidates whose parents have changed
         candidates_to_evaluate = (
-            context.get_candidates_not_evaluated_on_previous_tick()
+            context.get_candidates_not_evaluated_by_rule_on_previous_tick()
             | context.get_candidates_with_updated_or_will_update_parents()
         )
         for candidate in candidates_to_evaluate:
@@ -713,7 +717,7 @@ class SkipOnNotAllParentsUpdatedRule(
 
         # only need to evaluate net-new candidates and candidates whose parents have changed
         candidates_to_evaluate = (
-            context.get_candidates_not_evaluated_on_previous_tick()
+            context.get_candidates_not_evaluated_by_rule_on_previous_tick()
             | context.get_candidates_with_updated_or_will_update_parents()
         )
         for candidate in candidates_to_evaluate:
@@ -787,7 +791,7 @@ class SkipOnRequiredButNonexistentParentsRule(
     def evaluate_for_asset(self, context: RuleEvaluationContext) -> RuleEvaluationResults:
         asset_partitions_by_evaluation_data = defaultdict(set)
 
-        candidates_to_evaluate = context.get_candidates_not_evaluated_on_previous_tick()
+        candidates_to_evaluate = context.get_candidates_not_evaluated_by_rule_on_previous_tick()
         for candidate in candidates_to_evaluate:
             nonexistent_parent_partitions = context.asset_graph.get_parents_partitions(
                 context.instance_queryer,

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
@@ -96,6 +96,16 @@ class AssetEvaluationSpec(NamedTuple):
     num_discarded: int = 0
 
     @staticmethod
+    def empty(asset_key: str) -> "AssetEvaluationSpec":
+        return AssetEvaluationSpec(
+            asset_key=asset_key,
+            rule_evaluations=[],
+            num_requested=0,
+            num_skipped=0,
+            num_discarded=0,
+        )
+
+    @staticmethod
     def from_single_rule(
         asset_key: str,
         rule: AutoMaterializeRule,

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/auto_materialize_policy_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/auto_materialize_policy_scenarios.py
@@ -245,6 +245,7 @@ auto_materialize_policy_scenarios = {
                 )
             ],
             expected_evaluations=[
+                AssetEvaluationSpec.empty("daily"),
                 AssetEvaluationSpec(
                     asset_key="hourly",
                     rule_evaluations=[
@@ -269,7 +270,7 @@ auto_materialize_policy_scenarios = {
                     ],
                     num_requested=48,
                     num_discarded=4,
-                )
+                ),
             ],
         )
     ),
@@ -331,6 +332,7 @@ auto_materialize_policy_scenarios = {
             run_request(["hourly"], partition_key="2013-01-05-04:00"),
         ],
         expected_evaluations=[
+            AssetEvaluationSpec.empty("daily"),
             AssetEvaluationSpec(
                 asset_key="hourly",
                 rule_evaluations=[
@@ -355,7 +357,7 @@ auto_materialize_policy_scenarios = {
                 ],
                 num_requested=1,
                 num_discarded=4,
-            )
+            ),
         ],
     ),
     "auto_materialize_policy_max_materializations_not_exceeded": AssetReconciliationScenario(
@@ -375,6 +377,7 @@ auto_materialize_policy_scenarios = {
             run_request(["hourly"], partition_key="2013-01-05-00:00"),
         ],
         expected_evaluations=[
+            AssetEvaluationSpec.empty("daily"),
             AssetEvaluationSpec(
                 asset_key="hourly",
                 rule_evaluations=[
@@ -389,7 +392,7 @@ auto_materialize_policy_scenarios = {
                     ),
                 ],
                 num_requested=5,
-            )
+            ),
         ],
     ),
     "auto_materialize_policy_daily_to_unpartitioned_freshness": AssetReconciliationScenario(
@@ -409,6 +412,8 @@ auto_materialize_policy_scenarios = {
         unevaluated_runs=[run(["asset1", "asset2", "asset3", "asset4"]), run(["asset1", "asset2"])],
         expected_run_requests=[run_request(asset_keys=["asset3", "asset4"])],
         expected_evaluations=[
+            AssetEvaluationSpec.empty("asset1"),
+            AssetEvaluationSpec.empty("asset2"),
             AssetEvaluationSpec(
                 asset_key="asset3",
                 rule_evaluations=[
@@ -565,6 +570,7 @@ auto_materialize_policy_scenarios = {
                 ],
                 expected_run_requests=[],
                 expected_evaluations=[
+                    AssetEvaluationSpec.empty("C"),
                     AssetEvaluationSpec(
                         asset_key="D",
                         rule_evaluations=[

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/auto_materialize_policy_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/auto_materialize_policy_scenarios.py
@@ -857,6 +857,8 @@ auto_materialize_policy_scenarios = {
         current_time=create_pendulum_time(year=2023, month=1, day=1, hour=4),
         expected_run_requests=[run_request(["asset3"], "2023-01-01-03:00")],
         expected_evaluations=[
+            AssetEvaluationSpec.empty("asset1"),
+            AssetEvaluationSpec.empty("asset2"),
             AssetEvaluationSpec(
                 asset_key="asset3",
                 rule_evaluations=[
@@ -930,6 +932,8 @@ auto_materialize_policy_scenarios = {
             run_request(["asset3"], "2023-01-01-03:00"),
         ],
         expected_evaluations=[
+            AssetEvaluationSpec.empty("asset1"),
+            AssetEvaluationSpec.empty("asset2"),
             AssetEvaluationSpec(
                 asset_key="asset3",
                 rule_evaluations=[

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/auto_materialize_policy_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/auto_materialize_policy_scenarios.py
@@ -981,7 +981,7 @@ auto_materialize_policy_scenarios = {
         # can now run C because the skip rule is no longer true
         expected_run_requests=[run_request(["C"])],
     ),
-    "skipped_subset_partitioned": AssetReconciliationScenario(
+    "skipped_on_last_tick_subset_partitioned": AssetReconciliationScenario(
         assets=partitioned_vee,
         asset_selection=AssetSelection.keys("C"),
         cursor_from=AssetReconciliationScenario(
@@ -998,7 +998,7 @@ auto_materialize_policy_scenarios = {
         # can now run C[a] because the skip rule is no longer true
         expected_run_requests=[run_request(["C"], partition_key="a")],
     ),
-    "skipped_subset_partitioned2": AssetReconciliationScenario(
+    "skipped_on_last_tick_subset_partitioned2": AssetReconciliationScenario(
         assets=partitioned_vee,
         asset_selection=AssetSelection.keys("C"),
         cursor_from=AssetReconciliationScenario(

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/basic_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/basic_scenarios.py
@@ -113,6 +113,7 @@ basic_scenarios = {
         unevaluated_runs=[single_asset_run(asset_key="asset1")],
         expected_run_requests=[run_request(asset_keys=["asset2"])],
         expected_evaluations=[
+            AssetEvaluationSpec.empty("asset1"),
             AssetEvaluationSpec(
                 "asset2",
                 [
@@ -134,7 +135,7 @@ basic_scenarios = {
                     ),
                 ],
                 num_requested=1,
-            )
+            ),
         ],
     ),
     "parent_materialized_launch_two_children": AssetReconciliationScenario(
@@ -142,6 +143,7 @@ basic_scenarios = {
         unevaluated_runs=[single_asset_run(asset_key="asset1")],
         expected_run_requests=[run_request(asset_keys=["asset2", "asset3"])],
         expected_evaluations=[
+            AssetEvaluationSpec.empty("asset1"),
             AssetEvaluationSpec(
                 "asset2",
                 [
@@ -224,6 +226,7 @@ basic_scenarios = {
         unevaluated_runs=[single_asset_run(asset_key="parent1")],
         expected_run_requests=[run_request(asset_keys=["parent2", "child"])],
         expected_evaluations=[
+            AssetEvaluationSpec.empty("parent1"),
             AssetEvaluationSpec.from_single_rule(
                 "parent2", AutoMaterializeRule.materialize_on_missing()
             ),

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/freshness_policy_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/freshness_policy_scenarios.py
@@ -396,11 +396,14 @@ freshness_policy_scenarios = {
         evaluation_delta=datetime.timedelta(minutes=35),
         expected_run_requests=[run_request(asset_keys=["asset2", "asset5"])],
         expected_evaluations=[
+            AssetEvaluationSpec.empty("asset1"),
             AssetEvaluationSpec.from_single_rule(
                 "asset2",
                 AutoMaterializeRule.materialize_on_required_for_freshness(),
                 TextRuleEvaluationData("Required by downstream asset's policy"),
             ),
+            AssetEvaluationSpec.empty("asset3"),
+            AssetEvaluationSpec.empty("asset4"),
             AssetEvaluationSpec.from_single_rule(
                 "asset5",
                 AutoMaterializeRule.materialize_on_required_for_freshness(),

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/observable_source_asset_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/observable_source_asset_scenarios.py
@@ -242,7 +242,7 @@ observable_source_asset_scenarios = {
         assets=partitioned_downstream_of_changing_observable_source,
         unevaluated_runs=[],
         expected_run_requests=[],
-        expected_evaluations=[],
+        expected_evaluations=[AssetEvaluationSpec.empty("asset1")],
     ),
     "partitioned_downstream_of_unchanging_observable_source": AssetReconciliationScenario(
         assets=partitioned_downstream_of_unchanging_observable_source,

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/partition_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/partition_scenarios.py
@@ -467,6 +467,7 @@ partition_scenarios = {
                 num_requested=4,
                 num_skipped=1,
             ),
+            AssetEvaluationSpec.empty("daily"),
         ],
     ),
     "test_skip_entire_asset_on_backfill_in_progress": AssetReconciliationScenario(
@@ -528,6 +529,7 @@ partition_scenarios = {
                 num_requested=0,
                 num_skipped=5,
             ),
+            AssetEvaluationSpec.empty("daily"),
         ],
     ),
 }

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon.py
@@ -458,7 +458,9 @@ def test_daemon(scenario_item, daemon_not_paused_instance):
             [spec.num_requested for spec in scenario.expected_evaluations]
         )
         assert tick.requested_asset_keys == {
-            AssetKey.from_coercible(spec.asset_key) for spec in scenario.expected_evaluations
+            AssetKey.from_coercible(spec.asset_key)
+            for spec in scenario.expected_evaluations
+            if spec.num_requested > 0
         }
 
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon.py
@@ -585,9 +585,14 @@ def test_run_ids():
             assert set(run.asset_selection) == set(expected_run_request.asset_selection)
             assert run.tags.get(PARTITION_NAME_TAG) == expected_run_request.partition_key
 
-        evaluations = instance.schedule_storage.get_auto_materialize_asset_evaluations(
-            asset_key=AssetKey("asset4"), limit=100
+        evaluations = sorted(
+            instance.schedule_storage.get_auto_materialize_asset_evaluations(
+                asset_key=AssetKey("asset4"), limit=100
+            ),
+            key=lambda evaluation: evaluation.evaluation_id,
         )
-        assert len(evaluations) == 1
+        assert len(evaluations) == 2
         assert evaluations[0].evaluation.asset_key == AssetKey("asset4")
-        assert evaluations[0].evaluation.run_ids == {run.run_id for run in sorted_runs}
+        assert evaluations[0].evaluation.run_ids == set()
+        assert evaluations[1].evaluation.asset_key == AssetKey("asset4")
+        assert evaluations[1].evaluation.run_ids == {run.run_id for run in sorted_runs}


### PR DESCRIPTION
## Summary & Motivation

Builds on: https://github.com/dagster-io/dagster/pull/17075

This PR finally makes some logical changes (which should not impact any existing rules). In essence, whenever an asset enters the "skipped" state, its materialize rules will continually fire on each tick until it is materialized (either by the Asset Daemon or manually).

In order to make this efficient, we allow materialize rules to simply dig into their history and return their prior evaluation results, so no new computation needs to happen. For skip rules, they are allowed to choose which candidates they actually need to re-evaluate for. For all existing skip rules, the choice is simple -- only re-evaluate brand-new candidates, or old candidates whose parents have / will update.

For example, if you've decided to skip some partition of an asset because its parents are missing, you don't need to do any work to determine that its parents are still missing if none of its parents have been updated since the last tick.

In practice, this does not meaningfully impact runtime, even if there are large sets of assets in the skipped state (adds ~1 second per tick for ~3000 asset partitions in the skipped state).

## How I Tested These Changes
