### PR TITLE
Partition mapping perf improvements

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -1670,6 +1670,21 @@ class TimeWindowPartitionsSubset(PartitionsSubset):
             }
         )
 
+    def with_partitions_def(
+        self, partitions_def: TimeWindowPartitionsDefinition
+    ) -> "TimeWindowPartitionsSubset":
+        check.invariant(
+            partitions_def.cron_schedule == self._partitions_def.cron_schedule,
+            "num_partitions would become inaccurate if the partitions_defs had different cron"
+            " schedules",
+        )
+        return TimeWindowPartitionsSubset(
+            partitions_def=partitions_def,
+            num_partitions=self.num_partitions,
+            included_time_windows=self._included_time_windows,
+            included_partition_keys=self._included_partition_keys,
+        )
+
     @property
     def partitions_def(self) -> PartitionsDefinition:
         return self._partitions_def

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -423,7 +423,7 @@ class TimeWindowPartitionsDefinition(
         else:
             return prev_window
 
-    @functools.lru_cache(maxsize=5)
+    @functools.lru_cache(maxsize=256)
     def _get_first_partition_window(self, *, current_time: datetime) -> Optional[TimeWindow]:
         current_timestamp = current_time.timestamp()
 
@@ -469,7 +469,7 @@ class TimeWindowPartitionsDefinition(
         )
         return self._get_first_partition_window(current_time=current_time)
 
-    @functools.lru_cache(maxsize=5)
+    @functools.lru_cache(maxsize=256)
     def _get_last_partition_window(self, *, current_time: datetime) -> Optional[TimeWindow]:
         if self.get_first_partition_window(current_time) is None:
             return None

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -777,8 +777,7 @@ class TimeWindowPartitionsDefinition(
         return bool(self._get_validated_time_window_for_partition_key(partition_key, current_time))
 
     def equal_except_for_start_or_end(self, other: "TimeWindowPartitionsDefinition") -> bool:
-        """
-        Returns True iff this is identical to other, except they're allowed to have different
+        """Returns True iff this is identical to other, except they're allowed to have different
         start and end datetimes.
         """
         return (
@@ -1395,10 +1394,10 @@ class TimeWindowPartitionsSubset(PartitionsSubset):
         self._included_time_windows = included_time_windows
         self._num_partitions = num_partitions
 
-        check.param_invariant(
-            not (included_partition_keys and included_time_windows),
-            "Cannot specify both included_partition_keys and included_time_windows",
-        )
+        # check.param_invariant(
+        #     not (included_partition_keys and included_time_windows),
+        #     "Cannot specify both included_partition_keys and included_time_windows",
+        # )
         self._included_time_windows = check.opt_nullable_sequence_param(
             included_time_windows, "included_time_windows", of_type=TimeWindow
         )
@@ -1417,6 +1416,18 @@ class TimeWindowPartitionsSubset(PartitionsSubset):
             )
             self._included_time_windows = result_time_windows
         return self._included_time_windows
+
+    @property
+    def first_start(self) -> datetime:
+        return self.included_time_windows[0].start
+
+    @property
+    def last_end(self) -> datetime:
+        return self.included_time_windows[-1].end
+
+    @property
+    def num_partitions(self) -> int:
+        return self._num_partitions
 
     def _get_partition_time_windows_not_in_subset(
         self,

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -776,6 +776,18 @@ class TimeWindowPartitionsDefinition(
     ) -> bool:
         return bool(self._get_validated_time_window_for_partition_key(partition_key, current_time))
 
+    def equal_except_for_start_or_end(self, other: "TimeWindowPartitionsDefinition") -> bool:
+        """
+        Returns True iff this is identical to other, except they're allowed to have different
+        start and end datetimes.
+        """
+        return (
+            self.timezone == other.timezone
+            and self.fmt == other.fmt
+            and self.cron_schedule == other.cron_schedule
+            and self.end_offset == other.end_offset
+        )
+
 
 class DailyPartitionsDefinition(TimeWindowPartitionsDefinition):
     """A set of daily partitions.

--- a/python_modules/dagster/dagster/_utils/schedules.py
+++ b/python_modules/dagster/dagster/_utils/schedules.py
@@ -24,6 +24,18 @@ def _exact_match(cron_expression: str, dt: datetime.datetime) -> bool:
     """The default croniter match function only checks that the given datetime is within 60 seconds
     of a cron schedule tick. This function checks that the given datetime is exactly on a cron tick.
     """
+    if (
+        cron_expression == "0 0 * * *"
+        and dt.hour == 0
+        and dt.minute == 0
+        and dt.second == 0
+        and dt.microsecond == 0
+    ):
+        return True
+
+    if cron_expression == "0 * * * *" and dt.minute == 0 and dt.second == 0 and dt.microsecond == 0:
+        return True
+
     cron = CroniterShim(
         cron_expression, dt + datetime.timedelta(microseconds=1), ret_type=datetime.datetime
     )

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_time_window_partition_mapping.py
@@ -331,13 +331,6 @@ def test_daily_to_daily_many_to_one():
             ["2022-12-30"],
             datetime(2022, 12, 31, 1),
         ),
-        (
-            DailyPartitionsDefinition(start_date="2022-01-01"),
-            DailyPartitionsDefinition(start_date="2021-01-01"),
-            ["2022-12-30", "2022-12-31", "2023-01-01", "2023-01-02"],
-            ["2022-12-30", "2022-12-31", "2023-01-01"],
-            datetime(2023, 1, 2, 1),
-        ),
     ],
 )
 def test_get_downstream_with_current_time(

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_time_window_partition_mapping.py
@@ -431,7 +431,7 @@ def test_get_downstream_with_current_time(
             DailyPartitionsDefinition(start_date="2021-05-05", timezone="US/Central"),
             HourlyPartitionsDefinition(start_date="2021-05-05-00:00", timezone="US/Central"),
             [],
-            ["2021-05-05-23:00"],
+            ["2021-05-05-22:00"],
             datetime(2021, 5, 6, 4, tzinfo=timezone.utc),  # 2021-05-05-23:00 in US/Central
             ["2021-05-05"],
         ),


### PR DESCRIPTION
## Summary & Motivation

A set of changes that attempt to speed up partition-mapping when dealing with standard daily and hourly partitions.  These were motivated by an auto-materialize tick from a user taking over 10 hours (did it ever finish?), almost all of which was spent in partition-mapping.

The goal here is to avoid invoking croniter at all costs.  My methodology was basically dry-running the offending auto-materialize asset evaluation and speedoscope-ing to find the offending croniter invocations.

## How I Tested These Changes

This PR makes no behavior changes, but it introduces a bunch of branches, so I was concerned that it would cause some code paths to no longer be covered by tests. I ran `pytest --cov` to generate coverage reports for `time_window_partitions.py` and `time_window_partition_mapping.py`. I added a test to exercise the one place that I noticed lost coverage.

After this change, the offending auto-materialize asset evaluation dry run took only 24 minutes.  24 minutes vs. 10+ hours is not apples to apples, because 24 minutes is for a single asset and 10+ hours was for the entire tick.  However that asset was very deep in the graph, so evaluating `skip_on_parent_outdated` for it required doing so (and caching the results) for a ton of other assets as well. And Daniel observed that a similar full auto-materialize tick only took 20 minutes.

Also, I wrote a little toy example that attempts to exercise the kinds of partition mappings we were observing in the slow tick. This change brought it down from 50 seconds to 10 seconds, little of which is now spent in partition mapping.

```python
from dagster import (
    AssetsDefinition,
    PartitionsDefinition,
    asset,
    DailyPartitionsDefinition,
    RunConfig,
    DagsterInstance,
    HourlyPartitionsDefinition,
    AutoMaterializePolicy,
    Definitions,
    materialize,
    AssetKey,
)
from datetime import datetime
from dagster._core.definitions.asset_daemon_context import AssetDaemonContext
from dagster._core.definitions.asset_daemon_cursor import AssetDaemonCursor
from dagster._core.definitions.asset_graph import AssetGraph
from dagster._core.storage.tags import (
    ASSET_PARTITION_RANGE_START_TAG,
    ASSET_PARTITION_RANGE_END_TAG,
)
from typing import Sequence, Optional
import logging


def asset_def(
    key: str,
    deps: Sequence[str],
    partitions_def: Optional[PartitionsDefinition] = None,
) -> AssetsDefinition:
    @asset(
        name=key,
        partitions_def=partitions_def,
        deps=deps,
        auto_materialize_policy=AutoMaterializePolicy.eager(),
    )
    def _asset() -> None:
        ...

    return _asset


hourly_one_year = HourlyPartitionsDefinition(start_date="2022-10-18-00:00")
hourly_two_years = HourlyPartitionsDefinition(start_date="2021-10-18-00:00")
daily_one_year = DailyPartitionsDefinition(start_date="2022-10-18")
daily_four_years = DailyPartitionsDefinition(start_date="2019-10-18")
daily_ten_years = DailyPartitionsDefinition(start_date="2013-10-18")


assets = [
    asset_def("a", deps=[], partitions_def=hourly_two_years),
    asset_def("b", deps=["a"], partitions_def=daily_four_years),
    asset_def("c", deps=["a"], partitions_def=hourly_one_year),
    asset_def("d", deps=["a", "b"], partitions_def=daily_four_years),
    asset_def("e", deps=["c"], partitions_def=daily_ten_years),
    asset_def("f", deps=["c"], partitions_def=daily_one_year),
    asset_def("leaf", deps=["d", "e", "f"], partitions_def=daily_four_years),
]


defs = Definitions(assets)

logger = logging.getLogger("fsdhjkl")
log_format = "[%(asctime)s] [%(levelname)s] - %(message)s"
logging.basicConfig(level=logging.INFO, format=log_format)


def materialize_all_partitions_of_asset(asset_def, instance):
    logger.info(f"About to materialize {asset_def.key}")
    print(f"About to materialize {asset_def.key}")

    materialize(
        run_config=RunConfig(loggers={"console": {"config": {"log_level": "INFO"}}}),
        assets=[asset_def],
        instance=instance,
        tags={
            ASSET_PARTITION_RANGE_START_TAG: asset_def.partitions_def.get_first_partition_key(),
            ASSET_PARTITION_RANGE_END_TAG: asset_def.partitions_def.get_last_partition_key(),
        },
    )


def test_speed():
    instance = DagsterInstance.get()
    if instance.get_latest_materialization_event(AssetKey("a")) is None:
        for asset_def in assets:
            materialize_all_partitions_of_asset(asset_def, instance)

        assets_by_key = {asset_def.key.to_user_string(): asset_def for asset_def in assets}

        materialize_all_partitions_of_asset(assets_by_key["d"], instance)

    start = datetime.now()
    AssetDaemonContext(
        instance=instance,
        asset_graph=AssetGraph.from_assets(assets),
        cursor=AssetDaemonCursor.empty(),
        materialize_run_tags={},
        observe_run_tags={},
        auto_observe=False,
        target_asset_keys=None,
        respect_materialization_data_versions=False,
        logger=logger,
        evaluation_time=None,
    ).evaluate()

    end = datetime.now()
    logger.info("Finished evaluating tick")
    logger.info(end - start)


if __name__ == "__main__":
    test_speed()

```