### PR TITLE
feat(dbt): add dbt exception message to Dagster exception

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_exceptions/profiles.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_exceptions/profiles.yml
@@ -6,3 +6,8 @@ jaffle_shop:
       type: duckdb
       path: 'jaffle_shop.duckdb'
       threads: 24
+
+    error_dev:
+      type: duckdb
+      path: 'jaffle_shop.duckdb'
+      threads: '{{ env_var("DBT_DUCKDB_THREADS")}}'


### PR DESCRIPTION
## Summary & Motivation
Further refine https://github.com/dagster-io/dagster/pull/15958 by putting the dbt exception in the raised Dagster exception.

This way, the exception will continue to be legible when:

- A user has no understanding of Dagster compute logs
- A user has not deployed their Dagster instance with Dagster compute logs
- A user does not have access to their underlying compute to view the raw dbt logs

Example:

```
2023-10-13 12:12:32 -0400 - dagster.daemon.SensorDaemon - WARNING - Could not load location jaffle_dagster to check for sensors due to the following error: dagster_dbt.errors.DagsterDbtCliRuntimeError: The dbt CLI process failed with exit code 2. Check the Dagster stdout for the full information about the error, or view the dbt debug log: /Users/rexledesma/Dropbox/Mac (3)/Downloads/projects/jaffle_shop/target/9000183/dbt.log.

The above exception was caused by the following exception:
Parsing Error
  Env var required but not provided: 'DBT_DUCKDB_THREADS'
```

## How I Tested These Changes
pytest
