### PR TITLE
[partitions-subset] Ensure that identical PartitionsSubsets have identical serialized form

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -1135,7 +1135,13 @@ class DefaultPartitionsSubset(PartitionsSubset[T_str]):
     def serialize(self) -> str:
         # Serialize version number, so attempting to deserialize old versions can be handled gracefully.
         # Any time the serialization format changes, we should increment the version number.
-        return json.dumps({"version": self.SERIALIZATION_VERSION, "subset": list(self._subset)})
+        return json.dumps(
+            {
+                "version": self.SERIALIZATION_VERSION,
+                # sort to ensure that equivalent partition subsets have identical serialized forms
+                "subset": sorted(list(self._subset)),
+            }
+        )
 
     @classmethod
     def from_serialized(

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -1637,13 +1637,12 @@ class TimeWindowPartitionsSubset(PartitionsSubset):
         return json.dumps(
             {
                 "version": self.SERIALIZATION_VERSION,
-                # sort to ensure that equivalent partition subsets have identical serialized forms
-                "time_windows": sorted(
-                    [
-                        (window.start.timestamp(), window.end.timestamp())
-                        for window in self.included_time_windows
-                    ]
-                ),
+                # included_time_windows is already sorted, so no need to sort here to guarantee
+                # stable serialization between identical subsets
+                "time_windows": [
+                    (window.start.timestamp(), window.end.timestamp())
+                    for window in self.included_time_windows
+                ],
                 "num_partitions": self._num_partitions,
             }
         )

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -1637,10 +1637,13 @@ class TimeWindowPartitionsSubset(PartitionsSubset):
         return json.dumps(
             {
                 "version": self.SERIALIZATION_VERSION,
-                "time_windows": [
-                    (window.start.timestamp(), window.end.timestamp())
-                    for window in self.included_time_windows
-                ],
+                # sort to ensure that equivalent partition subsets have identical serialized forms
+                "time_windows": sorted(
+                    [
+                        (window.start.timestamp(), window.end.timestamp())
+                        for window in self.included_time_windows
+                    ]
+                ),
                 "num_partitions": self._num_partitions,
             }
         )

--- a/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_partition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_partition.py
@@ -151,6 +151,15 @@ def test_static_partitions_subset():
     assert "bar" in with_some_partitions
 
 
+def test_static_partitions_subset_identical_serialization():
+    # serialized subsets should be equal if the original subsets are equal
+    partitions = StaticPartitionsDefinition([str(i) for i in range(1000)])
+    subset = [str(i) for i in range(500)]
+    serialized1 = partitions.subset_with_partition_keys(subset).serialize()
+    serialized2 = partitions.subset_with_partition_keys(reversed(subset)).serialize()
+    assert serialized1 == serialized2
+
+
 def test_static_partitions_invalid_chars():
     with pytest.raises(DagsterInvalidDefinitionError):
         StaticPartitionsDefinition(["foo...bar"])

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from typing import Optional, Sequence, cast
+import random
 
 import pendulum.parser
 import pytest
@@ -790,6 +791,25 @@ def test_partition_subset_get_partition_keys_not_in_subset(case_str: str):
     expected_range_count = case_str.count("-+") + (1 if case_str[0] == "+" else 0)
     assert len(subset.included_time_windows) == expected_range_count, case_str
     assert len(subset) == case_str.count("+")
+
+
+def test_time_partitions_subset_identical_serialization():
+    # serialized subsets should be equal if the original subsets are equal
+    partitions_def = DailyPartitionsDefinition(start_date="2015-01-01")
+    partition_keys = [
+        *[f"2015-02-{i:02d}" for i in range(1, 20)],
+        *[f"2016-03-{i:02d}" for i in range(1, 15)],
+        *[f"2017-04-{i:02d}" for i in range(1, 10)],
+        *[f"2018-05-{i:02d}" for i in range(1, 5)],
+        *[f"2018-06-{i:02d}" for i in range(1, 10)],
+        *[f"2019-07-{i:02d}" for i in range(1, 15)],
+        *[f"2020-08-{i:02d}" for i in range(1, 20)],
+    ]
+    serialized1 = partitions_def.subset_with_partition_keys(partition_keys).serialize()
+    serialized2 = partitions_def.subset_with_partition_keys(
+        random.shuffle(partition_keys)
+    ).serialize()
+    assert serialized1 == serialized2
 
 
 @pytest.mark.parametrize(

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
@@ -806,9 +806,8 @@ def test_time_partitions_subset_identical_serialization():
         *[f"2020-08-{i:02d}" for i in range(1, 20)],
     ]
     serialized1 = partitions_def.subset_with_partition_keys(partition_keys).serialize()
-    serialized2 = partitions_def.subset_with_partition_keys(
-        random.shuffle(partition_keys)
-    ).serialize()
+    random.shuffle(partition_keys)
+    serialized2 = partitions_def.subset_with_partition_keys(partition_keys).serialize()
     assert serialized1 == serialized2
 
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
@@ -1,6 +1,6 @@
+import random
 from datetime import datetime
 from typing import Optional, Sequence, cast
-import random
 
 import pendulum.parser
 import pytest


### PR DESCRIPTION
## Summary & Motivation

It's much more convenient to just compare strings to determine if SerializedPartitionsSubsets are identical

## How I Tested These Changes
