### PR TITLE
Increase default StreamingExternalRepository timeout and make it configurable

### DIFF
--- a/python_modules/dagster/dagster/_grpc/client.py
+++ b/python_modules/dagster/dagster/_grpc/client.py
@@ -35,6 +35,7 @@ from .types import (
 )
 from .utils import (
     default_grpc_timeout,
+    default_repository_grpc_timeout,
     default_schedule_grpc_timeout,
     default_sensor_grpc_timeout,
     max_rx_bytes,
@@ -46,6 +47,7 @@ CLIENT_HEARTBEAT_INTERVAL = 1
 DEFAULT_GRPC_TIMEOUT = default_grpc_timeout()
 DEFAULT_SCHEDULE_GRPC_TIMEOUT = default_schedule_grpc_timeout()
 DEFAULT_SENSOR_GRPC_TIMEOUT = default_sensor_grpc_timeout()
+DEFAULT_REPOSITORY_GRPC_TIMEOUT = default_repository_grpc_timeout()
 
 
 def client_heartbeat_thread(client: "DagsterGrpcClient", shutdown_event: Event) -> None:
@@ -350,6 +352,7 @@ class DagsterGrpcClient:
         self,
         external_repository_origin: ExternalRepositoryOrigin,
         defer_snapshots: bool = False,
+        timeout=DEFAULT_REPOSITORY_GRPC_TIMEOUT,
     ):
         for res in self._streaming_query(
             "StreamingExternalRepository",
@@ -357,6 +360,7 @@ class DagsterGrpcClient:
             # Rename parameter
             serialized_repository_python_origin=serialize_value(external_repository_origin),
             defer_snapshots=defer_snapshots,
+            timeout=timeout,
         ):
             yield {
                 "sequence_number": res.sequence_number,

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_utils.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_utils.py
@@ -2,6 +2,7 @@ from dagster._core.test_utils import environ
 from dagster._grpc.utils import (
     default_grpc_server_shutdown_grace_period,
     default_grpc_timeout,
+    default_repository_grpc_timeout,
     default_schedule_grpc_timeout,
     default_sensor_grpc_timeout,
 )
@@ -13,43 +14,71 @@ def test_default_grpc_timeouts():
             "DAGSTER_GRPC_TIMEOUT_SECONDS": None,
             "DAGSTER_SCHEDULE_GRPC_TIMEOUT_SECONDS": None,
             "DAGSTER_SENSOR_GRPC_TIMEOUT_SECONDS": None,
+            "DAGSTER_REPOSITORY_GRPC_TIMEOUT_SECONDS": None,
         }
     ):
         assert default_grpc_timeout() == 60
         assert default_schedule_grpc_timeout() == 60
         assert default_sensor_grpc_timeout() == 60
         assert default_grpc_server_shutdown_grace_period() == 60
+        assert default_repository_grpc_timeout() == 180
 
 
 def test_override_grpc_timeouts():
     with environ(
         {
             "DAGSTER_GRPC_TIMEOUT_SECONDS": "120",
+            "DAGSTER_SCHEDULE_GRPC_TIMEOUT_SECONDS": None,
+            "DAGSTER_SENSOR_GRPC_TIMEOUT_SECONDS": None,
+            "DAGSTER_REPOSITORY_GRPC_TIMEOUT_SECONDS": None,
         }
     ):
         assert default_grpc_timeout() == 120
         assert default_schedule_grpc_timeout() == 120
         assert default_sensor_grpc_timeout() == 120
         assert default_grpc_server_shutdown_grace_period() == 120
