### PR TITLE
fix input mapping exception text for @graph and @graph_asset

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
@@ -432,11 +432,16 @@ def resolve_checked_op_fn_inputs(
     undeclared_inputs = explicit_names - used_inputs
     if not has_kwargs and undeclared_inputs:
         undeclared_inputs_printed = ", '".join(undeclared_inputs)
+        nothing_exemption = (
+            ", except for Ins that have the Nothing dagster_type"
+            if decorator_name not in {"@graph", "@graph_asset"}
+            else ""
+        )
         raise DagsterInvalidDefinitionError(
             f"{decorator_name} '{fn_name}' decorated function does not have argument(s)"
             f" '{undeclared_inputs_printed}'. {decorator_name}-decorated functions should have a"
-            " keyword argument for each of their Ins, except for Ins that have the Nothing"
-            " dagster_type. Alternatively, they can accept **kwargs."
+            f" keyword argument for each of their Ins{nothing_exemption}. Alternatively, they can"
+            " accept **kwargs."
         )
 
     inferred_props = {

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
@@ -10,6 +10,7 @@ from dagster import (
     DailyPartitionsDefinition,
     DimensionPartitionMapping,
     FreshnessPolicy,
+    GraphIn,
     IdentityPartitionMapping,
     In,
     MultiPartitionMapping,
@@ -23,6 +24,7 @@ from dagster import (
     TimeWindowPartitionMapping,
     _check as check,
     build_asset_context,
+    graph,
     graph_asset,
     graph_multi_asset,
     io_manager,
@@ -1250,3 +1252,21 @@ def test_dynamic_graph_asset_ins():
         return wait_until_job_done(run_id)
 
     assert materialize([some_graph_asset, foo]).success
+
+
+def test_graph_inputs_error():
+    try:
+
+        @graph_asset(ins={"start": AssetIn(dagster_type=Nothing)})
+        def _(): ...
+
+    except DagsterInvalidDefinitionError as err:
+        assert "except for Ins that have the Nothing dagster_type" not in str(err)
+
+    try:
+
+        @graph(ins={"start": GraphIn()})
+        def _(): ...
+
+    except DagsterInvalidDefinitionError as err:
+        assert "except for Ins that have the Nothing dagster_type" not in str(err)


### PR DESCRIPTION
The exemption around `Nothing` inputs does not apply to graph/graph_asset so don't include it in the error message

## How I Tested These Changes

added test