### PR TITLE
Handle undefined assetChecksAvailable in current session

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/ExecutionSessionStorage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/ExecutionSessionStorage.tsx
@@ -43,7 +43,7 @@ export interface IExecutionSession {
   mode: string | null;
   needsRefresh: boolean;
   assetSelection: {assetKey: AssetKeyInput; opNames: string[]}[] | null;
-  // Nullable for backwards compatability
+  // Nullable for backwards compatibility
   assetChecksAvailable?: Pick<AssetCheck, 'name' | 'canExecuteIndividually' | 'assetKey'>[];
   includeSeparatelyExecutableChecks: boolean;
   solidSelection: string[] | null;

--- a/js_modules/dagster-ui/packages/ui-core/src/app/ExecutionSessionStorage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/ExecutionSessionStorage.tsx
@@ -43,7 +43,8 @@ export interface IExecutionSession {
   mode: string | null;
   needsRefresh: boolean;
   assetSelection: {assetKey: AssetKeyInput; opNames: string[]}[] | null;
-  assetChecksAvailable: Pick<AssetCheck, 'name' | 'canExecuteIndividually' | 'assetKey'>[];
+  // Nullable for backwards compatability
+  assetChecksAvailable?: Pick<AssetCheck, 'name' | 'canExecuteIndividually' | 'assetKey'>[];
   includeSeparatelyExecutableChecks: boolean;
   solidSelection: string[] | null;
   solidSelectionQuery: string | null;

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadSession.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadSession.tsx
@@ -320,13 +320,15 @@ const LaunchpadSession: React.FC<LaunchpadSessionProps> = (props) => {
   const [showChecks, setShowChecks] = React.useState<
     typeof currentSession.assetChecksAvailable | null
   >(null);
-  const includedChecks = currentSession.assetChecksAvailable.filter(
-    (a) => a.canExecuteIndividually === AssetCheckCanExecuteIndividually.REQUIRES_MATERIALIZATION,
-  );
+  const includedChecks =
+    currentSession.assetChecksAvailable?.filter(
+      (a) => a.canExecuteIndividually === AssetCheckCanExecuteIndividually.REQUIRES_MATERIALIZATION,
+    ) ?? [];
 
-  const executableChecks = currentSession.assetChecksAvailable.filter(
-    (a) => a.canExecuteIndividually === AssetCheckCanExecuteIndividually.CAN_EXECUTE,
-  );
+  const executableChecks =
+    currentSession.assetChecksAvailable?.filter(
+      (a) => a.canExecuteIndividually === AssetCheckCanExecuteIndividually.CAN_EXECUTE,
+    ) ?? [];
 
   const buildExecutionVariables = () => {
     if (!currentSession) {


### PR DESCRIPTION
## Summary & Motivation

If you access a session from localStorage from before this release then this property won't exist. We correctly use the existential operator (?.) in [other places ](https://github.com/dagster-io/dagster/blob/45c5a47480b8f712d5c4c51e74213626d5061b79/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadSession.tsx#L209)but looks like we forgot to use it here.

## How I Tested These Changes

1. Switched to release-1.5.2
2. Made a new launchpad config
3. Switched back to release-1.5.3 and saw the error:
4. <img width="1164" alt="Screenshot 2023-10-11 at 11 28 22 PM" src="https://github.com/dagster-io/dagster/assets/2286579/bfdec5bf-241d-429c-b64b-e4cae1f478da">
5. Switched to this branch and saw the error go away

