### PR TITLE
[ui] Tidy up asset list dialog

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillRow.tsx
@@ -275,7 +275,7 @@ const BackfillTarget: React.FC<{
 
   const buildPipelineOrAssets = () => {
     if (assetSelection?.length) {
-      return <AssetKeyTagCollection assetKeys={assetSelection} modalTitle="Assets in backfill" />;
+      return <AssetKeyTagCollection assetKeys={assetSelection} dialogTitle="Assets in backfill" />;
     }
     if (partitionSet && repo) {
       return (

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/AssetTagCollections.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/AssetTagCollections.tsx
@@ -6,6 +6,7 @@ import {
   Dialog,
   DialogFooter,
   Icon,
+  MiddleTruncate,
   Tag,
 } from '@dagster-io/ui-components';
 import * as React from 'react';
@@ -22,11 +23,15 @@ import {TagActionsPopover} from '../ui/TagActions';
 import {VirtualizedItemListForDialog} from '../ui/VirtualizedItemListForDialog';
 
 const renderItemAssetKey = (assetKey: AssetKey) => (
-  <Link to={assetDetailsPathForKey(assetKey)}>{displayNameForAssetKey(assetKey)}</Link>
+  <Link to={assetDetailsPathForKey(assetKey)} style={{display: 'block', width: '100%'}}>
+    <MiddleTruncate text={displayNameForAssetKey(assetKey)} />
+  </Link>
 );
 
 const renderItemAssetCheck = (assetCheck: Check) => (
-  <Link to={assetDetailsPathForAssetCheck(assetCheck)}>{labelForAssetCheck(assetCheck)}</Link>
+  <Link to={assetDetailsPathForAssetCheck(assetCheck)} style={{display: 'block', width: '100%'}}>
+    <MiddleTruncate text={labelForAssetCheck(assetCheck)} />
+  </Link>
 );
 
 const labelForAssetCheck = (check: Check) => {
@@ -34,7 +39,7 @@ const labelForAssetCheck = (check: Check) => {
 };
 
 function useShowMoreDialog<T>(
-  modalTitle: string,
+  dialogTitle: string,
   items: T[] | null,
   renderItem: (item: T) => React.ReactNode,
 ) {
@@ -43,16 +48,16 @@ function useShowMoreDialog<T>(
   const dialog =
     !!items && items.length > 1 ? (
       <Dialog
-        title={modalTitle}
+        title={dialogTitle}
         onClose={() => setShowMore(false)}
-        style={{minWidth: '400px', maxWidth: '80vw', maxHeight: '70vh'}}
+        style={{minWidth: '400px', width: '50vw', maxWidth: '800px', maxHeight: '70vh'}}
         isOpen={showMore}
       >
-        <div style={{height: '340px', overflow: 'hidden'}}>
+        <div style={{height: '500px', overflow: 'hidden'}}>
           <VirtualizedItemListForDialog items={items} renderItem={renderItem} />
         </div>
         <DialogFooter topBorder>
-          <Button autoFocus onClick={() => setShowMore(false)}>
+          <Button intent="primary" autoFocus onClick={() => setShowMore(false)}>
             Done
           </Button>
         </DialogFooter>
@@ -64,10 +69,10 @@ function useShowMoreDialog<T>(
 
 export const AssetKeyTagCollection: React.FC<{
   assetKeys: AssetKey[] | null;
-  modalTitle?: string;
+  dialogTitle?: string;
   useTags?: boolean;
-}> = React.memo(({assetKeys, useTags, modalTitle = 'Assets in run'}) => {
-  const {setShowMore, dialog} = useShowMoreDialog(modalTitle, assetKeys, renderItemAssetKey);
+}> = React.memo(({assetKeys, useTags, dialogTitle = 'Assets in run'}) => {
+  const {setShowMore, dialog} = useShowMoreDialog(dialogTitle, assetKeys, renderItemAssetKey);
 
   if (!assetKeys || !assetKeys.length) {
     return null;
@@ -151,10 +156,10 @@ type Check = {name: string; assetKey: AssetKey};
 
 export const AssetCheckTagCollection: React.FC<{
   assetChecks: Check[] | null;
-  modalTitle?: string;
+  dialogTitle?: string;
   useTags?: boolean;
-}> = React.memo(({assetChecks, useTags, modalTitle = 'Asset checks in run'}) => {
-  const {setShowMore, dialog} = useShowMoreDialog(modalTitle, assetChecks, renderItemAssetCheck);
+}> = React.memo(({assetChecks, useTags, dialogTitle = 'Asset checks in run'}) => {
+  const {setShowMore, dialog} = useShowMoreDialog(dialogTitle, assetChecks, renderItemAssetCheck);
 
   if (!assetChecks || !assetChecks.length) {
     return null;


### PR DESCRIPTION
## Summary & Motivation

Some cleanup on the "list of assets" dialog used in the Backfills overview and elsewhere.

- Make the dialog wider, since there's no shortage of real estate. A lot of users have very long asset names.
- Use middle-truncation and nowrap to gracefully handle superlong names

## How I Tested These Changes

View Backfills page for backfills with lots of assets. Open dialog, verify that the list renders nicely.
