### PR TITLE
[dagster-dbt][tweak] add check guards on various dagster_dbt_translator API inputs

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
@@ -10,7 +10,6 @@ from typing import (
     Tuple,
 )
 
-import dagster._check as check
 from dagster import (
     AssetCheckSpec,
     AssetKey,
@@ -30,7 +29,7 @@ from .asset_utils import (
     default_code_version_fn,
     get_deps,
 )
-from .dagster_dbt_translator import DagsterDbtTranslator, DbtManifestWrapper
+from .dagster_dbt_translator import DagsterDbtTranslator, DbtManifestWrapper, validate_translator
 from .dbt_manifest import DbtManifestParam, validate_manifest
 from .utils import (
     ASSET_RESOURCE_TYPES,
@@ -249,15 +248,7 @@ def dbt_assets(
                 yield from dbt.cli(dbt_build_args, context=context).stream()
 
     """
-    check.inst_param(
-        dagster_dbt_translator,
-        "dagster_dbt_translator",
-        DagsterDbtTranslator,
-        additional_message=(
-            "Ensure that the argument is an instantiated class that subclasses"
-            " DagsterDbtTranslator."
-        ),
-    )
+    dagster_dbt_translator = validate_translator(dagster_dbt_translator)
     manifest = validate_manifest(manifest)
 
     unique_ids = select_unique_ids_from_manifest(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
@@ -596,6 +596,15 @@ def load_assets_from_dbt_project(
     target_dir = check.opt_str_param(target_dir, "target_dir", os.path.join(project_dir, "target"))
     select = check.opt_str_param(select, "select", "fqn:*")
     exclude = check.opt_str_param(exclude, "exclude", "")
+    dagster_dbt_translator = check.opt_inst_param(
+        dagster_dbt_translator,
+        "dagster_dbt_translator",
+        DagsterDbtTranslator,
+        additional_message=(
+            "Ensure that the argument is an instantiated class that subclasses"
+            " DagsterDbtTranslator."
+        ),
+    )
 
     _raise_warnings_for_deprecated_args(
         "load_assets_from_dbt_manifest",
@@ -796,6 +805,15 @@ def load_assets_from_dbt_manifest(
             this flag to False is advised to reduce the size of the resulting snapshot. Deprecated:
             instead, provide a custom DagsterDbtTranslator that overrides node_info_to_description.
     """
+    dagster_dbt_translator = check.opt_inst_param(
+        dagster_dbt_translator,
+        "dagster_dbt_translator",
+        DagsterDbtTranslator,
+        additional_message=(
+            "Ensure that the argument is an instantiated class that subclasses"
+            " DagsterDbtTranslator."
+        ),
+    )
     manifest = normalize_renamed_param(
         manifest,
         "manifest",

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
@@ -63,7 +63,7 @@ from dagster_dbt.core.resources import DbtCliClient
 from dagster_dbt.core.resources_v2 import DbtCliResource
 from dagster_dbt.core.types import DbtCliOutput
 from dagster_dbt.core.utils import build_command_args_from_flags, execute_cli
-from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator, validate_translator_opt
+from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator, validate_opt_translator
 from dagster_dbt.errors import DagsterDbtError
 from dagster_dbt.types import DbtOutput
 from dagster_dbt.utils import (
@@ -596,7 +596,7 @@ def load_assets_from_dbt_project(
     target_dir = check.opt_str_param(target_dir, "target_dir", os.path.join(project_dir, "target"))
     select = check.opt_str_param(select, "select", "fqn:*")
     exclude = check.opt_str_param(exclude, "exclude", "")
-    dagster_dbt_translator = validate_translator_opt(dagster_dbt_translator)
+    dagster_dbt_translator = validate_opt_translator(dagster_dbt_translator)
 
     _raise_warnings_for_deprecated_args(
         "load_assets_from_dbt_manifest",
@@ -797,7 +797,7 @@ def load_assets_from_dbt_manifest(
             this flag to False is advised to reduce the size of the resulting snapshot. Deprecated:
             instead, provide a custom DagsterDbtTranslator that overrides node_info_to_description.
     """
-    dagster_dbt_translator = validate_translator_opt(dagster_dbt_translator)
+    dagster_dbt_translator = validate_opt_translator(dagster_dbt_translator)
 
     manifest = normalize_renamed_param(
         manifest,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
@@ -63,7 +63,7 @@ from dagster_dbt.core.resources import DbtCliClient
 from dagster_dbt.core.resources_v2 import DbtCliResource
 from dagster_dbt.core.types import DbtCliOutput
 from dagster_dbt.core.utils import build_command_args_from_flags, execute_cli
-from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator
+from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator, validate_translator_opt
 from dagster_dbt.errors import DagsterDbtError
 from dagster_dbt.types import DbtOutput
 from dagster_dbt.utils import (
@@ -596,15 +596,7 @@ def load_assets_from_dbt_project(
     target_dir = check.opt_str_param(target_dir, "target_dir", os.path.join(project_dir, "target"))
     select = check.opt_str_param(select, "select", "fqn:*")
     exclude = check.opt_str_param(exclude, "exclude", "")
-    dagster_dbt_translator = check.opt_inst_param(
-        dagster_dbt_translator,
-        "dagster_dbt_translator",
-        DagsterDbtTranslator,
-        additional_message=(
-            "Ensure that the argument is an instantiated class that subclasses"
-            " DagsterDbtTranslator."
-        ),
-    )
+    dagster_dbt_translator = validate_translator_opt(dagster_dbt_translator)
 
     _raise_warnings_for_deprecated_args(
         "load_assets_from_dbt_manifest",
@@ -805,15 +797,8 @@ def load_assets_from_dbt_manifest(
             this flag to False is advised to reduce the size of the resulting snapshot. Deprecated:
             instead, provide a custom DagsterDbtTranslator that overrides node_info_to_description.
     """
-    dagster_dbt_translator = check.opt_inst_param(
-        dagster_dbt_translator,
-        "dagster_dbt_translator",
-        DagsterDbtTranslator,
-        additional_message=(
-            "Ensure that the argument is an instantiated class that subclasses"
-            " DagsterDbtTranslator."
-        ),
-    )
+    dagster_dbt_translator = validate_translator_opt(dagster_dbt_translator)
+
     manifest = normalize_renamed_param(
         manifest,
         "manifest",

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -40,13 +40,11 @@ from dagster._core.definitions.decorators.asset_decorator import (
 from dagster._utils.merger import merge_dicts
 from dagster._utils.warnings import deprecation_warning
 
-from .dagster_dbt_translator import (
-    DagsterDbtTranslator,
-)
 from .utils import input_name_fn, output_name_fn
 
 if TYPE_CHECKING:
     from .dagster_dbt_translator import (
+        DagsterDbtTranslator,
         DagsterDbtTranslatorSettings,
         DbtManifestWrapper,
     )
@@ -648,6 +646,10 @@ def get_asset_deps(
     Dict[str, List[str]],
     Dict[str, Dict[str, Any]],
 ]:
+
+    from .dagster_dbt_translator import (
+        DagsterDbtTranslator,
+    )
     dagster_dbt_translator = check.inst_param(
         dagster_dbt_translator,
         "dagster_dbt_translator",

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -646,10 +646,10 @@ def get_asset_deps(
     Dict[str, List[str]],
     Dict[str, Dict[str, Any]],
 ]:
-
     from .dagster_dbt_translator import (
         DagsterDbtTranslator,
     )
+
     dagster_dbt_translator = check.inst_param(
         dagster_dbt_translator,
         "dagster_dbt_translator",

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -646,11 +646,9 @@ def get_asset_deps(
     Dict[str, List[str]],
     Dict[str, Dict[str, Any]],
 ]:
-    from .dagster_dbt_translator import validate_translator
+    from .dagster_dbt_translator import DbtManifestWrapper, validate_translator
 
     dagster_dbt_translator = validate_translator(dagster_dbt_translator)
-
-    from .dagster_dbt_translator import DbtManifestWrapper
 
     asset_deps: Dict[AssetKey, Set[AssetKey]] = {}
     asset_ins: Dict[AssetKey, Tuple[str, In]] = {}

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -40,11 +40,13 @@ from dagster._core.definitions.decorators.asset_decorator import (
 from dagster._utils.merger import merge_dicts
 from dagster._utils.warnings import deprecation_warning
 
+from .dagster_dbt_translator import (
+    DagsterDbtTranslator,
+)
 from .utils import input_name_fn, output_name_fn
 
 if TYPE_CHECKING:
     from .dagster_dbt_translator import (
-        DagsterDbtTranslator,
         DagsterDbtTranslatorSettings,
         DbtManifestWrapper,
     )
@@ -646,6 +648,16 @@ def get_asset_deps(
     Dict[str, List[str]],
     Dict[str, Dict[str, Any]],
 ]:
+    dagster_dbt_translator = check.inst_param(
+        dagster_dbt_translator,
+        "dagster_dbt_translator",
+        DagsterDbtTranslator,
+        additional_message=(
+            "Ensure that the argument is an instantiated class that subclasses"
+            " DagsterDbtTranslator."
+        ),
+    )
+
     from .dagster_dbt_translator import DbtManifestWrapper
 
     asset_deps: Dict[AssetKey, Set[AssetKey]] = {}

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -646,19 +646,9 @@ def get_asset_deps(
     Dict[str, List[str]],
     Dict[str, Dict[str, Any]],
 ]:
-    from .dagster_dbt_translator import (
-        DagsterDbtTranslator,
-    )
+    from .dagster_dbt_translator import validate_translator
 
-    dagster_dbt_translator = check.inst_param(
-        dagster_dbt_translator,
-        "dagster_dbt_translator",
-        DagsterDbtTranslator,
-        additional_message=(
-            "Ensure that the argument is an instantiated class that subclasses"
-            " DagsterDbtTranslator."
-        ),
-    )
+    dagster_dbt_translator = validate_translator(dagster_dbt_translator)
 
     from .dagster_dbt_translator import DbtManifestWrapper
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -809,7 +809,7 @@ class DbtCliResource(ConfigurableResource):
                     dbt_macro_args = {"key": "value"}
                     dbt.cli(["run-operation", "my-macro", json.dumps(dbt_macro_args)]).wait()
         """
-        dagster_dbt_translator = check.inst_param(
+        dagster_dbt_translator = check.opt_inst_param(
             dagster_dbt_translator,
             "dagster_dbt_translator",
             DagsterDbtTranslator,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -27,6 +27,7 @@ from dagster import (
     AssetsDefinition,
     ConfigurableResource,
     Output,
+    _check as check,
     get_dagster_logger,
 )
 from dagster._annotations import public
@@ -105,6 +106,17 @@ class DbtCliEventMessage:
                 - AssetObservation for dbt test results that are not enabled as asset checks.
                 - AssetCheckResult for dbt test results that are enabled as asset checks.
         """
+        manifest = check.inst_param(manifest, "manifest", (Mapping[str, Any], str, Path))
+        dagster_dbt_translator = check.inst_param(
+            dagster_dbt_translator,
+            "dagster_dbt_translator",
+            DagsterDbtTranslator,
+            additional_message=(
+                "Ensure that the argument is an instantiated class that subclasses"
+                " DagsterDbtTranslator."
+            ),
+        )
+
         if self.raw_event["info"]["level"] == "debug":
             return
 
@@ -797,6 +809,16 @@ class DbtCliResource(ConfigurableResource):
                     dbt_macro_args = {"key": "value"}
                     dbt.cli(["run-operation", "my-macro", json.dumps(dbt_macro_args)]).wait()
         """
+        dagster_dbt_translator = check.inst_param(
+            dagster_dbt_translator,
+            "dagster_dbt_translator",
+            DagsterDbtTranslator,
+            additional_message=(
+                "Ensure that the argument is an instantiated class that subclasses"
+                " DagsterDbtTranslator."
+            ),
+        )
+
         target_path = target_path or self._get_unique_target_path(context=context)
         env = {
             **os.environ.copy(),

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -45,8 +45,8 @@ from ..asset_utils import (
 )
 from ..dagster_dbt_translator import (
     DagsterDbtTranslator,
+    validate_opt_translator,
     validate_translator,
-    validate_translator_opt,
 )
 from ..dbt_manifest import (
     DbtManifestParam,
@@ -806,7 +806,7 @@ class DbtCliResource(ConfigurableResource):
                     dbt_macro_args = {"key": "value"}
                     dbt.cli(["run-operation", "my-macro", json.dumps(dbt_macro_args)]).wait()
         """
-        dagster_dbt_translator = validate_translator_opt(dagster_dbt_translator)
+        dagster_dbt_translator = validate_opt_translator(dagster_dbt_translator)
 
         target_path = target_path or self._get_unique_target_path(context=context)
         env = {

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
@@ -387,7 +387,7 @@ def validate_translator(dagster_dbt_translator: DagsterDbtTranslator) -> Dagster
     )
 
 
-def validate_translator_opt(
+def validate_opt_translator(
     dagster_dbt_translator: Optional[DagsterDbtTranslator],
 ) -> Optional[DagsterDbtTranslator]:
     return check.opt_inst_param(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
@@ -1,7 +1,12 @@
 from dataclasses import dataclass
 from typing import Any, Mapping, Optional
 
-from dagster import AssetKey, AutoMaterializePolicy, FreshnessPolicy
+from dagster import (
+    AssetKey,
+    AutoMaterializePolicy,
+    FreshnessPolicy,
+    _check as check,
+)
 from dagster._annotations import public
 from dagster._core.definitions.events import (
     CoercibleToAssetKeyPrefix,
@@ -368,3 +373,29 @@ class KeyPrefixDagsterDbtTranslator(DagsterDbtTranslator):
 @dataclass
 class DbtManifestWrapper:
     manifest: Mapping[str, Any]
+
+
+def validate_translator(dagster_dbt_translator: DagsterDbtTranslator) -> DagsterDbtTranslator:
+    return check.inst_param(
+        dagster_dbt_translator,
+        "dagster_dbt_translator",
+        DagsterDbtTranslator,
+        additional_message=(
+            "Ensure that the argument is an instantiated class that subclasses"
+            " DagsterDbtTranslator."
+        ),
+    )
+
+
+def validate_translator_opt(
+    dagster_dbt_translator: Optional[DagsterDbtTranslator],
+) -> Optional[DagsterDbtTranslator]:
+    return check.opt_inst_param(
+        dagster_dbt_translator,
+        "dagster_dbt_translator",
+        DagsterDbtTranslator,
+        additional_message=(
+            "Ensure that the argument is an instantiated class that subclasses"
+            " DagsterDbtTranslator."
+        ),
+    )


### PR DESCRIPTION
## Summary

adds some check calls to ensure that a translator is passed rather than some other object (e.g. a translator class instead of an instance)
