### PR TITLE
[asset backfill deserialization 1/4] Serialize time partitions def in subset

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -1676,7 +1676,6 @@ class TimeWindowPartitionsSubset(PartitionsSubset):
         return cls(partitions_def, 0, [], set())
 
     def serialize(self) -> str:
-        partitions_def = cast(TimeWindowPartitionsDefinition, self.partitions_def)
         return json.dumps(
             {
                 "version": self.SERIALIZATION_VERSION,
@@ -1688,14 +1687,7 @@ class TimeWindowPartitionsSubset(PartitionsSubset):
                 ],
                 "num_partitions": self._num_partitions,
                 "time_partitions_def": serialize_value(
-                    TimeWindowPartitionsDefinition(
-                        start=partitions_def.start,
-                        fmt=partitions_def.fmt,
-                        timezone=partitions_def.timezone,
-                        end=partitions_def.end,
-                        end_offset=partitions_def.end_offset,
-                        cron_schedule=partitions_def.cron_schedule,
-                    )
+                    cast(TimeWindowPartitionsDefinition, self.partitions_def)
                 ),
             }
         )

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -67,6 +67,10 @@ class DatetimeFieldSerializer(FieldSerializer):
     """Serializes datetime objects to and from floats."""
 
     def pack(self, datetime: Optional[datetime], **_kwargs) -> Optional[float]:
+        if datetime:
+            check.invariant(datetime.tzinfo is not None)
+
+        # Get the timestamp in UTC
         return datetime.timestamp() if datetime else None
 
     def unpack(
@@ -141,6 +145,12 @@ class TimeWindowPartitionsDefinition(
 
         if isinstance(start, datetime):
             start_dt = pendulum.instance(start, tz=timezone)
+
+            if start.tzinfo:
+                # Pendulum.instance does not override the timezone of the datetime object,
+                # so we convert it to the provided timezone
+                start_dt = start_dt.in_tz(tz=timezone)
+
         else:
             start_dt = pendulum.instance(datetime.strptime(start, fmt), tz=timezone)
 

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -64,9 +64,7 @@ class TimeWindow(NamedTuple):
 
 
 class DatetimeFieldSerializer(FieldSerializer):
-    """TODO add docstring."""
-
-    # TODO test this
+    """Serializes datetime objects to and from floats."""
 
     def pack(self, datetime: Optional[datetime], **_kwargs) -> Optional[float]:
         return datetime.timestamp() if datetime else None
@@ -1676,6 +1674,7 @@ class TimeWindowPartitionsSubset(PartitionsSubset):
         return cls(partitions_def, 0, [], set())
 
     def serialize(self) -> str:
+        partitions_def = cast(TimeWindowPartitionsDefinition, self.partitions_def)
         return json.dumps(
             {
                 "version": self.SERIALIZATION_VERSION,
@@ -1687,7 +1686,14 @@ class TimeWindowPartitionsSubset(PartitionsSubset):
                 ],
                 "num_partitions": self._num_partitions,
                 "time_partitions_def": serialize_value(
-                    cast(TimeWindowPartitionsDefinition, self.partitions_def)
+                    TimeWindowPartitionsDefinition(
+                        start=partitions_def.start,
+                        fmt=partitions_def.fmt,
+                        timezone=partitions_def.timezone,
+                        end=partitions_def.end,
+                        end_offset=partitions_def.end_offset,
+                        cron_schedule=partitions_def.cron_schedule,
+                    )
                 ),
             }
         )

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitions_subset.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitions_subset.py
@@ -46,23 +46,6 @@ def test_static_partitions_subset_current_version_serialization():
     assert deserialized.get_partition_keys() == {"baz", "foo"}
 
 
-def test_time_window_subset_cannot_deserialize_invalid_version():
-    daily_partitions_def = DailyPartitionsDefinition(start_date="2023-01-01")
-    serialized_subset = (
-        daily_partitions_def.empty_subset().with_partition_keys(["2023-01-02"]).serialize()
-    )
-
-    assert set(daily_partitions_def.deserialize_subset(serialized_subset).get_partition_keys()) == {
-        "2023-01-02"
-    }
-
-    class NewSerializationVersionSubset(TimeWindowPartitionsSubset):
-        SERIALIZATION_VERSION = -2
-
-    with pytest.raises(DagsterInvalidDeserializationVersionError, match="version -2"):
-        NewSerializationVersionSubset.from_serialized(daily_partitions_def, serialized_subset)
-
-
 time_window_partitions = DailyPartitionsDefinition(start_date="2021-05-05")
 static_partitions = StaticPartitionsDefinition(["a", "b", "c"])
 composite = MultiPartitionsDefinition({"date": time_window_partitions, "abc": static_partitions})


### PR DESCRIPTION
This PR makes `TimeWindowPartitionsDefinitions` serializable and serializes them within `TimeWindowPartitionsSubset`s.

Subsequent PRs will rely on this new serialization to enable deserializing time window subsets even after the partitions def is changed/removed.