### PR TITLE
[ui] Autodetect links in context.log messages, render clickable links

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/LogsRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/LogsRow.tsx
@@ -8,6 +8,7 @@ import {PythonErrorInfo} from '../app/PythonErrorInfo';
 import {setHighlightedGanttChartTime} from '../gantt/GanttChart';
 import {LogLevel} from '../graphql/types';
 import {METADATA_ENTRY_FRAGMENT} from '../metadata/MetadataEntry';
+import {autolinkTextContent} from '../ui/autolinking';
 
 import {CellTruncationProvider} from './CellTruncationProvider';
 import {
@@ -247,11 +248,26 @@ interface UnstructuredProps {
   metadata: IRunMetadataDict;
 }
 
+export const UnstructuredDialogContent = ({message}: {message: string}) => {
+  const messageEl = React.createRef<HTMLDivElement>();
+  React.useEffect(() => {
+    if (messageEl.current) {
+      autolinkTextContent(messageEl.current, {useIdleCallback: true});
+    }
+  }, [message, messageEl]);
+
+  return (
+    <div style={{whiteSpace: 'pre-wrap', maxHeight: '70vh', overflow: 'auto'}} ref={messageEl}>
+      {message}
+    </div>
+  );
+};
+
 export class Unstructured extends React.Component<UnstructuredProps> {
   onExpand = () => {
     showCustomAlert({
       title: 'Log',
-      body: <div style={{whiteSpace: 'pre-wrap'}}>{this.props.node.message}</div>,
+      body: <UnstructuredDialogContent message={this.props.node.message} />,
     });
   };
 
@@ -288,6 +304,18 @@ const UnstructuredMemoizedContent: React.FC<{
   const step = stepKey ? metadata.steps[stepKey] : null;
   const stepStartTime = step?.start;
 
+  // Note: We need to render enough of our text content that the TruncationProvider wrapping the
+  // element knows whether to show "View full message", but that shows a modal with the full
+  // message - the full text is never needed in the log table. Clip to a max of 15,000 characters
+  // to avoid rendering 1M characters in a small box. 15k is 2700x580px with no whitespace.
+  const messageClipped = node.message.length > 15000 ? node.message.slice(0, 15000) : node.message;
+  const messageEl = React.createRef<HTMLDivElement>();
+  React.useEffect(() => {
+    if (messageEl.current) {
+      autolinkTextContent(messageEl.current, {useIdleCallback: messageClipped.length > 5000});
+    }
+  }, [messageClipped, messageEl]);
+
   return (
     <Row
       level={node.level}
@@ -304,8 +332,8 @@ const UnstructuredMemoizedContent: React.FC<{
       <EventTypeColumn>
         <span style={{marginLeft: 8}}>{node.level}</span>
       </EventTypeColumn>
-      <Box padding={{horizontal: 12}} style={{flex: 1}}>
-        {node.message}
+      <Box padding={{horizontal: 12}} style={{flex: 1}} ref={messageEl}>
+        {messageClipped}
       </Box>
     </Row>
   );

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/__tests__/autolinking.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/__tests__/autolinking.test.tsx
@@ -1,0 +1,142 @@
+import {render, screen, waitFor} from '@testing-library/react';
+import React from 'react';
+
+import {autolinkTextContent} from '../autolinking';
+
+const Test = ({message}: {message: string}) => {
+  const messageEl = React.createRef<HTMLDivElement>();
+  React.useEffect(() => {
+    if (messageEl.current) {
+      // Note: window.requestIdleCallback is not available in the test runner
+      autolinkTextContent(messageEl.current, {useIdleCallback: false});
+    }
+  }, [message, messageEl]);
+
+  return <div ref={messageEl}>{message}</div>;
+};
+
+describe('autolinking', () => {
+  it('linkifies http, https, but not bare domains', async () => {
+    const message = `
+        This is my log message with some URLS.
+
+        Linked:
+        https://apple.com/
+        http://dagsterlabs.com/
+        http://127.0.0.1/my-internal-service?success=true
+        http://username:password@127.0.0.1:8000/my-internal-service?success=true#paragraph-2
+
+        Not linked:
+        google.com
+        idea.io
+        tel://5402502334
+        mailto:bengotow@dagsterlabs.com
+        ftp://apple.com
+
+        Edge cases:
+        https://www.w3.org/TR/html-aria/#docconformance
+        https://www.zoom.us/j/7647885554 // looks like a phone number
+
+        Google maps worst case scenario:
+        https://www.google.com/maps/place/Nashville,+TN/@36.1865271,-86.9503948,11z/data=!3m1!4b1!4m6!3m5!1s0x8864ec3213eb903d:0x7d3fb9d0a1e9daa0!8m2!3d36.1626638!4d-86.7816016!16zL20vMDVqYm4?entry=ttu
+        `;
+
+    const rendered = render(<Test message={message} />);
+
+    waitFor(() => expect(screen.getByRole('link')).toBeDefined());
+
+    const links = screen.getAllByRole('link');
+    const hrefs = Array.from(links).map((el) => el.getAttribute('href'));
+    expect(hrefs).toEqual([
+      'https://apple.com/',
+      'http://dagsterlabs.com/',
+      'http://127.0.0.1/my-internal-service?success=true',
+      'http://username:password@127.0.0.1:8000/my-internal-service?success=true#paragraph-2',
+      'https://www.w3.org/TR/html-aria/#docconformance',
+      'https://www.zoom.us/j/7647885554',
+      'https://www.google.com/maps/place/Nashville,+TN/@36.1865271,-86.9503948,11z/data=!3m1!4b1!4m6!3m5!1s0x8864ec3213eb903d:0x7d3fb9d0a1e9daa0!8m2!3d36.1626638!4d-86.7816016!16zL20vMDVqYm4?entry=ttu',
+    ]);
+
+    expect(rendered.container.textContent!.trim()).toEqual(message.trim());
+  });
+
+  it('linkifies URLs in the text without altering the node text content', async () => {
+    const message = `
+    This is my log message with some https://cloud.google.com/dataproc/ docs: {
+        "kind": "discovery#restDescription",
+        "description": "Manages Hadoop-based clusters and jobs on Google Cloud Platform.",
+        "servicePath": "",
+        "basePath": "",
+        "revision": "20190627",
+        "documentationLink": "https://cloud.google.com/dataproc/",
+        "id": "dataproc:v1",
+        "discoveryVersion": "v1",
+        "schemas": {
+            "Cluster": {
+                "description": "Describes the identifying information, config, and status of a cluster of Compute Engine instances.",
+                "type": "object",
+                "properties": {
+                    "labels": {
+                        "description": "Optional. The labels to associate with this cluster. Label keys must contain 1 to 63 characters, and must conform to RFC 1035 (https://www.ietf.org/rfc/rfc1035.txt). Label values may be empty, but, if present, must contain 1 to 63 characters, and must conform to RFC 1035 (https://www.ietf.org/rfc/rfc1035.txt). No more than 32 labels can be associated with a cluster.",
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        }
+                    },
+                    "status": {
+                        "$ref": "ClusterStatus",
+                        "description": "Output only. Cluster status."
+                    },
+                    "metrics": {
+                        "$ref": "ClusterMetrics",
+                        "description": "Contains cluster daemon metrics such as HDFS and YARN stats.Beta Feature: This report is available for testing purposes only. It may be changed before final release."
+                    },
+                    "config": {
+                        "$ref": "ClusterConfig",
+                        "description": "Required. The cluster config. Note that Cloud Dataproc may set default values, and values may change when clusters are updated."
+                    },
+                    "statusHistory": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "ClusterStatus"
+                        },
+                        "description": "Output only. The previous cluster status."
+                    },
+                    "clusterUuid": {
+                        "description": "Output only. A cluster UUID (Unique Universal Identifier). Cloud Dataproc generates this value when it creates the cluster.",
+                        "type": "string"
+                    },
+                    "clusterName": {
+                        "type": "string",
+                        "description": "Required. The cluster name. Cluster names within a project must be unique. Names of deleted clusters can be reused."
+                    },
+                    "projectId": {
+                        "description": "Required. The Google Cloud Platform project ID that the cluster belongs to.",
+                        "type": "string"
+                    }
+                },
+                "id": "Cluster"
+            },
+        },
+        "version": "v1",
+        "baseUrl": "https://dataproc.googleapis.com/"
+    }
+    `;
+
+    const rendered = render(<Test message={message} />);
+
+    waitFor(() => expect(screen.getByRole('link')).toBeDefined());
+
+    const links = screen.getAllByRole('link');
+    const hrefs = Array.from(links).map((el) => el.getAttribute('href'));
+    expect(hrefs).toEqual([
+      'https://cloud.google.com/dataproc/',
+      'https://cloud.google.com/dataproc/',
+      'https://www.ietf.org/rfc/rfc1035.txt',
+      'https://www.ietf.org/rfc/rfc1035.txt',
+      'https://dataproc.googleapis.com/',
+    ]);
+
+    expect(rendered.container.textContent!.trim()).toEqual(message.trim());
+  });
+});

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/autolinking.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/autolinking.ts
@@ -1,0 +1,201 @@
+type AutolinkMatcher = {
+  // A regexp matching the text that should be linked
+  regexp: RegExp;
+  // A prefix that should be prepended to the text to create the link URL.
+  // If the regexp matches ben@dagsterlabs.com, the prefix would be "mailto:".
+  prefix: string;
+};
+
+function wrapRangeInNode(range: Range, nodeName: string) {
+  const newNode = document.createElement(nodeName);
+  try {
+    range.surroundContents(newNode);
+  } catch (error) {
+    newNode.appendChild(range.extractContents());
+    range.insertNode(newNode);
+  }
+  return newNode;
+}
+
+// If we're given an enormous text block, give up rather than trying to linkify
+// it's contents.
+const MAX_ATTEMPTED_TEXT_CONTENT_LENGTH = 1_000_000;
+
+// Test cases: https://regex101.com/r/pD7iS5/4
+function buildURLRegex() {
+  const commonTlds = [
+    'com',
+    'org',
+    'edu',
+    'gov',
+    'uk',
+    'net',
+    'ca',
+    'de',
+    'jp',
+    'fr',
+    'au',
+    'us',
+    'ru',
+    'ch',
+    'it',
+    'nl',
+    'se',
+    'no',
+    'es',
+    'mil',
+    'ly',
+  ];
+
+  const parts = [
+    '(',
+    // one of:
+    '(',
+    // This OR block matches any TLD if the URL includes a scheme, and only
+    // the top ten TLDs if the scheme is omitted.
+    // YES - https://dagsterlabs.ai
+    // YES - https://10.2.3.1
+    // YES - dagsterlabs.com
+    // NO  - dagsterlabs.ai
+    '(',
+    // scheme, ala https:// (mandatory)
+    '([A-Za-z]{3,9}:(?:\\/\\/))',
+
+    // username:password (optional)
+    '(?:[\\-;:&=\\+\\$,\\w]+@)?',
+
+    // one of:
+    '(',
+    // domain with any tld
+    '([a-zA-Z0-9-_]+\\.)*[a-zA-Z0-9][a-zA-Z0-9-_]+\\.[a-zA-Z]{2,11}',
+
+    '|',
+
+    // ip address
+    '(?:[0-9]{1,3}\\.){3}[0-9]{1,3}',
+    ')',
+
+    '|',
+
+    // scheme, ala https:// (mandatory)
+    '([A-Za-z]{3,9}:(?:\\/\\/))',
+
+    // username:password (optional)
+    '(?:[\\-;:&=\\+\\$,\\w]+@)?',
+
+    // one of:
+    '(',
+    // domain with common tld
+    `([a-zA-Z0-9-_]+\\.)*[a-zA-Z0-9][a-zA-Z0-9-_]+\\.(?:${commonTlds.join('|')})`,
+
+    '|',
+
+    // ip address
+    '(?:[0-9]{1,3}\\.){3}[0-9]{1,3}',
+    ')',
+    ')',
+
+    // :port (optional)
+    '(?::d*)?',
+
+    '|',
+
+    // mailto:username@password.com
+    'mailto:\\/*(?:\\w+\\.|[\\-;:&=\\+\\$.,\\w]+@)[A-Za-z0-9\\.\\-]+',
+    ')',
+
+    // optionally followed by:
+    '(',
+    // URL components
+    // (last character must not be puncation, hence two groups)
+    '(?:[\\+=~%\\/\\.\\w\\-_@:]*[\\+~%\\/\\w\\-:_])?',
+
+    // optionally followed by one or more query string ?asd=asd&as=asd type sections
+    "(?:\\?[\\-\\+=&;:%@$\\(\\)'\\*\\/~\\!\\.,\\w_]*[\\-\\+=&;~%@\\w_\\/])*",
+
+    // optionally followed by a #search-or-hash section
+    "(?:#['\\$\\&\\(\\)\\*\\+,;=\\.\\!\\/\\\\\\w%-?]*[\\/\\\\\\w])?",
+    ')?',
+    ')',
+  ];
+
+  return new RegExp(parts.join(''), 'gi');
+}
+
+function runOnTextNode(node: Node, matchers: AutolinkMatcher[]) {
+  // Important: This method iterates through the matchers to find the LONGEST match,
+  // and then inserts the <a> tag for it and operates on the remaining previous / next
+  // siblings.
+  //
+  // It looks for the longest match so that URLs that contain phone number fragments
+  // are parsed as URLs, etc. Here's an example:
+  // https://www.zoom.com/j/9158385033
+  //
+  // We might be able to "order" the regexps carefully to achieve the same result, but
+  // that would be pretty fragile and this "longest" algo more clearly expresses the
+  // behavior we really want.
+  //
+  if (node.parentElement) {
+    const withinScript = node.parentElement.tagName === 'SCRIPT';
+    const withinStyle = node.parentElement.tagName === 'STYLE';
+    const withinA = node.parentElement.closest('a') !== null;
+    if (withinScript || withinA || withinStyle) {
+      return;
+    }
+  }
+  if (!node.textContent) {
+    return;
+  }
+  const nodeTextContentLen = node.textContent.trim().length;
+  if (nodeTextContentLen < 4 || nodeTextContentLen > MAX_ATTEMPTED_TEXT_CONTENT_LENGTH) {
+    return;
+  }
+
+  let longest: {prefix: string; match: RegExpMatchArray} | null = null;
+  let longestLength = null;
+  for (const {prefix, regexp} of matchers) {
+    regexp.lastIndex = 0;
+    const match = regexp.exec(node.textContent);
+    if (match !== null) {
+      if (!longestLength || match[0].length > longestLength) {
+        longest = {prefix, match};
+        longestLength = match[0].length;
+      }
+    }
+  }
+
+  if (longest) {
+    const {prefix, match} = longest;
+    const href = `${prefix}${match[0]}`;
+    const range = document.createRange();
+    range.setStart(node, match.index || 0);
+    range.setEnd(node, (match.index || 0) + match[0].length);
+    const aTag = wrapRangeInNode(range, 'A') as HTMLAnchorElement;
+    aTag.href = href;
+    aTag.rel = 'nofollow noreferrer';
+    aTag.target = '_blank';
+    aTag.title = href;
+  }
+}
+
+export function autolinkTextContent(el: HTMLElement, options: {useIdleCallback: boolean}) {
+  const textWalker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
+  const matchers: AutolinkMatcher[] = [{prefix: '', regexp: buildURLRegex()}];
+
+  if (options.useIdleCallback) {
+    const fn: IdleRequestCallback = (deadline) => {
+      while (textWalker.nextNode()) {
+        runOnTextNode(textWalker.currentNode, matchers);
+        if (deadline.timeRemaining() <= 0) {
+          window.requestIdleCallback(fn, {timeout: 500});
+          return;
+        }
+      }
+    };
+    window.requestIdleCallback(fn, {timeout: 500});
+  } else {
+    while (textWalker.nextNode()) {
+      runOnTextNode(textWalker.currentNode, matchers);
+    }
+  }
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/autolinking.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/autolinking.ts
@@ -59,7 +59,8 @@ function buildURLRegex() {
     // NO  - dagsterlabs.ai
     '(',
     // scheme, ala https:// (mandatory)
-    '([A-Za-z]{3,9}:(?:\\/\\/))',
+    // '([A-Za-z]{3,9}:(?:\\/\\/))', << more open ended
+    '((http|https):(?:\\/\\/))',
 
     // username:password (optional)
     '(?:[\\-;:&=\\+\\$,\\w]+@)?',
@@ -78,7 +79,7 @@ function buildURLRegex() {
     '|',
 
     // scheme, ala https:// (mandatory)
-    '([A-Za-z]{3,9}:(?:\\/\\/))',
+    '((http|https):(?:\\/\\/))',
 
     // username:password (optional)
     '(?:[\\-;:&=\\+\\$,\\w]+@)?',
@@ -97,18 +98,13 @@ function buildURLRegex() {
 
     // :port (optional)
     '(?::d*)?',
-
-    '|',
-
-    // mailto:username@password.com
-    'mailto:\\/*(?:\\w+\\.|[\\-;:&=\\+\\$.,\\w]+@)[A-Za-z0-9\\.\\-]+',
     ')',
 
     // optionally followed by:
     '(',
     // URL components
     // (last character must not be puncation, hence two groups)
-    '(?:[\\+=~%\\/\\.\\w\\-_@:]*[\\+~%\\/\\w\\-:_])?',
+    '(?:[\\+=~%\\/\\.\\w\\-_@:,!]*[\\+~%\\/\\w\\-:_])?',
 
     // optionally followed by one or more query string ?asd=asd&as=asd type sections
     "(?:\\?[\\-\\+=&;:%@$\\(\\)'\\*\\/~\\!\\.,\\w_]*[\\-\\+=&;~%@\\w_\\/])*",


### PR DESCRIPTION
## Summary & Motivation

This is a fix for #15862. It's largely a port of the autolinker I wrote for Mailspring [here](https://github.com/Foundry376/Mailspring/blob/master/app/src/services/autolinker.ts), which doesn't require external packages and has gotten a handful of bug fixes over the years (MIT-licensed so it's safe to reference.)

The code uses a useEffect to look at the text node after it's rendered in React and adds the `a` tags directly at the DOM level. All the links open in new tabs and have rel=nofollow, noreferrer for safety's sake. It uses useIdleCallback + a DOM treewalker so if the text is huge it doesn't block the JS loop.

I also noticed that we render the full text of the logs into the log rows, even if they're enormous. We only ever show 12 lines with a conditional "Show More", so I added a sanity check that cuts the string down to 15k characters. That should be enough to trigger "Show More", even on a 4000px wide screen, and saves us from computing the bounding box of such enormous blocks of text. Hopefully nobody has been logging like this 😅

![image](https://github.com/dagster-io/dagster/assets/1037212/bcf74cb8-d6ae-445f-a0ba-63b360714eae)

## How I Tested These Changes

I created a test asset that logged both short and 500k+ text blocks containing links. 