### PR TITLE
add flag to sensor context for first tick after start

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
@@ -368,6 +368,7 @@ class GrapheneDryRunInstigationTick(graphene.ObjectType):
                     cursor=self._cursor,
                     last_completion_time=None,
                     last_run_key=None,
+                    last_start_time=None,
                 )
             except Exception:
                 sensor_data = serializable_error_info_from_exc_info(sys.exc_info())

--- a/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
@@ -368,7 +368,7 @@ class GrapheneDryRunInstigationTick(graphene.ObjectType):
                     cursor=self._cursor,
                     last_completion_time=None,
                     last_run_key=None,
-                    last_start_time=None,
+                    last_sensor_start_time=None,
                 )
             except Exception:
                 sensor_data = serializable_error_info_from_exc_info(sys.exc_info())

--- a/python_modules/dagster/dagster/_api/snapshot_sensor.py
+++ b/python_modules/dagster/dagster/_api/snapshot_sensor.py
@@ -49,6 +49,7 @@ def sync_get_external_sensor_execution_data_grpc(
     last_completion_time: Optional[float],
     last_run_key: Optional[str],
     cursor: Optional[str],
+    first_tick_after_start: bool = False,
     timeout: Optional[int] = DEFAULT_GRPC_TIMEOUT,
 ) -> SensorExecutionData:
     check.inst_param(repository_handle, "repository_handle", RepositoryHandle)
@@ -68,6 +69,7 @@ def sync_get_external_sensor_execution_data_grpc(
                 last_completion_time=last_completion_time,
                 last_run_key=last_run_key,
                 cursor=cursor,
+                first_tick_after_start=first_tick_after_start,
             ),
             timeout=timeout,
         ),

--- a/python_modules/dagster/dagster/_api/snapshot_sensor.py
+++ b/python_modules/dagster/dagster/_api/snapshot_sensor.py
@@ -21,6 +21,7 @@ def sync_get_external_sensor_execution_data_ephemeral_grpc(
     last_completion_time: Optional[float],
     last_run_key: Optional[str],
     cursor: Optional[str],
+    last_start_time: Optional[float] = None,
     timeout: Optional[int] = DEFAULT_GRPC_TIMEOUT,
 ) -> SensorExecutionData:
     from dagster._grpc.client import ephemeral_grpc_api_client
@@ -37,6 +38,7 @@ def sync_get_external_sensor_execution_data_ephemeral_grpc(
             last_completion_time,
             last_run_key,
             cursor,
+            last_start_time,
             timeout=timeout,
         )
 
@@ -49,12 +51,13 @@ def sync_get_external_sensor_execution_data_grpc(
     last_completion_time: Optional[float],
     last_run_key: Optional[str],
     cursor: Optional[str],
-    first_tick_after_start: bool = False,
+    last_start_time: Optional[float] = None,
     timeout: Optional[int] = DEFAULT_GRPC_TIMEOUT,
 ) -> SensorExecutionData:
     check.inst_param(repository_handle, "repository_handle", RepositoryHandle)
     check.str_param(sensor_name, "sensor_name")
     check.opt_float_param(last_completion_time, "last_completion_time")
+    check.opt_float_param(last_start_time, "last_start_time")
     check.opt_str_param(last_run_key, "last_run_key")
     check.opt_str_param(cursor, "cursor")
 
@@ -69,7 +72,7 @@ def sync_get_external_sensor_execution_data_grpc(
                 last_completion_time=last_completion_time,
                 last_run_key=last_run_key,
                 cursor=cursor,
-                first_tick_after_start=first_tick_after_start,
+                last_start_time=last_start_time,
             ),
             timeout=timeout,
         ),

--- a/python_modules/dagster/dagster/_api/snapshot_sensor.py
+++ b/python_modules/dagster/dagster/_api/snapshot_sensor.py
@@ -21,7 +21,7 @@ def sync_get_external_sensor_execution_data_ephemeral_grpc(
     last_completion_time: Optional[float],
     last_run_key: Optional[str],
     cursor: Optional[str],
-    last_start_time: Optional[float] = None,
+    last_sensor_start_time: Optional[float] = None,
     timeout: Optional[int] = DEFAULT_GRPC_TIMEOUT,
 ) -> SensorExecutionData:
     from dagster._grpc.client import ephemeral_grpc_api_client
@@ -38,7 +38,7 @@ def sync_get_external_sensor_execution_data_ephemeral_grpc(
             last_completion_time,
             last_run_key,
             cursor,
-            last_start_time,
+            last_sensor_start_time,
             timeout=timeout,
         )
 
@@ -51,13 +51,13 @@ def sync_get_external_sensor_execution_data_grpc(
     last_completion_time: Optional[float],
     last_run_key: Optional[str],
     cursor: Optional[str],
-    last_start_time: Optional[float] = None,
+    last_sensor_start_time: Optional[float] = None,
     timeout: Optional[int] = DEFAULT_GRPC_TIMEOUT,
 ) -> SensorExecutionData:
     check.inst_param(repository_handle, "repository_handle", RepositoryHandle)
     check.str_param(sensor_name, "sensor_name")
     check.opt_float_param(last_completion_time, "last_completion_time")
-    check.opt_float_param(last_start_time, "last_start_time")
+    check.opt_float_param(last_sensor_start_time, "last_sensor_start_time")
     check.opt_str_param(last_run_key, "last_run_key")
     check.opt_str_param(cursor, "cursor")
 
