### PR TITLE
Enhancement/databricks auth

### DIFF
--- a/python_modules/libraries/dagster-databricks/dagster_databricks/configs.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/configs.py
@@ -1085,3 +1085,30 @@ def define_oauth_credentials():
         ),
         default_value=None,
     )
+
+
+def define_azure_credentials():
+    return Field(
+        Noneable(
+            Shape(
+                fields={
+                    "azure_client_id": Field(
+                        str, is_required=True, description="Azure service principal client ID"
+                    ),
+                    "azure_client_secret": Field(
+                        str, is_required=True, description="Azure service principal client secret"
+                    ),
+                    "azure_tenant_id": Field(
+                        str, is_required=True, description="Azure service principal tenant ID"
+                    ),
+                }
+            ),
+        ),
+        description=(
+            "Azure service principal oauth credentials for interacting with the Databricks REST API"
+            " via a service"
+            " principal. See"
+            " https://learn.microsoft.com/en-us/azure/databricks/administration-guide/users-groups/service-principals"
+        ),
+        default_value=None,
+    )

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks.py
@@ -1,6 +1,8 @@
 import base64
 import logging
+import os
 import time
+from enum import Enum
 from typing import IO, Any, List, Mapping, Optional, Tuple, Union, cast
 
 import dagster
@@ -11,6 +13,13 @@ import databricks_cli.sdk
 import requests.exceptions
 from dagster._annotations import deprecated, public
 from databricks.sdk import WorkspaceClient
+from databricks.sdk.core import (
+    Config,
+    DefaultCredentials,
+    azure_service_principal,
+    oauth_service_principal,
+    pat_auth,
+)
 from databricks.sdk.service import compute, jobs
 from typing_extensions import Final
 
@@ -29,28 +38,215 @@ class DatabricksError(Exception):
     pass
 
 
