### PR TITLE
add note re: windows pex non-support

### DIFF
--- a/docs/content/dagster-cloud/deployment/serverless.mdx
+++ b/docs/content/dagster-cloud/deployment/serverless.mdx
@@ -100,6 +100,8 @@ dagster-cloud serverless deploy-python-executable ./my-dagster-project \
   --package-name assets_modern_data_stack
 ```
 
+Note: Windows users should use the `deploy` command instead of `deploy-python-executable`.
+
 ### Adding secrets
 
 Often you'll need to securely access secrets from your jobs. Dagster Cloud supports several methods for adding secrets - refer to the [Dagster Cloud environment variables and secrets documentation](/dagster-cloud/managing-deployments/environment-variables-and-secrets) for more info.

--- a/docs/content/dagster-cloud/deployment/serverless.mdx
+++ b/docs/content/dagster-cloud/deployment/serverless.mdx
@@ -100,7 +100,7 @@ dagster-cloud serverless deploy-python-executable ./my-dagster-project \
   --package-name assets_modern_data_stack
 ```
 
-Note: Windows users should use the `deploy` command instead of `deploy-python-executable`.
+**Note:** Windows users should use the `deploy` command instead of `deploy-python-executable`.
 
 ### Adding secrets
 


### PR DESCRIPTION
## Summary & Motivation
Windows users running into cryptic error messages when running serverless pex build commands.

## How I Tested These Changes
Inspection