### PR TITLE
add cursored support for in-progress materializations

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -409,7 +409,7 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
 
     @abstractmethod
     def get_latest_asset_partition_materialization_attempts_without_materializations(
-        self, asset_key: AssetKey
+        self, asset_key: AssetKey, after_storage_id: Optional[int] = None
     ) -> Mapping[str, Tuple[str, int]]:
         pass
 

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -1855,7 +1855,7 @@ class SqlEventLogStorage(EventLogStorage):
         return dict(latest_tags_by_partition)
 
     def get_latest_asset_partition_materialization_attempts_without_materializations(
-        self, asset_key: AssetKey
+        self, asset_key: AssetKey, after_storage_id: Optional[int] = None
     ) -> Mapping[str, Tuple[str, int]]:
         """Fetch the latest materialzation and materialization planned events for each partition of the given asset.
         Return the partitions that have a materialization planned event but no matching (same run) materialization event.
@@ -1872,6 +1872,7 @@ class SqlEventLogStorage(EventLogStorage):
                 DagsterEventType.ASSET_MATERIALIZATION,
                 DagsterEventType.ASSET_MATERIALIZATION_PLANNED,
             ],
+            after_cursor=after_storage_id,
         )
 
         latest_events_subquery = db_subquery(

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -519,10 +519,10 @@ class LegacyEventLogStorage(EventLogStorage, ConfigurableClass):
         )
 
     def get_latest_asset_partition_materialization_attempts_without_materializations(
-        self, asset_key: "AssetKey"
+        self, asset_key: "AssetKey", after_storage_id: Optional[int] = None
     ) -> Mapping[str, Tuple[str, int]]:
         return self._storage.event_log_storage.get_latest_asset_partition_materialization_attempts_without_materializations(
-            asset_key
+            asset_key, after_storage_id
         )
 
     def get_dynamic_partitions(self, partitions_def_name: str) -> Sequence[str]:

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -2650,6 +2650,14 @@ class TestEventLogStorage:
                     "bar": (run_id_2, records[0].storage_id),
                 }
             )
+            assert (
+                storage.get_latest_asset_partition_materialization_attempts_without_materializations(
+                    a, records[1].storage_id
+                )
+                == {
+                    "bar": (run_id_2, records[0].storage_id),
+                }
+            )
 
             storage.store_event(
                 EventLogEntry(


### PR DESCRIPTION
## Summary & Motivation
The partition status cache currently calls the storage method directly calls `get_latest_asset_partition_materialization_attempts_without_materializations` storage method when building the cached value from scratch, but calls `get_event_records` (for planned materializations) for the incremental cursored case.

This PR changes the storage method to accept a cursor value, so that we can use the storage method in both the from scratch and the incremental cursored case.

This allows the storage implementation (e.g. cloud) to make some performance optimizations.

## How I Tested These Changes
BK