### PR TITLE
[ui] Fix refresh error on backfills page when status is unsupported

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillRow.tsx
@@ -18,7 +18,7 @@ import {inProgressStatuses} from '../../runs/RunStatuses';
 import {RunStatusTagsWithCounts} from '../../runs/RunTimeline';
 import {runsPathWithFilters} from '../../runs/RunsFilterInput';
 import {TimestampDisplay} from '../../schedules/TimestampDisplay';
-import {LoadingOrNone, useDelayedRowQuery} from '../../workspace/VirtualizedWorkspaceTable';
+import {useDelayedRowQuery} from '../../workspace/VirtualizedWorkspaceTable';
 import {isThisThingAJob, useRepository} from '../../workspace/WorkspaceContext';
 import {buildRepoAddress} from '../../workspace/buildRepoAddress';
 import {repoAddressAsHumanString} from '../../workspace/repoAddressAsString';
@@ -36,35 +36,47 @@ import {
 } from './types/BackfillRow.types';
 import {BackfillTableFragment} from './types/BackfillTable.types';
 
-const NoBackfillStatusQuery = [
-  () => Promise.resolve({data: undefined} as QueryResult<undefined>),
-  {data: undefined, called: true, loading: false} as QueryResult<undefined>,
-] as const;
-
-export const BackfillRow = ({
-  backfill,
-  allPartitions,
-  showBackfillTarget,
-  onShowPartitionsRequested,
-  refetch,
-}: {
+interface BackfillRowProps {
   backfill: BackfillTableFragment;
   allPartitions?: string[];
   showBackfillTarget: boolean;
   onShowPartitionsRequested: (backfill: BackfillTableFragment) => void;
   refetch: () => void;
+}
+
+export const BackfillRow = (props: BackfillRowProps) => {
+  const statusUnsupported =
+    props.backfill.numPartitions === null ||
+    props.backfill.partitionNames === null ||
+    props.backfill.isAssetBackfill;
+
+  if (statusUnsupported) {
+    return <BackfillRowContent {...props} counts={null} statuses={null} statusQueryResult={null} />;
+  }
+  return (
+    <BackfillRowLoader backfillId={props.backfill.id} numPartitions={props.backfill.numPartitions}>
+      {(data) => <BackfillRowContent {...props} {...data} />}
+    </BackfillRowLoader>
+  );
+};
+
+interface LoadResult {
+  counts: {[runStatus: string]: number} | null;
+  statusQueryResult: QueryResult<any, any> | null;
+  statuses: PartitionStatusesForBackfillFragment['results'] | null;
+}
+
+export const BackfillRowLoader = (props: {
+  backfillId: string;
+  numPartitions: number | null;
+  children: (data: LoadResult) => React.ReactNode;
 }) => {
-  const repoAddress = backfill.partitionSet
-    ? buildRepoAddress(
-        backfill.partitionSet.repositoryOrigin.repositoryName,
-        backfill.partitionSet.repositoryOrigin.repositoryLocationName,
-      )
-    : null;
+  const {backfillId, numPartitions} = props;
 
   const statusDetails = useLazyQuery<SingleBackfillQuery, SingleBackfillQueryVariables>(
     SINGLE_BACKFILL_STATUS_DETAILS_QUERY,
     {
-      variables: {backfillId: backfill.id},
+      variables: {backfillId},
       notifyOnNetworkStatusChange: true,
     },
   );
@@ -72,26 +84,16 @@ export const BackfillRow = ({
   const statusCounts = useLazyQuery<SingleBackfillCountsQuery, SingleBackfillCountsQueryVariables>(
     SINGLE_BACKFILL_STATUS_COUNTS_QUERY,
     {
-      variables: {backfillId: backfill.id},
+      variables: {backfillId},
       notifyOnNetworkStatusChange: true,
     },
   );
 
-  const statusUnsupported =
-    backfill.numPartitions === null || backfill.partitionNames === null || backfill.isAssetBackfill;
-
   // Note: We switch queries based on how many partitions there are to display,
   // because the detail is nice for small backfills but breaks for 100k+ partitions.
   //
-  // If the number of partitions or partition names are missing, we use a mock to
-  // avoid executing any query at all. This is a bit awkward, but seems cleaner than
-  // making the hooks below support an optional query function / result.
-  const [statusQueryFn, statusQueryResult] = statusUnsupported
-    ? NoBackfillStatusQuery
-    : backfill.isAssetBackfill ||
-      (backfill.numPartitions || 0) > BACKFILL_PARTITIONS_COUNTS_THRESHOLD
-    ? statusCounts
-    : statusDetails;
+  const [statusQueryFn, statusQueryResult] =
+    (numPartitions || 0) > BACKFILL_PARTITIONS_COUNTS_THRESHOLD ? statusCounts : statusDetails;
 
   useDelayedRowQuery(statusQueryFn);
   useQueryRefreshAtInterval(statusQueryResult, FIFTEEN_SECONDS);
@@ -107,10 +109,51 @@ export const BackfillRow = ({
       );
       return {counts, statuses: null};
     }
-    const statuses = data.partitionBackfillOrError.partitionStatuses?.results;
+    const statuses = data.partitionBackfillOrError.partitionStatuses?.results || null;
     const counts = countBy(statuses, (k) => k.runStatus);
     return {counts, statuses};
   }, [data]);
+
+  return props.children({counts, statuses, statusQueryResult});
+};
+
+export const BackfillRowContent = ({
+  backfill,
+  allPartitions,
+  showBackfillTarget,
+  onShowPartitionsRequested,
+  refetch,
+  counts,
+  statuses,
+  statusQueryResult,
+}: BackfillRowProps & LoadResult) => {
+  const repoAddress = backfill.partitionSet
+    ? buildRepoAddress(
+        backfill.partitionSet.repositoryOrigin.repositoryName,
+        backfill.partitionSet.repositoryOrigin.repositoryLocationName,
+      )
+    : null;
+
+  const renderBackfillStatus = () =>
+    statusQueryResult?.loading ? (
+      <div style={{color: Colors.Gray500}}>Loading</div>
+    ) : (
+      <BackfillStatusTag backfill={backfill} counts={counts} />
+    );
+
+  const renderRunStatus = () => {
+    if (!backfill.isValidSerialization) {
+      return <p>A partitions definition has changed since this backfill ran.</p>;
+    }
+    if (statusQueryResult?.loading) {
+      return <div style={{color: Colors.Gray500}}>Loading</div>;
+    }
+    return counts ? (
+      <BackfillRunStatus backfill={backfill} counts={counts} statuses={statuses} />
+    ) : (
+      <div style={{color: Colors.Gray500}}>{'\u2013'}</div>
+    );
+  };
 
   return (
     <tr>
@@ -150,24 +193,8 @@ export const BackfillRow = ({
       <td style={{width: 160}}>
         <CreatedByTagCell tags={backfill.tags} repoAddress={repoAddress} />
       </td>
-      <td style={{width: 140}}>
-        {counts || statusUnsupported ? (
-          <BackfillStatusTag backfill={backfill} counts={counts} />
-        ) : (
-          <LoadingOrNone queryResult={statusQueryResult} noneString={'\u2013'} />
-        )}
-      </td>
-      <td>
-        {backfill.isValidSerialization ? (
-          counts && statuses !== undefined ? (
-            <BackfillRunStatus backfill={backfill} counts={counts} statuses={statuses} />
-          ) : (
-            <LoadingOrNone queryResult={statusQueryResult} noneString={'\u2013'} />
-          )
-        ) : (
-          <p>A partitions definition has changed since this backfill ran.</p>
-        )}
-      </td>
+      <td style={{width: 140}}>{renderBackfillStatus()}</td>
+      <td>{renderRunStatus()}</td>
       <td>
         <BackfillActionsMenu
           backfill={backfill}


### PR DESCRIPTION
## Summary & Motivation

My original approach (https://github.com/dagster-io/dagster/pull/12462/files#r1120397573) to conditionally disabling the per-row status query in the BackfillTable was to return a "fake" QueryResult. This caused a full-page error in prod because my `as QueryResult` was hiding the fact that the returned object was missing a `refetch` method. (Thanks @hellendag for spotting it was this code)

This fixes the bug and switches approaches entirely to something safer. I've split BackfillRow into two components and we conditionally load per-row data by conditionally rendering a loader component.

## How I Tested These Changes

We have full storybook coverage for this table's states so I was able to update the rendering here and verify all the states look the same. I also repro'd the "statusUnsupported" case and verified the refetch error is no longer happening.
