### PR TITLE
Fix auto-scroll in asset graph sidebar

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Node.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Node.tsx
@@ -29,6 +29,7 @@ import {FolderNodeNonAssetType, StatusCaseDot, getDisplayName} from './util';
 
 export const Node = ({
   graphData,
+  fullAssetGraphData,
   node,
   level,
   toggleOpen,
@@ -41,6 +42,7 @@ export const Node = ({
   viewType,
 }: {
   graphData: GraphData;
+  fullAssetGraphData: GraphData;
   node: GraphNode | FolderNodeNonAssetType;
   level: number;
   toggleOpen: () => void;
@@ -112,7 +114,7 @@ export const Node = ({
       {launchpadElement}
       <UpstreamDownstreamDialog
         title="Parent assets"
-        graphData={graphData}
+        graphData={fullAssetGraphData}
         assetKeys={upstream}
         isOpen={showParents}
         setIsOpen={setShowParents}
@@ -355,7 +357,7 @@ const GrayOnHoverBox = styled(Box)`
   }
 `;
 
-function StatusDot({node}: {node: GraphNode}) {
+function StatusDot({node}: {node: Pick<GraphNode, 'assetKey' | 'definition'>}) {
   const {liveData} = useAssetLiveData(node.assetKey);
   if (!liveData) {
     return <StatusCaseDot statusCase={StatusCase.LOADING} />;

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
@@ -278,10 +278,16 @@ export const AssetGraphExplorerSidebar = React.memo(
             ? renderedNodes.findIndex((node) => 'path' in node && node.path === selectedNode.path)
             : -1;
         } else {
-          return renderedNodes.findIndex(
-            (node) =>
-              nodePathKey(node) === nodePathKey(selectedNode) || node.id === selectedNode.id,
-          );
+          return renderedNodes.findIndex((node) => {
+            // If you select a node via the search dropdown or from the graph directly then
+            // selectedNode will have an `id` field and not a path. The nodes in renderedNodes
+            // will always have a path so we need to explicitly check if the id's match
+            if (!('path' in selectedNode)) {
+              return node.id === selectedNode.id;
+            } else {
+              return nodePathKey(node) === nodePathKey(selectedNode);
+            }
+          });
         }
       },
       // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
@@ -278,7 +278,10 @@ export const AssetGraphExplorerSidebar = React.memo(
             ? renderedNodes.findIndex((node) => 'path' in node && node.path === selectedNode.path)
             : -1;
         } else {
-          return renderedNodes.findIndex((node) => nodePathKey(node) === nodePathKey(selectedNode));
+          return renderedNodes.findIndex(
+            (node) =>
+              nodePathKey(node) === nodePathKey(selectedNode) || node.id === selectedNode.id,
+          );
         }
       },
       // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
@@ -367,6 +367,7 @@ export const AssetGraphExplorerSidebar = React.memo(
                         viewType={viewType}
                         isOpen={openNodes.has(nodePathKey(node))}
                         graphData={graphData}
+                        fullAssetGraphData={fullAssetGraphData}
                         node={row}
                         level={node.level}
                         isSelected={

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphData.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphData.tsx
@@ -4,6 +4,7 @@ import keyBy from 'lodash/keyBy';
 import reject from 'lodash/reject';
 import React from 'react';
 
+import {useFeatureFlags} from '../app/Flags';
 import {filterByQuery, GraphQueryItem} from '../app/GraphQueryImpl';
 import {AssetKey} from '../assets/types';
 import {asyncGetFullAssetLayoutIndexDB} from '../graph/asyncGraphLayout';
@@ -109,13 +110,15 @@ export function useAssetGraphData(opsQuery: string, options: AssetGraphFetchScop
   const [assetGraphDataMaybeCached, setAssetGraphDataMaybeCached] =
     React.useState<GraphData | null>(null);
 
+  const {flagDisableDAGCache} = useFeatureFlags();
+
   React.useLayoutEffect(() => {
     setAssetGraphDataMaybeCached(null);
     setIsCached(false);
     setIsCalculating(true);
     (async () => {
       let fullAssetGraphData = null;
-      if (applyingEmptyDefault && repoFilteredNodes) {
+      if (applyingEmptyDefault && repoFilteredNodes && !flagDisableDAGCache) {
         // build the graph data anyways to check if it's cached
         const {all} = filterByQuery(graphQueryItems, '*');
         fullAssetGraphData = buildGraphData(all.map((n) => n.node));
@@ -142,6 +145,7 @@ export function useAssetGraphData(opsQuery: string, options: AssetGraphFetchScop
     options.hideEdgesToNodesOutsideQuery,
     repoFilteredNodes,
     assetGraphData,
+    flagDisableDAGCache,
   ]);
 
   return {

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphData.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphData.tsx
@@ -116,6 +116,7 @@ export function useAssetGraphData(opsQuery: string, options: AssetGraphFetchScop
     setAssetGraphDataMaybeCached(null);
     setIsCached(false);
     setIsCalculating(true);
+    let cancel = false;
     (async () => {
       let fullAssetGraphData = null;
       if (applyingEmptyDefault && repoFilteredNodes && !flagDisableDAGCache) {
@@ -127,6 +128,9 @@ export function useAssetGraphData(opsQuery: string, options: AssetGraphFetchScop
         }
         if (fullAssetGraphData) {
           const isCached = await asyncGetFullAssetLayoutIndexDB.isCached(fullAssetGraphData);
+          if (cancel) {
+            return;
+          }
           if (isCached) {
             setAssetGraphDataMaybeCached(fullAssetGraphData);
             setIsCached(true);
@@ -139,6 +143,10 @@ export function useAssetGraphData(opsQuery: string, options: AssetGraphFetchScop
       setIsCached(false);
       setIsCalculating(false);
     })();
+
+    return () => {
+      cancel = true;
+    };
   }, [
     applyingEmptyDefault,
     graphQueryItems,

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
@@ -58,8 +58,8 @@ const _assetLayoutCacheKey = (graphData: GraphData, opts: LayoutAssetGraphOption
     return newObj;
   }
 
-  return `${opts?.horizontalDAGs ? 'horizontal:' : ''}${
-    opts?.tightTree ? 'tight-tree:' : ''
+  return `${opts?.horizontalDAGs ? 'horizontal:' : ''}${opts?.tightTree ? 'tight-tree:' : ''}${
+    opts?.longestPath ? 'longest-path' : ''
   }${JSON.stringify({
     downstream: recreateObjectWithKeysSorted(graphData.downstream),
     upstream: recreateObjectWithKeysSorted(graphData.upstream),


### PR DESCRIPTION
## Summary & Motivation

Fixes automatically scrolling in the asset-graph sidebar in some cases.

## How I Tested These Changes

Loaded the page with a node already selected via the URL parameter and saw the sidebar automatically scroll to it.
