### PR TITLE
[pythonic config][fix] Properly handle Pydantic validators w/ default values

### DIFF
--- a/python_modules/dagster/dagster/_config/pythonic_config/config.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/config.py
@@ -45,6 +45,7 @@ from .pydantic_compat_layer import (
     model_config,
     model_fields,
 )
+from .type_check_utils import is_literal
 from .typing_utils import BaseConfigMeta
 
 try:
@@ -270,7 +271,7 @@ class Config(MakeConfigCacheable, metaclass=BaseConfigMeta):
             field = model_fields(self).get(key)
 
             if field:
-                if value == field.default:
+                if not is_literal(field.annotation) and value == field.default:
                     continue
 
                 resolved_field_name = field.alias or key

--- a/python_modules/dagster/dagster/_config/pythonic_config/config.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/config.py
@@ -211,13 +211,6 @@ class Config(MakeConfigCacheable, metaclass=BaseConfigMeta):
         for key, value in config_dict.items():
             field = model_fields(self).get(key)
 
-            # This is useful in Pydantic 2.x when reconstructing a config object from a dict
-            # e.g. when instantiating a resource at runtime from its config dict
-            # In Pydantic 1.x, this is a no-op, since a non-required field without a
-            # value provided will default to None (required & optional are the same in 1.x)
-            if field and not field.is_required() and value is None:
-                continue
-
             if field and field.discriminator:
                 nested_dict = value
 
@@ -225,7 +218,7 @@ class Config(MakeConfigCacheable, metaclass=BaseConfigMeta):
                 if isinstance(value, Config):
                     nested_dict = _discriminated_union_config_dict_to_selector_config_dict(
                         discriminator_key,
-                        value._get_non_none_public_field_values(),  # noqa: SLF001
+                        value._get_non_default_public_field_values(),  # noqa: SLF001
                     )
 
                 nested_items = list(check.is_dict(nested_dict).items())
@@ -257,15 +250,15 @@ class Config(MakeConfigCacheable, metaclass=BaseConfigMeta):
         Inner fields are recursively converted to dictionaries, meaning nested config objects
         or EnvVars will be converted to the appropriate dictionary representation.
         """
-        public_fields = self._get_non_none_public_field_values()
+        public_fields = self._get_non_default_public_field_values()
         return {
             k: _config_value_to_dict_representation(model_fields(self).get(k), v)
             for k, v in public_fields.items()
         }
 
-    def _get_non_none_public_field_values(self) -> Mapping[str, Any]:
+    def _get_non_default_public_field_values(self) -> Mapping[str, Any]:
         """Returns a dictionary representation of this config object,
-        ignoring any private fields, and any optional fields that are None.
+        ignoring any private fields, and any defaulted fields which are equal to the default value.
 
         Inner fields are returned as-is in the dictionary,
         meaning any nested config objects will be returned as config objects, not dictionaries.
@@ -277,6 +270,9 @@ class Config(MakeConfigCacheable, metaclass=BaseConfigMeta):
             field = model_fields(self).get(key)
 
             if field:
+                if value == field.default:
+                    continue
+
                 resolved_field_name = field.alias or key
                 output[resolved_field_name] = value
             else:

--- a/python_modules/dagster/dagster/_config/pythonic_config/resource.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/resource.py
@@ -450,7 +450,7 @@ class ConfigurableResourceFactory(
         # Since Resource extends BaseModel and is a dataclass, we know that the
         # signature of any __init__ method will always consist of the fields
         # of this class. We can therefore safely pass in the values as kwargs.
-        out = self.__class__(**{**self._get_non_none_public_field_values(), **values})
+        out = self.__class__(**{**self._get_non_default_public_field_values(), **values})
         out._state__internal__ = out._state__internal__._replace(  # noqa: SLF001
             resource_context=self._state__internal__.resource_context
         )

--- a/python_modules/dagster/dagster/_config/pythonic_config/type_check_utils.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/type_check_utils.py
@@ -1,4 +1,4 @@
-from typing import Any, Type, Union
+from typing import Any, Literal, Type, Union
 
 try:
     # this type only exists in python 3.10+
@@ -48,3 +48,7 @@ def is_optional(annotation: Type) -> bool:
         return len(get_args(annotation)) == 2 and type(None) in get_args(annotation)
 
     return False
+
+
+def is_literal(annotation: Type) -> bool:
+    return get_origin(annotation) == Literal

--- a/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_validation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_validation.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import pytest
 from dagster import job, op
 from dagster._config.pythonic_config import Config
@@ -63,3 +65,63 @@ def test_validators_basic() -> None:
             {"ops": {"greet_user": {"config": {"name": "Arthur", "username": "arthur"}}}}
         )
     assert not executed
+
+
+def test_validator_default_contract() -> None:
+    # ensures Pydantic's validator decorator works as expected
+    # in particular that it does not validate default values
+    # but does validate any explicit inputs matching the default
+    class UserConfig(Config):
+        name: Optional[str] = None
+
+        @validator("name")
+        def name_must_not_be_provided(cls, name):
+            raise ValueError("I always error with a non-default value!")
+
+    UserConfig()
+    with pytest.raises(ValidationError, match="I always error with a non-default value!"):
+        UserConfig(name="Arthur Miller")
+    with pytest.raises(ValidationError, match="I always error with a non-default value!"):
+        UserConfig(name=None)
+
+
+def test_validator_default_contract_nested() -> None:
+    # as above, more complex case
+    class InnerConfig(Config):
+        name: Optional[str] = None
+
+        @validator("name")
+        def name_must_not_be_provided(cls, name):
+            raise ValueError("Inner always errors with a non-default value!")
+
+    class OuterConfig(Config):
+        inner: InnerConfig
+        name: Optional[str] = None
+
+        @validator("name")
+        def name_must_not_be_provided(cls, name):
+            raise ValueError("Outer always errors with a non-default value!")
+
+    OuterConfig(inner=InnerConfig())
+    with pytest.raises(ValidationError, match="Outer always errors with a non-default value!"):
+        OuterConfig(inner=InnerConfig(), name=None)
+    with pytest.raises(ValidationError, match="Inner always errors with a non-default value!"):
+        OuterConfig(inner=InnerConfig(name=None))
+
+    executed = {}
+
+    @op
+    def my_op(config: OuterConfig) -> None:
+        executed["my_op"] = True
+
+    @job
+    def my_job() -> None:
+        my_op()
+
+    assert my_job.execute_in_process().success
+    assert executed["my_op"]
+
+    executed.clear()
+
+    with pytest.raises(ValidationError, match="Outer always errors with a non-default value!"):
+        my_job.execute_in_process({"ops": {"my_op": {"config": {"name": None}}}})

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_validation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_validation.py
@@ -1,0 +1,87 @@
+from typing import Optional
+
+import pytest
+from dagster import Definitions, asset, job, op
+from dagster._config.pythonic_config import Config, ConfigurableResource
+from dagster._core.errors import DagsterResourceFunctionError
+from pydantic import ValidationError, validator
+
+
+def test_validator_default_contract_nested() -> None:
+    # ensures Pydantic's validator decorator works as expected
+    # in particular that it does not validate default values
+    # but does validate any explicit inputs matching the default
+    class InnerConfig(Config):
+        name: Optional[str] = None
+
+        @validator("name")
+        def name_must_not_be_provided(cls, name):
+            raise ValueError("Inner always errors with a non-default value!")
+
+    class MyResource(ConfigurableResource):
+        inner: InnerConfig
+        name: Optional[str] = None
+
+        @validator("name")
+        def name_must_not_be_provided(cls, name):
+            raise ValueError("Resource always errors with a non-default value!")
+
+    MyResource(inner=InnerConfig())
+    with pytest.raises(ValidationError, match="Resource always errors with a non-default value!"):
+        MyResource(inner=InnerConfig(), name=None)
+    with pytest.raises(ValidationError, match="Inner always errors with a non-default value!"):
+        MyResource(inner=InnerConfig(name=None))
+
+    executed = {}
+
+    @op
+    def my_op(resource: MyResource) -> None:
+        executed["my_op"] = True
+
+    @job
+    def my_job() -> None:
+        my_op()
+
+    assert my_job.execute_in_process(
+        resources={"resource": MyResource(inner=InnerConfig())}
+    ).success
+    assert executed["my_op"]
+
+    executed.clear()
+
+
+def test_validator_default_contract_runtime_config() -> None:
+    # as above, runtime resource configuration
+    class InnerConfig(Config):
+        name: Optional[str] = None
+
+        @validator("name")
+        def name_must_not_be_provided(cls, name):
+            raise ValueError("Inner always errors with a non-default value!")
+
+    class MyResource(ConfigurableResource):
+        inner: InnerConfig
+        name: Optional[str] = None
+
+        @validator("name")
+        def name_must_not_be_provided(cls, name):
+            raise ValueError("Resource always errors with a non-default value!")
+
+    executed = {}
+
+    @asset
+    def hello_world_asset(my_resource: MyResource):
+        executed["hello_world_asset"] = True
+
+    defs = Definitions(
+        assets=[hello_world_asset],
+        resources={"my_resource": MyResource.configure_at_launch()},
+    )
+
+    defs.get_implicit_global_asset_job_def().execute_in_process()
+    assert executed["hello_world_asset"]
+
+    with pytest.raises(DagsterResourceFunctionError):
+        defs.get_implicit_global_asset_job_def().execute_in_process(
+            {"resources": {"my_resource": {"config": {"name": None}}}}
+        )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources.py
@@ -481,7 +481,7 @@ class DbtCliClientResource(ConfigurableResourceWithCliFlags, IAttachDifferentObj
         context = self.get_resource_context()
         default_flags = {
             k: v
-            for k, v in self._get_non_none_public_field_values().items()
+            for k, v in self._get_non_default_public_field_values().items()
             if k not in COMMON_OPTION_KEYS
         }
 


### PR DESCRIPTION
## Summary

Updates our handling of passing defaulted values back into Pydantic model constructors. Previously, we'd pass in a model's config dictionary into its constructor, but this breaks the Pydantic [validator expectation](https://docs.pydantic.dev/latest/concepts/validators/#validation-of-default-values) that validators only run when a user explicitly provides input.

This was already not working as expected, but was further obfuscated by some changes in #16435.

## Test Plan

Adds some unit tests to test out this behavior in various config/resource scenarios.
