### PR TITLE
correctly determine if an op is in a graph backed asset when determining default context type

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -1326,7 +1326,7 @@ def build_execution_context(
     op            None                      OpExecutionContext
     """
     is_sda_step = step_context.is_sda_step
-    is_op_in_graph_asset = is_sda_step and step_context.is_op_in_graph
+    is_op_in_graph_asset = step_context.is_in_graph_asset
     context_annotation = EmptyAnnotation
     compute_fn = step_context.op_def._compute_fn  # noqa: SLF001
     compute_fn = (
@@ -1340,7 +1340,7 @@ def build_execution_context(
 
     # It would be nice to do this check at definition time, rather than at run time, but we don't
     # know if the op is part of an op job or a graph-backed asset until we have the step execution context
-    if context_annotation is AssetExecutionContext and not is_sda_step:
+    if context_annotation is AssetExecutionContext and not is_sda_step and not is_op_in_graph_asset:
         # AssetExecutionContext requires an AssetsDefinition during init, so an op in an op job
         # cannot be annotated with AssetExecutionContext
         raise DagsterInvalidDefinitionError(

--- a/python_modules/dagster/dagster/_core/execution/context/system.py
+++ b/python_modules/dagster/dagster/_core/execution/context/system.py
@@ -917,6 +917,17 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
                 return True
         return False
 
+    @property
+    def is_in_graph_asset(self) -> bool:
+        """If the step is an op in a graph-backed asset returns True. Checks by first confirming the
+        step is in a graph, then checking that the node corresponds to an AssetsDefinitions in the asset layer.
+        """
+        return (
+            self.is_op_in_graph
+            and self.job_def.asset_layer.assets_defs_by_node_handle.get(self.node_handle)
+            is not None
+        )
+
     def set_data_version(self, asset_key: AssetKey, data_version: "DataVersion") -> None:
         self._data_version_cache[asset_key] = data_version
 

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_context.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_context.py
@@ -169,11 +169,18 @@ def test_context_provided_to_multi_asset():
 
 
 def test_context_provided_to_graph_asset():
+    # op so that the ops to check context type are layered deeper in the graph
+    @op
+    def layered_op(context: AssetExecutionContext, x):
+        assert isinstance(context, AssetExecutionContext)
+        return x + 1
+
     @op
     def no_annotation_op(context):
         assert isinstance(context, OpExecutionContext)
         # AssetExecutionContext is an instance of OpExecutionContext, so add this additional check
         assert not isinstance(context, AssetExecutionContext)
+        return 1
 
     @graph_asset
     def no_annotation_asset():
@@ -184,10 +191,11 @@ def test_context_provided_to_graph_asset():
     @op
     def asset_annotation_op(context: AssetExecutionContext):
         assert isinstance(context, AssetExecutionContext)
+        return 1
 
     @graph_asset
     def asset_annotation_asset():
-        return asset_annotation_op()
+        return layered_op(asset_annotation_op())
 
     materialize([asset_annotation_asset])
 
@@ -196,38 +204,47 @@ def test_context_provided_to_graph_asset():
         assert isinstance(context, OpExecutionContext)
         # AssetExecutionContext is an instance of OpExecutionContext, so add this additional check
         assert not isinstance(context, AssetExecutionContext)
+        return 1
 
     @graph_asset
     def op_annotation_asset():
-        return op_annotation_op()
+        return layered_op(op_annotation_op())
 
     materialize([op_annotation_asset])
 
 
 def test_context_provided_to_graph_multi_asset():
+    # op so that the ops to check context type are layered deeper in the graph
+    @op
+    def layered_op(context: AssetExecutionContext, x):
+        assert isinstance(context, AssetExecutionContext)
+        return x + 1
+
     @op
     def no_annotation_op(context):
         assert isinstance(context, OpExecutionContext)
         # AssetExecutionContext is an instance of OpExecutionContext, so add this additional check
         assert not isinstance(context, AssetExecutionContext)
+        return 1
 
     @graph_multi_asset(
         outs={"out1": AssetOut(dagster_type=None), "out2": AssetOut(dagster_type=None)}
     )
     def no_annotation_asset():
-        return no_annotation_op(), no_annotation_op()
+        return layered_op(no_annotation_op()), layered_op(no_annotation_op())
 
     materialize([no_annotation_asset])
 
     @op
     def asset_annotation_op(context: AssetExecutionContext):
         assert isinstance(context, AssetExecutionContext)
+        return 1
 
     @graph_multi_asset(
         outs={"out1": AssetOut(dagster_type=None), "out2": AssetOut(dagster_type=None)}
     )
     def asset_annotation_asset():
-        return asset_annotation_op(), asset_annotation_op()
+        return layered_op(asset_annotation_op()), layered_op(asset_annotation_op())
 
     materialize([asset_annotation_asset])
 
@@ -236,12 +253,13 @@ def test_context_provided_to_graph_multi_asset():
         assert isinstance(context, OpExecutionContext)
         # AssetExecutionContext is an instance of OpExecutionContext, so add this additional check
         assert not isinstance(context, AssetExecutionContext)
+        return 1
 
     @graph_multi_asset(
         outs={"out1": AssetOut(dagster_type=None), "out2": AssetOut(dagster_type=None)}
     )
     def op_annotation_asset():
-        return op_annotation_op(), op_annotation_op()
+        return layered_op(op_annotation_op()), layered_op(op_annotation_op())
 
     materialize([op_annotation_asset])
 


### PR DESCRIPTION
## Summary & Motivation
When we introduced logic to determine what context type to provide to different step types (https://github.com/dagster-io/dagster/pull/16759) I determined if an op was in a graph backed asset by checking if it was an op in a graph AND if it was an sda step. However, this doesn't work when the op within the graph is nested within another op. So instead, we check if the step is in a graph and if it's node handle has an associated assets definition in the asset layer. 

## How I Tested These Changes
update unit tests to layer the ops