### PR TITLE
[external assets] fix for multiple asset specs for `external_assets_from_specs`

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/external_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/external_asset.py
@@ -99,6 +99,7 @@ def external_assets_from_specs(specs: Sequence[AssetSpec]) -> List[AssetsDefinit
         @multi_asset(
             specs=[
                 AssetSpec(
+                    name=spec.key.to_python_identifier(),
                     key=spec.key,
                     description=spec.description,
                     group_name=spec.group_name,

--- a/python_modules/dagster/dagster/_core/definitions/external_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/external_asset.py
@@ -97,9 +97,9 @@ def external_assets_from_specs(specs: Sequence[AssetSpec]) -> List[AssetsDefinit
         )
 
         @multi_asset(
+            name=spec.key.to_python_identifier(),
             specs=[
                 AssetSpec(
-                    name=spec.key.to_python_identifier(),
                     key=spec.key,
                     description=spec.description,
                     group_name=spec.group_name,
@@ -113,7 +113,7 @@ def external_assets_from_specs(specs: Sequence[AssetSpec]) -> List[AssetsDefinit
                     },
                     deps=spec.deps,
                 )
-            ]
+            ],
         )
         def _external_assets_def(context: AssetExecutionContext) -> None:
             raise DagsterInvariantViolationError(

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_external_assets.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_external_assets.py
@@ -53,6 +53,26 @@ def test_external_asset_basic_creation() -> None:
     assert assets_def.is_asset_executable(expected_key) is False
 
 
+def test_multi_external_asset_basic_creation() -> None:
+    for assets_def in external_assets_from_specs(
+        specs=[
+            AssetSpec(
+                key="external_asset_one",
+                description="desc",
+                metadata={"user_metadata": "value"},
+                group_name="a_group",
+            ),
+            AssetSpec(
+                key=AssetKey(["value", "another_spec"]),
+                description="desc",
+                metadata={"user_metadata": "value"},
+                group_name="a_group",
+            ),
+        ]
+    ):
+        assert isinstance(assets_def, AssetsDefinition)
+
+
 def test_invalid_external_asset_creation() -> None:
     invalid_specs = [
         AssetSpec("invalid_asset1", auto_materialize_policy=AutoMaterializePolicy.eager()),


### PR DESCRIPTION
## Summary & Motivation

`@multi_asset` will use the decorated function's name as the asset name if no param is provided, in `external_assets_from_specs` this can cause duplicate names when more than one spec is provided 

## How I Tested These Changes

new unit test case
