### PR TITLE
[AMP Timeline] Hack for overlapping ticks due to tick being stuck in started state

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationEvaluationHistoryTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationEvaluationHistoryTable.tsx
@@ -94,7 +94,7 @@ export const AutomaterializationEvaluationHistoryTable = ({
         margin={{top: 32}}
         border="top"
       >
-        <Box flex={{direction: 'row', gap: 8}}>
+        <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
           <ButtonGroup
             activeItems={new Set(['evaluations'])}
             buttons={[

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationRoot.tsx
@@ -81,9 +81,9 @@ export const AutomaterializationRoot = () => {
       return (
         ticks?.map((tick, index) => {
           // For ticks that get stuck in "Started" state without an endtimestamp.
-          if (!tick.endTimestamp && index !== ticks.length - 2) {
+          if (!tick.endTimestamp && index !== ticks.length - 1) {
             const copy = {...tick};
-            copy.endTimestamp = ticks[index + 1]!.timestamp;
+            copy.endTimestamp = ticks[index + 11]!.timestamp;
             copy.status = InstigationTickStatus.FAILURE;
             return copy;
           }

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationRoot.tsx
@@ -77,8 +77,9 @@ export const AutomaterializationRoot = () => {
   }
   const ticks = React.useMemo(
     () => {
+      const ticks = queryResult.data?.autoMaterializeTicks;
       return (
-        queryResult.data?.autoMaterializeTicks.map((tick, index, arr) => {
+        ticks?.map((tick, index, arr) => {
           // For ticks that get stuck in "Started" state without an endtimestamp.
           if (!tick.endTimestamp && index !== arr.length - 1) {
             tick.endTimestamp = ticks[index + 1]!.timestamp;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationRoot.tsx
@@ -79,9 +79,9 @@ export const AutomaterializationRoot = () => {
     () => {
       const ticks = queryResult.data?.autoMaterializeTicks;
       return (
-        ticks?.map((tick, index, arr) => {
+        ticks?.map((tick, index) => {
           // For ticks that get stuck in "Started" state without an endtimestamp.
-          if (!tick.endTimestamp && index !== arr.length - 1) {
+          if (!tick.endTimestamp && index !== ticks.length - 2) {
             tick.endTimestamp = ticks[index + 1]!.timestamp;
             tick.status = InstigationTickStatus.FAILURE;
           }

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationRoot.tsx
@@ -82,8 +82,10 @@ export const AutomaterializationRoot = () => {
         ticks?.map((tick, index) => {
           // For ticks that get stuck in "Started" state without an endtimestamp.
           if (!tick.endTimestamp && index !== ticks.length - 2) {
-            tick.endTimestamp = ticks[index + 1]!.timestamp;
-            tick.status = InstigationTickStatus.FAILURE;
+            const copy = {...tick};
+            copy.endTimestamp = ticks[index + 1]!.timestamp;
+            copy.status = InstigationTickStatus.FAILURE;
+            return copy;
           }
           return tick;
         }) ?? []

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationRoot.tsx
@@ -83,7 +83,7 @@ export const AutomaterializationRoot = () => {
           // For ticks that get stuck in "Started" state without an endtimestamp.
           if (!tick.endTimestamp && index !== ticks.length - 1) {
             const copy = {...tick};
-            copy.endTimestamp = ticks[index + 11]!.timestamp;
+            copy.endTimestamp = ticks[index + 1]!.timestamp;
             copy.status = InstigationTickStatus.FAILURE;
             return copy;
           }


### PR DESCRIPTION
## Summary & Motivation

Ticks can get stuck in the "started" state. As a workaround set the endTimestamp of a stuck tick to be the start timestamp of the next tick if there is one.

## How I Tested These Changes
shadow dagit.