### PR TITLE
[docs][infra] fix deeply nested left nav item not expand

### DIFF
--- a/docs/next/components/Sidebar.tsx
+++ b/docs/next/components/Sidebar.tsx
@@ -193,7 +193,7 @@ const RecursiveNavigation = ({
     itemOrSection === currentSection ||
     itemOrSection.path === asPathWithoutAnchor ||
     (itemOrSection.children &&
-      itemOrSection.children.find((item) => item.path === asPathWithoutAnchor));
+      itemOrSection.children.find((item) => asPathWithoutAnchor.startsWith(item.path)));
 
   const expanded = Boolean(navKeysToExpanded[navKey]);
 


### PR DESCRIPTION
## Summary & Motivation

Currently, when a user lands on a page that's nested in 3+ levels, the left nav won't expand. This PR fixes this issue.

| Status quo | Fix |
| ------------- | ------------- |
| https://docs.dagster.io/dagster-cloud/account/managing-users/managing-teams  | https://10-10--docs-infra-fix-deeply-nested-left-nav-item-not-expand.dagster.dagster-docs.io/dagster-cloud/account/managing-users/managing-teams  |
| <img width="882" alt="image" src="https://github.com/dagster-io/dagster/assets/4531914/2df7d0ba-df34-4537-92fb-4e8b893db0dd">  | <img width="921" alt="image" src="https://github.com/dagster-io/dagster/assets/4531914/7ea77d52-0b60-4e23-a36e-cef439891ad2">|


## How I Tested These Changes
