### PR TITLE
[asset backfill deserialization 3/4] Enable time partition subset deserialization when partition def changes

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
@@ -232,7 +232,7 @@ class AssetGraphSubset:
         cls,
         serialized_dict: Mapping[str, Any],
         asset_graph: AssetGraph,
-        allow_partial: bool = False,
+        error_on_partitions_def_changes: bool = True,
     ) -> "AssetGraphSubset":
         serializable_partitions_ids = serialized_dict.get(
             "serializable_partitions_def_ids_by_asset_key", {}
@@ -246,7 +246,7 @@ class AssetGraphSubset:
             asset_key = AssetKey.from_user_string(key)
 
             if asset_key not in asset_graph.all_asset_keys:
-                if not allow_partial:
+                if error_on_partitions_def_changes:
                     raise DagsterDefinitionChangedDeserializationError(
                         f"Asset {key} existed at storage-time, but no longer does"
                     )
@@ -255,7 +255,7 @@ class AssetGraphSubset:
             partitions_def = asset_graph.get_partitions_def(asset_key)
 
             if partitions_def is None:
-                if not allow_partial:
+                if error_on_partitions_def_changes:
                     raise DagsterDefinitionChangedDeserializationError(
                         f"Asset {key} had a PartitionsDefinition at storage-time, but no longer"
                         " does"
@@ -270,7 +270,7 @@ class AssetGraphSubset:
                     key
                 ),
             ):
-                if not allow_partial:
+                if error_on_partitions_def_changes:
                     raise DagsterDefinitionChangedDeserializationError(
                         f"Cannot deserialize stored partitions subset for asset {key}. This likely"
                         " indicates that the partitions definition has changed since this was"
@@ -282,6 +282,7 @@ class AssetGraphSubset:
                 partitions_def,
                 value,
                 partitions_def_class_names_by_asset_key.get(key),
+                error_on_partitions_def_changes=error_on_partitions_def_changes,
             )
 
             partitions_subsets_by_asset_key[asset_key] = partitions_subset

--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -1102,7 +1102,12 @@ def can_deserialize(
     elif serialized_partitions_def_class_name in [
         partitions_def.__name__ for partitions_def in TIME_PARTITIONS_SUBSET_PARTITIONS_DEFS
     ]:
-        if partitions_def and isinstance(partitions_def, TimeWindowPartitionsDefinition):
+        if (
+            partitions_def
+            and isinstance(partitions_def, TimeWindowPartitionsDefinition)
+            and partitions_def.get_serializable_unique_identifier()
+            == serialized_partitions_def_unique_id
+        ):
             return True
 
         else:  # No partitions def, or partitions def is not TimeWindowPartitionsDefinition

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -341,6 +341,7 @@ class AssetBackfillData(NamedTuple):
         serialized: str,
         asset_graph: AssetGraph,
         backfill_start_timestamp: float,
+        error_on_partitions_def_changes: bool = True,
     ) -> "AssetBackfillData":
         storage_dict = json.loads(serialized)
 
@@ -348,19 +349,23 @@ class AssetBackfillData(NamedTuple):
             target_subset=AssetGraphSubset.from_storage_dict(
                 storage_dict["serialized_target_subset"],
                 asset_graph,
+                error_on_partitions_def_changes=error_on_partitions_def_changes,
             ),
             requested_runs_for_target_roots=storage_dict["requested_runs_for_target_roots"],
             requested_subset=AssetGraphSubset.from_storage_dict(
                 storage_dict["serialized_requested_subset"],
                 asset_graph,
+                error_on_partitions_def_changes=error_on_partitions_def_changes,
             ),
             materialized_subset=AssetGraphSubset.from_storage_dict(
                 storage_dict["serialized_materialized_subset"],
                 asset_graph,
+                error_on_partitions_def_changes=error_on_partitions_def_changes,
             ),
             failed_and_downstream_subset=AssetGraphSubset.from_storage_dict(
                 storage_dict["serialized_failed_subset"],
                 asset_graph,
+                error_on_partitions_def_changes=error_on_partitions_def_changes,
             ),
             latest_storage_id=storage_dict["latest_storage_id"],
             backfill_start_time=utc_datetime_from_timestamp(backfill_start_timestamp),

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -154,6 +154,7 @@ class PartitionBackfill(
                     self.serialized_asset_backfill_data,
                     ExternalAssetGraph.from_workspace(workspace),
                     self.backfill_timestamp,
+                    error_on_partitions_def_changes=False,
                 )
             except DagsterDefinitionChangedDeserializationError:
                 return []
