### PR TITLE
Make adding asset evaluations to the DB idempotent

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/schedules/schema.py
+++ b/python_modules/dagster/dagster/_core/storage/schedules/schema.py
@@ -111,5 +111,6 @@ db.Index(
     "idx_asset_daemon_asset_evaluations_asset_key_evaluation_id",
     AssetDaemonAssetEvaluationsTable.c.asset_key,
     AssetDaemonAssetEvaluationsTable.c.evaluation_id,
+    mysql_length={"asset_key": 64},
     unique=True,
 )

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/schedule_storage/schedule_storage.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/schedule_storage/schedule_storage.py
@@ -1,4 +1,4 @@
-from typing import ContextManager, Optional, cast
+from typing import ContextManager, Optional, Sequence, cast
 
 import dagster._check as check
 import pendulum
@@ -6,9 +6,13 @@ import sqlalchemy as db
 import sqlalchemy.dialects as db_dialects
 import sqlalchemy.pool as db_pool
 from dagster._config.config_schema import UserConfigSchema
+from dagster._core.definitions.auto_materialize_rule import AutoMaterializeAssetEvaluation
 from dagster._core.storage.config import MySqlStorageConfig, mysql_config
 from dagster._core.storage.schedules import ScheduleStorageSqlMetadata, SqlScheduleStorage
-from dagster._core.storage.schedules.schema import InstigatorsTable
+from dagster._core.storage.schedules.schema import (
+    AssetDaemonAssetEvaluationsTable,
+    InstigatorsTable,
+)
 from dagster._core.storage.sql import (
     AlembicVersion,
     check_alembic_revision,
@@ -164,6 +168,40 @@ class MySQLScheduleStorage(SqlScheduleStorage, ConfigurableClass):
                 update_timestamp=pendulum.now("UTC"),
             )
         )
+
+    def add_auto_materialize_asset_evaluations(
+        self,
+        evaluation_id: int,
+        asset_evaluations: Sequence[AutoMaterializeAssetEvaluation],
+    ):
+        if not asset_evaluations:
+            return
+
+        # Define the base insert statement
+        insert_stmt = db_dialects.mysql.insert(AssetDaemonAssetEvaluationsTable).values(
+            [
+                {
+                    "evaluation_id": evaluation_id,
+                    "asset_key": evaluation.asset_key.to_string(),
+                    "asset_evaluation_body": serialize_value(evaluation),
+                    "num_requested": evaluation.num_requested,
+                    "num_skipped": evaluation.num_skipped,
+                    "num_discarded": evaluation.num_discarded,
+                }
+                for evaluation in asset_evaluations
+            ]
+        )
+
+        # Define the upsert statement using the ON DUPLICATE KEY UPDATE syntax for MySQL
+        upsert_stmt = insert_stmt.on_duplicate_key_update(
+            asset_evaluation_body=insert_stmt.inserted.asset_evaluation_body,
+            num_requested=insert_stmt.inserted.num_requested,
+            num_skipped=insert_stmt.inserted.num_skipped,
+            num_discarded=insert_stmt.inserted.num_discarded,
+        )
+
+        with self.connect() as conn:
+            conn.execute(upsert_stmt)
 
     def alembic_version(self) -> AlembicVersion:
         alembic_config = mysql_alembic_config(__file__)

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/run_storage/run_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/run_storage/run_storage.py
@@ -201,7 +201,7 @@ class PostgresRunStorage(SqlRunStorage, ConfigurableClass):
     def set_cursor_values(self, pairs: Mapping[str, str]) -> None:
         check.mapping_param(pairs, "pairs", key_type=str, value_type=str)
 
-        # pg speciic on_conflict_do_update
+        # pg specific on_conflict_do_update
         insert_stmt = db_dialects.postgresql.insert(KeyValueStoreTable).values(
             [{"key": k, "value": v} for k, v in pairs.items()]
         )


### PR DESCRIPTION
Summary:
This allows us to upsert the same evaluations in the asset daemon multiple times in the event that a tick fails

Sadly for this to work in sqlite it requires adding the evals one by one instead of in a batch. If you are using AMP on a large asset graph though, you should be using postgres or mysql, not sqlite.

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes
