### PR TITLE
[ui] Small UI tweaks around asset checks

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetLiveDataProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetLiveDataProvider.tsx
@@ -508,6 +508,8 @@ export const ASSET_NODE_LIVE_FRAGMENT = gql`
         id
         runId
         status
+        timestamp
+        stepKey
         evaluation {
           severity
         }

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/types/AssetLiveDataProvider.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/types/AssetLiveDataProvider.types.ts
@@ -45,6 +45,8 @@ export type AssetNodeLiveFragment = {
       id: string;
       runId: string;
       status: Types.AssetCheckExecutionResolvedStatus;
+      timestamp: number;
+      stepKey: string | null;
       evaluation: {__typename: 'AssetCheckEvaluation'; severity: Types.AssetCheckSeverity} | null;
     } | null;
   }>;
@@ -110,6 +112,8 @@ export type AssetGraphLiveQuery = {
         id: string;
         runId: string;
         status: Types.AssetCheckExecutionResolvedStatus;
+        timestamp: number;
+        stepKey: string | null;
         evaluation: {__typename: 'AssetCheckEvaluation'; severity: Types.AssetCheckSeverity} | null;
       } | null;
     }>;

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNodeStatusContent.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNodeStatusContent.tsx
@@ -222,14 +222,14 @@ export function _buildAssetNodeStatusContent({
     const numMissing = numPartitions - numFailed - numMaterialized;
     const {background, foreground, border} =
       StyleForAssetPartitionStatus[
-        overdue || numFailed
+        overdue || numFailed || checksFailed
           ? AssetPartitionStatus.FAILED
           : numMissing
           ? AssetPartitionStatus.MISSING
           : AssetPartitionStatus.MATERIALIZED
       ];
     const statusCase =
-      overdue || numFailed
+      overdue || numFailed || checksFailed
         ? (StatusCase.PARTITIONS_FAILED as const)
         : numMissing
         ? (StatusCase.PARTITIONS_MISSING as const)
@@ -302,8 +302,10 @@ export function _buildAssetNodeStatusContent({
             </OverdueLineagePopover>
           ) : runWhichFailedToMaterialize ? (
             <span style={{color: Colors.Red700}}>Failed</span>
-          ) : (
+          ) : lastMaterialization ? (
             <span style={{color: Colors.Red700}}>Materialized</span>
+          ) : (
+            <span style={{color: Colors.Red700}}>Never materialized</span>
           )}
 
           {expanded && <SpacerDot />}

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__fixtures__/AssetNode.fixtures.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__fixtures__/AssetNode.fixtures.ts
@@ -697,6 +697,16 @@ export const AssetNodeScenariosBase = [
   },
 
   {
+    title: 'Never Materialized, Failed Check',
+    liveData: {
+      ...LiveDataForNodeNeverMaterialized,
+      assetChecks: LiveDataForNodeMaterializedWithChecks.assetChecks,
+    },
+    definition: AssetNodeFragmentBasic,
+    expectedText: ['Never materialized'],
+  },
+
+  {
     title: 'Materialized',
     liveData: LiveDataForNodeMaterialized,
     definition: AssetNodeFragmentBasic,

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/util.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/util.tsx
@@ -53,54 +53,23 @@ export function StatusCaseDot({statusCase}: {statusCase: StatusCase}) {
 
   switch (type) {
     case 'loading':
-      return (
-        <LoadingDot
-          style={{
-            width: '10px',
-            height: '10px',
-            borderRadius: '50%',
-          }}
-        />
-      );
+      return <LoadingDot />;
     case 'missing':
       return (
         <Tooltip content="Missing" position="top">
-          <div
-            style={{
-              width: '12px',
-              height: '12px',
-              border: `2px solid ${Colors.Gray500}`,
-              borderRadius: '50%',
-            }}
-          />
+          <Dot style={{border: `2px solid ${Colors.Gray500}`}} />
         </Tooltip>
       );
     case 'failed':
       return (
         <Tooltip content="Failed" position="top">
-          <div
-            style={{
-              backgroundColor: Colors.Red500,
-              width: '10px',
-              height: '10px',
-              borderRadius: '50%',
-            }}
-          />
+          <Dot style={{backgroundColor: Colors.Red500}} />
         </Tooltip>
       );
     case 'inprogress':
-      return <Spinner purpose="body-text" />;
+      return <Spinner purpose="caption-text" />;
     case 'successful':
-      return (
-        <div
-          style={{
-            backgroundColor: Colors.Green500,
-            width: '10px',
-            height: '10px',
-            borderRadius: '50%',
-          }}
-        />
-      );
+      return <Dot style={{backgroundColor: Colors.Green500}} />;
   }
 }
 
@@ -118,6 +87,14 @@ const pulse = keyframes`
   }
 `;
 
-const LoadingDot = styled.div`
+// 1px margin for 12px total width (matches <Spinner /> size)
+const Dot = styled.div`
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  margin: 0 1px;
+`;
+
+const LoadingDot = styled(Dot)`
   animation: ${pulse} 1s ease-out infinite;
 `;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetSidebarActivitySummary.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetSidebarActivitySummary.tsx
