### PR TITLE
[RFC] Context to allow cloud to sort filter values

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadHooksContext.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadHooksContext.tsx
@@ -17,13 +17,13 @@ type LaunchpadHooksContextValue = {
     error: GenericError | PythonErrorFragment;
     fallback?: React.ReactNode;
   }>;
-  // TODO (salazarm): Remove this prop after cloud PR lands to override UserDisplay instead
-  RunCreatedByCell?: any;
+  StaticFilterSorter?: Record<string, (a: any, b: any) => number>;
 };
 
 export const LaunchpadHooksContext = React.createContext<LaunchpadHooksContextValue>({
   LaunchRootExecutionButton: undefined,
   useLaunchWithTelemetry: undefined,
+  StaticFilterSorter: undefined,
 });
 
 export function useLaunchPadHooks() {
@@ -33,6 +33,7 @@ export function useLaunchPadHooks() {
     MaterializeButton: OverrideMaterializeButton,
     UserDisplay: OverrideUserDisplay,
     PythonErrorInfoHeader,
+    StaticFilterSorter,
   } = React.useContext(LaunchpadHooksContext);
 
   return {
@@ -41,5 +42,6 @@ export function useLaunchPadHooks() {
     MaterializeButton: OverrideMaterializeButton ?? Button,
     PythonErrorInfoHeader,
     UserDisplay: OverrideUserDisplay ?? UserDisplay,
+    StaticFilterSorter,
   };
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/useStaticSetFilter.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/useStaticSetFilter.tsx
@@ -2,6 +2,7 @@ import {Box, Checkbox, IconName, Popover} from '@dagster-io/ui-components';
 import React from 'react';
 
 import {useUpdatingRef} from '../../hooks/useUpdatingRef';
+import {LaunchpadHooksContext} from '../../launchpad/LaunchpadHooksContext';
 
 import {FilterObject, FilterTag, FilterTagHighlightedText} from './useFilter';
 
@@ -33,7 +34,7 @@ export function useStaticSetFilter<TValue>({
   name,
   icon,
   getKey,
-  allValues,
+  allValues: _unsortedValues,
   renderLabel,
   renderActiveStateLabel,
   initialState,
@@ -43,6 +44,16 @@ export function useStaticSetFilter<TValue>({
   allowMultipleSelections = true,
   matchType = 'any-of',
 }: Args<TValue>): StaticSetFilter<TValue> {
+  const {StaticFilterSorter} = React.useContext(LaunchpadHooksContext);
+
+  const allValues = React.useMemo(() => {
+    const sorter = StaticFilterSorter?.[name];
+    if (sorter) {
+      return _unsortedValues.sort(sorter);
+    }
+    return _unsortedValues;
+  }, [StaticFilterSorter, name, _unsortedValues]);
+
   const [state, setState] = React.useState(() => new Set(initialState || []));
 
   React.useEffect(() => {


### PR DESCRIPTION
## Summary & Motivation

This is a pretty generic way for cloud to sort filter values. It allows Cloud to specify a sorting function for a filter by it's name.
This means that multiple filters with the same name could be targeted by cloud and this is intentional. The thinking behind it is that you might have a "User" filter in many parts of the app and we would very likely want cloud to target all of them instead of just a specific one. 
