### PR TITLE
remove unused env from helm chart

### DIFF
--- a/helm/dagster/charts/dagster-user-deployments/templates/helpers/_helpers.tpl
+++ b/helm/dagster/charts/dagster-user-deployments/templates/helpers/_helpers.tpl
@@ -87,8 +87,6 @@ This environment shared across all User Code containers
 {{- $dagsterHome := $global.dagsterHome | default .Values.dagsterHome }}
 
 DAGSTER_HOME: {{ $dagsterHome | quote }}
-DAGSTER_K8S_PG_PASSWORD_SECRET: {{ include "dagsterUserDeployments.postgresql.secretName" . | quote }}
-DAGSTER_K8S_INSTANCE_CONFIG_MAP: "{{ template "dagster.fullname" .}}-instance"
 DAGSTER_K8S_PIPELINE_RUN_NAMESPACE: "{{ .Release.Namespace }}"
 DAGSTER_K8S_PIPELINE_RUN_ENV_CONFIGMAP: "{{ template "dagster.fullname" . }}-pipeline-env"
 {{- end -}}

--- a/helm/dagster/templates/helpers/_helpers.tpl
+++ b/helm/dagster/templates/helpers/_helpers.tpl
@@ -198,6 +198,8 @@ This includes the Dagster webserver, Celery Workers, Run Worker, and Step Worker
 DAGSTER_HOME: {{ .Values.global.dagsterHome | quote }}
 DAGSTER_K8S_PIPELINE_RUN_NAMESPACE: "{{ .Release.Namespace }}"
 DAGSTER_K8S_PIPELINE_RUN_ENV_CONFIGMAP: "{{ template "dagster.fullname" . }}-pipeline-env"
+DAGSTER_K8S_PIPELINE_RUN_IMAGE: {{ include "dagster.dagsterImage.name" (list $ .Values.pipelineRun.image) | quote }}
+DAGSTER_K8S_PIPELINE_RUN_IMAGE_PULL_POLICY: "{{ .Values.pipelineRun.image.pullPolicy }}"
 {{- end -}}
 
 {{/* Assigns an ingress path port to the correct key based on its type */}}

--- a/helm/dagster/templates/helpers/_helpers.tpl
+++ b/helm/dagster/templates/helpers/_helpers.tpl
@@ -196,12 +196,8 @@ This includes the Dagster webserver, Celery Workers, Run Worker, and Step Worker
 */}}
 {{- define "dagster.shared_env" -}}
 DAGSTER_HOME: {{ .Values.global.dagsterHome | quote }}
-DAGSTER_K8S_PG_PASSWORD_SECRET: {{ include "dagster.postgresql.secretName" . | quote }}
-DAGSTER_K8S_INSTANCE_CONFIG_MAP: "{{ template "dagster.fullname" .}}-instance"
 DAGSTER_K8S_PIPELINE_RUN_NAMESPACE: "{{ .Release.Namespace }}"
 DAGSTER_K8S_PIPELINE_RUN_ENV_CONFIGMAP: "{{ template "dagster.fullname" . }}-pipeline-env"
-DAGSTER_K8S_PIPELINE_RUN_IMAGE: {{ include "dagster.dagsterImage.name" (list $ .Values.pipelineRun.image) | quote }}
-DAGSTER_K8S_PIPELINE_RUN_IMAGE_PULL_POLICY: "{{ .Values.pipelineRun.image.pullPolicy }}"
 {{- end -}}
 
 {{/* Assigns an ingress path port to the correct key based on its type */}}


### PR DESCRIPTION
Doesn't look like we read these anywhere, and they're sometimes wrong (I'm deprecating the pipelineRun helm section which sets the image ones)

I think it's a small chance that a user is relying on one of these