### PR TITLE
[config] make convert_to_config_dictionary public

### DIFF
--- a/python_modules/dagster/dagster/_config/pythonic_config/config.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/config.py
@@ -189,6 +189,9 @@ class Config(MakeConfigCacheable, metaclass=BaseConfigMeta):
         super().__init__(**modified_data)
 
     def _convert_to_config_dictionary(self) -> Mapping[str, Any]:
+        return self.convert_to_config_dictionary()
+
+    def convert_to_config_dictionary(self) -> Mapping[str, Any]:
         """Converts this Config object to a Dagster config dictionary, in the same format as the dictionary
         accepted as run config or as YAML in the launchpad.
 
@@ -276,7 +279,7 @@ def _config_value_to_dict_representation(field: Optional[ModelField], value: Any
                 ).items()
             }
         else:
-            return {k: v for k, v in value._convert_to_config_dictionary().items()}  # noqa: SLF001
+            return {k: v for k, v in value.convert_to_config_dictionary().items()}
     elif isinstance(value, Enum):
         return value.name
 

--- a/python_modules/dagster/dagster/_config/pythonic_config/resource.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/resource.py
@@ -347,7 +347,7 @@ class ConfigurableResourceFactory(
         # to the correct type under the hood - useful in particular for enums
         casted_data_without_resources = {
             k: v
-            for k, v in self._convert_to_config_dictionary().items()
+            for k, v in self.convert_to_config_dictionary().items()
             if k in data_without_resources
         }
         resolved_config_dict = config_dictionary_from_values(casted_data_without_resources, schema)
@@ -584,7 +584,7 @@ class ConfigurableResourceFactory(
         return self.from_resource_context(
             build_init_resource_context(
                 config=post_process_config(
-                    self._config_schema.config_type, self._convert_to_config_dictionary()
+                    self._config_schema.config_type, self.convert_to_config_dictionary()
                 ).value
             )
         )

--- a/python_modules/dagster/dagster/_core/definitions/configurable.py
+++ b/python_modules/dagster/dagster/_core/definitions/configurable.py
@@ -237,7 +237,7 @@ def _wrap_user_fn_if_pythonic_config(
         output = user_fn(**{param_name: config_input})
 
         if isinstance(output, Config):
-            return output._convert_to_config_dictionary()  # noqa: SLF001
+            return output.convert_to_config_dictionary()
         else:
             return output
 

--- a/python_modules/dagster/dagster/_core/definitions/op_invocation.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_invocation.py
@@ -200,7 +200,7 @@ def direct_invocation_result(
         assets_def=assets_def,
         resources_from_args=resources_by_param_name,
         config_from_args=(
-            config_input._convert_to_config_dictionary()  # noqa: SLF001
+            config_input.convert_to_config_dictionary()
             if isinstance(config_input, Config)
             else config_input
         ),

--- a/python_modules/dagster/dagster/_core/definitions/run_config.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_config.py
@@ -591,7 +591,7 @@ def _convert_config_classes_inner(configs: Any) -> Any:
 
     return {
         k: (
-            {"config": v._convert_to_config_dictionary()}  # noqa: SLF001
+            {"config": v.convert_to_config_dictionary()}
             if isinstance(v, Config)
             else _convert_config_classes_inner(v)
         )

--- a/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_pythonic_config_types.py
+++ b/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_pythonic_config_types.py
@@ -909,4 +909,4 @@ def test_to_config_dict_combined_with_cached_method() -> None:
 
     obj = ConfigWithCachedMethod(a_string="bar")
     obj.a_string_cached()
-    assert obj._convert_to_config_dictionary() == {"a_string": "bar"}  # noqa: SLF001
+    assert obj.convert_to_config_dictionary() == {"a_string": "bar"}

--- a/python_modules/libraries/dagster-datahub/dagster_datahub/resources.py
+++ b/python_modules/libraries/dagster-datahub/dagster_datahub/resources.py
@@ -91,7 +91,7 @@ class DatahubKafkaEmitterResource(ConfigurableResource):
 
     def get_emitter(self) -> DatahubKafkaEmitter:
         return DatahubKafkaEmitter(
-            KafkaEmitterConfig.parse_obj(self._convert_to_config_dictionary())
+            KafkaEmitterConfig.parse_obj(self.convert_to_config_dictionary())
         )
 
 


### PR DESCRIPTION
## Summary

Makes the `_convert_to_confnig_dictionary` utility on our config classes, since a few users have asked about this.

This is useful in case users want to convert/pass a config dictionary, and this is the only way to access some of the custom conversion logic to deal with things like discriminated unions. I think it's not too risky to make this public-facing since some folks are using the private method already.