### PR TITLE
[dagster-pyspark] add exclude arg to build_pyspark_zip

### DIFF
--- a/python_modules/libraries/dagster-pyspark/dagster_pyspark/utils.py
+++ b/python_modules/libraries/dagster-pyspark/dagster_pyspark/utils.py
@@ -1,11 +1,26 @@
 import os
+import re
 import zipfile
 
 import dagster._check as check
 
+DEFAULT_EXCLUDE = [
+    r".*pytest.*",
+    r".*__pycache__.*",
+    r".*pyc$",
+]
 
-def build_pyspark_zip(zip_file, path):
-    """Archives the current path into a file named `zip_file`."""
+
+def build_pyspark_zip(zip_file, path, exclude=DEFAULT_EXCLUDE) -> None:
+    """Archives the current path into a file named `zip_file`.
+
+    Args:
+        zip_file (str): The name of the zip file to create.
+        path (str): The path to archive.
+        exclude (Optional[List[str]]): A list of regular expression patterns to exclude paths from
+            the archive. Regular expressions will be matched against the absolute filepath with
+            `re.search`.
+    """
     check.str_param(zip_file, "zip_file")
     check.str_param(path, "path")
 
@@ -15,7 +30,7 @@ def build_pyspark_zip(zip_file, path):
                 abs_fname = os.path.join(root, fname)
 
                 # Skip various artifacts
-                if "pytest" in abs_fname or "__pycache__" in abs_fname or "pyc" in abs_fname:
+                if any([re.search(pattern, abs_fname) for pattern in exclude]):
                     continue
 
                 zf.write(abs_fname, os.path.relpath(os.path.join(root, fname), path))

--- a/python_modules/libraries/dagster-pyspark/dagster_pyspark_tests/test_utils.py
+++ b/python_modules/libraries/dagster-pyspark/dagster_pyspark_tests/test_utils.py
@@ -1,0 +1,20 @@
+import os
+import zipfile
+from pathlib import Path
+
+from dagster_pyspark.utils import build_pyspark_zip
+
+
+def test_build_pyspark_zip(tmp_path):
+    zip_path = tmp_path / "test.zip"
+    root = Path(tmp_path / "root")
+    os.mkdir(root)
+    os.mkdir(root / "foo")
+    os.mkdir(root / "foo/bar")
+    with open(root / "foo/bar/baz.txt", "w") as f:
+        f.write("hello world")
+    with open(root / "foo/baz.txt", "w") as f:
+        f.write("hello world")
+    build_pyspark_zip(str(zip_path), str(root), exclude=[r".*/bar/.*"])
+    with zipfile.ZipFile(zip_path, "r") as zf:
+        assert zf.namelist() == ["foo/baz.txt"]


### PR DESCRIPTION
## Summary & Motivation

Resolves #17219.

Adds an `exclude` param (replacing previously hardcoded default list) and a test for `build_pyspark_zip`.

## How I Tested These Changes

New unit test.