@@ -175,10 +175,7 @@ export const AssetSidebarActivitySummary: React.FC<Props> = ({
               }}
             >
               <MiddleTruncate text={`${check.name}`} />
-              <AssetCheckStatusTag
-                check={check}
-                execution={check.executionForLatestMaterialization}
-              />
+              <AssetCheckStatusTag execution={check.executionForLatestMaterialization} />
             </Box>
           ))}
           {liveData.assetChecks.length > 10 && (

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetCheckDetailModal.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetCheckDetailModal.tsx
@@ -26,6 +26,7 @@ import {AssetKeyInput} from '../../graphql/types';
 import {useDocumentTitle} from '../../hooks/useDocumentTitle';
 import {METADATA_ENTRY_FRAGMENT, MetadataEntries} from '../../metadata/MetadataEntry';
 import {MetadataEntryFragment} from '../../metadata/types/MetadataEntry.types';
+import {linkToRunEvent} from '../../runs/RunUtils';
 import {useCursorPaginatedQuery} from '../../runs/useCursorPaginatedQuery';
 import {TimestampDisplay} from '../../schedules/TimestampDisplay';
 
@@ -173,11 +174,16 @@ const AssetCheckDetailModalImpl = ({
                 <tr key={execution.id}>
                   <td>
                     {execution.evaluation?.timestamp ? (
-                      <Link to={`/runs/${execution.runId}`}>
+                      <Link
+                        to={linkToRunEvent(
+                          {id: execution.runId},
+                          {stepKey: execution.stepKey, timestamp: execution.timestamp},
+                        )}
+                      >
                         <TimestampDisplay timestamp={execution.evaluation.timestamp} />
                       </Link>
                     ) : (
-                      ' - '
+                      <TimestampDisplay timestamp={execution.timestamp} />
                     )}
                   </td>
                   <td>
@@ -192,7 +198,7 @@ const AssetCheckDetailModalImpl = ({
                     )}
                   </td>
                   <td>
-                    <AssetCheckStatusTag check={check} execution={execution} />
+                    <AssetCheckStatusTag execution={execution} />
                   </td>
                   <td>
                     <MetadataCell metadataEntries={execution.evaluation?.metadataEntries} />
@@ -255,6 +261,8 @@ export const ASSET_CHECK_EXECUTION_FRAGMENT = gql`
     id
     runId
     status
+    stepKey
+    timestamp
     evaluation {
       severity
       timestamp

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetCheckStatusTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetCheckStatusTag.tsx
@@ -2,22 +2,23 @@ import {BaseTag, Box, Colors, Icon, Spinner, Tag} from '@dagster-io/ui-component
 import * as React from 'react';
 
 import {assertUnreachable} from '../../app/Util';
-import {AssetCheckExecutionResolvedStatus, AssetCheckSeverity} from '../../graphql/types';
+import {
+  AssetCheckEvaluation,
+  AssetCheckExecution,
+  AssetCheckExecutionResolvedStatus,
+  AssetCheckSeverity,
+} from '../../graphql/types';
+import {linkToRunEvent} from '../../runs/RunUtils';
 import {TagActionsPopover} from '../../ui/TagActions';
 
 export const AssetCheckStatusTag = ({
   execution,
 }: {
-  check: {
-    name: string;
-  };
-  execution: {
-    runId: string;
-    status: AssetCheckExecutionResolvedStatus;
-    evaluation?: {
-      severity: AssetCheckSeverity;
-    } | null;
-  } | null;
+  execution:
+    | (Pick<AssetCheckExecution, 'runId' | 'status' | 'timestamp' | 'stepKey'> & {
+        evaluation: Pick<AssetCheckEvaluation, 'severity'> | null;
+      })
+    | null;
 }) => {
   // Note: this uses BaseTag for a "grayer" style than the default tag intent
   if (!execution) {
@@ -83,7 +84,10 @@ export const AssetCheckStatusTag = ({
       actions={[
         {
           label: 'View in run logs',
-          to: `/runs/${runId}`,
+          to: linkToRunEvent(
+            {id: runId},
+            {stepKey: execution.stepKey, timestamp: execution.timestamp},
+          ),
         },
       ]}
     >

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/VirtualizedAssetCheckTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/VirtualizedAssetCheckTable.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components';
 
+import {linkToRunEvent} from '../../runs/RunUtils';
 import {TimestampDisplay} from '../../schedules/TimestampDisplay';
 import {testId} from '../../testing/testId';
 import {HeaderCell, Row, RowCell, Container, Inner} from '../../ui/VirtualizedTable';
@@ -86,12 +87,17 @@ export const VirtualizedAssetCheckRow = ({assetNode, height, start, row}: AssetC
         </RowCell>
         <RowCell style={{flexDirection: 'row', alignItems: 'center'}}>
           <div>
-            <AssetCheckStatusTag check={row} execution={row.executionForLatestMaterialization} />
+            <AssetCheckStatusTag execution={row.executionForLatestMaterialization} />
           </div>
         </RowCell>
         <RowCell style={{flexDirection: 'row', alignItems: 'center'}}>
           {timestamp ? (
-            <Link to={`/runs/${execution.runId}`}>
+            <Link
+              to={linkToRunEvent(
+                {id: execution.runId},
+                {stepKey: execution.stepKey, timestamp: execution.timestamp},
+              )}
+            >
               <TimestampDisplay timestamp={timestamp} />
             </Link>
           ) : (

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/types/AssetCheckDetailModal.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/types/AssetCheckDetailModal.types.ts
@@ -7,6 +7,8 @@ export type AssetCheckExecutionFragment = {
   id: string;
   runId: string;
   status: Types.AssetCheckExecutionResolvedStatus;
+  stepKey: string | null;
+  timestamp: number;
   evaluation: {
     __typename: 'AssetCheckEvaluation';
     severity: Types.AssetCheckSeverity;
@@ -151,6 +153,8 @@ export type AssetCheckDetailsQuery = {
             id: string;
             runId: string;
             status: Types.AssetCheckExecutionResolvedStatus;
+            stepKey: string | null;
+            timestamp: number;
             evaluation: {
               __typename: 'AssetCheckEvaluation';
               severity: Types.AssetCheckSeverity;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/types/AssetChecks.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/types/AssetChecks.types.ts
@@ -38,6 +38,8 @@ export type AssetChecksQuery = {
             id: string;
             runId: string;
             status: Types.AssetCheckExecutionResolvedStatus;
+            stepKey: string | null;
+            timestamp: number;
             evaluation: {
               __typename: 'AssetCheckEvaluation';
               severity: Types.AssetCheckSeverity;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/types/VirtualizedAssetCheckTable.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/types/VirtualizedAssetCheckTable.types.ts
@@ -12,6 +12,8 @@ export type AssetCheckTableFragment = {
     id: string;
     runId: string;
     status: Types.AssetCheckExecutionResolvedStatus;
+    stepKey: string | null;
+    timestamp: number;
     evaluation: {
       __typename: 'AssetCheckEvaluation';
       severity: Types.AssetCheckSeverity;

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunUtils.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunUtils.tsx
@@ -36,7 +36,7 @@ export function assetKeysForRun(run: {
 
 export function linkToRunEvent(
   run: {id: string},
-  event: {timestamp?: string; stepKey: string | null},
+  event: {timestamp?: string | number; stepKey: string | null},
 ) {
   return `/runs/${run.id}?${qs.stringify({
     focusedTime: event.timestamp ? Number(event.timestamp) : undefined,


### PR DESCRIPTION
## Summary & Motivation

List of changes: https://www.notion.so/dagster/Asset-checks-UI-followups-8c188b748d0f449ca72a9e5ddf264090

- An asset with a failed check but no materializations no longer says "Materialized"

- Partitioned assets with failed checks are shown in red instead of gray on the asset graph

- The createdAt timestamp of the asset check is shown in the details modal if the asset check is in-flight

- The "View run logs" buttons all take you to the step + timestamp in the run logs

<img width="673" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/dbc9ed99-f6d8-481f-8ec9-37aa5255557f">

- I adjusted the size of the loading spinner in the new asset graph sidebar a bit because things would indent as they started loading because the spinner was wider.

<img width="200" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/44cf7e30-32f2-4d7d-8282-166c66400899">


## How I Tested These Changes

Manually tested and added a few storybooks for the new states