### PR TITLE
add beforeTimestamp and afterTimestamp fields to ticks queries

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -2357,6 +2357,8 @@ type InstigationState {
     limit: Int
     cursor: String
     statuses: [InstigationTickStatus!]
+    beforeTimestamp: Float
+    afterTimestamp: Float
   ): [InstigationTick!]!
   nextTick: DryRunInstigationTick
   runningCount: Int!
@@ -3082,6 +3084,8 @@ type Query {
     limit: Int
     cursor: String
     statuses: [InstigationTickStatus!]
+    beforeTimestamp: Float
+    afterTimestamp: Float
   ): [InstigationTick!]!
   assetChecksOrError(assetKey: AssetKeyInput!, checkName: String): AssetChecksOrError!
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -1520,6 +1520,8 @@ export type InstigationStateTickArgs = {
 };
 
 export type InstigationStateTicksArgs = {
+  afterTimestamp?: InputMaybe<Scalars['Float']>;
+  beforeTimestamp?: InputMaybe<Scalars['Float']>;
   cursor?: InputMaybe<Scalars['String']>;
   dayOffset?: InputMaybe<Scalars['Int']>;
   dayRange?: InputMaybe<Scalars['Int']>;
@@ -2954,6 +2956,8 @@ export type QueryAutoMaterializeEvaluationsForEvaluationIdArgs = {
 };
 
 export type QueryAutoMaterializeTicksArgs = {
+  afterTimestamp?: InputMaybe<Scalars['Float']>;
+  beforeTimestamp?: InputMaybe<Scalars['Float']>;
   cursor?: InputMaybe<Scalars['String']>;
   dayOffset?: InputMaybe<Scalars['Int']>;
   dayRange?: InputMaybe<Scalars['Int']>;

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_ticks.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_ticks.py
@@ -23,25 +23,29 @@ def get_instigation_ticks(
     limit: Optional[int],
     cursor: Optional[str],
     status_strings: Optional[Sequence[str]],
+    before: Optional[float],
+    after: Optional[float],
 ):
     from ..schema.instigation import GrapheneInstigationTick
 
-    before = None
-    if dayOffset:
-        before = pendulum.now("UTC").subtract(days=dayOffset).timestamp()
-    elif cursor:
-        parts = cursor.split(":")
-        if parts:
-            try:
-                before = float(parts[-1])
-            except (ValueError, IndexError):
-                warnings.warn(f"Invalid cursor for ticks: {cursor}")
+    if before is None:
+        if dayOffset:
+            before = pendulum.now("UTC").subtract(days=dayOffset).timestamp()
+        elif cursor:
+            parts = cursor.split(":")
+            if parts:
+                try:
+                    before = float(parts[-1])
+                except (ValueError, IndexError):
+                    warnings.warn(f"Invalid cursor for ticks: {cursor}")
 
-    after = (
-        pendulum.now("UTC").subtract(days=dayRange + (dayOffset or 0)).timestamp()
-        if dayRange
-        else None
-    )
+    if after is None:
+        after = (
+            pendulum.now("UTC").subtract(days=dayRange + (dayOffset or 0)).timestamp()
+            if dayRange
+            else None
+        )
+
     statuses = [TickStatus(status) for status in status_strings] if status_strings else None
 
     if batch_loader and limit and not cursor and not before and not after:

--- a/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
@@ -529,6 +529,8 @@ class GrapheneInstigationState(graphene.ObjectType):
         limit=graphene.Int(),
         cursor=graphene.String(),
         statuses=graphene.List(graphene.NonNull(GrapheneInstigationTickStatus)),
+        beforeTimestamp=graphene.Float(),
+        afterTimestamp=graphene.Float(),
     )
     nextTick = graphene.Field(GrapheneDryRunInstigationTick)
     runningCount = graphene.NonNull(graphene.Int)  # remove with cron scheduler
@@ -654,7 +656,15 @@ class GrapheneInstigationState(graphene.ObjectType):
         return GrapheneInstigationTick(graphene_info, matches[0]) if matches else None
 
     def resolve_ticks(
-        self, graphene_info, dayRange=None, dayOffset=None, limit=None, cursor=None, statuses=None
+        self,
+        graphene_info,
+        dayRange=None,
+        dayOffset=None,
+        limit=None,
+        cursor=None,
+        statuses=None,
+        beforeTimestamp=None,
+        afterTimestamp=None,
     ):
         return get_instigation_ticks(
             graphene_info=graphene_info,
@@ -667,6 +677,8 @@ class GrapheneInstigationState(graphene.ObjectType):
             limit=limit,
             cursor=cursor,
             status_strings=statuses,
+            before=beforeTimestamp,
+            after=afterTimestamp,
         )
 
     def resolve_nextTick(self, graphene_info: ResolveInfo):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -506,6 +506,8 @@ class GrapheneQuery(graphene.ObjectType):
         limit=graphene.Int(),
         cursor=graphene.String(),
         statuses=graphene.List(graphene.NonNull(GrapheneInstigationTickStatus)),
+        beforeTimestamp=graphene.Float(),
+        afterTimestamp=graphene.Float(),
         description="Fetch the history of auto-materialization ticks",
     )
 
@@ -1052,7 +1054,15 @@ class GrapheneQuery(graphene.ObjectType):
         )
 
     def resolve_autoMaterializeTicks(
-        self, graphene_info, dayRange=None, dayOffset=None, limit=None, cursor=None, statuses=None
+        self,
+        graphene_info,
+        dayRange=None,
+        dayOffset=None,
+        limit=None,
+        cursor=None,
+        statuses=None,
+        beforeTimestamp=None,
+        afterTimestamp=None,
     ):
         from dagster._daemon.asset_daemon import (
             FIXED_AUTO_MATERIALIZATION_ORIGIN_ID,
@@ -1070,6 +1080,8 @@ class GrapheneQuery(graphene.ObjectType):
             limit=limit,
             cursor=cursor,
             status_strings=statuses,
+            before=beforeTimestamp,
+            after=afterTimestamp,
         )
 
     def resolve_assetChecksOrError(


### PR DESCRIPTION
Summary:
To allow us to more granularly fetch the ticks that we need in the UI.

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes
