### PR TITLE
Add a "blocked" state in the backfill UI with a blocked reason

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -2608,6 +2608,7 @@ type PartitionBackfill {
   runs(limit: Int): [Run!]!
   unfinishedRuns(limit: Int): [Run!]!
   error: PythonError
+  blockedReason: String
   partitionStatuses: PartitionStatuses
   partitionStatusCounts: [PartitionStatusCounts!]!
   isAssetBackfill: Boolean!

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -2344,6 +2344,7 @@ export type PartitionBackfill = {
   __typename: 'PartitionBackfill';
   assetBackfillData: Maybe<AssetBackfillData>;
   assetSelection: Maybe<Array<AssetKey>>;
+  blockedReason: Maybe<Scalars['String']>;
   endTimestamp: Maybe<Scalars['Float']>;
   error: Maybe<PythonError>;
   fromFailure: Scalars['Boolean'];
@@ -8832,6 +8833,8 @@ export const buildPartitionBackfill = (
         : buildAssetBackfillData({}, relationshipsToOmit),
     assetSelection:
       overrides && overrides.hasOwnProperty('assetSelection') ? overrides.assetSelection! : [],
+    blockedReason:
+      overrides && overrides.hasOwnProperty('blockedReason') ? overrides.blockedReason! : 'omnis',
     endTimestamp:
       overrides && overrides.hasOwnProperty('endTimestamp') ? overrides.endTimestamp! : 0.33,
     error:

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillPage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillPage.tsx
@@ -397,6 +397,7 @@ export const BACKFILL_DETAILS_QUERY = gql`
     error {
       ...PythonErrorFragment
     }
+    blockedReason
     assetBackfillData {
       rootAssetTargetedRanges {
         start

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillRow.tsx
@@ -394,7 +394,19 @@ export const BackfillStatusTag = ({
 
   switch (backfill.status) {
     case BulkActionStatus.REQUESTED:
-      return <Tag>In progress</Tag>;
+      if (backfill.blockedReason) {
+        return (
+          <Box margin={{bottom: 12}}>
+            <TagButton
+              onClick={() => showCustomAlert({title: 'Warning', body: backfill.blockedReason})}
+            >
+              <Tag intent="warning">Blocked</Tag>
+            </TagButton>
+          </Box>
+        );
+      } else {
+        return <Tag>In progress</Tag>;
+      }
     case BulkActionStatus.FAILED:
       return (
         <Box margin={{bottom: 12}}>

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillStatusTagForPage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillStatusTagForPage.tsx
@@ -10,10 +10,11 @@ import {BulkActionStatus} from '../../graphql/types';
 type BackfillState = {
   status: BulkActionStatus;
   error: PythonErrorFragment | null;
+  blockedReason: string | null;
 };
 
 export const BackfillStatusTagForPage = ({backfill}: {backfill: BackfillState}) => {
-  const {status, error} = backfill;
+  const {status, error, blockedReason} = backfill;
   function errorState(status: string) {
     return (
       <Box margin={{bottom: 12}}>
@@ -28,10 +29,23 @@ export const BackfillStatusTagForPage = ({backfill}: {backfill: BackfillState}) 
     );
   }
 
+  function blockedState(status: string, blockedReason: string) {
+    return (
+      <Box margin={{bottom: 12}}>
+        <TagButton onClick={() => showCustomAlert({title: 'Warning', body: blockedReason})}>
+          <Tag intent="warning">{status}</Tag>
+        </TagButton>
+      </Box>
+    );
+  }
+
   switch (status) {
     case BulkActionStatus.REQUESTED:
-      return <Tag>In progress</Tag>;
-
+      if (blockedReason) {
+        return blockedState('Blocked', blockedReason);
+      } else {
+        return <Tag>In progress</Tag>;
+      }
     case BulkActionStatus.CANCELING:
       return errorState('Canceling');
     case BulkActionStatus.CANCELED:

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillTable.tsx
@@ -84,6 +84,7 @@ export const BACKFILL_TABLE_FRAGMENT = gql`
     error {
       ...PythonErrorFragment
     }
+    blockedReason
     ...BackfillActionsBackfillFragment
   }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/types/BackfillPage.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/types/BackfillPage.types.ts
@@ -17,6 +17,7 @@ export type BackfillStatusesByAssetQuery = {
         timestamp: number;
         endTimestamp: number | null;
         numPartitions: number | null;
+        blockedReason: string | null;
         hasCancelPermission: boolean;
         hasResumePermission: boolean;
         isAssetBackfill: boolean;
@@ -88,6 +89,7 @@ export type PartitionBackfillFragment = {
   timestamp: number;
   endTimestamp: number | null;
   numPartitions: number | null;
+  blockedReason: string | null;
   hasCancelPermission: boolean;
   hasResumePermission: boolean;
   isAssetBackfill: boolean;

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/types/BackfillTable.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/types/BackfillTable.types.ts
@@ -12,6 +12,7 @@ export type BackfillTableFragment = {
   numPartitions: number | null;
   timestamp: number;
   partitionSetName: string | null;
+  blockedReason: string | null;
   hasCancelPermission: boolean;
   hasResumePermission: boolean;
   numCancelable: number;

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/types/InstanceBackfills.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/types/InstanceBackfills.types.ts
@@ -55,6 +55,7 @@ export type InstanceBackfillsQuery = {
           partitionSetName: string | null;
           isAssetBackfill: boolean;
           partitionNames: Array<string> | null;
+          blockedReason: string | null;
           hasCancelPermission: boolean;
           hasResumePermission: boolean;
           numCancelable: number;

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/types/JobBackfillsTable.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/types/JobBackfillsTable.types.ts
@@ -26,6 +26,7 @@ export type JobBackfillsQuery = {
           numPartitions: number | null;
           timestamp: number;
           partitionSetName: string | null;
+          blockedReason: string | null;
           hasCancelPermission: boolean;
           hasResumePermission: boolean;
           numCancelable: number;

--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -154,6 +154,7 @@ class GraphenePartitionBackfill(graphene.ObjectType):
         limit=graphene.Int(),
     )
     error = graphene.Field(GraphenePythonError)
+    blockedReason = graphene.Field(graphene.String)
     partitionStatuses = graphene.Field(
         "dagster_graphql.schema.partition_sets.GraphenePartitionStatuses"
     )
@@ -396,6 +397,9 @@ class GraphenePartitionBackfill(graphene.ObjectType):
         if self._backfill_job.error:
             return GraphenePythonError(self._backfill_job.error)
         return None
+
+    def resolve_blockedReason(self, _graphene_info: ResolveInfo) -> Optional[str]:
+        return self._backfill_job.blocked_reason
 
     def resolve_hasCancelPermission(self, graphene_info: ResolveInfo) -> bool:
         if self._backfill_job.partition_set_origin is None:

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py
@@ -63,6 +63,7 @@ SINGLE_BACKFILL_QUERY = """
             runStatus
           }
         }
+        blockedReason
       }
     }
   }
@@ -374,6 +375,19 @@ def test_launch_asset_backfill():
             assert single_backfill_result.data
             assert (
                 single_backfill_result.data["partitionBackfillOrError"]["partitionStatuses"] is None
+            )
+
+            backfill = instance.get_backfill(backfill_id)
+            instance.update_backfill(
+                backfill.with_status(backfill.status, blocked_reason="WARNING WARNING")
+            )
+
+            single_backfill_result = execute_dagster_graphql(
+                context, SINGLE_BACKFILL_QUERY, variables={"backfillId": backfill_id}
+            )
+            assert (
+                single_backfill_result.data["partitionBackfillOrError"]["blockedReason"]
+                == "WARNING WARNING"
             )
 
 

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -56,6 +56,7 @@ class PartitionBackfill(
             ("reexecution_steps", Optional[Sequence[str]]),
             # only used by asset backfills
             ("serialized_asset_backfill_data", Optional[str]),
+            ("blocked_reason", Optional[str]),
         ],
     ),
 ):
@@ -73,6 +74,7 @@ class PartitionBackfill(
         last_submitted_partition_name: Optional[str] = None,
         reexecution_steps: Optional[Sequence[str]] = None,
         serialized_asset_backfill_data: Optional[str] = None,
+        blocked_reason: Optional[str] = None,
     ):
         check.invariant(
             not (asset_selection and reexecution_steps),
@@ -101,6 +103,7 @@ class PartitionBackfill(
             check.opt_str_param(last_submitted_partition_name, "last_submitted_partition_name"),
             check.opt_nullable_sequence_param(reexecution_steps, "reexecution_steps", of_type=str),
             check.opt_str_param(serialized_asset_backfill_data, "serialized_asset_backfill_data"),
+            check.opt_str_param(blocked_reason, "blocked_reason"),
         )
 
     @property
@@ -248,7 +251,7 @@ class PartitionBackfill(
         )
         return max(0, total_count - checkpoint_idx)
 
-    def with_status(self, status):
+    def with_status(self, status, blocked_reason: Optional[str] = None):
         check.inst_param(status, "status", BulkActionStatus)
         return PartitionBackfill(
             status=status,
@@ -263,6 +266,7 @@ class PartitionBackfill(
             error=self.error,
             asset_selection=self.asset_selection,
             serialized_asset_backfill_data=self.serialized_asset_backfill_data,
+            blocked_reason=blocked_reason,
         )
 
     def with_partition_checkpoint(self, last_submitted_partition_name):
@@ -280,6 +284,7 @@ class PartitionBackfill(
             error=self.error,
             asset_selection=self.asset_selection,
             serialized_asset_backfill_data=self.serialized_asset_backfill_data,
+            blocked_reason=self.blocked_reason,
         )
 
     def with_error(self, error):
@@ -297,6 +302,7 @@ class PartitionBackfill(
             error=error,
             asset_selection=self.asset_selection,
             serialized_asset_backfill_data=self.serialized_asset_backfill_data,
+            blocked_reason=self.blocked_reason,
         )
 
     def with_asset_backfill_data(
@@ -319,6 +325,7 @@ class PartitionBackfill(
             serialized_asset_backfill_data=asset_backfill_data.serialize(
                 dynamic_partitions_store=dynamic_partitions_store
             ),
+            blocked_reason=self.blocked_reason,
         )
 
     @classmethod


### PR DESCRIPTION
Summary:
Right now it's possible for a backfill to get 'stuck' where the only information about why is shown in the backfill daemon logs as an error. Instead, stick that information in the backfill message as a warning message that is displayed in the UI.

Test Plan: BK
Simulate a backfill with a blockedReason returned, view in the UI
![image](https://github.com/dagster-io/dagster/assets/8451211/73534f2a-fb04-46b2-9772-91639611735f)


## Summary & Motivation

## How I Tested These Changes
