### PR TITLE
[dagster-embedded-elt] Fix bug when creating multiple Sling assets

### DIFF
--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/asset_defs.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/asset_defs.py
@@ -12,6 +12,8 @@ from dagster._annotations import experimental
 
 from dagster_embedded_elt.sling.resources import SlingMode, SlingResource
 
+ASSET_KEY_SPLIT_REGEX = re.compile("[^a-zA-Z0-9_]")
+
 
 @experimental
 def build_sling_asset(
@@ -73,7 +75,12 @@ def build_sling_asset(
         update_key = [update_key]
 
     @multi_asset(
-        compute_kind="sling", specs=[asset_spec], required_resource_keys={sling_resource_key}
+        name="sling_"
+        + re.sub(ASSET_KEY_SPLIT_REGEX, "_", source_stream)
+        + re.sub(ASSET_KEY_SPLIT_REGEX, "_", target_object),
+        compute_kind="sling",
+        specs=[asset_spec],
+        required_resource_keys={sling_resource_key},
     )
     def sync(context: AssetExecutionContext) -> MaterializeResult:
         sling: SlingResource = getattr(context.resources, sling_resource_key)

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/asset_defs.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/asset_defs.py
@@ -12,8 +12,6 @@ from dagster._annotations import experimental
 
 from dagster_embedded_elt.sling.resources import SlingMode, SlingResource
 
-ASSET_KEY_SPLIT_REGEX = re.compile("[^a-zA-Z0-9_]")
-
 
 @experimental
 def build_sling_asset(
@@ -75,9 +73,7 @@ def build_sling_asset(
         update_key = [update_key]
 
     @multi_asset(
-        name="sling_"
-        + re.sub(ASSET_KEY_SPLIT_REGEX, "_", source_stream)
-        + re.sub(ASSET_KEY_SPLIT_REGEX, "_", target_object),
+        name=asset_spec.key.to_python_identifier(),
         compute_kind="sling",
         specs=[asset_spec],
         required_resource_keys={sling_resource_key},

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/test_assets.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/test_assets.py
@@ -2,7 +2,7 @@ import os
 import sqlite3
 import tempfile
 
-from dagster import AssetSpec, file_relative_path
+from dagster import AssetSpec, file_relative_path, Definitions
 from dagster._core.definitions import build_assets_job
 from dagster_embedded_elt.sling import SlingMode, SlingResource, build_sling_asset
 from dagster_embedded_elt.sling.resources import SlingSourceConnection, SlingTargetConnection
@@ -45,3 +45,41 @@ def test_build_sling_asset():
         assert res.success
         counts = sqlite3.connect(dbpath).execute("SELECT count(1) FROM main.tbl").fetchone()
         assert counts[0] == 3
+
+
+def test_can_build_two_assets():
+    with tempfile.TemporaryDirectory() as tmpdir_path:
+        fpath = os.path.abspath(file_relative_path(__file__, "test.csv"))
+        dbpath = os.path.join(tmpdir_path, "sqlite.db")
+
+        sling_resource = SlingResource(
+            source_connection=SlingSourceConnection(type="file"),
+            target_connection=SlingTargetConnection(
+                type="sqlite", connection_string=f"sqlite://{dbpath}"
+            ),
+        )
+
+        asset_def = build_sling_asset(
+            asset_spec=AssetSpec(key="asset1"),
+            source_stream=f"file://{fpath}",
+            target_object="main.first_tbl",
+            mode=SlingMode.FULL_REFRESH,
+            primary_key="SPECIES_CODE",
+            sling_resource_key="sling_resource",
+        )
+
+        asset_def_two = build_sling_asset(
+            asset_spec=AssetSpec(key="asset2"),
+            source_stream=f"file://{fpath}",
+            target_object="main.second_tbl",
+            mode=SlingMode.FULL_REFRESH,
+            primary_key="SPECIES_CODE",
+            sling_resource_key="sling_resource",
+        )
+
+        defs = Definitions(
+            assets=[asset_def, asset_def_two],
+            resources={"sling_resource": sling_resource},
+        )
+
+        assert defs

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/test_assets.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/test_assets.py
@@ -82,4 +82,5 @@ def test_can_build_two_assets():
             resources={"sling_resource": sling_resource},
         )
 
-        assert defs
+        assert defs.get_assets_def("asset1")
+        assert defs.get_assets_def("asset2")

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/test_assets.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/test_assets.py
@@ -2,7 +2,7 @@ import os
 import sqlite3
 import tempfile
 
-from dagster import AssetSpec, file_relative_path, Definitions
+from dagster import AssetSpec, Definitions, file_relative_path
 from dagster._core.definitions import build_assets_job
 from dagster_embedded_elt.sling import SlingMode, SlingResource, build_sling_asset
 from dagster_embedded_elt.sling.resources import SlingSourceConnection, SlingTargetConnection


### PR DESCRIPTION
## Summary & Motivation

This adds a generated name to the @multi_asset decorator for build_asset, using the a combination of the source stream and target object which should be unique across all assets.

I took inspiration from the Airbyte/Fivetran packages which do something similar although they rely on a unique connector id which we do not have here. I can't think of a good
reason to have multiple assets with the same source/destination but if there was, then there would still be a collision here. Would appreciate feedback on whether it's a good
assumption.

## How I Tested These Changes

Added a test, failed, made changes, passed.

