### PR TITLE
[ui] Fix job partitions UI showing 0 total partitions if >100 assets

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/AssetJobPartitionsView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/AssetJobPartitionsView.tsx
@@ -32,7 +32,7 @@ export const AssetJobPartitionsView: React.FC<{
   const {viewport, containerProps} = useViewport();
   const repositorySelector = repoAddressToSelector(repoAddress);
 
-  const assetGraph = useAssetGraphData('', {
+  const assetGraph = useAssetGraphData('*', {
     pipelineSelector: {
       pipelineName,
       repositoryName: repoAddress.name,


### PR DESCRIPTION
Fixes #17206

## Summary & Motivation

This partitions UI is actually showing "the partition status of all the assets in the job". Our mechanism for loading all the assets in the job is to ask for the graph data, but it was applying the "if more than 100, prompt them to choose '*'" behavior.

## How I Tested These Changes

Was able to repro and confirm the fix using Sandy's example in the ticket