@@ -174,6 +175,7 @@ class PartitionBackfill(
                     self.serialized_asset_backfill_data,
                     ExternalAssetGraph.from_workspace(workspace),
                     self.backfill_timestamp,
+                    error_on_partitions_def_changes=False,
                 )
             except DagsterDefinitionChangedDeserializationError:
                 return None
@@ -192,6 +194,7 @@ class PartitionBackfill(
                     self.serialized_asset_backfill_data,
                     ExternalAssetGraph.from_workspace(workspace),
                     self.backfill_timestamp,
+                    error_on_partitions_def_changes=False,
                 )
             except DagsterDefinitionChangedDeserializationError:
                 return 0
@@ -213,6 +216,7 @@ class PartitionBackfill(
                     self.serialized_asset_backfill_data,
                     ExternalAssetGraph.from_workspace(workspace),
                     self.backfill_timestamp,
+                    error_on_partitions_def_changes=False,
                 )
             except DagsterDefinitionChangedDeserializationError:
                 return None

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
@@ -700,7 +700,7 @@ def test_asset_graph_partial_deserialization(asset_graph_from_assets):
     ).to_storage_dict(None)
 
     asset_graph2 = get_ag2()
-    assert not AssetGraphSubset.can_deserialize(ag1_storage_dict, asset_graph2)
+    assert AssetGraphSubset.can_deserialize(ag1_storage_dict, asset_graph2)
     with pytest.raises(DagsterDefinitionChangedDeserializationError):
         AssetGraphSubset.from_storage_dict(
             ag1_storage_dict,
@@ -708,14 +708,17 @@ def test_asset_graph_partial_deserialization(asset_graph_from_assets):
         )
 
     ag2_subset = AssetGraphSubset.from_storage_dict(
-        ag1_storage_dict, asset_graph=asset_graph2, allow_partial=True
+        ag1_storage_dict, asset_graph=asset_graph2, error_on_partitions_def_changes=False
     )
     assert ag2_subset == AssetGraphSubset(
         asset_graph2,
         partitions_subsets_by_asset_key={
             AssetKey("partitioned1"): daily_partitions_def.subset_with_partition_keys(
                 ["2022-01-01", "2022-01-02", "2022-01-03"]
-            )
+            ),
+            AssetKey("partitioned2"): daily_partitions_def.subset_with_partition_keys(
+                ["2022-01-01", "2022-01-02", "2022-01-03"]
+            ),
         },
         non_partitioned_asset_keys={AssetKey("unpartitioned2")},
     )

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitions_subset.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitions_subset.py
@@ -106,7 +106,7 @@ def test_can_deserialize_default_changed_to_unpartitioned(serialized_default_sub
 @pytest.mark.parametrize(
     "serialized_time_subset,is_deserializable",
     [
-        (serialized_subset, False)
+        (serialized_subset, True if version in ("2", "current") else False)
         for version, serialized_subset in get_serialized_time_subsets_by_version()[1].items()
     ],
     ids=list(get_serialized_time_subsets_by_version()[1].keys()),
@@ -139,10 +139,11 @@ def test_can_deserialize_time_subset_changed_to_static(
     )
 
 
+# Only time window subsets of version 2+ can be deserialized
 @pytest.mark.parametrize(
     "serialized_time_subset,is_deserializable",
     [
-        (serialized_subset, False)
+        (serialized_subset, True if version in ("2", "current") else False)
         for version, serialized_subset in get_serialized_time_subsets_by_version()[1].items()
     ],
     ids=list(get_serialized_time_subsets_by_version()[1].keys()),


### PR DESCRIPTION
This PR enables flexible deserialization of time partitions subsets.

Now that `TimeWindowPartitionsSubsets` are serialized as part of the subset, whenever they are present we can successfully deserialize, even if the partitions def has changed. This PR enables this.

For older `TimeWindowPartitionsSubsets`, if the partitions def has not changed, we can deserialize. Otherwise, `can_deserialize` returns `False` and `from_serialized` errors.