@@ -72,7 +72,7 @@ def sync_get_external_sensor_execution_data_grpc(
                 last_completion_time=last_completion_time,
                 last_run_key=last_run_key,
                 cursor=cursor,
-                last_start_time=last_start_time,
+                last_sensor_start_time=last_sensor_start_time,
             ),
             timeout=timeout,
         ),

--- a/python_modules/dagster/dagster/_cli/sensor.py
+++ b/python_modules/dagster/dagster/_cli/sensor.py
@@ -283,7 +283,7 @@ def execute_preview_command(
                         since,
                         last_run_key,
                         cursor,
-                        last_start_time=None,
+                        last_sensor_start_time=None,
                     )
                 except Exception:
                     error_info = serializable_error_info_from_exc_info(sys.exc_info())

--- a/python_modules/dagster/dagster/_cli/sensor.py
+++ b/python_modules/dagster/dagster/_cli/sensor.py
@@ -283,6 +283,7 @@ def execute_preview_command(
                         since,
                         last_run_key,
                         cursor,
+                        last_start_time=None,
                     )
                 except Exception:
                     error_info = serializable_error_info_from_exc_info(sys.exc_info())

--- a/python_modules/dagster/dagster/_cli/sensor.py
+++ b/python_modules/dagster/dagster/_cli/sensor.py
@@ -373,6 +373,8 @@ def execute_cursor_command(sensor_name, cli_args, print_fn):
                             last_run_key=job_state.instigator_data.last_run_key,
                             min_interval=external_sensor.min_interval_seconds,
                             cursor=cursor_value,
+                            last_tick_start_timestamp=job_state.instigator_data.last_tick_start_timestamp,
+                            last_sensor_start_timestamp=job_state.instigator_data.last_sensor_start_timestamp,
                         ),
                     )
                 )

--- a/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
@@ -228,7 +228,7 @@ class MultiAssetSensorEvaluationContext(SensorEvaluationContext):
         instance: Optional[DagsterInstance] = None,
         resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
         definitions: Optional["Definitions"] = None,
-        last_start_time: Optional[float] = None,
+        last_sensor_start_time: Optional[float] = None,
     ):
         from dagster._core.definitions.definitions_class import Definitions
         from dagster._core.definitions.repository_definition import RepositoryDefinition
@@ -280,7 +280,7 @@ class MultiAssetSensorEvaluationContext(SensorEvaluationContext):
             instance=instance,
             repository_def=repository_def,
             resources=resource_defs,
-            last_start_time=last_start_time,
+            last_sensor_start_time=last_sensor_start_time,
         )
 
     def _cache_initial_unconsumed_events(self) -> None:
@@ -955,7 +955,7 @@ def build_multi_asset_sensor_context(
     cursor_from_latest_materializations: bool = False,
     resources: Optional[Mapping[str, object]] = None,
     definitions: Optional["Definitions"] = None,
-    last_start_time: Optional[float] = None,
+    last_sensor_start_time: Optional[float] = None,
 ) -> MultiAssetSensorEvaluationContext:
     """Builds multi asset sensor execution context for testing purposes using the provided parameters.
 
@@ -1004,7 +1004,7 @@ def build_multi_asset_sensor_context(
     )
 
     check.bool_param(cursor_from_latest_materializations, "cursor_from_latest_materializations")
-    check.opt_float_param(last_start_time, "last_start_time")
+    check.opt_float_param(last_sensor_start_time, "last_sensor_start_time")
 
     if cursor_from_latest_materializations:
         if cursor:
@@ -1042,7 +1042,7 @@ def build_multi_asset_sensor_context(
         monitored_assets=monitored_assets,
         repository_def=repository_def,
         resource_defs=wrap_resources_for_execution(resources),
-        last_start_time=last_start_time,
+        last_sensor_start_time=last_sensor_start_time,
     )
 
 

--- a/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
@@ -228,7 +228,7 @@ class MultiAssetSensorEvaluationContext(SensorEvaluationContext):
         instance: Optional[DagsterInstance] = None,
         resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
         definitions: Optional["Definitions"] = None,
-        first_tick_from_start: bool = False,
+        last_start_time: Optional[float] = None,
     ):
         from dagster._core.definitions.definitions_class import Definitions
         from dagster._core.definitions.repository_definition import RepositoryDefinition
@@ -280,7 +280,7 @@ class MultiAssetSensorEvaluationContext(SensorEvaluationContext):
             instance=instance,
             repository_def=repository_def,
             resources=resource_defs,
-            first_tick_after_start=first_tick_from_start,
+            last_start_time=last_start_time,
         )
 
     def _cache_initial_unconsumed_events(self) -> None:
@@ -955,7 +955,7 @@ def build_multi_asset_sensor_context(
     cursor_from_latest_materializations: bool = False,
     resources: Optional[Mapping[str, object]] = None,
     definitions: Optional["Definitions"] = None,
-    first_tick_from_start: bool = False,
+    last_start_time: Optional[float] = None,
 ) -> MultiAssetSensorEvaluationContext:
     """Builds multi asset sensor execution context for testing purposes using the provided parameters.
 
@@ -1004,7 +1004,7 @@ def build_multi_asset_sensor_context(
     )
 
     check.bool_param(cursor_from_latest_materializations, "cursor_from_latest_materializations")
-    check.bool_param(first_tick_from_start, "first_tick_from_start")
+    check.opt_float_param(last_start_time, "last_start_time")
 
     if cursor_from_latest_materializations:
         if cursor:
