### PR TITLE
[ui] Support for manually reporting materialization events from asset details

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/Permissions.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/Permissions.tsx
@@ -46,6 +46,7 @@ export type PermissionsFromJSON = {
   reload_repository_location?: PermissionResult;
   reload_workspace?: PermissionResult;
   wipe_assets?: PermissionResult;
+  report_runless_asset_events?: PermissionResult;
   launch_partition_backfill?: PermissionResult;
   cancel_partition_backfill?: PermissionResult;
   toggle_auto_materialize?: PermissionResult;
@@ -95,6 +96,7 @@ export const extractPermissions = (
     canReloadRepositoryLocation: permissionOrFallback('reload_repository_location'),
     canReloadWorkspace: permissionOrFallback('reload_workspace'),
     canWipeAssets: permissionOrFallback('wipe_assets'),
+    canReportRunlessAssetEvents: permissionOrFallback('report_runless_asset_events'),
     canLaunchPartitionBackfill: permissionOrFallback('launch_partition_backfill'),
     canCancelPartitionBackfill: permissionOrFallback('cancel_partition_backfill'),
     canToggleAutoMaterialize: permissionOrFallback('toggle_auto_materialize'),

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEventDetail.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEventDetail.tsx
@@ -1,4 +1,4 @@
-import {Box, Colors, Group, Heading, Icon, Mono, Subheading} from '@dagster-io/ui-components';
+import {Box, Colors, Group, Heading, Icon, Mono, Subheading, Tag} from '@dagster-io/ui-components';
 import React from 'react';
 import {Link} from 'react-router-dom';
 
@@ -15,6 +15,7 @@ import {AssetEventMetadataEntriesTable} from './AssetEventMetadataEntriesTable';
 import {AssetEventSystemTags} from './AssetEventSystemTags';
 import {AssetLineageElements} from './AssetLineageElements';
 import {AssetMaterializationUpstreamData} from './AssetMaterializationUpstreamData';
+import {RunlessEventTag} from './RunlessEventTag';
 import {
   AssetMaterializationFragment,
   AssetObservationFragment,
@@ -34,14 +35,11 @@ export const AssetEventDetail: React.FC<{
 
   return (
     <Box padding={{horizontal: 24, bottom: 24}} style={{flex: 1}}>
-      <Box
-        padding={{vertical: 24}}
-        border="bottom"
-        flex={{alignItems: 'center', justifyContent: 'space-between'}}
-      >
+      <Box padding={{vertical: 24}} border="bottom" flex={{alignItems: 'center', gap: 12}}>
         <Heading>
           <Timestamp timestamp={{ms: Number(event.timestamp)}} />
         </Heading>
+        {!event.runId ? <RunlessEventTag tags={event.tags} /> : undefined}
       </Box>
       <Box
         style={{display: 'grid', gridTemplateColumns: '1fr 1fr 1fr 1fr', gap: 16}}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEventDetail.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEventDetail.tsx
@@ -1,4 +1,4 @@
-import {Box, Colors, Group, Heading, Icon, Mono, Subheading, Tag} from '@dagster-io/ui-components';
+import {Box, Colors, Group, Heading, Icon, Mono, Subheading} from '@dagster-io/ui-components';
 import React from 'react';
 import {Link} from 'react-router-dom';
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEventList.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEventList.tsx
@@ -149,7 +149,7 @@ const AssetEventListEventRow: React.FC<{group: AssetEventGroup}> = ({group}) => 
       </Box>
       <Box flex={{gap: 4, direction: 'row'}}>
         {partition && <Tag>{partition}</Tag>}
-        {latest && run && (
+        {latest && run ? (
           <Tag>
             <AssetRunLink
               runId={run.id}
@@ -161,7 +161,9 @@ const AssetEventListEventRow: React.FC<{group: AssetEventGroup}> = ({group}) => 
               </Box>
             </AssetRunLink>
           </Tag>
-        )}
+        ) : latest && latest.runId === '' ? (
+          <Tag>Reported</Tag>
+        ) : undefined}
       </Box>
     </>
   );

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEventList.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEventList.tsx
@@ -9,6 +9,7 @@ import {RunStatusWithStats} from '../runs/RunStatusDots';
 import {titleForRun} from '../runs/RunUtils';
 import {Container, Inner, Row} from '../ui/VirtualizedTable';
 
+import {RunlessEventTag} from './RunlessEventTag';
 import {AssetEventGroup} from './groupByPartition';
 
 // This component is on the feature-flagged AssetOverview page and replaces AssetEventTable
@@ -161,8 +162,8 @@ const AssetEventListEventRow: React.FC<{group: AssetEventGroup}> = ({group}) => 
               </Box>
             </AssetRunLink>
           </Tag>
-        ) : latest && latest.runId === '' ? (
-          <Tag>Reported</Tag>
+        ) : latest && !latest.runId ? (
+          <RunlessEventTag tags={latest.tags} />
         ) : undefined}
       </Box>
     </>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
@@ -49,6 +49,7 @@ import {
   AssetViewDefinitionNodeFragment,
 } from './types/AssetView.types';
 import {healthRefreshHintFromLiveData} from './usePartitionHealthData';
+import {useReportEventsModal} from './useReportEventsModal';
 
 interface Props {
   assetKey: AssetKey;
@@ -239,6 +240,17 @@ export const AssetView = ({assetKey}: Props) => {
     }
   };
 
+  const reportEvents = useReportEventsModal(
+    definition
+      ? {
+          assetKey: definition.assetKey,
+          isPartitioned: definition.isPartitioned,
+          repository: definition.repository,
+        }
+      : null,
+      refreshState.refetch,
+  );
+
   return (
     <Box
       flex={{direction: 'column', grow: 1}}
@@ -271,8 +283,12 @@ export const AssetView = ({assetKey}: Props) => {
                 scope={{all: [definition], skipAllTerm: true}}
               />
             ) : definition && definition.jobNames.length > 0 && upstream ? (
-              <LaunchAssetExecutionButton scope={{all: [definition]}} />
+              <LaunchAssetExecutionButton
+                scope={{all: [definition]}}
+                additionalDropdownOptions={reportEvents.dropdownOptions}
+              />
             ) : undefined}
+            {reportEvents.element}
           </Box>
         }
       />

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
@@ -248,7 +248,7 @@ export const AssetView = ({assetKey}: Props) => {
           repository: definition.repository,
         }
       : null,
-      refreshState.refetch,
+    refreshState.refetch,
   );
 
   return (

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -56,6 +56,7 @@ import {DimensionRangeWizard} from '../partitions/DimensionRangeWizard';
 import {assembleIntoSpans, stringForSpan} from '../partitions/SpanRepresentation';
 import {DagsterTag} from '../runs/RunTag';
 import {testId} from '../testing/testId';
+import {ToggleableSection} from '../ui/ToggleableSection';
 import {useFeatureFlagForCodeLocation} from '../workspace/WorkspaceContext';
 import {RepoAddress} from '../workspace/types';
 
@@ -868,39 +869,3 @@ const Warnings: React.FC<{
     </ToggleableSection>
   );
 };
