### PR TITLE
change job to job_name in docs

### DIFF
--- a/docs/content/guides/dagster/branch_deployments.mdx
+++ b/docs/content/guides/dagster/branch_deployments.mdx
@@ -295,7 +295,7 @@ name: Dagster Branch Deployments
           with:
             location_name: ${{ matrix.location.name }}
             deployment: ${{ steps.deploy.outputs.deployment }}
-            job: clone_prod
+            job_name: clone_prod
           env:
             DAGSTER_CLOUD_URL: ${{ secrets.DAGSTER_CLOUD_URL }}
             DAGSTER_CLOUD_API_TOKEN: ${{ secrets.DAGSTER_CLOUD_API_TOKEN }}
@@ -430,7 +430,7 @@ name: Dagster Branch Deployments
           with:
             location_name: ${{ matrix.location.name }}
             deployment: ${{ steps.deploy.outputs.deployment }}
-            job: drop_prod_clone
+            job_name: drop_prod_clone
           env:
             DAGSTER_CLOUD_URL: ${{ secrets.DAGSTER_CLOUD_URL }}
             DAGSTER_CLOUD_API_TOKEN: ${{ secrets.DAGSTER_CLOUD_API_TOKEN }}


### PR DESCRIPTION
## Summary & Motivation
While trying to setup this database cloning step in GitHub Actions, I ran into the following error:
```shell
Warning: Unexpected input(s) 'job', valid inputs are ['entryPoint', 'args', 'organization_id', 'deployment', 'location_name', 'repository_name', 'job_name', 'tags_json', 'config_json', 'dagster_cloud_url']
```
This suggests that `job:` needs to be updated to `job_name:`

## How I Tested These Changes
Updating the input to `job_name` enabled this step to execute when deploying a new branch via GitHub Actions.