### PR TITLE
[ui] "Add tag to filter" on "Launched by" column tag

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/CreatedByTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/CreatedByTag.tsx
@@ -3,72 +3,125 @@ import React from 'react';
 import {Link} from 'react-router-dom';
 
 import {useLaunchPadHooks} from '../launchpad/LaunchpadHooksContext';
+import {TagActionsPopover} from '../ui/TagActions';
 import {RepoAddress} from '../workspace/types';
 import {workspacePathFromAddress} from '../workspace/workspacePath';
 
 import {DagsterTag} from './RunTag';
+import {RunFilterToken} from './RunsFilterInput';
 import {RunTagsFragment} from './types/RunTable.types';
 
 type Props = {
   repoAddress?: RepoAddress | null;
   tags: RunTagsFragment[];
+  onAddTag?: (token: RunFilterToken) => void;
 };
 
-export const CreatedByTagCell = React.memo(({repoAddress, tags}: Props) => {
+export const CreatedByTagCell = React.memo(({repoAddress, tags, onAddTag}: Props) => {
   return (
     <Box flex={{direction: 'column', alignItems: 'flex-start'}}>
-      <CreatedByTag repoAddress={repoAddress} tags={tags} />
+      <CreatedByTag repoAddress={repoAddress} tags={tags} onAddTag={onAddTag} />
     </Box>
   );
 });
 
-export const CreatedByTag = ({repoAddress, tags}: Props) => {
+type TagType =
+  | {
+      type: 'user' | 'schedule' | 'sensor' | 'auto-materialize' | 'auto-observe';
+      tag: RunTagsFragment;
+    }
+  | {type: 'manual'};
+
+const pluckTagFromList = (tags: RunTagsFragment[]): TagType => {
+  for (const tag of tags) {
+    const {key} = tag;
+    switch (key) {
+      case DagsterTag.User:
+        return {type: 'user', tag};
+      case DagsterTag.ScheduleName:
+        return {type: 'schedule', tag};
+      case DagsterTag.SensorName:
+        return {type: 'sensor', tag};
+      case DagsterTag.Automaterialize:
+        return {type: 'auto-materialize', tag};
+      case DagsterTag.CreatedBy: {
+        // Backwards compatibility
+        if (tag.value === 'auto_materialize') {
+          return {type: 'auto-materialize', tag};
+        } else {
+          continue;
+        }
+      }
+      case DagsterTag.AutoObserve:
+        return {type: 'auto-observe', tag};
+    }
+  }
+
+  return {type: 'manual'};
+};
+
+export const CreatedByTag = ({repoAddress, tags, onAddTag}: Props) => {
   const {UserDisplay} = useLaunchPadHooks();
 
-  const user = tags.find((tag) => tag.key === DagsterTag.User);
-  if (user) {
-    return <UserDisplay email={user.value} />;
+  const plucked = pluckTagFromList(tags);
+
+  if (plucked.type === 'manual') {
+    return <Tag icon="account_circle">Manually launched</Tag>;
   }
 
-  const scheduleTag = tags.find((tag) => tag.key === DagsterTag.ScheduleName);
-  if (scheduleTag) {
-    const scheduleName = scheduleTag.value;
-    const tagContent = repoAddress ? (
-      <Link to={workspacePathFromAddress(repoAddress, `/schedules/${scheduleName}`)}>
-        {scheduleName}
-      </Link>
-    ) : (
-      scheduleName
-    );
-    return <Tag icon="schedule">{tagContent}</Tag>;
+  const buildTagElement = () => {
+    const {type, tag} = plucked;
+    const {value} = tag;
+    switch (type) {
+      case 'user':
+        return <UserDisplay email={tag.value} />;
+      case 'schedule': {
+        return (
+          <Tag icon="schedule">
+            {repoAddress ? (
+              <Link to={workspacePathFromAddress(repoAddress, `/schedules/${value}`)}>{value}</Link>
+            ) : (
+              value
+            )}
+          </Tag>
+        );
+      }
+      case 'sensor': {
+        return (
+          <Tag icon="sensors">
+            {repoAddress ? (
+              <Link to={workspacePathFromAddress(repoAddress, `/sensors/${value}`)}>{value}</Link>
+            ) : (
+              value
+            )}
+          </Tag>
+        );
+      }
+      case 'auto-materialize':
+        return <Tag icon="auto_materialize_policy">Auto-materialize policy</Tag>;
+      case 'auto-observe':
+        return <Tag icon="auto_observe">Auto-observation</Tag>;
+    }
+  };
+
+  const tagElement = buildTagElement();
+  if (!onAddTag) {
+    return tagElement;
   }
 
-  const sensorTag = tags.find((tag) => tag.key === DagsterTag.SensorName);
-  if (sensorTag) {
-    const sensorName = sensorTag.value;
-    const tagContent = repoAddress ? (
-      <Link to={workspacePathFromAddress(repoAddress, `/sensors/${sensorName}`)}>{sensorName}</Link>
-    ) : (
-      sensorName
-    );
-    return <Tag icon="sensors">{tagContent}</Tag>;
-  }
-
-  const automaterialize = tags.some(
-    (tag) =>
-      tag.key === DagsterTag.Automaterialize ||
-      // Backwards compatibility
-      (tag.key === DagsterTag.CreatedBy && tag.value === 'auto_materialize'),
+  const {tag} = plucked;
+  const {key, value} = tag;
+  return (
+    <TagActionsPopover
+      data={tag}
+      actions={[
+        {
+          label: 'Add to filter',
+          onClick: () => onAddTag({token: 'tag', value: `${key}=${value}`}),
+        },
+      ]}
+    >
+      {tagElement}
+    </TagActionsPopover>
   );
-
-  if (automaterialize) {
-    return <Tag icon="auto_materialize_policy">Auto-materialize policy</Tag>;
-  }
-
-  const autoObserve = tags.some((tag) => tag.key === DagsterTag.AutoObserve);
-  if (autoObserve) {
-    return <Tag icon="auto_observe">Auto-observation</Tag>;
-  }
-
-  return <Tag icon="account_circle">Manually launched</Tag>;
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunTable.tsx
@@ -483,7 +483,11 @@ const RunRow: React.FC<{
       </td>
       {hideCreatedBy ? null : (
         <td>
-          <CreatedByTagCell repoAddress={repoAddressGuess} tags={run.tags || []} />
+          <CreatedByTagCell
+            repoAddress={repoAddressGuess}
+            tags={run.tags || []}
+            onAddTag={onAddTag}
+          />
         </td>
       )}
       <td>

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/UserDisplay.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/UserDisplay.tsx
@@ -11,13 +11,13 @@ type Props = {
  * This is primarily used to display users in filter dropdown + users in table cells
  */
 export function UserDisplay({email, isFilter}: Props) {
-  const icon = <SubwayDot label={email} blobSize={14} fontSize={9} />;
+  const icon = <SubwayDot label={email} blobSize={16} fontSize={10} />;
   return isFilter ? (
     <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
       <span>{icon}</span>
       {email}
     </Box>
   ) : (
-    <BaseTag key="user" icon={<div style={{marginRight: '4px'}}>{icon}</div>} label={email} />
+    <BaseTag key="user" icon={<div style={{margin: '0 4px 0 -4px'}}>{icon}</div>} label={email} />
   );
 }


### PR DESCRIPTION
## Summary & Motivation

Resolves #16835.

Show tag actions on the "Launched by" tags on the Runs table. Hover on a tag to see an affordance to add that key/value to the filter.

I also made a slight adjustment to `UserDisplay`, to make the subway dot letter slightly bigger and tweak the spacing to align better with tag icons.

## How I Tested These Changes

View Runs table, verify that I can filter by the "Launched by" tag, for all of the specified tag types.
