### PR TITLE
[amp refactors 1/3] Refactor DiscardOnMaxMaterializationsExceeded into rule

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeRightPanel.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeRightPanel.tsx
@@ -197,7 +197,6 @@ export const GET_POLICY_INFO_QUERY = gql`
         }
         autoMaterializePolicy {
           policyType
-          maxMaterializationsPerMinute
           rules {
             description
             decisionType

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/types/AutomaterializeRightPanel.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/types/AutomaterializeRightPanel.types.ts
@@ -21,7 +21,6 @@ export type GetPolicyInfoQuery = {
         autoMaterializePolicy: {
           __typename: 'AutoMaterializePolicy';
           policyType: Types.AutoMaterializePolicyType;
-          maxMaterializationsPerMinute: number | null;
           rules: Array<{
             __typename: 'AutoMaterializeRule';
             description: string;

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -717,7 +717,6 @@ type FreshnessPolicy {
 
 type AutoMaterializePolicy {
   policyType: AutoMaterializePolicyType!
-  maxMaterializationsPerMinute: Int
   rules: [AutoMaterializeRule!]!
 }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -506,7 +506,6 @@ export enum AutoMaterializeDecisionType {
 
 export type AutoMaterializePolicy = {
   __typename: 'AutoMaterializePolicy';
-  maxMaterializationsPerMinute: Maybe<Scalars['Int']>;
   policyType: AutoMaterializePolicyType;
   rules: Array<AutoMaterializeRule>;
 };
@@ -5319,10 +5318,6 @@ export const buildAutoMaterializePolicy = (
   relationshipsToOmit.add('AutoMaterializePolicy');
   return {
     __typename: 'AutoMaterializePolicy',
-    maxMaterializationsPerMinute:
-      overrides && overrides.hasOwnProperty('maxMaterializationsPerMinute')
-        ? overrides.maxMaterializationsPerMinute!
-        : 9783,
     policyType:
       overrides && overrides.hasOwnProperty('policyType')
         ? overrides.policyType!

--- a/python_modules/dagster-graphql/dagster_graphql/schema/auto_materialize_policy.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/auto_materialize_policy.py
@@ -7,7 +7,6 @@ from dagster._core.definitions.auto_materialize_policy import (
 from dagster._core.definitions.auto_materialize_rule import (
     AutoMaterializeDecisionType,
     AutoMaterializeRuleSnapshot,
-    DiscardOnMaxMaterializationsExceededRule,
 )
 
 from .util import non_null_list
@@ -33,7 +32,6 @@ class GrapheneAutoMaterializeRule(graphene.ObjectType):
 
 class GrapheneAutoMaterializePolicy(graphene.ObjectType):
     policyType = graphene.NonNull(graphene.Enum.from_enum(AutoMaterializePolicyType))
-    maxMaterializationsPerMinute = graphene.Int()
     rules = non_null_list(GrapheneAutoMaterializeRule)
 
     class Meta:
@@ -49,16 +47,7 @@ class GrapheneAutoMaterializePolicy(graphene.ObjectType):
             GrapheneAutoMaterializeRule(rule.to_snapshot())
             for rule in auto_materialize_policy.rules
         ]
-        if auto_materialize_policy.max_materializations_per_minute:
-            rules.append(
-                GrapheneAutoMaterializeRule(
-                    DiscardOnMaxMaterializationsExceededRule(
-                        limit=auto_materialize_policy.max_materializations_per_minute
-                    ).to_snapshot()
-                )
-            )
         super().__init__(
             rules=rules,
             policyType=auto_materialize_policy.policy_type,
-            maxMaterializationsPerMinute=auto_materialize_policy.max_materializations_per_minute,
         )

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
@@ -341,7 +341,6 @@ GET_AUTO_MATERIALIZE_POLICY = """
             id
             autoMaterializePolicy {
                 policyType
-                maxMaterializationsPerMinute
             }
         }
     }
@@ -2311,7 +2310,6 @@ class TestAssetAwareEventLog(ExecutingGraphQLContextTestMatrix):
         ]
         assert len(fresh_diamond_bottom) == 1
         assert fresh_diamond_bottom[0]["autoMaterializePolicy"]["policyType"] == "LAZY"
-        assert fresh_diamond_bottom[0]["autoMaterializePolicy"]["maxMaterializationsPerMinute"] == 1
 
     def test_has_asset_checks(self, graphql_context: WorkspaceRequestContext):
         result = execute_dagster_graphql(graphql_context, HAS_ASSET_CHECKS)

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_auto_materialize_policy.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_auto_materialize_policy.py
@@ -28,6 +28,7 @@ def test_without_rules():
             AutoMaterializeRule.materialize_on_required_for_freshness(),
             AutoMaterializeRule.skip_on_parent_outdated(),
             AutoMaterializeRule.skip_on_parent_missing(),
+            AutoMaterializeRule.discard_on_max_materializations_exceeded(limit=1),
         }
     )
 
@@ -40,6 +41,7 @@ def test_without_rules():
         rules={
             AutoMaterializeRule.skip_on_parent_outdated(),
             AutoMaterializeRule.skip_on_parent_missing(),
+            AutoMaterializeRule.discard_on_max_materializations_exceeded(limit=1),
         }
     )
 
@@ -74,6 +76,7 @@ def test_with_rules():
             AutoMaterializeRule.skip_on_parent_outdated(),
             AutoMaterializeRule.skip_on_parent_missing(),
             AutoMaterializeRule.materialize_on_required_for_freshness(),
+            AutoMaterializeRule.discard_on_max_materializations_exceeded(limit=1),
         )
         == AutoMaterializePolicy.eager()
     )


### PR DESCRIPTION
Currently, `DiscardOnMaxMaterializationsExceeded` does not exist as a rule on the auto-materialize policy. 

This PR refactors this to be evaluated as another rule.