### PR TITLE
[pipes] report when external process closed with exception

### DIFF
--- a/python_modules/dagster/dagster/_core/pipes/context.py
+++ b/python_modules/dagster/dagster/_core/pipes/context.py
@@ -9,6 +9,7 @@ from dagster_pipes import (
     PIPES_METADATA_TYPE_INFER,
     PipesContextData,
     PipesDataProvenance,
+    PipesException,
     PipesExtras,
     PipesMessage,
     PipesMetadataType,
@@ -38,7 +39,11 @@ from dagster._core.errors import DagsterPipesExecutionError
 from dagster._core.events import EngineEventData
 from dagster._core.execution.context.compute import OpExecutionContext
 from dagster._core.execution.context.invocation import BoundOpExecutionContext
-from dagster._utils.error import ExceptionInfo, serializable_error_info_from_exc_info
+from dagster._utils.error import (
+    ExceptionInfo,
+    SerializableErrorInfo,
+    serializable_error_info_from_exc_info,
+)
 
 if TYPE_CHECKING:
     from dagster._core.pipes.client import PipesMessageReader
@@ -139,7 +144,7 @@ class PipesMessageHandler:
         if message["method"] == "opened":
             self._handle_opened(message["params"])  # type: ignore
         elif message["method"] == "closed":
-            self._handle_closed()
+            self._handle_closed(message["params"])
         elif message["method"] == "report_asset_materialization":
             self._handle_report_asset_materialization(**message["params"])  # type: ignore
         elif message["method"] == "report_asset_check":
@@ -154,8 +159,16 @@ class PipesMessageHandler:
         self._context.log.info("[pipes] external process successfully opened dagster pipes.")
         self._message_reader.on_opened(opened_payload)
 
-    def _handle_closed(self) -> None:
+    def _handle_closed(self, params: Optional[Mapping[str, Any]]) -> None:
         self._received_closed_msg = True
+        if params and "exception" in params:
+            err_info = _ser_err_from_pipes_exc(params["exception"])
+            # report as an engine event to provide structured exception data
+            DagsterEvent.engine_event(
+                self._context.get_step_execution_context(),
+                "[pipes] external process pipes closed with exception",
+                EngineEventData(error=err_info),
+            )
 
     def _handle_report_asset_materialization(
         self,
@@ -388,4 +401,14 @@ def _convert_partition_key_range(
     return PipesTimeWindow(
         start=partition_key_range.start,
         end=partition_key_range.end,
+    )
+
+
+def _ser_err_from_pipes_exc(exc: PipesException):
+    return SerializableErrorInfo(
+        message=exc["message"],
+        stack=exc["stack"],
+        cls_name=exc["name"],
+        cause=_ser_err_from_pipes_exc(exc["cause"]) if exc["cause"] else None,
+        context=_ser_err_from_pipes_exc(exc["context"]) if exc["context"] else None,
     )


### PR DESCRIPTION
* adds `PipesException`, similar to `SerializableErrorInfo` but a `TypedDict` and uses `name` instead of `cls_name` (inspired by looking at serializing JS errors)
* adds this to the `closed` payload under the key `exception`
* on the orchestration side, log an engine event with a `SerializableErrorInfo` built from the `PipesException` 

## How I Tested These Changes

added test

![Screenshot 2023-11-01 at 11 42 42 AM](https://github.com/dagster-io/dagster/assets/202219/dee2f32f-3450-4bac-a01d-904814cf7429)
