### PR TITLE
RFC [pipes] change is_dagter_pipes_process setup

### DIFF
--- a/docs/sphinx/sections/api/apidocs/libraries/dagster-pipes.rst
+++ b/docs/sphinx/sections/api/apidocs/libraries/dagster-pipes.rst
@@ -18,8 +18,6 @@ with Dagster using teh Pipes protocol.
 
 .. autofunction:: decode_env_var
 
-.. autofunction:: is_dagster_pipes_process
-
 .. autoclass:: PipesContextLoader
 
 .. autoclass:: PipesMessageWriter

--- a/python_modules/dagster/dagster/_core/pipes/context.py
+++ b/python_modules/dagster/dagster/_core/pipes/context.py
@@ -4,8 +4,8 @@ from queue import Queue
 from typing import TYPE_CHECKING, Any, Dict, Iterator, Mapping, Optional, Set, Union
 
 from dagster_pipes import (
-    DAGSTER_PIPES_BOOTSTRAP_PARAM_NAMES,
-    IS_DAGSTER_PIPES_PROCESS,
+    DAGSTER_PIPES_CONTEXT_ENV_VAR,
+    DAGSTER_PIPES_MESSAGES_ENV_VAR,
     PIPES_METADATA_TYPE_INFER,
     PipesContextData,
     PipesDataProvenance,
@@ -258,9 +258,8 @@ class PipesSession:
             values that must be passed by the context injector.
         """
         return {
-            DAGSTER_PIPES_BOOTSTRAP_PARAM_NAMES[IS_DAGSTER_PIPES_PROCESS]: True,
-            DAGSTER_PIPES_BOOTSTRAP_PARAM_NAMES["context"]: self.context_injector_params,
-            DAGSTER_PIPES_BOOTSTRAP_PARAM_NAMES["messages"]: self.message_reader_params,
+            DAGSTER_PIPES_CONTEXT_ENV_VAR: self.context_injector_params,
+            DAGSTER_PIPES_MESSAGES_ENV_VAR: self.message_reader_params,
         }
 
     @public

--- a/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/in_process_client.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/in_process_client.py
@@ -58,6 +58,9 @@ class InProcessPipesParamLoader(PipesParamsLoader):
     def load_messages_params(self) -> PipesParams:
         return {}
 
+    def is_dagster_pipes_process(self) -> bool:
+        return True
+
 
 class InProcessContextInjector(PipesContextInjector):
     @contextmanager

--- a/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_subprocess.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_subprocess.py
@@ -385,13 +385,13 @@ def test_pipes_no_orchestration():
     def script_fn():
         from dagster_pipes import (
             PipesContext,
-            is_dagster_pipes_process,
+            PipesEnvVarParamsLoader,
             open_dagster_pipes,
         )
 
-        assert not is_dagster_pipes_process()
-
-        with open_dagster_pipes() as _:
+        loader = PipesEnvVarParamsLoader()
+        assert not loader.is_dagster_pipes_process()
+        with open_dagster_pipes(params_loader=loader) as _:
             context = PipesContext.get()
             context.log.info("hello world")
             context.report_asset_materialization(


### PR DESCRIPTION
This is motivated by 2 things:

* `DAGSTER_PIPES_IS_DAGSTER_PIPES_PROCESS=eJwrKSpNBQAEeQHB` (base64 zipped json `True`) feels a bit goofy to me. I just ignored it in the rust impl. 
* The `PipesParamsLoader` abstraction is in place to be able to cover places where we can't inject env vars. If we cant inject env vars than the current scheme will not work.

This led me to this PR where I
* defer `is_dagster_pipes_process` to the `PipesParamsLoader`
* just use the presence of DAGSTER_PIPES_CONTEXT env var instead 

## How I Tested These Changes

updated existing tests