### PR TITLE
[asset backfill] Fix 'all partitions' targeting

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -597,7 +597,10 @@ class AssetGraph:
                     if child_partitions_def:
                         if partitions_subset is None:
                             child_partitions_subset = (
-                                child_partitions_def.subset_with_all_partitions()
+                                child_partitions_def.subset_with_all_partitions(
+                                    current_time=current_time,
+                                    dynamic_partitions_store=dynamic_partitions_store,
+                                )
                             )
                             queued_subsets_by_asset_key[child] = child_partitions_subset
                         else:

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
@@ -42,7 +42,9 @@ class AssetGraphSubset:
 
     @property
     def asset_keys(self) -> AbstractSet[AssetKey]:
-        return self.partitions_subsets_by_asset_key.keys() | self._non_partitioned_asset_keys
+        return {
+            key for key, subset in self.partitions_subsets_by_asset_key.items() if len(subset) > 0
+        } | self._non_partitioned_asset_keys
 
     @property
     def num_partitions_and_non_partitioned_assets(self):

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
@@ -151,6 +151,11 @@ class AssetGraphSubset:
     ) -> "AssetGraphSubset":
         return self._oper(other, operator.sub)
 
+    def __and__(
+        self, other: Union["AssetGraphSubset", AbstractSet[AssetKeyPartitionKey]]
+    ) -> "AssetGraphSubset":
+        return self._oper(other, operator.and_)
+
     def filter_asset_keys(self, asset_keys: AbstractSet[AssetKey]) -> "AssetGraphSubset":
         return AssetGraphSubset(
             self.asset_graph,

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -1079,6 +1079,8 @@ def execute_asset_backfill_iteration_inner(
             asset_backfill_data.get_target_root_asset_partitions(instance_queryer)
         )
 
+        yield None
+
         next_latest_storage_id = instance_queryer.get_latest_storage_id_for_event_type(
             event_type=DagsterEventType.ASSET_MATERIALIZATION
         )

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
@@ -1216,4 +1216,24 @@ def test_asset_backfill_nonexistent_parent_partitions():
         backfill_start_time=pendulum.datetime(2023, 10, 8, 0, 0, 0),
     )
 
-    run_backfill_to_completion(asset_graph, assets_by_repo_name, asset_backfill_data, [], instance)
+    backfill_data, _, _ = run_backfill_to_completion(
+        asset_graph, assets_by_repo_name, asset_backfill_data, [], instance
+    )
+
+    assert set(backfill_data.target_subset.get_partitions_subset(foo.key).get_partition_keys()) == {
+        "2023-10-05",
+        "2023-10-06",
+        "2023-10-07",
+    }
+    assert set(
+        backfill_data.target_subset.get_partitions_subset(foo_child.key).get_partition_keys()
+    ) == {
+        "2023-10-01",
+        "2023-10-02",
+        "2023-10-03",
+        "2023-10-04",
+        "2023-10-05",
+        "2023-10-06",
+        "2023-10-07",
+    }
+    assert backfill_data.target_subset == backfill_data.materialized_subset

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
@@ -39,6 +39,11 @@ from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.events import AssetKeyPartitionKey
 from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
+from dagster._core.definitions.selector import (
+    PartitionRangeSelector,
+    PartitionsByAssetSelector,
+    PartitionsSelector,
+)
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.execution.asset_backfill import (
     AssetBackfillData,
@@ -1237,3 +1242,56 @@ def test_asset_backfill_nonexistent_parent_partitions():
         "2023-10-07",
     }
     assert backfill_data.target_subset == backfill_data.materialized_subset
+
+
+def test_connected_assets_disconnected_partitions():
+    instance = DagsterInstance.ephemeral()
+
+    @asset(partitions_def=DailyPartitionsDefinition("2023-10-01"))
+    def foo():
+        pass
+
+    @asset(partitions_def=DailyPartitionsDefinition("2023-10-01"))
+    def foo_child(foo):
+        pass
+
+    @asset(partitions_def=DailyPartitionsDefinition("2023-10-01"))
+    def foo_grandchild(foo_child):
+        pass
+
+    assets_by_repo_name = {"repo": [foo, foo_child, foo_grandchild]}
+    asset_graph = get_asset_graph(assets_by_repo_name)
+
+    backfill_start_time = pendulum.datetime(2023, 10, 30, 0, 0, 0)
+    instance_queryer = CachingInstanceQueryer(instance, asset_graph, backfill_start_time)
+    asset_backfill_data = AssetBackfillData.from_partitions_by_assets(
+        asset_graph,
+        instance_queryer,
+        backfill_start_time,
+        [
+            PartitionsByAssetSelector(
+                foo.key, PartitionsSelector(PartitionRangeSelector("2023-10-01", "2023-10-05"))
+            ),
+            PartitionsByAssetSelector(
+                foo_child.key,
+                PartitionsSelector(PartitionRangeSelector("2023-10-01", "2023-10-03")),
+            ),
+            PartitionsByAssetSelector(
+                foo_grandchild.key,
+                PartitionsSelector(PartitionRangeSelector("2023-10-10", "2023-10-13")),
+            ),
+        ],
+    )
+
+    target_root_partitions = asset_backfill_data.get_target_root_asset_partitions(instance_queryer)
+    assert set(target_root_partitions) == {
+        AssetKeyPartitionKey(asset_key=AssetKey(["foo"]), partition_key="2023-10-05"),
+        AssetKeyPartitionKey(asset_key=AssetKey(["foo"]), partition_key="2023-10-03"),
+        AssetKeyPartitionKey(asset_key=AssetKey(["foo"]), partition_key="2023-10-04"),
+        AssetKeyPartitionKey(asset_key=AssetKey(["foo"]), partition_key="2023-10-02"),
+        AssetKeyPartitionKey(asset_key=AssetKey(["foo"]), partition_key="2023-10-01"),
+        AssetKeyPartitionKey(asset_key=AssetKey(["foo_grandchild"]), partition_key="2023-10-11"),
+        AssetKeyPartitionKey(asset_key=AssetKey(["foo_grandchild"]), partition_key="2023-10-13"),
+        AssetKeyPartitionKey(asset_key=AssetKey(["foo_grandchild"]), partition_key="2023-10-12"),
+        AssetKeyPartitionKey(asset_key=AssetKey(["foo_grandchild"]), partition_key="2023-10-10"),
+    }


### PR DESCRIPTION
Similar to https://github.com/dagster-io/dagster/issues/16952.

In certain situations when the `allPartitions = True` flag is applied to an asset backfill, some downstream partitions hang and never get executed.

For example, in the following situation:
- Asset A, Daily starting 2023
- Asset B, Daily starting 2022 (dependent on A) 

The following happens:
1. Backfill is launched with `allPartitions = True`, causing all partitions of A and B are targeted
2. Backfill requests roots -- before the changes in this PR, that would be all partitions of A
3. In subsequent iterations, partitions downstream of A partitions get kicked off once A finishes executing. This would be partitions in B after 2023
4. 2022 partitions in B hang indefinitely

Instead, we should target 2022 partitions of B as part of the 'request roots' call.

This PR fixes this issue by updating the `get_target_root_asset_partitions` call to also find partitions that do not have parents in the target subset. Previously, it only found assets that do not have parents in the target subset.