### PR TITLE
[ui] Improve display of reported materialization events

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNodeStatusContent.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNodeStatusContent.tsx
@@ -78,6 +78,7 @@ export function buildAssetNodeStatusContent({
 }
 
 export function _buildSourceAssetNodeStatusContent({
+  assetKey,
   definition,
   liveData,
   expanded,
@@ -101,7 +102,7 @@ export function _buildSourceAssetNodeStatusContent({
             Observing...
           </span>
           {expanded && <SpacerDot />}
-          <AssetRunLink runId={materializingRunId} />
+          <AssetRunLink assetKey={assetKey} runId={materializingRunId} />
         </>
       ),
     };
@@ -118,6 +119,7 @@ export function _buildSourceAssetNodeStatusContent({
           {expanded && <SpacerDot />}
           <span style={{textAlign: 'right', overflow: 'hidden'}}>
             <AssetRunLink
+              assetKey={assetKey}
               runId={liveData.lastObservation.runId}
               event={{
                 stepKey: stepKeyForAsset(definition),
@@ -210,7 +212,7 @@ export function _buildAssetNodeStatusContent({
           </span>
           {expanded && <SpacerDot />}
           {!numMaterializing || numMaterializing === 1 ? (
-            <AssetRunLink runId={materializingRunId} />
+            <AssetRunLink assetKey={assetKey} runId={materializingRunId} />
           ) : undefined}
         </>
       ),
@@ -265,6 +267,7 @@ export function _buildAssetNodeStatusContent({
   const lastMaterializationLink = lastMaterialization ? (
     <span style={{overflow: 'hidden'}}>
       <AssetRunLink
+        assetKey={assetKey}
         runId={lastMaterialization.runId}
         event={{stepKey: stepKeyForAsset(definition), timestamp: lastMaterialization.timestamp}}
       >
@@ -312,7 +315,7 @@ export function _buildAssetNodeStatusContent({
 
           {runWhichFailedToMaterialize ? (
             <span style={{overflow: 'hidden'}}>
-              <AssetRunLink runId={runWhichFailedToMaterialize.id}>
+              <AssetRunLink assetKey={assetKey} runId={runWhichFailedToMaterialize.id}>
                 <TimestampDisplay
                   timestamp={Number(runWhichFailedToMaterialize.endTime)}
                   timeFormat={{showSeconds: false, showTimezone: false}}

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetRunLinking.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetRunLinking.tsx
@@ -2,6 +2,9 @@ import {Tooltip, Spinner, FontFamily} from '@dagster-io/ui-components';
 import React from 'react';
 import {Link} from 'react-router-dom';
 
+import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
+import {AssetViewParams} from '../assets/types';
+import {AssetKeyInput} from '../graphql/types';
 import {titleForRun, linkToRunEvent} from '../runs/RunUtils';
 
 import {LiveDataForNode} from './Utils';
@@ -28,19 +31,31 @@ export const AssetLatestRunSpinner: React.FC<{
 };
 
 export const AssetRunLink: React.FC<{
-  children?: React.ReactNode;
   runId: string;
+  assetKey: AssetKeyInput;
+  children?: React.ReactNode;
   event?: Parameters<typeof linkToRunEvent>[1];
-}> = ({runId, children, event}) => (
-  <Link
-    to={event ? linkToRunEvent({id: runId}, event) : `/runs/${runId}`}
-    target="_blank"
-    rel="noreferrer"
-  >
-    {children || (
-      <span style={{fontSize: '1.2em', fontFamily: FontFamily.monospace}}>
-        {titleForRun({id: runId})}
-      </span>
-    )}
-  </Link>
-);
+}> = ({assetKey, runId, children, event}) => {
+  const content = children || (
+    <span style={{fontSize: '1.2em', fontFamily: FontFamily.monospace}}>
+      {titleForRun({id: runId})}
+    </span>
+  );
+
+  const buildLink = () => {
+    if (runId === '') {
+      // reported event
+      const params: AssetViewParams = event
+        ? {view: 'events', time: `${event.timestamp}`}
+        : {view: 'events'};
+      return assetDetailsPathForKey(assetKey, params);
+    }
+    return event ? linkToRunEvent({id: runId}, event) : `/runs/${runId}`;
+  };
+
+  return (
+    <Link to={buildLink()} target="_blank" rel="noreferrer">
+      {content}
+    </Link>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__stories__/SidebarAssetInfo.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__stories__/SidebarAssetInfo.stories.tsx
@@ -147,7 +147,7 @@ const buildSidebarQueryMock = (
   },
 });
 
-const EventsMock: MockedResponse<AssetEventsQuery> = {
+const buildEventsMock = ({reported}: {reported: boolean}): MockedResponse<AssetEventsQuery> => ({
   request: {
     query: ASSET_EVENTS_QUERY,
     variables: {
@@ -172,28 +172,30 @@ const EventsMock: MockedResponse<AssetEventsQuery> = {
           {
             __typename: 'MaterializationEvent',
             description: '1234',
-            runId: '12345',
             metadataEntries: [],
             partition: null,
-            timestamp: '12345678654',
+            timestamp: '1234567865400',
             assetLineage: [],
             label: null,
             stepKey: 'op',
             tags: [],
-            runOrError: {
-              __typename: 'Run',
-              pipelineName: '__ASSET_JOB_1',
-              mode: 'default',
-              pipelineSnapshotId: null,
-              id: '12345',
-              status: RunStatus.SUCCESS,
-              repositoryOrigin: {
-                __typename: 'RepositoryOrigin',
-                id: 'test.py',
-                repositoryLocationName: 'repo',
-                repositoryName: 'test.py',
-              },
-            },
+            runId: reported ? '' : '12345',
+            runOrError: reported
+              ? {__typename: 'RunNotFoundError'}
+              : {
+                  __typename: 'Run',
+                  pipelineName: '__ASSET_JOB_1',
+                  mode: 'default',
+                  pipelineSnapshotId: null,
+                  id: '12345',
+                  status: RunStatus.SUCCESS,
+                  repositoryOrigin: {
+                    __typename: 'RepositoryOrigin',
+                    id: 'test.py',
+                    repositoryLocationName: 'repo',
+                    repositoryName: 'test.py',
+                  },
+                },
           },
         ],
         assetObservations: [
@@ -203,7 +205,7 @@ const EventsMock: MockedResponse<AssetEventsQuery> = {
             runId: '12345',
             metadataEntries: [],
             partition: null,
-            timestamp: '12345678654',
+            timestamp: '1234567865400',
             label: null,
             stepKey: 'op',
             tags: [],
@@ -226,7 +228,7 @@ const EventsMock: MockedResponse<AssetEventsQuery> = {
       },
     },
   },
-};
+});
 
 const TestContainer: React.FC<{
   mocks?: MockedResponse<Record<string, any>>[];
@@ -236,7 +238,7 @@ const TestContainer: React.FC<{
     cache={createAppCache()}
     mocks={
       mocks || [
-        EventsMock,
+        buildEventsMock({reported: false}),
         buildPartitionHealthMock(MockAssetKey.path[0]!),
         buildSidebarQueryMock(),
       ]
@@ -248,9 +250,23 @@ const TestContainer: React.FC<{
   </MockedProvider>
 );
 
-export const AssetWithMaterializations = () => {
+export const AssetWithMaterialization = () => {
   return (
     <TestContainer>
+      <SidebarAssetInfo graphNode={buildGraphNodeMock({})} />
+    </TestContainer>
+  );
+};
+
+export const AssetWithReportedMaterialization = () => {
+  return (
+    <TestContainer
+      mocks={[
+        buildEventsMock({reported: true}),
+        buildPartitionHealthMock(MockAssetKey.path[0]!),
+        buildSidebarQueryMock(),
+      ]}
+    >
       <SidebarAssetInfo graphNode={buildGraphNodeMock({})} />
     </TestContainer>
   );
@@ -260,7 +276,7 @@ export const AssetWithPolicies = () => {
   return (
     <TestContainer
       mocks={[
-        EventsMock,
+        buildEventsMock({reported: false}),
         buildPartitionHealthMock(MockAssetKey.path[0]!),
         buildSidebarQueryMock({
           autoMaterializePolicy: buildAutoMaterializePolicy({

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEventDetail.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEventDetail.tsx
@@ -5,6 +5,7 @@ import {Link} from 'react-router-dom';
 import {Timestamp} from '../app/time/Timestamp';
 import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
 import {AssetKeyInput} from '../graphql/types';
+import {Description} from '../pipelines/Description';
 import {PipelineReference} from '../pipelines/PipelineReference';
 import {RunStatusWithStats} from '../runs/RunStatusDots';
 import {titleForRun, linkToRunEvent} from '../runs/RunUtils';
@@ -16,6 +17,7 @@ import {AssetEventSystemTags} from './AssetEventSystemTags';
 import {AssetLineageElements} from './AssetLineageElements';
 import {AssetMaterializationUpstreamData} from './AssetMaterializationUpstreamData';
 import {RunlessEventTag} from './RunlessEventTag';
+import {isRunlessEvent} from './isRunlessEvent';
 import {
   AssetMaterializationFragment,
   AssetObservationFragment,
@@ -39,7 +41,7 @@ export const AssetEventDetail: React.FC<{
         <Heading>
           <Timestamp timestamp={{ms: Number(event.timestamp)}} />
         </Heading>
-        {!event.runId ? <RunlessEventTag tags={event.tags} /> : undefined}
+        {isRunlessEvent(event) ? <RunlessEventTag tags={event.tags} /> : undefined}
       </Box>
       <Box
         style={{display: 'grid', gridTemplateColumns: '1fr 1fr 1fr 1fr', gap: 16}}
@@ -106,7 +108,7 @@ export const AssetEventDetail: React.FC<{
       {event.description && (
         <Box padding={{top: 24}} flex={{direction: 'column', gap: 8}}>
           <Subheading>Description</Subheading>
-          {event.description}
+          <Description description={event.description} />
         </Box>
       )}
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEvents.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEvents.tsx
@@ -189,6 +189,7 @@ export const AssetEvents: React.FC<Props> = ({
               groups={grouped}
               focused={focused}
               setFocused={onSetFocused}
+              assetKey={assetKey}
             />
           )}
         </Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetSidebarActivitySummary.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetSidebarActivitySummary.tsx
@@ -20,6 +20,7 @@ import {AssetCheckStatusTag} from './asset-checks/AssetCheckStatusTag';
 import {ExecuteChecksButton} from './asset-checks/ExecuteChecksButton';
 import {assetDetailsPathForKey} from './assetDetailsPathForKey';
 import {useGroupedEvents} from './groupByPartition';
+import {isRunlessEvent} from './isRunlessEvent';
 import {useRecentAssetEvents} from './useRecentAssetEvents';
 
 interface Props {
@@ -99,7 +100,13 @@ export const AssetSidebarActivitySummary: React.FC<Props> = ({
       {loadedPartitionKeys.length > 1 ? null : (
         <>
           <SidebarSection
-            title={!isSourceAsset ? 'Materialization in last run' : 'Observation in last run'}
+            title={
+              !isSourceAsset
+                ? displayedEvent && isRunlessEvent(displayedEvent)
+                  ? 'Last reported materialization'
+                  : 'Materialization in last run'
+                : 'Observation in last run'
+            }
           >
             {displayedEvent ? (
               <div style={{margin: -1, maxWidth: '100%', overflowX: 'auto'}}>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/LastMaterializationMetadata.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/LastMaterializationMetadata.tsx
@@ -7,6 +7,7 @@ import {Timestamp} from '../app/time/Timestamp';
 import {isHiddenAssetGroupJob, LiveDataForNode} from '../asset-graph/Utils';
 import {AssetKeyInput} from '../graphql/types';
 import {MetadataEntry} from '../metadata/MetadataEntry';
+import {Description} from '../pipelines/Description';
 import {PipelineReference} from '../pipelines/PipelineReference';
 import {linkToRunEvent, titleForRun} from '../runs/RunUtils';
 import {useStepLogs} from '../runs/StepLogsDialog';
@@ -15,6 +16,7 @@ import {buildRepoAddress} from '../workspace/buildRepoAddress';
 
 import {AssetLineageElements} from './AssetLineageElements';
 import {StaleReasonsTags} from './Stale';
+import {isRunlessEvent} from './isRunlessEvent';
 import {
   AssetObservationFragment,
   AssetMaterializationFragment,
@@ -47,73 +49,90 @@ export const LatestMaterializationMetadata: React.FC<{
       {latestEvent ? (
         <MetadataTable>
           <tbody>
-            <tr>
-              <td>Run</td>
-              <td>
-                {latestRun ? (
-                  <div>
-                    <Box
-                      flex={{
-                        direction: 'row',
-                        justifyContent: 'space-between',
-                        gap: 8,
-                        alignItems: 'flex-start',
-                      }}
-                    >
-                      <Box>
-                        {'Run '}
-                        <Link to={`/runs/${latestEvent.runId}?timestamp=${latestEvent.timestamp}`}>
-                          <Mono>{titleForRun({id: latestEvent.runId})}</Mono>
-                        </Link>
-                      </Box>
-                      {stepLogs.button}
-                    </Box>
-                    {!isHiddenAssetGroupJob(latestRun.pipelineName) && (
-                      <>
-                        <Box padding={{left: 8, top: 4}}>
-                          <PipelineReference
-                            showIcon
-                            pipelineName={latestRun.pipelineName}
-                            pipelineHrefContext={repoAddress || 'repo-unknown'}
-                            snapshotId={latestRun.pipelineSnapshotId}
-                            isJob={isThisThingAJob(repo, latestRun.pipelineName)}
-                          />
-                        </Box>
-                        <Group direction="row" padding={{left: 8}} spacing={8} alignItems="center">
-                          <Icon name="linear_scale" color={Colors.Gray400} />
-                          <Link to={linkToRunEvent(latestRun, latestEvent)}>
-                            {latestEvent.stepKey}
+            {!isRunlessEvent(latestEvent) ? (
+              <tr>
+                <td>Run</td>
+                <td>
+                  {latestRun ? (
+                    <div>
+                      <Box
+                        flex={{
+                          direction: 'row',
+                          justifyContent: 'space-between',
+                          gap: 8,
+                          alignItems: 'flex-start',
+                        }}
+                      >
+                        <Box>
+                          {'Run '}
+                          <Link
+                            to={`/runs/${latestEvent.runId}?timestamp=${latestEvent.timestamp}`}
+                          >
+                            <Mono>{titleForRun({id: latestEvent.runId})}</Mono>
                           </Link>
-                        </Group>
-                      </>
-                    )}
-                  </div>
-                ) : (
-                  'No materialization events'
-                )}
-              </td>
-            </tr>
-            {latest?.partition ? (
+                        </Box>
+                        {stepLogs.button}
+                      </Box>
+                      {!isHiddenAssetGroupJob(latestRun.pipelineName) && (
+                        <>
+                          <Box padding={{left: 8, top: 4}}>
+                            <PipelineReference
+                              showIcon
+                              pipelineName={latestRun.pipelineName}
+                              pipelineHrefContext={repoAddress || 'repo-unknown'}
+                              snapshotId={latestRun.pipelineSnapshotId}
+                              isJob={isThisThingAJob(repo, latestRun.pipelineName)}
+                            />
+                          </Box>
+                          <Group
+                            direction="row"
+                            padding={{left: 8}}
+                            spacing={8}
+                            alignItems="center"
+                          >
+                            <Icon name="linear_scale" color={Colors.Gray400} />
+                            <Link to={linkToRunEvent(latestRun, latestEvent)}>
+                              {latestEvent.stepKey}
+                            </Link>
+                          </Group>
+                        </>
+                      )}
+                    </div>
+                  ) : (
+                    'No materialization events'
+                  )}
+                </td>
+              </tr>
+            ) : null}
+            {latestEvent.partition ? (
               <tr>
                 <td>Partition</td>
-                <td>{latest ? latest.partition : 'No materialization events'}</td>
+                <td>{latestEvent.partition}</td>
               </tr>
             ) : null}
             <tr>
               <td>Timestamp</td>
               <td>
                 <Box flex={{gap: 8, alignItems: 'center'}}>
-                  {latestEvent ? (
-                    <Timestamp timestamp={{ms: Number(latestEvent.timestamp)}} />
-                  ) : (
-                    'No materialization events'
-                  )}
+                  <Timestamp timestamp={{ms: Number(latestEvent.timestamp)}} />
                   {liveData && (
                     <StaleReasonsTags assetKey={assetKey} liveData={liveData} include="all" />
                   )}
                 </Box>
               </td>
             </tr>
+            {isRunlessEvent(latestEvent) ? (
+              <tr>
+                <td>Description</td>
+                <td style={{color: Colors.Gray800}}>
+                  <Description
+                    description={latestEvent.description}
+                    fontSize={14}
+                    maxHeight={150}
+                  />
+                </td>
+              </tr>
+            ) : null}
             {latestAssetLineage?.length ? (
               <tr>
                 <td>Parent assets</td>
@@ -125,7 +144,7 @@ export const LatestMaterializationMetadata: React.FC<{
                 </td>
               </tr>
             ) : null}
-            {latestEvent?.metadataEntries.map((entry) => (
+            {latestEvent.metadataEntries.map((entry) => (
               <tr key={`metadata-${entry.label}`}>
                 <td>{entry.label}</td>
                 <td>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/isRunlessEvent.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/isRunlessEvent.ts
@@ -1,0 +1,4 @@
+// Just definining this to give an otherwise innocuous looking check a better name
+export function isRunlessEvent(event: {runId: string}) {
+  return event.runId === '';
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/Description.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/Description.tsx
@@ -6,6 +6,7 @@ import {Markdown} from '../ui/Markdown';
 interface IDescriptionProps {
   description: string | null;
   maxHeight?: number;
+  fontSize?: string | number;
 }
 
 interface IDescriptionState {
@@ -80,6 +81,7 @@ export class Description extends React.Component<IDescriptionProps, IDescription
         }}
         style={{
           maxHeight: expanded ? undefined : this.props.maxHeight || DEFAULT_MAX_HEIGHT,
+          fontSize: this.props.fontSize || '0.8rem',
         }}
       >
         {!expanded && hasMore && <Mask />}
@@ -99,7 +101,6 @@ export class Description extends React.Component<IDescriptionProps, IDescription
 
 const Container = styled.div`
   overflow: hidden;
-  font-size: 0.8rem;
   position: relative;
   p:last-child {
     margin-bottom: 0;

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedAssetRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedAssetRow.tsx
@@ -167,6 +167,7 @@ export const VirtualizedAssetRow = (props: AssetRowProps) => {
                 </Box>
               ) : liveData?.lastMaterialization ? (
                 <AssetRunLink
+                  assetKey={{path}}
                   runId={liveData.lastMaterialization.runId}
                   event={{
                     stepKey: liveData.stepKey,


### PR DESCRIPTION
## Summary & Motivation

This PR makes a few small improvements to the experience around "runless" reported materialization events:

- In the sidebar, the title of the section changes from `Materialization in last run` to `Last reported materialization`. The "Run" row is removed and a "Description" row is added. Note: I left "Materialization system tags" and plots because I think those could be populated via the API?

- In the asset list view and graph, links to the materialization (eg: the timestamps) all go to the specific event entry on the asset events tab rather than to a 404ing run page.

- Long descriptions truncate with a "Show more" in both the details page and the asset graph sidebar.

After: (note the description is just a worst-case scenario of long copy pasta)
![image](https://github.com/dagster-io/dagster/assets/1037212/204d52ea-0a34-49db-bd92-733124a4116c)


## How I Tested These Changes

Report materializations from the Materialize button on the Asset Details page, see that things look a bit better. I also added a reported event storybook to the sidebar stories.

![image](https://github.com/dagster-io/dagster/assets/1037212/0215af72-93a6-460c-b7a2-97485ca130bd)


