### PR TITLE
[external-assets] allow partition defs on specs

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_spec.py
@@ -6,12 +6,14 @@ from dagster._annotations import PublicAttr, experimental
 from dagster._core.errors import DagsterInvariantViolationError
 
 from .auto_materialize_policy import AutoMaterializePolicy
+from .backfill_policy import BackfillPolicy
 from .events import (
     AssetKey,
     CoercibleToAssetKey,
 )
 from .freshness_policy import FreshnessPolicy
 from .metadata import MetadataUserInput
+from .partition import PartitionsDefinition
 
 if TYPE_CHECKING:
     from dagster._core.definitions.asset_dep import AssetDep, CoercibleToAssetDep
@@ -60,6 +62,8 @@ class AssetSpec(
             ("code_version", PublicAttr[Optional[str]]),
             ("freshness_policy", PublicAttr[Optional[FreshnessPolicy]]),
             ("auto_materialize_policy", PublicAttr[Optional[AutoMaterializePolicy]]),
+            ("backfill_policy", PublicAttr[Optional[BackfillPolicy]]),
+            ("partitions_def", PublicAttr[Optional[PartitionsDefinition]]),
         ],
     )
 ):
@@ -85,6 +89,7 @@ class AssetSpec(
         auto_materialize_policy (Optional[AutoMaterializePolicy]): AutoMaterializePolicy to apply to
             the specified asset.
         backfill_policy (Optional[BackfillPolicy]): BackfillPolicy to apply to the specified asset.
+        partitions_def (Optional[PartitionsDefinition]): PartitionsDefinition to apply to the specified asset.
     """
 
     def __new__(
@@ -99,6 +104,8 @@ class AssetSpec(
         code_version: Optional[str] = None,
         freshness_policy: Optional[FreshnessPolicy] = None,
         auto_materialize_policy: Optional[AutoMaterializePolicy] = None,
+        backfill_policy: Optional[BackfillPolicy] = None,
+        partitions_def: Optional[PartitionsDefinition] = None,
     ):
         from dagster._core.definitions.asset_dep import AssetDep
 
@@ -135,5 +142,11 @@ class AssetSpec(
                 auto_materialize_policy,
                 "auto_materialize_policy",
                 AutoMaterializePolicy,
+            ),
+            backfill_policy=check.opt_inst_param(
+                backfill_policy, "backfill_policy", BackfillPolicy
+            ),
+            partitions_def=check.opt_inst_param(
+                partitions_def, "partitions_def", PartitionsDefinition
             ),
         )

--- a/python_modules/dagster/dagster/_core/definitions/external_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/external_asset.py
@@ -97,6 +97,7 @@ def external_assets_from_specs(specs: Sequence[AssetSpec]) -> List[AssetsDefinit
         )
 
         @multi_asset(
+            name=spec.key.to_python_identifier(),
             specs=[
                 AssetSpec(
                     key=spec.key,
@@ -112,7 +113,8 @@ def external_assets_from_specs(specs: Sequence[AssetSpec]) -> List[AssetsDefinit
                     },
                     deps=spec.deps,
                 )
-            ]
+            ],
+            partitions_def=spec.partitions_def,
         )
         def _external_assets_def(context: AssetExecutionContext) -> None:
             raise DagsterInvariantViolationError(


### PR DESCRIPTION
## Summary & Motivation

This adds a partitions_def param as well as making the backfill_policy documented param real

## How I Tested These Changes

- [ ] need to add test cases but used in the s3 data lake demo
