### PR TITLE
:bug: fix loading partitioned parent assets in BranchingIOManager

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/branching/branching_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/branching/branching_io_manager.py
@@ -74,7 +74,11 @@ class BranchingIOManager(ConfigurableIOManager):
             event_log_entry = latest_materialization_log_entry(
                 instance=context.instance,
                 asset_key=context.asset_key,
-                partition_key=context.partition_key if context.has_partition_key else None,
+                partition_key=(
+                    context.upstream_output.partition_key
+                    if context.upstream_output and context.upstream_output.has_partition_key
+                    else None
+                ),
             )
             if (
                 event_log_entry

--- a/scripts/gen_airbyte_classes.py
+++ b/scripts/gen_airbyte_classes.py
@@ -361,9 +361,11 @@ def create_connector_class_definition(
         nested_defs = "\n".join([textwrap.indent(nested_def, "    ") for nested_def in nested])
     fields_in = ", ".join(
         [
-            f"{field_name}: {field_type} = None"
-            if isinstance(field_type, OptType)
-            else f"{field_name}: {field_type.annotation(scope=cls_name, quote=True)}"
+            (
+                f"{field_name}: {field_type} = None"
+                if isinstance(field_type, OptType)
+                else f"{field_name}: {field_type.annotation(scope=cls_name, quote=True)}"
+            )
             for field_name, field_type in sorted(
                 cls_def.items(), key=lambda x: isinstance(x[1], OptType)
             )
@@ -399,9 +401,11 @@ def create_connector_class_definition(
         self_fields=self_fields,
         nested_defs=nested_defs,
         human_readable_name=connector_name_human_readable,
-        docs_url=f"\n        Documentation can be found at {docs_url}\n"
-        if docs_url and docs_url != "https://docsurl.com"
-        else "",
+        docs_url=(
+            f"\n        Documentation can be found at {docs_url}\n"
+            if docs_url and docs_url != "https://docsurl.com"
+            else ""
+        ),
     )
 
 


### PR DESCRIPTION
## Summary & Motivation

Currently the `BranchingIOManager` is incorrectly using the current Run partition_key to load upstream partitions. It should use the upstream output partition key instead. 

## How I Tested These Changes
Tested at my job at Sanas