### PR TITLE
Include run worker failure reason in system logs, even if we don't include it in structured event logs

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -752,12 +752,18 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
 
                 failure_text = []
 
+                cluster_failure_info = (
+                    f"Task {t.get('taskArn')} failed. Stop code: {t.get('stopCode')}. Stop"
+                    + f" reason: {t.get('stoppedReason')}."
+                    + f" {container_str} {[c.get('name') for c in failed_containers]} failed."
+                )
+
+                logging.warning(
+                    "Run monitoring detected run worker failure: " + cluster_failure_info
+                )
+
                 if self.include_cluster_info_in_failure_messages:
-                    failure_text.append(
-                        f"Task {t.get('taskArn')} failed. Stop code: {t.get('stopCode')}. Stop"
-                        f" reason: {t.get('stoppedReason')}."
-                        + f" {container_str} {[c.get('name') for c in failed_containers]} failed."
-                    )
+                    failure_text.append(cluster_failure_info)
 
                 logs = []
 


### PR DESCRIPTION
Summary:
sometimes we don't include the reason an ECS task failed in the event logs for the run, but it's still useful to know why it failed in the operational logs for the agent/daemon/etc. that launched the run.

Test Plan:
Existing BK verifies that run worker monitoring is still working in general with the correct messages
Check logs for our existing ECS cluster fleet for this message

## Summary & Motivation

## How I Tested These Changes
