### PR TITLE
Add `sandbox="allow-scripts"` to dagstermill UI.

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/ui/NotebookButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/NotebookButton.tsx
@@ -67,7 +67,7 @@ export const NotebookButton: React.FC<{
             src={`${rootServerURI}/notebook?path=${encodeURIComponent(
               path,
             )}&repoLocName=${repoLocation}`}
-            sandbox=""
+            sandbox="allow-scripts"
             style={{border: 0, background: 'white'}}
             seamless={true}
             width="100%"


### PR DESCRIPTION
## Summary & Motivation
This fixes #11694 and will for example allow plotly renders to succeed.

## How I Tested These Changes
I manually patched the DOM in Chrome to verify that plotly renders with this setting.