### PR TITLE
[docs] add context type hints

### DIFF
--- a/docs/content/concepts/assets/asset-checks.mdx
+++ b/docs/content/concepts/assets/asset-checks.mdx
@@ -70,11 +70,18 @@ When defining an asset using the <PyObject object="asset" displayText="@asset" /
 ```python file=/concepts/assets/asset_checks/asset_with_check.py
 import pandas as pd
 
-from dagster import AssetCheckResult, AssetCheckSpec, Definitions, Output, asset
+from dagster import (
+    AssetCheckResult,
+    AssetCheckSpec,
+    AssetExecutionContext,
+    Definitions,
+    Output,
+    asset,
+)
 
 
 @asset(check_specs=[AssetCheckSpec(name="orders_id_has_no_nulls", asset="orders")])
-def orders(context):
+def orders(context: AssetExecutionContext):
     orders_df = pd.DataFrame({"order_id": [1, 2], "item_id": [432, 878]})
 
     # save the output and indicate that it's been saved

--- a/docs/content/concepts/assets/asset-observations.mdx
+++ b/docs/content/concepts/assets/asset-observations.mdx
@@ -33,7 +33,7 @@ from dagster import AssetObservation, op
 
 
 @op
-def observation_op(context):
+def observation_op(context: OpExecutionContext):
     df = read_df()
     context.log_event(
         AssetObservation(asset_key="observation_asset", metadata={"num_rows": len(df)})
@@ -59,7 +59,7 @@ from dagster import AssetMaterialization, AssetObservation, MetadataValue, op
 
 
 @op
-def observes_dataset_op(context):
+def observes_dataset_op(context: OpExecutionContext):
     df = read_df()
     remote_storage_path = persist_to_storage(df)
     context.log_event(
@@ -93,7 +93,7 @@ height={1146}
 If you are observing a single slice of an asset (e.g. a single day's worth of data on a larger table), rather than mutating or creating it entirely, you can indicate this to Dagster by including the `partition` argument on the object.
 
 ```python file=/concepts/assets/observations.py startafter=start_partitioned_asset_observation endbefore=end_partitioned_asset_observation
-from dagster import AssetMaterialization, Config, op
+from dagster import AssetMaterialization, Config, op, OpExecutionContext
 
 
 class MyOpConfig(Config):
@@ -101,7 +101,7 @@ class MyOpConfig(Config):
 
 
 @op
-def partitioned_dataset_op(context, config: MyOpConfig):
+def partitioned_dataset_op(context: OpExecutionContext, config: MyOpConfig):
     partition_date = config.date
     df = read_df_for_date(partition_date)
     context.log_event(

--- a/docs/content/concepts/assets/graph-backed-assets.mdx
+++ b/docs/content/concepts/assets/graph-backed-assets.mdx
@@ -32,7 +32,7 @@ from dagster_slack import SlackResource
 
 
 @op
-def fetch_files_from_slack(context, slack: SlackResource) -> pd.DataFrame:
+def fetch_files_from_slack(slack: SlackResource) -> pd.DataFrame:
     files = slack.get_client().files_list(channel="#random")
     return pd.DataFrame(
         [
@@ -131,7 +131,7 @@ During execution, if we select just `baz_asset` for materialization, the below i
 
 ```python file=/concepts/assets/subset_graph_backed_asset.py startafter=start_graph_backed_asset_foo endbefore=end_graph_backed_asset_foo
 @op(out={"foo_1": Out(is_required=False), "foo_2": Out(is_required=False)})
-def foo(context, bar_1):
+def foo(context: OpExecutionContext, bar_1):
     # Selectively returns outputs based on selected assets
     if "foo_1" in context.selected_output_names:
         yield Output(bar_1 + 1, output_name="foo_1")

--- a/docs/content/concepts/assets/multi-assets.mdx
+++ b/docs/content/concepts/assets/multi-assets.mdx
@@ -31,7 +31,7 @@ The function responsible for computing the contents of any software-defined asse
 The easiest way to create a multi-asset is with the <PyObject object="multi_asset" decorator /> decorator. This decorator functions similarly to the <PyObject object="asset" decorator /> decorator, but requires an `outs` parameter specifying each output asset of the function.
 
 ```python file=/concepts/assets/multi_assets.py startafter=start_basic_multi_asset endbefore=end_basic_multi_asset
-from dagster import AssetOut, multi_asset
+from dagster import AssetOut, multi_asset, AssetExecutionContext
 
 
 @multi_asset(
@@ -100,7 +100,7 @@ from dagster import AssetOut, Output, multi_asset
     },
     can_subset=True,
 )
-def split_actions(context):
+def split_actions(context: AssetExecutionContext):
     if "a" in context.selected_output_names:
         yield Output(value=123, output_name="a")
     if "b" in context.selected_output_names:

--- a/docs/content/concepts/assets/software-defined-assets.mdx
+++ b/docs/content/concepts/assets/software-defined-assets.mdx
@@ -553,7 +553,7 @@ Consider the following asset that uses a context object:
 
 ```python file=/concepts/assets/asset_testing.py startafter=start_with_context_asset endbefore=end_with_context_asset
 @asset
-def uses_context(context):
+def uses_context(context: AssetExecutionContext):
     context.log.info(context.run_id)
     return "bar"
 ```

--- a/docs/content/concepts/configuration/config-schema-legacy.mdx
+++ b/docs/content/concepts/configuration/config-schema-legacy.mdx
@@ -44,18 +44,18 @@ Below we define a simple op and asset with identical `config_schemas` defining a
 
 ```python file=/concepts/configuration/configurable_op_asset_resource.py startafter=start endbefore=end
 @op(config_schema={"person_name": str})
-def op_using_config(context):
+def op_using_config(context: OpExecutionContext):
     return f'hello {context.op_config["person_name"]}'
 
 
 @asset(config_schema={"person_name": str})
-def asset_using_config(context):
+def asset_using_config(context: AssetExecutionContext):
     # Note how asset config is also accessed with context.op_config
     return f'hello {context.op_config["person_name"]}'
 
 
 @resource(config_schema={"url": str})
-def resource_using_config(context):
+def resource_using_config(context: InitResourceContext):
     return MyDatabaseConnection(context.resource_config["url"])
 ```
 
@@ -143,18 +143,25 @@ asset_result = materialize(
 A common use case for configuration is passing secrets to connect to external services. Resources, which can be used to model connections to external services, accept secrets as configuration values. These secrets can be read from your environment variables:
 
 ```python file=/concepts/configuration/env_vars_config.py startafter=start_database_example endbefore=end_database_example
-from dagster import StringSource, job, op, resource
+from dagster import (
+    InitResourceContext,
+    OpExecutionContext,
+    StringSource,
+    job,
+    op,
+    resource,
+)
 
 
 @resource(config_schema={"username": StringSource, "password": StringSource})
-def database_client(context):
+def database_client(context: InitResourceContext):
     username = context.resource_config["username"]
     password = context.resource_config["password"]
     ...
 
 
 @op(required_resource_keys={"database"})
-def get_one(context):
+def get_one(context: OpExecutionContext):
     context.resources.database.execute_query("SELECT 1")
 
 
@@ -190,7 +197,7 @@ It defaults to <PyObject module="dagster" object="Any" /> type, meaning Dagster 
 
 ```python file=/concepts/configuration/make_values_resource_any.py startafter=start_file_example endbefore=end_file_example
 @op(required_resource_keys={"file_dir"})
-def add_file(context):
+def add_file(context: OpExecutionContext):
     filename = f"{context.resources.file_dir}/new_file.txt"
     open(filename, "x", encoding="utf8").close()
 
@@ -198,7 +205,7 @@ def add_file(context):
 
 
 @op(required_resource_keys={"file_dir"})
-def total_num_files(context):
+def total_num_files(context: OpExecutionContext):
     files_in_dir = os.listdir(context.resources.file_dir)
     context.log.info(f"Total number of files: {len(files_in_dir)}")
 
@@ -221,7 +228,7 @@ Alternatively, if you want to provide different config values for each op within
 
 ```python file=/concepts/configuration/make_values_resource_config_schema.py startafter=start_file_example endbefore=end_file_example
 @op(required_resource_keys={"file_dirs"})
-def write_file(context):
+def write_file(context: OpExecutionContext):
     filename = f"{context.resources.file_dirs['write_file_dir']}/new_file.txt"
     open(filename, "x", encoding="utf8").close()
 
@@ -229,7 +236,7 @@ def write_file(context):
 
 
 @op(required_resource_keys={"file_dirs"})
-def total_num_files(context):
+def total_num_files(context: OpExecutionContext):
     files_in_dir = os.listdir(context.resources.file_dirs["count_file_dir"])
     context.log.info(f"Total number of files: {len(files_in_dir)}")
 

--- a/docs/content/concepts/configuration/configured.mdx
+++ b/docs/content/concepts/configuration/configured.mdx
@@ -114,7 +114,7 @@ def unsigned_s3_session(config):
 You can use the `configured` API with any definition type in the same way. For example, to configure an op, you can simply invoke `configured` on the op definition:
 
 ```python file=/concepts/configuration/configured_op_example.py
-from dagster import Field, configured, op
+from dagster import Field, OpExecutionContext, configured, op
 
 
 @op(
@@ -123,7 +123,7 @@ from dagster import Field, configured, op
         "word": Field(str, is_required=False, default_value="hello"),
     }
 )
-def example(context):
+def example(context: OpExecutionContext):
     for _ in range(context.op_config["iterations"]):
         context.log.info(context.op_config["word"])
 
@@ -206,7 +206,7 @@ When using the decorator syntax (`@configured`), the resulting op definition wil
     },
     ins={"xs": In(List[Int])},
 )
-def get_dataset(context, xs):
+def get_dataset(context: OpExecutionContext, xs):
     if context.op_config["is_sample"]:
         return xs[:5]
     else:

--- a/docs/content/concepts/io-management/io-managers.mdx
+++ b/docs/content/concepts/io-management/io-managers.mdx
@@ -623,8 +623,9 @@ class DataframeTableIOManager(ConfigurableIOManager):
 
     def load_input(self, context: InputContext):
         # upstream_output.name is the name given to the Out that we're loading for
-        table_name = context.upstream_output.name
-        return read_dataframe_from_table(name=table_name)
+        if context.upstream_output:
+            table_name = context.upstream_output.name
+            return read_dataframe_from_table(name=table_name)
 
 
 @job(resource_defs={"io_manager": DataframeTableIOManager()})
@@ -725,14 +726,22 @@ In this case, the table names are encoded in the job definition. If, instead, yo
 ```python file=/concepts/io_management/metadata.py startafter=io_manager_start_marker endbefore=io_manager_end_marker
 class MyIOManager(ConfigurableIOManager):
     def handle_output(self, context: OutputContext, obj):
-        table_name = context.metadata["table"]
-        schema = context.metadata["schema"]
-        write_dataframe_to_table(name=table_name, schema=schema, dataframe=obj)
+        if context.metadata:
+            table_name = context.metadata["table"]
+            schema = context.metadata["schema"]
+            write_dataframe_to_table(name=table_name, schema=schema, dataframe=obj)
+        else:
+            raise Exception(
+                f"op {context.op_def.name} doesn't have schema and metadata set"
+            )
 
     def load_input(self, context: InputContext):
-        table_name = context.upstream_output.metadata["table"]
-        schema = context.upstream_output.metadata["schema"]
-        return read_dataframe_from_table(name=table_name, schema=schema)
+        if context.upstream_output and context.upstream_output.metadata:
+            table_name = context.upstream_output.metadata["table"]
+            schema = context.upstream_output.metadata["schema"]
+            return read_dataframe_from_table(name=table_name, schema=schema)
+        else:
+            raise Exception("Upstream output doesn't have schema and metadata set")
 ```
 
 ### Per-input loading in assets
@@ -809,9 +818,10 @@ class MyIOManager(IOManager):
         self.storage_dict[(context.step_key, context.name)] = obj
 
     def load_input(self, context: InputContext):
-        return self.storage_dict[
-            (context.upstream_output.step_key, context.upstream_output.name)
-        ]
+        if context.upstream_output:
+            return self.storage_dict[
+                (context.upstream_output.step_key, context.upstream_output.name)
+            ]
 
 
 def test_my_io_manager_handle_output():
@@ -844,8 +854,9 @@ class DataframeTableIOManagerWithMetadata(ConfigurableIOManager):
         context.add_output_metadata({"num_rows": len(obj), "table_name": table_name})
 
     def load_input(self, context: InputContext):
-        table_name = context.upstream_output.name
-        return read_dataframe_from_table(name=table_name)
+        if context.upstream_output:
+            table_name = context.upstream_output.name
+            return read_dataframe_from_table(name=table_name)
 ```
 
 Any entries yielded this way will be attached to the `Handled Output` event for this output.

--- a/docs/content/concepts/io-management/io-managers.mdx
+++ b/docs/content/concepts/io-management/io-managers.mdx
@@ -391,7 +391,7 @@ If your I/O manager is more complex, or needs to manage internal state, it may m
 In this case, we implement a stateful I/O manager which maintains a cache.
 
 ```python file=/concepts/io_management/custom_io_manager.py startafter=start_io_manager_factory_marker endbefore=end_io_manager_factory_marker
-from dagster import IOManager, ConfigurableIOManagerFactory
+from dagster import IOManager, ConfigurableIOManagerFactory, OutputContext, InputContext
 import requests
 
 
@@ -401,10 +401,10 @@ class ExternalIOManager(IOManager):
         # setup stateful cache
         self._cache = {}
 
-    def handle_output(self, context, obj):
+    def handle_output(self, context: OutputContext, obj):
         ...
 
-    def load_input(self, context):
+    def load_input(self, context: InputContext):
         if context.asset_key in self._cache:
             return self._cache[context.asset_key]
         ...
@@ -470,10 +470,10 @@ class MyPartitionedIOManager(IOManager):
         else:
             return "/".join(context.asset_key.path)
 
-    def handle_output(self, context, obj):
+    def handle_output(self, context: OutputContext, obj):
         write_csv(self._get_path(context), obj)
 
-    def load_input(self, context):
+    def load_input(self, context: InputContext):
         return read_csv(self._get_path(context))
 ```
 
@@ -542,7 +542,7 @@ Since the method for loading an input is directly affected by the way the corres
 ```python file=/concepts/io_management/input_managers.py startafter=start_plain_input_manager endbefore=end_plain_input_manager
 # in this case PandasIOManager is an existing IO Manager
 class MyNumpyLoader(PandasIOManager):
-    def load_input(self, context) -> np.ndarray:
+    def load_input(self, context: InputContext) -> np.ndarray:
         file_path = "path/to/dataframe"
         array = np.genfromtxt(file_path, delimiter=",", dtype=None)
         return array
@@ -571,19 +571,19 @@ class BetterPandasIOManager(ConfigurableIOManager):
             f"{output_context.step_key}_{output_context.name}.csv",
         )
 
-    def handle_output(self, context, obj: pd.DataFrame):
+    def handle_output(self, context: OutputContext, obj: pd.DataFrame):
         file_path = self._get_path(context)
         os.makedirs(os.path.dirname(file_path), exist_ok=True)
         if obj is not None:
             obj.to_csv(file_path, index=False)
 
-    def load_input(self, context) -> pd.DataFrame:
+    def load_input(self, context: InputContext) -> pd.DataFrame:
         return pd.read_csv(self._get_path(context.upstream_output))
 
 
 # write a subclass that uses _get_path for your custom loading logic
 class MyBetterNumpyLoader(BetterPandasIOManager):
-    def load_input(self, context) -> np.ndarray:
+    def load_input(self, context: InputContext) -> np.ndarray:
         file_path = self._get_path(context.upstream_output)
         array = np.genfromtxt(file_path, delimiter=",", dtype=None)
         return array
@@ -616,12 +616,12 @@ from dagster import ConfigurableIOManager, io_manager
 
 
 class DataframeTableIOManager(ConfigurableIOManager):
-    def handle_output(self, context, obj):
+    def handle_output(self, context: OutputContext, obj):
         # name is the name given to the Out that we're storing for
         table_name = context.name
         write_dataframe_to_table(name=table_name, dataframe=obj)
 
-    def load_input(self, context):
+    def load_input(self, context: InputContext):
         # upstream_output.name is the name given to the Out that we're loading for
         table_name = context.upstream_output.name
         return read_dataframe_from_table(name=table_name)
@@ -724,12 +724,12 @@ In this case, the table names are encoded in the job definition. If, instead, yo
 
 ```python file=/concepts/io_management/metadata.py startafter=io_manager_start_marker endbefore=io_manager_end_marker
 class MyIOManager(ConfigurableIOManager):
-    def handle_output(self, context, obj):
+    def handle_output(self, context: OutputContext, obj):
         table_name = context.metadata["table"]
         schema = context.metadata["schema"]
         write_dataframe_to_table(name=table_name, schema=schema, dataframe=obj)
 
-    def load_input(self, context):
+    def load_input(self, context: InputContext):
         table_name = context.upstream_output.metadata["table"]
         schema = context.upstream_output.metadata["schema"]
         return read_dataframe_from_table(name=table_name, schema=schema)
@@ -743,7 +743,7 @@ In this example, we store `upstream_asset` as a Pandas DataFrame, and we write a
 
 ```python file=/concepts/assets/asset_input_managers_numpy.py startafter=start_numpy_example endbefore=end_numpy_example
 class PandasAssetIOManager(ConfigurableIOManager):
-    def handle_output(self, context, obj):
+    def handle_output(self, context: OutputContext, obj):
         file_path = self._get_path(context)
         store_pandas_dataframe(name=file_path, table=obj)
 
@@ -753,13 +753,13 @@ class PandasAssetIOManager(ConfigurableIOManager):
             f"{context.asset_key.path[-1]}.csv",
         )
 
-    def load_input(self, context) -> pd.DataFrame:
+    def load_input(self, context: InputContext) -> pd.DataFrame:
         file_path = self._get_path(context)
         return load_pandas_dataframe(name=file_path)
 
 
 class NumpyAssetIOManager(PandasAssetIOManager):
-    def load_input(self, context) -> np.ndarray:
+    def load_input(self, context: InputContext) -> np.ndarray:
         file_path = self._get_path(context)
         return load_numpy_array(name=file_path)
 
@@ -793,7 +793,9 @@ Here's an example for a simple I/O manager that stores outputs in an in-memory d
 
 ```python file=/concepts/io_management/test_io_manager.py
 from dagster import (
+    InputContext,
     IOManager,
+    OutputContext,
     build_input_context,
     build_output_context,
 )
@@ -803,10 +805,10 @@ class MyIOManager(IOManager):
     def __init__(self):
         self.storage_dict = {}
 
-    def handle_output(self, context, obj):
+    def handle_output(self, context: OutputContext, obj):
         self.storage_dict[(context.step_key, context.name)] = obj
 
-    def load_input(self, context):
+    def load_input(self, context: InputContext):
         return self.storage_dict[
             (context.upstream_output.step_key, context.upstream_output.name)
         ]
@@ -835,13 +837,13 @@ Sometimes, you may want to record some metadata while handling an output in an I
 
 ```python file=/concepts/io_management/custom_io_manager.py startafter=start_metadata_marker endbefore=end_metadata_marker
 class DataframeTableIOManagerWithMetadata(ConfigurableIOManager):
-    def handle_output(self, context, obj):
+    def handle_output(self, context: OutputContext, obj):
         table_name = context.name
         write_dataframe_to_table(name=table_name, dataframe=obj)
 
         context.add_output_metadata({"num_rows": len(obj), "table_name": table_name})
 
-    def load_input(self, context):
+    def load_input(self, context: InputContext):
         table_name = context.upstream_output.name
         return read_dataframe_from_table(name=table_name)
 ```

--- a/docs/content/concepts/io-management/unconnected-inputs.mdx
+++ b/docs/content/concepts/io-management/unconnected-inputs.mdx
@@ -225,7 +225,8 @@ class MyIOManager(ConfigurableIOManager):
         write_dataframe_to_table(name=table_name, dataframe=obj)
 
     def load_input(self, context: InputContext):
-        return read_dataframe_from_table(name=context.upstream_output.name)
+        if context.upstream_output:
+            return read_dataframe_from_table(name=context.upstream_output.name)
 
 
 @input_manager

--- a/docs/content/concepts/io-management/unconnected-inputs.mdx
+++ b/docs/content/concepts/io-management/unconnected-inputs.mdx
@@ -33,7 +33,7 @@ Here's a basic job with an unconnected string input:
 
 ```python file=/concepts/io_management/load_from_config.py startafter=def_start_marker endbefore=def_end_marker
 @op
-def my_op(context, input_string: str):
+def my_op(context: OpExecutionContext, input_string: str):
     context.log.info(f"input string: {input_string}")
 
 
