### PR TITLE
Make our pytest pin in dagster[test] less restrictive

### DIFF
--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -123,7 +123,7 @@ setup(
             "pytest-rerunfailures==10.0",
             "pytest-runner==5.2",
             "pytest-xdist==2.1.0",
-            "pytest==7.0.1",  # last version supporting python 3.6
+            "pytest>=7.0.1",
             "responses<=0.23.1",  # https://github.com/getsentry/responses/issues/654
             "syrupy<4",  # 3.7 compatible,
             "tox==3.25.0",


### PR DESCRIPTION
Summary:
We no longer require 3.6 support and later versions remove a dependancy that is being flagged by dependabot.

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes
