### PR TITLE
[asset backfill deserialization 2/4] Add can_deserialize and from_deserialize methods

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -262,7 +262,7 @@ class GraphenePartitionBackfill(graphene.ObjectType):
         return max_end_time
 
     def resolve_isValidSerialization(self, _graphene_info: ResolveInfo) -> bool:
-        return self._backfill_job.is_valid_serialization(_graphene_info.context)
+        return self._backfill_job.can_deserialize(_graphene_info.context)
 
     def resolve_partitionNames(self, _graphene_info: ResolveInfo) -> Optional[Sequence[str]]:
         return self._backfill_job.get_partition_names(_graphene_info.context)

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -1641,26 +1641,11 @@ class TimeWindowPartitionsSubset(PartitionsSubset):
         cls,
         partitions_def: PartitionsDefinition,
         serialized: str,
-        serialized_partitions_def_unique_id: Optional[str],
-        serialized_partitions_def_class_name: Optional[str],
     ) -> bool:
-        if serialized_partitions_def_unique_id:
-            return (
-                partitions_def.get_serializable_unique_identifier()
-                == serialized_partitions_def_unique_id
-            )
-
-        if (
-            serialized_partitions_def_class_name
-            # note: all TimeWindowPartitionsDefinition subclasses will get serialized as raw
-            # TimeWindowPartitionsDefinitions, so this class name check will not always pass,
-            # hence the unique id check above
-            and serialized_partitions_def_class_name != partitions_def.__class__.__name__
-        ):
-            return False
-
         data = json.loads(serialized)
