### PR TITLE
[2/n] AMP Timeline Polish

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/Flags.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/Flags.tsx
@@ -16,7 +16,6 @@ export const FeatureFlag = {
   flagDisableAutoLoadDefaults: 'flagDisableAutoLoadDefaults' as const,
   flagDAGSidebar: 'flagDAGSidebar' as const,
   flagDisableDAGCache: 'flagDisableDAGCache' as const,
-  flagEnableAMPTimeline: 'flagEnableAMPTimeline' as const,
   flagTightTreeDag: 'flagTightTreeDag' as const,
   flagLongestPathDag: 'flagLongestPathDag' as const,
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/app/getVisibleFeatureFlagRows.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/getVisibleFeatureFlagRows.tsx
@@ -58,10 +58,6 @@ export const getVisibleFeatureFlagRows = () => [
     flagType: FeatureFlag.flagDisableDAGCache,
   },
   {
-    key: 'Experimental Auto-materialize policy timeline page',
-    flagType: FeatureFlag.flagEnableAMPTimeline,
-  },
-  {
     key: 'Experimental tight tree DAG algorithm (Faster)',
     flagType: FeatureFlag.flagTightTreeDag,
     label: (

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationEvaluationHistoryTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationEvaluationHistoryTable.tsx
@@ -9,6 +9,7 @@ import {
   Table,
 } from '@dagster-io/ui-components';
 import React from 'react';
+import styled from 'styled-components';
 
 import {useQueryRefreshAtInterval} from '../../app/QueryRefresh';
 import {Timestamp} from '../../app/time/Timestamp';
@@ -149,13 +150,13 @@ export const AutomaterializationEvaluationHistoryTable = ({
           />
         </Box>
       </Box>
-      <Table>
+      <TableWrapper>
         <thead>
           <tr>
-            <th>Timestamp</th>
-            <th>Status</th>
-            <th>Duration</th>
-            <th>Result</th>
+            <th style={{width: 120}}>Timestamp</th>
+            <th style={{width: 90}}>Status</th>
+            <th style={{width: 90}}>Duration</th>
+            <th style={{width: 180}}>Result</th>
           </tr>
         </thead>
         <tbody>
@@ -194,7 +195,7 @@ export const AutomaterializationEvaluationHistoryTable = ({
             </tr>
           ))}
         </tbody>
-      </Table>
+      </TableWrapper>
       <div style={{paddingBottom: '16px'}}>
         <CursorHistoryControls {...paginationProps} />
       </div>
@@ -234,3 +235,10 @@ function StatusCheckbox({
     />
   );
 }
+
+const TableWrapper = styled(Table)`
+  th,
+  td {
+    vertical-align: middle !important;
+  }
+`;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationRoot.tsx
@@ -134,7 +134,21 @@ export const AutomaterializationRoot = () => {
         <Alert
           intent="info"
           title="[Experimental] Dagster can automatically materialize assets when criteria are met."
-          description="Auto-materialization enables a declarative approach to asset scheduling – instead of defining imperative workflows to materialize your assets, you just describe the conditions under which they should be materialized. Learn more about auto-materialization here."
+          description={
+            <>
+              Auto-materialization enables a declarative approach to asset scheduling – instead of
+              defining imperative workflows to materialize your assets, you just describe the
+              conditions under which they should be materialized.{' '}
+              <a
+                href="https://docs.dagster.io/concepts/assets/asset-auto-execution"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Learn more about auto-materialization here
+              </a>
+              .
+            </>
+          }
         />
       </Box>
       <Table>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationTickDetailDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationTickDetailDialog.tsx
@@ -251,7 +251,7 @@ const RowGrid = styled(Box)`
   grid-template-columns: ${TEMPLATE_COLUMNS};
   height: 100%;
   > * {
-    padding-top: 26px 0px;
+    justify-content: center;
   }
 `;
 

--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/TickHistory.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/TickHistory.tsx
@@ -86,8 +86,8 @@ export const TicksTable = ({
   name: string;
   repoAddress: RepoAddress;
   tabs?: React.ReactElement;
-  setTimerange: (range?: [number, number]) => void;
-  setParentStatuses: (statuses?: InstigationTickStatus[]) => void;
+  setTimerange?: (range?: [number, number]) => void;
+  setParentStatuses?: (statuses?: InstigationTickStatus[]) => void;
 }) => {
   const [shownStates, setShownStates] = useQueryPersistedState<ShownStatusState>({
     encode: (states) => {
@@ -154,19 +154,19 @@ export const TicksTable = ({
         const start = ticks[ticks.length - 1]?.timestamp;
         const end = ticks[0]?.endTimestamp;
         if (start && end) {
-          setTimerange([start, end]);
+          setTimerange?.([start, end]);
         }
       }
     } else {
-      setTimerange(undefined);
+      setTimerange?.(undefined);
     }
   }, [paginationProps.hasPrevCursor, ticks, setTimerange]);
 
   React.useEffect(() => {
     if (paginationProps.hasPrevCursor) {
-      setParentStatuses(Array.from(statuses));
+      setParentStatuses?.(Array.from(statuses));
     } else {
-      setParentStatuses(undefined);
+      setParentStatuses?.(undefined);
     }
   }, [paginationProps.hasPrevCursor, setParentStatuses, statuses]);
 

--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/TickHistory.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/TickHistory.tsx
@@ -26,7 +26,7 @@ import {showSharedToaster} from '../app/DomUtils';
 import {useFeatureFlags} from '../app/Flags';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {PythonErrorInfo} from '../app/PythonErrorInfo';
-import {ONE_MONTH, useQueryRefreshAtInterval} from '../app/QueryRefresh';
+import {useQueryRefreshAtInterval} from '../app/QueryRefresh';
 import {useCopyToClipboard} from '../app/browser';
 import {
   DynamicPartitionsRequestType,
@@ -80,10 +80,14 @@ export const TicksTable = ({
   name,
   repoAddress,
   tabs,
+  setTimerange,
+  setParentStatuses,
 }: {
   name: string;
   repoAddress: RepoAddress;
   tabs?: React.ReactElement;
+  setTimerange: (range?: [number, number]) => void;
+  setParentStatuses: (statuses?: InstigationTickStatus[]) => void;
 }) => {
   const [shownStates, setShownStates] = useQueryPersistedState<ShownStatusState>({
     encode: (states) => {
@@ -106,9 +110,14 @@ export const TicksTable = ({
   });
   const {flagSensorScheduleLogging} = useFeatureFlags();
   const instigationSelector = {...repoAddressToSelector(repoAddress), name};
-  const statuses = Object.keys(shownStates)
-    .filter((status) => shownStates[status as keyof typeof shownStates])
-    .map((status) => status as InstigationTickStatus);
+  const statuses = React.useMemo(
+    () =>
+      Object.keys(shownStates)
+        .filter((status) => shownStates[status as keyof typeof shownStates])
+        .map((status) => status as InstigationTickStatus),
+    [shownStates],
+  );
+
   const {queryResult, paginationProps} = useCursorPaginatedQuery<
     TickHistoryQuery,
     TickHistoryQueryVariables
@@ -132,11 +141,52 @@ export const TicksTable = ({
     query: JOB_TICK_HISTORY_QUERY,
     pageSize: PAGE_SIZE,
   });
+
+  const state = queryResult?.data?.instigationStateOrError;
+  const ticks = React.useMemo(
+    () => (state?.__typename === 'InstigationState' ? state.ticks : []),
+    [state],
+  );
+
+  React.useEffect(() => {
+    if (paginationProps.hasPrevCursor) {
+      if (ticks && ticks.length) {
+        const start = ticks[ticks.length - 1]?.timestamp;
+        const end = ticks[0]?.endTimestamp;
+        if (start && end) {
+          setTimerange([start, end]);
+        }
+      }
+    } else {
+      setTimerange(undefined);
+    }
+  }, [paginationProps.hasPrevCursor, ticks, setTimerange]);
+
+  React.useEffect(() => {
+    if (paginationProps.hasPrevCursor) {
+      setParentStatuses(Array.from(statuses));
+    } else {
+      setParentStatuses(undefined);
+    }
+  }, [paginationProps.hasPrevCursor, setParentStatuses, statuses]);
+
+  React.useEffect(() => {
+    if (paginationProps.hasPrevCursor && !ticks.length && !queryResult.loading) {
+      paginationProps.reset();
+    }
+    // paginationProps.reset isn't memoized
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ticks, queryResult.loading, paginationProps.hasPrevCursor]);
+
   const [logTick, setLogTick] = React.useState<InstigationTick>();
   const {data} = queryResult;
 
   if (!data) {
-    return null;
+    return (
+      <Box padding={{vertical: 48}}>
+        <Spinner purpose="page" />
+      </Box>
+    );
   }
 
   if (data.instigationStateOrError.__typename === 'PythonError') {
@@ -151,7 +201,7 @@ export const TicksTable = ({
     );
   }
 
-  const {ticks, instigationType} = data.instigationStateOrError;
+  const {instigationType} = data.instigationStateOrError;
 
   if (!ticks.length && statuses.length === Object.keys(DEFAULT_SHOWN_STATUS_STATE).length) {
     return null;
@@ -230,10 +280,16 @@ export const TickHistoryTimeline = ({
   name,
   repoAddress,
   onHighlightRunIds,
+  beforeTimestamp,
+  afterTimestamp,
+  statuses,
 }: {
   name: string;
   repoAddress: RepoAddress;
   onHighlightRunIds?: (runIds: string[]) => void;
+  beforeTimestamp?: number;
+  afterTimestamp?: number;
+  statuses?: InstigationTickStatus[];
 }) => {
   const [selectedTime, setSelectedTime] = useQueryPersistedState<number | undefined>({
     encode: (timestamp) => ({time: timestamp}),
@@ -246,12 +302,22 @@ export const TickHistoryTimeline = ({
   const queryResult = useQuery<TickHistoryQuery, TickHistoryQueryVariables>(
     JOB_TICK_HISTORY_QUERY,
     {
-      variables: {instigationSelector, limit: 15},
+      variables: {
+        instigationSelector,
+        beforeTimestamp,
+        afterTimestamp,
+        statuses,
+        limit: beforeTimestamp ? undefined : 15,
+      },
       notifyOnNetworkStatusChange: true,
     },
   );
 
-  useQueryRefreshAtInterval(queryResult, pollingPaused ? ONE_MONTH : 1000);
+  useQueryRefreshAtInterval(
+    queryResult,
+    1000,
+    !(pollingPaused || (beforeTimestamp && afterTimestamp)),
+  );
   const {data, error} = queryResult;
 
   if (!data || error) {
@@ -290,7 +356,6 @@ export const TickHistoryTimeline = ({
       pausePolling(true);
     }
   };
-
   return (
     <>
       <TickDetailsDialog
@@ -303,7 +368,14 @@ export const TickHistoryTimeline = ({
         <Subheading>Recent ticks</Subheading>
       </Box>
       <Box border="top">
-        <LiveTickTimeline ticks={ticks} onHoverTick={onTickHover} onSelectTick={onTickClick} />
+        <LiveTickTimeline
+          ticks={ticks}
+          onHoverTick={onTickHover}
+          onSelectTick={onTickClick}
+          exactRange={
+            beforeTimestamp && afterTimestamp ? [afterTimestamp, beforeTimestamp] : undefined
+          }
+        />
       </Box>
     </>
   );
@@ -437,12 +509,21 @@ const JOB_TICK_HISTORY_QUERY = gql`
     $limit: Int
     $cursor: String
     $statuses: [InstigationTickStatus!]
+    $beforeTimestamp: Float
+    $afterTimestamp: Float
   ) {
     instigationStateOrError(instigationSelector: $instigationSelector) {
       ... on InstigationState {
         id
         instigationType
-        ticks(dayRange: $dayRange, limit: $limit, cursor: $cursor, statuses: $statuses) {
+        ticks(
+          dayRange: $dayRange
+          limit: $limit
+          cursor: $cursor
+          statuses: $statuses
+          beforeTimestamp: $beforeTimestamp
+          afterTimestamp: $afterTimestamp
+        ) {
           id
           ...HistoryTick
         }

--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/TickHistory.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/TickHistory.tsx
@@ -49,7 +49,7 @@ import {LiveTickTimeline} from './LiveTickTimeline2';
 import {TickDetailsDialog} from './TickDetailsDialog';
 import {HistoryTickFragment} from './types/InstigationUtils.types';
 import {TickHistoryQuery, TickHistoryQueryVariables} from './types/TickHistory.types';
-import {truncate} from './util';
+import {isOldTickWithoutEndtimestamp, truncate} from './util';
 
 Chart.register(zoomPlugin);
 
@@ -238,7 +238,7 @@ export const TicksTable = ({
         </Box>
       </Box>
       {ticks.length ? (
-        <Table>
+        <TableWrapper>
           <thead>
             <tr>
               <th style={{width: 120}}>Timestamp</th>
@@ -261,7 +261,7 @@ export const TicksTable = ({
               />
             ))}
           </tbody>
-        </Table>
+        </TableWrapper>
       ) : (
         <Box padding={{vertical: 32}} flex={{justifyContent: 'center'}}>
           <NonIdealState icon="no-results" title="No ticks to display" />
@@ -420,7 +420,14 @@ function TickRow({
         <TickStatusTag tick={tick} />
       </td>
       <td>
-        <TimeElapsed startUnix={tick.timestamp} endUnix={tick.endTimestamp || Date.now() / 1000} />
+        {isOldTickWithoutEndtimestamp(tick) ? (
+          '- '
+        ) : (
+          <TimeElapsed
+            startUnix={tick.timestamp}
+            endUnix={tick.endTimestamp || Date.now() / 1000}
+          />
+        )}
       </td>
       {tick.instigationType === InstigationType.SENSOR ? (
         <td style={{width: 120}}>
@@ -557,5 +564,12 @@ const CopyButton = styled.button`
 
   :focus ${IconWrapper} {
     background-color: ${Colors.Link};
+  }
+`;
+
+const TableWrapper = styled(Table)`
+  th,
+  td {
+    vertical-align: middle !important;
   }
 `;

--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/types/TickHistory.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/types/TickHistory.types.ts
@@ -8,6 +8,8 @@ export type TickHistoryQueryVariables = Types.Exact<{
   limit?: Types.InputMaybe<Types.Scalars['Int']>;
   cursor?: Types.InputMaybe<Types.Scalars['String']>;
   statuses?: Types.InputMaybe<Array<Types.InstigationTickStatus> | Types.InstigationTickStatus>;
+  beforeTimestamp?: Types.InputMaybe<Types.Scalars['Float']>;
+  afterTimestamp?: Types.InputMaybe<Types.Scalars['Float']>;
 }>;
 
 export type TickHistoryQuery = {

--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/util.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/util.ts
@@ -1,3 +1,5 @@
+import {InstigationTick, InstigationTickStatus} from '../graphql/types';
+
 const TRUNCATION_THRESHOLD = 100;
 const TRUNCATION_BUFFER = 5;
 
@@ -5,3 +7,9 @@ export const truncate = (str: string) =>
   str.length > TRUNCATION_THRESHOLD
     ? `${str.slice(0, TRUNCATION_THRESHOLD - TRUNCATION_BUFFER)}…`
     : str;
+
+export function isOldTickWithoutEndtimestamp(
+  tick: Pick<InstigationTick, 'timestamp' | 'endTimestamp' | 'status'>,
+) {
+  return tick.status !== InstigationTickStatus.STARTED && !tick.endTimestamp;
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewAssetsRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewAssetsRoot.tsx
@@ -454,6 +454,7 @@ const RowGrid = styled(Box)`
   grid-template-columns: ${TEMPLATE_COLUMNS};
   height: 100%;
   > * {
+    vertical-align: middle;
   }
 `;
 

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewAssetsRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewAssetsRoot.tsx
@@ -454,7 +454,6 @@ const RowGrid = styled(Box)`
   grid-template-columns: ${TEMPLATE_COLUMNS};
   height: 100%;
   > * {
-    padding-top: 26px 0px;
   }
 `;
 

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewRoot.tsx
@@ -13,7 +13,6 @@ import {OverviewSchedulesRoot} from './OverviewSchedulesRoot';
 import {OverviewSensorsRoot} from './OverviewSensorsRoot';
 
 export const OverviewRoot = () => {
-  const {flagEnableAMPTimeline} = useFeatureFlags();
   return (
     <Switch>
       <Route path="/overview/activity">
@@ -28,11 +27,9 @@ export const OverviewRoot = () => {
       <Route path="/overview/sensors">
         <OverviewSensorsRoot />
       </Route>
-      {flagEnableAMPTimeline ? (
-        <Route path="/overview/amp">
-          <AutomaterializationRoot />
-        </Route>
-      ) : null}
+      <Route path="/overview/automaterialize">
+        <AutomaterializationRoot />
+      </Route>
       <Route path="/overview/backfills/:backfillId">
         <BackfillPage />
       </Route>

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewRoot.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import {Redirect, Route, Switch} from 'react-router-dom';
 
-import {useFeatureFlags} from '../app/Flags';
 import {AutomaterializationRoot} from '../assets/auto-materialization/AutomaterializationRoot';
 import {InstanceBackfills} from '../instance/InstanceBackfills';
 import {BackfillPage} from '../instance/backfill/BackfillPage';

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewTabs.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewTabs.tsx
@@ -2,7 +2,6 @@ import {QueryResult} from '@apollo/client';
 import {Box, Colors, Spinner, Tabs} from '@dagster-io/ui-components';
 import * as React from 'react';
 
-import {useFeatureFlags} from '../app/Flags';
 import {QueryRefreshCountdown, QueryRefreshState} from '../app/QueryRefresh';
 import {useAutomaterializeDaemonStatus} from '../assets/AutomaterializeDaemonStatusTag';
 import {TabLink} from '../ui/TabLink';

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewTabs.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewTabs.tsx
@@ -17,7 +17,6 @@ export const OverviewTabs = <TData extends Record<string, any>>(props: Props<TDa
   const {refreshState, tab} = props;
 
   const automaterialize = useAutomaterializeDaemonStatus();
-  const {flagEnableAMPTimeline} = useFeatureFlags();
 
   return (
     <Box flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'flex-end'}}>
@@ -26,30 +25,28 @@ export const OverviewTabs = <TData extends Record<string, any>>(props: Props<TDa
         <TabLink id="jobs" title="Jobs" to="/overview/jobs" />
         <TabLink id="schedules" title="Schedules" to="/overview/schedules" />
         <TabLink id="sensors" title="Sensors" to="/overview/sensors" />
-        {flagEnableAMPTimeline ? (
-          <TabLink
-            id="amp"
-            title={
-              <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
-                <div>Auto-materialize</div>
-                {automaterialize.loading ? (
-                  <Spinner purpose="body-text" />
-                ) : (
-                  <div
-                    style={{
-                      width: '10px',
-                      height: '10px',
-                      borderRadius: '50%',
-                      backgroundColor:
-                        automaterialize.paused === false ? Colors.Blue200 : Colors.Gray200,
-                    }}
-                  />
-                )}
-              </Box>
-            }
-            to="/overview/amp"
-          />
-        ) : null}
+        <TabLink
+          id="amp"
+          title={
+            <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
+              <div>Auto-materialize</div>
+              {automaterialize.loading ? (
+                <Spinner purpose="body-text" />
+              ) : (
+                <div
+                  style={{
+                    width: '10px',
+                    height: '10px',
+                    borderRadius: '50%',
+                    backgroundColor:
+                      automaterialize.paused === false ? Colors.Blue200 : Colors.Gray200,
+                  }}
+                />
+              )}
+            </Box>
+          }
+          to="/overview/automaterialize"
+        />
         <TabLink id="resources" title="Resources" to="/overview/resources" />
         <TabLink id="backfills" title="Backfills" to="/overview/backfills" />
       </Tabs>

--- a/js_modules/dagster-ui/packages/ui-core/src/schedules/ScheduleRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/schedules/ScheduleRoot.tsx
@@ -45,19 +45,6 @@ export const ScheduleRoot: React.FC<Props> = (props) => {
 
   const [selectedTab, setSelectedTab] = React.useState<string>('ticks');
 
-  const [statuses, setStatuses] = React.useState<undefined | InstigationTickStatus[]>(undefined);
-  const [timeRange, setTimerange] = React.useState<undefined | [number, number]>(undefined);
-  const variables = React.useMemo(() => {
-    if (timeRange || statuses) {
-      return {
-        afterTimestamp: timeRange?.[0],
-        beforeTimestamp: timeRange?.[1],
-        statuses,
-      };
-    }
-    return {};
-  }, [statuses, timeRange]);
-
   const queryResult = useQuery<ScheduleRootQuery, ScheduleRootQueryVariables>(SCHEDULE_ROOT_QUERY, {
     variables: {
       scheduleSelector,

--- a/js_modules/dagster-ui/packages/ui-core/src/schedules/ScheduleRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/schedules/ScheduleRoot.tsx
@@ -45,6 +45,19 @@ export const ScheduleRoot: React.FC<Props> = (props) => {
 
   const [selectedTab, setSelectedTab] = React.useState<string>('ticks');
 
+  const [statuses, setStatuses] = React.useState<undefined | InstigationTickStatus[]>(undefined);
+  const [timeRange, setTimerange] = React.useState<undefined | [number, number]>(undefined);
+  const variables = React.useMemo(() => {
+    if (timeRange || statuses) {
+      return {
+        afterTimestamp: timeRange?.[0],
+        beforeTimestamp: timeRange?.[1],
+        statuses,
+      };
+    }
+    return {};
+  }, [statuses, timeRange]);
+
   const queryResult = useQuery<ScheduleRootQuery, ScheduleRootQueryVariables>(SCHEDULE_ROOT_QUERY, {
     variables: {
       scheduleSelector,

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorRoot.tsx
@@ -32,6 +32,19 @@ export const SensorRoot: React.FC<{repoAddress: RepoAddress}> = ({repoAddress}) 
     sensorName,
   };
 
+  const [statuses, setStatuses] = React.useState<undefined | InstigationTickStatus[]>(undefined);
+  const [timeRange, setTimerange] = React.useState<undefined | [number, number]>(undefined);
+  const variables = React.useMemo(() => {
+    if (timeRange || statuses) {
+      return {
+        afterTimestamp: timeRange?.[0],
+        beforeTimestamp: timeRange?.[1],
+        statuses,
+      };
+    }
+    return {};
+  }, [statuses, timeRange]);
+
   const [selectedTab, setSelectedTab] = useQueryPersistedState<'evaluations' | 'runs'>(
     React.useMemo(
       () => ({
@@ -96,10 +109,20 @@ export const SensorRoot: React.FC<{repoAddress: RepoAddress}> = ({repoAddress}) 
                 padding={{vertical: 16, horizontal: 24}}
               />
             ) : null}
-            <TickHistoryTimeline repoAddress={repoAddress} name={sensorOrError.name} />
+            <TickHistoryTimeline
+              repoAddress={repoAddress}
+              name={sensorOrError.name}
+              {...variables}
+            />
             <Box margin={{top: 32}} border="top">
               {selectedTab === 'evaluations' ? (
-                <TicksTable tabs={tabs} repoAddress={repoAddress} name={sensorOrError.name} />
+                <TicksTable
+                  tabs={tabs}
+                  repoAddress={repoAddress}
+                  name={sensorOrError.name}
+                  setParentStatuses={setStatuses}
+                  setTimerange={setTimerange}
+                />
               ) : (
                 <SensorPreviousRuns repoAddress={repoAddress} sensor={sensorOrError} tabs={tabs} />
               )}

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorRoot.tsx
@@ -7,6 +7,7 @@ import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {PythonErrorInfo} from '../app/PythonErrorInfo';
 import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../app/QueryRefresh';
 import {useTrackPageView} from '../app/analytics';
+import {InstigationTickStatus} from '../graphql/types';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
 import {INSTANCE_HEALTH_FRAGMENT} from '../instance/InstanceHealthFragment';


### PR DESCRIPTION
## Summary & Motivation

Fixes:
- Old ticks with no end timestamp should not show an infinite duration
- "Learn more about auto-materialization here" link should be linkified to AMP docs
- Vertical spacing tweaks in "view details" dialog
- column lines move around when you switch checkboxes

## How I Tested These Changes

locally
<img width="793" alt="Screenshot 2023-10-17 at 7 15 09 AM" src="https://github.com/dagster-io/dagster/assets/2286579/71094e5a-9a05-44bf-a117-2b29c87e1653">
<img width="1000" alt="Screenshot 2023-10-17 at 7 15 02 AM" src="https://github.com/dagster-io/dagster/assets/2286579/fa8cb6ab-f588-4dff-a18a-8217f128b478">
<img width="1402" alt="Screenshot 2023-10-17 at 7 14 59 AM" src="https://github.com/dagster-io/dagster/assets/2286579/add852cd-1459-4a59-be58-2e3cb2857236">