-
-const ToggleableSection = ({
-  isInitiallyOpen,
-  title,
-  children,
-  background,
-}: {
-  isInitiallyOpen: boolean;
-  title: React.ReactNode;
-  children: React.ReactNode;
-  background?: string;
-}) => {
-  const [isOpen, setIsOpen] = React.useState(isInitiallyOpen);
-  return (
-    <Box>
-      <Box
-        onClick={() => setIsOpen(!isOpen)}
-        background={background ?? Colors.Gray50}
-        border="bottom"
-        flex={{alignItems: 'center', direction: 'row'}}
-        padding={{vertical: 12, horizontal: 24}}
-        style={{cursor: 'pointer'}}
-      >
-        <Rotateable $rotate={!isOpen}>
-          <Icon name="arrow_drop_down" />
-        </Rotateable>
-        <div style={{flex: 1}}>{title}</div>
-      </Box>
-      {isOpen && <Box>{children}</Box>}
-    </Box>
-  );
-};
-
-const Rotateable = styled.span<{$rotate: boolean}>`
-  ${({$rotate}) => ($rotate ? 'transform: rotate(-90deg);' : '')}
-`;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -19,7 +19,6 @@ import {
 import reject from 'lodash/reject';
 import React from 'react';
 import {useHistory} from 'react-router-dom';
-import styled from 'styled-components';
 
 import {showCustomAlert} from '../app/CustomAlertProvider';
 import {PipelineRunTag} from '../app/ExecutionSessionStorage';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetExecutionButton.tsx
@@ -175,7 +175,18 @@ export const LaunchAssetExecutionButton: React.FC<{
   liveDataForStale?: LiveData; // For "stale" dropdown options
   intent?: 'primary' | 'none';
   preferredJobName?: string;
-}> = ({scope, liveDataForStale, preferredJobName, intent = 'primary'}) => {
+  additionalDropdownOptions?: {
+    label: string;
+    icon?: JSX.Element;
+    onClick: () => void;
+  }[];
+}> = ({
+  scope,
+  liveDataForStale,
+  preferredJobName,
+  additionalDropdownOptions,
+  intent = 'primary',
+}) => {
   const {onClick, loading, launchpadElement} = useMaterializationAction(preferredJobName);
   const [isOpen, setIsOpen] = React.useState(false);
 
@@ -251,6 +262,14 @@ export const LaunchAssetExecutionButton: React.FC<{
                   onClick(firstOption.assetKeys, e, true);
                 }}
               />
+              {additionalDropdownOptions?.map((option) => (
+                <MenuItem
+                  key={option.label}
+                  text={option.label}
+                  icon={option.icon}
+                  onClick={option.onClick}
+                />
+              ))}
             </Menu>
           }
         >

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/RunlessEventTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/RunlessEventTag.tsx
@@ -1,0 +1,12 @@
+import {Tag} from '@dagster-io/ui-components';
+import React from 'react';
+
+import {DagsterTag} from '../runs/RunTag';
+
+export const RunlessEventTag: React.FC<{
+  tags: Array<{__typename: 'EventTag'; key: string; value: string}>;
+}> = ({tags}) => {
+  const user = tags.find((t) => t.key === DagsterTag.User);
+
+  return user ? <Tag>Reported by {user.value}</Tag> : <Tag>Reported</Tag>;
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/RunlessEventTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/RunlessEventTag.tsx
@@ -6,7 +6,9 @@ import {DagsterTag} from '../runs/RunTag';
 export const RunlessEventTag: React.FC<{
   tags: Array<{__typename: 'EventTag'; key: string; value: string}>;
 }> = ({tags}) => {
-  const user = tags.find((t) => t.key === DagsterTag.User);
+  const user = tags.find((t) => t.key === DagsterTag.ReportingUser);
 
+  // Note: This does not use UserDisplay because in cloud, the UserDisplay component is hardcoded to a
+  // 14pt font size. I think it'd be nice to make that component more flexible and revisit.
   return user ? <Tag>Reported by {user.value}</Tag> : <Tag>Reported</Tag>;
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/useReportEventsModal.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/useReportEventsModal.types.ts
@@ -1,0 +1,27 @@
+// Generated GraphQL types, do not edit manually.
+
+import * as Types from '../../graphql/types';
+
+export type ReportEventMutationVariables = Types.Exact<{
+  eventParams: Types.ReportRunlessAssetEventsParams;
+}>;
+
+export type ReportEventMutation = {
+  __typename: 'Mutation';
+  reportRunlessAssetEvents:
+    | {
+        __typename: 'PythonError';
+        message: string;
+        stack: Array<string>;
+        errorChain: Array<{
+          __typename: 'ErrorChainLink';
+          isExplicitLink: boolean;
+          error: {__typename: 'PythonError'; message: string; stack: Array<string>};
+        }>;
+      }
+    | {
+        __typename: 'ReportRunlessAssetEventsSuccess';
+        assetKey: {__typename: 'AssetKey'; path: Array<string>};
+      }
+    | {__typename: 'UnauthorizedError'; message: string};
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useReportEventsModal.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useReportEventsModal.tsx
@@ -165,7 +165,12 @@ const ReportEventDialogBody: React.FC<{
       canOutsideClickClose
       onClose={() => setIsOpen(false)}
     >
-      <DialogHeader icon="info" label="Report materialization event" />
+      <DialogHeader
+        icon="info"
+        label={
+          asset.isPartitioned ? 'Report materialization events' : 'Report materialization event'
+        }
+      />
       <Box padding={{horizontal: 20, top: 16, bottom: 24}}>
         <Body2>
           Let Dagster know about a materialization that happened outside of Dagster. This is
@@ -246,7 +251,9 @@ const ReportEventDialogBody: React.FC<{
           canShow={!canReportRunlessAssetEvents}
         >
           <Button intent="primary" onClick={onReportEvent} disabled={!canReportRunlessAssetEvents}>
-            Report event
+            {keysFiltered.length > 1
+              ? `Report ${keysFiltered.length.toLocaleString()} events`
+              : 'Report event'}
           </Button>
         </Tooltip>
       </DialogFooter>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useReportEventsModal.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useReportEventsModal.tsx
@@ -44,13 +44,14 @@ type Asset = {
 };
 
 export function useReportEventsModal(asset: Asset | null, onEventReported: () => void) {
-  const [recordEventOpen, setRecordEventOpen] = React.useState(false);
+  const [isOpen, setIsOpen] = React.useState(false);
+
   const dropdownOptions = React.useMemo(
     () => [
       {
-        label: 'Record materialization event',
+        label: 'Report materialization event',
         icon: <Icon name="materialization" />,
-        onClick: () => setRecordEventOpen(true),
+        onClick: () => setIsOpen(true),
       },
     ],
     [],
@@ -59,12 +60,13 @@ export function useReportEventsModal(asset: Asset | null, onEventReported: () =>
   const element = asset ? (
     <ReportEventDialogBody
       asset={asset}
-      isOpen={recordEventOpen}
-      setIsOpen={setRecordEventOpen}
+      isOpen={isOpen}
+      setIsOpen={setIsOpen}
       repoAddress={buildRepoAddress(asset.repository.name, asset.repository.location.name)}
       onEventReported={onEventReported}
     />
   ) : undefined;
+
   return {
     dropdownOptions,
     element,
@@ -123,7 +125,7 @@ const ReportEventDialogBody: React.FC<{
 
     if (!data || data.__typename === 'PythonError') {
       await showSharedToaster({
-        message: <div>An unexpected error occurred. This event was not recorded.</div>,
+        message: <div>An unexpected error occurred. This event was not reported.</div>,
         icon: 'error',
         intent: 'danger',
         action: data
@@ -143,9 +145,9 @@ const ReportEventDialogBody: React.FC<{
       await showSharedToaster({
         message:
           keysFiltered.length > 1 ? (
-            <div>Your events have been recorded.</div>
+            <div>Your events have been reported.</div>
           ) : (
-            <div>Your event has been recorded.</div>
+            <div>Your event has been reported.</div>
           ),
         icon: 'materialization',
         intent: 'success',

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useReportEventsModal.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useReportEventsModal.tsx
@@ -10,11 +10,13 @@ import {
   Icon,
   Subheading,
   TextInput,
+  Tooltip,
 } from '@dagster-io/ui-components';
 import React from 'react';
 
 import {showCustomAlert} from '../app/CustomAlertProvider';
 import {showSharedToaster} from '../app/DomUtils';
+import {usePermissionsForLocation} from '../app/Permissions';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {PythonErrorInfo} from '../app/PythonErrorInfo';
 import {AssetEventType, AssetKeyInput, PartitionDefinitionType} from '../graphql/types';
@@ -77,6 +79,10 @@ const ReportEventDialogBody: React.FC<{
   onEventReported: () => void;
 }> = ({asset, repoAddress, isOpen, setIsOpen, onEventReported}) => {
   const [description, setDescription] = React.useState('');
+  const {
+    permissions: {canReportRunlessAssetEvents},
+    disabledReasons,
+  } = usePermissionsForLocation(repoAddress.location);
 
   const [mutation] = useMutation<ReportEventMutation, ReportEventMutationVariables>(
     REPORT_EVENT_MUTATION,
@@ -233,9 +239,14 @@ const ReportEventDialogBody: React.FC<{
       </Box>
       <DialogFooter topBorder>
         <Button onClick={() => setIsOpen(false)}>Cancel</Button>
-        <Button intent="primary" onClick={onReportEvent}>
-          Report event
-        </Button>
+        <Tooltip
+          content={disabledReasons.canReportRunlessAssetEvents}
+          canShow={!canReportRunlessAssetEvents}
+        >
+          <Button intent="primary" onClick={onReportEvent} disabled={!canReportRunlessAssetEvents}>
+            Report event
+          </Button>
+        </Tooltip>
       </DialogFooter>
     </Dialog>
   );

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useReportEventsModal.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useReportEventsModal.tsx
@@ -1,0 +1,259 @@
+import {gql, useMutation} from '@apollo/client';
+import {
+  Body2,
+  Box,
+  Button,
+  Caption,
+  Dialog,
+  DialogFooter,
+  DialogHeader,
+  Icon,
+  Subheading,
+  TextInput,
+} from '@dagster-io/ui-components';
+import React from 'react';
+
+import {showCustomAlert} from '../app/CustomAlertProvider';
+import {showSharedToaster} from '../app/DomUtils';
+import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
+import {PythonErrorInfo} from '../app/PythonErrorInfo';
+import {AssetEventType, AssetKeyInput, PartitionDefinitionType} from '../graphql/types';
+import {DimensionRangeWizard} from '../partitions/DimensionRangeWizard';
+import {ToggleableSection} from '../ui/ToggleableSection';
+import {buildRepoAddress} from '../workspace/buildRepoAddress';
+import {RepoAddress} from '../workspace/types';
+
+import {partitionCountString} from './AssetNodePartitionCounts';
+import {
+  explodePartitionKeysInSelectionMatching,
+  mergedAssetHealth,
+} from './MultipartitioningSupport';
+import {
+  ReportEventMutation,
+  ReportEventMutationVariables,
+} from './types/useReportEventsModal.types';
+import {usePartitionDimensionSelections} from './usePartitionDimensionSelections';
+import {keyCountInSelections, usePartitionHealthData} from './usePartitionHealthData';
+
+type Asset = {
+  isPartitioned: boolean;
+  assetKey: AssetKeyInput;
+  repository: {name: string; location: {name: string}};
+};
+
+export function useReportEventsModal(asset: Asset | null, onEventReported: () => void) {
+  const [recordEventOpen, setRecordEventOpen] = React.useState(false);
+  const dropdownOptions = React.useMemo(
+    () => [
+      {
+        label: 'Record materialization event',
+        icon: <Icon name="materialization" />,
+        onClick: () => setRecordEventOpen(true),
+      },
+    ],
+    [],
+  );
+
+  const element = asset ? (
+    <ReportEventDialogBody
+      asset={asset}
+      isOpen={recordEventOpen}
+      setIsOpen={setRecordEventOpen}
+      repoAddress={buildRepoAddress(asset.repository.name, asset.repository.location.name)}
+      onEventReported={onEventReported}
+    />
+  ) : undefined;
+  return {
+    dropdownOptions,
+    element,
+  };
+}
+
+const ReportEventDialogBody: React.FC<{
+  asset: Asset;
+  repoAddress: RepoAddress;
+  isOpen: boolean;
+  setIsOpen: (open: boolean) => void;
+  onEventReported: () => void;
+}> = ({asset, repoAddress, isOpen, setIsOpen, onEventReported}) => {
+  const [description, setDescription] = React.useState('');
+
+  const [mutation] = useMutation<ReportEventMutation, ReportEventMutationVariables>(
+    REPORT_EVENT_MUTATION,
+  );
+
+  const [lastRefresh, setLastRefresh] = React.useState(Date.now());
+  const assetHealth = mergedAssetHealth(
+    usePartitionHealthData(
+      asset.isPartitioned ? [asset.assetKey] : [],
+      lastRefresh.toString(),
+      'background',
+    ),
+  );
+  const isDynamic = assetHealth.dimensions.some((d) => d.type === PartitionDefinitionType.DYNAMIC);
+  const [selections, setSelections] = usePartitionDimensionSelections({
+    assetHealth,
+    modifyQueryString: false,
+    skipPartitionKeyValidation: isDynamic,
+    shouldReadPartitionQueryStringParam: true,
+  });
+
+  const keysFiltered = React.useMemo(() => {
+    return explodePartitionKeysInSelectionMatching(selections, () => true);
+  }, [selections]);
+
+  const onReportEvent = async () => {
+    const result = await mutation({
+      variables: {
+        eventParams: {
+          eventType: AssetEventType.ASSET_MATERIALIZATION,
+          partitionKeys: asset.isPartitioned ? keysFiltered : undefined,
+          assetKey: {path: asset.assetKey.path},
+          description,
+        },
+      },
+    });
+    const data = result.data?.reportRunlessAssetEvents;
+
+    if (!data || data.__typename === 'PythonError') {
+      await showSharedToaster({
+        message: <div>An unexpected error occurred. This event was not recorded.</div>,
+        icon: 'error',
+        intent: 'danger',
+        action: data
+          ? {
+              text: 'View error',
+              onClick: () => showCustomAlert({body: <PythonErrorInfo error={data} />}),
+            }
+          : undefined,
+      });
+    } else if (data.__typename === 'UnauthorizedError') {
+      await showSharedToaster({
+        message: <div>{data.message}</div>,
+        icon: 'error',
+        intent: 'danger',
+      });
+    } else {
+      await showSharedToaster({
+        message:
+          keysFiltered.length > 1 ? (
+            <div>Your events have been recorded.</div>
+          ) : (
+            <div>Your event has been recorded.</div>
+          ),
+        icon: 'materialization',
+        intent: 'success',
+      });
+      onEventReported();
+      setIsOpen(false);
+    }
+  };
+
+  return (
+    <Dialog
+      style={{width: 700}}
+      isOpen={isOpen}
+      canEscapeKeyClose
+      canOutsideClickClose
+      onClose={() => setIsOpen(false)}
+    >
+      <DialogHeader icon="info" label="Report materialization event" />
+      <Box padding={{horizontal: 20, top: 16, bottom: 24}}>
+        <Body2>
+          Let Dagster know about a materialization that happened outside of Dagster. This is
+          typically only needed in exceptional circumstances.
+        </Body2>
+      </Box>
+
+      {asset.isPartitioned ? (
+        <ToggleableSection
+          isInitiallyOpen={true}
+          title={
+            <Box flex={{direction: 'row', justifyContent: 'space-between'}}>
+              <Subheading>Partition selection</Subheading>
+              <span>{partitionCountString(keyCountInSelections(selections))}</span>
+            </Box>
+          }
+        >
+          {selections.map((range, idx) => (
+            <Box
+              key={range.dimension.name}
+              border="bottom"
+              padding={{vertical: 12, horizontal: 24}}
+            >
+              <Box as={Subheading} flex={{alignItems: 'center', gap: 8}}>
+                <Icon name="partition" />
+                {range.dimension.name}
+              </Box>
+              <Box>
+                Select partitions to materialize.{' '}
+                {range.dimension.type === PartitionDefinitionType.TIME_WINDOW
+                  ? 'Click and drag to select a range on the timeline.'
+                  : null}
+              </Box>
+
+              <DimensionRangeWizard
+                partitionKeys={range.dimension.partitionKeys}
+                health={{
+                  ranges: assetHealth.rangesForSingleDimension(
+                    idx,
+                    selections.length === 2 ? selections[1 - idx]!.selectedRanges : undefined,
+                  ),
+                }}
+                dimensionType={range.dimension.type}
+                selected={range.selectedKeys}
+                setSelected={(selectedKeys) =>
+                  setSelections((selections) =>
+                    selections.map((r) =>
+                      r.dimension === range.dimension ? {...r, selectedKeys} : r,
+                    ),
+                  )
+                }
+                partitionDefinitionName={range.dimension.name}
+                repoAddress={repoAddress}
+                refetch={async () => setLastRefresh(Date.now())}
+              />
+            </Box>
+          ))}
+        </ToggleableSection>
+      ) : undefined}
+
+      <Box
+        padding={{horizontal: 20, top: asset.isPartitioned ? 16 : 0, bottom: 16}}
+        flex={{direction: 'column', gap: 12}}
+      >
+        <Box flex={{direction: 'column', gap: 4}}>
+          <Caption>Description</Caption>
+          <TextInput
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="Add a description"
+          />
+        </Box>
+      </Box>
+      <DialogFooter topBorder>
+        <Button onClick={() => setIsOpen(false)}>Cancel</Button>
+        <Button intent="primary" onClick={onReportEvent}>
+          Report event
+        </Button>
+      </DialogFooter>
+    </Dialog>
+  );
+};
+
+const REPORT_EVENT_MUTATION = gql`
+  mutation ReportEventMutation($eventParams: ReportRunlessAssetEventsParams!) {
+    reportRunlessAssetEvents(eventParams: $eventParams) {
+      ...PythonErrorFragment
+      ... on UnauthorizedError {
+        message
+      }
+      ... on ReportRunlessAssetEventsSuccess {
+        assetKey {
+          path
+        }
+      }
+    }
+  }
+  ${PYTHON_ERROR_FRAGMENT}
+`;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useReportEventsModal.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useReportEventsModal.tsx
@@ -50,7 +50,7 @@ export function useReportEventsModal(asset: Asset | null, onEventReported: () =>
     () => [
       {
         label: 'Report materialization event',
-        icon: <Icon name="materialization" />,
+        icon: <Icon name="asset_non_sda" />,
         onClick: () => setIsOpen(true),
       },
     ],
@@ -171,10 +171,14 @@ const ReportEventDialogBody: React.FC<{
           asset.isPartitioned ? 'Report materialization events' : 'Report materialization event'
         }
       />
-      <Box padding={{horizontal: 20, top: 16, bottom: 24}}>
+      <Box
+        padding={{horizontal: 20, top: 16, bottom: 24}}
+        border={asset.isPartitioned ? {side: 'bottom'} : undefined}
+      >
         <Body2>
-          Let Dagster know about a materialization that happened outside of Dagster. This is
-          typically only needed in exceptional circumstances.
+          Let Dagster know about a materialization that happened outside of Dagster. Typically used
+          for testing or for manually fixing incorrect information in the asset catalog, not for
+          normal operations.
         </Body2>
       </Box>
 

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunTable.tsx
@@ -415,10 +415,10 @@ const RunRow: React.FC<{
       <td style={{position: 'relative'}}>
         <Box flex={{direction: 'column', gap: 5}}>
           {isHiddenAssetGroupJob(run.pipelineName) ? (
-            <>
-              <AssetCheckTagCollection assetChecks={run.assetCheckSelection} />
+            <Box flex={{gap: 16}}>
               <AssetKeyTagCollection assetKeys={assetKeysForRun(run)} />
-            </>
+              <AssetCheckTagCollection assetChecks={run.assetCheckSelection} />
+            </Box>
           ) : (
             <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
               <PipelineReference

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunTag.tsx
@@ -28,6 +28,7 @@ export enum DagsterTag {
   AssetEventCodeVersion = 'dagster/code_version',
   AssetEvaluationID = 'dagster/asset_evaluation_id',
   SnapshotID = 'dagster/snapshot_id', // This only exists on the client, not the server.
+  ReportingUser = 'dagster/reporting_user',
   User = 'user',
 
   // Hidden tags (using ".dagster" HIDDEN_TAG_PREFIX)

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/ToggleableSection.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/ToggleableSection.tsx
@@ -1,0 +1,39 @@
+import {Box, Colors, Icon} from '@dagster-io/ui-components';
+import React from 'react';
+import styled from 'styled-components';
+
+export const ToggleableSection = ({
+  isInitiallyOpen,
+  title,
+  children,
+  background,
+}: {
+  isInitiallyOpen: boolean;
+  title: React.ReactNode;
+  children: React.ReactNode;
+  background?: string;
+}) => {
+  const [isOpen, setIsOpen] = React.useState(isInitiallyOpen);
+  return (
+    <Box>
+      <Box
+        onClick={() => setIsOpen(!isOpen)}
+        background={background ?? Colors.Gray50}
+        border="bottom"
+        flex={{alignItems: 'center', direction: 'row'}}
+        padding={{vertical: 12, horizontal: 24}}
+        style={{cursor: 'pointer'}}
+      >
+        <Rotateable $rotate={!isOpen}>
+          <Icon name="arrow_drop_down" />
+        </Rotateable>
+        <div style={{flex: 1}}>{title}</div>
+      </Box>
+      {isOpen && <Box>{children}</Box>}
+    </Box>
+  );
+};
+
+const Rotateable = styled.span<{$rotate: boolean}>`
+  ${({$rotate}) => ($rotate ? 'transform: rotate(-90deg);' : '')}
+`;


### PR DESCRIPTION
Design: https://www.figma.com/file/V1V87q5hW7Z6G8T3T1XbTn/Manual_AddEvent?type=design&node-id=12-30&mode=design&t=oNRAFHi3u6HhLuMo-0


## Summary & Motivation


This PR adds a new option to the materialize dropdown on the asset details page. (and ONLY this copy of the button)

![image](https://github.com/dagster-io/dagster/assets/1037212/e22e3b05-a557-4c73-b431-d3172919e419)

The new option opens a modal which allows you to manually record that an asset materialization has taken place. If the asset is partitioned, you can choose partitions from this modal and we pass the partition keys through to the mutation.

![image](https://github.com/dagster-io/dagster/assets/1037212/6b5b169c-9c53-414f-9d12-b274026f4e11)
![image](https://github.com/dagster-io/dagster/assets/1037212/c792365b-71a0-4f7b-a5b3-35bb6750c2a6)


Events created in this manner seem to have a runId = "", and I'm using that to display a tag that says "Reported" in two places:

![image](https://github.com/dagster-io/dagster/assets/1037212/969bff5d-f8f4-4562-83d4-b3eb3a8b74e5)


## How I Tested These Changes

- Just manual testing so far with partitioned and unpartitioned assets. Everything seems to work nicely once you have these in the system, the statuses of the partitions update as expected. 

- Will add a few jest tests for this but it sounds like we want to ship this ASAP so I may apply everyone's feedback first.