### PR TITLE
[time-window-partitions] Allow empty time window partitions def with get partition keys not in subset

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -1417,7 +1417,7 @@ class TimeWindowPartitionsSubset(PartitionsSubset):
         last_tw = self._partitions_def.get_last_partition_window(current_time=current_time)
 
         if not first_tw or not last_tw:
-            check.failed("No partitions found")
+            return []
 
         if len(self.included_time_windows) == 0:
             return [TimeWindow(first_tw.start, last_tw.end)]

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
@@ -792,6 +792,14 @@ def test_partition_subset_get_partition_keys_not_in_subset(case_str: str):
     assert len(subset) == case_str.count("+")
 
 
+def test_future_start_date() -> None:
+    with pendulum.test(pendulum.parse("2023-01-01")):
+        partitions_def = DailyPartitionsDefinition(start_date="2024-01-01")
+        assert partitions_def.get_partition_keys() == []
+        assert partitions_def.empty_subset().get_partition_keys() == []
+        assert partitions_def.empty_subset().get_partition_keys_not_in_subset() == []
+
+
 @pytest.mark.parametrize(
     "initial, added",
     [


### PR DESCRIPTION
## Summary & Motivation

Resolves: https://github.com/dagster-io/dagster/issues/17191

There's no reason for this to cause an error, PartitionsDefs with no partitions are technically allowed, and we can handle this gracefully.

## How I Tested These Changes
