### PR TITLE
Add DebugCrashFlags support to asset daemon

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/job_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/job_backfill.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import time
 from typing import Callable, Iterable, Mapping, Optional, Sequence, Tuple, cast
 
@@ -32,6 +31,7 @@ from dagster._core.workspace.context import (
     BaseWorkspaceRequestContext,
     IWorkspaceProcessContext,
 )
+from dagster._utils import check_for_debug_crash
 from dagster._utils.error import SerializableErrorInfo
 from dagster._utils.merger import merge_dicts
 
@@ -68,7 +68,7 @@ def execute_job_backfill_iteration(
         chunk, checkpoint, has_more = _get_partitions_chunk(
             instance, logger, backfill, CHECKPOINT_COUNT
         )
-        _check_for_debug_crash(debug_crash_flags, "BEFORE_SUBMIT")
+        check_for_debug_crash(debug_crash_flags, "BEFORE_SUBMIT")
 
         if chunk:
             for _run_id in submit_backfill_runs(
@@ -83,7 +83,7 @@ def execute_job_backfill_iteration(
                 if backfill.status != BulkActionStatus.REQUESTED:
                     return
 
-        _check_for_debug_crash(debug_crash_flags, "AFTER_SUBMIT")
+        check_for_debug_crash(debug_crash_flags, "AFTER_SUBMIT")
 
         if has_more:
             # refetch, in case the backfill was updated in the meantime
@@ -357,16 +357,3 @@ def _fetch_last_run(
     )
 
     return runs[0] if runs else None
-
-
-def _check_for_debug_crash(debug_crash_flags: Optional[Mapping[str, int]], key) -> None:
-    if not debug_crash_flags:
-        return
-
-    kill_signal = debug_crash_flags.get(key)
-    if not kill_signal:
-        return
-
-    os.kill(os.getpid(), kill_signal)
-    time.sleep(10)
-    raise Exception("Process didn't terminate after sending crash signal")

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -1,8 +1,6 @@
 import logging
-import os
 import sys
 import threading
-import time
 from collections import defaultdict
 from concurrent.futures import Future, ThreadPoolExecutor
 from contextlib import ExitStack
@@ -55,7 +53,7 @@ from dagster._core.telemetry import SENSOR_RUN_CREATED, hash_name, log_action
 from dagster._core.utils import InheritContextThreadPoolExecutor
 from dagster._core.workspace.context import IWorkspaceProcessContext
 from dagster._scheduler.stale import resolve_stale_or_missing_assets
-from dagster._utils import DebugCrashFlags, SingleInstigatorDebugCrashFlags
+from dagster._utils import DebugCrashFlags, SingleInstigatorDebugCrashFlags, check_for_debug_crash
 from dagster._utils.error import SerializableErrorInfo, serializable_error_info_from_exc_info
 from dagster._utils.merger import merge_dicts
 
@@ -223,21 +221,6 @@ class SensorLaunchContext:
                 before=pendulum.now("UTC").subtract(days=day_offset).timestamp(),
                 tick_statuses=list(statuses),
             )
-
-
-def _check_for_debug_crash(
-    debug_crash_flags: Optional[SingleInstigatorDebugCrashFlags], key: str
-) -> None:
-    if not debug_crash_flags:
-        return
-
-    kill_signal = debug_crash_flags.get(key)
-    if not kill_signal:
-        return
-
-    os.kill(os.getpid(), kill_signal)
-    time.sleep(10)
-    raise Exception("Process didn't terminate after sending crash signal")
 
 
 VERBOSE_LOGS_INTERVAL = 60
@@ -525,12 +508,12 @@ def _process_tick_generator(
             )
         )
 
-        _check_for_debug_crash(sensor_debug_crash_flags, "TICK_CREATED")
+        check_for_debug_crash(sensor_debug_crash_flags, "TICK_CREATED")
 
         with SensorLaunchContext(
             external_sensor, tick, instance, logger, tick_retention_settings, sensor_state_lock
         ) as tick_context:
-            _check_for_debug_crash(sensor_debug_crash_flags, "TICK_HELD")
+            check_for_debug_crash(sensor_debug_crash_flags, "TICK_HELD")
             yield from _evaluate_sensor(
                 workspace_process_context,
                 tick_context,
@@ -624,7 +607,7 @@ def _submit_run_request(
     if isinstance(run, SkippedSensorRun):
         return SubmitRunRequestResult(run_key=run_request.run_key, error_info=None, run=run)
 
-    _check_for_debug_crash(sensor_debug_crash_flags, "RUN_CREATED")
+    check_for_debug_crash(sensor_debug_crash_flags, "RUN_CREATED")
 
     error_info = None
     try:
@@ -635,7 +618,7 @@ def _submit_run_request(
         error_info = serializable_error_info_from_exc_info(sys.exc_info())
         logger.error(f"Run {run.run_id} created successfully but failed to launch: {error_info}")
 
-    _check_for_debug_crash(sensor_debug_crash_flags, "RUN_LAUNCHED")
+    check_for_debug_crash(sensor_debug_crash_flags, "RUN_LAUNCHED")
     return SubmitRunRequestResult(run_key=run_request.run_key, error_info=error_info, run=run)
 
 

--- a/python_modules/dagster/dagster/_scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/_scheduler/scheduler.py
@@ -1,9 +1,7 @@
 import datetime
 import logging
-import os
 import sys
 import threading
-import time
 from collections import defaultdict
 from concurrent.futures import Future, ThreadPoolExecutor
 from contextlib import ExitStack
@@ -41,7 +39,7 @@ from dagster._core.utils import InheritContextThreadPoolExecutor
 from dagster._core.workspace.context import IWorkspaceProcessContext
 from dagster._scheduler.stale import resolve_stale_or_missing_assets
 from dagster._seven.compat.pendulum import to_timezone
-from dagster._utils import DebugCrashFlags, SingleInstigatorDebugCrashFlags
+from dagster._utils import DebugCrashFlags, SingleInstigatorDebugCrashFlags, check_for_debug_crash
 from dagster._utils.error import SerializableErrorInfo, serializable_error_info_from_exc_info
 from dagster._utils.log import default_date_format_string
 from dagster._utils.merger import merge_dicts
@@ -538,13 +536,13 @@ def launch_scheduled_runs_for_schedule_iterator(
                 )
             )
 
-            _check_for_debug_crash(schedule_debug_crash_flags, "TICK_CREATED")
+            check_for_debug_crash(schedule_debug_crash_flags, "TICK_CREATED")
 
         with _ScheduleLaunchContext(
             external_schedule, tick, instance, logger, tick_retention_settings
         ) as tick_context:
             try:
-                _check_for_debug_crash(schedule_debug_crash_flags, "TICK_HELD")
+                check_for_debug_crash(schedule_debug_crash_flags, "TICK_HELD")
 
                 yield from _schedule_runs_at_time(
                     workspace_process_context,
@@ -598,21 +596,6 @@ def launch_scheduled_runs_for_schedule_iterator(
         instigator_data,
         end_datetime_utc.timestamp(),
     )
-
-
-def _check_for_debug_crash(
-    debug_crash_flags: Optional[SingleInstigatorDebugCrashFlags], key: str
-) -> None:
-    if not debug_crash_flags:
-        return
-
-    kill_signal = debug_crash_flags.get(key)
-    if not kill_signal:
-        return
-
-    os.kill(os.getpid(), kill_signal)
-    time.sleep(10)
-    raise Exception("Process didn't terminate after sending crash signal")
 
 
 class SubmitRunRequestResult(NamedTuple):
@@ -676,7 +659,7 @@ def _submit_run_request(
             run_request,
         )
 
-    _check_for_debug_crash(debug_crash_flags, "RUN_CREATED")
+    check_for_debug_crash(debug_crash_flags, "RUN_CREATED")
 
     error_info = None
 
@@ -787,11 +770,11 @@ def _schedule_runs_at_time(
             )
         else:
             run = check.not_none(run_request_result.submitted_run)
-            _check_for_debug_crash(debug_crash_flags, "RUN_LAUNCHED")
+            check_for_debug_crash(debug_crash_flags, "RUN_LAUNCHED")
             tick_context.add_run_info(run_id=run.run_id, run_key=run_request_result.run_key)
-            _check_for_debug_crash(debug_crash_flags, "RUN_ADDED")
+            check_for_debug_crash(debug_crash_flags, "RUN_ADDED")
 
-    _check_for_debug_crash(debug_crash_flags, "TICK_SUCCESS")
+    check_for_debug_crash(debug_crash_flags, "TICK_SUCCESS")
     tick_context.update_state(TickStatus.SUCCESS)
 
 

--- a/python_modules/dagster/dagster/_utils/__init__.py
+++ b/python_modules/dagster/dagster/_utils/__init__.py
@@ -82,6 +82,21 @@ SingleInstigatorDebugCrashFlags: TypeAlias = Mapping[str, int]
 DebugCrashFlags: TypeAlias = Mapping[str, SingleInstigatorDebugCrashFlags]
 
 
+def check_for_debug_crash(
+    debug_crash_flags: Optional[SingleInstigatorDebugCrashFlags], key: str
+) -> None:
+    if not debug_crash_flags:
+        return
+
+    kill_signal = debug_crash_flags.get(key)
+    if not kill_signal:
+        return
+
+    os.kill(os.getpid(), kill_signal)
+    time.sleep(10)
+    raise Exception("Process didn't terminate after sending crash signal")
+
+
 # Use this to get the "library version" (pre-1.0 version) from the "core version" (post 1.0
 # version). 16 is from the 0.16.0 that library versions stayed on when core went to 1.0.0.
 def library_version_from_core_version(core_version: str) -> str:

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
@@ -18,6 +18,7 @@ from typing import (
     Union,
 )
 
+import dagster._check as check
 import mock
 import pendulum
 import pytest
@@ -77,6 +78,7 @@ from dagster._core.test_utils import (
 )
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._daemon.asset_daemon import AssetDaemon
+from dagster._utils import SingleInstigatorDebugCrashFlags
 
 
 class RunSpec(NamedTuple):
@@ -418,7 +420,12 @@ class AssetReconciliationScenario(
 
         return run_requests, cursor, evaluations
 
-    def do_daemon_scenario(self, instance, scenario_name):
+    def do_daemon_scenario(
+        self,
+        instance,
+        scenario_name,
+        debug_crash_flags: Optional[SingleInstigatorDebugCrashFlags] = None,
+    ):
         assert bool(self.assets) != bool(
             self.code_locations
         ), "Must specify either assets or code_locations"
@@ -457,7 +464,9 @@ class AssetReconciliationScenario(
                     )
                 else:
                     all_assets = [
-                        asset for assets in self.code_locations.values() for asset in assets
+                        asset
+                        for assets in check.not_none(self.code_locations).values()
+                        for asset in assets
                     ]
                     do_run(
                         asset_keys=run.asset_keys,
@@ -494,7 +503,11 @@ class AssetReconciliationScenario(
                 ), workspace.get_code_location_error("test_location")
 
                 try:
-                    list(AssetDaemon(interval_seconds=42).run_iteration(workspace_context))
+                    list(
+                        AssetDaemon(interval_seconds=42)._run_iteration_impl(  # noqa: SLF001
+                            workspace_context, debug_crash_flags or {}
+                        )
+                    )
 
                     if self.expected_error_message:
                         raise Exception(

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon.py
@@ -1,6 +1,11 @@
+import multiprocessing
+from typing import TYPE_CHECKING
+
 import pendulum
 import pytest
 from dagster import AssetKey
+from dagster._core.instance import DagsterInstance
+from dagster._core.instance.ref import InstanceRef
 from dagster._core.instance_for_test import instance_for_test
 from dagster._core.scheduler.instigation import (
     InstigatorType,
@@ -9,6 +14,9 @@ from dagster._core.scheduler.instigation import (
 )
 from dagster._core.storage.dagster_run import DagsterRunStatus
 from dagster._core.storage.tags import PARTITION_NAME_TAG
+from dagster._core.test_utils import (
+    cleanup_test_instance,
+)
 from dagster._daemon.asset_daemon import (
     FIXED_AUTO_MATERIALIZATION_INSTIGATOR_NAME,
     FIXED_AUTO_MATERIALIZATION_ORIGIN_ID,
@@ -16,6 +24,7 @@ from dagster._daemon.asset_daemon import (
     get_current_evaluation_id,
     set_auto_materialize_paused,
 )
+from dagster._utils import SingleInstigatorDebugCrashFlags, get_terminate_signal
 
 from .scenarios.auto_materialize_policy_scenarios import (
     auto_materialize_policy_scenarios,
@@ -23,6 +32,9 @@ from .scenarios.auto_materialize_policy_scenarios import (
 from .scenarios.auto_observe_scenarios import auto_observe_scenarios
 from .scenarios.multi_code_location_scenarios import multi_code_location_scenarios
 from .scenarios.scenarios import ASSET_RECONCILIATION_SCENARIOS
+
+if TYPE_CHECKING:
+    from pendulum.datetime import DateTime
 
 
 @pytest.fixture
@@ -168,6 +180,90 @@ def test_error_daemon_tick(daemon_not_paused_instance):
         assert ticks[0].tick_data.auto_materialize_evaluation_id == 1
         assert ticks[0].tick_data.run_requests == []
         assert error_asset_scenario.expected_error_message in str(ticks[0].tick_data.error)
+
+
+spawn_ctx = multiprocessing.get_context("spawn")
+
+
+def _test_asset_daemon_in_subprocess(
+    scenario_name,
+    instance_ref: InstanceRef,
+    execution_datetime: "DateTime",
+    debug_crash_flags: SingleInstigatorDebugCrashFlags,
+) -> None:
+    scenario = daemon_scenarios[scenario_name]
+    with DagsterInstance.from_ref(instance_ref) as instance:
+        try:
+            with pendulum.test(execution_datetime):
+                scenario.do_daemon_scenario(
+                    instance, scenario_name=scenario_name, debug_crash_flags=debug_crash_flags
+                )
+        finally:
+            cleanup_test_instance(instance)
+
+
+def test_asset_daemon_failure_recovery(daemon_not_paused_instance):
+    # Verifies that if we crash after creating run requests, the tick can retry and continue
+    # on without issue
+    instance = daemon_not_paused_instance
+    freeze_datetime = pendulum.now("UTC")
+    scenario = daemon_scenarios["auto_materialize_policy_lazy_freshness_missing"]
+
+    # Run a tick where the daemon crashes after run requests are created
+    asset_daemon_process = spawn_ctx.Process(
+        target=_test_asset_daemon_in_subprocess,
+        args=[
+            "auto_materialize_policy_lazy_freshness_missing",
+            instance.get_ref(),
+            freeze_datetime,
+            {"RUN_REQUESTS_CREATED": get_terminate_signal()},
+        ],
+    )
+    asset_daemon_process.start()
+    asset_daemon_process.join(timeout=60)
+
+    ticks = instance.get_ticks(
+        origin_id=FIXED_AUTO_MATERIALIZATION_ORIGIN_ID,
+        selector_id=FIXED_AUTO_MATERIALIZATION_SELECTOR_ID,
+    )
+
+    assert len(ticks) == 1
+    assert ticks[0]
+    assert ticks[0].status == TickStatus.STARTED
+    assert ticks[0].timestamp == freeze_datetime.timestamp()
+    assert not ticks[0].tick_data.end_timestamp == freeze_datetime.timestamp()
+    assert not len(ticks[0].tick_data.run_ids)
+    assert ticks[0].tick_data.auto_materialize_evaluation_id == 1
+
+    freeze_datetime = pendulum.now("UTC").add(seconds=1)
+
+    # Run another tick with no crash, daemon continues on and succeeds
+    asset_daemon_process = spawn_ctx.Process(
+        target=_test_asset_daemon_in_subprocess,
+        args=[
+            "auto_materialize_policy_lazy_freshness_missing",
+            instance.get_ref(),
+            freeze_datetime,
+            None,  # No crash this time
+        ],
+    )
+    asset_daemon_process.start()
+    asset_daemon_process.join(timeout=60)
+
+    ticks = instance.get_ticks(
+        origin_id=FIXED_AUTO_MATERIALIZATION_ORIGIN_ID,
+        selector_id=FIXED_AUTO_MATERIALIZATION_SELECTOR_ID,
+    )
+
+    assert len(ticks) == 2
+
+    assert ticks[0]
+    assert ticks[0].status == TickStatus.SUCCESS
+    assert ticks[0].timestamp == freeze_datetime.timestamp()
+    assert ticks[0].tick_data.end_timestamp == freeze_datetime.timestamp()
+    assert len(ticks[0].tick_data.run_ids) == 1
+    assert ticks[0].tick_data.auto_materialize_evaluation_id == 1
+    assert ticks[0].tick_data.run_requests == scenario.expected_run_requests
 
 
 @pytest.fixture


### PR DESCRIPTION
Summary:
This adds the ability to write tests that crash the asset daemon at various points and introspect the resulting ticks/runs/asset evaluations. No behavior changes wrt idempotency and failure recovery yet - those will come next, but for now just a test that verifies the current behavior when there's a crash after creating run requests - the tick stays in STARTED, and on the next iteration another tick is created with the same evaluation ID. Subsequent PRs will add additional crash callsites and actually customize our idempotency / failure recovery behavior.

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes
