### PR TITLE
[graphql] Allow fetching targeted ranges for any asset in backfill, fix links

### DIFF
--- a/js_modules/dagster-ui/packages/app-oss/src/pages/index.tsx
+++ b/js_modules/dagster-ui/packages/app-oss/src/pages/index.tsx
@@ -39,6 +39,8 @@ if (process.env.NODE_ENV === 'development' && typeof window !== 'undefined') {
     }
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    return originalError(...args);
+    const err = originalError(...args);
+    Object.setPrototypeOf(err, window.Error.prototype);
+    return err;
   };
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -2634,6 +2634,7 @@ type PartitionBackfill {
   error: PythonError
   partitionStatuses: PartitionStatuses
   partitionStatusCounts: [PartitionStatusCounts!]!
+  partitionsTargetedForAssetKey(assetKey: AssetKeyInput): AssetBackfillTargetPartitions
   isAssetBackfill: Boolean!
   assetBackfillData: AssetBackfillData
   hasCancelPermission: Boolean!
@@ -2650,10 +2651,19 @@ enum BulkActionStatus {
   CANCELING
 }
 
+type AssetBackfillTargetPartitions {
+  ranges: [PartitionKeyRange!]
+  partitionKeys: [String!]
+}
+
+type PartitionKeyRange {
+  start: String!
+  end: String!
+}
+
 type AssetBackfillData {
   assetBackfillStatuses: [AssetBackfillStatus!]!
-  rootAssetTargetedRanges: [PartitionKeyRange!]
-  rootAssetTargetedPartitions: [String!]
+  rootTargetedPartitions: AssetBackfillTargetPartitions!
 }
 
 union AssetBackfillStatus = AssetPartitionsStatusCounts | UnpartitionedAssetStatus
@@ -2671,11 +2681,6 @@ type UnpartitionedAssetStatus {
   inProgress: Boolean!
   materialized: Boolean!
   failed: Boolean!
-}
-
-type PartitionKeyRange {
-  start: String!
-  end: String!
 }
 
 union PartitionSetOrError = PartitionSet | PartitionSetNotFoundError | PythonError

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -108,11 +108,16 @@ export type AssetAssetObservationsArgs = {
 export type AssetBackfillData = {
   __typename: 'AssetBackfillData';
   assetBackfillStatuses: Array<AssetBackfillStatus>;
-  rootAssetTargetedPartitions: Maybe<Array<Scalars['String']>>;
-  rootAssetTargetedRanges: Maybe<Array<PartitionKeyRange>>;
+  rootTargetedPartitions: AssetBackfillTargetPartitions;
 };
 
 export type AssetBackfillStatus = AssetPartitionsStatusCounts | UnpartitionedAssetStatus;
+
+export type AssetBackfillTargetPartitions = {
+  __typename: 'AssetBackfillTargetPartitions';
+  partitionKeys: Maybe<Array<Scalars['String']>>;
+  ranges: Maybe<Array<PartitionKeyRange>>;
+};
 
 export type AssetCheck = {
   __typename: 'AssetCheck';
@@ -2360,6 +2365,7 @@ export type PartitionBackfill = {
   partitionSetName: Maybe<Scalars['String']>;
   partitionStatusCounts: Array<PartitionStatusCounts>;
   partitionStatuses: Maybe<PartitionStatuses>;
+  partitionsTargetedForAssetKey: Maybe<AssetBackfillTargetPartitions>;
   reexecutionSteps: Maybe<Array<Scalars['String']>>;
   runs: Array<Run>;
   status: BulkActionStatus;
@@ -2367,6 +2373,10 @@ export type PartitionBackfill = {
   timestamp: Scalars['Float'];
   unfinishedRuns: Array<Run>;
   user: Maybe<Scalars['String']>;
+};
+
+export type PartitionBackfillPartitionsTargetedForAssetKeyArgs = {
+  assetKey?: InputMaybe<AssetKeyInput>;
 };
 
 export type PartitionBackfillRunsArgs = {
@@ -4538,14 +4548,26 @@ export const buildAssetBackfillData = (
       overrides && overrides.hasOwnProperty('assetBackfillStatuses')
         ? overrides.assetBackfillStatuses!
         : [],
-    rootAssetTargetedPartitions:
-      overrides && overrides.hasOwnProperty('rootAssetTargetedPartitions')
-        ? overrides.rootAssetTargetedPartitions!
-        : [],
-    rootAssetTargetedRanges:
-      overrides && overrides.hasOwnProperty('rootAssetTargetedRanges')
-        ? overrides.rootAssetTargetedRanges!
-        : [],
+    rootTargetedPartitions:
+      overrides && overrides.hasOwnProperty('rootTargetedPartitions')
+        ? overrides.rootTargetedPartitions!
+        : relationshipsToOmit.has('AssetBackfillTargetPartitions')
+        ? ({} as AssetBackfillTargetPartitions)
+        : buildAssetBackfillTargetPartitions({}, relationshipsToOmit),
+  };
+};
+
+export const buildAssetBackfillTargetPartitions = (
+  overrides?: Partial<AssetBackfillTargetPartitions>,
+  _relationshipsToOmit: Set<string> = new Set(),
+): {__typename: 'AssetBackfillTargetPartitions'} & AssetBackfillTargetPartitions => {
+  const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
+  relationshipsToOmit.add('AssetBackfillTargetPartitions');
+  return {
+    __typename: 'AssetBackfillTargetPartitions',
+    partitionKeys:
+      overrides && overrides.hasOwnProperty('partitionKeys') ? overrides.partitionKeys! : [],
+    ranges: overrides && overrides.hasOwnProperty('ranges') ? overrides.ranges! : [],
   };
 };
 
@@ -8899,6 +8921,12 @@ export const buildPartitionBackfill = (
         : relationshipsToOmit.has('PartitionStatuses')
         ? ({} as PartitionStatuses)
         : buildPartitionStatuses({}, relationshipsToOmit),
+    partitionsTargetedForAssetKey:
+      overrides && overrides.hasOwnProperty('partitionsTargetedForAssetKey')
+        ? overrides.partitionsTargetedForAssetKey!
+        : relationshipsToOmit.has('AssetBackfillTargetPartitions')
+        ? ({} as AssetBackfillTargetPartitions)
+        : buildAssetBackfillTargetPartitions({}, relationshipsToOmit),
     reexecutionSteps:
       overrides && overrides.hasOwnProperty('reexecutionSteps') ? overrides.reexecutionSteps! : [],
     runs: overrides && overrides.hasOwnProperty('runs') ? overrides.runs! : [],

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/__tests__/BackfillPage.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/__tests__/BackfillPage.test.tsx
@@ -8,6 +8,7 @@ import {AnalyticsContext} from '../../../app/analytics';
 import {
   BulkActionStatus,
   buildAssetBackfillData,
+  buildAssetBackfillTargetPartitions,
   buildAssetKey,
   buildAssetPartitionsStatusCounts,
   buildPartitionBackfill,
@@ -39,8 +40,11 @@ const mocks = [
       data: {
         partitionBackfillOrError: buildPartitionBackfill({
           assetBackfillData: buildAssetBackfillData({
-            rootAssetTargetedPartitions: ['1', '2', '3'],
-            rootAssetTargetedRanges: [buildPartitionKeyRange({start: '1', end: '2'})],
+            rootTargetedPartitions: {
+              __typename: 'AssetBackfillTargetPartitions',
+              partitionKeys: ['1', '2', '3'],
+              ranges: [buildPartitionKeyRange({start: '1', end: '2'})],
+            },
             assetBackfillStatuses: [
               {
                 ...buildAssetPartitionsStatusCounts({
@@ -168,7 +172,12 @@ describe('BackfillPage', () => {
 describe('PartitionSelection', () => {
   it('renders the targeted partitions when rootAssetTargetedPartitions is provided and length <= 3', async () => {
     const {getByText} = render(
-      <PartitionSelection numPartitions={3} rootAssetTargetedPartitions={['1', '2', '3']} />,
+      <PartitionSelection
+        numPartitions={3}
+        rootTargetedPartitions={buildAssetBackfillTargetPartitions({
+          partitionKeys: ['1', '2', '3'],
+        })}
+      />,
     );
 
     expect(getByText('1')).toBeInTheDocument();
@@ -178,7 +187,12 @@ describe('PartitionSelection', () => {
 
   it('renders the targeted partitions in a dialog when rootAssetTargetedPartitions is provided and length > 3', async () => {
     const {getByText} = render(
-      <PartitionSelection numPartitions={4} rootAssetTargetedPartitions={['1', '2', '3', '4']} />,
+      <PartitionSelection
+        numPartitions={4}
+        rootTargetedPartitions={buildAssetBackfillTargetPartitions({
+          partitionKeys: ['1', '2', '3', '4'],
+        })}
+      />,
     );
 
     await userEvent.click(getByText('4 partitions'));
@@ -193,7 +207,9 @@ describe('PartitionSelection', () => {
     const {getByText} = render(
       <PartitionSelection
         numPartitions={1}
-        rootAssetTargetedRanges={[buildPartitionKeyRange({start: '1', end: '2'})]}
+        rootTargetedPartitions={buildAssetBackfillTargetPartitions({
+          ranges: [buildPartitionKeyRange({start: '1', end: '2'})],
+        })}
       />,
     );
 
@@ -204,10 +220,12 @@ describe('PartitionSelection', () => {
     const {getByText} = render(
       <PartitionSelection
         numPartitions={2}
-        rootAssetTargetedRanges={[
-          buildPartitionKeyRange({start: '1', end: '2'}),
-          buildPartitionKeyRange({start: '3', end: '4'}),
-        ]}
+        rootTargetedPartitions={buildAssetBackfillTargetPartitions({
+          ranges: [
+            buildPartitionKeyRange({start: '1', end: '2'}),
+            buildPartitionKeyRange({start: '3', end: '4'}),
+          ],
+        })}
       />,
     );
 

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/__tests__/BackfillPage.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/__tests__/BackfillPage.test.tsx
@@ -176,6 +176,7 @@ describe('PartitionSelection', () => {
         numPartitions={3}
         rootTargetedPartitions={buildAssetBackfillTargetPartitions({
           partitionKeys: ['1', '2', '3'],
+          ranges: null,
         })}
       />,
     );
@@ -191,6 +192,7 @@ describe('PartitionSelection', () => {
         numPartitions={4}
         rootTargetedPartitions={buildAssetBackfillTargetPartitions({
           partitionKeys: ['1', '2', '3', '4'],
+          ranges: null,
         })}
       />,
     );
@@ -208,6 +210,7 @@ describe('PartitionSelection', () => {
       <PartitionSelection
         numPartitions={1}
         rootTargetedPartitions={buildAssetBackfillTargetPartitions({
+          partitionKeys: null,
           ranges: [buildPartitionKeyRange({start: '1', end: '2'})],
         })}
       />,
@@ -221,6 +224,7 @@ describe('PartitionSelection', () => {
       <PartitionSelection
         numPartitions={2}
         rootTargetedPartitions={buildAssetBackfillTargetPartitions({
+          partitionKeys: null,
           ranges: [
             buildPartitionKeyRange({start: '1', end: '2'}),
             buildPartitionKeyRange({start: '3', end: '4'}),

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/types/BackfillPage.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/types/BackfillPage.types.ts
@@ -34,12 +34,11 @@ export type BackfillStatusesByAssetQuery = {
         } | null;
         assetBackfillData: {
           __typename: 'AssetBackfillData';
-          rootAssetTargetedPartitions: Array<string> | null;
-          rootAssetTargetedRanges: Array<{
-            __typename: 'PartitionKeyRange';
-            start: string;
-            end: string;
-          }> | null;
+          rootTargetedPartitions: {
+            __typename: 'AssetBackfillTargetPartitions';
+            partitionKeys: Array<string> | null;
+            ranges: Array<{__typename: 'PartitionKeyRange'; start: string; end: string}> | null;
+          };
           assetBackfillStatuses: Array<
             | {
                 __typename: 'AssetPartitionsStatusCounts';
@@ -105,12 +104,11 @@ export type PartitionBackfillFragment = {
   } | null;
   assetBackfillData: {
     __typename: 'AssetBackfillData';
-    rootAssetTargetedPartitions: Array<string> | null;
-    rootAssetTargetedRanges: Array<{
-      __typename: 'PartitionKeyRange';
-      start: string;
-      end: string;
-    }> | null;
+    rootTargetedPartitions: {
+      __typename: 'AssetBackfillTargetPartitions';
+      partitionKeys: Array<string> | null;
+      ranges: Array<{__typename: 'PartitionKeyRange'; start: string; end: string}> | null;
+    };
     assetBackfillStatuses: Array<
       | {
           __typename: 'AssetPartitionsStatusCounts';
@@ -139,4 +137,25 @@ export type PartitionBackfillFragment = {
       repositoryLocationName: string;
     };
   } | null;
+};
+
+export type BackfillPartitionsForAssetKeyQueryVariables = Types.Exact<{
+  backfillId: Types.Scalars['String'];
+  assetKey: Types.AssetKeyInput;
+}>;
+
+export type BackfillPartitionsForAssetKeyQuery = {
+  __typename: 'Query';
+  partitionBackfillOrError:
+    | {__typename: 'BackfillNotFoundError'}
+    | {
+        __typename: 'PartitionBackfill';
+        id: string;
+        partitionsTargetedForAssetKey: {
+          __typename: 'AssetBackfillTargetPartitions';
+          partitionKeys: Array<string> | null;
+          ranges: Array<{__typename: 'PartitionKeyRange'; start: string; end: string}> | null;
+        } | null;
+      }
+    | {__typename: 'PythonError'};
 };

--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -354,7 +354,7 @@ class GraphenePartitionBackfill(graphene.ObjectType):
 
     def resolve_partitionsTargetedForAssetKey(
         self, graphene_info: ResolveInfo, asset_key
-    ) -> PartitionsSubset:
+    ) -> Optional[PartitionsSubset]:
         from dagster._core.definitions.events import AssetKey
 
         if not self._backfill_job.is_asset_backfill:
@@ -365,6 +365,7 @@ class GraphenePartitionBackfill(graphene.ObjectType):
         )
         if not root_partitions_subset:
             return None
+
         return GrapheneAssetBackfillTargetPartitions(root_partitions_subset)
 
     def resolve_assetBackfillData(

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py
@@ -73,11 +73,13 @@ ASSET_BACKFILL_DATA_QUERY = """
     partitionBackfillOrError(backfillId: $backfillId) {
       ... on PartitionBackfill {
         assetBackfillData {
-            rootAssetTargetedRanges {
+            rootTargetedPartitions {
+                partitionKeys
+                ranges {
                 start
                 end
+                }
             }
-            rootAssetTargetedPartitions
         }
         isAssetBackfill
       }
@@ -673,7 +675,7 @@ def test_launch_asset_backfill_with_upstream_anchor_asset_and_non_partitioned_as
             )
             targeted_ranges = asset_backfill_data_result.data["partitionBackfillOrError"][
                 "assetBackfillData"
-            ]["rootAssetTargetedRanges"]
+            ]["rootTargetedPartitions"]["ranges"]
             assert len(targeted_ranges) == 1
             assert targeted_ranges[0]["start"] == "2020-01-02-22:00"
             assert targeted_ranges[0]["end"] == "2020-01-03-00:00"

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
@@ -103,11 +103,13 @@ BACKFILL_STATUS_BY_ASSET = """
                     failed
                 }
             }
-            rootAssetTargetedRanges {
+            rootTargetedPartitions {
+                partitionKeys
+                ranges {
                 start
                 end
+                }
             }
-            rootAssetTargetedPartitions
         }
       }
       ... on PythonError {
@@ -819,8 +821,8 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
         assert result.data
         backfill_data = result.data["partitionBackfillOrError"]["assetBackfillData"]
 
-        assert backfill_data["rootAssetTargetedRanges"] is None
-        assert set(backfill_data["rootAssetTargetedPartitions"]) == set(partitions)
+        assert backfill_data["rootTargetedPartitions"]["ranges"] is None
+        assert set(backfill_data["rootTargetedPartitions"]["partitionKeys"]) == set(partitions)
 
         asset_partition_status_counts = backfill_data["assetBackfillStatuses"]
         assert len(asset_partition_status_counts) == 1
@@ -889,7 +891,7 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
         assert result.data
         backfill_data = result.data["partitionBackfillOrError"]["assetBackfillData"]
 
-        assert backfill_data["rootAssetTargetedRanges"] == [
+        assert backfill_data["rootTargetedPartitions"]["ranges"] == [
             {"start": "2023-01-09", "end": "2023-01-09"}
         ]
 

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -251,6 +251,10 @@ class AssetBackfillData(NamedTuple):
 
         return list(root_subset.iterate_asset_partitions())
 
+    def get_target_partitions_subset(self, asset_key: AssetKey) -> PartitionsSubset:
+        # Return the targeted partitions for the root partitioned asset keys
+        return self.target_subset.get_partitions_subset(asset_key)
+
     def get_target_root_partitions_subset(self) -> PartitionsSubset:
         """Returns the most upstream partitions subset that was targeted by the backfill."""
         partitioned_asset_keys = {

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -162,6 +162,26 @@ class PartitionBackfill(
         else:
             return []
 
+    def get_target_partitions_subset(
+        self, workspace: IWorkspace, asset_key: AssetKey
+    ) -> Optional[PartitionsSubset]:
+        if not self.is_valid_serialization(workspace):
+            return None
+
+        if self.serialized_asset_backfill_data is not None:
+            try:
+                asset_backfill_data = AssetBackfillData.from_serialized(
+                    self.serialized_asset_backfill_data,
+                    ExternalAssetGraph.from_workspace(workspace),
+                    self.backfill_timestamp,
+                )
+            except DagsterDefinitionChangedDeserializationError:
+                return None
+
+            return asset_backfill_data.get_target_partitions_subset(asset_key)
+        else:
+            return None
+
     def get_target_root_partitions_subset(
         self, workspace: IWorkspace
     ) -> Optional[PartitionsSubset]:


### PR DESCRIPTION
## Summary & Motivation

Fixes #16953 

This PR adds a new resolver to PartitionBackfill that allows us to fetch the targeted partitions / ranges for any asset in a backfill, not just the root set. When you click one of the assets on this page, we fetch the ranges for that asset and take you to the asset detail page with that range selected.

When I added this, I also moved `rootAssetTargetedRanges` and `rootAssetTargetedPartitions` into a nested object and renamed partitions => partitionKeys -- I think this is nice since we always pass the two together and these same two keys are needed for the new resolver.


![image](https://github.com/dagster-io/dagster/assets/1037212/5bf8a66d-2316-4126-a9c7-d9725aed24a4)

<img width="1072" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/ce324dad-3c58-4d5d-8e02-8a3697ed3b89">



## How I Tested These Changes

Updated existing tests