### PR TITLE
[graphql] Sort nodes in resolve_assetNodes so they are stable across reload

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -909,7 +909,7 @@ class GrapheneQuery(graphene.ObjectType):
             asset_graph=load_asset_graph,
         )
 
-        return [
+        nodes = [
             GrapheneAssetNode(
                 node.repository_location,
                 node.external_repository,
@@ -921,6 +921,7 @@ class GrapheneQuery(graphene.ObjectType):
             )
             for node in results
         ]
+        return sorted(nodes, key=lambda node: node.id)
 
     def resolve_assetNodeOrError(self, graphene_info: ResolveInfo, assetKey: GrapheneAssetKeyInput):
         asset_key_input = cast(Mapping[str, Sequence[str]], assetKey)

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_assets.ambr
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_assets.ambr
@@ -448,7 +448,47 @@
       dict({
         'freshnessInfo': None,
         'freshnessPolicy': None,
-        'id': 'test.test_repo.["dummy_source_asset"]',
+        'id': 'test.test_repo.["asset_1"]',
+      }),
+      dict({
+        'freshnessInfo': None,
+        'freshnessPolicy': None,
+        'id': 'test.test_repo.["asset_2"]',
+      }),
+      dict({
+        'freshnessInfo': None,
+        'freshnessPolicy': None,
+        'id': 'test.test_repo.["asset_3"]',
+      }),
+      dict({
+        'freshnessInfo': None,
+        'freshnessPolicy': None,
+        'id': 'test.test_repo.["asset_one"]',
+      }),
+      dict({
+        'freshnessInfo': None,
+        'freshnessPolicy': None,
+        'id': 'test.test_repo.["asset_two"]',
+      }),
+      dict({
+        'freshnessInfo': None,
+        'freshnessPolicy': None,
+        'id': 'test.test_repo.["asset_yields_observation"]',
+      }),
+      dict({
+        'freshnessInfo': None,
+        'freshnessPolicy': None,
+        'id': 'test.test_repo.["bar"]',
+      }),
+      dict({
+        'freshnessInfo': None,
+        'freshnessPolicy': None,
+        'id': 'test.test_repo.["baz"]',
+      }),
+      dict({
+        'freshnessInfo': None,
+        'freshnessPolicy': None,
+        'id': 'test.test_repo.["check_in_op_asset"]',
       }),
       dict({
         'freshnessInfo': None,
@@ -458,7 +498,67 @@
       dict({
         'freshnessInfo': None,
         'freshnessPolicy': None,
-        'id': 'test.test_repo.["check_in_op_asset"]',
+        'id': 'test.test_repo.["downstream_asset"]',
+      }),
+      dict({
+        'freshnessInfo': None,
+        'freshnessPolicy': None,
+        'id': 'test.test_repo.["downstream_dynamic_partitioned_asset"]',
+      }),
+      dict({
+        'freshnessInfo': None,
+        'freshnessPolicy': None,
+        'id': 'test.test_repo.["downstream_static_partitioned_asset"]',
+      }),
+      dict({
+        'freshnessInfo': None,
+        'freshnessPolicy': None,
+        'id': 'test.test_repo.["downstream_time_partitioned_asset"]',
+      }),
+      dict({
+        'freshnessInfo': None,
+        'freshnessPolicy': None,
+        'id': 'test.test_repo.["downstream_weekly_partitioned_asset"]',
+      }),
+      dict({
+        'freshnessInfo': None,
+        'freshnessPolicy': None,
+        'id': 'test.test_repo.["dummy_source_asset"]',
+      }),
+      dict({
+        'freshnessInfo': None,
+        'freshnessPolicy': None,
+        'id': 'test.test_repo.["dynamic_in_multipartitions_fail"]',
+      }),
+      dict({
+        'freshnessInfo': None,
+        'freshnessPolicy': None,
+        'id': 'test.test_repo.["dynamic_in_multipartitions_success"]',
+      }),
+      dict({
+        'freshnessInfo': None,
+        'freshnessPolicy': None,
+        'id': 'test.test_repo.["executable_asset"]',
+      }),
+      dict({
+        'freshnessInfo': None,
+        'freshnessPolicy': None,
+        'id': 'test.test_repo.["fail_partition_materialization"]',
+      }),
+      dict({
+        'freshnessInfo': None,
+        'freshnessPolicy': None,
+        'id': 'test.test_repo.["first_asset"]',
+      }),
+      dict({
+        'freshnessInfo': None,
+        'freshnessPolicy': None,
+        'id': 'test.test_repo.["foo"]',
+      }),
+      dict({
+        'freshnessInfo': None,
+        'freshnessPolicy': None,
+        'id': 'test.test_repo.["foo_bar"]',
       }),
       dict({
         'freshnessInfo': dict({
@@ -489,42 +589,47 @@
       dict({
         'freshnessInfo': None,
         'freshnessPolicy': None,
+        'id': 'test.test_repo.["grouped_asset_1"]',
+      }),
+      dict({
+        'freshnessInfo': None,
+        'freshnessPolicy': None,
+        'id': 'test.test_repo.["grouped_asset_2"]',
+      }),
+      dict({
+        'freshnessInfo': None,
+        'freshnessPolicy': None,
+        'id': 'test.test_repo.["grouped_asset_4"]',
+      }),
+      dict({
+        'freshnessInfo': None,
+        'freshnessPolicy': None,
+        'id': 'test.test_repo.["hanging_asset"]',
+      }),
+      dict({
+        'freshnessInfo': None,
+        'freshnessPolicy': None,
+        'id': 'test.test_repo.["hanging_graph"]',
+      }),
+      dict({
+        'freshnessInfo': None,
+        'freshnessPolicy': None,
+        'id': 'test.test_repo.["hanging_partition_asset"]',
+      }),
+      dict({
+        'freshnessInfo': None,
+        'freshnessPolicy': None,
         'id': 'test.test_repo.["int_asset"]',
       }),
       dict({
         'freshnessInfo': None,
         'freshnessPolicy': None,
-        'id': 'test.test_repo.["str_asset"]',
+        'id': 'test.test_repo.["middle_static_partitioned_asset_1"]',
       }),
       dict({
         'freshnessInfo': None,
         'freshnessPolicy': None,
-        'id': 'test.test_repo.["no_multipartitions_1"]',
-      }),
-      dict({
-        'freshnessInfo': None,
-        'freshnessPolicy': None,
-        'id': 'test.test_repo.["one"]',
-      }),
-      dict({
-        'freshnessInfo': None,
-        'freshnessPolicy': None,
-        'id': 'test.test_repo.["two"]',
-      }),
-      dict({
-        'freshnessInfo': None,
-        'freshnessPolicy': None,
-        'id': 'test.test_repo.["typed_asset"]',
-      }),
-      dict({
-        'freshnessInfo': None,
-        'freshnessPolicy': None,
-        'id': 'test.test_repo.["unpartitioned_upstream_of_partitioned"]',
-      }),
-      dict({
-        'freshnessInfo': None,
-        'freshnessPolicy': None,
-        'id': 'test.test_repo.["untyped_asset"]',
+        'id': 'test.test_repo.["middle_static_partitioned_asset_2"]',
       }),
       dict({
         'freshnessInfo': None,
@@ -544,107 +649,32 @@
       dict({
         'freshnessInfo': None,
         'freshnessPolicy': None,
-        'id': 'test.test_repo.["dynamic_in_multipartitions_fail"]',
+        'id': 'test.test_repo.["never_runs_asset"]',
       }),
       dict({
         'freshnessInfo': None,
         'freshnessPolicy': None,
-        'id': 'test.test_repo.["dynamic_in_multipartitions_success"]',
+        'id': 'test.test_repo.["no_multipartitions_1"]',
       }),
       dict({
         'freshnessInfo': None,
         'freshnessPolicy': None,
-        'id': 'test.test_repo.["downstream_static_partitioned_asset"]',
+        'id': 'test.test_repo.["one"]',
       }),
       dict({
         'freshnessInfo': None,
         'freshnessPolicy': None,
-        'id': 'test.test_repo.["middle_static_partitioned_asset_1"]',
+        'id': 'test.test_repo.["str_asset"]',
       }),
       dict({
         'freshnessInfo': None,
         'freshnessPolicy': None,
-        'id': 'test.test_repo.["middle_static_partitioned_asset_2"]',
+        'id': 'test.test_repo.["two"]',
       }),
       dict({
         'freshnessInfo': None,
         'freshnessPolicy': None,
-        'id': 'test.test_repo.["upstream_static_partitioned_asset"]',
-      }),
-      dict({
-        'freshnessInfo': None,
-        'freshnessPolicy': None,
-        'id': 'test.test_repo.["hanging_partition_asset"]',
-      }),
-      dict({
-        'freshnessInfo': None,
-        'freshnessPolicy': None,
-        'id': 'test.test_repo.["upstream_daily_partitioned_asset"]',
-      }),
-      dict({
-        'freshnessInfo': None,
-        'freshnessPolicy': None,
-        'id': 'test.test_repo.["downstream_weekly_partitioned_asset"]',
-      }),
-      dict({
-        'freshnessInfo': None,
-        'freshnessPolicy': None,
-        'id': 'test.test_repo.["asset_1"]',
-      }),
-      dict({
-        'freshnessInfo': None,
-        'freshnessPolicy': None,
-        'id': 'test.test_repo.["downstream_dynamic_partitioned_asset"]',
-      }),
-      dict({
-        'freshnessInfo': None,
-        'freshnessPolicy': None,
-        'id': 'test.test_repo.["upstream_dynamic_partitioned_asset"]',
-      }),
-      dict({
-        'freshnessInfo': None,
-        'freshnessPolicy': None,
-        'id': 'test.test_repo.["executable_asset"]',
-      }),
-      dict({
-        'freshnessInfo': None,
-        'freshnessPolicy': None,
-        'id': 'test.test_repo.["unexecutable_asset"]',
-      }),
-      dict({
-        'freshnessInfo': None,
-        'freshnessPolicy': None,
-        'id': 'test.test_repo.["fail_partition_materialization"]',
-      }),
-      dict({
-        'freshnessInfo': None,
-        'freshnessPolicy': None,
-        'id': 'test.test_repo.["asset_2"]',
-      }),
-      dict({
-        'freshnessInfo': None,
-        'freshnessPolicy': None,
-        'id': 'test.test_repo.["asset_3"]',
-      }),
-      dict({
-        'freshnessInfo': None,
-        'freshnessPolicy': None,
-        'id': 'test.test_repo.["bar"]',
-      }),
-      dict({
-        'freshnessInfo': None,
-        'freshnessPolicy': None,
-        'id': 'test.test_repo.["baz"]',
-      }),
-      dict({
-        'freshnessInfo': None,
-        'freshnessPolicy': None,
-        'id': 'test.test_repo.["foo"]',
-      }),
-      dict({
-        'freshnessInfo': None,
-        'freshnessPolicy': None,
-        'id': 'test.test_repo.["foo_bar"]',
+        'id': 'test.test_repo.["typed_asset"]',
       }),
       dict({
         'freshnessInfo': None,
@@ -654,42 +684,7 @@
       dict({
         'freshnessInfo': None,
         'freshnessPolicy': None,
-        'id': 'test.test_repo.["downstream_asset"]',
-      }),
-      dict({
-        'freshnessInfo': None,
-        'freshnessPolicy': None,
-        'id': 'test.test_repo.["hanging_graph"]',
-      }),
-      dict({
-        'freshnessInfo': None,
-        'freshnessPolicy': None,
-        'id': 'test.test_repo.["first_asset"]',
-      }),
-      dict({
-        'freshnessInfo': None,
-        'freshnessPolicy': None,
-        'id': 'test.test_repo.["hanging_asset"]',
-      }),
-      dict({
-        'freshnessInfo': None,
-        'freshnessPolicy': None,
-        'id': 'test.test_repo.["never_runs_asset"]',
-      }),
-      dict({
-        'freshnessInfo': None,
-        'freshnessPolicy': None,
-        'id': 'test.test_repo.["grouped_asset_1"]',
-      }),
-      dict({
-        'freshnessInfo': None,
-        'freshnessPolicy': None,
-        'id': 'test.test_repo.["grouped_asset_2"]',
-      }),
-      dict({
-        'freshnessInfo': None,
-        'freshnessPolicy': None,
-        'id': 'test.test_repo.["grouped_asset_4"]',
+        'id': 'test.test_repo.["unexecutable_asset"]',
       }),
       dict({
         'freshnessInfo': None,
@@ -704,17 +699,27 @@
       dict({
         'freshnessInfo': None,
         'freshnessPolicy': None,
-        'id': 'test.test_repo.["asset_yields_observation"]',
+        'id': 'test.test_repo.["unpartitioned_upstream_of_partitioned"]',
       }),
       dict({
         'freshnessInfo': None,
         'freshnessPolicy': None,
-        'id': 'test.test_repo.["yield_partition_materialization"]',
+        'id': 'test.test_repo.["untyped_asset"]',
       }),
       dict({
         'freshnessInfo': None,
         'freshnessPolicy': None,
-        'id': 'test.test_repo.["downstream_time_partitioned_asset"]',
+        'id': 'test.test_repo.["upstream_daily_partitioned_asset"]',
+      }),
+      dict({
+        'freshnessInfo': None,
+        'freshnessPolicy': None,
+        'id': 'test.test_repo.["upstream_dynamic_partitioned_asset"]',
+      }),
+      dict({
+        'freshnessInfo': None,
+        'freshnessPolicy': None,
+        'id': 'test.test_repo.["upstream_static_partitioned_asset"]',
       }),
       dict({
         'freshnessInfo': None,
@@ -724,12 +729,7 @@
       dict({
         'freshnessInfo': None,
         'freshnessPolicy': None,
-        'id': 'test.test_repo.["asset_one"]',
-      }),
-      dict({
-        'freshnessInfo': None,
-        'freshnessPolicy': None,
-        'id': 'test.test_repo.["asset_two"]',
+        'id': 'test.test_repo.["yield_partition_materialization"]',
       }),
     ]),
   })


### PR DESCRIPTION
## Summary & Motivation

Hey folks - This PR sorts the asset nodes returned from resolve_assetNodes. We believe that instability in the sort order is causing cache invalidation in a few places in the JS and also (maybe?) causing the asset graph layout to change.

I've only observed sort differences across "reload definitions" calls, so we could potentially move this sorting to the load step also. 

I put this at the very end of the resolver after the ids have been generated for each node so the sorter should be a simple property retrieval. If this is slow, we could potentially dig deeper and see if it's the sort order of the repositories that is changing and not of individual assets, but sorting here seems like the best way to make sure the behavior doesn't change in the future.

## How I Tested These Changes

Ran existing tests, updated them as necessary