### PR TITLE
[ui] Disambiguate some SplitPanelContainer identifiers

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -294,7 +294,7 @@ const AssetGraphExplorerWithData: React.FC<WithDataProps> = ({
   const explorer = (
     <SplitPanelContainer
       key="explorer"
-      identifier="explorer"
+      identifier="asset-graph-explorer"
       firstInitialPercent={70}
       firstMinSize={400}
       first={

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/GraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/GraphExplorer.tsx
@@ -197,7 +197,7 @@ export const GraphExplorer: React.FC<GraphExplorerProps> = (props) => {
 
   return (
     <SplitPanelContainer
-      identifier="explorer"
+      identifier="graph-explorer"
       firstInitialPercent={70}
       first={
         <ErrorBoundary region="op graph">

--- a/js_modules/dagster-ui/packages/ui-core/src/resources/ResourceRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/resources/ResourceRoot.tsx
@@ -162,7 +162,7 @@ export const ResourceRoot: React.FC<Props> = (props) => {
           return (
             <div style={{height: '100%', display: 'flex'}}>
               <SplitPanelContainer
-                identifier="explorer"
+                identifier="resource-explorer"
                 firstInitialPercent={50}
                 firstMinSize={400}
                 first={


### PR DESCRIPTION
## Summary & Motivation

We're currently reusing the `explorer` identifier on SplitPanelContainer for the asset graph explorer, job graph explorer, and resource explorer.

This means that they're all sharing the same `localStorage` key for tracking the panel widths. There's no need to overload this value in this way from what I can tell, so let's give them their own identifiers.

This might resolve an issue where the panel was unexpectedly hidden for a user viewing the asset graph. That is, they may have collapsed the panel in some other situation, but the collapsed state persisted here.

## How I Tested These Changes

Adjust split panel on explorer UIs, verify that the keys are separate in localStorage.
