### PR TITLE
[ui] Load asset check names for the selected asset faster

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/SidebarAssetInfo.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/SidebarAssetInfo.tsx
@@ -18,7 +18,10 @@ import {DependsOnSelfBanner} from '../assets/DependsOnSelfBanner';
 import {PartitionHealthSummary} from '../assets/PartitionHealthSummary';
 import {UnderlyingOpsOrGraph} from '../assets/UnderlyingOpsOrGraph';
 import {Version} from '../assets/Version';
-import {EXECUTE_CHECKS_BUTTON_ASSET_NODE_FRAGMENT} from '../assets/asset-checks/ExecuteChecksButton';
+import {
+  EXECUTE_CHECKS_BUTTON_ASSET_NODE_FRAGMENT,
+  EXECUTE_CHECKS_BUTTON_CHECK_FRAGMENT,
+} from '../assets/asset-checks/ExecuteChecksButton';
 import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
 import {
   healthRefreshHintFromLiveData,
@@ -272,6 +275,10 @@ const SIDEBAR_ASSET_FRAGMENT = gql`
     requiredResources {
       resourceKey
     }
+    assetChecks {
+      name
+      ...ExecuteChecksButtonCheckFragment
+    }
 
     ...AssetNodeConfigFragment
     ...AssetNodeOpMetadataFragment
@@ -282,6 +289,7 @@ const SIDEBAR_ASSET_FRAGMENT = gql`
   ${METADATA_ENTRY_FRAGMENT}
   ${ASSET_NODE_OP_METADATA_FRAGMENT}
   ${EXECUTE_CHECKS_BUTTON_ASSET_NODE_FRAGMENT}
+  ${EXECUTE_CHECKS_BUTTON_CHECK_FRAGMENT}
 `;
 
 export const SIDEBAR_ASSET_QUERY = gql`

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__stories__/SidebarAssetInfo.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__stories__/SidebarAssetInfo.stories.tsx
@@ -73,6 +73,7 @@ const buildSidebarQueryMock = (
         description: null,
         configField: null,
         metadataEntries: [],
+        assetChecks: [],
         jobNames: ['test_job'],
         autoMaterializePolicy: null,
         freshnessPolicy: null,

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/types/SidebarAssetInfo.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/types/SidebarAssetInfo.types.ts
@@ -142,6 +142,11 @@ export type SidebarAssetFragment = {
     location: {__typename: 'RepositoryLocation'; id: string; name: string};
   };
   requiredResources: Array<{__typename: 'ResourceRequirement'; resourceKey: string}>;
+  assetChecks: Array<{
+    __typename: 'AssetCheck';
+    name: string;
+    canExecuteIndividually: Types.AssetCheckCanExecuteIndividually;
+  }>;
   configField: {
     __typename: 'ConfigTypeField';
     name: string;
@@ -15707,6 +15712,11 @@ export type SidebarAssetQuery = {
           location: {__typename: 'RepositoryLocation'; id: string; name: string};
         };
         requiredResources: Array<{__typename: 'ResourceRequirement'; resourceKey: string}>;
+        assetChecks: Array<{
+          __typename: 'AssetCheck';
+          name: string;
+          canExecuteIndividually: Types.AssetCheckCanExecuteIndividually;
+        }>;
         configField: {
           __typename: 'ConfigTypeField';
           name: string;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetSidebarActivitySummary.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetSidebarActivitySummary.tsx
@@ -160,38 +160,50 @@ export const AssetSidebarActivitySummary: React.FC<Props> = ({
           columnCount={1}
         />
       </SidebarSection>
-      {liveData && liveData.assetChecks.length > 0 && (
+      {asset.assetChecks.length > 0 && (
         <SidebarSection title="Checks">
           <Box padding={{horizontal: 24, vertical: 12}} flex={{gap: 12, alignItems: 'center'}}>
-            <ExecuteChecksButton assetNode={asset} checks={liveData.assetChecks} />
+            <ExecuteChecksButton assetNode={asset} checks={asset.assetChecks} />
             <Link to={assetDetailsPathForKey(asset.assetKey, {view: 'checks'})}>
               View all check details
             </Link>
           </Box>
 
-          {liveData.assetChecks.slice(0, 10).map((check) => (
-            <Box
-              key={check.name}
-              border={{side: 'top', width: 1, color: Colors.KeylineGray}}
-              padding={{vertical: 8, right: 12, left: 24}}
-              flex={{
-                gap: 8,
-                direction: 'row',
-                alignItems: 'center',
-                justifyContent: 'space-between',
-              }}
-            >
-              <MiddleTruncate text={`${check.name}`} />
-              <AssetCheckStatusTag execution={check.executionForLatestMaterialization} />
-            </Box>
-          ))}
-          {liveData.assetChecks.length > 10 && (
+          {asset.assetChecks.slice(0, 10).map((check) => {
+            const execution =
+              liveData &&
+              liveData.assetChecks?.find((c) => c.name === check.name)
+                ?.executionForLatestMaterialization;
+
+            return (
+              <Box
+                key={check.name}
+                style={{minHeight: 40}}
+                border={{side: 'top', width: 1, color: Colors.KeylineGray}}
+                padding={{vertical: 8, right: 12, left: 24}}
+                flex={{
+                  gap: 8,
+                  direction: 'row',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                }}
+              >
+                <MiddleTruncate text={`${check.name}`} />
+                {execution ? (
+                  <AssetCheckStatusTag execution={execution} />
+                ) : (
+                  <Spinner purpose="caption-text" />
+                )}
+              </Box>
+            );
+          })}
+          {asset.assetChecks.length > 10 && (
             <Box
               padding={{vertical: 12, right: 12, left: 24}}
               border={{side: 'top', width: 1, color: Colors.KeylineGray}}
             >
               <Link to={assetDetailsPathForKey(asset.assetKey, {view: 'checks'})}>
-                View {liveData.assetChecks.length - 10} more…
+                View {asset.assetChecks.length - 10} more…
               </Link>
             </Box>
           )}


### PR DESCRIPTION
## Summary & Motivation

This partially addresses https://github.com/dagster-io/dagster/issues/17015. Previously we wouldn't show asset checks in the asset graph sidebar until the live data updated, which can take a while. This updates the sidebar to load the check names explicitly, showing that part of the UI along with the rest of the definition.

While the live data is loading, you'll see this new intermediate state, which I think is preferrable!

<img width="885" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/e8cf54ee-ceee-4704-86f3-e01d16268e09">

## How I Tested These Changes

Click around a large asset graph while the live data is still loading, observe that you can see asset checks are defined for the selected asset.