### PR TITLE
Use "tight tree" algorithm as ranker in asset graph

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/Flags.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/Flags.tsx
@@ -17,6 +17,7 @@ export const FeatureFlag = {
   flagDAGSidebar: 'flagDAGSidebar' as const,
   flagDisableDAGCache: 'flagDisableDAGCache' as const,
   flagEnableAMPTimeline: 'flagEnableAMPTimeline' as const,
+  flagTightTreeDag: 'flagTightTreeDag' as const,
 };
 export type FeatureFlagType = keyof typeof FeatureFlag;
 

--- a/js_modules/dagster-ui/packages/ui-core/src/app/GraphQueryImpl.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/GraphQueryImpl.ts
@@ -84,14 +84,18 @@ function expansionDepthForClause(clause: string) {
   return clause.includes('*') ? Number.MAX_SAFE_INTEGER : clause.length;
 }
 
-export function filterByQuery<T extends GraphQueryItem>(items: T[], query: string) {
+export function filterByQuery<T extends GraphQueryItem>(
+  items: T[],
+  query: string,
+  flagTightTreeDag: boolean,
+) {
   if (query === '*') {
     return {all: items, applyingEmptyDefault: false, focus: []};
   }
   if (query === '') {
     return {
-      all: items.length >= MAX_RENDERED_FOR_EMPTY_QUERY ? [] : items,
-      applyingEmptyDefault: items.length >= MAX_RENDERED_FOR_EMPTY_QUERY,
+      all: !flagTightTreeDag && items.length >= MAX_RENDERED_FOR_EMPTY_QUERY ? [] : items,
+      applyingEmptyDefault: !flagTightTreeDag && items.length >= MAX_RENDERED_FOR_EMPTY_QUERY,
       focus: [],
     };
   }

--- a/js_modules/dagster-ui/packages/ui-core/src/app/getVisibleFeatureFlagRows.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/getVisibleFeatureFlagRows.tsx
@@ -61,4 +61,8 @@ export const getVisibleFeatureFlagRows = () => [
     key: 'Experimental Auto-materialize policy timeline page',
     flagType: FeatureFlag.flagEnableAMPTimeline,
   },
+  {
+    key: 'Experimental fast tight tree DAG algorithm',
+    flagType: FeatureFlag.flagTightTreeDag,
+  },
 ];

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/layout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/layout.ts
@@ -39,7 +39,7 @@ const GROUP_NODE_PREFIX = 'group__';
 
 const MARGIN = 100;
 
-export type LayoutAssetGraphOptions = {horizontalDAGs: boolean};
+export type LayoutAssetGraphOptions = {horizontalDAGs: boolean; tightTree: boolean};
 
 export const layoutAssetGraph = (
   graphData: GraphData,
@@ -139,6 +139,10 @@ export const layoutAssetGraph = (
     const label = path[path.length - 1] || '';
     g.setNode(id, getAssetLinkDimensions(label, opts));
   });
+
+  if (opts.tightTree) {
+    g.graph().ranker = 'tight-tree';
+  }
 
   dagre.layout(g);
 

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
@@ -183,7 +183,7 @@ export function useAssetLayout(graphData: GraphData) {
   const {flagDisableDAGCache} = useFeatureFlags();
 
   React.useEffect(() => {
-    const opts = {horizontalDAGs: flags.flagHorizontalDAGs};
+    const opts = {horizontalDAGs: flags.flagHorizontalDAGs, tightTree: flags.flagTightTreeDag};
 
     async function runAsyncLayout() {
       dispatch({type: 'loading'});


### PR DESCRIPTION
## Summary & Motivation

Did some profiling/debugging and found this algorithm is extremely fast even for 1000+ large asset graphs.
I also did not notice much of a difference in the graphs it produced except that we may need to redo our horizontal graph logic.

## How I Tested These Changes
Locally.
