### PR TITLE
[pipes] update PipesContext variable name: context -> pipes

### DIFF
--- a/docs/content/guides/dagster-pipes/subprocess/modify-external-code.mdx
+++ b/docs/content/guides/dagster-pipes/subprocess/modify-external-code.mdx
@@ -47,7 +47,7 @@ def main():
     orders_df = pd.DataFrame({"order_id": [1, 2], "item_id": [432, 878]})
     total_orders = len(orders_df)
     # get the Dagster Pipes context
-    context = PipesContext.get()
+    pipes = PipesContext.get()
     print(f"processing total {total_orders} orders")
 
 
@@ -61,7 +61,7 @@ if __name__ == "__main__":
 
 ## Step 2: Send log messages to Dagster
 
-Dagster Pipes context offers a built-in logging capability that enables you to stream log messages back to Dagster. Instead of printing to the standard output, you can use the `context.log` method on <PyObject module="dagster_pipes" object="PipesContext" /> to send log messages back to Dagster. In this case, we’re sending an `info` level log message:
+Dagster Pipes context offers a built-in logging capability that enables you to stream log messages back to Dagster. Instead of printing to the standard output, you can use the <PyObject module="dagster_pipes" object="PipesContext" method="log" /> to send log messages back to Dagster. In this case, we’re sending an `info` level log message:
 
 ```python file=/guides/dagster/dagster_pipes/subprocess/part_2/step_2/external_code.py
 import pandas as pd
@@ -72,8 +72,8 @@ def main():
     orders_df = pd.DataFrame({"order_id": [1, 2], "item_id": [432, 878]})
     total_orders = len(orders_df)
     # get the Dagster Pipes context
-    context = PipesContext.get()
-    context.log.info(f"processing total {total_orders} orders")
+    pipes = PipesContext.get()
+    pipes.log.info(f"processing total {total_orders} orders")
 
 
 if __name__ == "__main__":
@@ -115,9 +115,9 @@ def main():
     orders_df = pd.DataFrame({"order_id": [1, 2], "item_id": [432, 878]})
     total_orders = len(orders_df)
     # get the Dagster Pipes context
-    context = PipesContext.get()
+    pipes = PipesContext.get()
     # send structured metadata back to Dagster
-    context.report_asset_materialization(metadata={"total_orders": total_orders})
+    pipes.report_asset_materialization(metadata={"total_orders": total_orders})
 
 
 if __name__ == "__main__":
@@ -162,11 +162,11 @@ def main():
     orders_df = pd.DataFrame({"order_id": [1, 2], "item_id": [432, 878]})
     total_orders = len(orders_df)
     # get the Dagster Pipes context
-    context = PipesContext.get()
+    pipes = PipesContext.get()
     # send structured metadata back to Dagster
-    context.report_asset_materialization(metadata={"total_orders": total_orders})
+    pipes.report_asset_materialization(metadata={"total_orders": total_orders})
     # report data quality check result back to Dagster
-    context.report_asset_check(
+    pipes.report_asset_check(
         passed=orders_df[["item_id"]].notnull().all().bool(),
         check_name="no_empty_order_check",
     )
@@ -254,11 +254,11 @@ def main():
     orders_df = pd.DataFrame({"order_id": [1, 2], "item_id": [432, 878]})
     total_orders = len(orders_df)
     # get the Dagster Pipes context
-    context = PipesContext.get()
+    pipes = PipesContext.get()
     # send structured metadata back to Dagster
-    context.report_asset_materialization(metadata={"total_orders": total_orders})
+    pipes.report_asset_materialization(metadata={"total_orders": total_orders})
     # report data quality check result back to Dagster
-    context.report_asset_check(
+    pipes.report_asset_check(
         passed=orders_df[["item_id"]].notnull().all().bool(),
         check_name="no_empty_order_check",
     )

--- a/docs/content/guides/dagster-pipes/subprocess/reference.mdx
+++ b/docs/content/guides/dagster-pipes/subprocess/reference.mdx
@@ -29,11 +29,11 @@ def main():
     orders_df = pd.DataFrame({"order_id": [1, 2], "item_id": [432, 878]})
     total_orders = len(orders_df)
     # get the Dagster Pipes context
-    context = PipesContext.get()
+    pipes = PipesContext.get()
     # get all extras provided by Dagster asset
-    print(context.extras)
+    print(pipes.extras)
     # get the value of an extra
-    print(context.get_extra("foo"))
+    print(pipes.get_extra("foo"))
     # get env var
     print(os.environ["MY_ENV_VAR_IN_SUBPROCESS"])
 
@@ -106,9 +106,9 @@ from dagster_pipes import PipesContext, open_dagster_pipes
 def main():
     orders_df = pd.DataFrame({"order_id": [1, 2], "item_id": [432, 878]})
     # get the Dagster Pipes context
-    context = PipesContext.get()
+    pipes = PipesContext.get()
     # send structured metadata back to Dagster
-    context.report_asset_check(
+    pipes.report_asset_check(
         asset_key="my_asset",
         passed=orders_df[["item_id"]].notnull().all().bool(),
         check_name="no_empty_order_check",
@@ -200,12 +200,12 @@ def main():
     total_users = orders_df["user_id"].nunique()
 
     # get the Dagster Pipes context
-    context = PipesContext.get()
+    pipes = PipesContext.get()
     # send structured metadata back to Dagster. asset_key is required when there are multiple assets
-    context.report_asset_materialization(
+    pipes.report_asset_materialization(
         asset_key="orders", metadata={"total_orders": total_orders}
     )
-    context.report_asset_materialization(
+    pipes.report_asset_materialization(
         asset_key="users", metadata={"total_users": total_users}
     )
 

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/subprocess/part_2/step_1/external_code.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/subprocess/part_2/step_1/external_code.py
@@ -8,7 +8,7 @@ def main():
     orders_df = pd.DataFrame({"order_id": [1, 2], "item_id": [432, 878]})
     total_orders = len(orders_df)
     # get the Dagster Pipes context
-    context = PipesContext.get()
+    pipes = PipesContext.get()
     print(f"processing total {total_orders} orders")
 
 

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/subprocess/part_2/step_2/external_code.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/subprocess/part_2/step_2/external_code.py
@@ -6,8 +6,8 @@ def main():
     orders_df = pd.DataFrame({"order_id": [1, 2], "item_id": [432, 878]})
     total_orders = len(orders_df)
     # get the Dagster Pipes context
-    context = PipesContext.get()
-    context.log.info(f"processing total {total_orders} orders")
+    pipes = PipesContext.get()
+    pipes.log.info(f"processing total {total_orders} orders")
 
 
 if __name__ == "__main__":

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/subprocess/part_2/step_3_check/external_code.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/subprocess/part_2/step_3_check/external_code.py
@@ -6,11 +6,11 @@ def main():
     orders_df = pd.DataFrame({"order_id": [1, 2], "item_id": [432, 878]})
     total_orders = len(orders_df)
     # get the Dagster Pipes context
-    context = PipesContext.get()
+    pipes = PipesContext.get()
     # send structured metadata back to Dagster
-    context.report_asset_materialization(metadata={"total_orders": total_orders})
+    pipes.report_asset_materialization(metadata={"total_orders": total_orders})
     # report data quality check result back to Dagster
-    context.report_asset_check(
+    pipes.report_asset_check(
         passed=orders_df[["item_id"]].notnull().all().bool(),
         check_name="no_empty_order_check",
     )

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/subprocess/part_2/step_3_materialization/external_code.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/subprocess/part_2/step_3_materialization/external_code.py
@@ -6,9 +6,9 @@ def main():
     orders_df = pd.DataFrame({"order_id": [1, 2], "item_id": [432, 878]})
     total_orders = len(orders_df)
     # get the Dagster Pipes context
-    context = PipesContext.get()
+    pipes = PipesContext.get()
     # send structured metadata back to Dagster
-    context.report_asset_materialization(metadata={"total_orders": total_orders})
+    pipes.report_asset_materialization(metadata={"total_orders": total_orders})
 
 
 if __name__ == "__main__":

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/subprocess/with_asset_check/external_code.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/subprocess/with_asset_check/external_code.py
@@ -5,9 +5,9 @@ from dagster_pipes import PipesContext, open_dagster_pipes
 def main():
     orders_df = pd.DataFrame({"order_id": [1, 2], "item_id": [432, 878]})
     # get the Dagster Pipes context
-    context = PipesContext.get()
+    pipes = PipesContext.get()
     # send structured metadata back to Dagster
-    context.report_asset_check(
+    pipes.report_asset_check(
         asset_key="my_asset",
         passed=orders_df[["item_id"]].notnull().all().bool(),
         check_name="no_empty_order_check",

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/subprocess/with_extras_env/external_code.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/subprocess/with_extras_env/external_code.py
@@ -10,11 +10,11 @@ def main():
     orders_df = pd.DataFrame({"order_id": [1, 2], "item_id": [432, 878]})
     total_orders = len(orders_df)
     # get the Dagster Pipes context
-    context = PipesContext.get()
+    pipes = PipesContext.get()
     # get all extras provided by Dagster asset
-    print(context.extras)
+    print(pipes.extras)
     # get the value of an extra
-    print(context.get_extra("foo"))
+    print(pipes.get_extra("foo"))
     # get env var
     print(os.environ["MY_ENV_VAR_IN_SUBPROCESS"])
 

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/subprocess/with_multi_asset/external_code.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/subprocess/with_multi_asset/external_code.py
@@ -10,12 +10,12 @@ def main():
     total_users = orders_df["user_id"].nunique()
 
     # get the Dagster Pipes context
-    context = PipesContext.get()
+    pipes = PipesContext.get()
     # send structured metadata back to Dagster. asset_key is required when there are multiple assets
-    context.report_asset_materialization(
+    pipes.report_asset_materialization(
         asset_key="orders", metadata={"total_orders": total_orders}
     )
-    context.report_asset_materialization(
+    pipes.report_asset_materialization(
         asset_key="users", metadata={"total_users": total_users}
     )
 

--- a/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/domain_specific_dsl/user_scripts/fetch_the_tickers.py
+++ b/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/domain_specific_dsl/user_scripts/fetch_the_tickers.py
@@ -1,4 +1,4 @@
 from dagster_pipes import open_dagster_pipes
 
-with open_dagster_pipes() as context:
-    context.log.info(f"Got tickers: {context.extras['tickers']}")
+with open_dagster_pipes() as pipes:
+    pipes.log.info(f"Got tickers: {pipes.extras['tickers']}")

--- a/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/pure_assets_dsl/sql_script.py
+++ b/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/pure_assets_dsl/sql_script.py
@@ -11,8 +11,8 @@ class SomeSqlClient:
 if __name__ == "__main__":
     sql = sys.argv[1]
 
-    with open_dagster_pipes() as context:
+    with open_dagster_pipes() as pipes:
         client = SomeSqlClient()
         client.query(sql)
-        context.report_asset_materialization(metadata={"sql": sql})
-        context.log.info(f"Ran {sql}")
+        pipes.report_asset_materialization(metadata={"sql": sql})
+        pipes.log.info(f"Ran {sql}")

--- a/examples/experimental/external_assets/pipes/join_iot.py
+++ b/examples/experimental/external_assets/pipes/join_iot.py
@@ -2,8 +2,8 @@ import numpy as np
 import pandas as pd
 from dagster_pipes import open_dagster_pipes
 
-with open_dagster_pipes() as context:
-    context.log.info("joining iot telem data in partition ({context.partition_key})....")
+with open_dagster_pipes() as pipes:
+    pipes.log.info("joining iot telem data in partition ({pipes.partition_key})....")
     data = pd.DataFrame(
         {
             "trace_id": range(1000),
@@ -12,4 +12,4 @@ with open_dagster_pipes() as context:
             ),
         }
     )
-    context.report_asset_materialization(metadata={"row_count": len(data)})
+    pipes.report_asset_materialization(metadata={"row_count": len(data)})

--- a/examples/experimental/external_assets/pipes/join_iot_check.py
+++ b/examples/experimental/external_assets/pipes/join_iot_check.py
@@ -1,7 +1,7 @@
 from dagster_pipes import open_dagster_pipes
 
-with open_dagster_pipes() as context:
-    context.log.info("checking iot telem data....")
-    context.report_asset_check(
+with open_dagster_pipes() as pipes:
+    pipes.log.info("checking iot telem data....")
+    pipes.report_asset_check(
         asset_key="telem_post_processing", check_name="telem_post_processing_check", passed=True
     )

--- a/python_modules/dagster-test/dagster_test/toys/external_execution/numbers_example/number_sum.py
+++ b/python_modules/dagster-test/dagster_test/toys/external_execution/numbers_example/number_sum.py
@@ -2,12 +2,12 @@ from dagster_pipes import open_dagster_pipes
 
 from .util import compute_data_version, load_asset_value, store_asset_value
 
-with open_dagster_pipes() as context:
-    storage_root = context.get_extra("storage_root")
+with open_dagster_pipes() as pipes:
+    storage_root = pipes.get_extra("storage_root")
     number_y = load_asset_value("number_y", storage_root)
     number_x = load_asset_value("number_x", storage_root)
     value = number_x + number_y
     store_asset_value("number_sum", storage_root, value)
 
-    context.log.info(f"{context.asset_key}: {number_x} + {number_y} = {value}")
-    context.report_asset_materialization(data_version=compute_data_version(value))
+    pipes.log.info(f"{pipes.asset_key}: {number_x} + {number_y} = {value}")
+    pipes.report_asset_materialization(data_version=compute_data_version(value))

--- a/python_modules/dagster-test/dagster_test/toys/external_execution/numbers_example/number_x.py
+++ b/python_modules/dagster-test/dagster_test/toys/external_execution/numbers_example/number_x.py
@@ -2,12 +2,12 @@ from dagster_pipes import open_dagster_pipes
 
 from .util import compute_data_version, store_asset_value
 
-with open_dagster_pipes() as context:
-    storage_root = context.get_extra("storage_root")
+with open_dagster_pipes() as pipes:
+    storage_root = pipes.get_extra("storage_root")
 
-    multiplier = context.get_extra("multiplier")
+    multiplier = pipes.get_extra("multiplier")
     value = 2 * multiplier
     store_asset_value("number_x", storage_root, value)
 
-    context.log.info(f"{context.asset_key}: {2} * {multiplier} = {value}")
-    context.report_asset_materialization(data_version=compute_data_version(value))
+    pipes.log.info(f"{pipes.asset_key}: {2} * {multiplier} = {value}")
+    pipes.report_asset_materialization(data_version=compute_data_version(value))

--- a/python_modules/dagster-test/dagster_test/toys/external_execution/numbers_example/number_y.py
+++ b/python_modules/dagster-test/dagster_test/toys/external_execution/numbers_example/number_y.py
@@ -4,14 +4,14 @@ from dagster_pipes import open_dagster_pipes
 
 from .util import compute_data_version, store_asset_value
 
-with open_dagster_pipes() as context:
-    storage_root = context.get_extra("storage_root")
+with open_dagster_pipes() as pipes:
+    storage_root = pipes.get_extra("storage_root")
 
     value = int(os.environ["NUMBER_Y"])
     store_asset_value("number_y", storage_root, value)
 
-    context.log.info(f"{context.asset_key}: {value} read from $NUMBER_Y environment variable.")
-    context.report_asset_materialization(
+    pipes.log.info(f"{pipes.asset_key}: {value} read from $NUMBER_Y environment variable.")
+    pipes.report_asset_materialization(
         metadata={"is_even": value % 2 == 0},
         data_version=compute_data_version(value),
     )

--- a/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_subprocess.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_subprocess.py
@@ -202,8 +202,8 @@ def test_pipes_subprocess_client_no_return():
     def script_fn():
         from dagster_pipes import open_dagster_pipes
 
-        with open_dagster_pipes() as context:
-            context.report_asset_materialization()
+        with open_dagster_pipes() as pipes:
+            pipes.report_asset_materialization()
 
     @asset
     def foo(context: OpExecutionContext, client: PipesSubprocessClient):
@@ -227,11 +227,11 @@ def test_pipes_multi_asset():
     def script_fn():
         from dagster_pipes import open_dagster_pipes
 
-        with open_dagster_pipes() as context:
-            context.report_asset_materialization(
+        with open_dagster_pipes() as pipes:
+            pipes.report_asset_materialization(
                 {"foo_meta": "ok"}, data_version="alpha", asset_key="foo"
             )
-            context.report_asset_materialization(data_version="alpha", asset_key="bar")
+            pipes.report_asset_materialization(data_version="alpha", asset_key="bar")
 
     @multi_asset(specs=[AssetSpec("foo"), AssetSpec("bar")])
     def foo_bar(context: AssetExecutionContext, pipes_subprocess_client: PipesSubprocessClient):
@@ -286,8 +286,8 @@ def test_pipes_typed_metadata():
     def script_fn():
         from dagster_pipes import open_dagster_pipes
 
-        with open_dagster_pipes() as context:
-            context.report_asset_materialization(
+        with open_dagster_pipes() as pipes:
+            pipes.report_asset_materialization(
                 metadata={
                     "infer_meta": "bar",
                     "text_meta": {"raw_value": "bar", "type": "text"},
@@ -366,8 +366,8 @@ def test_pipes_asset_invocation():
     def script_fn():
         from dagster_pipes import open_dagster_pipes
 
-        with open_dagster_pipes() as context:
-            context.log.info("hello world")
+        with open_dagster_pipes() as pipes:
+            pipes.log.info("hello world")
 
     @asset
     def foo(context: AssetExecutionContext, pipes_subprocess_client: PipesSubprocessClient):
@@ -392,10 +392,10 @@ def test_pipes_no_orchestration():
         loader = PipesEnvVarParamsLoader()
         assert not loader.is_dagster_pipes_process()
         with open_dagster_pipes(params_loader=loader) as _:
-            context = PipesContext.get()
-            context.log.info("hello world")
-            context.report_asset_materialization(
-                metadata={"bar": context.get_extra("bar")},
+            pipes = PipesContext.get()
+            pipes.log.info("hello world")
+            pipes.report_asset_materialization(
+                metadata={"bar": pipes.get_extra("bar")},
                 data_version="alpha",
             )
 


### PR DESCRIPTION
## Summary & Motivation
instead of `context`, we name `PipesContext` variables `pipes`. this PR also updates some docs copy to eliminate the mention of the "context" name.

`pipes.report_x` feels great.

but a few places where pipes feel odd:
- when it's accessing a property through "the context made available to pipes process", e.g. `pipes.asset_keys`, `pipes.partition_key`, `pipes.log.info`. the apis are the same as e.x. `context.log.info` in asset body but the variable naming convention make it feel different.
- `pipes = PipesContext.get()` imo context feels more natural in this line. but this might be minor?

## How I Tested These Changes
