### PR TITLE
remove file mount recommendation for dagster.yaml

### DIFF
--- a/docs/content/dagster-cloud/deployment/agents/amazon-ecs/manually-provisioning-ecs-agent.mdx
+++ b/docs/content/dagster-cloud/deployment/agents/amazon-ecs/manually-provisioning-ecs-agent.mdx
@@ -123,7 +123,6 @@ To successfully run your ECS agent, you'll need to have the following IAM roles 
 2. Add a configured `dagster.yaml` file to your container. You can do this by:
 
    - Building it into your image
-   - [Mounting a volume](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_data_volumes.html), or
    - Echoing it to a file in your task definition's command **before starting the agent**
 
    Refer to the [ECS configuration reference](/dagster-cloud/deployment/agents/amazon-ecs/configuration-reference#per-deployment-configuration) for more info about the required fields.


### PR DESCRIPTION
## Summary & Motivation

While this can work its more difficult than the other options and can lead to a misunderstanding of how the config is propagated to the container (ie modifying the file after dagster is running), we don't use this pattern ourselves.

## How I Tested These Changes