@@ -1042,7 +1042,7 @@ def build_multi_asset_sensor_context(
         monitored_assets=monitored_assets,
         repository_def=repository_def,
         resource_defs=wrap_resources_for_execution(resources),
-        first_tick_from_start=first_tick_from_start,
+        last_start_time=last_start_time,
     )
 
 

--- a/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
@@ -228,6 +228,7 @@ class MultiAssetSensorEvaluationContext(SensorEvaluationContext):
         instance: Optional[DagsterInstance] = None,
         resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
         definitions: Optional["Definitions"] = None,
+        first_tick_from_start: bool = False,
     ):
         from dagster._core.definitions.definitions_class import Definitions
         from dagster._core.definitions.repository_definition import RepositoryDefinition
@@ -279,6 +280,7 @@ class MultiAssetSensorEvaluationContext(SensorEvaluationContext):
             instance=instance,
             repository_def=repository_def,
             resources=resource_defs,
+            first_tick_after_start=first_tick_from_start,
         )
 
     def _cache_initial_unconsumed_events(self) -> None:
@@ -953,6 +955,7 @@ def build_multi_asset_sensor_context(
     cursor_from_latest_materializations: bool = False,
     resources: Optional[Mapping[str, object]] = None,
     definitions: Optional["Definitions"] = None,
+    first_tick_from_start: bool = False,
 ) -> MultiAssetSensorEvaluationContext:
     """Builds multi asset sensor execution context for testing purposes using the provided parameters.
 
@@ -1001,6 +1004,7 @@ def build_multi_asset_sensor_context(
     )
 
     check.bool_param(cursor_from_latest_materializations, "cursor_from_latest_materializations")
+    check.bool_param(first_tick_from_start, "first_tick_from_start")
 
     if cursor_from_latest_materializations:
         if cursor:
@@ -1038,6 +1042,7 @@ def build_multi_asset_sensor_context(
         monitored_assets=monitored_assets,
         repository_def=repository_def,
         resource_defs=wrap_resources_for_execution(resources),
+        first_tick_from_start=first_tick_from_start,
     )
 
 

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -331,6 +331,7 @@ class SensorEvaluationContext:
     @public
     @property
     def is_first_tick_since_sensor_start(self) -> bool:
+        """Flag representing if this is the first tick since the sensor was started."""
         return not self._last_tick_completion_time or (
             self._last_sensor_start_time is not None
             and self._last_sensor_start_time > self._last_tick_completion_time

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -147,6 +147,7 @@ class SensorEvaluationContext:
         sensor_name: Optional[str] = None,
         resources: Optional[Mapping[str, "ResourceDefinition"]] = None,
         definitions: Optional["Definitions"] = None,
+        first_tick_after_start: bool = False,
     ):
         from dagster._core.definitions.definitions_class import Definitions
         from dagster._core.definitions.repository_definition import RepositoryDefinition
@@ -157,6 +158,9 @@ class SensorEvaluationContext:
             last_completion_time, "last_completion_time"
         )
         self._last_run_key = check.opt_str_param(last_run_key, "last_run_key")
+        self._first_tick_after_start = check.bool_param(
+            first_tick_after_start, "first_tick_after_start"
+        )
         self._cursor = check.opt_str_param(cursor, "cursor")
         self._repository_name = check.opt_str_param(repository_name, "repository_name")
         self._repository_def = normalize_to_repository(
@@ -226,6 +230,7 @@ class SensorEvaluationContext:
                 **(self._resource_defs or {}),
                 **wrap_resources_for_execution(resources_dict),
             },
+            first_tick_after_start=self._first_tick_after_start,
         )
 
     @public
@@ -381,6 +386,10 @@ class SensorEvaluationContext:
     @property
     def log_key(self) -> Optional[List[str]]:
         return self._log_key
+
+    @property
+    def first_tick_after_start(self):
+        return self._first_tick_after_start
 
 
 RawSensorEvaluationFunctionReturn = Union[
@@ -1062,6 +1071,7 @@ def build_sensor_context(
     resources: Optional[Mapping[str, object]] = None,
     definitions: Optional["Definitions"] = None,
     instance_ref: Optional["InstanceRef"] = None,
+    first_tick_from_start: bool = False,
 ) -> SensorEvaluationContext:
     """Builds sensor execution context using the provided parameters.
 
@@ -1082,6 +1092,7 @@ def build_sensor_context(
         definitions (Optional[Definitions]): `Definitions` object that the sensor is defined in.
             If needed by the sensor, top-level resource definitions will be pulled from these
             definitions. You can provide either this or `repository_def`.
+        first_tick (bool): Whether this is the first tick of the sensor since starting.
 
     Examples:
         .. code-block:: python
@@ -1113,6 +1124,7 @@ def build_sensor_context(
         repository_def=repository_def,
         sensor_name=sensor_name,
         resources=wrap_resources_for_execution(resources),
+        first_tick_after_start=first_tick_from_start,
     )
 
 

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -147,18 +147,20 @@ class SensorEvaluationContext:
         sensor_name: Optional[str] = None,
         resources: Optional[Mapping[str, "ResourceDefinition"]] = None,
         definitions: Optional["Definitions"] = None,
-        last_start_time: Optional[float] = None,
+        last_sensor_start_time: Optional[float] = None,
     ):
         from dagster._core.definitions.definitions_class import Definitions
         from dagster._core.definitions.repository_definition import RepositoryDefinition
 
         self._exit_stack = ExitStack()
         self._instance_ref = check.opt_inst_param(instance_ref, "instance_ref", InstanceRef)
