### PR TITLE
only create flower ConfigMap if flower is enabled

### DIFF
--- a/helm/dagster/templates/configmap-env-flower.yaml
+++ b/helm/dagster/templates/configmap-env-flower.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.flower.enabled -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -13,3 +14,4 @@ data:
   {{- range $name, $value := .Values.flower.env }}
   {{ $name }}: {{ $value | quote }}
   {{- end }}
+{{- end }}


### PR DESCRIPTION
## Summary & Motivation

I noticed that even if I had `flower: { enabled: false }` in my values file, the `flower-env` configmap would still be created.

The only reference I can find in the templates directory to `flower-env` is this template, and the flower deployment, which is also encapsulated in the same if-then-else.

## How I Tested These Changes

I installed the modified chart with flower disabled and the configmap was not created.