### PR TITLE
[dagster-embedded-elt] Fix for mode param not being passed to Sling CLI

### DIFF
--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/resources.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/resources.py
@@ -173,6 +173,7 @@ class SlingResource(ConfigurableResource):
 
         with self._setup_config():
             config = {
+                "mode": mode,
                 "source": {
                     "conn": "SLING_SOURCE",
                     "stream": source_stream,


### PR DESCRIPTION
## Summary & Motivation

The mode parameter was not being passed to the Sling CLI resulting in
a FULL_REFRESH on every run.

## How I Tested These Changes

Added a test case

Fixes #17301 
