### PR TITLE
[docs] Use https for sitemap URLs

### DIFF
--- a/docs/next/pages/sitemap.xml.tsx
+++ b/docs/next/pages/sitemap.xml.tsx
@@ -1,6 +1,6 @@
 import {latestAllPaths} from 'util/navigation';
 
-const toUrl = (host, route) => `<url><loc>http://${host}${route}</loc></url>`;
+const toUrl = (host, route) => `<url><loc>https://${host}${route}</loc></url>`;
 
 const createSitemap = (host, routes) =>
   `<?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
## Summary & Motivation

I have a hunch that our search crawler is failing to make proper use of our sitemap.xml. I think it may be because the sitemap exclusively uses `http://` URLs instead of `https://`, even though all of these URLs will 307 -> 302 to `https`.

I'm changing the sitemap generator to use `https` instead.

## How I Tested These Changes

View sitemap.xml locally and in preview, verify that the URLs look correct.
