### PR TITLE
speed up cron expr _exact_match helper

### DIFF
--- a/python_modules/dagster/dagster/_utils/schedules.py
+++ b/python_modules/dagster/dagster/_utils/schedules.py
@@ -24,6 +24,18 @@ def _exact_match(cron_expression: str, dt: datetime.datetime) -> bool:
     """The default croniter match function only checks that the given datetime is within 60 seconds
     of a cron schedule tick. This function checks that the given datetime is exactly on a cron tick.
     """
+    if (
+        cron_expression == "0 0 * * *"
+        and dt.hour == 0
+        and dt.minute == 0
+        and dt.second == 0
+        and dt.microsecond == 0
+    ):
+        return True
+
+    if cron_expression == "0 * * * *" and dt.minute == 0 and dt.second == 0 and dt.microsecond == 0:
+        return True
+
     cron = CroniterShim(
         cron_expression, dt + datetime.timedelta(microseconds=1), ret_type=datetime.datetime
     )


### PR DESCRIPTION
## Summary & Motivation

We have fancy logic to avoid expensive calls to croniter when the cron expressions are simple. However, once place where we still make an expensive call to croniter even with a simpler cron expression is in the `_exact_match` function.

## How I Tested These Changes

In a small benchmark I put together, this brought the total auto-materialize evaluation time down from 16 seconds to 12 seconds.