### PR TITLE
[1/n][AMP Timeline / Sensor Timeline] Make paginating forward/backward in table move timeline forward and backward + unfeature gate

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/Flags.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/Flags.tsx
@@ -16,7 +16,6 @@ export const FeatureFlag = {
   flagDisableAutoLoadDefaults: 'flagDisableAutoLoadDefaults' as const,
   flagDAGSidebar: 'flagDAGSidebar' as const,
   flagDisableDAGCache: 'flagDisableDAGCache' as const,
-  flagEnableAMPTimeline: 'flagEnableAMPTimeline' as const,
   flagTightTreeDag: 'flagTightTreeDag' as const,
   flagLongestPathDag: 'flagLongestPathDag' as const,
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/app/getVisibleFeatureFlagRows.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/getVisibleFeatureFlagRows.tsx
@@ -58,10 +58,6 @@ export const getVisibleFeatureFlagRows = () => [
     flagType: FeatureFlag.flagDisableDAGCache,
   },
   {
-    key: 'Experimental Auto-materialize policy timeline page',
-    flagType: FeatureFlag.flagEnableAMPTimeline,
-  },
-  {
     key: 'Experimental tight tree DAG algorithm (Faster)',
     flagType: FeatureFlag.flagTightTreeDag,
     label: (

--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/TickHistory.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/TickHistory.tsx
@@ -86,8 +86,8 @@ export const TicksTable = ({
   name: string;
   repoAddress: RepoAddress;
   tabs?: React.ReactElement;
-  setTimerange: (range?: [number, number]) => void;
-  setParentStatuses: (statuses?: InstigationTickStatus[]) => void;
+  setTimerange?: (range?: [number, number]) => void;
+  setParentStatuses?: (statuses?: InstigationTickStatus[]) => void;
 }) => {
   const [shownStates, setShownStates] = useQueryPersistedState<ShownStatusState>({
     encode: (states) => {
@@ -154,19 +154,19 @@ export const TicksTable = ({
         const start = ticks[ticks.length - 1]?.timestamp;
         const end = ticks[0]?.endTimestamp;
         if (start && end) {
-          setTimerange([start, end]);
+          setTimerange?.([start, end]);
         }
       }
     } else {
-      setTimerange(undefined);
+      setTimerange?.(undefined);
     }
   }, [paginationProps.hasPrevCursor, ticks, setTimerange]);
 
   React.useEffect(() => {
     if (paginationProps.hasPrevCursor) {
-      setParentStatuses(Array.from(statuses));
+      setParentStatuses?.(Array.from(statuses));
     } else {
-      setParentStatuses(undefined);
+      setParentStatuses?.(undefined);
     }
   }, [paginationProps.hasPrevCursor, setParentStatuses, statuses]);
 

--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/TickHistory.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/TickHistory.tsx
@@ -26,7 +26,7 @@ import {showSharedToaster} from '../app/DomUtils';
 import {useFeatureFlags} from '../app/Flags';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {PythonErrorInfo} from '../app/PythonErrorInfo';
-import {ONE_MONTH, useQueryRefreshAtInterval} from '../app/QueryRefresh';
+import {useQueryRefreshAtInterval} from '../app/QueryRefresh';
 import {useCopyToClipboard} from '../app/browser';
 import {
   DynamicPartitionsRequestType,
@@ -80,10 +80,14 @@ export const TicksTable = ({
   name,
   repoAddress,
   tabs,
+  setTimerange,
+  setParentStatuses,
 }: {
   name: string;
   repoAddress: RepoAddress;
   tabs?: React.ReactElement;
+  setTimerange: (range?: [number, number]) => void;
+  setParentStatuses: (statuses?: InstigationTickStatus[]) => void;
 }) => {
   const [shownStates, setShownStates] = useQueryPersistedState<ShownStatusState>({
     encode: (states) => {
@@ -106,9 +110,14 @@ export const TicksTable = ({
   });
   const {flagSensorScheduleLogging} = useFeatureFlags();
   const instigationSelector = {...repoAddressToSelector(repoAddress), name};
-  const statuses = Object.keys(shownStates)
-    .filter((status) => shownStates[status as keyof typeof shownStates])
-    .map((status) => status as InstigationTickStatus);
+  const statuses = React.useMemo(
+    () =>
+      Object.keys(shownStates)
+        .filter((status) => shownStates[status as keyof typeof shownStates])
+        .map((status) => status as InstigationTickStatus),
+    [shownStates],
+  );
+
   const {queryResult, paginationProps} = useCursorPaginatedQuery<
     TickHistoryQuery,
     TickHistoryQueryVariables
@@ -132,11 +141,52 @@ export const TicksTable = ({
     query: JOB_TICK_HISTORY_QUERY,
     pageSize: PAGE_SIZE,
   });
+
+  const state = queryResult?.data?.instigationStateOrError;
+  const ticks = React.useMemo(
+    () => (state?.__typename === 'InstigationState' ? state.ticks : []),
+    [state],
+  );
+
+  React.useEffect(() => {
+    if (paginationProps.hasPrevCursor) {
+      if (ticks && ticks.length) {
+        const start = ticks[ticks.length - 1]?.timestamp;
+        const end = ticks[0]?.endTimestamp;
+        if (start && end) {
+          setTimerange([start, end]);
+        }
+      }
+    } else {
+      setTimerange(undefined);
+    }
+  }, [paginationProps.hasPrevCursor, ticks, setTimerange]);
+
+  React.useEffect(() => {
+    if (paginationProps.hasPrevCursor) {
+      setParentStatuses(Array.from(statuses));
+    } else {
+      setParentStatuses(undefined);
+    }
+  }, [paginationProps.hasPrevCursor, setParentStatuses, statuses]);
+
+  React.useEffect(() => {
+    if (paginationProps.hasPrevCursor && !ticks.length && !queryResult.loading) {
+      paginationProps.reset();
+    }
+    // paginationProps.reset isn't memoized
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ticks, queryResult.loading, paginationProps.hasPrevCursor]);
+
   const [logTick, setLogTick] = React.useState<InstigationTick>();
   const {data} = queryResult;
 
   if (!data) {
-    return null;
+    return (
+      <Box padding={{vertical: 48}}>
+        <Spinner purpose="page" />
+      </Box>
+    );
   }
 
   if (data.instigationStateOrError.__typename === 'PythonError') {
@@ -151,7 +201,7 @@ export const TicksTable = ({
     );
   }
 
-  const {ticks, instigationType} = data.instigationStateOrError;
+  const {instigationType} = data.instigationStateOrError;
 
   if (!ticks.length && statuses.length === Object.keys(DEFAULT_SHOWN_STATUS_STATE).length) {
     return null;
@@ -230,10 +280,16 @@ export const TickHistoryTimeline = ({
   name,
   repoAddress,
   onHighlightRunIds,
+  beforeTimestamp,
+  afterTimestamp,
+  statuses,
 }: {
   name: string;
   repoAddress: RepoAddress;
   onHighlightRunIds?: (runIds: string[]) => void;
+  beforeTimestamp?: number;
+  afterTimestamp?: number;
+  statuses?: InstigationTickStatus[];
 }) => {
   const [selectedTime, setSelectedTime] = useQueryPersistedState<number | undefined>({
     encode: (timestamp) => ({time: timestamp}),
@@ -246,12 +302,22 @@ export const TickHistoryTimeline = ({
   const queryResult = useQuery<TickHistoryQuery, TickHistoryQueryVariables>(
     JOB_TICK_HISTORY_QUERY,
     {
-      variables: {instigationSelector, limit: 15},
+      variables: {
+        instigationSelector,
+        beforeTimestamp,
+        afterTimestamp,
+        statuses,
+        limit: beforeTimestamp ? undefined : 15,
+      },
       notifyOnNetworkStatusChange: true,
     },
   );
 
-  useQueryRefreshAtInterval(queryResult, pollingPaused ? ONE_MONTH : 1000);
+  useQueryRefreshAtInterval(
+    queryResult,
+    1000,
+    !(pollingPaused || (beforeTimestamp && afterTimestamp)),
+  );
   const {data, error} = queryResult;
 
   if (!data || error) {
@@ -290,7 +356,6 @@ export const TickHistoryTimeline = ({
       pausePolling(true);
     }
   };
-
   return (
     <>
       <TickDetailsDialog
@@ -303,7 +368,14 @@ export const TickHistoryTimeline = ({
         <Subheading>Recent ticks</Subheading>
       </Box>
       <Box border="top">
-        <LiveTickTimeline ticks={ticks} onHoverTick={onTickHover} onSelectTick={onTickClick} />
+        <LiveTickTimeline
+          ticks={ticks}
+          onHoverTick={onTickHover}
+          onSelectTick={onTickClick}
+          exactRange={
+            beforeTimestamp && afterTimestamp ? [afterTimestamp, beforeTimestamp] : undefined
+          }
+        />
       </Box>
     </>
   );
@@ -437,12 +509,21 @@ const JOB_TICK_HISTORY_QUERY = gql`
     $limit: Int
     $cursor: String
     $statuses: [InstigationTickStatus!]
+    $beforeTimestamp: Float
+    $afterTimestamp: Float
   ) {
     instigationStateOrError(instigationSelector: $instigationSelector) {
       ... on InstigationState {
         id
         instigationType
-        ticks(dayRange: $dayRange, limit: $limit, cursor: $cursor, statuses: $statuses) {
+        ticks(
+          dayRange: $dayRange
+          limit: $limit
+          cursor: $cursor
+          statuses: $statuses
+          beforeTimestamp: $beforeTimestamp
+          afterTimestamp: $afterTimestamp
+        ) {
           id
           ...HistoryTick
         }

--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/types/TickHistory.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/types/TickHistory.types.ts
@@ -8,6 +8,8 @@ export type TickHistoryQueryVariables = Types.Exact<{
   limit?: Types.InputMaybe<Types.Scalars['Int']>;
   cursor?: Types.InputMaybe<Types.Scalars['String']>;
   statuses?: Types.InputMaybe<Array<Types.InstigationTickStatus> | Types.InstigationTickStatus>;
+  beforeTimestamp?: Types.InputMaybe<Types.Scalars['Float']>;
+  afterTimestamp?: Types.InputMaybe<Types.Scalars['Float']>;
 }>;
 
 export type TickHistoryQuery = {

--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/util.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/util.ts
@@ -1,3 +1,5 @@
+import {InstigationTick, InstigationTickStatus} from '../graphql/types';
+
 const TRUNCATION_THRESHOLD = 100;
 const TRUNCATION_BUFFER = 5;
 
@@ -5,3 +7,9 @@ export const truncate = (str: string) =>
   str.length > TRUNCATION_THRESHOLD
     ? `${str.slice(0, TRUNCATION_THRESHOLD - TRUNCATION_BUFFER)}…`
     : str;
+
+export function isOldTickWithoutEndtimestamp(
+  tick: Pick<InstigationTick, 'timestamp' | 'endTimestamp' | 'status'>,
+) {
+  return tick.status !== InstigationTickStatus.STARTED && !tick.endTimestamp;
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewRoot.tsx
@@ -13,7 +13,6 @@ import {OverviewSchedulesRoot} from './OverviewSchedulesRoot';
 import {OverviewSensorsRoot} from './OverviewSensorsRoot';
 
 export const OverviewRoot = () => {
-  const {flagEnableAMPTimeline} = useFeatureFlags();
   return (
     <Switch>
       <Route path="/overview/activity">
@@ -28,11 +27,9 @@ export const OverviewRoot = () => {
       <Route path="/overview/sensors">
         <OverviewSensorsRoot />
       </Route>
-      {flagEnableAMPTimeline ? (
-        <Route path="/overview/amp">
-          <AutomaterializationRoot />
-        </Route>
-      ) : null}
+      <Route path="/overview/automaterialize">
+        <AutomaterializationRoot />
+      </Route>
       <Route path="/overview/backfills/:backfillId">
         <BackfillPage />
       </Route>

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewRoot.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import {Redirect, Route, Switch} from 'react-router-dom';
 
-import {useFeatureFlags} from '../app/Flags';
 import {AutomaterializationRoot} from '../assets/auto-materialization/AutomaterializationRoot';
 import {InstanceBackfills} from '../instance/InstanceBackfills';
 import {BackfillPage} from '../instance/backfill/BackfillPage';

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewTabs.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewTabs.tsx
@@ -2,7 +2,6 @@ import {QueryResult} from '@apollo/client';
 import {Box, Colors, Spinner, Tabs} from '@dagster-io/ui-components';
 import * as React from 'react';
 
-import {useFeatureFlags} from '../app/Flags';
 import {QueryRefreshCountdown, QueryRefreshState} from '../app/QueryRefresh';
 import {useAutomaterializeDaemonStatus} from '../assets/AutomaterializeDaemonStatusTag';
 import {TabLink} from '../ui/TabLink';

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewTabs.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewTabs.tsx
@@ -17,7 +17,6 @@ export const OverviewTabs = <TData extends Record<string, any>>(props: Props<TDa
   const {refreshState, tab} = props;
 
   const automaterialize = useAutomaterializeDaemonStatus();
-  const {flagEnableAMPTimeline} = useFeatureFlags();
 
   return (
     <Box flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'flex-end'}}>
@@ -26,30 +25,28 @@ export const OverviewTabs = <TData extends Record<string, any>>(props: Props<TDa
         <TabLink id="jobs" title="Jobs" to="/overview/jobs" />
         <TabLink id="schedules" title="Schedules" to="/overview/schedules" />
         <TabLink id="sensors" title="Sensors" to="/overview/sensors" />
-        {flagEnableAMPTimeline ? (
-          <TabLink
-            id="amp"
-            title={
-              <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
-                <div>Auto-materialize</div>
-                {automaterialize.loading ? (
-                  <Spinner purpose="body-text" />
-                ) : (
-                  <div
-                    style={{
-                      width: '10px',
-                      height: '10px',
-                      borderRadius: '50%',
-                      backgroundColor:
-                        automaterialize.paused === false ? Colors.Blue200 : Colors.Gray200,
-                    }}
-                  />
-                )}
-              </Box>
-            }
-            to="/overview/amp"
-          />
-        ) : null}
+        <TabLink
+          id="amp"
+          title={
+            <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
+              <div>Auto-materialize</div>
+              {automaterialize.loading ? (
+                <Spinner purpose="body-text" />
+              ) : (
+                <div
+                  style={{
+                    width: '10px',
+                    height: '10px',
+                    borderRadius: '50%',
+                    backgroundColor:
+                      automaterialize.paused === false ? Colors.Blue200 : Colors.Gray200,
+                  }}
+                />
+              )}
+            </Box>
+          }
+          to="/overview/automaterialize"
+        />
         <TabLink id="resources" title="Resources" to="/overview/resources" />
         <TabLink id="backfills" title="Backfills" to="/overview/backfills" />
       </Tabs>

--- a/js_modules/dagster-ui/packages/ui-core/src/schedules/ScheduleRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/schedules/ScheduleRoot.tsx
@@ -45,19 +45,6 @@ export const ScheduleRoot: React.FC<Props> = (props) => {
 
   const [selectedTab, setSelectedTab] = React.useState<string>('ticks');
 
-  const [statuses, setStatuses] = React.useState<undefined | InstigationTickStatus[]>(undefined);
-  const [timeRange, setTimerange] = React.useState<undefined | [number, number]>(undefined);
-  const variables = React.useMemo(() => {
-    if (timeRange || statuses) {
-      return {
-        afterTimestamp: timeRange?.[0],
-        beforeTimestamp: timeRange?.[1],
-        statuses,
-      };
-    }
-    return {};
-  }, [statuses, timeRange]);
-
   const queryResult = useQuery<ScheduleRootQuery, ScheduleRootQueryVariables>(SCHEDULE_ROOT_QUERY, {
     variables: {
       scheduleSelector,

--- a/js_modules/dagster-ui/packages/ui-core/src/schedules/ScheduleRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/schedules/ScheduleRoot.tsx
@@ -45,6 +45,19 @@ export const ScheduleRoot: React.FC<Props> = (props) => {
 
   const [selectedTab, setSelectedTab] = React.useState<string>('ticks');
 
+  const [statuses, setStatuses] = React.useState<undefined | InstigationTickStatus[]>(undefined);
+  const [timeRange, setTimerange] = React.useState<undefined | [number, number]>(undefined);
+  const variables = React.useMemo(() => {
+    if (timeRange || statuses) {
+      return {
+        afterTimestamp: timeRange?.[0],
+        beforeTimestamp: timeRange?.[1],
+        statuses,
+      };
+    }
+    return {};
+  }, [statuses, timeRange]);
+
   const queryResult = useQuery<ScheduleRootQuery, ScheduleRootQueryVariables>(SCHEDULE_ROOT_QUERY, {
     variables: {
       scheduleSelector,

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorRoot.tsx
@@ -32,6 +32,19 @@ export const SensorRoot: React.FC<{repoAddress: RepoAddress}> = ({repoAddress}) 
     sensorName,
   };
 
+  const [statuses, setStatuses] = React.useState<undefined | InstigationTickStatus[]>(undefined);
+  const [timeRange, setTimerange] = React.useState<undefined | [number, number]>(undefined);
+  const variables = React.useMemo(() => {
+    if (timeRange || statuses) {
+      return {
+        afterTimestamp: timeRange?.[0],
+        beforeTimestamp: timeRange?.[1],
+        statuses,
+      };
+    }
+    return {};
+  }, [statuses, timeRange]);
+
   const [selectedTab, setSelectedTab] = useQueryPersistedState<'evaluations' | 'runs'>(
     React.useMemo(
       () => ({
@@ -96,10 +109,20 @@ export const SensorRoot: React.FC<{repoAddress: RepoAddress}> = ({repoAddress}) 
                 padding={{vertical: 16, horizontal: 24}}
               />
             ) : null}
-            <TickHistoryTimeline repoAddress={repoAddress} name={sensorOrError.name} />
+            <TickHistoryTimeline
+              repoAddress={repoAddress}
+              name={sensorOrError.name}
+              {...variables}
+            />
             <Box margin={{top: 32}} border="top">
               {selectedTab === 'evaluations' ? (
-                <TicksTable tabs={tabs} repoAddress={repoAddress} name={sensorOrError.name} />
+                <TicksTable
+                  tabs={tabs}
+                  repoAddress={repoAddress}
+                  name={sensorOrError.name}
+                  setParentStatuses={setStatuses}
+                  setTimerange={setTimerange}
+                />
               ) : (
                 <SensorPreviousRuns repoAddress={repoAddress} sensor={sensorOrError} tabs={tabs} />
               )}

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorRoot.tsx
@@ -7,6 +7,7 @@ import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {PythonErrorInfo} from '../app/PythonErrorInfo';
 import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../app/QueryRefresh';
 import {useTrackPageView} from '../app/analytics';
+import {InstigationTickStatus} from '../graphql/types';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
 import {INSTANCE_HEALTH_FRAGMENT} from '../instance/InstanceHealthFragment';


### PR DESCRIPTION
## Summary & Motivation

- Make paginating forward and backwards in the table also move the timeline forwards and backwards.
- un-feature-gate the AMP timeline
- Default checkboxes to exclude "None requested"
- Update URL to not mention "AMP" (suggest "auto_materialize"?) 

## How I Tested These Changes

https://www.loom.com/share/fafbc31bc18f4e14966d58cbc190f958
