### PR TITLE
[pythonic resources] Ensure nested CM resources are setup, torn down correctly

### DIFF
--- a/python_modules/dagster/dagster/_config/pythonic_config/resource.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/resource.py
@@ -498,6 +498,7 @@ class ConfigurableResourceFactory(
                 for attr_name, resource in resources_to_update.items()
                 if attr_name not in partial_resources_to_update
             }
+            print("RESOURCES_TO_UPDATE", resources_to_update)
 
             to_update = {**resources_to_update, **partial_resources_to_update}
             yield self._with_updated_values(to_update)
@@ -981,8 +982,10 @@ def _call_resource_fn_with_default(
     else:
         result = cast(ResourceFunctionWithoutContext, obj.resource_fn)()
 
-    is_fn_generator = inspect.isgenerator(obj.resource_fn) or isinstance(
-        obj.resource_fn, contextlib.ContextDecorator
+    is_fn_generator = (
+        inspect.isgenerator(obj.resource_fn)
+        or isinstance(obj.resource_fn, contextlib.ContextDecorator)
+        or isinstance(result, contextlib.AbstractContextManager)
     )
     if is_fn_generator:
         return stack.enter_context(cast(contextlib.AbstractContextManager, result))

--- a/python_modules/dagster/dagster/_config/pythonic_config/resource.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/resource.py
@@ -498,7 +498,6 @@ class ConfigurableResourceFactory(
                 for attr_name, resource in resources_to_update.items()
                 if attr_name not in partial_resources_to_update
             }
-            print("RESOURCES_TO_UPDATE", resources_to_update)
 
             to_update = {**resources_to_update, **partial_resources_to_update}
             yield self._with_updated_values(to_update)

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
@@ -704,7 +704,6 @@ def _store_output(
     # don't store asset check outputs or asset observation outputs
     step_output = step_context.step.step_output_named(step_output_handle.output_name)
     asset_key = step_output.properties.asset_key
-    print("output_manager", type(output_manager))
     if step_output.properties.asset_check_key or (
         step_context.output_observes_source_asset(step_output_handle.output_name)
     ):
@@ -720,7 +719,6 @@ def _store_output(
     elif not inspect.isgeneratorfunction(output_manager.handle_output):
 
         def _gen_fn():
-            print("output_manager", type(output_manager))
             gen_output = output_manager.handle_output(output_context, output.value)
             for event in output_context.consume_events():
                 yield event

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
@@ -704,6 +704,7 @@ def _store_output(
     # don't store asset check outputs or asset observation outputs
     step_output = step_context.step.step_output_named(step_output_handle.output_name)
     asset_key = step_output.properties.asset_key
+    print("output_manager", type(output_manager))
     if step_output.properties.asset_check_key or (
         step_context.output_observes_source_asset(step_output_handle.output_name)
     ):
@@ -719,6 +720,7 @@ def _store_output(
     elif not inspect.isgeneratorfunction(output_manager.handle_output):
 
         def _gen_fn():
+            print("output_manager", type(output_manager))
             gen_output = output_manager.handle_output(output_context, output.value)
             for event in output_context.consume_events():
                 yield event

--- a/python_modules/dagster/dagster/_core/storage/branching/branching_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/branching/branching_io_manager.py
@@ -3,7 +3,6 @@ from typing import Any, Optional
 from dagster import InputContext, OutputContext
 from dagster._config.pythonic_config import (
     ConfigurableIOManager,
-    ConfigurableResourceFactory,
     ResourceDependency,
 )
 from dagster._core.definitions.events import AssetKey, AssetMaterialization
@@ -11,7 +10,6 @@ from dagster._core.definitions.metadata import TextMetadataValue
 from dagster._core.event_api import EventRecordsFilter
 from dagster._core.events import DagsterEventType
 from dagster._core.events.log import EventLogEntry
-from dagster._core.execution.context.init import InitResourceContext
 from dagster._core.instance import DagsterInstance
 from dagster._core.storage.io_manager import IOManager
 
@@ -107,15 +105,3 @@ class BranchingIOManager(ConfigurableIOManager):
                 f'Branching Manager: Writing "{context.asset_key.to_user_string()}" to branch'
                 f' "{self.branch_name}"'
             )
-
-    def setup_for_execution(self, context: InitResourceContext):
-        if isinstance(self.parent_io_manager, ConfigurableResourceFactory):
-            self.parent_io_manager.setup_for_execution(context)
-        if isinstance(self.branch_io_manager, ConfigurableResourceFactory):
-            self.branch_io_manager.setup_for_execution(context)
-
-    def teardown_after_execution(self, context: InitResourceContext) -> None:
-        if isinstance(self.parent_io_manager, ConfigurableResourceFactory):
-            self.parent_io_manager.teardown_after_execution(context)
-        if isinstance(self.branch_io_manager, ConfigurableResourceFactory):
-            self.branch_io_manager.teardown_after_execution(context)

--- a/python_modules/dagster/dagster_tests/storage_tests/branching_io_manager_tests/test_branching_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/branching_io_manager_tests/test_branching_io_manager.py
@@ -10,7 +10,12 @@ from dagster._core.events.log import EventLogEntry
 from dagster._core.instance import DagsterInstance
 from dagster._core.storage.branching.branching_io_manager import BranchingIOManager
 
-from .utils import AssetBasedInMemoryIOManager, DefinitionsRunner
+from .utils import (
+    LOG,
+    AssetBasedInMemoryIOManager,
+    ConfigurableAssetBasedInMemoryIOManager,
+    DefinitionsRunner,
+)
 
 
 @asset
@@ -76,6 +81,38 @@ def test_write_staging_label():
         ),
     ) as staging_runner:
         assert staging_runner.materialize_all_assets().success
+
+        all_mat_log_records = staging_runner.get_all_asset_materialization_event_records("now_time")
+        assert all_mat_log_records
+
+        assert len(all_mat_log_records) == 1
+        asset_mat = all_mat_log_records[0].event_log_entry.asset_materialization
+
+        assert asset_mat
+        assert get_branch_name_from_materialization(asset_mat) == "dev"
+
+
+def test_setup_teardown() -> None:
+    with DefinitionsRunner.ephemeral(
+        Definitions(
+            assets=[now_time],
+            resources={
+                "io_manager": BranchingIOManager(
+                    parent_io_manager=ConfigurableAssetBasedInMemoryIOManager(name="parent"),
+                    branch_io_manager=ConfigurableAssetBasedInMemoryIOManager(name="branch"),
+                )
+            },
+        ),
+    ) as staging_runner:
+        LOG.clear()
+        assert staging_runner.materialize_all_assets().success
+        assert len(LOG) == 4
+        assert LOG == [
+            "setup_for_execution parent",
+            "setup_for_execution branch",
+            "teardown_after_execution branch",
+            "teardown_after_execution parent",
+        ]
 
         all_mat_log_records = staging_runner.get_all_asset_materialization_event_records("now_time")
         assert all_mat_log_records

--- a/python_modules/dagster/dagster_tests/storage_tests/branching_io_manager_tests/utils.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/branching_io_manager_tests/utils.py
@@ -113,8 +113,8 @@ LOG = []
 
 
 class ConfigurableAssetBasedInMemoryIOManager(ConfigurableIOManager):
-    """In memory I/O manager for testing asset-based jobs and workflows. Can handle both
-    partitioned and unpartitioned assets.
+    """ConfigurableResource version of the above. This is useful for testing
+    that the config system is working correctly & to test the setup/teardown logic.
     """
 
     name: str


### PR DESCRIPTION
## Summary

Fixes an issue where nested resources' context managers were not being properly opened in some cases. The `AbstractContextManager` check should catch cases of CMs which are not GeneratorContextManagers.

## Test Plan

New unit tests which triggered this case.

Adds a unit test for the branching IO manager and removes the nested setup/teardown logic from #14751, since that should happen by default now with this PR.