+class AuthTypeEnum(Enum):
+    OAUTH_M2M = "oauth-m2m"
+    PAT = "pat"
+    AZURE_CLIENT_SECRET = "azure-client-secret"
+    DEFAULT = "default"
+
+
+class WorkspaceClientFactory:
+    def __init__(
+        self,
+        host: Optional[str],
+        token: Optional[str],
+        oauth_client_id: Optional[str],
+        oauth_client_secret: Optional[str],
+        azure_client_id: Optional[str],
+        azure_client_secret: Optional[str],
+        azure_tenant_id: Optional[str],
+    ):
+        """Initialize the Databricks Workspace client. Users may provide explicit credentials for a PAT, databricks
+        service principal oauth credentials, or azure service principal credentials. If no credentials are provided,
+        the underlying WorkspaceClient from `databricks.sdk` will attempt to read credentials from the environment or
+        from the `~/.databrickscfg` file. For more information, see the Databricks SDK docs on various ways you can
+        authenticate with the WorkspaceClient, through which most interactions with the Databricks API occur.
+        <https://docs.databricks.com/en/dev-tools/auth.html#authentication-for-databricks-automation>`_.
+        """
+        self._raise_if_multiple_auth_types(
+            token=token,
+            oauth_client_id=oauth_client_id,
+            oauth_client_secret=oauth_client_secret,
+            azure_client_id=azure_client_id,
+            azure_client_secret=azure_client_secret,
+            azure_tenant_id=azure_tenant_id,
+        )
+        self._assert_valid_credentials_combos(
+            oauth_client_id=oauth_client_id,
+            oauth_client_secret=oauth_client_secret,
+            azure_client_id=azure_client_id,
+            azure_client_secret=azure_client_secret,
+            azure_tenant_id=azure_tenant_id,
+        )
+        auth_type = self._get_auth_type(
+            token,
+            oauth_client_id,
+            oauth_client_secret,
+            azure_client_id,
+            azure_client_secret,
+            azure_tenant_id,
+        )
+        product_info = {"product": "dagster-databricks", "product_version": __version__}
+
+        # Figure out what credentials provider to use based on any explicitly-provided credentials. If none were
+        # provided, then fallback to the default credentials provider, which will attempt to read credentials from
+        # the environment or from a `~/.databrickscfg` file, if it exists.
+
+        if auth_type == AuthTypeEnum.OAUTH_M2M:
+            host = self._resolve_host(host)
+            c = Config(
+                host=host,
+                client_id=oauth_client_id,
+                client_secret=oauth_client_secret,
+                credentials_provider=oauth_service_principal,
+                **product_info,
+            )
+        elif auth_type == AuthTypeEnum.PAT:
+            host = self._resolve_host(host)
+            c = Config(host=host, token=token, credentials_provider=pat_auth, **product_info)
+        elif auth_type == AuthTypeEnum.AZURE_CLIENT_SECRET:
+            host = self._resolve_host(host)
+            c = Config(
+                host=host,
+                azure_client_id=azure_client_id,
+                azure_client_secret=azure_client_secret,
+                azure_tenant_id=azure_tenant_id,
+                credentials_provider=azure_service_principal,
+                **product_info,
+            )
+        elif auth_type == AuthTypeEnum.DEFAULT:
+            # Can be used to automatically read credentials from environment or ~/.databrickscfg file. This is common
+            # when launching Databricks jobs from a laptop development setting through Dagster
+            if host is not None:
+                # This allows for explicit override of the host, while letting other credentials be read from the
+                # environment or ~/.databrickscfg file
+                c = Config(host=host, credentials_provider=DefaultCredentials(), **product_info)
+            else:
+                # The initialization machinery in the Config object will look for the host and other auth info in the
+                # environment, as long as no values are provided for those attributes (including None)
+                c = Config(credentials_provider=DefaultCredentials(), **product_info)
+        else:
+            raise ValueError(f"Unexpected auth type {auth_type}")
+        self.config = c
+
+    def _raise_if_multiple_auth_types(
+        self,
+        token: Optional[str] = None,
+        oauth_client_id: Optional[str] = None,
+        oauth_client_secret: Optional[str] = None,
+        azure_client_id: Optional[str] = None,
+        azure_client_secret: Optional[str] = None,
+        azure_tenant_id: Optional[str] = None,
+    ):
+        more_than_one_auth_type_provided = (
+            sum(
+                [
+                    True
+                    for _ in [
+                        token,
+                        (oauth_client_id and oauth_client_secret),
+                        (azure_client_id and azure_client_secret and azure_tenant_id),
+                    ]
+                    if _
+                ]
+            )
+            > 1
+        )
+        if more_than_one_auth_type_provided:
+            raise ValueError(
+                "Can only provide one of token, oauth credentials, or azure credentials"
+            )
+
+    @staticmethod
+    def _get_auth_type(
+        token: Optional[str],
+        oauth_client_id: Optional[str],
+        oauth_client_secret: Optional[str],
+        azure_client_id: Optional[str],
+        azure_client_secret: Optional[str],
+        azure_tenant_id: Optional[str],
+    ) -> AuthTypeEnum:
+        """Get the type of authentication used to initialize the WorkspaceClient."""
+        if oauth_client_id and oauth_client_secret:
+            auth_type = AuthTypeEnum.OAUTH_M2M
+        elif token:
+            auth_type = AuthTypeEnum.PAT
+        elif azure_client_id and azure_client_secret and azure_tenant_id:
+            auth_type = AuthTypeEnum.AZURE_CLIENT_SECRET
+        else:
+            auth_type = AuthTypeEnum.DEFAULT
+        return auth_type
+
+    @staticmethod
+    def _assert_valid_credentials_combos(
+        oauth_client_id: Optional[str] = None,
+        oauth_client_secret: Optional[str] = None,
+        azure_client_id: Optional[str] = None,
+        azure_client_secret: Optional[str] = None,
+        azure_tenant_id: Optional[str] = None,
+    ):
+        """Ensure that all required credentials are provided for the given auth type."""
+        if (
+            oauth_client_id
+            and not oauth_client_secret
+            or oauth_client_secret
+            and not oauth_client_id
+        ):
+            raise ValueError(
+                "If using databricks service principal oauth credentials, both oauth_client_id and"
+                " oauth_client_secret must be provided"
+            )
+        if (
+            (azure_client_id and not azure_client_secret and not azure_tenant_id)
+            or (azure_client_secret and not azure_client_id and not azure_tenant_id)
+            or (azure_tenant_id and not azure_client_id and not azure_client_secret)
+        ):
+            raise ValueError(
+                "If using azure service principal auth, azure_client_id, azure_client_secret, and"
+                " azure_tenant_id must be provided"
+            )
+
+    def get_workspace_client(self) -> WorkspaceClient:
+        return WorkspaceClient(config=self.config)
+
+    @staticmethod
+    def _resolve_host(host: Optional[str]) -> str:
+        host = host if host else os.getenv("DATABRICKS_HOST")
+        if host is None:
+            raise ValueError(
+                "Must provide host explicitly or in DATABRICKS_HOST env var when providing"
+                " credentials explicitly"
+            )
+        return host
+
+
 class DatabricksClient:
     """A thin wrapper over the Databricks REST API."""
 
     def __init__(
         self,
-        host: str,
+        host: Optional[str] = None,
         token: Optional[str] = None,
         oauth_client_id: Optional[str] = None,
         oauth_client_secret: Optional[str] = None,
+        azure_client_id: Optional[str] = None,
+        azure_client_secret: Optional[str] = None,
+        azure_tenant_id: Optional[str] = None,
         workspace_id: Optional[str] = None,
     ):
         self.host = host
         self.workspace_id = workspace_id
 
