### PR TITLE
[RFC] allow different nodes in the same repo to have the same name

### DIFF
--- a/python_modules/dagster/dagster_tests/definitions_tests/test_repository_definition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_repository_definition.py
@@ -116,14 +116,7 @@ def test_dupe_op_repo_definition():
             }
         }
 
-    with pytest.raises(
-        DagsterInvalidDefinitionError,
-        match=(
-            "Conflicting definitions found in repository with name 'same'. Op/Graph definition"
-            " names must be unique within a repository."
-        ),
-    ):
-        error_repo.get_all_jobs()
+    error_repo.get_all_jobs()
 
 
 def test_non_lazy_job_dict():
@@ -446,17 +439,7 @@ def test_dupe_graph_defs():
 
         return graph_collide
 
-    with pytest.raises(
-        DagsterInvalidDefinitionError,
-        match="Op/Graph definition names must be unique within a repository",
-    ):
-        get_collision_repo().get_all_jobs()
-
-    with pytest.raises(
-        DagsterInvalidDefinitionError,
-        match="Op/Graph definition names must be unique within a repository",
-    ):
-        get_collision_repo().get_all_jobs()
+    get_collision_repo().get_all_jobs()
 
 
 def test_dupe_unresolved_job_defs():


### PR DESCRIPTION
## Summary & Motivation

Since time immemorial, Dagster has had the constraint that node (i.e. op and graph) names within a repository must be unique. I.e. you can't have two ops with different implementations that share a name.

In the past, when Dagit had more of an IDE vibe, we had good reason for this. Ops played a much more central role in the UI. There were views in the UI that allowed you to see the list of ops defined in a repository.  Ops were expected to be widely reusable.

From what I can tell, Dagster no longer has these views, and there isn't anywhere in the UI that expects ops to have unique names.

At the same time, this constraint has been a stumbling block in a few different situations:
- https://github.com/dagster-io/dagster/issues/8076
- https://github.com/dagster-io/dagster/issues/17190
- https://github.com/dagster-io/dagster/issues/12406
- https://github.com/dagster-io/dagster/issues/9436#issuecomment-1445216199

This PR proposes removing the constraint.

## How I Tested These Changes

`dagster dev -f` on the below code snippet, and then clicked around the UI, launched runs.

```python
from dagster import op, job, Definitions


def make_op1():
    @op
    def op1():
        ...

    return op1


def make_op1_2():
    @op
    def op1():
        ...

    return op1


@job
def job1():
    make_op1()()


@job
def job2():
    make_op1_2()()


defs = Definitions(jobs=[job1, job2])
```