### PR TITLE
Fix status being set to failure in AMP timeline

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationRoot.tsx
@@ -103,7 +103,7 @@ export const AutomaterializationRoot = () => {
       return (
         ticks?.map((tick, index) => {
           // For ticks that get stuck in "Started" state without an endTimestamp.
-          if (index !== 0 && !isOldTickWithoutEndtimestamp(tick)) {
+          if (index !== 0 && !isOldTickWithoutEndtimestamp(tick) && !tick.endTimestamp) {
             const copy = {...tick};
             copy.endTimestamp = ticks[index - 1]!.timestamp;
             copy.status = InstigationTickStatus.FAILURE;


### PR DESCRIPTION
## Summary & Motivation

A last minute change made were erroneously marked as failed.

## How I Tested These Changes
locally tested the AMP Timeline page