-        self._workspace_client = WorkspaceClient(
-            host=host,
+        workspace_client_factory = WorkspaceClientFactory(
+            oauth_client_id=oauth_client_id,
+            oauth_client_secret=oauth_client_secret,
+            azure_client_id=azure_client_id,
+            azure_client_secret=azure_client_secret,
+            azure_tenant_id=azure_tenant_id,
             token=token,
-            client_id=oauth_client_id,
-            client_secret=oauth_client_secret,
-            product="dagster-databricks",
-            product_version=__version__,
+            host=host,
         )
+        self._workspace_client = workspace_client_factory.get_workspace_client()
 
         # TODO: This is the old shim client that we were previously using. Arguably this is
         # confusing for users to use since this is an unofficial wrapper around the documented
@@ -306,29 +502,35 @@ class DatabricksJobRunner:
 
     def __init__(
         self,
-        host: str,
+        host: Optional[str] = None,
         token: Optional[str] = None,
         oauth_client_id: Optional[str] = None,
         oauth_client_secret: Optional[str] = None,
+        azure_client_id: Optional[str] = None,
+        azure_client_secret: Optional[str] = None,
+        azure_tenant_id: Optional[str] = None,
         poll_interval_sec: float = 5,
         max_wait_time_sec: int = DEFAULT_RUN_MAX_WAIT_TIME_SEC,
     ):
-        self.host = check.str_param(host, "host")
-        check.invariant(
-            token is None or (oauth_client_id is None and oauth_client_secret is None),
-            "Must provide either databricks_token or oauth_credentials, but cannot provide both",
-        )
+        self.host = check.opt_str_param(host, "host")
         self.token = check.opt_str_param(token, "token")
-        self.oauth_client_id = check.opt_str_param(oauth_client_id, "oauth_client_id")
-        self.oauth_client_secret = check.opt_str_param(oauth_client_secret, "oauth_client_secret")
         self.poll_interval_sec = check.numeric_param(poll_interval_sec, "poll_interval_sec")
         self.max_wait_time_sec = check.int_param(max_wait_time_sec, "max_wait_time_sec")
+
+        oauth_client_id = check.opt_str_param(oauth_client_id, "oauth_client_id")
+        oauth_client_secret = check.opt_str_param(oauth_client_secret, "oauth_client_secret")
+        azure_client_id = check.opt_str_param(azure_client_id, "azure_client_id")
+        azure_client_secret = check.opt_str_param(azure_client_secret, "azure_client_secret")
+        azure_tenant_id = check.opt_str_param(azure_tenant_id, "azure_tenant_id")
 
         self._client: DatabricksClient = DatabricksClient(
             host=self.host,
             token=self.token,
             oauth_client_id=oauth_client_id,
             oauth_client_secret=oauth_client_secret,
+            azure_client_id=azure_client_id,
+            azure_client_secret=azure_client_secret,
+            azure_tenant_id=azure_tenant_id,
         )
 
     @property

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/resources.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/resources.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 
 from dagster import (
     Config,
@@ -23,18 +23,38 @@ class OauthCredentials(Config):
     client_secret: str = Field(description="OAuth client secret")
 
 
+class AzureServicePrincipalCredentials(Config):
+    """Azure service principal credentials for Azure Databricks.
+
+    See https://learn.microsoft.com/en-us/azure/databricks/dev-tools/auth#--azure-service-principal-authentication.
+    """
+
+    azure_client_id: str = Field(description="The client ID of the Azure service principal")
+    azure_client_secret: str = Field(description="The client secret of the Azure service principal")
+    azure_tenant_id: str = Field(description="The tenant ID of the Azure service principal")
+
+
 class DatabricksClientResource(ConfigurableResource, IAttachDifferentObjectToOpContext):
     """Resource which provides a Python client for interacting with Databricks within an
     op or asset.
     """
 
-    host: str = Field(description="Databricks host, e.g. https://uksouth.azuredatabricks.com")
+    host: Optional[str] = Field(
+        description="Databricks host, e.g. https://uksouth.azuredatabricks.com", default=None
+    )
     token: Optional[str] = Field(default=None, description="Databricks access token")
     oauth_credentials: Optional[OauthCredentials] = Field(
         default=None,
         description=(
             "Databricks OAuth credentials for using a service principal. See"
             " https://docs.databricks.com/en/dev-tools/auth.html#oauth-2-0"
+        ),
+    )
+    azure_credentials: Optional[AzureServicePrincipalCredentials] = Field(
+        default=None,
+        description=(
+            "Azure service principal credentials. See"
+            " https://learn.microsoft.com/en-us/azure/databricks/dev-tools/auth#requirements-for-oauth-u2m-authentication-setup"
         ),
     )
     workspace_id: Optional[str] = Field(
@@ -47,13 +67,17 @@ class DatabricksClientResource(ConfigurableResource, IAttachDifferentObjectToOpC
     )
 
     @compat_model_validator(mode="before")
-    def has_token_or_oauth_credentials(cls, values):
+    def has_token_or_oauth_credentials(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         token = values.get("token")
         oauth_credentials = values.get("oauth_credentials")
-        if not token and not oauth_credentials:
-            raise ValueError("Must provide either token or oauth_credentials")
-        if token and oauth_credentials:
-            raise ValueError("Must provide either token or oauth_credentials, not both")
+        azure_credentials = values.get("azure_credentials")
+        present = [True for v in [token, oauth_credentials, azure_credentials] if v is not None]
+        if len(present) > 1:
+            raise ValueError(
+                "Must provide one of token or oauth_credentials or azure_credentials, not multiple"
+            )
+        elif not len(present):
+            raise ValueError("Must provide one of token or oauth_credentials or azure_credentials")
         return values
 
     @classmethod
@@ -68,12 +92,24 @@ class DatabricksClientResource(ConfigurableResource, IAttachDifferentObjectToOpC
             client_id = None
             client_secret = None
 
+        if self.azure_credentials:
+            azure_client_id = self.azure_credentials.azure_client_id
+            azure_client_secret = self.azure_credentials.azure_client_secret
+            azure_tenant_id = self.azure_credentials.azure_tenant_id
+        else:
+            azure_client_id = None
+            azure_client_secret = None
+            azure_tenant_id = None
+
         return DatabricksClient(
             host=self.host,
             token=self.token,
             oauth_client_id=client_id,
             oauth_client_secret=client_secret,
             workspace_id=self.workspace_id,
+            azure_client_id=azure_client_id,
+            azure_client_secret=azure_client_secret,
+            azure_tenant_id=azure_tenant_id,
         )
 
     def get_object_to_set_on_execution_context(self) -> Any:

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_pyspark.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_pyspark.py
@@ -217,7 +217,7 @@ def test_pyspark_databricks(
                             config,
                             {
                                 "databricks_host": "https://",
-                                "databricks_token": "",
+                                "databricks_token": "abc123",
                                 "poll_interval_sec": 0.1,
                                 "local_dagster_job_package_path": os.path.abspath(
                                     os.path.dirname(__file__)
@@ -255,7 +255,7 @@ def test_pyspark_databricks(
                                 config,
                                 {
                                     "databricks_host": "https://",
-                                    "databricks_token": "",
+                                    "databricks_token": "abc123",
                                     "poll_interval_sec": 0.1,
                                     "local_dagster_job_package_path": os.path.abspath(
                                         os.path.dirname(__file__)


### PR DESCRIPTION
## Summary & Motivation
This PR includes two improvements: 
1) added ability for users to authenticate with Databricks using an Azure service principal (which is different from a Databricks service principal, for which authentication is already possible through the `oauth_client_id` / `oauth_client_secret` parameters.
2) Explicitly provide correct credentials_provider object for the credentials provided by the user to the Databricks WorkspaceClient at construction time. The underlying authentication mechanism in the databricks-sdk WorkspaceClient  does some really strange stuff as it works through a chain of possible auth methods, and tends to try to authenticate using its DefaultCredentialsProvider and environment variables if any databricks-related environment variables are present (even just DATABRICKS_HOST), regardless of whether explicit credentials are provided for things like the azure or databricks service principal. This was causing issues for users who might have a DATABRICKS_HOST env var set, but were trying to authenticate using a service principal. This fix also makes it easier for users to authenticate using a ~/.databrickscfg file, or just using env vars without explicitly passing them as Dagster config. 

## How I Tested These Changes

Authentication was tested for the DatabrickPysparkStepLauncher and DatabricksClient for oauth, personal access token, and azure service principal methods by testing that runs were able to launch successfully. Additional unit tests were added to ensure validation of combinations of credentials is working as expected.

## Note:
There are two tests [here](https://github.com/zyd14/dagster/blob/75e2f745ba80f1045cf4d3a5806b6754c18e3983/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_pipes.py#L1-L157) which rely on a real workspace client which seems to require DATABRICKS_HOST and DATABRICKS_TOKEN env vars. It looks like maybe these tests were made for some kind of manual integration testing? It's unclear to me how to get these tests running locally. If they're not made for manual integration testing, it seems that maybe some of the external dependencies like the WorkspaceClient should get mocked out.
