### PR TITLE
Clarfiy serverless whitelist docs

### DIFF
--- a/docs/content/dagster-cloud/deployment/serverless.mdx
+++ b/docs/content/dagster-cloud/deployment/serverless.mdx
@@ -301,7 +301,7 @@ Unlike Hybrid, Serverless Deployments on Dagster Cloud require direct access to 
 
 ## Whitelisting Dagster's IP addresses
 
-To communicate with Dagster Cloud, you may need to whitelist the following static IP addresses:
+Serverless code will make requests from one of the following IP addresses. You may need to whitelist them for services your code interacts with.
 
 ```plain
 34.216.9.66


### PR DESCRIPTION
currently it sounds like these are the ip addresses to make gql requests to or something, not the client ips
https://dagster.slack.com/archives/C02LJ7G0LAZ/p1697720483602899