@@ -59,6 +59,7 @@ from typing import Dict, Union
 
 from dagster import (
     DagsterTypeLoaderContext,
+    OpExecutionContext,
     dagster_type_loader,
     job,
     op,
@@ -88,7 +89,7 @@ class Apple:
 
 
 @op
-def my_op(context, input_apple: Apple):
+def my_op(context: OpExecutionContext, input_apple: Apple):
     context.log.info(f"input apple diameter: {input_apple.diameter}")
 
 
@@ -146,7 +147,7 @@ Another option is to define a class that implements the <PyObject module="dagste
 
 ```python file=/concepts/io_management/input_managers.py startafter=start_load_unconnected_input endbefore=end_load_unconnected_input
 class Table1InputManager(InputManager):
-    def load_input(self, context):
+    def load_input(self, context: InputContext):
         return read_dataframe_from_table(name="table_1")
 
 
@@ -165,7 +166,7 @@ If you also want to use `Table1InputManager` to store outputs, or you want to ov
 ```python file=/concepts/io_management/input_managers.py startafter=start_load_unconnected_io endbefore=end_load_unconnected_io
 # in this example, TableIOManager is defined elsewhere and we just want to override load_input
 class Table1IOManager(TableIOManager):
-    def load_input(self, context):
+    def load_input(self, context: InputContext):
         return read_dataframe_from_table(name="table_1")
 
 
@@ -184,7 +185,7 @@ To accomplish this, you can define an `input_config_schema` on the IO manager or
 
 ```python file=/concepts/io_management/input_managers.py startafter=start_per_input_config endbefore=end_per_input_config
 class MyConfigurableInputLoader(InputManager):
-    def load_input(self, context):
+    def load_input(self, context: InputContext):
         return read_dataframe_from_table(name=context.config["table"])
 
 
@@ -219,11 +220,11 @@ To accomplish this, you can set up the `input_manager_key` on `op2`'s `In` to po
 
 ```python file=/concepts/io_management/input_managers.py startafter=start_load_input_subset endbefore=end_load_input_subset
 class MyIOManager(ConfigurableIOManager):
-    def handle_output(self, context, obj):
+    def handle_output(self, context: OutputContext, obj):
         table_name = context.name
         write_dataframe_to_table(name=table_name, dataframe=obj)
 
-    def load_input(self, context):
+    def load_input(self, context: InputContext):
         return read_dataframe_from_table(name=context.upstream_output.name)
 
 
@@ -257,7 +258,7 @@ So far, this is set up so that `op2` always loads `table_1` even if you execute 
 
 ```python file=/concepts/io_management/input_managers.py startafter=start_better_load_input_subset endbefore=end_better_load_input_subset
 class MyNewInputLoader(MyIOManager):
-    def load_input(self, context):
+    def load_input(self, context: InputContext):
         if context.upstream_output is None:
             # load input from table since there is no upstream output
             return read_dataframe_from_table(name="table_1")

--- a/docs/content/concepts/logging/custom-loggers.mdx
+++ b/docs/content/concepts/logging/custom-loggers.mdx
@@ -51,7 +51,7 @@ def json_console_logger(init_context):
 
 
 @op
-def hello_logs(context):
+def hello_logs(context: OpExecutionContext):
     context.log.info("Hello, world!")
 
 

--- a/docs/content/concepts/logging/loggers.mdx
+++ b/docs/content/concepts/logging/loggers.mdx
@@ -43,11 +43,11 @@ Any op can emit log messages at any point in its computation. For example:
 ```python file=/concepts/logging/builtin_logger.py startafter=start_builtin_logger_marker_0 endbefore=end_builtin_logger_marker_0
 # demo_logger.py
 
-from dagster import job, op
+from dagster import job, op, OpExecutionContext
 
 
 @op
-def hello_logs(context):
+def hello_logs(context: OpExecutionContext):
     context.log.info("Hello, world!")
 
 
@@ -153,11 +153,11 @@ For example, if an error is introduced into an op's logic:
 ```python file=/concepts/logging/builtin_logger.py startafter=start_builtin_logger_error_marker_0 endbefore=end_builtin_logger_error_marker_0
 # demo_logger_error.py
 
-from dagster import job, op
+from dagster import job, op, OpExecutionContext
 
 
 @op
-def hello_logs_error(context):
+def hello_logs_error(context: OpExecutionContext):
     raise Exception("Somebody set up us the bomb")
 
 
@@ -204,7 +204,7 @@ Dagster recognizes this by attaching loggers to jobs so that you can seamlessly 
 
 ```python file=/concepts/logging/logging_jobs.py startafter=start_logging_mode_marker_0 endbefore=end_logging_mode_marker_0
 @op
-def log_op(context):
+def log_op(context: OpExecutionContext):
     context.log.info("Hello, world!")
 
 

--- a/docs/content/concepts/logging/python-logging.mdx
+++ b/docs/content/concepts/logging/python-logging.mdx
@@ -188,7 +188,7 @@ If we execute the following job:
 
 ```python file=/concepts/logging/file_output_pipeline.py startafter=start_custom_file_output_log endbefore=end_custom_file_output_log
 @op
-def file_log_op(context):
+def file_log_op(context: OpExecutionContext):
     context.log.info("Hello world!")
 
 

--- a/docs/content/concepts/ops-jobs-graphs/graphs.mdx
+++ b/docs/content/concepts/ops-jobs-graphs/graphs.mdx
@@ -37,16 +37,16 @@ To create an op graph, use the <PyObject module="dagster" object="graph" decorat
 In the following example, we return one output from the root op (`return_one`) and pass data along through single inputs and outputs:
 
 ```python file=/concepts/ops_jobs_graphs/graphs/linear_graph.py startafter=start_marker endbefore=end_marker
-from dagster import graph, op
+from dagster import OpExecutionContext, graph, op
 
 
 @op
-def return_one(context) -> int:
+def return_one(context: OpExecutionContext) -> int:
     return 1
 
 
 @op
-def add_one(context, number: int) -> int:
+def add_one(context: OpExecutionContext, number: int) -> int:
     return number + 1
 
 
@@ -98,21 +98,21 @@ height={250}
 A single output can be passed to multiple inputs on downstream ops. In this example, the output from the first op is passed to two different ops. The outputs of those ops are combined and passed to the final op:
 
 ```python file=/concepts/ops_jobs_graphs/graphs/multiple_io_graph.py startafter=start_marker endbefore=end_marker
-from dagster import graph, op
+from dagster import OpExecutionContext, graph, op
 
 
 @op
-def return_one(context) -> int:
+def return_one(context: OpExecutionContext) -> int:
     return 1
 
 
 @op
-def add_one(context, number: int):
+def add_one(context: OpExecutionContext, number: int):
     return number + 1
 
 
 @op
-def adder(context, a: int, b: int) -> int:
+def adder(context: OpExecutionContext, a: int, b: int) -> int:
     return a + b
 
 

--- a/docs/content/concepts/ops-jobs-graphs/nesting-graphs.mdx
+++ b/docs/content/concepts/ops-jobs-graphs/nesting-graphs.mdx
@@ -26,7 +26,7 @@ We use the term _node_ to refer to both ops and graphs, because both ops and gra
 As a baseline, here's a job that does not use nesting. It starts with an op that returns a number, then uses two ops to convert it from Celsius to Fahrenheight, then logs the result:
 
 ```python file=/concepts/ops_jobs_graphs/unnested_ops.py
-from dagster import job, op
+from dagster import OpExecutionContext, job, op
 
 
 @op
@@ -45,7 +45,7 @@ def multiply_by_one_point_eight(number):
 
 
 @op
-def log_number(context, number):
+def log_number(context: OpExecutionContext, number):
     context.log.info(f"number: {number}")
 
 
@@ -88,12 +88,12 @@ This example two ops that both take config and are wrapped by a graph, which is 
 
 ```python file=/concepts/ops_jobs_graphs/nested_graphs.py startafter=start_composite_solid_config_marker endbefore=end_composite_solid_config_marker
 @op(config_schema={"n": float})
-def add_n(context, number):
+def add_n(context: OpExecutionContext, number):
     return number + context.op_config["n"]
 
 
 @op(config_schema={"m": float})
-def multiply_by_m(context, number):
+def multiply_by_m(context: OpExecutionContext, number):
     return number * context.op_config["m"]
 
 

--- a/docs/content/concepts/ops-jobs-graphs/op-events.mdx
+++ b/docs/content/concepts/ops-jobs-graphs/op-events.mdx
@@ -100,11 +100,11 @@ The <PyObject object="EventMetadata" /> class contains a set of static wrappers 
 The following example demonstrates how you might use this functionality:
 
 ```python file=/concepts/ops_jobs_graphs/op_events.py startafter=start_op_output_3 endbefore=end_op_output_3
-from dagster import MetadataValue, Output, op
+from dagster import MetadataValue, Output, op, OpExecutionContext
 
 
 @op
-def my_metadata_output(context) -> Output:
+def my_metadata_output(context: OpExecutionContext) -> Output:
     df = get_some_data()
     return Output(
         df,
@@ -129,11 +129,11 @@ Generally, you'd want to send this event directly after you persist the asset to
 If you're using [Software-defined Assets](/concepts/assets/software-defined-assets), you don't need to record these events explicitly – the framework handles it for you.
 
 ```python file=/concepts/ops_jobs_graphs/op_events.py startafter=start_asset_op endbefore=end_asset_op
-from dagster import AssetMaterialization, op
+from dagster import AssetMaterialization, op, OpExecutionContext
 
 
 @op
-def my_asset_op(context):
+def my_asset_op(context: OpExecutionContext):
     df = get_some_data()
     store_to_s3(df)
     context.log_event(
@@ -175,11 +175,11 @@ To learn more about assets and how they are surfaced once you send this event, c
 Attaching metadata to Asset Materializations is an important way of tracking aspects of a given asset over time. This functions essentially identically to other events which accept a `metadata` parameter, allowing you to attach a set of structured labels and values to display.
 
 ```python file=concepts/assets/materialization_ops.py startafter=start_materialization_ops_marker_2 endbefore=end_materialization_ops_marker_2
-from dagster import AssetMaterialization, MetadataValue, op
+from dagster import AssetMaterialization, MetadataValue, op, OpExecutionContext
 
 
 @op
-def my_metadata_materialization_op(context):
+def my_metadata_materialization_op(context: OpExecutionContext):
     df = read_df()
     remote_storage_path = persist_to_storage(df)
     context.log_event(
@@ -212,7 +212,7 @@ from dagster import AssetObservation, op
 
 
 @op
-def observation_op(context):
+def observation_op(context: OpExecutionContext):
     df = read_df()
     context.log_event(
         AssetObservation(asset_key="observation_asset", metadata={"num_rows": len(df)})
@@ -229,11 +229,11 @@ To learn more about asset observations, check out the [Asset Observation](/conce
 Ops can emit structured events to represent the results of a data quality test. The data quality event class is the <PyObject object="ExpectationResult" />. To generate an expectation result, we can log or yield an <PyObject object="ExpectationResult" /> event in our op.
 
 ```python file=/concepts/ops_jobs_graphs/op_events.py startafter=start_expectation_op endbefore=end_expectation_op
-from dagster import ExpectationResult, op
+from dagster import ExpectationResult, op, OpExecutionContext
 
 
 @op
-def my_expectation_op(context, df):
+def my_expectation_op(context: OpExecutionContext, df):
     do_some_transform(df)
     context.log_event(
         ExpectationResult(success=len(df) > 0, description="ensure dataframe has rows")
@@ -248,11 +248,11 @@ Like many other event types in Dagster, there are a variety of types of metadata
 This example shows metadata entries of different types attached to the same expectation result:
 
 ```python file=/concepts/ops_jobs_graphs/op_events.py startafter=start_metadata_expectation_op endbefore=end_metadata_expectation_op
-from dagster import ExpectationResult, MetadataValue, op
+from dagster import ExpectationResult, MetadataValue, op, OpExecutionContext
 
 
 @op
-def my_metadata_expectation_op(context, df):
+def my_metadata_expectation_op(context: OpExecutionContext, df):
     df = do_some_transform(df)
     context.log_event(
         ExpectationResult(

--- a/docs/content/concepts/ops-jobs-graphs/op-jobs.mdx
+++ b/docs/content/concepts/ops-jobs-graphs/op-jobs.mdx
@@ -136,7 +136,7 @@ The options are discussed below:
 You can supply a <PyObject object="RunConfig"/> object or raw config dictionary. The supplied config will be used to configure the op job whenever it's launched. It will show up in the Dagster UI Launchpad and can be overridden.
 
 ```python file=/concepts/ops_jobs_graphs/jobs_with_default_config.py
-from dagster import Config, RunConfig, job, op
+from dagster import Config, OpExecutionContext, RunConfig, job, op
 
 
 class DoSomethingConfig(Config):
@@ -144,7 +144,7 @@ class DoSomethingConfig(Config):
 
 
 @op
-def do_something(context, config: DoSomethingConfig):
+def do_something(context: OpExecutionContext, config: DoSomethingConfig):
     context.log.info("config_param: " + config.config_param)
 
 
@@ -176,7 +176,7 @@ Supplying a <PyObject object="ConfigMapping" /> allows you to expose a narrower 
 Instead of needing to configure every op and resource individually when launching the op job, you can supply a smaller number of values to the outer config. The <PyObject object="ConfigMapping" /> will then translate it into config for all the job's ops and resources.
 
 ```python file=/concepts/ops_jobs_graphs/jobs_with_config_mapping.py
-from dagster import Config, RunConfig, config_mapping, job, op
+from dagster import Config, OpExecutionContext, RunConfig, config_mapping, job, op
 
 
 class DoSomethingConfig(Config):
@@ -184,7 +184,7 @@ class DoSomethingConfig(Config):
 
 
 @op
-def do_something(context, config: DoSomethingConfig) -> None:
+def do_something(context: OpExecutionContext, config: DoSomethingConfig) -> None:
     context.log.info("config_param: " + config.config_param)
 
 

--- a/docs/content/concepts/partitions-schedules-sensors/backfills.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/backfills.mdx
@@ -55,7 +55,13 @@ To get this behavior, you need to:
 For example:
 
 ```python file=/concepts/partitions_schedules_sensors/backfills/single_run_backfill_asset.py startafter=start_marker endbefore=end_marker
-from dagster import AssetKey, BackfillPolicy, DailyPartitionsDefinition, asset
+from dagster import (
+    AssetExecutionContext,
+    AssetKey,
+    BackfillPolicy,
+    DailyPartitionsDefinition,
+    asset,
+)
 
 
 @asset(
@@ -63,7 +69,7 @@ from dagster import AssetKey, BackfillPolicy, DailyPartitionsDefinition, asset
     backfill_policy=BackfillPolicy.single_run(),
     deps=[AssetKey("raw_events")],
 )
-def events(context):
+def events(context: AssetExecutionContext):
     start_datetime, end_datetime = context.partition_time_window
 
     input_data = read_data_in_datetime_range(start_datetime, end_datetime)
@@ -75,15 +81,15 @@ def events(context):
 If you are using an I/O manager to handle saving and loading your data, you'll need to ensure the I/O manager is also using these methods. If you're using any of the built-in database I/O managers, like [Snowflake](/integrations/snowflake), [BigQuery](/integrations/bigquery), or [DuckDB](/\_apidocs/libraries/dagster-duckdb), you'll have this out-of-the-box. **Note**: This doesn't apply to file system I/O managers.
 
 ```python file=/concepts/partitions_schedules_sensors/backfills/single_run_backfill_io_manager.py startafter=start_marker endbefore=end_marker
-from dagster import IOManager
+from dagster import InputContext, IOManager, OutputContext
 
 
 class MyIOManager(IOManager):
-    def load_input(self, context):
+    def load_input(self, context: InputContext):
         start_datetime, end_datetime = context.asset_partitions_time_window
         return read_data_in_datetime_range(start_datetime, end_datetime)
 
-    def handle_output(self, context, obj):
+    def handle_output(self, context: OutputContext, obj):
         start_datetime, end_datetime = context.asset_partitions_time_window
         return overwrite_data_in_datetime_range(start_datetime, end_datetime, obj)
 ```

--- a/docs/content/concepts/partitions-schedules-sensors/partitioning-assets.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/partitioning-assets.mdx
@@ -108,7 +108,8 @@ from dagster import (
     )
 )
 def multi_partitions_asset(context: AssetExecutionContext):
-    context.log.info(context.partition_key.keys_by_dimension)
+    if isinstance(context.partition_key, MultiPartitionKey):
+        context.log.info(context.partition_key.keys_by_dimension)
 ```
 
 In this example, the asset would contain a partition for each combination of color and date:
@@ -166,8 +167,8 @@ def image_sensor(context: SensorEvaluationContext):
     new_images = [
         img_filename
         for img_filename in os.listdir(os.getenv("MY_DIRECTORY"))
-        if not context.instance.has_dynamic_partition(
-            images_partitions_def.name, img_filename
+        if not images_partitions_def.has_partition_key(
+            img_filename, dynamic_partitions_store=context.instance
         )
     ]
 

--- a/docs/content/concepts/partitions-schedules-sensors/partitioning-assets.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/partitioning-assets.mdx
@@ -59,11 +59,11 @@ The following example demonstrates creating an asset that has a partition for ea
 ```python file=/concepts/partitions_schedules_sensors/partitioned_asset.py
 import urllib.request
 
-from dagster import DailyPartitionsDefinition, asset
+from dagster import AssetExecutionContext, DailyPartitionsDefinition, asset
 
 
 @asset(partitions_def=DailyPartitionsDefinition(start_date="2022-01-01"))
-def my_daily_partitioned_asset(context) -> None:
+def my_daily_partitioned_asset(context: AssetExecutionContext) -> None:
     partition_date_str = context.asset_partition_key_for_output()
 
     url = f"coolweatherwebsite.com/weather_obs&date={partition_date_str}"
@@ -91,6 +91,7 @@ Consider the following asset:
 
 ```python file=/concepts/partitions_schedules_sensors/multipartitions_asset.py startafter=start_multi_partitions_marker endbefore=end_multi_partitions_marker
 from dagster import (
+    AssetExecutionContext,
     DailyPartitionsDefinition,
     MultiPartitionsDefinition,
     StaticPartitionsDefinition,
@@ -106,7 +107,7 @@ from dagster import (
         }
     )
 )
-def multi_partitions_asset(context):
+def multi_partitions_asset(context: AssetExecutionContext):
     context.log.info(context.partition_key.keys_by_dimension)
 ```
 
@@ -148,7 +149,7 @@ images_partitions_def = DynamicPartitionsDefinition(name="images")
 
 
 @asset(partitions_def=images_partitions_def)
-def images(context):
+def images(context: AssetExecutionContext):
     ...
 ```
 
@@ -161,7 +162,7 @@ images_job = define_asset_job(
 
 
 @sensor(job=images_job)
-def image_sensor(context):
+def image_sensor(context: SensorEvaluationContext):
     new_images = [
         img_filename
         for img_filename in os.listdir(os.getenv("MY_DIRECTORY"))
@@ -195,11 +196,11 @@ For example, this example demonstrates how to define an asset that relies on an 
 ```python file=/concepts/partitions_schedules_sensors/partitioned_asset_uses_io_manager.py
 import pandas as pd
 
-from dagster import DailyPartitionsDefinition, asset
+from dagster import AssetExecutionContext, DailyPartitionsDefinition, asset
 
 
 @asset(partitions_def=DailyPartitionsDefinition(start_date="2022-01-01"))
-def my_daily_partitioned_asset(context) -> pd.DataFrame:
+def my_daily_partitioned_asset(context: AssetExecutionContext) -> pd.DataFrame:
     partition_date_str = context.asset_partition_key_for_output()
     return pd.read_csv(f"coolweatherwebsite.com/weather_obs&date={partition_date_str}")
 ```

--- a/docs/content/concepts/partitions-schedules-sensors/partitioning-ops.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/partitioning-ops.mdx
@@ -57,7 +57,7 @@ The most common kind of partitioned job is a time-partitioned job - each partiti
 Before we dive in, let's look at a non-partitioned job that computes some data for a given date:
 
 ```python file=/concepts/partitions_schedules_sensors/date_config_job.py
-from dagster import Config, job, op
+from dagster import Config, OpExecutionContext, job, op
 
 
 class ProcessDateConfig(Config):
@@ -65,7 +65,7 @@ class ProcessDateConfig(Config):
 
 
 @op
-def process_data_for_date(context, config: ProcessDateConfig):
+def process_data_for_date(context: OpExecutionContext, config: ProcessDateConfig):
     date = config.date
     context.log.info(f"processing data for {date}")
 
@@ -119,7 +119,7 @@ def do_stuff_partitioned():
 Not all jobs are partitioned by time. For example, the following example shows a partitioned job where the partitions are continents:
 
 ```python file=/concepts/partitions_schedules_sensors/static_partitioned_job.py
-from dagster import Config, job, op, static_partitioned_config
+from dagster import Config, OpExecutionContext, job, op, static_partitioned_config
 
 CONTINENTS = [
     "Africa",
@@ -142,7 +142,7 @@ class ContinentOpConfig(Config):
 
 
 @op
-def continent_op(context, config: ContinentOpConfig):
+def continent_op(context: OpExecutionContext, config: ContinentOpConfig):
     context.log.info(config.continent_name)
 
 

--- a/docs/content/concepts/partitions-schedules-sensors/schedules.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/schedules.mdx
@@ -70,7 +70,7 @@ If you want to vary the behavior of your job based on the time it's scheduled to
 
 ```python file=concepts/partitions_schedules_sensors/schedules/schedules.py startafter=start_run_config_schedule endbefore=end_run_config_schedule
 @op(config_schema={"scheduled_date": str})
-def configurable_op(context):
+def configurable_op(context: OpExecutionContext):
     context.log.info(context.op_config["scheduled_date"])
 
 
@@ -155,7 +155,7 @@ You can also create a schedule for a static partition. The Partitioned Jobs conc
 For example, if we have the continents static partitioned job from the Partitioned Jobs concept page
 
 ```python file=/concepts/partitions_schedules_sensors/static_partitioned_job.py
-from dagster import Config, job, op, static_partitioned_config
+from dagster import Config, OpExecutionContext, job, op, static_partitioned_config
 
 CONTINENTS = [
     "Africa",
@@ -178,7 +178,7 @@ class ContinentOpConfig(Config):
 
 
 @op
-def continent_op(context, config: ContinentOpConfig):
+def continent_op(context: OpExecutionContext, config: ContinentOpConfig):
     context.log.info(config.continent_name)
 
 

--- a/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
@@ -51,7 +51,7 @@ class FileConfig(Config):
 
 
 @op
-def process_file(context, config: FileConfig):
+def process_file(context: OpExecutionContext, config: FileConfig):
     context.log.info(config.filename)
 
 

--- a/docs/content/concepts/partitions-schedules-sensors/testing-partitions.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/testing-partitions.mdx
@@ -59,7 +59,7 @@ def test_my_partitioned_config():
 If you want to test that a <PyObject object="PartitionedConfig" /> creates the partitions you expect, use the `get_partition_keys` or `get_run_config_for_partition_key` functions:
 
 ```python file=/concepts/partitions_schedules_sensors/partitioned_config_test.py startafter=start_partition_keys endbefore=end_partition_keys
-from dagster import Config
+from dagster import Config, OpExecutionContext
 
 
 @daily_partitioned_config(start_date=datetime(2020, 1, 1), minute_offset=15)
@@ -82,7 +82,7 @@ class ProcessDataConfig(Config):
 
 
 @op
-def process_data(context, config: ProcessDataConfig):
+def process_data(context: OpExecutionContext, config: ProcessDataConfig):
     s = config.start
     e = config.end
     context.log.info(f"processing data for {s} - {e}")

--- a/docs/content/concepts/resources-legacy.mdx
+++ b/docs/content/concepts/resources-legacy.mdx
@@ -76,11 +76,11 @@ def cereal_fetcher(init_context):
 Software-defined assets use resource keys to access resources:
 
 ```python file=/concepts/resources/resources.py startafter=start_asset_use_resource endbefore=end_asset_use_resource
-from dagster import asset
+from dagster import asset, AssetExecutionContext
 
 
 @asset(required_resource_keys={"foo"})
-def asset_requires_resource(context):
+def asset_requires_resource(context: AssetExecutionContext):
     do_something_with_resource(context.resources.foo)
 ```
 
@@ -147,7 +147,7 @@ CREATE_TABLE_1_QUERY = "create table_1 as select * from table_0"
 
 
 @op(required_resource_keys={"database"})
-def op_requires_resources(context):
+def op_requires_resources(context: OpExecutionContext):
     context.resources.database.execute_query(CREATE_TABLE_1_QUERY)
 ```
 
@@ -230,7 +230,7 @@ At spinup time, Dagster will run the code within the try block, and be expecting
 
 ```python file=/concepts/resources/resources.py startafter=start_cm_resource_op endbefore=end_cm_resource_op
 @op(required_resource_keys={"db_connection"})
-def use_db_connection(context):
+def use_db_connection(context: OpExecutionContext):
     db_conn = context.resources.db_connection
     ...
 ```
@@ -350,7 +350,7 @@ from dagster import graph, op
 
 
 @op(required_resource_keys={"client"})
-def get_client(context):
+def get_client(context: OpExecutionContext):
     return context.resources.client
 ```
 

--- a/docs/content/concepts/testing.mdx
+++ b/docs/content/concepts/testing.mdx
@@ -90,7 +90,7 @@ def get_data_without_resource():
 Dagster allows you to define multiple "jobs" from the same computation graph. With resources, you can modify the op above to:
 
 ```python file=/concepts/resources/tests.py startafter=start_test_after_marker endbefore=end_test_after_marker
-from dagster import graph, op, ConfigurableResource
+from dagster import graph, op, ConfigurableResource, OpExecutionContext
 
 
 class MyApi(ConfigurableResource):
@@ -104,7 +104,7 @@ def get_data(api: MyApi):
 
 
 @op
-def do_something(context, data):
+def do_something(context: OpExecutionContext, data):
     output = process(data)
     return output
 

--- a/docs/content/deployment/guides/kubernetes/customizing-your-deployment.mdx
+++ b/docs/content/deployment/guides/kubernetes/customizing-your-deployment.mdx
@@ -182,7 +182,7 @@ For example, for an asset:
         }
     }
 )
-def my_asset(context):
+def my_asset(context: AssetExecutionContext):
     context.log.info("running")
 
 my_job = define_asset_job(name="my_job", selection="my_asset", executor_def=k8s_job_executor)
@@ -202,7 +202,7 @@ or an op:
         }
     }
 )
-def my_op(context):
+def my_op(context: OpExecutionContext):
     context.log.info("running")
 
 @job(executor_def=k8s_job_executor)

--- a/docs/content/guides/dagster-pipes/subprocess/reference.mdx
+++ b/docs/content/guides/dagster-pipes/subprocess/reference.mdx
@@ -130,6 +130,7 @@ On Dagster's side, the `PipesClientCompletedInvocation` object returned from `Pi
 import shutil
 
 from dagster import (
+    AssetCheckResult,
     AssetExecutionContext,
     Definitions,
     MaterializeResult,
@@ -138,7 +139,6 @@ from dagster import (
     asset_check,
     file_relative_path,
 )
-from dagster._core.definitions.asset_check_result import AssetCheckResult
 
 
 @asset
@@ -148,7 +148,7 @@ def my_asset():
 
 @asset_check(asset="my_asset")
 def no_empty_order_check(
-    context, pipes_subprocess_client: PipesSubprocessClient
+    context: AssetExecutionContext, pipes_subprocess_client: PipesSubprocessClient
 ) -> AssetCheckResult:
     cmd = [
         shutil.which("python"),

--- a/docs/content/guides/dagster/dagster_type_factories.mdx
+++ b/docs/content/guides/dagster/dagster_type_factories.mdx
@@ -69,7 +69,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 
-from dagster import AssetMaterialization, job, op
+from dagster import AssetMaterialization, OpExecutionContext, job, op
 
 
 @op
@@ -81,7 +81,7 @@ def load_trips():
 
 
 @op
-def generate_plot(context, trips):
+def generate_plot(context: OpExecutionContext, trips):
     minute_lengths = [x.total_seconds() / 60 for x in trips.end_time - trips.start_time]
     bin_edges = np.histogram_bin_edges(minute_lengths, 15)
     fig, ax = plt.subplots(figsize=(10, 5))
@@ -210,7 +210,7 @@ import numpy as np
 import pandas as pd
 import pandera as pa
 
-from dagster import AssetMaterialization, Field, In, Out, job, op
+from dagster import AssetMaterialization, Field, In, OpExecutionContext, Out, job, op
 
 from .factory import pandera_schema_to_dagster_type
 
@@ -234,7 +234,7 @@ TripsDataFrame = pandera_schema_to_dagster_type(
 
 # We've added a Dagster type for this op's output
 @op(out=Out(TripsDataFrame), config_schema={"clean": Field(bool, False)})
-def load_trips(context):
+def load_trips(context: OpExecutionContext):
     df = pd.read_csv(
         "./ebike_trips.csv",
         parse_dates=["start_time", "end_time"],
@@ -246,7 +246,7 @@ def load_trips(context):
 
 # We've added a Dagster type for this op's input
 @op(ins={"trips": In(TripsDataFrame)})
-def generate_plot(context, trips):
+def generate_plot(context: OpExecutionContext, trips):
     minute_lengths = [x.total_seconds() / 60 for x in trips.end_time - trips.start_time]
     bin_edges = np.histogram_bin_edges(minute_lengths, 15)
     fig, ax = plt.subplots(figsize=(10, 5))

--- a/docs/content/guides/dagster/managing-ml.mdx
+++ b/docs/content/guides/dagster/managing-ml.mdx
@@ -109,13 +109,13 @@ In this example, the model is being evaluated against the previous model’s acc
 
 ```python file=/guides/dagster/managing_ml/managing_ml_code.py startafter=conditional_monitoring_start  endbefore=conditional_monitoring_end
 from sklearn import linear_model
-from dagster import asset, Output, AssetKey
+from dagster import asset, Output, AssetKey, AssetExecutionContext
 import numpy as np
 from sklearn.model_selection import train_test_split
 
 
 @asset(output_required=False)
-def conditional_machine_learning_model(context):
+def conditional_machine_learning_model(context: AssetExecutionContext):
     X, y = np.random.randint(5000, size=(5000, 2)), range(5000)
     X_train, X_test, y_train, y_test = train_test_split(
         X, y, test_size=0.33, random_state=42

--- a/docs/content/guides/dagster/managing-ml.mdx
+++ b/docs/content/guides/dagster/managing-ml.mdx
@@ -129,15 +129,23 @@ def conditional_machine_learning_model(context: AssetExecutionContext):
         AssetKey(["conditional_machine_learning_model"])
     )
     if materialization is None:
-        yield Output(reg, metadata={"model_accuracy": reg.score(X_test, y_test)})
+        yield Output(reg, metadata={"model_accuracy": float(reg.score(X_test, y_test))})
 
     else:
-        previous_model_accuracy = materialization.asset_materialization.metadata[
-            "model_accuracy"
-        ]
+        previous_model_accuracy = None
+        if materialization.asset_materialization and isinstance(
+            materialization.asset_materialization.metadata["model_accuracy"].value,
+            float,
+        ):
+            previous_model_accuracy = float(
+                materialization.asset_materialization.metadata["model_accuracy"].value
+            )
         new_model_accuracy = reg.score(X_test, y_test)
-        if new_model_accuracy > previous_model_accuracy:
-            yield Output(reg, metadata={"model_accuracy": new_model_accuracy})
+        if (
+            previous_model_accuracy is None
+            or new_model_accuracy > previous_model_accuracy
+        ):
+            yield Output(reg, metadata={"model_accuracy": float(new_model_accuracy)})
 ```
 
 A sensor can be set up that triggers if an asset fails to materialize. Alerts can be customized and sent through e-mail or natively through Slack. In this example, a Slack message is sent anytime the `ml_job` fails.

--- a/docs/content/guides/dagster/migrating-to-pythonic-resources-and-config.mdx
+++ b/docs/content/guides/dagster/migrating-to-pythonic-resources-and-config.mdx
@@ -210,21 +210,21 @@ class FancyDbClient:
 # Alternatively could have been imported from third-party library
 # from fancy_db import FancyDbClient
 
-from dagster import InitResourceContext, asset, resource
+from dagster import AssetExecutionContext, InitResourceContext, asset, resource
 
 @resource(config_schema={"conn_string": str})
 def fancy_db_resource(context: InitResourceContext) -> FancyDbClient:
     return FancyDbClient(context.resource_config["conn_string"])
 
 @asset(required_resource_keys={"fancy_db"})
-def existing_asset(context) -> None:
+def existing_asset(context: AssetExecutionContext) -> None:
     context.resources.fancy_db.execute_query("SELECT * FROM foo")
 ```
 
 With Pythonic-style resources you would write a class that can return that client from a method. In code that consumes that resource you would call that method to access the underlying client.
 
 ```python file=/guides/dagster/migrating_to_python_resources_and_config/migrating_resources.py  startafter=begin_new_third_party_resource endbefore=end_new_third_party_resource dedent=4
-from dagster import ConfigurableResource, asset
+from dagster import AssetExecutionContext, ConfigurableResource, asset
 
 class FancyDbResource(ConfigurableResource):
     conn_string: str
@@ -243,7 +243,7 @@ def new_asset(fancy_db: FancyDbResource) -> None:
 In the old API, `@resource` functions could also be context managers to handle initialization and cleanup tasks. This context manager was called by framework code rather than user code:
 
 ```python file=/guides/dagster/migrating_to_python_resources_and_config/migrating_resources.py  startafter=begin_old_resource_code_contextmanager endbefore=end_old_resource_code_contextmanager dedent=4
-from dagster import InitResourceContext, asset, resource
+from dagster import AssetExecutionContext, InitResourceContext, asset, resource
 
 @resource(config_schema={"conn_string": str})
 def fancy_db_resource(context: InitResourceContext) -> Iterator[FancyDbClient]:
@@ -256,7 +256,7 @@ def fancy_db_resource(context: InitResourceContext) -> Iterator[FancyDbClient]:
         some_expensive_teardown()
 
 @asset(required_resource_keys={"fancy_db"})
-def asset_one(context) -> None:
+def asset_one(context: AssetExecutionContext) -> None:
     # some_expensive_setup() has been called, but some_expensive_teardown() has not
     context.resources.fancy_db.execute_query("SELECT * FROM foo")
 ```
@@ -291,7 +291,7 @@ While there are benefits to managing object access in a resource rather than hav
 
 ```python file=/guides/dagster/migrating_to_python_resources_and_config/migrating_resources.py  startafter=begin_broken_unmigrated_code endbefore=end_broken_unmigrated_code dedent=4
 @asset(required_resource_keys={"fancy_db"})
-def existing_asset(context) -> None:
+def existing_asset(context: AssetExecutionContext) -> None:
     # This code is now broken because the resource is no longer a FancyDbClient
     # but it is a FancyDbResource.
     context.resources.fancy_db.execute_query("SELECT * FROM foo")
@@ -304,7 +304,12 @@ You can accomplish this by using Dagster's framework support, `IAttachDifferentO
 This framework can be implemented while you migrate your code, so that both new and old code can co-exist:
 
 ```python file=/guides/dagster/migrating_to_python_resources_and_config/migrating_resources.py  startafter=begin_new_third_party_resource_with_interface endbefore=end_new_third_party_resource_with_interface dedent=4    return FancyDbClient(self.conn_string)
-from dagster import ConfigurableResource, IAttachDifferentObjectToOpContext, asset
+from dagster import (
+    AssetExecutionContext,
+    ConfigurableResource,
+    IAttachDifferentObjectToOpContext,
+    asset,
+)
 
 class FancyDbResource(ConfigurableResource, IAttachDifferentObjectToOpContext):
     conn_string: str
@@ -321,7 +326,7 @@ def new_asset(fancy_db: FancyDbResource) -> None:
     client.execute_query("SELECT * FROM foo")
 
 @asset(required_resource_keys={"fancy_db"})
-def existing_asset(context) -> None:
+def existing_asset(context: AssetExecutionContext) -> None:
     # This code now works because context.resources.fancy_db is now a FancyDbClient
     context.resources.fancy_db.execute_query("SELECT * FROM foo")
 ```

--- a/docs/content/integrations/airflow/from-airflow-to-dagster.mdx
+++ b/docs/content/integrations/airflow/from-airflow-to-dagster.mdx
@@ -75,7 +75,7 @@ In Dagster, the minimum unit of computation is an op. This directly corresponds 
 
 ```python file=/integrations/airflow/tutorial_rewrite_dagster.py startafter=start_ops endbefore=end_ops
 @op
-def print_date(context) -> datetime:
+def print_date(context: OpExecutionContext) -> datetime:
     ds = datetime.now()
     context.log.info(ds)
     return ds
@@ -87,7 +87,7 @@ def sleep():
 
 
 @op
-def templated(context, ds: datetime):
+def templated(context: OpExecutionContext, ds: datetime):
     for _i in range(5):
         context.log.info(ds)
         context.log.info(ds - timedelta(days=7))
@@ -169,6 +169,7 @@ from dagster import (
     Definitions,
     In,
     Nothing,
+    OpExecutionContext,
     RetryPolicy,
     ScheduleDefinition,
     job,
@@ -178,7 +179,7 @@ from dagster import (
 
 
 @op
-def print_date(context) -> datetime:
+def print_date(context: OpExecutionContext) -> datetime:
     ds = datetime.now()
     context.log.info(ds)
     return ds
@@ -190,7 +191,7 @@ def sleep():
 
 
 @op
-def templated(context, ds: datetime):
+def templated(context: OpExecutionContext, ds: datetime):
     for _i in range(5):
         context.log.info(ds)
         context.log.info(ds - timedelta(days=7))

--- a/docs/content/integrations/bigquery/reference.mdx
+++ b/docs/content/integrations/bigquery/reference.mdx
@@ -231,7 +231,7 @@ from dagster import (
     },
 )
 def iris_data_partitioned(context: AssetExecutionContext) -> pd.DataFrame:
-    partition = partition = context.partition_key.keys_by_dimension
+    partition = context.partition_key.keys_by_dimension
     species = partition["species"]
     date = partition["date"]
 

--- a/docs/content/integrations/bigquery/reference.mdx
+++ b/docs/content/integrations/bigquery/reference.mdx
@@ -100,7 +100,7 @@ In order to store static partitioned assets in BigQuery, you must specify `parti
 ```python file=/integrations/bigquery/reference/static_partition.py startafter=start_example endbefore=end_example
 import pandas as pd
 
-from dagster import StaticPartitionsDefinition, asset
+from dagster import AssetExecutionContext, StaticPartitionsDefinition, asset
 
 
 @asset(
@@ -109,7 +109,7 @@ from dagster import StaticPartitionsDefinition, asset
     ),
     metadata={"partition_expr": "SPECIES"},
 )
-def iris_data_partitioned(context) -> pd.DataFrame:
+def iris_data_partitioned(context: AssetExecutionContext) -> pd.DataFrame:
     species = context.asset_partition_key_for_output()
 
     full_df = pd.read_csv(
@@ -157,14 +157,14 @@ Like static partitioned assets, you can specify `partition_expr` metadata on the
 ```python file=/integrations/bigquery/reference/time_partition.py startafter=start_example endbefore=end_example
 import pandas as pd
 
-from dagster import DailyPartitionsDefinition, asset
+from dagster import AssetExecutionContext, DailyPartitionsDefinition, asset
 
 
 @asset(
     partitions_def=DailyPartitionsDefinition(start_date="2023-01-01"),
     metadata={"partition_expr": "TIMESTAMP_SECONDS(TIME)"},
 )
-def iris_data_per_day(context) -> pd.DataFrame:
+def iris_data_per_day(context: AssetExecutionContext) -> pd.DataFrame:
     partition = context.asset_partition_key_for_output()
 
     # get_iris_data_for_date fetches all of the iris data for a given date,
@@ -209,6 +209,7 @@ The BigQuery I/O manager can also store data partitioned on multiple dimensions.
 import pandas as pd
 
 from dagster import (
+    AssetExecutionContext,
     DailyPartitionsDefinition,
     MultiPartitionsDefinition,
     StaticPartitionsDefinition,
@@ -229,7 +230,7 @@ from dagster import (
         "partition_expr": {"date": "TIMESTAMP_SECONDS(TIME)", "species": "SPECIES"}
     },
 )
-def iris_data_partitioned(context) -> pd.DataFrame:
+def iris_data_partitioned(context: AssetExecutionContext) -> pd.DataFrame:
     partition = partition = context.partition_key.keys_by_dimension
     species = partition["species"]
     date = partition["date"]
@@ -415,13 +416,13 @@ from pyspark.sql.types import (
     StructType,
 )
 
-from dagster import Definitions, asset
+from dagster import AssetExecutionContext, Definitions, asset
 
 BIGQUERY_JARS = "com.google.cloud.spark:spark-bigquery-with-dependencies_2.12:0.28.0"
 
 
 @asset(required_resource_keys={"pyspark"})
-def iris_data(context) -> DataFrame:
+def iris_data(context: AssetExecutionContext) -> DataFrame:
     spark = context.resources.pyspark.spark_session
 
     schema = StructType(

--- a/docs/content/integrations/dbt/reference.mdx
+++ b/docs/content/integrations/dbt/reference.mdx
@@ -629,7 +629,7 @@ from dagster_dbt import get_asset_keys_by_output_name_for_source
         ).items()
     }
 )
-def jaffle_shop(context):
+def jaffle_shop(context: AssetExecutionContext):
     output_names = list(context.selected_output_names)
     yield Output(value=..., output_name=output_names[0])
     yield Output(value=..., output_name=output_names[1])

--- a/docs/content/integrations/dbt/using-dbt-with-dagster/downstream-assets.mdx
+++ b/docs/content/integrations/dbt/using-dbt-with-dagster/downstream-assets.mdx
@@ -62,7 +62,7 @@ To add the `order_count_chart` asset:
        compute_kind="python",
        deps=get_asset_key_for_model([jaffle_shop_dbt_assets], "customers"),
    )
-   def order_count_chart(context):
+   def order_count_chart(context: AssetExecutionContext):
        # read the contents of the customers table into a Pandas DataFrame
        connection = duckdb.connect(os.fspath(duckdb_database_path))
        customers = connection.sql("select * from customers").df()

--- a/docs/content/integrations/dbt/using-dbt-with-dagster/upstream-assets.mdx
+++ b/docs/content/integrations/dbt/using-dbt-with-dagster/upstream-assets.mdx
@@ -58,7 +58,7 @@ duckdb_database_path = dbt_project_dir.joinpath("tutorial.duckdb")
 
 
 @asset(compute_kind="python")
-def raw_customers(context) -> None:
+def raw_customers(context: AssetExecutionContext) -> None:
     data = pd.read_csv("https://docs.dagster.io/assets/customers.csv")
     connection = duckdb.connect(os.fspath(duckdb_database_path))
     connection.execute("create schema if not exists jaffle_shop")

--- a/docs/content/integrations/duckdb/reference.mdx
+++ b/docs/content/integrations/duckdb/reference.mdx
@@ -103,7 +103,7 @@ To store static partitioned assets in DuckDB, specify `partition_expr` metadata 
 ```python file=/integrations/duckdb/reference/static_partition.py startafter=start_example endbefore=end_example
 import pandas as pd
 
-from dagster import StaticPartitionsDefinition, asset
+from dagster import AssetExecutionContext, StaticPartitionsDefinition, asset
 
 
 @asset(
@@ -112,7 +112,7 @@ from dagster import StaticPartitionsDefinition, asset
     ),
     metadata={"partition_expr": "SPECIES"},
 )
-def iris_dataset_partitioned(context) -> pd.DataFrame:
+def iris_dataset_partitioned(context: AssetExecutionContext) -> pd.DataFrame:
     species = context.asset_partition_key_for_output()
 
     full_df = pd.read_csv(
@@ -160,14 +160,14 @@ Like static partitioned assets, you can specify `partition_expr` metadata on the
 ```python file=/integrations/duckdb/reference/time_partition.py startafter=start_example endbefore=end_example
 import pandas as pd
 
-from dagster import DailyPartitionsDefinition, asset
+from dagster import AssetExecutionContext, DailyPartitionsDefinition, asset
 
 
 @asset(
     partitions_def=DailyPartitionsDefinition(start_date="2023-01-01"),
     metadata={"partition_expr": "TO_TIMESTAMP(TIME)"},
 )
-def iris_data_per_day(context) -> pd.DataFrame:
+def iris_data_per_day(context: AssetExecutionContext) -> pd.DataFrame:
     partition = context.asset_partition_key_for_output()
 
     # get_iris_data_for_date fetches all of the iris data for a given date,
@@ -212,9 +212,10 @@ The DuckDB I/O manager can also store data partitioned on multiple dimensions. T
 import pandas as pd
 
 from dagster import (
+    AssetExecutionContext,
     DailyPartitionsDefinition,
     MultiPartitionsDefinition,
-    StaticPartitionDefinition,
+    StaticPartitionsDefinition,
     asset,
 )
 
@@ -223,14 +224,14 @@ from dagster import (
     partitions_def=MultiPartitionsDefinition(
         {
             "date": DailyPartitionsDefinition(start_date="2023-01-01"),
-            "species": StaticPartitionDefinition(
+            "species": StaticPartitionsDefinition(
                 ["Iris-setosa", "Iris-virginica", "Iris-versicolor"]
             ),
         }
     ),
     metadata={"partition_expr": {"date": "TO_TIMESTAMP(TIME)", "species": "SPECIES"}},
 )
-def iris_dataset_partitioned(context) -> pd.DataFrame:
+def iris_dataset_partitioned(context: AssetExecutionContext) -> pd.DataFrame:
     partition = partition = context.partition_key.keys_by_dimension
     species = partition["species"]
     date = partition["date"]
@@ -410,11 +411,11 @@ from pyspark.sql.types import (
     StructType,
 )
 
-from dagster import Definitions, asset
+from dagster import AssetExecutionContext, Definitions, asset
 
 
 @asset(required_resource_keys={"pyspark"})
-def iris_dataset(context) -> DataFrame:
+def iris_dataset(context: AssetExecutionContext) -> DataFrame:
     spark = context.resources.pyspark.spark_session
 
     schema = StructType(

--- a/docs/content/integrations/duckdb/reference.mdx
+++ b/docs/content/integrations/duckdb/reference.mdx
@@ -232,7 +232,7 @@ from dagster import (
     metadata={"partition_expr": {"date": "TO_TIMESTAMP(TIME)", "species": "SPECIES"}},
 )
 def iris_dataset_partitioned(context: AssetExecutionContext) -> pd.DataFrame:
-    partition = partition = context.partition_key.keys_by_dimension
+    partition = context.partition_key.keys_by_dimension
     species = partition["species"]
     date = partition["date"]
 

--- a/docs/content/integrations/snowflake/reference.mdx
+++ b/docs/content/integrations/snowflake/reference.mdx
@@ -232,6 +232,7 @@ import pandas as pd
 from dagster import (
     AssetExecutionContext,
     DailyPartitionsDefinition,
+    MultiPartitionKey,
     MultiPartitionsDefinition,
     StaticPartitionsDefinition,
     asset,
@@ -252,7 +253,7 @@ from dagster import (
     },
 )
 def iris_dataset_partitioned(context: AssetExecutionContext) -> pd.DataFrame:
-    partition = partition = context.partition_key.keys_by_dimension
+    partition = context.partition_key.keys_by_dimension
     species = partition["species"]
     date = partition["date"]
 

--- a/docs/content/integrations/snowflake/reference.mdx
+++ b/docs/content/integrations/snowflake/reference.mdx
@@ -121,7 +121,7 @@ In order to store static partitioned assets in Snowflake, you must specify `part
 ```python file=/integrations/snowflake/static_partition.py startafter=start_example endbefore=end_example
 import pandas as pd
 
-from dagster import StaticPartitionsDefinition, asset
+from dagster import AssetExecutionContext, StaticPartitionsDefinition, asset
 
 
 @asset(
@@ -130,7 +130,7 @@ from dagster import StaticPartitionsDefinition, asset
     ),
     metadata={"partition_expr": "SPECIES"},
 )
-def iris_dataset_partitioned(context) -> pd.DataFrame:
+def iris_dataset_partitioned(context: AssetExecutionContext) -> pd.DataFrame:
     species = context.asset_partition_key_for_output()
 
     full_df = pd.read_csv(
@@ -178,14 +178,14 @@ Like static partitioned assets, you can specify `partition_expr` metadata on the
 ```python file=/integrations/snowflake/time_partition.py startafter=start_example endbefore=end_example
 import pandas as pd
 
-from dagster import DailyPartitionsDefinition, asset
+from dagster import AssetExecutionContext, DailyPartitionsDefinition, asset
 
 
 @asset(
     partitions_def=DailyPartitionsDefinition(start_date="2023-01-01"),
     metadata={"partition_expr": "TO_TIMESTAMP(TIME::INT)"},
 )
-def iris_data_per_day(context) -> pd.DataFrame:
+def iris_data_per_day(context: AssetExecutionContext) -> pd.DataFrame:
     partition = context.asset_partition_key_for_output()
 
     # get_iris_data_for_date fetches all of the iris data for a given date,
@@ -230,9 +230,10 @@ The Snowflake I/O manager can also store data partitioned on multiple dimensions
 import pandas as pd
 
 from dagster import (
+    AssetExecutionContext,
     DailyPartitionsDefinition,
     MultiPartitionsDefinition,
-    StaticPartitionDefinition,
+    StaticPartitionsDefinition,
     asset,
 )
 
@@ -241,7 +242,7 @@ from dagster import (
     partitions_def=MultiPartitionsDefinition(
         {
             "date": DailyPartitionsDefinition(start_date="2023-01-01"),
-            "species": StaticPartitionDefinition(
+            "species": StaticPartitionsDefinition(
                 ["Iris-setosa", "Iris-virginica", "Iris-versicolor"]
             ),
         }
@@ -250,7 +251,7 @@ from dagster import (
         "partition_expr": {"date": "TO_TIMESTAMP(TIME::INT)", "species": "SPECIES"}
     },
 )
-def iris_dataset_partitioned(context) -> pd.DataFrame:
+def iris_dataset_partitioned(context: AssetExecutionContext) -> pd.DataFrame:
     partition = partition = context.partition_key.keys_by_dimension
     species = partition["species"]
     date = partition["date"]
@@ -448,13 +449,13 @@ from pyspark.sql.types import (
     StructType,
 )
 
-from dagster import Definitions, EnvVar, asset
+from dagster import AssetExecutionContext, Definitions, EnvVar, asset
 
 SNOWFLAKE_JARS = "net.snowflake:snowflake-jdbc:3.8.0,net.snowflake:spark-snowflake_2.12:2.8.2-spark_3.0"
 
 
 @asset(required_resource_keys={"pyspark"})
-def iris_dataset(context) -> DataFrame:
+def iris_dataset(context: AssetExecutionContext) -> DataFrame:
     spark = context.resources.pyspark.spark_session
 
     schema = StructType(

--- a/examples/docs_snippets/docs_snippets/concepts/assets/asset_checks/asset_with_check.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/asset_checks/asset_with_check.py
@@ -1,10 +1,10 @@
 import pandas as pd
 
-from dagster import AssetCheckResult, AssetCheckSpec, Definitions, Output, asset
+from dagster import AssetCheckResult, AssetCheckSpec, Definitions, Output, asset, AssetExecutionContext
 
 
 @asset(check_specs=[AssetCheckSpec(name="orders_id_has_no_nulls", asset="orders")])
-def orders(context):
+def orders(context: AssetExecutionContext):
     orders_df = pd.DataFrame({"order_id": [1, 2], "item_id": [432, 878]})
 
     # save the output and indicate that it's been saved

--- a/examples/docs_snippets/docs_snippets/concepts/assets/asset_checks/asset_with_check.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/asset_checks/asset_with_check.py
@@ -1,6 +1,13 @@
 import pandas as pd
 
-from dagster import AssetCheckResult, AssetCheckSpec, Definitions, Output, asset, AssetExecutionContext
+from dagster import (
+    AssetCheckResult,
+    AssetCheckSpec,
+    AssetExecutionContext,
+    Definitions,
+    Output,
+    asset,
+)
 
 
 @asset(check_specs=[AssetCheckSpec(name="orders_id_has_no_nulls", asset="orders")])

--- a/examples/docs_snippets/docs_snippets/concepts/assets/asset_input_managers_numpy.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/asset_input_managers_numpy.py
@@ -7,11 +7,11 @@ from dagster import (
     AssetIn,
     ConfigurableIOManager,
     Definitions,
+    InputContext,
     IOManager,
+    OutputContext,
     asset,
     io_manager,
-    InputContext,
-    OutputContext
 )
 
 from .asset_input_managers import (

--- a/examples/docs_snippets/docs_snippets/concepts/assets/asset_input_managers_numpy.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/asset_input_managers_numpy.py
@@ -10,6 +10,8 @@ from dagster import (
     IOManager,
     asset,
     io_manager,
+    InputContext,
+    OutputContext
 )
 
 from .asset_input_managers import (
@@ -22,7 +24,7 @@ from .asset_input_managers import (
 
 
 class PandasAssetIOManager(ConfigurableIOManager):
-    def handle_output(self, context, obj):
+    def handle_output(self, context: OutputContext, obj):
         file_path = self._get_path(context)
         store_pandas_dataframe(name=file_path, table=obj)
 
@@ -32,13 +34,13 @@ class PandasAssetIOManager(ConfigurableIOManager):
             f"{context.asset_key.path[-1]}.csv",
         )
 
-    def load_input(self, context) -> pd.DataFrame:
+    def load_input(self, context: InputContext) -> pd.DataFrame:
         file_path = self._get_path(context)
         return load_pandas_dataframe(name=file_path)
 
 
 class NumpyAssetIOManager(PandasAssetIOManager):
-    def load_input(self, context) -> np.ndarray:
+    def load_input(self, context: InputContext) -> np.ndarray:
         file_path = self._get_path(context)
         return load_numpy_array(name=file_path)
 

--- a/examples/docs_snippets/docs_snippets/concepts/assets/asset_testing.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/asset_testing.py
@@ -1,4 +1,4 @@
-from dagster import asset, build_asset_context, AssetExecutionContext
+from dagster import AssetExecutionContext, asset, build_asset_context
 
 # start_simple_asset
 

--- a/examples/docs_snippets/docs_snippets/concepts/assets/asset_testing.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/asset_testing.py
@@ -1,4 +1,4 @@
-from dagster import asset, build_asset_context
+from dagster import asset, build_asset_context, AssetExecutionContext
 
 # start_simple_asset
 
@@ -44,7 +44,7 @@ def test_more_complex_asset():
 
 
 @asset
-def uses_context(context):
+def uses_context(context: AssetExecutionContext):
     context.log.info(context.run_id)
     return "bar"
 

--- a/examples/docs_snippets/docs_snippets/concepts/assets/graph_backed_asset.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/graph_backed_asset.py
@@ -7,6 +7,7 @@ from dagster import (
     AssetSelection,
     define_asset_job,
     Definitions,
+    OpExecutionContext
 )
 from mock import MagicMock
 
@@ -22,7 +23,7 @@ from dagster_slack import SlackResource
 
 
 @op
-def fetch_files_from_slack(context, slack: SlackResource) -> pd.DataFrame:
+def fetch_files_from_slack(slack: SlackResource) -> pd.DataFrame:
     files = slack.get_client().files_list(channel="#random")
     return pd.DataFrame(
         [

--- a/examples/docs_snippets/docs_snippets/concepts/assets/graph_backed_asset.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/graph_backed_asset.py
@@ -7,7 +7,7 @@ from dagster import (
     AssetSelection,
     define_asset_job,
     Definitions,
-    OpExecutionContext
+    OpExecutionContext,
 )
 from mock import MagicMock
 

--- a/examples/docs_snippets/docs_snippets/concepts/assets/load_asset_values.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/load_asset_values.py
@@ -1,12 +1,12 @@
 from dagster import (
     AssetKey,
     Definitions,
+    InputContext,
     IOManager,
     IOManagerDefinition,
+    OutputContext,
     asset,
     with_resources,
-    OutputContext,
-    InputContext
 )
 
 

--- a/examples/docs_snippets/docs_snippets/concepts/assets/load_asset_values.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/load_asset_values.py
@@ -5,14 +5,16 @@ from dagster import (
     IOManagerDefinition,
     asset,
     with_resources,
+    OutputContext,
+    InputContext
 )
 
 
 class MyIOManager(IOManager):
-    def handle_output(self, context, obj):
+    def handle_output(self, context: OutputContext, obj):
         assert False
 
-    def load_input(self, context):
+    def load_input(self, context: InputContext):
         return 5
 
 

--- a/examples/docs_snippets/docs_snippets/concepts/assets/materialization_ops.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/materialization_ops.py
@@ -18,7 +18,7 @@ def calculate_bytes(df):
 
 
 # start_materialization_ops_marker_0
-from dagster import op
+from dagster import op, OpExecutionContext
 
 
 @op
@@ -35,7 +35,7 @@ from dagster import AssetMaterialization, op
 
 
 @op
-def my_materialization_op(context):
+def my_materialization_op(context: OpExecutionContext):
     df = read_df()
     remote_storage_path = persist_to_storage(df)
     context.log_event(
@@ -50,7 +50,7 @@ def my_materialization_op(context):
 
 
 # start_partitioned_asset_materialization
-from dagster import AssetMaterialization, Config, op
+from dagster import AssetMaterialization, Config, op, OpExecutionContext
 
 
 class MyOpConfig(Config):
@@ -58,7 +58,7 @@ class MyOpConfig(Config):
 
 
 @op
-def my_partitioned_asset_op(context, config: MyOpConfig):
+def my_partitioned_asset_op(context: OpExecutionContext, config: MyOpConfig):
     partition_date = config.date
     df = read_df_for_date(partition_date)
     remote_storage_path = persist_to_storage(df)
@@ -72,11 +72,11 @@ def my_partitioned_asset_op(context, config: MyOpConfig):
 
 
 # start_materialization_ops_marker_2
-from dagster import AssetMaterialization, MetadataValue, op
+from dagster import AssetMaterialization, MetadataValue, op, OpExecutionContext
 
 
 @op
-def my_metadata_materialization_op(context):
+def my_metadata_materialization_op(context: OpExecutionContext):
     df = read_df()
     remote_storage_path = persist_to_storage(df)
     context.log_event(
@@ -100,11 +100,11 @@ def my_metadata_materialization_op(context):
 
 
 # start_materialization_ops_marker_3
-from dagster import AssetKey, AssetMaterialization, Output, job, op
+from dagster import AssetKey, AssetMaterialization, Output, job, op, OpExecutionContext
 
 
 @op
-def my_asset_key_materialization_op(context):
+def my_asset_key_materialization_op(context: OpExecutionContext):
     df = read_df()
     remote_storage_path = persist_to_storage(df)
     yield AssetMaterialization(

--- a/examples/docs_snippets/docs_snippets/concepts/assets/multi_assets.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/multi_assets.py
@@ -2,7 +2,7 @@
 
 
 # start_basic_multi_asset
-from dagster import AssetOut, multi_asset
+from dagster import AssetOut, multi_asset, AssetExecutionContext
 
 
 @multi_asset(
@@ -44,7 +44,7 @@ from dagster import AssetOut, Output, multi_asset
     },
     can_subset=True,
 )
-def split_actions(context):
+def split_actions(context: AssetExecutionContext):
     if "a" in context.selected_output_names:
         yield Output(value=123, output_name="a")
     if "b" in context.selected_output_names:

--- a/examples/docs_snippets/docs_snippets/concepts/assets/observations.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/observations.py
@@ -1,6 +1,6 @@
 # ruff: isort: skip_file
 
-from dagster import job, op
+from dagster import job, op, OpExecutionContext
 
 
 def read_df():
@@ -24,7 +24,7 @@ from dagster import AssetObservation, op
 
 
 @op
-def observation_op(context):
+def observation_op(context: OpExecutionContext):
     df = read_df()
     context.log_event(
         AssetObservation(asset_key="observation_asset", metadata={"num_rows": len(df)})
@@ -35,7 +35,7 @@ def observation_op(context):
 # end_observation_asset_marker_0
 
 # start_partitioned_asset_observation
-from dagster import AssetMaterialization, Config, op
+from dagster import AssetMaterialization, Config, op, OpExecutionContext
 
 
 class MyOpConfig(Config):
@@ -43,7 +43,7 @@ class MyOpConfig(Config):
 
 
 @op
-def partitioned_dataset_op(context, config: MyOpConfig):
+def partitioned_dataset_op(context: OpExecutionContext, config: MyOpConfig):
     partition_date = config.date
     df = read_df_for_date(partition_date)
     context.log_event(
@@ -60,7 +60,7 @@ from dagster import AssetMaterialization, AssetObservation, MetadataValue, op
 
 
 @op
-def observes_dataset_op(context):
+def observes_dataset_op(context: OpExecutionContext):
     df = read_df()
     remote_storage_path = persist_to_storage(df)
     context.log_event(

--- a/examples/docs_snippets/docs_snippets/concepts/assets/subset_graph_backed_asset.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/subset_graph_backed_asset.py
@@ -6,12 +6,13 @@ from dagster import (
     define_asset_job,
     graph_multi_asset,
     op,
+    OpExecutionContext
 )
 
 
 # start_graph_backed_asset_foo
 @op(out={"foo_1": Out(is_required=False), "foo_2": Out(is_required=False)})
-def foo(context, bar_1):
+def foo(context: OpExecutionContext, bar_1):
     # Selectively returns outputs based on selected assets
     if "foo_1" in context.selected_output_names:
         yield Output(bar_1 + 1, output_name="foo_1")

--- a/examples/docs_snippets/docs_snippets/concepts/assets/subset_graph_backed_asset.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/subset_graph_backed_asset.py
@@ -1,12 +1,12 @@
 from dagster import (
     AssetOut,
     Definitions,
+    OpExecutionContext,
     Out,
     Output,
     define_asset_job,
     graph_multi_asset,
     op,
-    OpExecutionContext
 )
 
 

--- a/examples/docs_snippets/docs_snippets/concepts/configuration/configurable_op_asset_resource.py
+++ b/examples/docs_snippets/docs_snippets/concepts/configuration/configurable_op_asset_resource.py
@@ -1,4 +1,4 @@
-from dagster import asset, job, op, repository, resource
+from dagster import asset, job, op, repository, resource, OpExecutionContext, AssetExecutionContext, InitResourceContext
 
 
 class MyDatabaseConnection:
@@ -8,18 +8,18 @@ class MyDatabaseConnection:
 
 # start_marker
 @op(config_schema={"person_name": str})
-def op_using_config(context):
+def op_using_config(context: OpExecutionContext):
     return f'hello {context.op_config["person_name"]}'
 
 
 @asset(config_schema={"person_name": str})
-def asset_using_config(context):
+def asset_using_config(context: AssetExecutionContext):
     # Note how asset config is also accessed with context.op_config
     return f'hello {context.op_config["person_name"]}'
 
 
 @resource(config_schema={"url": str})
-def resource_using_config(context):
+def resource_using_config(context: InitResourceContext):
     return MyDatabaseConnection(context.resource_config["url"])
 
 

--- a/examples/docs_snippets/docs_snippets/concepts/configuration/configurable_op_asset_resource.py
+++ b/examples/docs_snippets/docs_snippets/concepts/configuration/configurable_op_asset_resource.py
@@ -1,4 +1,13 @@
-from dagster import asset, job, op, repository, resource, OpExecutionContext, AssetExecutionContext, InitResourceContext
+from dagster import (
+    AssetExecutionContext,
+    InitResourceContext,
+    OpExecutionContext,
+    asset,
+    job,
+    op,
+    repository,
+    resource,
+)
 
 
 class MyDatabaseConnection:

--- a/examples/docs_snippets/docs_snippets/concepts/configuration/configured_named_op_example.py
+++ b/examples/docs_snippets/docs_snippets/concepts/configuration/configured_named_op_example.py
@@ -1,4 +1,4 @@
-from dagster import Field, In, Int, List, configured, job, op
+from dagster import Field, In, Int, List, configured, job, op, OpExecutionContext
 
 
 # start_configured_named
@@ -8,7 +8,7 @@ from dagster import Field, In, Int, List, configured, job, op
     },
     ins={"xs": In(List[Int])},
 )
-def get_dataset(context, xs):
+def get_dataset(context: OpExecutionContext, xs):
     if context.op_config["is_sample"]:
         return xs[:5]
     else:

--- a/examples/docs_snippets/docs_snippets/concepts/configuration/configured_named_op_example.py
+++ b/examples/docs_snippets/docs_snippets/concepts/configuration/configured_named_op_example.py
@@ -1,4 +1,4 @@
-from dagster import Field, In, Int, List, configured, job, op, OpExecutionContext
+from dagster import Field, In, Int, List, OpExecutionContext, configured, job, op
 
 
 # start_configured_named

--- a/examples/docs_snippets/docs_snippets/concepts/configuration/configured_op_example.py
+++ b/examples/docs_snippets/docs_snippets/concepts/configuration/configured_op_example.py
@@ -1,4 +1,4 @@
-from dagster import Field, configured, op, OpExecutionContext
+from dagster import Field, OpExecutionContext, configured, op
 
 
 @op(

--- a/examples/docs_snippets/docs_snippets/concepts/configuration/configured_op_example.py
+++ b/examples/docs_snippets/docs_snippets/concepts/configuration/configured_op_example.py
@@ -1,4 +1,4 @@
-from dagster import Field, configured, op
+from dagster import Field, configured, op, OpExecutionContext
 
 
 @op(
@@ -7,7 +7,7 @@ from dagster import Field, configured, op
         "word": Field(str, is_required=False, default_value="hello"),
     }
 )
-def example(context):
+def example(context: OpExecutionContext):
     for _ in range(context.op_config["iterations"]):
         context.log.info(context.op_config["word"])
 

--- a/examples/docs_snippets/docs_snippets/concepts/configuration/env_vars_config.py
+++ b/examples/docs_snippets/docs_snippets/concepts/configuration/env_vars_config.py
@@ -1,5 +1,12 @@
 # start_database_example
-from dagster import StringSource, job, op, resource, InitResourceContext, OpExecutionContext
+from dagster import (
+    InitResourceContext,
+    OpExecutionContext,
+    StringSource,
+    job,
+    op,
+    resource,
+)
 
 
 @resource(config_schema={"username": StringSource, "password": StringSource})

--- a/examples/docs_snippets/docs_snippets/concepts/configuration/env_vars_config.py
+++ b/examples/docs_snippets/docs_snippets/concepts/configuration/env_vars_config.py
@@ -1,16 +1,16 @@
 # start_database_example
-from dagster import StringSource, job, op, resource
+from dagster import StringSource, job, op, resource, InitResourceContext, OpExecutionContext
 
 
 @resource(config_schema={"username": StringSource, "password": StringSource})
-def database_client(context):
+def database_client(context: InitResourceContext):
     username = context.resource_config["username"]
     password = context.resource_config["password"]
     ...
 
 
 @op(required_resource_keys={"database"})
-def get_one(context):
+def get_one(context: OpExecutionContext):
     context.resources.database.execute_query("SELECT 1")
 
 

--- a/examples/docs_snippets/docs_snippets/concepts/configuration/make_values_resource_any.py
+++ b/examples/docs_snippets/docs_snippets/concepts/configuration/make_values_resource_any.py
@@ -1,12 +1,12 @@
 import os
 
-from dagster import job, make_values_resource, op
+from dagster import job, make_values_resource, op, OpExecutionContext
 
 # start_file_example
 
 
 @op(required_resource_keys={"file_dir"})
-def add_file(context):
+def add_file(context: OpExecutionContext):
     filename = f"{context.resources.file_dir}/new_file.txt"
     open(filename, "x", encoding="utf8").close()
 
@@ -14,7 +14,7 @@ def add_file(context):
 
 
 @op(required_resource_keys={"file_dir"})
-def total_num_files(context):
+def total_num_files(context: OpExecutionContext):
     files_in_dir = os.listdir(context.resources.file_dir)
     context.log.info(f"Total number of files: {len(files_in_dir)}")
 

--- a/examples/docs_snippets/docs_snippets/concepts/configuration/make_values_resource_any.py
+++ b/examples/docs_snippets/docs_snippets/concepts/configuration/make_values_resource_any.py
@@ -1,6 +1,6 @@
 import os
 
-from dagster import job, make_values_resource, op, OpExecutionContext
+from dagster import OpExecutionContext, job, make_values_resource, op
 
 # start_file_example
 

--- a/examples/docs_snippets/docs_snippets/concepts/configuration/make_values_resource_config_schema.py
+++ b/examples/docs_snippets/docs_snippets/concepts/configuration/make_values_resource_config_schema.py
@@ -1,6 +1,6 @@
 import os
 
-from dagster import job, make_values_resource, op, OpExecutionContext
+from dagster import OpExecutionContext, job, make_values_resource, op
 
 # start_file_example
 

--- a/examples/docs_snippets/docs_snippets/concepts/configuration/make_values_resource_config_schema.py
+++ b/examples/docs_snippets/docs_snippets/concepts/configuration/make_values_resource_config_schema.py
@@ -1,12 +1,12 @@
 import os
 
-from dagster import job, make_values_resource, op
+from dagster import job, make_values_resource, op, OpExecutionContext
 
 # start_file_example
 
 
 @op(required_resource_keys={"file_dirs"})
-def write_file(context):
+def write_file(context: OpExecutionContext):
     filename = f"{context.resources.file_dirs['write_file_dir']}/new_file.txt"
     open(filename, "x", encoding="utf8").close()
 
@@ -14,7 +14,7 @@ def write_file(context):
 
 
 @op(required_resource_keys={"file_dirs"})
-def total_num_files(context):
+def total_num_files(context: OpExecutionContext):
     files_in_dir = os.listdir(context.resources.file_dirs["count_file_dir"])
     context.log.info(f"Total number of files: {len(files_in_dir)}")
 

--- a/examples/docs_snippets/docs_snippets/concepts/io_management/custom_io_manager.py
+++ b/examples/docs_snippets/docs_snippets/concepts/io_management/custom_io_manager.py
@@ -110,8 +110,9 @@ class DataframeTableIOManager(ConfigurableIOManager):
 
     def load_input(self, context: InputContext):
         # upstream_output.name is the name given to the Out that we're loading for
-        table_name = context.upstream_output.name
-        return read_dataframe_from_table(name=table_name)
+        if context.upstream_output:
+            table_name = context.upstream_output.name
+            return read_dataframe_from_table(name=table_name)
 
 
 @job(resource_defs={"io_manager": DataframeTableIOManager()})
@@ -131,8 +132,9 @@ class DataframeTableIOManagerWithMetadata(ConfigurableIOManager):
         context.add_output_metadata({"num_rows": len(obj), "table_name": table_name})
 
     def load_input(self, context: InputContext):
-        table_name = context.upstream_output.name
-        return read_dataframe_from_table(name=table_name)
+        if context.upstream_output:
+            table_name = context.upstream_output.name
+            return read_dataframe_from_table(name=table_name)
 
 
 # end_metadata_marker

--- a/examples/docs_snippets/docs_snippets/concepts/io_management/custom_io_manager.py
+++ b/examples/docs_snippets/docs_snippets/concepts/io_management/custom_io_manager.py
@@ -52,7 +52,7 @@ class MyIOManager(ConfigurableIOManager):
 
 # start_io_manager_factory_marker
 
-from dagster import IOManager, ConfigurableIOManagerFactory
+from dagster import IOManager, ConfigurableIOManagerFactory, OutputContext, InputContext
 import requests
 
 
@@ -62,10 +62,10 @@ class ExternalIOManager(IOManager):
         # setup stateful cache
         self._cache = {}
 
-    def handle_output(self, context, obj):
+    def handle_output(self, context: OutputContext, obj):
         ...
 
-    def load_input(self, context):
+    def load_input(self, context: InputContext):
         if context.asset_key in self._cache:
             return self._cache[context.asset_key]
         ...
@@ -89,10 +89,10 @@ class MyPartitionedIOManager(IOManager):
         else:
             return "/".join(context.asset_key.path)
 
-    def handle_output(self, context, obj):
+    def handle_output(self, context: OutputContext, obj):
         write_csv(self._get_path(context), obj)
 
-    def load_input(self, context):
+    def load_input(self, context: InputContext):
         return read_csv(self._get_path(context))
 
 
@@ -103,12 +103,12 @@ from dagster import ConfigurableIOManager, io_manager
 
 
 class DataframeTableIOManager(ConfigurableIOManager):
-    def handle_output(self, context, obj):
+    def handle_output(self, context: OutputContext, obj):
         # name is the name given to the Out that we're storing for
         table_name = context.name
         write_dataframe_to_table(name=table_name, dataframe=obj)
 
-    def load_input(self, context):
+    def load_input(self, context: InputContext):
         # upstream_output.name is the name given to the Out that we're loading for
         table_name = context.upstream_output.name
         return read_dataframe_from_table(name=table_name)
@@ -124,13 +124,13 @@ def my_job():
 
 # start_metadata_marker
 class DataframeTableIOManagerWithMetadata(ConfigurableIOManager):
-    def handle_output(self, context, obj):
+    def handle_output(self, context: OutputContext, obj):
         table_name = context.name
         write_dataframe_to_table(name=table_name, dataframe=obj)
 
         context.add_output_metadata({"num_rows": len(obj), "table_name": table_name})
 
-    def load_input(self, context):
+    def load_input(self, context: InputContext):
         table_name = context.upstream_output.name
         return read_dataframe_from_table(name=table_name)
 

--- a/examples/docs_snippets/docs_snippets/concepts/io_management/input_managers.py
+++ b/examples/docs_snippets/docs_snippets/concepts/io_management/input_managers.py
@@ -7,12 +7,12 @@ import pandas as pd
 from dagster import (
     ConfigurableIOManager,
     In,
+    InputContext,
     InputManager,
+    OutputContext,
     input_manager,
     job,
     op,
-    OutputContext,
-    InputContext
 )
 
 

--- a/examples/docs_snippets/docs_snippets/concepts/io_management/input_managers.py
+++ b/examples/docs_snippets/docs_snippets/concepts/io_management/input_managers.py
@@ -205,7 +205,8 @@ class MyIOManager(ConfigurableIOManager):
         write_dataframe_to_table(name=table_name, dataframe=obj)
 
     def load_input(self, context: InputContext):
-        return read_dataframe_from_table(name=context.upstream_output.name)
+        if context.upstream_output:
+            return read_dataframe_from_table(name=context.upstream_output.name)
 
 
 @input_manager

--- a/examples/docs_snippets/docs_snippets/concepts/io_management/load_custom_type_from_config.py
+++ b/examples/docs_snippets/docs_snippets/concepts/io_management/load_custom_type_from_config.py
@@ -7,6 +7,7 @@ from dagster import (
     job,
     op,
     usable_as_dagster_type,
+    OpExecutionContext
 )
 
 
@@ -32,7 +33,7 @@ class Apple:
 
 
 @op
-def my_op(context, input_apple: Apple):
+def my_op(context: OpExecutionContext, input_apple: Apple):
     context.log.info(f"input apple diameter: {input_apple.diameter}")
 
 

--- a/examples/docs_snippets/docs_snippets/concepts/io_management/load_custom_type_from_config.py
+++ b/examples/docs_snippets/docs_snippets/concepts/io_management/load_custom_type_from_config.py
@@ -3,11 +3,11 @@ from typing import Dict, Union
 
 from dagster import (
     DagsterTypeLoaderContext,
+    OpExecutionContext,
     dagster_type_loader,
     job,
     op,
     usable_as_dagster_type,
-    OpExecutionContext
 )
 
 

--- a/examples/docs_snippets/docs_snippets/concepts/io_management/load_from_config.py
+++ b/examples/docs_snippets/docs_snippets/concepts/io_management/load_from_config.py
@@ -1,9 +1,9 @@
-from dagster import job, op
+from dagster import job, op, OpExecutionContext
 
 
 # def_start_marker
 @op
-def my_op(context, input_string: str):
+def my_op(context: OpExecutionContext, input_string: str):
     context.log.info(f"input string: {input_string}")
 
 

--- a/examples/docs_snippets/docs_snippets/concepts/io_management/load_from_config.py
+++ b/examples/docs_snippets/docs_snippets/concepts/io_management/load_from_config.py
@@ -1,4 +1,4 @@
-from dagster import job, op, OpExecutionContext
+from dagster import OpExecutionContext, job, op
 
 
 # def_start_marker

--- a/examples/docs_snippets/docs_snippets/concepts/io_management/metadata.py
+++ b/examples/docs_snippets/docs_snippets/concepts/io_management/metadata.py
@@ -1,4 +1,13 @@
-from dagster import ConfigurableIOManager, IOManager, Out, io_manager, job, op, OutputContext, InputContext
+from dagster import (
+    ConfigurableIOManager,
+    InputContext,
+    IOManager,
+    Out,
+    OutputContext,
+    io_manager,
+    job,
+    op,
+)
 
 
 def connect():

--- a/examples/docs_snippets/docs_snippets/concepts/io_management/metadata.py
+++ b/examples/docs_snippets/docs_snippets/concepts/io_management/metadata.py
@@ -1,4 +1,4 @@
-from dagster import ConfigurableIOManager, IOManager, Out, io_manager, job, op
+from dagster import ConfigurableIOManager, IOManager, Out, io_manager, job, op, OutputContext, InputContext
 
 
 def connect():
@@ -29,12 +29,12 @@ def op_2(_input_dataframe):
 
 # io_manager_start_marker
 class MyIOManager(ConfigurableIOManager):
-    def handle_output(self, context, obj):
+    def handle_output(self, context: OutputContext, obj):
         table_name = context.metadata["table"]
         schema = context.metadata["schema"]
         write_dataframe_to_table(name=table_name, schema=schema, dataframe=obj)
 
-    def load_input(self, context):
+    def load_input(self, context: InputContext):
         table_name = context.upstream_output.metadata["table"]
         schema = context.upstream_output.metadata["schema"]
         return read_dataframe_from_table(name=table_name, schema=schema)

--- a/examples/docs_snippets/docs_snippets/concepts/io_management/metadata.py
+++ b/examples/docs_snippets/docs_snippets/concepts/io_management/metadata.py
@@ -39,14 +39,22 @@ def op_2(_input_dataframe):
 # io_manager_start_marker
 class MyIOManager(ConfigurableIOManager):
     def handle_output(self, context: OutputContext, obj):
-        table_name = context.metadata["table"]
-        schema = context.metadata["schema"]
-        write_dataframe_to_table(name=table_name, schema=schema, dataframe=obj)
+        if context.metadata:
+            table_name = context.metadata["table"]
+            schema = context.metadata["schema"]
+            write_dataframe_to_table(name=table_name, schema=schema, dataframe=obj)
+        else:
+            raise Exception(
+                f"op {context.op_def.name} doesn't have schema and metadata set"
+            )
 
     def load_input(self, context: InputContext):
-        table_name = context.upstream_output.metadata["table"]
-        schema = context.upstream_output.metadata["schema"]
-        return read_dataframe_from_table(name=table_name, schema=schema)
+        if context.upstream_output and context.upstream_output.metadata:
+            table_name = context.upstream_output.metadata["table"]
+            schema = context.upstream_output.metadata["schema"]
+            return read_dataframe_from_table(name=table_name, schema=schema)
+        else:
+            raise Exception("Upstream output doesn't have schema and metadata set")
 
 
 # io_manager_end_marker

--- a/examples/docs_snippets/docs_snippets/concepts/io_management/output_config.py
+++ b/examples/docs_snippets/docs_snippets/concepts/io_management/output_config.py
@@ -1,4 +1,4 @@
-from dagster import IOManager, io_manager, job, op, OutputContext, InputContext
+from dagster import InputContext, IOManager, OutputContext, io_manager, job, op
 
 
 def connect():

--- a/examples/docs_snippets/docs_snippets/concepts/io_management/output_config.py
+++ b/examples/docs_snippets/docs_snippets/concepts/io_management/output_config.py
@@ -1,4 +1,4 @@
-from dagster import IOManager, io_manager, job, op
+from dagster import IOManager, io_manager, job, op, OutputContext, InputContext
 
 
 def connect():
@@ -25,11 +25,11 @@ def op_2(_input_dataframe):
 
 # io_manager_start_marker
 class MyIOManager(IOManager):
-    def handle_output(self, context, obj):
+    def handle_output(self, context: OutputContext, obj):
         table_name = context.config["table"]
         write_dataframe_to_table(name=table_name, dataframe=obj)
 
-    def load_input(self, context):
+    def load_input(self, context: InputContext):
         table_name = context.upstream_output.config["table"]
         return read_dataframe_from_table(name=table_name)
 

--- a/examples/docs_snippets/docs_snippets/concepts/io_management/output_config.py
+++ b/examples/docs_snippets/docs_snippets/concepts/io_management/output_config.py
@@ -30,8 +30,9 @@ class MyIOManager(IOManager):
         write_dataframe_to_table(name=table_name, dataframe=obj)
 
     def load_input(self, context: InputContext):
-        table_name = context.upstream_output.config["table"]
-        return read_dataframe_from_table(name=table_name)
+        if context.upstream_output:
+            table_name = context.upstream_output.config["table"]
+            return read_dataframe_from_table(name=table_name)
 
 
 @io_manager(output_config_schema={"table": str})

--- a/examples/docs_snippets/docs_snippets/concepts/io_management/test_io_manager.py
+++ b/examples/docs_snippets/docs_snippets/concepts/io_management/test_io_manager.py
@@ -2,6 +2,8 @@ from dagster import (
     IOManager,
     build_input_context,
     build_output_context,
+    OutputContext,
+    InputContext
 )
 
 
@@ -9,10 +11,10 @@ class MyIOManager(IOManager):
     def __init__(self):
         self.storage_dict = {}
 
-    def handle_output(self, context, obj):
+    def handle_output(self, context: OutputContext, obj):
         self.storage_dict[(context.step_key, context.name)] = obj
 
-    def load_input(self, context):
+    def load_input(self, context: InputContext):
         return self.storage_dict[
             (context.upstream_output.step_key, context.upstream_output.name)
         ]

--- a/examples/docs_snippets/docs_snippets/concepts/io_management/test_io_manager.py
+++ b/examples/docs_snippets/docs_snippets/concepts/io_management/test_io_manager.py
@@ -15,9 +15,10 @@ class MyIOManager(IOManager):
         self.storage_dict[(context.step_key, context.name)] = obj
 
     def load_input(self, context: InputContext):
-        return self.storage_dict[
-            (context.upstream_output.step_key, context.upstream_output.name)
-        ]
+        if context.upstream_output:
+            return self.storage_dict[
+                (context.upstream_output.step_key, context.upstream_output.name)
+            ]
 
 
 def test_my_io_manager_handle_output():

--- a/examples/docs_snippets/docs_snippets/concepts/io_management/test_io_manager.py
+++ b/examples/docs_snippets/docs_snippets/concepts/io_management/test_io_manager.py
@@ -1,9 +1,9 @@
 from dagster import (
+    InputContext,
     IOManager,
+    OutputContext,
     build_input_context,
     build_output_context,
-    OutputContext,
-    InputContext
 )
 
 

--- a/examples/docs_snippets/docs_snippets/concepts/logging/builtin_logger.py
+++ b/examples/docs_snippets/docs_snippets/concepts/logging/builtin_logger.py
@@ -6,11 +6,11 @@ from dagster import Definitions
 # start_builtin_logger_marker_0
 # demo_logger.py
 
-from dagster import job, op
+from dagster import job, op, OpExecutionContext
 
 
 @op
-def hello_logs(context):
+def hello_logs(context: OpExecutionContext):
     context.log.info("Hello, world!")
 
 
@@ -25,11 +25,11 @@ def demo_job():
 # start_builtin_logger_error_marker_0
 # demo_logger_error.py
 
-from dagster import job, op
+from dagster import job, op, OpExecutionContext
 
 
 @op
-def hello_logs_error(context):
+def hello_logs_error(context: OpExecutionContext):
     raise Exception("Somebody set up us the bomb")
 
 

--- a/examples/docs_snippets/docs_snippets/concepts/logging/custom_logger.py
+++ b/examples/docs_snippets/docs_snippets/concepts/logging/custom_logger.py
@@ -2,7 +2,7 @@
 import json
 import logging
 
-from dagster import Field, job, logger, op
+from dagster import Field, job, logger, op, OpExecutionContext
 
 # start_custom_logger_marker_0
 
@@ -34,7 +34,7 @@ def json_console_logger(init_context):
 
 
 @op
-def hello_logs(context):
+def hello_logs(context: OpExecutionContext):
     context.log.info("Hello, world!")
 
 

--- a/examples/docs_snippets/docs_snippets/concepts/logging/file_output_pipeline.py
+++ b/examples/docs_snippets/docs_snippets/concepts/logging/file_output_pipeline.py
@@ -1,11 +1,11 @@
 # ruff: isort: skip_file
-from dagster import job, op
+from dagster import job, op, OpExecutionContext
 
 # start_custom_file_output_log
 
 
 @op
-def file_log_op(context):
+def file_log_op(context: OpExecutionContext):
     context.log.info("Hello world!")
 
 

--- a/examples/docs_snippets/docs_snippets/concepts/logging/logging_jobs.py
+++ b/examples/docs_snippets/docs_snippets/concepts/logging/logging_jobs.py
@@ -1,11 +1,11 @@
 from dagster_aws.cloudwatch.loggers import cloudwatch_logger
 
-from dagster import colored_console_logger, graph, op, repository
+from dagster import OpExecutionContext, colored_console_logger, graph, op, repository
 
 
 # start_logging_mode_marker_0
 @op
-def log_op(context):
+def log_op(context: OpExecutionContext):
     context.log.info("Hello, world!")
 
 

--- a/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/graphs/graphs.py
+++ b/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/graphs/graphs.py
@@ -11,7 +11,7 @@ def my_op():
 
 # start_graph_one
 @op
-def return_one(context):
+def return_one(context: OpExecutionContext):
     return 1
 
 

--- a/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/graphs/graphs.py
+++ b/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/graphs/graphs.py
@@ -1,7 +1,7 @@
 # ruff: isort: skip_file
 
 
-from dagster import graph, op
+from dagster import graph, op, OpExecutionContext
 
 
 @op
@@ -16,7 +16,7 @@ def return_one(context):
 
 
 @op
-def add_one(context, number: int):
+def add_one(context: OpExecutionContext, number: int):
     return number + 1
 
 

--- a/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/graphs/linear_graph.py
+++ b/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/graphs/linear_graph.py
@@ -1,5 +1,5 @@
 # start_marker
-from dagster import graph, op
+from dagster import graph, op, OpExecutionContext
 
 
 @op
@@ -8,7 +8,7 @@ def return_one(context) -> int:
 
 
 @op
-def add_one(context, number: int) -> int:
+def add_one(context: OpExecutionContext, number: int) -> int:
     return number + 1
 
 

--- a/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/graphs/linear_graph.py
+++ b/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/graphs/linear_graph.py
@@ -1,9 +1,9 @@
 # start_marker
-from dagster import graph, op, OpExecutionContext
+from dagster import OpExecutionContext, graph, op
 
 
 @op
-def return_one(context) -> int:
+def return_one(context: OpExecutionContext) -> int:
     return 1
 
 

--- a/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/graphs/multiple_io_graph.py
+++ b/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/graphs/multiple_io_graph.py
@@ -1,5 +1,5 @@
 # start_marker
-from dagster import graph, op
+from dagster import graph, op, OpExecutionContext
 
 
 @op
@@ -8,12 +8,12 @@ def return_one(context) -> int:
 
 
 @op
-def add_one(context, number: int):
+def add_one(context: OpExecutionContext, number: int):
     return number + 1
 
 
 @op
-def adder(context, a: int, b: int) -> int:
+def adder(context: OpExecutionContext, a: int, b: int) -> int:
     return a + b
 
 

--- a/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/graphs/multiple_io_graph.py
+++ b/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/graphs/multiple_io_graph.py
@@ -1,9 +1,9 @@
 # start_marker
-from dagster import graph, op, OpExecutionContext
+from dagster import OpExecutionContext, graph, op
 
 
 @op
-def return_one(context) -> int:
+def return_one(context: OpExecutionContext) -> int:
     return 1
 
 

--- a/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/jobs.py
+++ b/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/jobs.py
@@ -11,7 +11,7 @@ def my_op():
 
 # start_pipeline_example_marker
 @op
-def return_one(context):
+def return_one(context: OpExecutionContext):
     return 1
 
 

--- a/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/jobs.py
+++ b/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/jobs.py
@@ -1,7 +1,7 @@
 # ruff: isort: skip_file
 
 
-from dagster import DependencyDefinition, GraphDefinition, job, op
+from dagster import DependencyDefinition, GraphDefinition, job, op, OpExecutionContext
 
 
 @op
@@ -16,7 +16,7 @@ def return_one(context):
 
 
 @op
-def add_one(context, number: int):
+def add_one(context: OpExecutionContext, number: int):
     return number + 1
 
 

--- a/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/jobs_with_config_mapping.py
+++ b/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/jobs_with_config_mapping.py
@@ -1,4 +1,4 @@
-from dagster import Config, RunConfig, config_mapping, job, op
+from dagster import Config, RunConfig, config_mapping, job, op, OpExecutionContext
 
 
 class DoSomethingConfig(Config):
@@ -6,7 +6,7 @@ class DoSomethingConfig(Config):
 
 
 @op
-def do_something(context, config: DoSomethingConfig) -> None:
+def do_something(context: OpExecutionContext, config: DoSomethingConfig) -> None:
     context.log.info("config_param: " + config.config_param)
 
 

--- a/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/jobs_with_config_mapping.py
+++ b/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/jobs_with_config_mapping.py
@@ -1,4 +1,4 @@
-from dagster import Config, RunConfig, config_mapping, job, op, OpExecutionContext
+from dagster import Config, OpExecutionContext, RunConfig, config_mapping, job, op
 
 
 class DoSomethingConfig(Config):

--- a/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/jobs_with_default_config.py
+++ b/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/jobs_with_default_config.py
@@ -1,4 +1,4 @@
-from dagster import Config, RunConfig, job, op, OpExecutionContext
+from dagster import Config, OpExecutionContext, RunConfig, job, op
 
 
 class DoSomethingConfig(Config):

--- a/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/jobs_with_default_config.py
+++ b/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/jobs_with_default_config.py
@@ -1,4 +1,4 @@
-from dagster import Config, RunConfig, job, op
+from dagster import Config, RunConfig, job, op, OpExecutionContext
 
 
 class DoSomethingConfig(Config):
@@ -6,7 +6,7 @@ class DoSomethingConfig(Config):
 
 
 @op
-def do_something(context, config: DoSomethingConfig):
+def do_something(context: OpExecutionContext, config: DoSomethingConfig):
     context.log.info("config_param: " + config.config_param)
 
 

--- a/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/linear_job.py
+++ b/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/linear_job.py
@@ -1,5 +1,5 @@
 # start_marker
-from dagster import job, op
+from dagster import job, op, OpExecutionContext
 
 
 @op
@@ -8,7 +8,7 @@ def return_one(context) -> int:
 
 
 @op
-def add_one(context, number: int) -> int:
+def add_one(context: OpExecutionContext, number: int) -> int:
     return number + 1
 
 

--- a/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/linear_job.py
+++ b/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/linear_job.py
@@ -1,9 +1,9 @@
 # start_marker
-from dagster import job, op, OpExecutionContext
+from dagster import OpExecutionContext, job, op
 
 
 @op
-def return_one(context) -> int:
+def return_one(context: OpExecutionContext) -> int:
     return 1
 
 

--- a/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/multiple_io_job.py
+++ b/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/multiple_io_job.py
@@ -1,5 +1,5 @@
 # start_marker
-from dagster import job, op, OpExecutionContext
+from dagster import OpExecutionContext, job, op
 
 
 @op

--- a/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/multiple_io_job.py
+++ b/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/multiple_io_job.py
@@ -1,19 +1,19 @@
 # start_marker
-from dagster import job, op
+from dagster import job, op, OpExecutionContext
 
 
 @op
-def return_one(context) -> int:
+def return_one(context: OpExecutionContext) -> int:
     return 1
 
 
 @op
-def add_one(context, number: int):
+def add_one(context: OpExecutionContext, number: int):
     return number + 1
 
 
 @op
-def adder(context, a: int, b: int) -> int:
+def adder(context: OpExecutionContext, a: int, b: int) -> int:
     return a + b
 
 

--- a/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/nested_graphs.py
+++ b/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/nested_graphs.py
@@ -1,7 +1,7 @@
 # ruff: isort: skip_file
 
 
-from dagster import graph, job, op
+from dagster import graph, job, op, OpExecutionContext
 
 from .unnested_ops import (
     add_thirty_two,
@@ -29,12 +29,12 @@ def all_together_nested():
 
 
 @op(config_schema={"n": float})
-def add_n(context, number):
+def add_n(context: OpExecutionContext, number):
     return number + context.op_config["n"]
 
 
 @op(config_schema={"m": float})
-def multiply_by_m(context, number):
+def multiply_by_m(context: OpExecutionContext, number):
     return number * context.op_config["m"]
 
 

--- a/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/op_events.py
+++ b/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/op_events.py
@@ -89,11 +89,11 @@ def my_multiple_generic_output_op() -> Tuple[Output[int], Output[str]]:
 # end_op_output_4
 
 # start_metadata_expectation_op
-from dagster import ExpectationResult, MetadataValue, op
+from dagster import ExpectationResult, MetadataValue, op, OpExecutionContext
 
 
 @op
-def my_metadata_expectation_op(context, df):
+def my_metadata_expectation_op(context: OpExecutionContext, df):
     df = do_some_transform(df)
     context.log_event(
         ExpectationResult(
@@ -191,11 +191,11 @@ def my_asset_op_yields():
 # end_asset_op_yield
 
 # start_expectation_op
-from dagster import ExpectationResult, op
+from dagster import ExpectationResult, op, OpExecutionContext
 
 
 @op
-def my_expectation_op(context, df):
+def my_expectation_op(context: OpExecutionContext, df):
     do_some_transform(df)
     context.log_event(
         ExpectationResult(success=len(df) > 0, description="ensure dataframe has rows")

--- a/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/op_events.py
+++ b/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/op_events.py
@@ -41,11 +41,11 @@ def flaky_operation():
 
 
 # start_op_output_3
-from dagster import MetadataValue, Output, op
+from dagster import MetadataValue, Output, op, OpExecutionContext
 
 
 @op
-def my_metadata_output(context) -> Output:
+def my_metadata_output(context: OpExecutionContext) -> Output:
     df = get_some_data()
     return Output(
         df,
@@ -151,11 +151,11 @@ def my_retry_op():
 # end_retry_op
 
 # start_asset_op
-from dagster import AssetMaterialization, op
+from dagster import AssetMaterialization, op, OpExecutionContext
 
 
 @op
-def my_asset_op(context):
+def my_asset_op(context: OpExecutionContext):
     df = get_some_data()
     store_to_s3(df)
     context.log_event(

--- a/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/unnested_ops.py
+++ b/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/unnested_ops.py
@@ -1,4 +1,4 @@
-from dagster import job, op, OpExecutionContext
+from dagster import OpExecutionContext, job, op
 
 
 @op

--- a/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/unnested_ops.py
+++ b/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/unnested_ops.py
@@ -1,4 +1,4 @@
-from dagster import job, op
+from dagster import job, op, OpExecutionContext
 
 
 @op
@@ -17,7 +17,7 @@ def multiply_by_one_point_eight(number):
 
 
 @op
-def log_number(context, number):
+def log_number(context: OpExecutionContext, number):
     context.log.info(f"number: {number}")
 
 

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/backfills/single_run_backfill_asset.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/backfills/single_run_backfill_asset.py
@@ -1,5 +1,11 @@
 # start_marker
-from dagster import AssetKey, BackfillPolicy, DailyPartitionsDefinition, asset
+from dagster import (
+    AssetExecutionContext,
+    AssetKey,
+    BackfillPolicy,
+    DailyPartitionsDefinition,
+    asset,
+)
 
 
 @asset(
@@ -7,7 +13,7 @@ from dagster import AssetKey, BackfillPolicy, DailyPartitionsDefinition, asset
     backfill_policy=BackfillPolicy.single_run(),
     deps=[AssetKey("raw_events")],
 )
-def events(context):
+def events(context: AssetExecutionContext):
     start_datetime, end_datetime = context.partition_time_window
 
     input_data = read_data_in_datetime_range(start_datetime, end_datetime)

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/backfills/single_run_backfill_io_manager.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/backfills/single_run_backfill_io_manager.py
@@ -1,13 +1,13 @@
 # start_marker
-from dagster import IOManager
+from dagster import IOManager, InputContext, OutputContext
 
 
 class MyIOManager(IOManager):
-    def load_input(self, context):
+    def load_input(self, context: InputContext):
         start_datetime, end_datetime = context.asset_partitions_time_window
         return read_data_in_datetime_range(start_datetime, end_datetime)
 
-    def handle_output(self, context, obj):
+    def handle_output(self, context: OutputContext, obj):
         start_datetime, end_datetime = context.asset_partitions_time_window
         return overwrite_data_in_datetime_range(start_datetime, end_datetime, obj)
 

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/backfills/single_run_backfill_io_manager.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/backfills/single_run_backfill_io_manager.py
@@ -1,5 +1,5 @@
 # start_marker
-from dagster import IOManager, InputContext, OutputContext
+from dagster import InputContext, IOManager, OutputContext
 
 
 class MyIOManager(IOManager):

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/date_config_job.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/date_config_job.py
@@ -1,4 +1,4 @@
-from dagster import Config, job, op
+from dagster import Config, job, op, OpExecutionContext
 
 
 class ProcessDateConfig(Config):
@@ -6,7 +6,7 @@ class ProcessDateConfig(Config):
 
 
 @op
-def process_data_for_date(context, config: ProcessDateConfig):
+def process_data_for_date(context: OpExecutionContext, config: ProcessDateConfig):
     date = config.date
     context.log.info(f"processing data for {date}")
 

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/date_config_job.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/date_config_job.py
@@ -1,4 +1,4 @@
-from dagster import Config, job, op, OpExecutionContext
+from dagster import Config, OpExecutionContext, job, op
 
 
 class ProcessDateConfig(Config):

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/dynamic_partitioned_asset.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/dynamic_partitioned_asset.py
@@ -37,8 +37,8 @@ def image_sensor(context: SensorEvaluationContext):
     new_images = [
         img_filename
         for img_filename in os.listdir(os.getenv("MY_DIRECTORY"))
-        if not context.instance.has_dynamic_partition(
-            images_partitions_def.name, img_filename
+        if not images_partitions_def.has_partition_key(
+            img_filename, dynamic_partitions_store=context.instance
         )
     ]
 

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/dynamic_partitioned_asset.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/dynamic_partitioned_asset.py
@@ -1,10 +1,12 @@
 import os
 
 from dagster import (
+    AssetExecutionContext,
     AssetSelection,
     Definitions,
     DynamicPartitionsDefinition,
     RunRequest,
+    SensorEvaluationContext,
     SensorResult,
     asset,
     define_asset_job,
@@ -16,7 +18,7 @@ images_partitions_def = DynamicPartitionsDefinition(name="images")
 
 
 @asset(partitions_def=images_partitions_def)
-def images(context):
+def images(context: AssetExecutionContext):
     ...
 
 
@@ -31,7 +33,7 @@ images_job = define_asset_job(
 
 
 @sensor(job=images_job)
-def image_sensor(context):
+def image_sensor(context: SensorEvaluationContext):
     new_images = [
         img_filename
         for img_filename in os.listdir(os.getenv("MY_DIRECTORY"))

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/multipartitions_asset.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/multipartitions_asset.py
@@ -1,5 +1,6 @@
 # start_multi_partitions_marker
 from dagster import (
+    AssetExecutionContext,
     DailyPartitionsDefinition,
     MultiPartitionsDefinition,
     StaticPartitionsDefinition,
@@ -15,7 +16,7 @@ from dagster import (
         }
     )
 )
-def multi_partitions_asset(context):
+def multi_partitions_asset(context: AssetExecutionContext):
     context.log.info(context.partition_key.keys_by_dimension)
 
 

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/multipartitions_asset.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/multipartitions_asset.py
@@ -17,7 +17,8 @@ from dagster import (
     )
 )
 def multi_partitions_asset(context: AssetExecutionContext):
-    context.log.info(context.partition_key.keys_by_dimension)
+    if isinstance(context.partition_key, MultiPartitionKey):
+        context.log.info(context.partition_key.keys_by_dimension)
 
 
 # end_multi_partitions_marker

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/partitioned_asset.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/partitioned_asset.py
@@ -1,10 +1,10 @@
 import urllib.request
 
-from dagster import DailyPartitionsDefinition, asset
+from dagster import AssetExecutionContext, DailyPartitionsDefinition, asset
 
 
 @asset(partitions_def=DailyPartitionsDefinition(start_date="2022-01-01"))
-def my_daily_partitioned_asset(context) -> None:
+def my_daily_partitioned_asset(context: AssetExecutionContext) -> None:
     partition_date_str = context.asset_partition_key_for_output()
 
     url = f"coolweatherwebsite.com/weather_obs&date={partition_date_str}"

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/partitioned_asset_uses_io_manager.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/partitioned_asset_uses_io_manager.py
@@ -1,9 +1,9 @@
 import pandas as pd
 
-from dagster import DailyPartitionsDefinition, asset
+from dagster import AssetExecutionContext, DailyPartitionsDefinition, asset
 
 
 @asset(partitions_def=DailyPartitionsDefinition(start_date="2022-01-01"))
-def my_daily_partitioned_asset(context) -> pd.DataFrame:
+def my_daily_partitioned_asset(context: AssetExecutionContext) -> pd.DataFrame:
     partition_date_str = context.asset_partition_key_for_output()
     return pd.read_csv(f"coolweatherwebsite.com/weather_obs&date={partition_date_str}")

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/partitioned_config_test.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/partitioned_config_test.py
@@ -36,7 +36,7 @@ def test_my_partitioned_config():
 # end_partition_config
 
 # start_partition_keys
-from dagster import Config
+from dagster import Config, OpExecutionContext
 
 
 @daily_partitioned_config(start_date=datetime(2020, 1, 1), minute_offset=15)
@@ -59,7 +59,7 @@ class ProcessDataConfig(Config):
 
 
 @op
-def process_data(context, config: ProcessDataConfig):
+def process_data(context: OpExecutionContext, config: ProcessDataConfig):
     s = config.start
     e = config.end
     context.log.info(f"processing data for {s} - {e}")

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/partitioned_job.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/partitioned_job.py
@@ -1,9 +1,9 @@
 # ruff: isort: skip_file
-from dagster import job, op
+from dagster import job, op, OpExecutionContext
 
 
 @op(config_schema={"date": str})
-def process_data_for_date(context):
+def process_data_for_date(context: OpExecutionContext):
     date = context.op_config["date"]
     context.log.info(f"processing data for {date}")
 

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/schedules/schedules.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/schedules/schedules.py
@@ -1,5 +1,6 @@
 from dagster import (
     DefaultScheduleStatus,
+    OpExecutionContext,
     RunRequest,
     ScheduleDefinition,
     ScheduleEvaluationContext,
@@ -37,7 +38,7 @@ basic_schedule = ScheduleDefinition(job=asset_job, cron_schedule="0 0 * * *")
 
 # start_run_config_schedule
 @op(config_schema={"scheduled_date": str})
-def configurable_op(context):
+def configurable_op(context: OpExecutionContext):
     context.log.info(context.op_config["scheduled_date"])
 
 

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/sensors.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/sensors.py
@@ -12,7 +12,7 @@ from dagster import (
     DagsterRunStatus,
     run_status_sensor,
     run_failure_sensor,
-    OpExecutionContext
+    OpExecutionContext,
 )
 
 

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/sensors.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/sensors.py
@@ -12,6 +12,7 @@ from dagster import (
     DagsterRunStatus,
     run_status_sensor,
     run_failure_sensor,
+    OpExecutionContext
 )
 
 
@@ -24,7 +25,7 @@ class FileConfig(Config):
 
 
 @op
-def process_file(context, config: FileConfig):
+def process_file(context: OpExecutionContext, config: FileConfig):
     context.log.info(config.filename)
 
 

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/static_partitioned_job.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/static_partitioned_job.py
@@ -1,4 +1,4 @@
-from dagster import Config, job, op, static_partitioned_config, OpExecutionContext
+from dagster import Config, OpExecutionContext, job, op, static_partitioned_config
 
 CONTINENTS = [
     "Africa",

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/static_partitioned_job.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/static_partitioned_job.py
@@ -1,4 +1,4 @@
-from dagster import Config, job, op, static_partitioned_config
+from dagster import Config, job, op, static_partitioned_config, OpExecutionContext
 
 CONTINENTS = [
     "Africa",
@@ -21,7 +21,7 @@ class ContinentOpConfig(Config):
 
 
 @op
-def continent_op(context, config: ContinentOpConfig):
+def continent_op(context: OpExecutionContext, config: ContinentOpConfig):
     context.log.info(config.continent_name)
 
 

--- a/examples/docs_snippets/docs_snippets/concepts/resources/resources.py
+++ b/examples/docs_snippets/docs_snippets/concepts/resources/resources.py
@@ -1,6 +1,6 @@
 # ruff: isort: skip_file
 
-from dagster import ResourceDefinition, graph, job
+from dagster import ResourceDefinition, graph, job, OpExecutionContext
 
 
 # start_resource_example
@@ -26,7 +26,7 @@ CREATE_TABLE_1_QUERY = "create table_1 as select * from table_0"
 
 
 @op(required_resource_keys={"database"})
-def op_requires_resources(context):
+def op_requires_resources(context: OpExecutionContext):
     context.resources.database.execute_query(CREATE_TABLE_1_QUERY)
 
 
@@ -146,7 +146,7 @@ from dagster import graph, op
 
 
 @op(required_resource_keys={"client"})
-def get_client(context):
+def get_client(context: OpExecutionContext):
     return context.resources.client
 
 
@@ -204,7 +204,7 @@ def db_connection():
 
 # start_cm_resource_op
 @op(required_resource_keys={"db_connection"})
-def use_db_connection(context):
+def use_db_connection(context: OpExecutionContext):
     db_conn = context.resources.db_connection
     ...
 
@@ -251,11 +251,11 @@ def do_something_with_resource(_):
 
 
 # start_asset_use_resource
-from dagster import asset
+from dagster import asset, AssetExecutionContext
 
 
 @asset(required_resource_keys={"foo"})
-def asset_requires_resource(context):
+def asset_requires_resource(context: AssetExecutionContext):
     do_something_with_resource(context.resources.foo)
 
 

--- a/examples/docs_snippets/docs_snippets/concepts/resources/tests.py
+++ b/examples/docs_snippets/docs_snippets/concepts/resources/tests.py
@@ -25,7 +25,7 @@ def get_data_without_resource():
 # end_test_before_marker
 
 # start_test_after_marker
-from dagster import graph, op, ConfigurableResource
+from dagster import graph, op, ConfigurableResource, OpExecutionContext
 
 
 class MyApi(ConfigurableResource):
@@ -39,7 +39,7 @@ def get_data(api: MyApi):
 
 
 @op
-def do_something(context, data):
+def do_something(context: OpExecutionContext, data):
     output = process(data)
     return output
 

--- a/examples/docs_snippets/docs_snippets/deploying/kubernetes/k8s_config_tag_asset.py
+++ b/examples/docs_snippets/docs_snippets/deploying/kubernetes/k8s_config_tag_asset.py
@@ -1,6 +1,6 @@
 from dagster_k8s import k8s_job_executor
 
-from dagster import asset, define_asset_job
+from dagster import AssetExecutionContext, asset, define_asset_job
 
 
 # fmt: off
@@ -16,7 +16,7 @@ from dagster import asset, define_asset_job
         }
     }
 )
-def my_asset(context):
+def my_asset(context: AssetExecutionContext):
     context.log.info("running")
 
 my_job = define_asset_job(name="my_job", selection="my_asset", executor_def=k8s_job_executor)

--- a/examples/docs_snippets/docs_snippets/deploying/kubernetes/k8s_config_tag_job.py
+++ b/examples/docs_snippets/docs_snippets/deploying/kubernetes/k8s_config_tag_job.py
@@ -1,9 +1,9 @@
-from dagster import job, op
+from dagster import OpExecutionContext, job, op
 
 
 # fmt: off
 @op
-def my_op(context):
+def my_op(context: OpExecutionContext):
     context.log.info("running")
 
 # start_k8s_config

--- a/examples/docs_snippets/docs_snippets/deploying/kubernetes/k8s_config_tag_op.py
+++ b/examples/docs_snippets/docs_snippets/deploying/kubernetes/k8s_config_tag_op.py
@@ -1,6 +1,6 @@
 from dagster_k8s import k8s_job_executor
 
-from dagster import job, op
+from dagster import OpExecutionContext, job, op
 
 
 # fmt: off
@@ -16,7 +16,7 @@ from dagster import job, op
         }
     }
 )
-def my_op(context):
+def my_op(context: OpExecutionContext):
     context.log.info("running")
 
 @job(executor_def=k8s_job_executor)

--- a/examples/docs_snippets/docs_snippets/guides/dagster/automating_pipelines/config_schedule.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/automating_pipelines/config_schedule.py
@@ -1,8 +1,15 @@
-from dagster import RunRequest, ScheduleEvaluationContext, job, op, schedule
+from dagster import (
+    OpExecutionContext,
+    RunRequest,
+    ScheduleEvaluationContext,
+    job,
+    op,
+    schedule,
+)
 
 
 @op(config_schema={"activity_selection": str})
-def configurable_op(context):
+def configurable_op(context: OpExecutionContext):
     pass
 
 

--- a/examples/docs_snippets/docs_snippets/guides/dagster/automating_pipelines/s3_sensor.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/automating_pipelines/s3_sensor.py
@@ -1,12 +1,20 @@
 # ruff: isort: skip_file
 
 from dagster_aws.s3.sensor import get_s3_keys
-from dagster import sensor, op, job, build_sensor_context, RunRequest, SkipReason
+from dagster import (
+    sensor,
+    op,
+    job,
+    build_sensor_context,
+    RunRequest,
+    SkipReason,
+    OpExecutionContext,
+)
 import os
 
 
 @op(config_schema={"filename": str})
-def process_file(context):
+def process_file(context: OpExecutionContext):
     filename = context.op_config["filename"]
     context.log.info(filename)
 

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/subprocess/with_asset_check/dagster_code.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/subprocess/with_asset_check/dagster_code.py
@@ -1,6 +1,7 @@
 import shutil
 
 from dagster import (
+    AssetCheckResult,
     AssetExecutionContext,
     Definitions,
     MaterializeResult,
@@ -8,8 +9,6 @@ from dagster import (
     asset,
     asset_check,
     file_relative_path,
-    AssetExecutionContext,
-    AssetCheckResult
 )
 
 

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/subprocess/with_asset_check/dagster_code.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/subprocess/with_asset_check/dagster_code.py
@@ -8,8 +8,9 @@ from dagster import (
     asset,
     asset_check,
     file_relative_path,
+    AssetExecutionContext,
+    AssetCheckResult
 )
-from dagster._core.definitions.asset_check_result import AssetCheckResult
 
 
 @asset
@@ -19,7 +20,7 @@ def my_asset():
 
 @asset_check(asset="my_asset")
 def no_empty_order_check(
-    context, pipes_subprocess_client: PipesSubprocessClient
+    context: AssetExecutionContext, pipes_subprocess_client: PipesSubprocessClient
 ) -> AssetCheckResult:
     cmd = [
         shutil.which("python"),

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_type_factories/job_1.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_type_factories/job_1.py
@@ -2,7 +2,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 
-from dagster import AssetMaterialization, job, op
+from dagster import AssetMaterialization, job, op, OpExecutionContext
 
 
 @op
@@ -14,7 +14,7 @@ def load_trips():
 
 
 @op
-def generate_plot(context, trips):
+def generate_plot(context: OpExecutionContext, trips):
     minute_lengths = [x.total_seconds() / 60 for x in trips.end_time - trips.start_time]
     bin_edges = np.histogram_bin_edges(minute_lengths, 15)
     fig, ax = plt.subplots(figsize=(10, 5))

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_type_factories/job_1.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_type_factories/job_1.py
@@ -2,7 +2,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 
-from dagster import AssetMaterialization, job, op, OpExecutionContext
+from dagster import AssetMaterialization, OpExecutionContext, job, op
 
 
 @op

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_type_factories/job_2.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_type_factories/job_2.py
@@ -3,7 +3,7 @@ import numpy as np
 import pandas as pd
 import pandera as pa
 
-from dagster import AssetMaterialization, Field, In, Out, job, op
+from dagster import AssetMaterialization, Field, In, Out, job, op, OpExecutionContext
 
 from .factory import pandera_schema_to_dagster_type
 
@@ -27,7 +27,7 @@ TripsDataFrame = pandera_schema_to_dagster_type(
 
 # We've added a Dagster type for this op's output
 @op(out=Out(TripsDataFrame), config_schema={"clean": Field(bool, False)})
-def load_trips(context):
+def load_trips(context: OpExecutionContext):
     df = pd.read_csv(
         "./ebike_trips.csv",
         parse_dates=["start_time", "end_time"],
@@ -39,7 +39,7 @@ def load_trips(context):
 
 # We've added a Dagster type for this op's input
 @op(ins={"trips": In(TripsDataFrame)})
-def generate_plot(context, trips):
+def generate_plot(context: OpExecutionContext, trips):
     minute_lengths = [x.total_seconds() / 60 for x in trips.end_time - trips.start_time]
     bin_edges = np.histogram_bin_edges(minute_lengths, 15)
     fig, ax = plt.subplots(figsize=(10, 5))

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_type_factories/job_2.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_type_factories/job_2.py
@@ -3,7 +3,7 @@ import numpy as np
 import pandas as pd
 import pandera as pa
 
-from dagster import AssetMaterialization, Field, In, Out, job, op, OpExecutionContext
+from dagster import AssetMaterialization, Field, In, OpExecutionContext, Out, job, op
 
 from .factory import pandera_schema_to_dagster_type
 

--- a/examples/docs_snippets/docs_snippets/guides/dagster/enriching_with_software_defined_assets/mylib.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/enriching_with_software_defined_assets/mylib.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 
 from pandas import DataFrame
 
-from dagster import IOManager, io_manager, OutputContext, InputContext
+from dagster import InputContext, IOManager, OutputContext, io_manager
 
 
 def create_db_connection() -> Any:

--- a/examples/docs_snippets/docs_snippets/guides/dagster/enriching_with_software_defined_assets/mylib.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/enriching_with_software_defined_assets/mylib.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 
 from pandas import DataFrame
 
-from dagster import IOManager, io_manager
+from dagster import IOManager, io_manager, OutputContext, InputContext
 
 
 def create_db_connection() -> Any:
@@ -25,11 +25,11 @@ def fetch_products() -> DataFrame:
 @io_manager
 def snowflake_io_manager():
     class SnowflakeIOManager(IOManager):
-        def handle_output(self, context, obj):
+        def handle_output(self, context: OutputContext, obj):
             del context
             del obj
 
-        def load_input(self, context):
+        def load_input(self, context: InputContext):
             return DataFrame()
 
     return SnowflakeIOManager()
@@ -38,11 +38,11 @@ def snowflake_io_manager():
 @io_manager
 def s3_io_manager():
     class S3IOManager(IOManager):
-        def handle_output(self, context, obj):
+        def handle_output(self, context: OutputContext, obj):
             del context
             del obj
 
-        def load_input(self, context):
+        def load_input(self, context: InputContext):
             return None
 
     return S3IOManager()

--- a/examples/docs_snippets/docs_snippets/guides/dagster/managing_ml/managing_ml_code.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/managing_ml/managing_ml_code.py
@@ -97,15 +97,23 @@ def conditional_machine_learning_model(context: AssetExecutionContext):
         AssetKey(["conditional_machine_learning_model"])
     )
     if materialization is None:
-        yield Output(reg, metadata={"model_accuracy": reg.score(X_test, y_test)})
+        yield Output(reg, metadata={"model_accuracy": float(reg.score(X_test, y_test))})
 
     else:
-        previous_model_accuracy = materialization.asset_materialization.metadata[
-            "model_accuracy"
-        ]
+        previous_model_accuracy = None
+        if materialization.asset_materialization and isinstance(
+            materialization.asset_materialization.metadata["model_accuracy"].value,
+            float,
+        ):
+            previous_model_accuracy = float(
+                materialization.asset_materialization.metadata["model_accuracy"].value
+            )
         new_model_accuracy = reg.score(X_test, y_test)
-        if new_model_accuracy > previous_model_accuracy:
-            yield Output(reg, metadata={"model_accuracy": new_model_accuracy})
+        if (
+            previous_model_accuracy is None
+            or new_model_accuracy > previous_model_accuracy
+        ):
+            yield Output(reg, metadata={"model_accuracy": float(new_model_accuracy)})
 
 
 ## conditional_monitoring_end

--- a/examples/docs_snippets/docs_snippets/guides/dagster/managing_ml/managing_ml_code.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/managing_ml/managing_ml_code.py
@@ -77,13 +77,13 @@ basic_schedule = ScheduleDefinition(job=ml_asset_job, cron_schedule="0 9 * * *")
 ## conditional_monitoring_start
 
 from sklearn import linear_model
-from dagster import asset, Output, AssetKey
+from dagster import asset, Output, AssetKey, AssetExecutionContext
 import numpy as np
 from sklearn.model_selection import train_test_split
 
 
 @asset(output_required=False)
-def conditional_machine_learning_model(context):
+def conditional_machine_learning_model(context: AssetExecutionContext):
     X, y = np.random.randint(5000, size=(5000, 2)), range(5000)
     X_train, X_test, y_train, y_test = train_test_split(
         X, y, test_size=0.33, random_state=42

--- a/examples/docs_snippets/docs_snippets/guides/dagster/migrating_to_python_resources_and_config/migrating_resources.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/migrating_to_python_resources_and_config/migrating_resources.py
@@ -137,14 +137,14 @@ def old_third_party_resource() -> Definitions:
     # Alternatively could have been imported from third-party library
     # from fancy_db import FancyDbClient
 
-    from dagster import InitResourceContext, asset, resource
+    from dagster import AssetExecutionContext, InitResourceContext, asset, resource
 
     @resource(config_schema={"conn_string": str})
     def fancy_db_resource(context: InitResourceContext) -> FancyDbClient:
         return FancyDbClient(context.resource_config["conn_string"])
 
     @asset(required_resource_keys={"fancy_db"})
-    def existing_asset(context) -> None:
+    def existing_asset(context: AssetExecutionContext) -> None:
         context.resources.fancy_db.execute_query("SELECT * FROM foo")
 
     # end_old_third_party_resource
@@ -177,7 +177,7 @@ def old_resource_code_contextmanager() -> Definitions:
 
     # begin_old_resource_code_contextmanager
 
-    from dagster import InitResourceContext, asset, resource
+    from dagster import AssetExecutionContext, InitResourceContext, asset, resource
 
     @resource(config_schema={"conn_string": str})
     def fancy_db_resource(context: InitResourceContext) -> Iterator[FancyDbClient]:
@@ -190,7 +190,7 @@ def old_resource_code_contextmanager() -> Definitions:
             some_expensive_teardown()
 
     @asset(required_resource_keys={"fancy_db"})
-    def asset_one(context) -> None:
+    def asset_one(context: AssetExecutionContext) -> None:
         # some_expensive_setup() has been called, but some_expensive_teardown() has not
         context.resources.fancy_db.execute_query("SELECT * FROM foo")
 
@@ -251,7 +251,7 @@ def new_third_party_resource_old_code_broken() -> Definitions:
             ...
 
     # begin_new_third_party_resource
-    from dagster import ConfigurableResource, asset
+    from dagster import AssetExecutionContext, ConfigurableResource, asset
 
     class FancyDbResource(ConfigurableResource):
         conn_string: str
@@ -268,7 +268,7 @@ def new_third_party_resource_old_code_broken() -> Definitions:
 
     # begin_broken_unmigrated_code
     @asset(required_resource_keys={"fancy_db"})
-    def existing_asset(context) -> None:
+    def existing_asset(context: AssetExecutionContext) -> None:
         # This code is now broken because the resource is no longer a FancyDbClient
         # but it is a FancyDbResource.
         context.resources.fancy_db.execute_query("SELECT * FROM foo")
@@ -296,7 +296,12 @@ def new_third_party_resource_fixed() -> Definitions:
             ...
 
     # begin_new_third_party_resource_with_interface
-    from dagster import ConfigurableResource, IAttachDifferentObjectToOpContext, asset
+    from dagster import (
+        AssetExecutionContext,
+        ConfigurableResource,
+        IAttachDifferentObjectToOpContext,
+        asset,
+    )
 
     class FancyDbResource(ConfigurableResource, IAttachDifferentObjectToOpContext):
         conn_string: str
@@ -313,7 +318,7 @@ def new_third_party_resource_fixed() -> Definitions:
         client.execute_query("SELECT * FROM foo")
 
     @asset(required_resource_keys={"fancy_db"})
-    def existing_asset(context) -> None:
+    def existing_asset(context: AssetExecutionContext) -> None:
         # This code now works because context.resources.fancy_db is now a FancyDbClient
         context.resources.fancy_db.execute_query("SELECT * FROM foo")
 

--- a/examples/docs_snippets/docs_snippets/integrations/airflow/hello_cereal.py
+++ b/examples/docs_snippets/docs_snippets/integrations/airflow/hello_cereal.py
@@ -2,7 +2,7 @@ import csv
 
 import requests
 
-from dagster import job, op
+from dagster import job, op, OpExecutionContext
 
 
 @op
@@ -13,7 +13,7 @@ def download_cereals():
 
 
 @op
-def find_sugariest(context, cereals):
+def find_sugariest(context: OpExecutionContext, cereals):
     sorted_by_sugar = sorted(cereals, key=lambda cereal: cereal["sugars"])
     context.log.info(f'{sorted_by_sugar[-1]["name"]} is the sugariest cereal')
 

--- a/examples/docs_snippets/docs_snippets/integrations/airflow/hello_cereal.py
+++ b/examples/docs_snippets/docs_snippets/integrations/airflow/hello_cereal.py
@@ -2,7 +2,7 @@ import csv
 
 import requests
 
-from dagster import job, op, OpExecutionContext
+from dagster import OpExecutionContext, job, op
 
 
 @op

--- a/examples/docs_snippets/docs_snippets/integrations/airflow/tutorial_rewrite_complete.py
+++ b/examples/docs_snippets/docs_snippets/integrations/airflow/tutorial_rewrite_complete.py
@@ -11,6 +11,7 @@ from dagster import (
     job,
     op,
     schedule,
+    OpExecutionContext
 )
 
 
@@ -27,7 +28,7 @@ def sleep():
 
 
 @op
-def templated(context, ds: datetime):
+def templated(context: OpExecutionContext, ds: datetime):
     for _i in range(5):
         context.log.info(ds)
         context.log.info(ds - timedelta(days=7))

--- a/examples/docs_snippets/docs_snippets/integrations/airflow/tutorial_rewrite_complete.py
+++ b/examples/docs_snippets/docs_snippets/integrations/airflow/tutorial_rewrite_complete.py
@@ -6,17 +6,17 @@ from dagster import (
     Definitions,
     In,
     Nothing,
+    OpExecutionContext,
     RetryPolicy,
     ScheduleDefinition,
     job,
     op,
     schedule,
-    OpExecutionContext
 )
 
 
 @op
-def print_date(context) -> datetime:
+def print_date(context: OpExecutionContext) -> datetime:
     ds = datetime.now()
     context.log.info(ds)
     return ds

--- a/examples/docs_snippets/docs_snippets/integrations/airflow/tutorial_rewrite_dagster.py
+++ b/examples/docs_snippets/docs_snippets/integrations/airflow/tutorial_rewrite_dagster.py
@@ -11,6 +11,7 @@ from dagster import (
     job,
     op,
     schedule,
+    OpExecutionContext
 )
 
 
@@ -28,7 +29,7 @@ def sleep():
 
 
 @op
-def templated(context, ds: datetime):
+def templated(context: OpExecutionContext, ds: datetime):
     for _i in range(5):
         context.log.info(ds)
         context.log.info(ds - timedelta(days=7))

--- a/examples/docs_snippets/docs_snippets/integrations/airflow/tutorial_rewrite_dagster.py
+++ b/examples/docs_snippets/docs_snippets/integrations/airflow/tutorial_rewrite_dagster.py
@@ -6,18 +6,18 @@ from dagster import (
     Definitions,
     In,
     Nothing,
+    OpExecutionContext,
     RetryPolicy,
     ScheduleDefinition,
     job,
     op,
     schedule,
-    OpExecutionContext
 )
 
 
 # start_ops
 @op
-def print_date(context) -> datetime:
+def print_date(context: OpExecutionContext) -> datetime:
     ds = datetime.now()
     context.log.info(ds)
     return ds

--- a/examples/docs_snippets/docs_snippets/integrations/bigquery/reference/multi_partition.py
+++ b/examples/docs_snippets/docs_snippets/integrations/bigquery/reference/multi_partition.py
@@ -7,6 +7,7 @@ def get_iris_data_for_date(*args, **kwargs):
 import pandas as pd
 
 from dagster import (
+    AssetExecutionContext,
     DailyPartitionsDefinition,
     MultiPartitionsDefinition,
     StaticPartitionsDefinition,
@@ -27,7 +28,7 @@ from dagster import (
         "partition_expr": {"date": "TIMESTAMP_SECONDS(TIME)", "species": "SPECIES"}
     },
 )
-def iris_data_partitioned(context) -> pd.DataFrame:
+def iris_data_partitioned(context: AssetExecutionContext) -> pd.DataFrame:
     partition = partition = context.partition_key.keys_by_dimension
     species = partition["species"]
     date = partition["date"]

--- a/examples/docs_snippets/docs_snippets/integrations/bigquery/reference/multi_partition.py
+++ b/examples/docs_snippets/docs_snippets/integrations/bigquery/reference/multi_partition.py
@@ -29,7 +29,7 @@ from dagster import (
     },
 )
 def iris_data_partitioned(context: AssetExecutionContext) -> pd.DataFrame:
-    partition = partition = context.partition_key.keys_by_dimension
+    partition = context.partition_key.keys_by_dimension  # type: ignore
     species = partition["species"]
     date = partition["date"]
 

--- a/examples/docs_snippets/docs_snippets/integrations/bigquery/reference/pyspark_with_spark_resource.py
+++ b/examples/docs_snippets/docs_snippets/integrations/bigquery/reference/pyspark_with_spark_resource.py
@@ -12,13 +12,13 @@ from pyspark.sql.types import (
     StructType,
 )
 
-from dagster import Definitions, asset
+from dagster import AssetExecutionContext, Definitions, asset
 
 BIGQUERY_JARS = "com.google.cloud.spark:spark-bigquery-with-dependencies_2.12:0.28.0"
 
 
 @asset(required_resource_keys={"pyspark"})
-def iris_data(context) -> DataFrame:
+def iris_data(context: AssetExecutionContext) -> DataFrame:
     spark = context.resources.pyspark.spark_session
 
     schema = StructType(

--- a/examples/docs_snippets/docs_snippets/integrations/bigquery/reference/static_partition.py
+++ b/examples/docs_snippets/docs_snippets/integrations/bigquery/reference/static_partition.py
@@ -2,7 +2,7 @@
 
 import pandas as pd
 
-from dagster import StaticPartitionsDefinition, asset
+from dagster import AssetExecutionContext, StaticPartitionsDefinition, asset
 
 
 @asset(
@@ -11,7 +11,7 @@ from dagster import StaticPartitionsDefinition, asset
     ),
     metadata={"partition_expr": "SPECIES"},
 )
-def iris_data_partitioned(context) -> pd.DataFrame:
+def iris_data_partitioned(context: AssetExecutionContext) -> pd.DataFrame:
     species = context.asset_partition_key_for_output()
 
     full_df = pd.read_csv(

--- a/examples/docs_snippets/docs_snippets/integrations/bigquery/reference/time_partition.py
+++ b/examples/docs_snippets/docs_snippets/integrations/bigquery/reference/time_partition.py
@@ -6,14 +6,14 @@ def get_iris_data_for_date(*args, **kwargs):
 
 import pandas as pd
 
-from dagster import DailyPartitionsDefinition, asset
+from dagster import AssetExecutionContext, DailyPartitionsDefinition, asset
 
 
 @asset(
     partitions_def=DailyPartitionsDefinition(start_date="2023-01-01"),
     metadata={"partition_expr": "TIMESTAMP_SECONDS(TIME)"},
 )
-def iris_data_per_day(context) -> pd.DataFrame:
+def iris_data_per_day(context: AssetExecutionContext) -> pd.DataFrame:
     partition = context.asset_partition_key_for_output()
 
     # get_iris_data_for_date fetches all of the iris data for a given date,

--- a/examples/docs_snippets/docs_snippets/integrations/dbt/dbt.py
+++ b/examples/docs_snippets/docs_snippets/integrations/dbt/dbt.py
@@ -144,7 +144,7 @@ def scope_upstream_multi_asset():
             ).items()
         }
     )
-    def jaffle_shop(context):
+    def jaffle_shop(context: AssetExecutionContext):
         output_names = list(context.selected_output_names)
         yield Output(value=..., output_name=output_names[0])
         yield Output(value=..., output_name=output_names[1])

--- a/examples/docs_snippets/docs_snippets/integrations/dbt/tutorial/downstream_assets/assets.py
+++ b/examples/docs_snippets/docs_snippets/integrations/dbt/tutorial/downstream_assets/assets.py
@@ -16,7 +16,7 @@ duckdb_database_path = dbt_project_dir.joinpath("tutorial.duckdb")
 
 
 @asset(compute_kind="python")
-def raw_customers(context) -> None:
+def raw_customers(context: AssetExecutionContext) -> None:
     data = pd.read_csv("https://docs.dagster.io/assets/customers.csv")
     connection = duckdb.connect(os.fspath(duckdb_database_path))
     connection.execute("create schema if not exists jaffle_shop")
@@ -38,7 +38,7 @@ def jaffle_shop_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
     compute_kind="python",
     deps=get_asset_key_for_model([jaffle_shop_dbt_assets], "customers"),
 )
-def order_count_chart(context):
+def order_count_chart(context: AssetExecutionContext):
     # read the contents of the customers table into a Pandas DataFrame
     connection = duckdb.connect(os.fspath(duckdb_database_path))
     customers = connection.sql("select * from customers").df()

--- a/examples/docs_snippets/docs_snippets/integrations/dbt/tutorial/upstream_assets/assets.py
+++ b/examples/docs_snippets/docs_snippets/integrations/dbt/tutorial/upstream_assets/assets.py
@@ -13,7 +13,7 @@ duckdb_database_path = dbt_project_dir.joinpath("tutorial.duckdb")
 
 
 @asset(compute_kind="python")
-def raw_customers(context) -> None:
+def raw_customers(context: AssetExecutionContext) -> None:
     data = pd.read_csv("https://docs.dagster.io/assets/customers.csv")
     connection = duckdb.connect(os.fspath(duckdb_database_path))
     connection.execute("create schema if not exists jaffle_shop")

--- a/examples/docs_snippets/docs_snippets/integrations/duckdb/reference/multi_partition.py
+++ b/examples/docs_snippets/docs_snippets/integrations/duckdb/reference/multi_partition.py
@@ -7,9 +7,10 @@ def get_iris_data_for_date(*args, **kwargs):
 import pandas as pd
 
 from dagster import (
+    AssetExecutionContext,
     DailyPartitionsDefinition,
     MultiPartitionsDefinition,
-    StaticPartitionDefinition,
+    StaticPartitionsDefinition,
     asset,
 )
 
@@ -18,14 +19,14 @@ from dagster import (
     partitions_def=MultiPartitionsDefinition(
         {
             "date": DailyPartitionsDefinition(start_date="2023-01-01"),
-            "species": StaticPartitionDefinition(
+            "species": StaticPartitionsDefinition(
                 ["Iris-setosa", "Iris-virginica", "Iris-versicolor"]
             ),
         }
     ),
     metadata={"partition_expr": {"date": "TO_TIMESTAMP(TIME)", "species": "SPECIES"}},
 )
-def iris_dataset_partitioned(context) -> pd.DataFrame:
+def iris_dataset_partitioned(context: AssetExecutionContext) -> pd.DataFrame:
     partition = partition = context.partition_key.keys_by_dimension
     species = partition["species"]
     date = partition["date"]

--- a/examples/docs_snippets/docs_snippets/integrations/duckdb/reference/multi_partition.py
+++ b/examples/docs_snippets/docs_snippets/integrations/duckdb/reference/multi_partition.py
@@ -27,7 +27,7 @@ from dagster import (
     metadata={"partition_expr": {"date": "TO_TIMESTAMP(TIME)", "species": "SPECIES"}},
 )
 def iris_dataset_partitioned(context: AssetExecutionContext) -> pd.DataFrame:
-    partition = partition = context.partition_key.keys_by_dimension
+    partition = context.partition_key.keys_by_dimension  # type: ignore
     species = partition["species"]
     date = partition["date"]
 

--- a/examples/docs_snippets/docs_snippets/integrations/duckdb/reference/pyspark_with_spark_resource.py
+++ b/examples/docs_snippets/docs_snippets/integrations/duckdb/reference/pyspark_with_spark_resource.py
@@ -11,11 +11,11 @@ from pyspark.sql.types import (
     StructType,
 )
 
-from dagster import Definitions, asset
+from dagster import AssetExecutionContext, Definitions, asset
 
 
 @asset(required_resource_keys={"pyspark"})
-def iris_dataset(context) -> DataFrame:
+def iris_dataset(context: AssetExecutionContext) -> DataFrame:
     spark = context.resources.pyspark.spark_session
 
     schema = StructType(

--- a/examples/docs_snippets/docs_snippets/integrations/duckdb/reference/static_partition.py
+++ b/examples/docs_snippets/docs_snippets/integrations/duckdb/reference/static_partition.py
@@ -2,7 +2,7 @@
 
 import pandas as pd
 
-from dagster import StaticPartitionsDefinition, asset
+from dagster import AssetExecutionContext, StaticPartitionsDefinition, asset
 
 
 @asset(
@@ -11,7 +11,7 @@ from dagster import StaticPartitionsDefinition, asset
     ),
     metadata={"partition_expr": "SPECIES"},
 )
-def iris_dataset_partitioned(context) -> pd.DataFrame:
+def iris_dataset_partitioned(context: AssetExecutionContext) -> pd.DataFrame:
     species = context.asset_partition_key_for_output()
 
     full_df = pd.read_csv(

--- a/examples/docs_snippets/docs_snippets/integrations/duckdb/reference/time_partition.py
+++ b/examples/docs_snippets/docs_snippets/integrations/duckdb/reference/time_partition.py
@@ -6,14 +6,14 @@ def get_iris_data_for_date(*args, **kwargs):
 
 import pandas as pd
 
-from dagster import DailyPartitionsDefinition, asset
+from dagster import AssetExecutionContext, DailyPartitionsDefinition, asset
 
 
 @asset(
     partitions_def=DailyPartitionsDefinition(start_date="2023-01-01"),
     metadata={"partition_expr": "TO_TIMESTAMP(TIME)"},
 )
-def iris_data_per_day(context) -> pd.DataFrame:
+def iris_data_per_day(context: AssetExecutionContext) -> pd.DataFrame:
     partition = context.asset_partition_key_for_output()
 
     # get_iris_data_for_date fetches all of the iris data for a given date,

--- a/examples/docs_snippets/docs_snippets/integrations/snowflake/multi_partition.py
+++ b/examples/docs_snippets/docs_snippets/integrations/snowflake/multi_partition.py
@@ -1,5 +1,8 @@
+import pandas as pd
+
+
 def get_iris_data_for_date(*args, **kwargs):
-    pass
+    return pd.DataFrame()
 
 
 # start_example
@@ -9,6 +12,7 @@ import pandas as pd
 from dagster import (
     AssetExecutionContext,
     DailyPartitionsDefinition,
+    MultiPartitionKey,
     MultiPartitionsDefinition,
     StaticPartitionsDefinition,
     asset,
@@ -29,7 +33,7 @@ from dagster import (
     },
 )
 def iris_dataset_partitioned(context: AssetExecutionContext) -> pd.DataFrame:
-    partition = partition = context.partition_key.keys_by_dimension
+    partition = context.partition_key.keys_by_dimension  # type: ignore
     species = partition["species"]
     date = partition["date"]
 

--- a/examples/docs_snippets/docs_snippets/integrations/snowflake/multi_partition.py
+++ b/examples/docs_snippets/docs_snippets/integrations/snowflake/multi_partition.py
@@ -7,9 +7,10 @@ def get_iris_data_for_date(*args, **kwargs):
 import pandas as pd
 
 from dagster import (
+    AssetExecutionContext,
     DailyPartitionsDefinition,
     MultiPartitionsDefinition,
-    StaticPartitionDefinition,
+    StaticPartitionsDefinition,
     asset,
 )
 
@@ -18,7 +19,7 @@ from dagster import (
     partitions_def=MultiPartitionsDefinition(
         {
             "date": DailyPartitionsDefinition(start_date="2023-01-01"),
-            "species": StaticPartitionDefinition(
+            "species": StaticPartitionsDefinition(
                 ["Iris-setosa", "Iris-virginica", "Iris-versicolor"]
             ),
         }
@@ -27,7 +28,7 @@ from dagster import (
         "partition_expr": {"date": "TO_TIMESTAMP(TIME::INT)", "species": "SPECIES"}
     },
 )
-def iris_dataset_partitioned(context) -> pd.DataFrame:
+def iris_dataset_partitioned(context: AssetExecutionContext) -> pd.DataFrame:
     partition = partition = context.partition_key.keys_by_dimension
     species = partition["species"]
     date = partition["date"]

--- a/examples/docs_snippets/docs_snippets/integrations/snowflake/pyspark_with_spark_resource.py
+++ b/examples/docs_snippets/docs_snippets/integrations/snowflake/pyspark_with_spark_resource.py
@@ -11,13 +11,13 @@ from pyspark.sql.types import (
     StructType,
 )
 
-from dagster import Definitions, EnvVar, asset
+from dagster import AssetExecutionContext, Definitions, EnvVar, asset
 
 SNOWFLAKE_JARS = "net.snowflake:snowflake-jdbc:3.8.0,net.snowflake:spark-snowflake_2.12:2.8.2-spark_3.0"
 
 
 @asset(required_resource_keys={"pyspark"})
-def iris_dataset(context) -> DataFrame:
+def iris_dataset(context: AssetExecutionContext) -> DataFrame:
     spark = context.resources.pyspark.spark_session
 
     schema = StructType(

--- a/examples/docs_snippets/docs_snippets/integrations/snowflake/static_partition.py
+++ b/examples/docs_snippets/docs_snippets/integrations/snowflake/static_partition.py
@@ -2,7 +2,7 @@
 
 import pandas as pd
 
-from dagster import StaticPartitionsDefinition, asset
+from dagster import AssetExecutionContext, StaticPartitionsDefinition, asset
 
 
 @asset(
@@ -11,7 +11,7 @@ from dagster import StaticPartitionsDefinition, asset
     ),
     metadata={"partition_expr": "SPECIES"},
 )
-def iris_dataset_partitioned(context) -> pd.DataFrame:
+def iris_dataset_partitioned(context: AssetExecutionContext) -> pd.DataFrame:
     species = context.asset_partition_key_for_output()
 
     full_df = pd.read_csv(

--- a/examples/docs_snippets/docs_snippets/integrations/snowflake/time_partition.py
+++ b/examples/docs_snippets/docs_snippets/integrations/snowflake/time_partition.py
@@ -6,14 +6,14 @@ def get_iris_data_for_date(*args, **kwargs):
 
 import pandas as pd
 
-from dagster import DailyPartitionsDefinition, asset
+from dagster import AssetExecutionContext, DailyPartitionsDefinition, asset
 
 
 @asset(
     partitions_def=DailyPartitionsDefinition(start_date="2023-01-01"),
     metadata={"partition_expr": "TO_TIMESTAMP(TIME::INT)"},
 )
-def iris_data_per_day(context) -> pd.DataFrame:
+def iris_data_per_day(context: AssetExecutionContext) -> pd.DataFrame:
     partition = context.asset_partition_key_for_output()
 
     # get_iris_data_for_date fetches all of the iris data for a given date,

--- a/examples/docs_snippets/docs_snippets/intro_tutorial/airflow.py
+++ b/examples/docs_snippets/docs_snippets/intro_tutorial/airflow.py
@@ -2,11 +2,11 @@ import csv
 
 import requests
 
-from dagster import job, op
+from dagster import OpExecutionContext, job, op
 
 
 @op
-def hello_cereal(context):
+def hello_cereal(context: OpExecutionContext):
     response = requests.get("https://docs.dagster.io/assets/cereal.csv")
     lines = response.text.split("\n")
     cereals = [row for row in csv.DictReader(lines)]

--- a/examples/docs_snippets/docs_snippets/intro_tutorial/basics/testing/custom_types_test.py
+++ b/examples/docs_snippets/docs_snippets/intro_tutorial/basics/testing/custom_types_test.py
@@ -11,6 +11,7 @@ from dagster import (
     dagster_type_loader,
     job,
     op,
+    OpExecutionContext
 )
 
 
@@ -60,7 +61,7 @@ else:
 
 
 @op
-def sort_by_calories(context, cereals: LessSimpleDataFrame):
+def sort_by_calories(context: OpExecutionContext, cereals: LessSimpleDataFrame):
     sorted_cereals = sorted(cereals, key=lambda cereal: cereal["calories"])
     context.log.info(
         "Least caloric cereal: {least_caloric}".format(

--- a/examples/docs_snippets/docs_snippets/intro_tutorial/basics/testing/custom_types_test.py
+++ b/examples/docs_snippets/docs_snippets/intro_tutorial/basics/testing/custom_types_test.py
@@ -6,12 +6,12 @@ from dagster import (
     DagsterType,
     Failure,
     Field,
+    OpExecutionContext,
     String,
     check_dagster_type,
     dagster_type_loader,
     job,
     op,
-    OpExecutionContext
 )
 
 

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/partitions_schedules_sensors_tests/test_sensors.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/partitions_schedules_sensors_tests/test_sensors.py
@@ -1,6 +1,6 @@
 from unittest import mock
 
-from dagster import Definitions, build_sensor_context, job, op
+from dagster import Definitions, OpExecutionContext, build_sensor_context, job, op
 from docs_snippets.concepts.partitions_schedules_sensors.sensors.sensor_alert import (
     email_on_run_failure,
     my_slack_on_run_failure,
@@ -19,7 +19,7 @@ from docs_snippets.concepts.partitions_schedules_sensors.sensors.sensors import 
 
 
 @op(config_schema={"fail": bool})
-def foo(context):
+def foo(context: OpExecutionContext):
     if context.op_config["fail"]:
         raise Exception("This will always fail!")
 

--- a/examples/docs_snippets/docs_snippets_tests/guides_tests/assets_ops_graphs_tests/test_op_graph_asset_input.py
+++ b/examples/docs_snippets/docs_snippets_tests/guides_tests/assets_ops_graphs_tests/test_op_graph_asset_input.py
@@ -1,4 +1,4 @@
-from dagster import IOManager
+from dagster import InputContext, IOManager, OutputContext
 from docs_snippets.guides.dagster.assets_ops_graphs.op_graph_asset_input import (
     send_emails_job,
 )
@@ -6,10 +6,10 @@ from docs_snippets.guides.dagster.assets_ops_graphs.op_graph_asset_input import 
 
 def test_send_emails_job():
     class EmailsIOManager(IOManager):
-        def load_input(self, context):
+        def load_input(self, context: InputContext):
             ...
 
-        def handle_output(self, context, obj):
+        def handle_output(self, context: OutputContext, obj):
             ...
 
     send_emails_job.graph.execute_in_process(

--- a/examples/docs_snippets/docs_snippets_tests/intro_tutorial_tests/test_type_guide.py
+++ b/examples/docs_snippets/docs_snippets_tests/intro_tutorial_tests/test_type_guide.py
@@ -12,6 +12,7 @@ from dagster import (
     DagsterTypeCheckDidNotPass,
     In,
     Nothing,
+    OpExecutionContext,
     Out,
     PythonObjectDagsterType,
     dagster_type_loader,
@@ -193,7 +194,7 @@ def test_nothing_fanin_actually_test():
     ordering = {"counter": 0}
 
     @op(out=Out(Nothing))
-    def start_first_job_section(context):
+    def start_first_job_section(context: OpExecutionContext):
         ordering["counter"] += 1
         ordering[context.op.name] = ordering["counter"]
 
@@ -201,12 +202,12 @@ def test_nothing_fanin_actually_test():
         ins={"first_section_done": In(Nothing)},
         out=Out(Nothing),
     )
-    def perform_clean_up(context):
+    def perform_clean_up(context: OpExecutionContext):
         ordering["counter"] += 1
         ordering[context.op.name] = ordering["counter"]
 
     @op(ins={"on_cleanup_tasks_done": In(Nothing)})
-    def start_next_job_section(context):
+    def start_next_job_section(context: OpExecutionContext):
         ordering["counter"] += 1
         ordering[context.op.name] = ordering["counter"]
         return "worked"


### PR DESCRIPTION
## Summary & Motivation
This PR adds type hints to the `context` args in our code snippets in the docs site. I did a search of the `examples/docs_snippets` folder for `context` and updated type hints as necessary. I didn't get to all of them, particularly the ones where I wasn't sure what the type hint should be (looking at you mulit_asset_sensor). I'm planning to do another pass and knock the remaining ones out (probably in a stacked pr)

so sorry this PR is massive. I wasn't sure how to split it out

Adding context type annotations revealed several pyright issues, these are fixed in https://github.com/dagster-io/dagster/pull/17193 so that this PR is easier to review

## How I Tested These Changes