-        return isinstance(data, list) or (
+        return (
+            isinstance(data, list) and all(isinstance(time_window, list) for time_window in data)
+        ) or (
             isinstance(data, dict)
             and data.get("time_windows") is not None
             and data.get("num_partitions") is not None

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -329,7 +329,7 @@ class AssetBackfillData(NamedTuple):
         )
 
     @classmethod
-    def is_valid_serialization(cls, serialized: str, asset_graph: AssetGraph) -> bool:
+    def can_deserialize(cls, serialized: str, asset_graph: AssetGraph) -> bool:
         storage_dict = json.loads(serialized)
         return AssetGraphSubset.can_deserialize(
             storage_dict["serialized_target_subset"], asset_graph
@@ -337,23 +337,30 @@ class AssetBackfillData(NamedTuple):
 
     @classmethod
     def from_serialized(
-        cls, serialized: str, asset_graph: AssetGraph, backfill_start_timestamp: float
+        cls,
+        serialized: str,
+        asset_graph: AssetGraph,
+        backfill_start_timestamp: float,
     ) -> "AssetBackfillData":
         storage_dict = json.loads(serialized)
 
         return cls(
             target_subset=AssetGraphSubset.from_storage_dict(
-                storage_dict["serialized_target_subset"], asset_graph
+                storage_dict["serialized_target_subset"],
+                asset_graph,
             ),
             requested_runs_for_target_roots=storage_dict["requested_runs_for_target_roots"],
             requested_subset=AssetGraphSubset.from_storage_dict(
-                storage_dict["serialized_requested_subset"], asset_graph
+                storage_dict["serialized_requested_subset"],
+                asset_graph,
             ),
             materialized_subset=AssetGraphSubset.from_storage_dict(
-                storage_dict["serialized_materialized_subset"], asset_graph
+                storage_dict["serialized_materialized_subset"],
+                asset_graph,
             ),
             failed_and_downstream_subset=AssetGraphSubset.from_storage_dict(
-                storage_dict["serialized_failed_subset"], asset_graph
+                storage_dict["serialized_failed_subset"],
+                asset_graph,
             ),
             latest_storage_id=storage_dict["latest_storage_id"],
             backfill_start_time=utc_datetime_from_timestamp(backfill_start_timestamp),

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -131,9 +131,9 @@ class PartitionBackfill(
             return self.tags.get(USER_TAG)
         return None
 
-    def is_valid_serialization(self, workspace: IWorkspace) -> bool:
+    def can_deserialize(self, workspace: IWorkspace) -> bool:
         if self.serialized_asset_backfill_data is not None:
-            return AssetBackfillData.is_valid_serialization(
+            return AssetBackfillData.can_deserialize(
                 self.serialized_asset_backfill_data, ExternalAssetGraph.from_workspace(workspace)
             )
         else:
@@ -145,7 +145,7 @@ class PartitionBackfill(
         """Returns a sequence of backfill statuses for each targeted asset key in the asset graph,
         in topological order.
         """
-        if not self.is_valid_serialization(workspace):
+        if not self.can_deserialize(workspace):
             return []
 
         if self.serialized_asset_backfill_data is not None:
@@ -165,7 +165,7 @@ class PartitionBackfill(
     def get_target_root_partitions_subset(
         self, workspace: IWorkspace
     ) -> Optional[PartitionsSubset]:
-        if not self.is_valid_serialization(workspace):
+        if not self.can_deserialize(workspace):
             return None
 
         if self.serialized_asset_backfill_data is not None:
@@ -183,7 +183,7 @@ class PartitionBackfill(
             return None
 
     def get_num_partitions(self, workspace: IWorkspace) -> Optional[int]:
-        if not self.is_valid_serialization(workspace):
+        if not self.can_deserialize(workspace):
             return 0
 
         if self.serialized_asset_backfill_data is not None:
@@ -204,7 +204,7 @@ class PartitionBackfill(
             return len(self.partition_names)
 
     def get_partition_names(self, workspace: IWorkspace) -> Optional[Sequence[str]]:
-        if not self.is_valid_serialization(workspace):
+        if not self.can_deserialize(workspace):
             return []
 
         if self.serialized_asset_backfill_data is not None:

--- a/python_modules/dagster/dagster/_core/execution/context/input.py
+++ b/python_modules/dagster/dagster/_core/execution/context/input.py
@@ -688,13 +688,7 @@ class KeyRangeNoPartitionsDefPartitionsSubset(PartitionsSubset):
         raise NotImplementedError()
 
     @classmethod
-    def can_deserialize(
-        cls,
-        partitions_def: "PartitionsDefinition",
-        serialized: str,
-        serialized_partitions_def_unique_id: Optional[str],
-        serialized_partitions_def_class_name: Optional[str],
-    ) -> bool:
+    def can_deserialize(cls, partitions_def: "PartitionsDefinition", serialized: str) -> bool:
         raise NotImplementedError()
 
     @classmethod

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitions_subset.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitions_subset.py
@@ -1,11 +1,22 @@
 import pytest
 from dagster import DailyPartitionsDefinition, MultiPartitionsDefinition, StaticPartitionsDefinition
 from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionsSubset
-from dagster._core.definitions.partition import DefaultPartitionsSubset
+from dagster._core.definitions.partition import (
+    DefaultPartitionsSubset,
+    can_deserialize,
+    from_serialized,
+)
 from dagster._core.definitions.time_window_partitions import (
+    TimeWindowPartitionsDefinition,
     TimeWindowPartitionsSubset,
 )
-from dagster._core.errors import DagsterInvalidDeserializationVersionError
+from dagster._core.errors import (
+    DagsterInvalidDeserializationVersionError,
+)
+
+from dagster_tests.definitions_tests.test_time_window_partitions import (
+    get_serialized_time_subsets_by_version,
+)
 
 
 def test_default_subset_cannot_deserialize_invalid_version():
@@ -27,23 +38,146 @@ def test_default_subset_cannot_deserialize_invalid_version():
         NewSerializationVersionSubset.from_serialized(static_partitions_def, serialized_subset)
 
 
-def test_static_partitions_subset_backwards_compat():
-    partitions = StaticPartitionsDefinition(["foo", "bar", "baz", "qux"])
-    serialization = '["baz", "foo"]'
+static_partitions_def = StaticPartitionsDefinition(["foo", "bar", "baz", "qux"])
+SERIALIZED_DEFAULT_SUBSET_BY_VERSION = {
+    "list_no_version": '["baz", "foo"]',
+    "version_1": '{"version": 1, "subset": ["foo", "baz"]}',
+    "current": (
+        StaticPartitionsDefinition(["foo", "bar", "baz", "qux"])
+        .empty_subset()
+        .with_partition_keys(["foo", "baz"])
+        .serialize()
+    ),
+}
 
-    deserialized = partitions.deserialize_subset(serialization)
+
+@pytest.mark.parametrize(
+    "serialized_default_subset",
+    list(SERIALIZED_DEFAULT_SUBSET_BY_VERSION.values()),
+    ids=list(SERIALIZED_DEFAULT_SUBSET_BY_VERSION.keys()),
+)
+def test_static_partitions_subset_deserialization(serialized_default_subset: str):
+    deserialized = static_partitions_def.deserialize_subset(serialized_default_subset)
     assert deserialized.get_partition_keys() == {"baz", "foo"}
 
+    assert static_partitions_def.can_deserialize_subset(serialized_default_subset) is True
 
-def test_static_partitions_subset_current_version_serialization():
-    partitions = StaticPartitionsDefinition(["foo", "bar", "baz", "qux"])
-    serialization = partitions.empty_subset().with_partition_keys(["foo", "baz"]).serialize()
-    deserialized = partitions.deserialize_subset(serialization)
-    assert deserialized.get_partition_keys() == {"baz", "foo"}
+    # Deserializable if still default partitions subset partitions def
+    assert can_deserialize(static_partitions_def, serialized_default_subset, None, None) is True
 
-    serialization = '{"version": 1, "subset": ["foo", "baz"]}'
-    deserialized = partitions.deserialize_subset(serialization)
-    assert deserialized.get_partition_keys() == {"baz", "foo"}
+
+@pytest.mark.parametrize(
+    "serialized_default_subset",
+    list(SERIALIZED_DEFAULT_SUBSET_BY_VERSION.values()),
+    ids=list(SERIALIZED_DEFAULT_SUBSET_BY_VERSION.keys()),
+)
+def test_can_deserialize_default_changed_to_time(serialized_default_subset: str):
+    time_window_partitions_def = DailyPartitionsDefinition(start_date="2021-05-05")
+
+    # We don't know which type of subset it is and the partitions def has changed, so we can't deserialize
+    assert (
+        can_deserialize(
+            time_window_partitions_def,
+            serialized_default_subset,
+            serialized_partitions_def_unique_id=None,
+            serialized_partitions_def_class_name=None,
+        )
+        is False
+    )
+
+
+@pytest.mark.parametrize(
+    "serialized_default_subset",
+    list(SERIALIZED_DEFAULT_SUBSET_BY_VERSION.values()),
+    ids=list(SERIALIZED_DEFAULT_SUBSET_BY_VERSION.keys()),
+)
+def test_can_deserialize_default_changed_to_unpartitioned(serialized_default_subset: str):
+    assert (
+        can_deserialize(
+            None,
+            serialized_default_subset,
+            serialized_partitions_def_unique_id=None,
+            serialized_partitions_def_class_name=None,
+        )
+        is False
+    )
+
+
+@pytest.mark.parametrize(
+    "serialized_time_subset,is_deserializable",
+    [
+        (serialized_subset, False)
+        for version, serialized_subset in get_serialized_time_subsets_by_version()[1].items()
+    ],
+    ids=list(get_serialized_time_subsets_by_version()[1].keys()),
+)
+def test_can_deserialize_time_subset_changed_to_static(
+    serialized_time_subset: str, is_deserializable: bool
+):
+    time_partitions_def, _ = get_serialized_time_subsets_by_version()
+    static_partitions_def = StaticPartitionsDefinition(["1", "2"])
+
+    # We don't know which type of subset it is and the partitions def has changed, so we can't deserialize
+    assert (
+        can_deserialize(
+            static_partitions_def,
+            serialized_time_subset,
+            serialized_partitions_def_unique_id=None,
+            serialized_partitions_def_class_name=None,
+        )
+        is False
+    )
+
+    assert (
+        can_deserialize(
+            static_partitions_def,
+            serialized_time_subset,
+            serialized_partitions_def_unique_id=time_partitions_def.get_serializable_unique_identifier(),
+            serialized_partitions_def_class_name=TimeWindowPartitionsDefinition.__name__,
+        )
+        is is_deserializable
+    )
+
+
+@pytest.mark.parametrize(
+    "serialized_time_subset,is_deserializable",
+    [
+        (serialized_subset, False)
+        for version, serialized_subset in get_serialized_time_subsets_by_version()[1].items()
+    ],
+    ids=list(get_serialized_time_subsets_by_version()[1].keys()),
+)
+def test_can_deserialize_time_subset_changed_to_unpartitioned(
+    serialized_time_subset: str, is_deserializable: bool
+):
+    partitions_def, _ = get_serialized_time_subsets_by_version()
+
+    deserializable = can_deserialize(
+        None,
+        serialized_time_subset,
+        serialized_partitions_def_unique_id=partitions_def.get_serializable_unique_identifier(),
+        serialized_partitions_def_class_name=TimeWindowPartitionsDefinition.__name__,
+    )
+
+    assert deserializable == is_deserializable
+
+    if deserializable:
+        from_serialized(
+            None,
+            serialized_time_subset,
+            TimeWindowPartitionsDefinition.__name__,
+        )
+
+    # If no partitions definition and no class name/uid, then we can't deserialize
+    assert (
+        can_deserialize(
+            None,
+            serialized_time_subset,
+            serialized_partitions_def_unique_id=None,
+            serialized_partitions_def_class_name=None,
+        )
+        is False
+    )
 
 
 time_window_partitions = DailyPartitionsDefinition(start_date="2021-05-05")

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
@@ -768,8 +768,8 @@ def test_serialization(static_serialization, time_window_serialization):
         {"repo": [daily_asset, static_asset]}
     )
 
-    assert AssetBackfillData.is_valid_serialization(time_window_serialization, asset_graph) is True
-    assert AssetBackfillData.is_valid_serialization(static_serialization, asset_graph) is True
+    assert AssetBackfillData.can_deserialize(time_window_serialization, asset_graph) is True
+    assert AssetBackfillData.can_deserialize(static_serialization, asset_graph) is True
 
     daily_asset._partitions_def = static_partitions  # noqa: SLF001
     static_asset._partitions_def = time_window_partitions  # noqa: SLF001
@@ -778,8 +778,8 @@ def test_serialization(static_serialization, time_window_serialization):
         {"repo": [daily_asset, static_asset]}
     )
 
-    assert AssetBackfillData.is_valid_serialization(time_window_serialization, asset_graph) is False
-    assert AssetBackfillData.is_valid_serialization(static_serialization, asset_graph) is False
+    assert AssetBackfillData.can_deserialize(time_window_serialization, asset_graph) is False
+    assert AssetBackfillData.can_deserialize(static_serialization, asset_graph) is False
 
     static_asset._partitions_def = StaticPartitionsDefinition(keys + ["x"])  # noqa: SLF001
 
@@ -787,7 +787,7 @@ def test_serialization(static_serialization, time_window_serialization):
         {"repo": [daily_asset, static_asset]}
     )
 
-    assert AssetBackfillData.is_valid_serialization(static_serialization, asset_graph) is True
+    assert AssetBackfillData.can_deserialize(static_serialization, asset_graph) is True
 
 
 def test_asset_backfill_status_counts():

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
@@ -981,11 +981,7 @@ def test_time_window_partitions_subset_deserialization():
     _, serialized_time_subsets_by_version = get_serialized_time_subsets_by_version()
 
     for serialized in serialized_time_subsets_by_version.values():
-        assert partitions_def.can_deserialize_subset(
-            serialized,
-            partitions_def.get_serializable_unique_identifier(),
-            TimeWindowPartitionsDefinition.__name__,
-        )
+        assert partitions_def.can_deserialize_subset(serialized)
 
         deserialized = partitions_def.deserialize_subset(serialized)
         assert deserialized.get_partition_keys() == ["2015-01-02", "2015-01-04"]


### PR DESCRIPTION
This PR refactors partitions subset deserialization logic to use unified `can_deserialize` and `from_deserialize` methods, instead of partition definition specific deserialization methods. This will enable future PRs to use a common deserialization entry point that handles partitions defs being changed or removed.

This PR does not change functionality of `can_deserialize` or `from_serialized`. When the provided partitions def is incompatible with the partitions def of the serialized partitions subset:
- `can_deserialize` returns False
- `from_deserialized` errors

`PartitionsSubset.can_deserialize` is now only called in backcompat cases (pre 1.1.20) where we need to validate the json structure.