### PR TITLE
Add ephemeral storage to list of transient startup failures

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -717,6 +717,9 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
         if "Timeout waiting for network interface provisioning to complete" in stopped_reason:
             return True
 
+        if "Timeout waiting for EphemeralStorage provisioning to complete" in stopped_reason:
+            return True
+
         if "CannotPullContainerError" in stopped_reason and "i/o timeout" in stopped_reason:
             return True
 

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
@@ -1143,6 +1143,13 @@ def test_status(
     assert not started_health_check.transient
     assert started_health_check.run_worker_id == "abcdef"
 
+    task["stoppedReason"] = "Timeout waiting for EphemeralStorage provisioning to complete."
+
+    started_health_check = instance.run_launcher.check_run_worker_health(run)
+    assert started_health_check.status == WorkerStatus.FAILED
+    assert not started_health_check.transient
+    assert started_health_check.run_worker_id == "abcdef"
+
     task["stoppedReason"] = (
         "CannotPullContainerError: pull image manifest has been retried 5 time(s): Get"
         ' "https://myfakeimage:myfakemanifest":'


### PR DESCRIPTION
Summary:
Another new and exciting way for ECS run tasks to transiently fail on startup

Test Plan: Bk

## Summary & Motivation

## How I Tested These Changes
