### PR TITLE
[Run table filters] Sort users/sensors/schedules

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFilterInput.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFilterInput.tsx
@@ -10,6 +10,7 @@ import memoize from 'lodash/memoize';
 import qs from 'qs';
 import * as React from 'react';
 
+import {COMMON_COLLATOR} from '../app/Util';
 import {__ASSET_JOB_PREFIX} from '../asset-graph/Utils';
 import {RunsFilter, RunStatus} from '../graphql/types';
 import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
@@ -237,9 +238,9 @@ export const useRunsFilterInput = ({tokens, onChange, enabledFilters}: RunsFilte
   const createdByValues = React.useMemo(
     () => [
       tagToFilterValue(DagsterTag.Automaterialize, 'true'),
-      ...[...sensorValues].sort(),
-      ...[...scheduleValues].sort(),
-      ...[...userValues].sort(),
+      ...[...sensorValues].sort((a, b) => COMMON_COLLATOR.compare(a.label, b.label)),
+      ...[...scheduleValues].sort((a, b) => COMMON_COLLATOR.compare(a.label, b.label)),
+      ...[...userValues].sort((a, b) => COMMON_COLLATOR.compare(a.label, b.label)),
     ],
     [sensorValues, scheduleValues, userValues],
   );

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFilterInput.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFilterInput.tsx
@@ -237,9 +237,9 @@ export const useRunsFilterInput = ({tokens, onChange, enabledFilters}: RunsFilte
   const createdByValues = React.useMemo(
     () => [
       tagToFilterValue(DagsterTag.Automaterialize, 'true'),
-      ...sensorValues,
-      ...scheduleValues,
-      ...userValues,
+      ...[...sensorValues].sort(),
+      ...[...scheduleValues].sort(),
+      ...[...userValues].sort(),
     ],
     [sensorValues, scheduleValues, userValues],
   );


### PR DESCRIPTION
## Summary & Motivation
Sort these values because they end up getting refetched due to the component being removed from the DOM and and then being re-added. We should fix this too separately, but it's very hairy due to how everything is constructed.... global state would trivially solve the problem...