+        assert default_repository_grpc_timeout() == 180
 
     with environ(
         {
+            "DAGSTER_GRPC_TIMEOUT_SECONDS": "240",
+            "DAGSTER_SCHEDULE_GRPC_TIMEOUT_SECONDS": None,
+            "DAGSTER_SENSOR_GRPC_TIMEOUT_SECONDS": None,
+            "DAGSTER_REPOSITORY_GRPC_TIMEOUT_SECONDS": None,
+        }
+    ):
+        assert default_grpc_timeout() == 240
+        assert default_schedule_grpc_timeout() == 240
+        assert default_sensor_grpc_timeout() == 240
+        assert default_grpc_server_shutdown_grace_period() == 240
+        assert default_repository_grpc_timeout() == 240
+
+    with environ(
+        {
+            "DAGSTER_GRPC_TIMEOUT_SECONDS": None,
             "DAGSTER_SCHEDULE_GRPC_TIMEOUT_SECONDS": "45",
+            "DAGSTER_SENSOR_GRPC_TIMEOUT_SECONDS": None,
+            "DAGSTER_REPOSITORY_GRPC_TIMEOUT_SECONDS": None,
         }
     ):
         assert default_grpc_timeout() == 60
         assert default_schedule_grpc_timeout() == 45
         assert default_sensor_grpc_timeout() == 60
         assert default_grpc_server_shutdown_grace_period() == 60
+        assert default_repository_grpc_timeout() == 180
 
     with environ(
         {
+            "DAGSTER_GRPC_TIMEOUT_SECONDS": None,
+            "DAGSTER_SCHEDULE_GRPC_TIMEOUT_SECONDS": None,
             "DAGSTER_SENSOR_GRPC_TIMEOUT_SECONDS": "45",
+            "DAGSTER_REPOSITORY_GRPC_TIMEOUT_SECONDS": None,
         }
     ):
         assert default_grpc_timeout() == 60
         assert default_schedule_grpc_timeout() == 60
         assert default_sensor_grpc_timeout() == 45
+        assert default_repository_grpc_timeout() == 180
         assert default_grpc_server_shutdown_grace_period() == 60
 
     with environ(
@@ -57,9 +86,25 @@ def test_override_grpc_timeouts():
             "DAGSTER_GRPC_TIMEOUT_SECONDS": "75",
             "DAGSTER_SCHEDULE_GRPC_TIMEOUT_SECONDS": "120",
             "DAGSTER_SENSOR_GRPC_TIMEOUT_SECONDS": "400",
+            "DAGSTER_REPOSITORY_GRPC_TIMEOUT_SECONDS": None,
         }
     ):
         assert default_grpc_timeout() == 75
         assert default_schedule_grpc_timeout() == 120
         assert default_sensor_grpc_timeout() == 400
+        assert default_repository_grpc_timeout() == 180
         assert default_grpc_server_shutdown_grace_period() == 400
+
+    with environ(
+        {
+            "DAGSTER_GRPC_TIMEOUT_SECONDS": None,
+            "DAGSTER_SCHEDULE_GRPC_TIMEOUT_SECONDS": None,
+            "DAGSTER_SENSOR_GRPC_TIMEOUT_SECONDS": None,
+            "DAGSTER_REPOSITORY_GRPC_TIMEOUT_SECONDS": "300",
+        }
+    ):
+        assert default_grpc_timeout() == 60
+        assert default_schedule_grpc_timeout() == 60
+        assert default_sensor_grpc_timeout() == 60
+        assert default_grpc_server_shutdown_grace_period() == 60
+        assert default_repository_grpc_timeout() == 300


### PR DESCRIPTION
Summary:
StreamingExternalRepository is a grpc call made when loading code location snapshots over gRPC. On larger repositories with lots of jobs and/or beefy snapshots, we've gotten reports of 60 seconds being insufficient to get all the data serialized and over the wire.

This PR does two things to address that:

- bumps the default up to 180 seconds instead of 60 seconds. Unlike with sensors and schedules, there's little risk of bumping up this timeout since this is on code location startup - it's not going to starve out other operations on the same server.

- Make the timeout configurable via env var to be even higher, for truly large repositories.

## Summary & Motivation

## How I Tested These Changes
