### PR TITLE
fix(dbt): add explicit test for empty `profiles_dir`

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -604,19 +604,22 @@ class DbtCliResource(ConfigurableResource):
         return os.fspath(resolved_project_dir)
 
     @validator("profiles_dir")
-    def validate_profiles_dir(cls, profiles_dir: str) -> str:
-        resolved_project_dir = cls._validate_absolute_path_exists(profiles_dir)
+    def validate_profiles_dir(cls, profiles_dir: Optional[str]) -> Optional[str]:
+        if profiles_dir is None:
+            return None
+
+        resolved_profiles_dir = cls._validate_absolute_path_exists(profiles_dir)
 
         cls._validate_path_contains_file(
-            path=resolved_project_dir,
+            path=resolved_profiles_dir,
             file_name=DBT_PROFILES_YML_NAME,
             error_message=(
-                f"{resolved_project_dir} does not contain a {DBT_PROFILES_YML_NAME} file. Please"
+                f"{resolved_profiles_dir} does not contain a {DBT_PROFILES_YML_NAME} file. Please"
                 " specify a valid path to a dbt profile directory."
             ),
         )
 
-        return os.fspath(resolved_project_dir)
+        return os.fspath(resolved_profiles_dir)
 
     @validator("dbt_executable")
     def validate_dbt_executable(cls, dbt_executable: str) -> str:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resources_v2.py
@@ -215,8 +215,8 @@ def test_dbt_profile_configuration() -> None:
     assert dbt_cli_invocation.is_successful()
 
 
-@pytest.mark.parametrize("profiles_dir", [TEST_PROJECT_DIR, Path(TEST_PROJECT_DIR)])
-def test_dbt_profile_dir_configuration(profiles_dir: Union[str, Path]) -> None:
+@pytest.mark.parametrize("profiles_dir", [None, TEST_PROJECT_DIR, Path(TEST_PROJECT_DIR)])
+def test_dbt_profiles_dir_configuration(profiles_dir: Union[str, Path]) -> None:
     dbt = DbtCliResource(
         project_dir=TEST_PROJECT_DIR,
         profiles_dir=profiles_dir,  # type: ignore


### PR DESCRIPTION
## Summary & Motivation
The internal resource framework had some shifts to make way for Pydantic 2 support. Before these changes, the resolution of `Optional` parameters that are explicitly given a `None` did not match their defaults.

Here, we explicitly test that passing in `None` to an optional paramter like `profiles_dir` does not cause any errors. 

## How I Tested These Changes
pytest with explicit `None` passed into `profiles_dir`. Then try cherry-picking into `dagster-1.5.3` release branch, see that it succeeds (since this was inadvertently hidden by our framework changes to the resource system). 
