### PR TITLE
Fix permisison checks when an asset key with no code location is under consideration

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
@@ -36,10 +36,19 @@ def _assert_permission_for_asset_graph(
     asset_selection: Optional[Sequence[AssetKey]],
     permission: str,
 ) -> None:
-    if asset_selection:
-        repo_handles = [
-            asset_graph.get_repository_handle(asset_key) for asset_key in asset_selection
-        ]
+    asset_keys = set(asset_selection or [])
+
+    # If any of the asset keys don't map to a location (e.g. because they are no longer in the
+    # graph) need deployment-wide permissions - no valid code location to check
+    if asset_keys.difference(asset_graph.repository_handles_by_key.keys()):
+        assert_permission(
+            graphene_info,
+            permission,
+        )
+        return
+
+    if asset_keys:
+        repo_handles = [asset_graph.get_repository_handle(asset_key) for asset_key in asset_keys]
     else:
         repo_handles = asset_graph.repository_handles_by_key.values()
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py
@@ -182,6 +182,26 @@ def test_launch_asset_backfill_read_only_context():
                 == "LaunchBackfillSuccess"
             )
 
+            # assets that aren't in the asset graph at all fail permissions check
+            # because they can't be mapped to a particular code location
+            launch_backfill_result = execute_dagster_graphql(
+                read_only_context,
+                LAUNCH_PARTITION_BACKFILL_MUTATION,
+                variables={
+                    "backfillParams": {
+                        "partitionNames": ["a", "b"],
+                        "assetSelection": [{"path": ["doesnot", "exist"]}],
+                    }
+                },
+            )
+            assert launch_backfill_result
+            assert launch_backfill_result.data
+
+            assert (
+                launch_backfill_result.data["launchPartitionBackfill"]["__typename"]
+                == "UnauthorizedError"
+            )
+
 
 def test_launch_asset_backfill_all_partitions():
     repo = get_repo()


### PR DESCRIPTION
Summary:
Asset keys that don't map to a particular code location (e.g. because the asset was removed but it still has a backfill) were hitting a KeyError in this permissions check when they try to index into the repo handles in the asset graph. Instead, fall back to ignoring per-location permissions and require deployment-wide permissions.

Test Plan: New test case

## Summary & Motivation

## How I Tested These Changes
