### PR TITLE
:feat: empty group name is error

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -619,7 +619,7 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
             "Cannot use both group_name and group_names_by_output_name",
         )
 
-        if group_name:
+        if group_name is not None:
             group_names_by_key = {
                 asset_key: group_name for asset_key in keys_by_output_name_with_prefix.values()
             }

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -460,7 +460,9 @@ class _Asset:
             partitions_def=self.partitions_def,
             partition_mappings=partition_mappings if partition_mappings else None,
             resource_defs=wrapped_resource_defs,
-            group_names_by_key={out_asset_key: self.group_name} if self.group_name else None,
+            group_names_by_key=(
+                {out_asset_key: self.group_name} if self.group_name is not None else None
+            ),
             freshness_policies_by_key=(
                 {out_asset_key: self.freshness_policy} if self.freshness_policy else None
             ),

--- a/python_modules/dagster/dagster/_core/definitions/load_assets_from_modules.py
+++ b/python_modules/dagster/dagster/_core/definitions/load_assets_from_modules.py
@@ -452,7 +452,9 @@ def assets_with_attributes(
         assets_defs = [
             asset.with_attributes(
                 group_names_by_key=(
-                    {asset_key: group_name for asset_key in asset.keys} if group_name else None
+                    {asset_key: group_name for asset_key in asset.keys}
+                    if group_name is not None
+                    else None
                 ),
                 freshness_policy=freshness_policy,
                 auto_materialize_policy=auto_materialize_policy,

--- a/python_modules/dagster/dagster/_core/definitions/utils.py
+++ b/python_modules/dagster/dagster/_core/definitions/utils.py
@@ -132,6 +132,11 @@ def validate_group_name(group_name: Optional[str]) -> str:
     if group_name:
         check_valid_chars(group_name)
         return group_name
+    elif group_name == "":
+        raise DagsterInvalidDefinitionError(
+            "You have passed an empty string for group_name."
+            "Set group_name=None to use the default group_name or set non-empty string"
+        )
     return DEFAULT_GROUP_NAME
 
 

--- a/python_modules/dagster/dagster/_core/definitions/utils.py
+++ b/python_modules/dagster/dagster/_core/definitions/utils.py
@@ -134,7 +134,7 @@ def validate_group_name(group_name: Optional[str]) -> str:
         return group_name
     elif group_name == "":
         raise DagsterInvalidDefinitionError(
-            "You have passed an empty string for group_name."
+            "Empty asset group name was provided, which is not permitted."
             "Set group_name=None to use the default group_name or set non-empty string"
         )
     return DEFAULT_GROUP_NAME

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -851,6 +851,18 @@ def test_group_name_requirements():
         def bad_name():
             return 2
 
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match=(
+            "You have passed an empty string for group_name."
+            "Set group_name=None to use the default group_name or set non-empty string"
+        ),
+    ):
+
+        @asset(group_name="")
+        def empty_name():
+            return 3
+
 
 def test_from_graph_w_key_prefix():
     @op

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -854,7 +854,7 @@ def test_group_name_requirements():
     with pytest.raises(
         DagsterInvalidDefinitionError,
         match=(
-            "You have passed an empty string for group_name."
+            "Empty asset group name was provided, which is not permitted."
             "Set group_name=None to use the default group_name or set non-empty string"
         ),
     ):


### PR DESCRIPTION
## Summary & Motivation
f an empty-string asset group_name is provided, it should trigger an error rather than silently adopting the default group name.

Additional information regarding this matter can be located in issue  #8667 

The rationale behind this decision is that supplying group_name="" can be misleading and is likely indicative of an issue in the process of constructing the group name. It is essential to actively inform the user of this situation and encourage them to specify a valid group_name or use None to indicate the default value.

## How I Tested These Changes
I added a new test in test_assets