### PR TITLE
[ui] Fix the height of partitioned observable source assets in graph

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/layout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/layout.ts
@@ -272,16 +272,16 @@ export const getAssetNodeDimensions = (def: {
   } else {
     let height = 100; // top tags area + name + description
 
-    if (def.isPartitioned) {
-      height += 40;
-    }
     if (def.isSource) {
-      height += 30; // observed
+      height += 30; // last observed
     } else {
       height += 26; // status row
+      if (def.isPartitioned) {
+        height += 40;
+      }
     }
 
-    height += 30; // tag
+    height += 30; // tags beneath
 
     return {width, height};
   }


### PR DESCRIPTION
## Summary & Motivation

I believe this was a piece left out of https://github.com/dagster-io/dagster/pull/16186/files

Before:

<img width="563" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/aef99c4d-7d42-4b99-9760-1da002e13f53">

After:

<img width="556" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/2dcb907c-8213-4117-a410-3652a61626f6">

## How I Tested These Changes