-        self._last_completion_time = check.opt_float_param(
+        self._last_tick_completion_time = check.opt_float_param(
             last_completion_time, "last_completion_time"
         )
         self._last_run_key = check.opt_str_param(last_run_key, "last_run_key")
-        self._last_start_time = check.opt_float_param(last_start_time, "last_start_time")
+        self._last_sensor_start_time = check.opt_float_param(
+            last_sensor_start_time, "last_sensor_start_time"
+        )
         self._cursor = check.opt_str_param(cursor, "cursor")
         self._repository_name = check.opt_str_param(repository_name, "repository_name")
         self._repository_def = normalize_to_repository(
@@ -217,7 +219,7 @@ class SensorEvaluationContext:
 
         return SensorEvaluationContext(
             instance_ref=self._instance_ref,
-            last_completion_time=self._last_completion_time,
+            last_completion_time=self._last_tick_completion_time,
             last_run_key=self._last_run_key,
             cursor=self._cursor,
             repository_name=self._repository_name,
@@ -228,7 +230,7 @@ class SensorEvaluationContext:
                 **(self._resource_defs or {}),
                 **wrap_resources_for_execution(resources_dict),
             },
-            last_start_time=self._last_start_time,
+            last_sensor_start_time=self._last_sensor_start_time,
         )
 
     @public
@@ -307,18 +309,32 @@ class SensorEvaluationContext:
 
     @public
     @property
-    def last_completion_time(self) -> Optional[float]:
+    def last_tick_completion_time(self) -> Optional[float]:
         """Optional[float]: Timestamp representing the last time this sensor completed an evaluation."""
-        return self._last_completion_time
+        return self._last_tick_completion_time
 
     @public
     @property
-    def last_start_time(self) -> Optional[float]:
+    def last_completion_time(self) -> Optional[float]:
+        """Optional[float]: Timestamp representing the last time this sensor completed an evaluation. Legacy alias of last_tick_completion_time, renamed for clarity."""
+        return self._last_tick_completion_time
+
+    @public
+    @property
+    def last_sensor_start_time(self) -> Optional[float]:
         """Optional[float]: Timestamp representing the last time this sensor was started. Can be
         used in concert with last_completion_time to determine if this is the first tick since the
         sensor was started.
         """
-        return self._last_start_time
+        return self._last_sensor_start_time
+
+    @public
+    @property
+    def is_first_tick_since_sensor_start(self) -> bool:
+        return not self._last_tick_completion_time or (
+            self._last_sensor_start_time is not None
+            and self._last_sensor_start_time > self._last_tick_completion_time
+        )
 
     @public
     @property
@@ -1074,7 +1090,7 @@ def build_sensor_context(
     resources: Optional[Mapping[str, object]] = None,
     definitions: Optional["Definitions"] = None,
     instance_ref: Optional["InstanceRef"] = None,
-    last_start_time: Optional[float] = None,
+    last_sensor_start_time: Optional[float] = None,
 ) -> SensorEvaluationContext:
     """Builds sensor execution context using the provided parameters.
 
@@ -1095,7 +1111,7 @@ def build_sensor_context(
         definitions (Optional[Definitions]): `Definitions` object that the sensor is defined in.
             If needed by the sensor, top-level resource definitions will be pulled from these
             definitions. You can provide either this or `repository_def`.
-        last_start_time (Optional[float]): The last time the sensor was started.
+        last_sensor_start_time (Optional[float]): The last time the sensor was started.
 
     Examples:
         .. code-block:: python
@@ -1127,7 +1143,7 @@ def build_sensor_context(
         repository_def=repository_def,
         sensor_name=sensor_name,
         resources=wrap_resources_for_execution(resources),
-        last_start_time=last_start_time,
+        last_sensor_start_time=last_sensor_start_time,
     )
 
 

--- a/python_modules/dagster/dagster/_core/host_representation/code_location.py
+++ b/python_modules/dagster/dagster/_core/host_representation/code_location.py
@@ -214,6 +214,7 @@ class CodeLocation(AbstractContextManager):
         last_completion_time: Optional[float],
         last_run_key: Optional[str],
         cursor: Optional[str],
+        first_tick_start_time: bool = False,
     ) -> "SensorExecutionData":
         pass
 
@@ -498,6 +499,7 @@ class InProcessCodeLocation(CodeLocation):
         last_completion_time: Optional[float],
         last_run_key: Optional[str],
         cursor: Optional[str],
+        first_tick_after_start: bool = False,
     ) -> "SensorExecutionData":
         result = get_external_sensor_execution(
             self._get_repo_def(repository_handle.repository_name),
@@ -506,6 +508,7 @@ class InProcessCodeLocation(CodeLocation):
             last_completion_time,
             last_run_key,
             cursor,
+            first_tick_after_start=first_tick_after_start,
         )
         if isinstance(result, ExternalSensorExecutionErrorData):
             raise DagsterUserCodeProcessError.from_error_info(result.error)
@@ -854,6 +857,7 @@ class GrpcServerCodeLocation(CodeLocation):
         last_completion_time: Optional[float],
         last_run_key: Optional[str],
         cursor: Optional[str],
+        first_tick_start_time: bool = False,
     ) -> "SensorExecutionData":
         from dagster._api.snapshot_sensor import sync_get_external_sensor_execution_data_grpc
 
@@ -865,6 +869,7 @@ class GrpcServerCodeLocation(CodeLocation):
             last_completion_time,
             last_run_key,
             cursor,
+            first_tick_start_time,
         )
 
     def get_external_partition_set_execution_param_data(

--- a/python_modules/dagster/dagster/_core/host_representation/code_location.py
+++ b/python_modules/dagster/dagster/_core/host_representation/code_location.py
@@ -214,7 +214,7 @@ class CodeLocation(AbstractContextManager):
         last_completion_time: Optional[float],
         last_run_key: Optional[str],
         cursor: Optional[str],
-        last_start_time: Optional[float],
+        last_sensor_start_time: Optional[float],
     ) -> "SensorExecutionData":
         pass
 
@@ -499,7 +499,7 @@ class InProcessCodeLocation(CodeLocation):
         last_completion_time: Optional[float],
         last_run_key: Optional[str],
         cursor: Optional[str],
-        last_start_time: Optional[float],
+        last_sensor_start_time: Optional[float],
     ) -> "SensorExecutionData":
         result = get_external_sensor_execution(
             self._get_repo_def(repository_handle.repository_name),
@@ -508,7 +508,7 @@ class InProcessCodeLocation(CodeLocation):
             last_completion_time,
             last_run_key,
             cursor,
-            last_start_time,
+            last_sensor_start_time,
         )
         if isinstance(result, ExternalSensorExecutionErrorData):
             raise DagsterUserCodeProcessError.from_error_info(result.error)
@@ -857,7 +857,7 @@ class GrpcServerCodeLocation(CodeLocation):
         last_completion_time: Optional[float],
         last_run_key: Optional[str],
         cursor: Optional[str],
-        last_start_time: Optional[float],
+        last_sensor_start_time: Optional[float],
     ) -> "SensorExecutionData":
         from dagster._api.snapshot_sensor import sync_get_external_sensor_execution_data_grpc
 
@@ -869,7 +869,7 @@ class GrpcServerCodeLocation(CodeLocation):
             last_completion_time,
             last_run_key,
             cursor,
-            last_start_time,
+            last_sensor_start_time,
         )
 
     def get_external_partition_set_execution_param_data(

--- a/python_modules/dagster/dagster/_core/host_representation/code_location.py
+++ b/python_modules/dagster/dagster/_core/host_representation/code_location.py
@@ -214,7 +214,7 @@ class CodeLocation(AbstractContextManager):
         last_completion_time: Optional[float],
         last_run_key: Optional[str],
         cursor: Optional[str],
-        first_tick_start_time: bool = False,
+        last_start_time: Optional[float],
     ) -> "SensorExecutionData":
         pass
 
@@ -499,7 +499,7 @@ class InProcessCodeLocation(CodeLocation):
         last_completion_time: Optional[float],
         last_run_key: Optional[str],
         cursor: Optional[str],
-        first_tick_after_start: bool = False,
+        last_start_time: Optional[float],
     ) -> "SensorExecutionData":
         result = get_external_sensor_execution(
             self._get_repo_def(repository_handle.repository_name),
@@ -508,7 +508,7 @@ class InProcessCodeLocation(CodeLocation):
             last_completion_time,
             last_run_key,
             cursor,
-            first_tick_after_start=first_tick_after_start,
+            last_start_time,
         )
         if isinstance(result, ExternalSensorExecutionErrorData):
             raise DagsterUserCodeProcessError.from_error_info(result.error)
@@ -857,7 +857,7 @@ class GrpcServerCodeLocation(CodeLocation):
         last_completion_time: Optional[float],
         last_run_key: Optional[str],
         cursor: Optional[str],
-        first_tick_start_time: bool = False,
+        last_start_time: Optional[float],
     ) -> "SensorExecutionData":
         from dagster._api.snapshot_sensor import sync_get_external_sensor_execution_data_grpc
 
@@ -869,7 +869,7 @@ class GrpcServerCodeLocation(CodeLocation):
             last_completion_time,
             last_run_key,
             cursor,
-            first_tick_start_time,
+            last_start_time,
         )
 
     def get_external_partition_set_execution_param_data(

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -2640,7 +2640,7 @@ class DagsterInstance(DynamicPartitionsStore):
             data = cast(SensorInstigatorData, stored_state.instigator_data)
             return self.update_instigator_state(
                 stored_state.with_status(InstigatorStatus.RUNNING).with_data(
-                    data.with_start_time(pendulum.now("UTC").timestamp())
+                    data.with_sensor_start_timestamp(pendulum.now("UTC").timestamp())
                 )
             )
 

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -28,6 +28,7 @@ from typing import (
     cast,
 )
 
+import pendulum
 import yaml
 from typing_extensions import Protocol, Self, TypeAlias, TypeVar, runtime_checkable
 
@@ -2629,11 +2630,19 @@ class DagsterInstance(DynamicPartitionsStore):
                     external_sensor.get_external_origin(),
                     InstigatorType.SENSOR,
                     InstigatorStatus.RUNNING,
-                    SensorInstigatorData(min_interval=external_sensor.min_interval_seconds),
+                    SensorInstigatorData(
+                        min_interval=external_sensor.min_interval_seconds,
+                        last_sensor_start_timestamp=pendulum.now("UTC").timestamp(),
+                    ),
                 )
             )
         else:
-            return self.update_instigator_state(stored_state.with_status(InstigatorStatus.RUNNING))
+            data = cast(SensorInstigatorData, stored_state.instigator_data)
+            return self.update_instigator_state(
+                stored_state.with_status(InstigatorStatus.RUNNING).with_data(
+                    data.with_start_time(pendulum.now("UTC").timestamp())
+                )
+            )
 
     def stop_sensor(
         self,

--- a/python_modules/dagster/dagster/_core/scheduler/instigation.py
+++ b/python_modules/dagster/dagster/_core/scheduler/instigation.py
@@ -89,8 +89,7 @@ class SensorInstigatorData(
             # the last time a tick was initiated, used to prevent issuing multiple threads from
             # evaluating ticks within the minimum interval
             ("last_tick_start_timestamp", Optional[float]),
-            # the last time the sensor was started, used to add a flag to the sensor context for
-            # the first tick after a sensor start
+            # the last time the sensor was started
             ("last_sensor_start_timestamp", Optional[float]),
         ],
     )
@@ -123,13 +122,6 @@ class SensorInstigatorData(
             self.cursor,
             self.last_tick_start_timestamp,
             start_time,
-        )
-
-    @property
-    def first_tick_after_start(self) -> bool:
-        return bool(
-            self.last_sensor_start_timestamp
-            and self.last_sensor_start_timestamp > (self.last_tick_timestamp or 0)
         )
 
 

--- a/python_modules/dagster/dagster/_core/scheduler/instigation.py
+++ b/python_modules/dagster/dagster/_core/scheduler/instigation.py
@@ -113,15 +113,15 @@ class SensorInstigatorData(
             check.opt_float_param(last_sensor_start_timestamp, "last_sensor_start_timestamp"),
         )
 
-    def with_start_time(self, start_time: float) -> "SensorInstigatorData":
-        check.float_param(start_time, "start_time")
+    def with_sensor_start_timestamp(self, start_timestamp: float) -> "SensorInstigatorData":
+        check.float_param(start_timestamp, "start_timestamp")
         return SensorInstigatorData(
             self.last_tick_timestamp,
             self.last_run_key,
             self.min_interval,
             self.cursor,
             self.last_tick_start_timestamp,
-            start_time,
+            start_timestamp,
         )
 
 

--- a/python_modules/dagster/dagster/_core/scheduler/instigation.py
+++ b/python_modules/dagster/dagster/_core/scheduler/instigation.py
@@ -89,6 +89,9 @@ class SensorInstigatorData(
             # the last time a tick was initiated, used to prevent issuing multiple threads from
             # evaluating ticks within the minimum interval
             ("last_tick_start_timestamp", Optional[float]),
+            # the last time the sensor was started, used to add a flag to the sensor context for
+            # the first tick after a sensor start
+            ("last_sensor_start_timestamp", Optional[float]),
         ],
     )
 ):
@@ -99,6 +102,7 @@ class SensorInstigatorData(
         min_interval: Optional[int] = None,
         cursor: Optional[str] = None,
         last_tick_start_timestamp: Optional[float] = None,
+        last_sensor_start_timestamp: Optional[float] = None,
     ):
         return super(SensorInstigatorData, cls).__new__(
             cls,
@@ -107,6 +111,25 @@ class SensorInstigatorData(
             check.opt_int_param(min_interval, "min_interval"),
             check.opt_str_param(cursor, "cursor"),
             check.opt_float_param(last_tick_start_timestamp, "last_tick_start_timestamp"),
+            check.opt_float_param(last_sensor_start_timestamp, "last_sensor_start_timestamp"),
+        )
+
+    def with_start_time(self, start_time: float) -> "SensorInstigatorData":
+        check.float_param(start_time, "start_time")
+        return SensorInstigatorData(
+            self.last_tick_timestamp,
+            self.last_run_key,
+            self.min_interval,
+            self.cursor,
+            self.last_tick_start_timestamp,
+            start_time,
+        )
+
+    @property
+    def first_tick_after_start(self) -> bool:
+        return bool(
+            self.last_sensor_start_timestamp
+            and self.last_sensor_start_timestamp > (self.last_tick_timestamp or 0)
         )
 
 

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -171,7 +171,9 @@ class SensorLaunchContext:
                 self._external_sensor.get_external_origin_id(), self._external_sensor.selector_id
             )
             last_run_key = state.instigator_data.last_run_key if state.instigator_data else None  # type: ignore  # (possible none)
-            last_sensor_start_timestamp = state.instigator_data.last_sensor_start_timestamp if state.instigator_data else None  # type: ignore  # (possible none)
+            last_sensor_start_timestamp = (
+                state.instigator_data.last_sensor_start_timestamp if state.instigator_data else None  # type: ignore  # (possible none)
+            )
             if self._tick.run_keys and should_update_cursor_and_last_run_key:
                 last_run_key = self._tick.run_keys[-1]
 
@@ -659,7 +661,7 @@ def _evaluate_sensor(
         instigator_data.last_tick_timestamp if instigator_data else None,
         instigator_data.last_run_key if instigator_data else None,
         instigator_data.cursor if instigator_data else None,
-        instigator_data.first_tick_after_start if instigator_data else None,
+        instigator_data.last_sensor_start_timestamp if instigator_data else None,
     )
 
     yield

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -171,6 +171,7 @@ class SensorLaunchContext:
                 self._external_sensor.get_external_origin_id(), self._external_sensor.selector_id
             )
             last_run_key = state.instigator_data.last_run_key if state.instigator_data else None  # type: ignore  # (possible none)
+            last_sensor_start_timestamp = state.instigator_data.last_sensor_start_timestamp if state.instigator_data else None  # type: ignore  # (possible none)
             if self._tick.run_keys and should_update_cursor_and_last_run_key:
                 last_run_key = self._tick.run_keys[-1]
 
@@ -190,6 +191,7 @@ class SensorLaunchContext:
                         min_interval=self._external_sensor.min_interval_seconds,
                         cursor=cursor,
                         last_tick_start_timestamp=marked_timestamp,
+                        last_sensor_start_timestamp=last_sensor_start_timestamp,
                     )
                 )
             )
@@ -397,7 +399,10 @@ def execute_sensor_iteration(
                 external_sensor.get_external_origin(),
                 InstigatorType.SENSOR,
                 InstigatorStatus.AUTOMATICALLY_RUNNING,
-                SensorInstigatorData(min_interval=external_sensor.min_interval_seconds),
+                SensorInstigatorData(
+                    min_interval=external_sensor.min_interval_seconds,
+                    last_sensor_start_timestamp=pendulum.now("UTC").timestamp(),
+                ),
             )
             instance.add_instigator_state(sensor_state)
         elif _is_under_min_interval(sensor_state, external_sensor):
@@ -654,6 +659,7 @@ def _evaluate_sensor(
         instigator_data.last_tick_timestamp if instigator_data else None,
         instigator_data.last_run_key if instigator_data else None,
         instigator_data.cursor if instigator_data else None,
+        instigator_data.first_tick_after_start if instigator_data else None,
     )
 
     yield

--- a/python_modules/dagster/dagster/_grpc/impl.py
+++ b/python_modules/dagster/dagster/_grpc/impl.py
@@ -336,7 +336,7 @@ def get_external_sensor_execution(
     last_completion_timestamp: Optional[float],
     last_run_key: Optional[str],
     cursor: Optional[str],
-    last_start_timestamp: Optional[float],
+    last_sensor_start_timestamp: Optional[float],
 ):
     from dagster._core.execution.resources_init import get_transitive_required_resource_keys
 
@@ -361,7 +361,7 @@ def get_external_sensor_execution(
             repository_def=repo_def,
             sensor_name=sensor_name,
             resources=resources_to_build,
-            last_start_time=last_start_timestamp,
+            last_sensor_start_time=last_sensor_start_timestamp,
         ) as sensor_context:
             with user_code_error_boundary(
                 SensorExecutionError,

--- a/python_modules/dagster/dagster/_grpc/impl.py
+++ b/python_modules/dagster/dagster/_grpc/impl.py
@@ -336,7 +336,7 @@ def get_external_sensor_execution(
     last_completion_timestamp: Optional[float],
     last_run_key: Optional[str],
     cursor: Optional[str],
-    first_tick_after_start: Optional[bool],
+    last_start_timestamp: Optional[float],
 ):
     from dagster._core.execution.resources_init import get_transitive_required_resource_keys
 
@@ -361,7 +361,7 @@ def get_external_sensor_execution(
             repository_def=repo_def,
             sensor_name=sensor_name,
             resources=resources_to_build,
-            first_tick_after_start=bool(first_tick_after_start),
+            last_start_time=last_start_timestamp,
         ) as sensor_context:
             with user_code_error_boundary(
                 SensorExecutionError,

--- a/python_modules/dagster/dagster/_grpc/impl.py
+++ b/python_modules/dagster/dagster/_grpc/impl.py
@@ -336,6 +336,7 @@ def get_external_sensor_execution(
     last_completion_timestamp: Optional[float],
     last_run_key: Optional[str],
     cursor: Optional[str],
+    first_tick_after_start: Optional[bool],
 ):
     from dagster._core.execution.resources_init import get_transitive_required_resource_keys
 
@@ -360,6 +361,7 @@ def get_external_sensor_execution(
             repository_def=repo_def,
             sensor_name=sensor_name,
             resources=resources_to_build,
+            first_tick_after_start=bool(first_tick_after_start),
         ) as sensor_context:
             with user_code_error_boundary(
                 SensorExecutionError,

--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -726,6 +726,7 @@ class DagsterApiServer(DagsterApiServicer):
                     args.last_completion_time,
                     args.last_run_key,
                     args.cursor,
+                    args.first_tick_after_start,
                 )
             )
         except Exception:

--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -726,7 +726,7 @@ class DagsterApiServer(DagsterApiServicer):
                     args.last_completion_time,
                     args.last_run_key,
                     args.cursor,
-                    args.first_tick_after_start,
+                    args.last_start_time,
                 )
             )
         except Exception:

--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -726,7 +726,7 @@ class DagsterApiServer(DagsterApiServicer):
                     args.last_completion_time,
                     args.last_run_key,
                     args.cursor,
-                    args.last_start_time,
+                    args.last_sensor_start_time,
                 )
             )
         except Exception:

--- a/python_modules/dagster/dagster/_grpc/types.py
+++ b/python_modules/dagster/dagster/_grpc/types.py
@@ -582,7 +582,7 @@ class SensorExecutionArgs(
             ("last_completion_time", Optional[float]),
             ("last_run_key", Optional[str]),
             ("cursor", Optional[str]),
-            ("first_tick_after_start", Optional[bool]),
+            ("last_start_time", Optional[float]),
         ],
     )
 ):
@@ -594,7 +594,7 @@ class SensorExecutionArgs(
         last_completion_time: Optional[float],
         last_run_key: Optional[str],
         cursor: Optional[str],
-        first_tick_after_start: Optional[bool] = False,
+        last_start_time: Optional[float],
     ):
         return super(SensorExecutionArgs, cls).__new__(
             cls,
@@ -608,9 +608,7 @@ class SensorExecutionArgs(
             ),
             last_run_key=check.opt_str_param(last_run_key, "last_run_key"),
             cursor=check.opt_str_param(cursor, "cursor"),
-            first_tick_after_start=check.opt_bool_param(
-                first_tick_after_start, "first_tick_after_start"
-            ),
+            last_start_time=check.opt_float_param(last_start_time, "last_start_time"),
         )
 
 

--- a/python_modules/dagster/dagster/_grpc/types.py
+++ b/python_modules/dagster/dagster/_grpc/types.py
@@ -582,6 +582,7 @@ class SensorExecutionArgs(
             ("last_completion_time", Optional[float]),
             ("last_run_key", Optional[str]),
             ("cursor", Optional[str]),
+            ("first_tick_after_start", Optional[bool]),
         ],
     )
 ):
@@ -593,6 +594,7 @@ class SensorExecutionArgs(
         last_completion_time: Optional[float],
         last_run_key: Optional[str],
         cursor: Optional[str],
+        first_tick_after_start: Optional[bool] = False,
     ):
         return super(SensorExecutionArgs, cls).__new__(
             cls,
@@ -606,6 +608,9 @@ class SensorExecutionArgs(
             ),
             last_run_key=check.opt_str_param(last_run_key, "last_run_key"),
             cursor=check.opt_str_param(cursor, "cursor"),
+            first_tick_after_start=check.opt_bool_param(
+                first_tick_after_start, "first_tick_after_start"
+            ),
         )
 
 

--- a/python_modules/dagster/dagster/_grpc/types.py
+++ b/python_modules/dagster/dagster/_grpc/types.py
@@ -582,7 +582,7 @@ class SensorExecutionArgs(
             ("last_completion_time", Optional[float]),
             ("last_run_key", Optional[str]),
             ("cursor", Optional[str]),
-            ("last_start_time", Optional[float]),
+            ("last_sensor_start_time", Optional[float]),
         ],
     )
 ):
@@ -594,7 +594,7 @@ class SensorExecutionArgs(
         last_completion_time: Optional[float],
         last_run_key: Optional[str],
         cursor: Optional[str],
-        last_start_time: Optional[float],
+        last_sensor_start_time: Optional[float],
     ):
         return super(SensorExecutionArgs, cls).__new__(
             cls,
@@ -608,7 +608,9 @@ class SensorExecutionArgs(
             ),
             last_run_key=check.opt_str_param(last_run_key, "last_run_key"),
             cursor=check.opt_str_param(cursor, "cursor"),
-            last_start_time=check.opt_float_param(last_start_time, "last_start_time"),
+            last_sensor_start_time=check.opt_float_param(
+                last_sensor_start_time, "last_sensor_start_time"
+            ),
         )
 
 

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_sensor.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_sensor.py
@@ -45,7 +45,7 @@ def test_external_sensor_deserialize_error(instance):
                         last_completion_time=None,
                         last_run_key=None,
                         cursor=None,
-                        last_start_time=None,
+                        last_sensor_start_time=None,
                     )
                 )
             )

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_sensor.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_sensor.py
@@ -45,6 +45,7 @@ def test_external_sensor_deserialize_error(instance):
                         last_completion_time=None,
                         last_run_key=None,
                         cursor=None,
+                        last_start_time=None,
                     )
                 )
             )

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -226,11 +226,7 @@ def run_cursor_sensor(context):
 @sensor(job_name="the_job")
 def start_skip_sensor(context):
     # skips the first tick after a start
-    if (
-        not context.last_completion_time
-        or context.last_start_time
-        and context.last_start_time > context.last_completion_time
-    ):
+    if context.is_first_tick_since_sensor_start:
         return SkipReason()
     return RunRequest()
 

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -226,7 +226,11 @@ def run_cursor_sensor(context):
 @sensor(job_name="the_job")
 def start_skip_sensor(context):
     # skips the first tick after a start
-    if context.first_tick_after_start:
+    if (
+        not context.last_completion_time
+        or context.last_start_time
+        and context.last_start_time > context.last_completion_time
+    ):
         return SkipReason()
     return RunRequest()
 

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_persistent.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_persistent.py
@@ -825,6 +825,7 @@ def test_sensor_timeout(entrypoint):
                         last_completion_time=None,
                         last_run_key=None,
                         cursor=None,
+                        last_start_time=None,
                     ),
                     timeout=2,
                 )
@@ -840,6 +841,7 @@ def test_sensor_timeout(entrypoint):
                     last_completion_time=None,
                     last_run_key=None,
                     cursor=None,
+                    last_start_time=None,
                 ),
             )
     finally:

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_persistent.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_persistent.py
@@ -825,7 +825,7 @@ def test_sensor_timeout(entrypoint):
                         last_completion_time=None,
                         last_run_key=None,
                         cursor=None,
-                        last_start_time=None,
+                        last_sensor_start_time=None,
                     ),
                     timeout=2,
                 )
@@ -841,7 +841,7 @@ def test_sensor_timeout(entrypoint):
                     last_completion_time=None,
                     last_run_key=None,
                     cursor=None,
-                    last_start_time=None,
+                    last_sensor_start_time=None,
                 ),
             )
     finally:


### PR DESCRIPTION
## Summary & Motivation
For sensors that have been turned off for some time, it's useful to have some indication so that user code can decide to limit the range of values to examine (e.g. only look at the last 5 minutes worth of data).

This PR adds the last start time to the stored sensor data, and then adds a flag to the sensor context by comparing the last tick timestamp to the last start timestamp.

## How I Tested These Changes
BK, TBD