### PR TITLE
Fix error on op selection

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/test/utils.py
+++ b/python_modules/dagster-graphql/dagster_graphql/test/utils.py
@@ -195,14 +195,16 @@ def infer_pipeline_selector(
     graphql_context: WorkspaceRequestContext,
     pipeline_name: str,
     op_selection: Optional[Sequence[str]] = None,
+    asset_selection: Optional[Sequence[GqlAssetKey]] = None,
+    asset_check_selection: Optional[Sequence[GqlAssetCheckHandle]] = None,
 ) -> Selector:
     selector = infer_repository_selector(graphql_context)
     selector.update(
         {
             "pipelineName": pipeline_name,
             "solidSelection": op_selection,
-            "assetSelection": [],
-            "assetCheckSelection": [],
+            "assetSelection": asset_selection,
+            "assetCheckSelection": asset_check_selection,
         }
     )
     return selector

--- a/python_modules/dagster-graphql/dagster_graphql/test/utils.py
+++ b/python_modules/dagster-graphql/dagster_graphql/test/utils.py
@@ -201,6 +201,8 @@ def infer_pipeline_selector(
         {
             "pipelineName": pipeline_name,
             "solidSelection": op_selection,
+            "assetSelection": [],
+            "assetCheckSelection": [],
         }
     )
     return selector

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -1461,7 +1461,9 @@ class DagsterInstance(DynamicPartitionsStore):
         check.opt_set_param(asset_selection, "asset_selection", of_type=AssetKey)
         check.opt_set_param(asset_check_selection, "asset_check_selection", of_type=AssetCheckKey)
 
-        if asset_selection is not None or asset_check_selection is not None:
+        # asset_selection gets coerced from [] to None, but asset_check_selection doesn't. We
+        # allow asset_check_selection to be [] when op_selection is set.
+        if asset_selection is not None or asset_check_selection:
             check.invariant(
                 op_selection is None,
                 "Cannot pass op_selection with either of asset_selection or asset_check_selection",

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -1461,8 +1461,10 @@ class DagsterInstance(DynamicPartitionsStore):
         check.opt_set_param(asset_selection, "asset_selection", of_type=AssetKey)
         check.opt_set_param(asset_check_selection, "asset_check_selection", of_type=AssetCheckKey)
 
-        # asset_selection gets coerced from [] to None, but asset_check_selection doesn't. We
-        # allow asset_check_selection to be [] when op_selection is set.
+        # asset_selection will always be None on an op job, but asset_check_selection may be
+        # None or []. This is because [] and None are different for asset checks: None means
+        # include all asset checks on selected assets, while [] means include no asset checks.
+        # In an op job (which has no asset checks), these two are equivalent.
         if asset_selection is not None or asset_check_selection:
             check.invariant(
                 op_selection is None,


### PR DESCRIPTION
With https://github.com/dagster-io/dagster/pull/16640/files#diff-3a0d9c2e7d488c33f5be6fdf25298f9b03277b1bc73417d53e0a51688d32e8b6, we started passing assetCheckSelection: [] for op jobs. This was untested, and hit this invariant because unlike for assets where [] gets turned in to None, we maintain a difference between None and [] with asset checks

This is ripe for rethinking