### PR TITLE
Unpin acryl-datahub

### DIFF
--- a/python_modules/libraries/dagster-datahub/dagster_datahub/resources.py
+++ b/python_modules/libraries/dagster-datahub/dagster_datahub/resources.py
@@ -25,7 +25,7 @@ class DatahubRESTEmitterResource(ConfigurableResource):
     retry_max_times: Optional[int] = None
     extra_headers: Optional[Dict[str, str]] = None
     ca_certificate_path: Optional[str] = None
-    server_telemetry_id: Optional[str] = None
+    server_telemetry_id: Optional[str] = None  # No-op - no longer accepted in DatahubRestEmitter
     disable_ssl_verification: bool = False
 
     @classmethod
@@ -43,7 +43,6 @@ class DatahubRESTEmitterResource(ConfigurableResource):
             retry_max_times=self.retry_max_times,
             extra_headers=self.extra_headers,
             ca_certificate_path=self.ca_certificate_path,
-            server_telemetry_id=self.server_telemetry_id,
             disable_ssl_verification=self.disable_ssl_verification,
         )
 
@@ -61,7 +60,6 @@ def datahub_rest_emitter(init_context: InitResourceContext) -> DatahubRestEmitte
         retry_max_times=init_context.resource_config.get("retry_max_times"),
         extra_headers=init_context.resource_config.get("extra_headers"),
         ca_certificate_path=init_context.resource_config.get("ca_certificate_path"),
-        server_telemetry_id=init_context.resource_config.get("server_telemetry_id"),
         disable_ssl_verification=init_context.resource_config.get("disable_ssl_verification"),
     )
     # Attempt to hit the server to ensure the resource is properly configured

--- a/python_modules/libraries/dagster-datahub/setup.py
+++ b/python_modules/libraries/dagster-datahub/setup.py
@@ -36,7 +36,7 @@ setup(
     packages=find_packages(exclude=["dagster_datahub_tests*"]),
     include_package_data=True,
     install_requires=[
-        "acryl-datahub[datahub-rest, datahub-kafka]<=0.10.2",
+        "acryl-datahub[datahub-rest, datahub-kafka]",
         f"dagster{pin}",
         "packaging",
         "requests",


### PR DESCRIPTION
dependabot is unhappy about this pin - removing it renders this 'server_telemetry_id' field obselete, but https://github.com/datahub-project/datahub/pull/8017/files implies that the field here wasn't actually used for anything, and removing it appears to have not had an affect. Leaving the field in config for now to avoid the unlikely event of it being a breaking change.

Test Plan: BK

