### PR TITLE
[AMP Timeline] Show ticks stuck in started state as "started" without a duration + fix bar widths

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationEvaluationHistoryTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationEvaluationHistoryTable.tsx
@@ -161,39 +161,51 @@ export const AutomaterializationEvaluationHistoryTable = ({
         </thead>
         <tbody>
           {/* Use previous data to stop page from jumping while new data loads */}
-          {(queryResult.data || queryResult.previousData)?.autoMaterializeTicks.map((tick) => (
-            <tr key={tick.id}>
-              <td>
-                <Timestamp timestamp={{unix: tick.timestamp}} timeFormat={{showTimezone: true}} />
-              </td>
-              <td>
-                <TickStatusTag tick={tick} />
-              </td>
-              <td>
-                <TimeElapsed
-                  startUnix={tick.timestamp}
-                  endUnix={tick.endTimestamp || Date.now() / 1000}
-                />
-              </td>
-              <td>
-                {[InstigationTickStatus.SKIPPED, InstigationTickStatus.SUCCESS].includes(
-                  tick.status,
-                ) ? (
-                  <ButtonLink
-                    onClick={() => {
-                      setSelectedTick(tick);
-                    }}
-                  >
-                    <Body2>
-                      {tick.requestedAssetMaterializationCount} materializations requested
-                    </Body2>
-                  </ButtonLink>
-                ) : (
-                  ' - '
-                )}
-              </td>
-            </tr>
-          ))}
+          {(queryResult.data || queryResult.previousData)?.autoMaterializeTicks.map(
+            (tick, index) => (
+              <tr key={tick.id}>
+                <td>
+                  <Timestamp timestamp={{unix: tick.timestamp}} timeFormat={{showTimezone: true}} />
+                </td>
+                <td>
+                  <TickStatusTag
+                    tick={tick}
+                    // This is a hack for ticks that get stuck in started
+                    isStuckStarted={index !== 0 && tick.status === InstigationTickStatus.STARTED}
+                  />
+                </td>
+                <td>
+                  <TimeElapsed
+                    startUnix={tick.timestamp}
+                    endUnix={
+                      tick.status === InstigationTickStatus.STARTED &&
+                      index === 0 &&
+                      !paginationProps.hasPrevCursor
+                        ? Date.now() / 1000
+                        : tick.endTimestamp
+                    }
+                  />
+                </td>
+                <td>
+                  {[InstigationTickStatus.SKIPPED, InstigationTickStatus.SUCCESS].includes(
+                    tick.status,
+                  ) ? (
+                    <ButtonLink
+                      onClick={() => {
+                        setSelectedTick(tick);
+                      }}
+                    >
+                      <Body2>
+                        {tick.requestedAssetMaterializationCount} materializations requested
+                      </Body2>
+                    </ButtonLink>
+                  ) : (
+                    ' - '
+                  )}
+                </td>
+              </tr>
+            ),
+          )}
         </tbody>
       </TableWrapper>
       <div style={{paddingBottom: '16px'}}>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationEvaluationHistoryTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationEvaluationHistoryTable.tsx
@@ -165,7 +165,9 @@ export const AutomaterializationEvaluationHistoryTable = ({
             (tick, index) => {
               // This is a hack for ticks that get stuck in started
               const isTickStuckInStartedState =
-                index !== 0 && tick.status === InstigationTickStatus.STARTED;
+                index !== 0 &&
+                tick.status === InstigationTickStatus.STARTED &&
+                !paginationProps.hasPrevCursor;
 
               return (
                 <tr key={tick.id}>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationEvaluationHistoryTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationEvaluationHistoryTable.tsx
@@ -162,49 +162,49 @@ export const AutomaterializationEvaluationHistoryTable = ({
         <tbody>
           {/* Use previous data to stop page from jumping while new data loads */}
           {(queryResult.data || queryResult.previousData)?.autoMaterializeTicks.map(
-            (tick, index) => (
-              <tr key={tick.id}>
-                <td>
-                  <Timestamp timestamp={{unix: tick.timestamp}} timeFormat={{showTimezone: true}} />
-                </td>
-                <td>
-                  <TickStatusTag
-                    tick={tick}
-                    // This is a hack for ticks that get stuck in started
-                    isStuckStarted={index !== 0 && tick.status === InstigationTickStatus.STARTED}
-                  />
-                </td>
-                <td>
-                  <TimeElapsed
-                    startUnix={tick.timestamp}
-                    endUnix={
-                      tick.status === InstigationTickStatus.STARTED &&
-                      index === 0 &&
-                      !paginationProps.hasPrevCursor
-                        ? Date.now() / 1000
-                        : tick.endTimestamp
-                    }
-                  />
-                </td>
-                <td>
-                  {[InstigationTickStatus.SKIPPED, InstigationTickStatus.SUCCESS].includes(
-                    tick.status,
-                  ) ? (
-                    <ButtonLink
-                      onClick={() => {
-                        setSelectedTick(tick);
-                      }}
-                    >
-                      <Body2>
-                        {tick.requestedAssetMaterializationCount} materializations requested
-                      </Body2>
-                    </ButtonLink>
-                  ) : (
-                    ' - '
-                  )}
-                </td>
-              </tr>
-            ),
+            (tick, index) => {
+              // This is a hack for ticks that get stuck in started
+              const isTickStuckInStartedState =
+                index !== 0 && tick.status === InstigationTickStatus.STARTED;
+
+              return (
+                <tr key={tick.id}>
+                  <td>
+                    <Timestamp
+                      timestamp={{unix: tick.timestamp}}
+                      timeFormat={{showTimezone: true}}
+                    />
+                  </td>
+                  <td>
+                    <TickStatusTag tick={tick} isStuckStarted={isTickStuckInStartedState} />
+                  </td>
+                  <td>
+                    {isTickStuckInStartedState ? (
+                      ' - '
+                    ) : (
+                      <TimeElapsed startUnix={tick.timestamp} endUnix={tick.endTimestamp} />
+                    )}
+                  </td>
+                  <td>
+                    {[InstigationTickStatus.SKIPPED, InstigationTickStatus.SUCCESS].includes(
+                      tick.status,
+                    ) ? (
+                      <ButtonLink
+                        onClick={() => {
+                          setSelectedTick(tick);
+                        }}
+                      >
+                        <Body2>
+                          {tick.requestedAssetMaterializationCount} materializations requested
+                        </Body2>
+                      </ButtonLink>
+                    ) : (
+                      ' - '
+                    )}
+                  </td>
+                </tr>
+              );
+            },
           )}
         </tbody>
       </TableWrapper>

--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/LiveTickTimeline2.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/LiveTickTimeline2.tsx
@@ -76,7 +76,7 @@ export const LiveTickTimeline = <T extends HistoryTickFragment | AssetDaemonTick
   }, [exactRange, isPaused]);
 
   const maxX = exactRange?.[1] ? exactRange[1] * 1000 : now + timeAfter;
-  const minX = exactRange?.[0] ? Math.min(exactRange[0] * 1000, maxX - timeRange) : now - timeRange;
+  const minX = exactRange?.[0] ? exactRange[0] * 1000 : now - timeRange;
 
   const fullRange = maxX - minX;
 
@@ -92,8 +92,10 @@ export const LiveTickTimeline = <T extends HistoryTickFragment | AssetDaemonTick
       const startX = getX(1000 * tick.timestamp!, viewport.width, minX, fullRange);
       const endTimestamp = isOldTickWithoutEndtimestamp(tick)
         ? tick.timestamp
-        : tick.endTimestamp ?? now;
-      const endX = 'endTimestamp' in tick ? getX(endTimestamp, viewport.width, minX, fullRange) : 0;
+        : tick.endTimestamp
+        ? tick.endTimestamp * 1000
+        : now;
+      const endX = getX(endTimestamp, viewport.width, minX, fullRange);
       return {
         ...tick,
         width: Math.max(endX - startX, MIN_WIDTH),

--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/TickStatusTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/TickStatusTag.tsx
@@ -86,7 +86,7 @@ export const TickStatusTag = ({
         }
         return successTag;
     }
-  }, [tick]);
+  }, [isStuckStarted, tick]);
 
   return (
     <>

--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/TickStatusTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/TickStatusTag.tsx
@@ -19,10 +19,12 @@ import {HistoryTickFragment} from '../instigation/types/InstigationUtils.types';
 
 export const TickStatusTag = ({
   tick,
+  isStuckStarted,
 }: {
   tick:
     | Pick<AssetDaemonTickFragment, 'status' | 'error' | 'requestedAssetMaterializationCount'>
     | Pick<HistoryTickFragment, 'status' | 'skipReason' | 'runIds' | 'runKeys' | 'error'>;
+  isStuckStarted?: boolean;
 }) => {
   const [showErrors, setShowErrors] = React.useState(false);
   const tag = React.useMemo(() => {
@@ -31,7 +33,7 @@ export const TickStatusTag = ({
       case InstigationTickStatus.STARTED:
         return (
           <Tag intent="primary" icon="spinner">
-            Evaluating
+            {isStuckStarted ? 'Started' : 'Evaluating'}
           </Tag>
         );
       case InstigationTickStatus.SKIPPED:


### PR DESCRIPTION
## Summary & Motivation

- Fix the widths of the bars by multiplying the endTimestamp by 1000
- Show "Started" instead of "evaluating" if the tick is not the first tick and has a state of started
- Also don't show a duration 

## How I Tested These Changes
![Screenshot 2023-10-19 at 10 43 10 AM](https://github.com/dagster-io/dagster/assets/2286579/392e14a4-8834-4c2a-b382-f1694b7c67cb)

