### PR TITLE
Reverse horizontal + vertical asset graph layout options for tight-tree and take options into account for cache key.

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/layout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/layout.ts
@@ -47,27 +47,31 @@ export const layoutAssetGraph = (
 ): AssetGraphLayout => {
   const g = new dagre.graphlib.Graph({compound: true});
 
-  g.setGraph(
-    opts.horizontalDAGs
-      ? {
-          rankdir: 'LR',
-          marginx: MARGIN,
-          marginy: MARGIN,
-          nodesep: -10,
-          edgesep: 90,
-          ranksep: 60,
-          ranker: opts.tightTree ? 'tight-tree' : 'network-simplex',
-        }
-      : {
-          rankdir: 'TB',
-          marginx: MARGIN,
-          marginy: MARGIN,
-          nodesep: 40,
-          edgesep: 10,
-          ranksep: 10,
-          ranker: opts.tightTree ? 'tight-tree' : 'network-simplex',
-        },
-  );
+  const option1 = {
+    rankdir: 'LR',
+    marginx: MARGIN,
+    marginy: MARGIN,
+    nodesep: -10,
+    edgesep: 90,
+    ranksep: 60,
+    ranker: opts.tightTree ? 'tight-tree' : 'network-simplex',
+  };
+  const option2 = {
+    rankdir: 'TB',
+    marginx: MARGIN,
+    marginy: MARGIN,
+    nodesep: 40,
+    edgesep: 10,
+    ranksep: 10,
+    ranker: opts.tightTree ? 'tight-tree' : 'network-simplex',
+  };
+  let horizontal = option1;
+  let vertical = option2;
+  if (opts.tightTree) {
+    horizontal = option2;
+    vertical = option1;
+  }
+  g.setGraph(opts.horizontalDAGs ? horizontal : vertical);
   g.setDefaultEdgeLabel(() => ({}));
 
   const parentNodeIdForNode = (node: GraphNode) =>

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
@@ -33,7 +33,10 @@ const asyncGetFullOpLayout = asyncMemoize((ops: ILayoutOp[], opts: LayoutOpGraph
 
 // Asset Graph
 
-const _assetLayoutCacheKey = (graphData: GraphData, opts: LayoutAssetGraphOptions) => {
+const _assetLayoutCacheKey = (graphData: GraphData, opts?: LayoutAssetGraphOptions) => {
+  if (!opts) {
+    debugger;
+  }
   // Note: The "show secondary edges" toggle means that we need a cache key that incorporates
   // both the displayed nodes and the displayed edges.
 
@@ -58,8 +61,8 @@ const _assetLayoutCacheKey = (graphData: GraphData, opts: LayoutAssetGraphOption
     return newObj;
   }
 
-  return `${opts.horizontalDAGs ? 'horizontal:' : ''}${
-    opts.tightTree ? 'tight-tree:' : ''
+  return `${opts?.horizontalDAGs ? 'horizontal:' : ''}${
+    opts?.tightTree ? 'tight-tree:' : ''
   }${JSON.stringify({
     downstream: recreateObjectWithKeysSorted(graphData.downstream),
     upstream: recreateObjectWithKeysSorted(graphData.upstream),
@@ -178,15 +181,15 @@ export function useAssetLayout(graphData: GraphData) {
   const [state, dispatch] = React.useReducer(reducer, initialState);
   const flags = useFeatureFlags();
 
-  const cacheKey = _assetLayoutCacheKey(graphData);
+  const opts = {horizontalDAGs: flags.flagHorizontalDAGs, tightTree: flags.flagTightTreeDag};
+
+  const cacheKey = _assetLayoutCacheKey(graphData, opts);
   const nodeCount = Object.keys(graphData.nodes).length;
   const runAsync = nodeCount >= ASYNC_LAYOUT_SOLID_COUNT;
 
   const {flagDisableDAGCache} = useFeatureFlags();
 
   React.useEffect(() => {
-    const opts = {horizontalDAGs: flags.flagHorizontalDAGs, tightTree: flags.flagTightTreeDag};
-
     async function runAsyncLayout() {
       dispatch({type: 'loading'});
       let layout;

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
@@ -33,7 +33,7 @@ const asyncGetFullOpLayout = asyncMemoize((ops: ILayoutOp[], opts: LayoutOpGraph
 
 // Asset Graph
 
-const _assetLayoutCacheKey = (graphData: GraphData) => {
+const _assetLayoutCacheKey = (graphData: GraphData, opts: LayoutAssetGraphOptions) => {
   // Note: The "show secondary edges" toggle means that we need a cache key that incorporates
   // both the displayed nodes and the displayed edges.
 
@@ -58,11 +58,13 @@ const _assetLayoutCacheKey = (graphData: GraphData) => {
     return newObj;
   }
 
-  return JSON.stringify({
+  return `${opts.horizontalDAGs ? 'horizontal:' : ''}${
+    opts.tightTree ? 'tight-tree:' : ''
+  }${JSON.stringify({
     downstream: recreateObjectWithKeysSorted(graphData.downstream),
     upstream: recreateObjectWithKeysSorted(graphData.upstream),
     nodes: Object.keys(graphData.nodes).sort(),
-  });
+  })}`;
 };
 
 const getFullAssetLayout = memoize(layoutAssetGraph, _assetLayoutCacheKey);

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
@@ -33,10 +33,7 @@ const asyncGetFullOpLayout = asyncMemoize((ops: ILayoutOp[], opts: LayoutOpGraph
 
 // Asset Graph
 
-const _assetLayoutCacheKey = (graphData: GraphData, opts?: LayoutAssetGraphOptions) => {
-  if (!opts) {
-    debugger;
-  }
+const _assetLayoutCacheKey = (graphData: GraphData, opts: LayoutAssetGraphOptions) => {
   // Note: The "show secondary edges" toggle means that we need a cache key that incorporates
   // both the displayed nodes and the displayed edges.
 

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
@@ -178,7 +178,10 @@ export function useAssetLayout(graphData: GraphData) {
   const [state, dispatch] = React.useReducer(reducer, initialState);
   const flags = useFeatureFlags();
 
-  const opts = {horizontalDAGs: flags.flagHorizontalDAGs, tightTree: flags.flagTightTreeDag};
+  const opts = React.useMemo(
+    () => ({horizontalDAGs: flags.flagHorizontalDAGs, tightTree: flags.flagTightTreeDag}),
+    [flags],
+  );
 
   const cacheKey = _assetLayoutCacheKey(graphData, opts);
   const nodeCount = Object.keys(graphData.nodes).length;
@@ -204,7 +207,7 @@ export function useAssetLayout(graphData: GraphData) {
     } else {
       void runAsyncLayout();
     }
-  }, [cacheKey, graphData, runAsync, flags, flagDisableDAGCache]);
+  }, [cacheKey, graphData, runAsync, flags, flagDisableDAGCache, opts]);
 
   return {
     loading: state.loading || !state.layout || state.cacheKey !== cacheKey,


### PR DESCRIPTION
## Summary & Motivation

Reverse horizontal + vertical asset graph layout options for tight-tree (as suggested by @bengotow ) and also take options into account for the cache key.

## How I Tested These Changes

locally