### PR TITLE
[duckdb] rename `config` config to `connection_config`

### DIFF
--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
@@ -154,7 +154,7 @@ class DuckDBIOManager(ConfigurableIOManagerFactory):
             # my_table will just contain the data from column "a"
             ...
 
-    Set DuckDB configuration options using the config field. See
+    Set DuckDB configuration options using the connection_config field. See
     https://duckdb.org/docs/sql/configuration.html for all available settings.
 
     .. code-block:: python
@@ -162,13 +162,19 @@ class DuckDBIOManager(ConfigurableIOManagerFactory):
         defs = Definitions(
             assets=[my_table],
             resources={"io_manager": MyDuckDBIOManager(database="my_db.duckdb",
-                                                       config={"arrow_large_buffer_size": True})}
+                                                       connection_config={"arrow_large_buffer_size": True})}
         )
 
     """
 
     database: str = Field(description="Path to the DuckDB database.")
-    config: Dict[str, Any] = Field(description="DuckDB configuration options.", default={})
+    connection_config: Dict[str, Any] = Field(
+        description=(
+            "DuckDB connection configuration options. See"
+            " https://duckdb.org/docs/sql/configuration.html"
+        ),
+        default={},
+    )
     schema_: Optional[str] = Field(
         default=None, alias="schema", description="Name of the schema to use."
     )  # schema is a reserved word for pydantic
@@ -224,7 +230,7 @@ class DuckDbClient(DbClient):
             kwargs={
                 "database": context.resource_config["database"],
                 "read_only": False,
-                "config": context.resource_config["config"],
+                "config": context.resource_config["connection_config"],
             },
             max_retries=10,
         )

--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb/resource.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb/resource.py
@@ -34,7 +34,13 @@ class DuckDBResource(ConfigurableResource):
             " database "
         )
     )
-    config: Dict[str, Any] = Field(description="DuckDB configuration options.", default={})
+    connection_config: Dict[str, Any] = Field(
+        description=(
+            "DuckDB connection configuration options. See"
+            " https://duckdb.org/docs/sql/configuration.html"
+        ),
+        default={},
+    )
 
     @classmethod
     def _is_dagster_maintained(cls) -> bool:
@@ -45,7 +51,11 @@ class DuckDBResource(ConfigurableResource):
         conn = backoff(
             fn=duckdb.connect,
             retry_on=(RuntimeError, duckdb.IOException),
-            kwargs={"database": self.database, "read_only": False, "config": self.config},
+            kwargs={
+                "database": self.database,
+                "read_only": False,
+                "config": self.connection_config,
+            },
             max_retries=10,
         )
 

--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb_tests/test_resource.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb_tests/test_resource.py
@@ -28,14 +28,14 @@ def test_resource(tmp_path):
 
 
 @pytest.mark.parametrize(
-    "config",
+    "connection_config",
     [{"arrow_large_buffer_size": False}, {"arrow_large_buffer_size": True}],
 )
-def test_config(tmp_path, config):
+def test_config(tmp_path, connection_config):
     @op(required_resource_keys={"duckdb"})
     def check_config_op(context):
         with context.resources.duckdb.get_connection() as conn:
-            for name, value in config.items():
+            for name, value in connection_config.items():
                 res = conn.execute(f"SELECT current_setting('{name}')").fetchone()
 
                 assert res[0] == value
@@ -43,7 +43,8 @@ def test_config(tmp_path, config):
     @job(
         resource_defs={
             "duckdb": DuckDBResource(
-                database=os.path.join(tmp_path, "unit_test.duckdb"), config=config
+                database=os.path.join(tmp_path, "unit_test.duckdb"),
+                connection_config=connection_config,
             )
         }
     )


### PR DESCRIPTION
## Summary & Motivation
https://github.com/dagster-io/dagster/pull/16494 added a `config` field to the DuckDB IO manager and resource so that users could set the `config` parameter of the `duckdb.connect` function. This is good configuration to add, so I merged the PR, but on further thought, I wonder if having a config field named `config` is an overload of the term "config". This PR proposes renaming it to `connection_config`. 

this would not be a breaking change as the PR adding `config` is not released

## How I Tested These Changes
