### PR TITLE
Add CannotPullContainerError with i/o timeout to list of transient ECS failures

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -713,13 +713,20 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
     def include_cluster_info_in_failure_messages(self):
         return True
 
+    def _is_transient_stop_reason(self, stopped_reason: str):
+        if "Timeout waiting for network interface provisioning to complete" in stopped_reason:
+            return True
+
+        if "CannotPullContainerError" in stopped_reason and "i/o timeout" in stopped_reason:
+            return True
+
+        return False
+
     def _is_transient_startup_failure(self, run, task):
         if not task.get("stoppedReason"):
             return False
-        return (
-            run.status == DagsterRunStatus.STARTING
-            and "Timeout waiting for network interface provisioning to complete"
-            in task.get("stoppedReason")
+        return run.status == DagsterRunStatus.STARTING and self._is_transient_stop_reason(
+            task.get("stoppedReason")
         )
 
     def check_run_worker_health(self, run: DagsterRun):

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
@@ -1143,6 +1143,17 @@ def test_status(
     assert not started_health_check.transient
     assert started_health_check.run_worker_id == "abcdef"
 
+    task["stoppedReason"] = (
+        "CannotPullContainerError: pull image manifest has been retried 5 time(s): Get"
+        ' "https://myfakeimage:myfakemanifest":'
+        " dial tcp 12.345.678.78:443: i/o timeout"
+    )
+
+    started_health_check = instance.run_launcher.check_run_worker_health(run)
+    assert started_health_check.status == WorkerStatus.FAILED
+    assert not started_health_check.transient
+    assert started_health_check.run_worker_id == "abcdef"
+
     # STARTING runs with these errors are considered a transient failure that can be retried
     starting_run = instance.create_run_for_job(
         job,


### PR DESCRIPTION
Summary:
This appears to be another reason for ECS task flakiness. Include it in the list of errors that mark a run health check as a transient issue that can be potentially retried on startup failure.

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes
