### PR TITLE
Improved crash and error recovery in the asset daemon

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -913,6 +913,10 @@ class DagsterInstance(DynamicPartitionsStore):
             "respect_materialization_data_versions", False
         )
 
+    @property
+    def auto_materialize_max_tick_retries(self) -> int:
+        return self.get_settings("auto_materialize").get("max_tick_retries", 3)
+
     # python logs
 
     @property

--- a/python_modules/dagster/dagster/_core/instance/config.py
+++ b/python_modules/dagster/dagster/_core/instance/config.py
@@ -7,7 +7,15 @@ from dagster import (
     Bool,
     _check as check,
 )
-from dagster._config import Field, Permissive, ScalarUnion, Selector, StringSource, validate_config
+from dagster._config import (
+    Field,
+    IntSource,
+    Permissive,
+    ScalarUnion,
+    Selector,
+    StringSource,
+    validate_config,
+)
 from dagster._core.errors import DagsterInvalidConfigError
 from dagster._core.storage.config import mysql_config, pg_config
 from dagster._serdes import class_from_code_pointer
@@ -359,6 +367,14 @@ def dagster_instance_config_schema() -> Mapping[str, Field]:
                 "minimum_interval_seconds": Field(int, is_required=False),
                 "run_tags": Field(dict, is_required=False),
                 "respect_materialization_data_versions": Field(Bool, is_required=False),
+                "max_tick_retries": Field(
+                    IntSource,
+                    default_value=3,
+                    is_required=False,
+                    description=(
+                        "For each auto-materialize tick that raises an error, how many times to retry that tick"
+                    ),
+                ),
             }
         ),
     }

--- a/python_modules/dagster/dagster/_core/scheduler/instigation.py
+++ b/python_modules/dagster/dagster/_core/scheduler/instigation.py
@@ -492,15 +492,25 @@ class TickData(
         status (TickStatus): The status of the tick, which can be updated
         timestamp (float): The timestamp at which this instigator evaluation started
         run_id (str): The run created by the tick.
+        run_keys (Sequence[str]): Unique user-specified identifiers for the runs created by this
+            instigator.
         error (SerializableErrorInfo): The error caught during execution. This is set only when
             the status is ``TickStatus.Failure``
         skip_reason (str): message for why the tick was skipped
+        cursor (Optional[str]): Cursor output by this tick.
         origin_run_ids (List[str]): The runs originated from the schedule/sensor.
         failure_count (int): The number of times this tick has failed. If the status is not
             FAILED, this is the number of previous failures before it reached the current state.
         dynamic_partitions_request_results (Sequence[DynamicPartitionsRequestResult]): The results
             of the dynamic partitions requests evaluated within the tick.
-
+        end_timestamp (Optional[float]) Time that this tick finished.
+        run_requests (Optional[Sequence[RunRequest]]) The RunRequests that were requested by this
+            tick. Currently only used by the AUTO_MATERIALIZE type.
+        auto_materialize_evaluation_id (Optinoal[int]) For AUTO_MATERIALIZE ticks, the evaluation ID
+            that can be used to index into the asset_daemon_asset_evaluations table.
+        reserved_run_ids (Optional[Sequence[str]]): A list of run IDs to use for each of the
+            run_requests. Used to ensure that if the tick fails partway through, we don't create
+            any duplicate runs for the tick. Currently only used by AUTO_MATERIALIZE ticks.
     """
 
     def __new__(

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -424,6 +424,7 @@ class AssetDaemon(IntervalDaemon):
                     pipeline_and_execution_plan_cache,
                     self._logger,
                     debug_crash_flags,
+                    i,
                 )
 
                 tick_context.add_run_info(run_id=submitted_run.run_id)
@@ -469,6 +470,7 @@ def submit_asset_run(
     pipeline_and_execution_plan_cache: Dict[int, Tuple[ExternalJob, ExternalExecutionPlan]],
     logger: logging.Logger,
     debug_crash_flags: SingleInstigatorDebugCrashFlags,
+    run_request_index: int,
 ) -> DagsterRun:
     check.invariant(
         not run_request.run_config, "Asset materialization run requests have no custom run config"
@@ -536,6 +538,7 @@ def submit_asset_run(
             )
 
         check_for_debug_crash(debug_crash_flags, "EXECUTION_PLAN_CREATED")
+        check_for_debug_crash(debug_crash_flags, f"EXECUTION_PLAN_CREATED_{run_request_index}")
 
         external_job, external_execution_plan = pipeline_and_execution_plan_cache[selector_id]
 
@@ -562,10 +565,12 @@ def submit_asset_run(
         )
 
     check_for_debug_crash(debug_crash_flags, "RUN_CREATED")
+    check_for_debug_crash(debug_crash_flags, f"RUN_CREATED_{run_request_index}")
 
     instance.submit_run(run_to_submit.run_id, workspace)
 
     check_for_debug_crash(debug_crash_flags, "RUN_SUBMITTED")
+    check_for_debug_crash(debug_crash_flags, f"RUN_SUBMITTED_{run_request_index}")
 
     asset_key_str = ", ".join([asset_key.to_user_string() for asset_key in asset_keys])
 

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -2,14 +2,7 @@ import logging
 import sys
 from collections import defaultdict
 from types import TracebackType
-from typing import (
-    Dict,
-    List,
-    Optional,
-    Sequence,
-    Tuple,
-    Type,
-)
+from typing import Dict, Optional, Sequence, Tuple, Type
 
 import pendulum
 
@@ -22,6 +15,10 @@ from dagster._core.definitions.run_request import (
     RunRequest,
 )
 from dagster._core.definitions.selector import JobSubsetSelector
+from dagster._core.errors import (
+    DagsterCodeLocationLoadError,
+    DagsterUserCodeUnreachableError,
+)
 from dagster._core.host_representation.external import (
     ExternalExecutionPlan,
     ExternalJob,
@@ -32,12 +29,13 @@ from dagster._core.scheduler.instigation import (
     TickData,
     TickStatus,
 )
-from dagster._core.storage.dagster_run import DagsterRunStatus
+from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus
 from dagster._core.storage.tags import (
     ASSET_EVALUATION_ID_TAG,
     AUTO_MATERIALIZE_TAG,
     AUTO_OBSERVE_TAG,
 )
+from dagster._core.utils import make_new_run_id
 from dagster._core.workspace.context import IWorkspaceProcessContext
 from dagster._core.workspace.workspace import IWorkspace
 from dagster._daemon.daemon import DaemonIterator, IntervalDaemon
@@ -89,18 +87,28 @@ class AutoMaterializeLaunchContext:
         instance: DagsterInstance,
         logger: logging.Logger,
         tick_retention_settings,
+        debug_crash_flags: SingleInstigatorDebugCrashFlags,
+        max_retries: int,
     ):
         self._tick = tick
         self._logger = logger
         self._instance = instance
 
         self._purge_settings = defaultdict(set)
+
+        self._debug_crash_flags = debug_crash_flags
         for status, day_offset in tick_retention_settings.items():
             self._purge_settings[day_offset].add(status)
+
+        self._max_retries = max_retries
 
     @property
     def status(self) -> TickStatus:
         return self._tick.status
+
+    @property
+    def tick(self) -> InstigatorTick:
+        return self._tick
 
     @property
     def logger(self) -> logging.Logger:
@@ -109,8 +117,16 @@ class AutoMaterializeLaunchContext:
     def add_run_info(self, run_id=None):
         self._tick = self._tick.with_run_info(run_id)
 
-    def set_run_requests(self, run_requests: Sequence[RunRequest]):
-        self._tick = self._tick.with_run_requests(run_requests)
+    def set_run_requests(
+        self,
+        run_requests: Sequence[RunRequest],
+        reserved_run_ids: Optional[Sequence[str]],
+        cursor: Optional[str] = None,
+    ):
+        self._tick = self._tick.with_run_requests(
+            run_requests, reserved_run_ids=reserved_run_ids, cursor=cursor
+        )
+        return self._tick
 
     def update_state(self, status: TickStatus, **kwargs: object):
         self._tick = self._tick.with_status(status=status, **kwargs)
@@ -129,10 +145,46 @@ class AutoMaterializeLaunchContext:
 
         # Log the error if the failure wasn't an interrupt or the daemon generator stopping
         if exception_value and not isinstance(exception_value, GeneratorExit):
-            error_data = serializable_error_info_from_exc_info(sys.exc_info())
-            self.update_state(TickStatus.FAILURE, error=error_data)
+            if isinstance(
+                exception_value, (DagsterUserCodeUnreachableError, DagsterCodeLocationLoadError)
+            ):
+                try:
+                    raise Exception(
+                        "Unable to reach the code server. Auto-materialization will resume once the code server is available."
+                    ) from exception_value
+                except:
+                    error_data = serializable_error_info_from_exc_info(sys.exc_info())
+                    self._logger.exception("Auto-materialize daemon caught an error")
+                    self.update_state(
+                        TickStatus.FAILURE,
+                        error=error_data,
+                        # don't increment the failure count - retry until the server is available again
+                        failure_count=self._tick.failure_count,
+                    )
+            else:
+                error_data = serializable_error_info_from_exc_info(sys.exc_info())
+                self.update_state(
+                    TickStatus.FAILURE, error=error_data, failure_count=self._tick.failure_count + 1
+                )
 
-        self._write()
+        check.invariant(
+            self._tick.status != TickStatus.STARTED,
+            "Tick must be in a terminal state when the AutoMaterializeLaunchContext is closed",
+        )
+
+        # Update the cursor if we are not going to retry the tick
+        if self._tick.tick_data.cursor and (
+            self._tick.status != TickStatus.FAILURE or self._tick.failure_count > self._max_retries
+        ):
+            self._instance.daemon_cursor_storage.set_cursor_values(
+                {CURSOR_KEY: self._tick.tick_data.cursor}
+            )
+
+        check_for_debug_crash(self._debug_crash_flags, "CURSOR_UPDATED")
+
+        # write the new tick status to the database
+
+        self.write()
 
         for day_offset, statuses in self._purge_settings.items():
             if day_offset <= 0:
@@ -144,7 +196,7 @@ class AutoMaterializeLaunchContext:
                 tick_statuses=list(statuses),
             )
 
-    def _write(self) -> None:
+    def write(self) -> None:
         self._instance.update_tick(self._tick)
 
 
@@ -229,118 +281,179 @@ class AssetDaemon(IntervalDaemon):
             InstigatorType.AUTO_MATERIALIZE
         )
 
-        evaluation_id = cursor.evaluation_id + 1
-
-        tick = instance.create_tick(
-            TickData(
-                instigator_origin_id=FIXED_AUTO_MATERIALIZATION_ORIGIN_ID,
-                instigator_name=FIXED_AUTO_MATERIALIZATION_INSTIGATOR_NAME,
-                instigator_type=InstigatorType.AUTO_MATERIALIZE,
-                status=TickStatus.STARTED,
-                timestamp=evaluation_time.timestamp(),
-                selector_id=FIXED_AUTO_MATERIALIZATION_SELECTOR_ID,
-                auto_materialize_evaluation_id=evaluation_id,
-            )
+        ticks = instance.get_ticks(
+            FIXED_AUTO_MATERIALIZATION_ORIGIN_ID, FIXED_AUTO_MATERIALIZATION_SELECTOR_ID, limit=1
         )
+        latest_tick = ticks[0] if ticks else None
+
+        max_retries = instance.get_settings("auto_materialize").get("max_tick_retries")
+
+        if latest_tick and (latest_tick.status == TickStatus.STARTED):
+            self._logger.warn("Tick was interrupted part-way through, resuming")
+            tick: InstigatorTick = check.not_none(latest_tick)
+        elif (
+            latest_tick
+            and (latest_tick.status == TickStatus.FAILURE)
+            and latest_tick.tick_data.failure_count <= max_retries
+        ):
+            self._logger.info("Retrying failed tick")
+            tick = instance.create_tick(
+                latest_tick.tick_data.with_status(
+                    TickStatus.STARTED,
+                    error=None,
+                    timestamp=evaluation_time.timestamp(),
+                    end_timestamp=None,
+                ),
+            )
+        else:
+            tick = instance.create_tick(
+                TickData(
+                    instigator_origin_id=FIXED_AUTO_MATERIALIZATION_ORIGIN_ID,
+                    instigator_name=FIXED_AUTO_MATERIALIZATION_INSTIGATOR_NAME,
+                    instigator_type=InstigatorType.AUTO_MATERIALIZE,
+                    status=TickStatus.STARTED,
+                    timestamp=evaluation_time.timestamp(),
+                    selector_id=FIXED_AUTO_MATERIALIZATION_SELECTOR_ID,
+                    auto_materialize_evaluation_id=cursor.evaluation_id + 1,
+                )
+            )
 
         with AutoMaterializeLaunchContext(
-            tick, instance, self._logger, tick_retention_settings
+            tick,
+            instance,
+            self._logger,
+            tick_retention_settings,
+            debug_crash_flags,
+            max_retries=max_retries,
         ) as tick_context:
-            run_requests, new_cursor, evaluations = AssetDaemonContext(
-                asset_graph=asset_graph,
-                target_asset_keys=target_asset_keys,
-                instance=instance,
-                cursor=cursor,
-                materialize_run_tags={
-                    **instance.auto_materialize_run_tags,
-                },
-                observe_run_tags={AUTO_OBSERVE_TAG: "true"},
-                auto_observe=True,
-                respect_materialization_data_versions=instance.auto_materialize_respect_materialization_data_versions,
-                logger=self._logger,
-            ).evaluate()
+            if (
+                tick.tick_data.run_requests
+                and tick.tick_data.reserved_run_ids
+                and tick.tick_data.cursor
+            ):
+                # Unfinished or retried tick already generated evaluations and run requests and cursor, now
+                # need to finish it
+                new_cursor = AssetDaemonCursor.from_serialized(tick.tick_data.cursor, asset_graph)
+                run_requests = tick.tick_data.run_requests
+                reserved_run_ids = tick.tick_data.reserved_run_ids
+
+                if schedule_storage.supports_auto_materialize_asset_evaluations:
+                    evaluation_records = (
+                        schedule_storage.get_auto_materialize_evaluations_for_evaluation_id(
+                            new_cursor.evaluation_id
+                        )
+                    )
+                    evaluations_by_asset_key = {
+                        evaluation_record.asset_key: evaluation_record.evaluation
+                        for evaluation_record in evaluation_records
+                    }
+                else:
+                    evaluations_by_asset_key = {}
+            else:
+                run_requests, new_cursor, evaluations = AssetDaemonContext(
+                    asset_graph=asset_graph,
+                    target_asset_keys=target_asset_keys,
+                    instance=instance,
+                    cursor=cursor,
+                    materialize_run_tags={
+                        **instance.auto_materialize_run_tags,
+                    },
+                    observe_run_tags={AUTO_OBSERVE_TAG: "true"},
+                    auto_observe=True,
+                    respect_materialization_data_versions=instance.auto_materialize_respect_materialization_data_versions,
+                    logger=self._logger,
+                ).evaluate()
+
+                check_for_debug_crash(debug_crash_flags, "EVALUATIONS_FINISHED")
+
+                evaluations_by_asset_key = {
+                    evaluation.asset_key: evaluation for evaluation in evaluations
+                }
+
+                # Write the asset evaluations without run IDs first
+                if schedule_storage.supports_auto_materialize_asset_evaluations:
+                    schedule_storage.add_auto_materialize_asset_evaluations(
+                        new_cursor.evaluation_id, list(evaluations_by_asset_key.values())
+                    )
+                    check_for_debug_crash(debug_crash_flags, "ASSET_EVALUATIONS_ADDED")
+
+                reserved_run_ids = [make_new_run_id() for _ in range(len(run_requests))]
+
+                tick = tick_context.set_run_requests(
+                    run_requests=run_requests,
+                    reserved_run_ids=reserved_run_ids,
+                    cursor=new_cursor.serialize(),
+                )
+                tick_context.write()
 
             self._logger.info(
-                f"Tick produced {len(run_requests)} run{'s' if len(run_requests) != 1 else ''} and"
-                f" {len(evaluations)} asset evaluation{'s' if len(evaluations) != 1 else ''} for"
-                f" evaluation ID {new_cursor.evaluation_id}"
+                "Tick produced"
+                f" {len(run_requests)} run{'s' if len(run_requests) != 1 else ''} and"
+                f" {len(evaluations_by_asset_key)} asset"
+                f" evaluation{'s' if len(evaluations_by_asset_key) != 1 else ''} for evaluation ID"
+                f" {new_cursor.evaluation_id}"
             )
 
             check_for_debug_crash(debug_crash_flags, "RUN_REQUESTS_CREATED")
-
-            evaluations_by_asset_key = {
-                evaluation.asset_key: evaluation for evaluation in evaluations
-            }
 
             pipeline_and_execution_plan_cache: Dict[
                 int, Tuple[ExternalJob, ExternalExecutionPlan]
             ] = {}
 
-            submit_job_inputs: List[Tuple[RunRequest, ExternalJob, ExternalExecutionPlan]] = []
+            check.invariant(len(run_requests) == len(reserved_run_ids))
 
-            # First do work that is most likely to fail before doing any writes (to make
-            # double-creation of runs less likely)
-            for run_request in run_requests:
-                yield
-                submit_job_inputs.append(
-                    get_asset_run_submit_input(
-                        run_request._replace(
-                            tags={
-                                **run_request.tags,
-                                AUTO_MATERIALIZE_TAG: "true",
-                                ASSET_EVALUATION_ID_TAG: str(new_cursor.evaluation_id),
-                            }
-                        ),
-                        instance,
-                        workspace,
-                        asset_graph,
-                        pipeline_and_execution_plan_cache,
-                    )
-                )
+            updated_evaluation_asset_keys = set()
 
-            tick_context.set_run_requests(run_requests=run_requests)
-
-            # Now submit all runs to the queue
-            for submit_job_input in submit_job_inputs:
-                yield
-
-                run_request, external_job, external_execution_plan = submit_job_input
+            for i in range(len(run_requests)):
+                reserved_run_id = reserved_run_ids[i]
+                run_request = run_requests[i]
 
                 asset_keys = check.not_none(run_request.asset_selection)
 
-                run = submit_asset_run(
-                    run_request, instance, workspace, external_job, external_execution_plan
+                submitted_run = submit_asset_run(
+                    reserved_run_id,
+                    run_request._replace(
+                        tags={
+                            **run_request.tags,
+                            AUTO_MATERIALIZE_TAG: "true",
+                            ASSET_EVALUATION_ID_TAG: str(new_cursor.evaluation_id),
+                        }
+                    ),
+                    instance,
+                    workspace,
+                    asset_graph,
+                    pipeline_and_execution_plan_cache,
+                    self._logger,
+                    debug_crash_flags,
                 )
 
-                asset_key_str = ", ".join([asset_key.to_user_string() for asset_key in asset_keys])
+                tick_context.add_run_info(run_id=submitted_run.run_id)
 
-                self._logger.info(
-                    f"Launched run {run.run_id} for assets {asset_key_str} with tags"
-                    f" {run_request.tags}"
-                )
-
-                tick_context.add_run_info(run_id=run.run_id)
-
-                # add run id to evaluations
+                # write the submitted run ID to any evaluations
                 for asset_key in asset_keys:
                     # asset keys for observation runs don't have evaluations
                     if asset_key in evaluations_by_asset_key:
                         evaluation = evaluations_by_asset_key[asset_key]
                         evaluations_by_asset_key[asset_key] = evaluation._replace(
-                            run_ids=evaluation.run_ids | {run.run_id}
+                            run_ids=evaluation.run_ids | {submitted_run.run_id}
                         )
+                        updated_evaluation_asset_keys.add(asset_key)
 
-            instance.daemon_cursor_storage.set_cursor_values({CURSOR_KEY: new_cursor.serialize()})
+            evaluations_to_update = [
+                evaluations_by_asset_key[asset_key] for asset_key in updated_evaluation_asset_keys
+            ]
+            if evaluations_to_update:
+                schedule_storage.add_auto_materialize_asset_evaluations(
+                    new_cursor.evaluation_id, evaluations_to_update
+                )
+
+            check_for_debug_crash(debug_crash_flags, "RUN_IDS_ADDED_TO_EVALUATIONS")
+
             tick_context.update_state(
                 TickStatus.SUCCESS if len(run_requests) > 0 else TickStatus.SKIPPED,
             )
 
-        # We enforce uniqueness per (asset key, evaluation id). Store the evaluations after the cursor,
-        # so that if the daemon crashes and doesn't update the cursor we don't try to write duplicates.
         if schedule_storage.supports_auto_materialize_asset_evaluations:
-            schedule_storage.add_auto_materialize_asset_evaluations(
-                new_cursor.evaluation_id, list(evaluations_by_asset_key.values())
-            )
             schedule_storage.purge_asset_evaluations(
                 before=pendulum.now("UTC").subtract(days=EVALUATIONS_TTL_DAYS).timestamp(),
             )
@@ -348,94 +461,118 @@ class AssetDaemon(IntervalDaemon):
         self._logger.info("Finished auto-materialization tick")
 
 
-def get_asset_run_submit_input(
+def submit_asset_run(
+    run_id: str,
     run_request: RunRequest,
     instance: DagsterInstance,
     workspace: IWorkspace,
     asset_graph: ExternalAssetGraph,
-    pipeline_and_execution_plan_cache: Dict[int, Tuple[ExternalJob, ExternalExecutionPlan]] = {},
-) -> Tuple[RunRequest, ExternalJob, ExternalExecutionPlan]:
+    pipeline_and_execution_plan_cache: Dict[int, Tuple[ExternalJob, ExternalExecutionPlan]],
+    logger: logging.Logger,
+    debug_crash_flags: SingleInstigatorDebugCrashFlags,
+) -> DagsterRun:
     check.invariant(
         not run_request.run_config, "Asset materialization run requests have no custom run config"
     )
-
     asset_keys = check.not_none(run_request.asset_selection)
+
     check.invariant(len(asset_keys) > 0)
 
-    repo_handle = asset_graph.get_repository_handle(asset_keys[0])
+    # check if the run already exists
 
-    # Check that all asset keys are from the same repo
-    for key in asset_keys[1:]:
-        check.invariant(repo_handle == asset_graph.get_repository_handle(key))
+    run_to_submit = None
 
-    location_name = repo_handle.code_location_origin.location_name
-    repository_name = repo_handle.repository_name
-    code_location = workspace.get_code_location(location_name)
-    job_name = check.not_none(
-        asset_graph.get_implicit_job_name_for_assets(
-            asset_keys, code_location.get_repository(repository_name)
+    existing_run = instance.get_run_by_id(run_id)
+    if existing_run:
+        if existing_run.status != DagsterRunStatus.NOT_STARTED:
+            logger.warn(
+                f"Run {run_id} already submitted on a previously interrupted tick, skipping"
+            )
+            return existing_run
+        else:
+            logger.warn(
+                f"Run {run_id} already created on a previously interrupted tick, submitting"
+            )
+            run_to_submit = existing_run
+
+    if not run_to_submit:
+        repo_handle = asset_graph.get_repository_handle(asset_keys[0])
+
+        # Check that all asset keys are from the same repo
+        for key in asset_keys[1:]:
+            check.invariant(repo_handle == asset_graph.get_repository_handle(key))
+
+        location_name = repo_handle.code_location_origin.location_name
+        repository_name = repo_handle.repository_name
+        code_location = workspace.get_code_location(location_name)
+        job_name = check.not_none(
+            asset_graph.get_implicit_job_name_for_assets(
+                asset_keys, code_location.get_repository(repository_name)
+            )
         )
-    )
 
-    job_selector = JobSubsetSelector(
-        location_name=location_name,
-        repository_name=repository_name,
-        job_name=job_name,
-        op_selection=None,
-        asset_selection=asset_keys,
-    )
+        job_selector = JobSubsetSelector(
+            location_name=location_name,
+            repository_name=repository_name,
+            job_name=job_name,
+            op_selection=None,
+            asset_selection=asset_keys,
+        )
 
-    selector_id = hash_collection(job_selector)
+        selector_id = hash_collection(job_selector)
 
-    if selector_id not in pipeline_and_execution_plan_cache:
-        external_job = code_location.get_external_job(job_selector)
+        if selector_id not in pipeline_and_execution_plan_cache:
+            external_job = code_location.get_external_job(job_selector)
 
-        external_execution_plan = code_location.get_external_execution_plan(
-            external_job,
-            run_config={},
+            external_execution_plan = code_location.get_external_execution_plan(
+                external_job,
+                run_config={},
+                step_keys_to_execute=None,
+                known_state=None,
+                instance=instance,
+            )
+            pipeline_and_execution_plan_cache[selector_id] = (
+                external_job,
+                external_execution_plan,
+            )
+
+        check_for_debug_crash(debug_crash_flags, "EXECUTION_PLAN_CREATED")
+
+        external_job, external_execution_plan = pipeline_and_execution_plan_cache[selector_id]
+
+        execution_plan_snapshot = external_execution_plan.execution_plan_snapshot
+
+        run_to_submit = instance.create_run(
+            job_name=external_job.name,
+            run_id=run_id,
+            run_config=None,
+            resolved_op_selection=None,
             step_keys_to_execute=None,
-            known_state=None,
-            instance=instance,
+            status=DagsterRunStatus.NOT_STARTED,
+            op_selection=None,
+            root_run_id=None,
+            parent_run_id=None,
+            tags=run_request.tags,
+            job_snapshot=external_job.job_snapshot,
+            execution_plan_snapshot=execution_plan_snapshot,
+            parent_job_snapshot=external_job.parent_job_snapshot,
+            external_job_origin=external_job.get_external_origin(),
+            job_code_origin=external_job.get_python_origin(),
+            asset_selection=frozenset(asset_keys),
+            asset_check_selection=None,
         )
-        pipeline_and_execution_plan_cache[selector_id] = (
-            external_job,
-            external_execution_plan,
-        )
 
-    external_job, external_execution_plan = pipeline_and_execution_plan_cache[selector_id]
+    check_for_debug_crash(debug_crash_flags, "RUN_CREATED")
 
-    return (run_request, external_job, external_execution_plan)
+    instance.submit_run(run_to_submit.run_id, workspace)
 
+    check_for_debug_crash(debug_crash_flags, "RUN_SUBMITTED")
 
-def submit_asset_run(
-    run_request: RunRequest,
-    instance: DagsterInstance,
-    workspace: IWorkspace,
-    external_job: ExternalJob,
-    external_execution_plan: ExternalExecutionPlan,
-):
-    asset_keys = check.not_none(run_request.asset_selection)
+    asset_key_str = ", ".join([asset_key.to_user_string() for asset_key in asset_keys])
 
-    execution_plan_snapshot = external_execution_plan.execution_plan_snapshot
-
-    run = instance.create_run(
-        job_name=external_job.name,
-        run_id=None,
-        run_config=None,
-        resolved_op_selection=None,
-        step_keys_to_execute=None,
-        status=DagsterRunStatus.NOT_STARTED,
-        op_selection=None,
-        root_run_id=None,
-        parent_run_id=None,
-        tags=run_request.tags,
-        job_snapshot=external_job.job_snapshot,
-        execution_plan_snapshot=execution_plan_snapshot,
-        parent_job_snapshot=external_job.parent_job_snapshot,
-        external_job_origin=external_job.get_external_origin(),
-        job_code_origin=external_job.get_python_origin(),
-        asset_selection=frozenset(asset_keys),
-        asset_check_selection=None,
+    logger.info(
+        f"Submitted run {run_to_submit.run_id} for assets {asset_key_str} with tags"
+        f" {run_request.tags}"
     )
-    instance.submit_run(run.run_id, workspace)
-    return run
+
+    return run_to_submit

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -489,6 +489,10 @@ def submit_asset_run(
             logger.warn(
                 f"Run {run_id} already submitted on a previously interrupted tick, skipping"
             )
+
+            check_for_debug_crash(debug_crash_flags, "RUN_SUBMITTED")
+            check_for_debug_crash(debug_crash_flags, f"RUN_SUBMITTED_{run_request_index}")
+
             return existing_run
         else:
             logger.warn(

--- a/python_modules/dagster/dagster/_utils/__init__.py
+++ b/python_modules/dagster/dagster/_utils/__init__.py
@@ -78,7 +78,7 @@ DEFAULT_WORKSPACE_YAML_FILENAME = "workspace.yaml"
 
 PrintFn: TypeAlias = Callable[[Any], None]
 
-SingleInstigatorDebugCrashFlags: TypeAlias = Mapping[str, int]
+SingleInstigatorDebugCrashFlags: TypeAlias = Mapping[str, Union[int, Exception]]
 DebugCrashFlags: TypeAlias = Mapping[str, SingleInstigatorDebugCrashFlags]
 
 
@@ -88,11 +88,15 @@ def check_for_debug_crash(
     if not debug_crash_flags:
         return
 
-    kill_signal = debug_crash_flags.get(key)
-    if not kill_signal:
+    kill_signal_or_exception = debug_crash_flags.get(key)
+
+    if not kill_signal_or_exception:
         return
 
-    os.kill(os.getpid(), kill_signal)
+    if isinstance(kill_signal_or_exception, Exception):
+        raise kill_signal_or_exception
+
+    os.kill(os.getpid(), kill_signal_or_exception)
     time.sleep(10)
     raise Exception("Process didn't terminate after sending crash signal")
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon.py
@@ -168,9 +168,19 @@ def test_daemon_ticks(daemon_paused_instance):
         assert ticks[0].tick_data.run_requests == []
 
 
-def test_error_loop_daemon_tick(
-    daemon_not_paused_instance,
-):
+@pytest.mark.parametrize(
+    "crash_location",
+    [
+        "RUN_REQUESTS_CREATED",
+        "RUN_IDS_ADDED_TO_EVALUATIONS",
+        "RUN_CREATED",
+        "RUN_SUBMITTED",
+        "EXECUTION_PLAN_CREATED_1",
+        "RUN_CREATED_1",
+        "RUN_SUBMITTED_1",
+    ],
+)
+def test_error_loop_daemon_tick(daemon_not_paused_instance, crash_location):
     instance = daemon_not_paused_instance
     error_asset_scenario = daemon_scenarios[
         "auto_materialize_policy_max_materializations_not_exceeded"
@@ -183,7 +193,7 @@ def test_error_loop_daemon_tick(
     for trial_num in range(3):
         test_time = execution_time.add(seconds=15 * trial_num)
         with pendulum.test(test_time):
-            debug_crash_flags = {"EXECUTION_PLAN_CREATED_1": Exception(f"Oops {trial_num}")}
+            debug_crash_flags = {crash_location: Exception(f"Oops {trial_num}")}
 
             with pytest.raises(Exception, match=f"Oops {trial_num}"):
                 error_asset_scenario.do_daemon_scenario(

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_failure_recovery.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_failure_recovery.py
@@ -1,0 +1,553 @@
+import multiprocessing
+from typing import TYPE_CHECKING
+
+import pendulum
+import pytest
+from dagster import AssetKey
+from dagster._core.instance import DagsterInstance
+from dagster._core.instance.ref import InstanceRef
+from dagster._core.instance_for_test import instance_for_test
+from dagster._core.scheduler.instigation import (
+    TickStatus,
+)
+from dagster._core.storage.tags import PARTITION_NAME_TAG
+from dagster._core.test_utils import (
+    cleanup_test_instance,
+)
+from dagster._daemon.asset_daemon import (
+    FIXED_AUTO_MATERIALIZATION_ORIGIN_ID,
+    FIXED_AUTO_MATERIALIZATION_SELECTOR_ID,
+    MAX_TIME_TO_RESUME_TICK_SECONDS,
+    _get_raw_cursor,
+    set_auto_materialize_paused,
+)
+from dagster._utils import SingleInstigatorDebugCrashFlags, get_terminate_signal
+
+from .test_asset_daemon import _assert_run_requests_match, daemon_scenarios
+
+if TYPE_CHECKING:
+    from pendulum.datetime import DateTime
+
+
+@pytest.fixture
+def instance():
+    with instance_for_test() as the_instance:
+        yield the_instance
+
+
+@pytest.fixture
+def daemon_paused_instance():
+    with instance_for_test(
+        overrides={
+            "run_launcher": {
+                "module": "dagster._core.launcher.sync_in_memory_run_launcher",
+                "class": "SyncInMemoryRunLauncher",
+            },
+            "auto_materialize": {
+                "max_tick_retries": 2,
+            },
+        }
+    ) as the_instance:
+        yield the_instance
+
+
+@pytest.fixture
+def daemon_not_paused_instance(daemon_paused_instance):
+    set_auto_materialize_paused(daemon_paused_instance, False)
+    return daemon_paused_instance
+
+
+def test_old_tick_not_resumed(daemon_not_paused_instance):
+    instance = daemon_not_paused_instance
+    error_asset_scenario = daemon_scenarios[
+        "auto_materialize_policy_max_materializations_not_exceeded"
+    ]
+    execution_time = error_asset_scenario.current_time
+    error_asset_scenario = error_asset_scenario._replace(current_time=None)
+
+    debug_crash_flags = {"RUN_CREATED": Exception("OOPS")}
+
+    with pendulum.test(execution_time):
+        with pytest.raises(Exception, match="OOPS"):
+            error_asset_scenario.do_daemon_scenario(
+                instance,
+                scenario_name="auto_materialize_policy_max_materializations_not_exceeded",
+                debug_crash_flags=debug_crash_flags,
+            )
+
+        ticks = instance.get_ticks(
+            origin_id=FIXED_AUTO_MATERIALIZATION_ORIGIN_ID,
+            selector_id=FIXED_AUTO_MATERIALIZATION_SELECTOR_ID,
+        )
+
+        assert len(ticks) == 1
+        assert ticks[0].tick_data.auto_materialize_evaluation_id == 1
+        assert ticks[0].timestamp == execution_time.timestamp()
+
+    # advancing past MAX_TIME_TO_RESUME_TICK_SECONDS gives up and advances to a new evaluation
+    execution_time = execution_time.add(seconds=MAX_TIME_TO_RESUME_TICK_SECONDS + 1)
+    with pendulum.test(execution_time):
+        with pytest.raises(Exception, match="OOPS"):
+            error_asset_scenario.do_daemon_scenario(
+                instance,
+                scenario_name="auto_materialize_policy_max_materializations_not_exceeded",
+                debug_crash_flags=debug_crash_flags,
+            )
+
+        ticks = instance.get_ticks(
+            origin_id=FIXED_AUTO_MATERIALIZATION_ORIGIN_ID,
+            selector_id=FIXED_AUTO_MATERIALIZATION_SELECTOR_ID,
+        )
+
+        assert len(ticks) == 2
+        assert ticks[0].tick_data.auto_materialize_evaluation_id == 2
+
+    # advancing less than that retries the same tick
+    execution_time = execution_time.add(seconds=MAX_TIME_TO_RESUME_TICK_SECONDS - 1)
+    with pendulum.test(execution_time):
+        with pytest.raises(Exception, match="OOPS"):
+            error_asset_scenario.do_daemon_scenario(
+                instance,
+                scenario_name="auto_materialize_policy_max_materializations_not_exceeded",
+                debug_crash_flags=debug_crash_flags,
+            )
+
+        ticks = instance.get_ticks(
+            origin_id=FIXED_AUTO_MATERIALIZATION_ORIGIN_ID,
+            selector_id=FIXED_AUTO_MATERIALIZATION_SELECTOR_ID,
+        )
+
+        assert len(ticks) == 3
+        assert ticks[0].tick_data.auto_materialize_evaluation_id == 2
+
+
+@pytest.mark.parametrize(
+    "crash_location",
+    [
+        "EVALUATIONS_FINISHED",
+        "RUN_REQUESTS_CREATED",
+    ],
+)
+def test_error_loop_before_cursor_written(daemon_not_paused_instance, crash_location):
+    instance = daemon_not_paused_instance
+    error_asset_scenario = daemon_scenarios[
+        "auto_materialize_policy_max_materializations_not_exceeded"
+    ]
+    execution_time = error_asset_scenario.current_time
+    error_asset_scenario = error_asset_scenario._replace(current_time=None)
+
+    for trial_num in range(3):
+        test_time = execution_time.add(seconds=15 * trial_num)
+        with pendulum.test(test_time):
+            debug_crash_flags = {crash_location: Exception(f"Oops {trial_num}")}
+
+            with pytest.raises(Exception, match=f"Oops {trial_num}"):
+                error_asset_scenario.do_daemon_scenario(
+                    instance,
+                    scenario_name="auto_materialize_policy_max_materializations_not_exceeded",
+                    debug_crash_flags=debug_crash_flags,
+                )
+
+            ticks = instance.get_ticks(
+                origin_id=FIXED_AUTO_MATERIALIZATION_ORIGIN_ID,
+                selector_id=FIXED_AUTO_MATERIALIZATION_SELECTOR_ID,
+            )
+
+            assert len(ticks) == trial_num + 1
+            assert ticks[0].status == TickStatus.FAILURE
+            assert ticks[0].timestamp == test_time.timestamp()
+            assert ticks[0].tick_data.end_timestamp == test_time.timestamp()
+            assert ticks[0].tick_data.auto_materialize_evaluation_id == 1
+
+            # each tick is considered a brand new retry since it happened before the cursor
+            # was written
+            assert ticks[0].tick_data.failure_count == 1
+
+            assert f"Oops {trial_num}" in str(ticks[0].tick_data.error)
+
+            # Run requests are still on the tick since they were stored there before the
+            # failure happened during run submission
+            _assert_run_requests_match(
+                error_asset_scenario.expected_run_requests, ticks[0].tick_data.run_requests
+            )
+
+            # Cursor never writes since failure happens before cursor write
+            cursor = _get_raw_cursor(instance)
+            assert not cursor
+
+    test_time = test_time.add(seconds=45)
+    with pendulum.test(test_time):
+        # Next successful tick recovers
+        error_asset_scenario.do_daemon_scenario(
+            instance,
+            scenario_name="auto_materialize_policy_max_materializations_not_exceeded",
+            debug_crash_flags={},
+        )
+    ticks = instance.get_ticks(
+        origin_id=FIXED_AUTO_MATERIALIZATION_ORIGIN_ID,
+        selector_id=FIXED_AUTO_MATERIALIZATION_SELECTOR_ID,
+    )
+
+    assert len(ticks) == 4
+    assert ticks[0].status == TickStatus.SUCCESS
+    assert ticks[0].timestamp == test_time.timestamp()
+    assert ticks[0].tick_data.end_timestamp == test_time.timestamp()
+    assert ticks[0].tick_data.auto_materialize_evaluation_id == 1  # finally finishes
+
+    runs = instance.get_runs()
+    assert len(runs) == 5
+
+
+@pytest.mark.parametrize(
+    "crash_location",
+    [
+        "RUN_CREATED",  # exception after creating any run
+        "RUN_SUBMITTED",  # exception after submitting any run
+        "EXECUTION_PLAN_CREATED_1",  # exception after running code for 2nd run
+        "RUN_CREATED_1",  # exception after creating 2nd run
+        "RUN_SUBMITTED_1",  # exception after submitting 2nd run
+        "RUN_IDS_ADDED_TO_EVALUATIONS",  # exception after updating asset evaluations
+    ],
+)
+def test_error_loop_after_cursor_written(daemon_not_paused_instance, crash_location):
+    instance = daemon_not_paused_instance
+    error_asset_scenario = daemon_scenarios[
+        "auto_materialize_policy_max_materializations_not_exceeded"
+    ]
+    execution_time = error_asset_scenario.current_time
+    error_asset_scenario = error_asset_scenario._replace(current_time=None)
+
+    last_cursor = None
+
+    for trial_num in range(3):
+        test_time = execution_time.add(seconds=15 * trial_num)
+        with pendulum.test(test_time):
+            debug_crash_flags = {crash_location: Exception(f"Oops {trial_num}")}
+
+            with pytest.raises(Exception, match=f"Oops {trial_num}"):
+                error_asset_scenario.do_daemon_scenario(
+                    instance,
+                    scenario_name="auto_materialize_policy_max_materializations_not_exceeded",
+                    debug_crash_flags=debug_crash_flags,
+                )
+
+            ticks = instance.get_ticks(
+                origin_id=FIXED_AUTO_MATERIALIZATION_ORIGIN_ID,
+                selector_id=FIXED_AUTO_MATERIALIZATION_SELECTOR_ID,
+            )
+
+            assert len(ticks) == trial_num + 1
+            assert ticks[0].status == TickStatus.FAILURE
+            assert ticks[0].timestamp == test_time.timestamp()
+            assert ticks[0].tick_data.end_timestamp == test_time.timestamp()
+            assert ticks[0].tick_data.auto_materialize_evaluation_id == 1
+
+            # failure count only increases if the cursor was written - otherwise
+            # each tick is considered a brand new retry
+            assert ticks[0].tick_data.failure_count == trial_num + 1
+
+            assert f"Oops {trial_num}" in str(ticks[0].tick_data.error)
+
+            # Run requests are still on the tick since they were stored there before the
+            # failure happened during run submission
+            _assert_run_requests_match(
+                error_asset_scenario.expected_run_requests, ticks[0].tick_data.run_requests
+            )
+
+            # Same cursor due to the retry
+            retry_cursor = _get_raw_cursor(instance)
+            if trial_num > 0:
+                assert retry_cursor == last_cursor
+
+            last_cursor = retry_cursor
+
+    # Next tick moves on to use the new cursor / evaluation ID since we have passed the maximum
+    # number of retries
+    test_time = execution_time.add(seconds=45)
+    with pendulum.test(test_time):
+        debug_crash_flags = {"RUN_IDS_ADDED_TO_EVALUATIONS": Exception("Oops new tick")}
+        with pytest.raises(Exception, match="Oops new tick"):
+            error_asset_scenario.do_daemon_scenario(
+                instance,
+                scenario_name="auto_materialize_policy_max_materializations_not_exceeded",
+                debug_crash_flags=debug_crash_flags,
+            )
+
+        ticks = instance.get_ticks(
+            origin_id=FIXED_AUTO_MATERIALIZATION_ORIGIN_ID,
+            selector_id=FIXED_AUTO_MATERIALIZATION_SELECTOR_ID,
+        )
+
+        assert len(ticks) == 4
+        assert ticks[0].status == TickStatus.FAILURE
+        assert ticks[0].timestamp == test_time.timestamp()
+        assert ticks[0].tick_data.end_timestamp == test_time.timestamp()
+        assert ticks[0].tick_data.auto_materialize_evaluation_id == 2  # advances
+
+        assert "Oops new tick" in str(ticks[0].tick_data.error)
+
+        assert ticks[0].tick_data.failure_count == 1  # starts over
+
+        # Cursor has moved on
+        moved_on_cursor = _get_raw_cursor(instance)
+        assert moved_on_cursor != last_cursor
+
+    test_time = test_time.add(seconds=45)
+    with pendulum.test(test_time):
+        # Next successful tick recovers
+        error_asset_scenario.do_daemon_scenario(
+            instance,
+            scenario_name="auto_materialize_policy_max_materializations_not_exceeded",
+            debug_crash_flags={},
+        )
+
+    ticks = instance.get_ticks(
+        origin_id=FIXED_AUTO_MATERIALIZATION_ORIGIN_ID,
+        selector_id=FIXED_AUTO_MATERIALIZATION_SELECTOR_ID,
+    )
+
+    assert len(ticks) == 5
+    assert ticks[0].status != TickStatus.FAILURE
+    assert ticks[0].timestamp == test_time.timestamp()
+    assert ticks[0].tick_data.end_timestamp == test_time.timestamp()
+    assert ticks[0].tick_data.auto_materialize_evaluation_id == 2  # finishes
+
+
+spawn_ctx = multiprocessing.get_context("spawn")
+
+
+def _test_asset_daemon_in_subprocess(
+    scenario_name,
+    instance_ref: InstanceRef,
+    execution_datetime: "DateTime",
+    debug_crash_flags: SingleInstigatorDebugCrashFlags,
+) -> None:
+    scenario = daemon_scenarios[scenario_name]
+    with DagsterInstance.from_ref(instance_ref) as instance:
+        try:
+            scenario._replace(current_time=execution_datetime).do_daemon_scenario(
+                instance, scenario_name=scenario_name, debug_crash_flags=debug_crash_flags
+            )
+        finally:
+            cleanup_test_instance(instance)
+
+
+@pytest.mark.parametrize(
+    "crash_location",
+    [
+        "EVALUATIONS_FINISHED",
+        "ASSET_EVALUATIONS_ADDED",
+        "RUN_REQUESTS_CREATED",
+        "CURSOR_UPDATED",
+        "RUN_IDS_ADDED_TO_EVALUATIONS",
+        "EXECUTION_PLAN_CREATED_1",  # exception after running code for 2nd run
+        "RUN_CREATED",
+        "RUN_SUBMITTED",
+        "RUN_CREATED_1",  # exception after creating 2nd run
+        "RUN_SUBMITTED_1",  # exception after submitting 2nd run
+    ],
+)
+def test_asset_daemon_crash_recovery(daemon_not_paused_instance, crash_location):
+    # Verifies that if we crash at various points during the tick, the next tick recovers and
+    # produces the correct number of runs
+    instance = daemon_not_paused_instance
+    scenario = daemon_scenarios["auto_materialize_policy_max_materializations_not_exceeded"]
+
+    # Run a tick where the daemon crashes after run requests are created
+    asset_daemon_process = spawn_ctx.Process(
+        target=_test_asset_daemon_in_subprocess,
+        args=[
+            "auto_materialize_policy_max_materializations_not_exceeded",
+            instance.get_ref(),
+            scenario.current_time,
+            {crash_location: get_terminate_signal()},
+        ],
+    )
+    asset_daemon_process.start()
+    asset_daemon_process.join(timeout=60)
+
+    ticks = instance.get_ticks(
+        origin_id=FIXED_AUTO_MATERIALIZATION_ORIGIN_ID,
+        selector_id=FIXED_AUTO_MATERIALIZATION_SELECTOR_ID,
+    )
+
+    assert len(ticks) == 1
+    assert ticks[0]
+    assert ticks[0].status == TickStatus.STARTED
+    assert ticks[0].timestamp == scenario.current_time.timestamp()
+    assert not ticks[0].tick_data.end_timestamp == scenario.current_time.timestamp()
+
+    assert not len(ticks[0].tick_data.run_ids)
+    assert ticks[0].tick_data.auto_materialize_evaluation_id == 1
+
+    freeze_datetime = scenario.current_time.add(seconds=1)
+
+    # Run another tick with no crash, daemon continues on and succeeds
+    asset_daemon_process = spawn_ctx.Process(
+        target=_test_asset_daemon_in_subprocess,
+        args=[
+            "auto_materialize_policy_max_materializations_not_exceeded",
+            instance.get_ref(),
+            freeze_datetime,
+            None,  # No crash this time
+        ],
+    )
+    asset_daemon_process.start()
+    asset_daemon_process.join(timeout=60)
+
+    ticks = instance.get_ticks(
+        origin_id=FIXED_AUTO_MATERIALIZATION_ORIGIN_ID,
+        selector_id=FIXED_AUTO_MATERIALIZATION_SELECTOR_ID,
+    )
+
+    cursor_written = crash_location not in (
+        "EVALUATIONS_FINISHED",
+        "ASSET_EVALUATIONS_ADDED",
+        "RUN_REQUESTS_CREATED",
+    )
+
+    # Tick is resumed if the cursor was written before the crash, otherwise a new
+    # tick is created
+    assert len(ticks) == 1 if cursor_written else 2
+
+    assert ticks[0]
+    assert ticks[0].status == TickStatus.SUCCESS
+    assert (
+        ticks[0].timestamp == scenario.current_time.timestamp()
+        if cursor_written
+        else freeze_datetime.timestamp()
+    )
+    assert ticks[0].tick_data.end_timestamp == freeze_datetime.timestamp()
+    assert len(ticks[0].tick_data.run_ids) == 5
+    assert ticks[0].tick_data.auto_materialize_evaluation_id == 1
+
+    if len(ticks) == 2:
+        # first tick is intercepted and moved into skipped instead of being stuck in STARTED
+        assert ticks[1].status == TickStatus.SKIPPED
+
+    _assert_run_requests_match(scenario.expected_run_requests, ticks[0].tick_data.run_requests)
+
+    runs = instance.get_runs()
+    assert len(runs) == 5
+
+    def sort_run_key_fn(run):
+        return (min(run.asset_selection), run.tags.get(PARTITION_NAME_TAG))
+
+    sorted_runs = sorted(runs[: len(scenario.expected_run_requests)], key=sort_run_key_fn)
+
+    evaluations = instance.schedule_storage.get_auto_materialize_asset_evaluations(
+        asset_key=AssetKey("hourly"), limit=100
+    )
+    assert len(evaluations) == 1
+    assert evaluations[0].evaluation.asset_key == AssetKey("hourly")
+    assert evaluations[0].evaluation.run_ids == {run.run_id for run in sorted_runs}
+
+
+@pytest.mark.parametrize(
+    "crash_location",
+    [
+        "EVALUATIONS_FINISHED",
+        "ASSET_EVALUATIONS_ADDED",
+        "RUN_REQUESTS_CREATED",
+        "RUN_IDS_ADDED_TO_EVALUATIONS",
+        "RUN_CREATED",
+        "RUN_SUBMITTED",
+        "RUN_CREATED_2",
+        "RUN_SUBMITTED_2",
+    ],
+)
+def test_asset_daemon_exception_recovery(daemon_not_paused_instance, crash_location):
+    # Verifies that if we raise an exception at various points during the tick, the next tick
+    # recovers and produces the correct number of runs
+    instance = daemon_not_paused_instance
+    scenario = daemon_scenarios["auto_materialize_policy_max_materializations_not_exceeded"]
+
+    asset_daemon_process = spawn_ctx.Process(
+        target=_test_asset_daemon_in_subprocess,
+        args=[
+            "auto_materialize_policy_max_materializations_not_exceeded",
+            instance.get_ref(),
+            scenario.current_time,
+            {crash_location: Exception("OOPS")},
+        ],
+    )
+    asset_daemon_process.start()
+    asset_daemon_process.join(timeout=60)
+
+    ticks = instance.get_ticks(
+        origin_id=FIXED_AUTO_MATERIALIZATION_ORIGIN_ID,
+        selector_id=FIXED_AUTO_MATERIALIZATION_SELECTOR_ID,
+    )
+
+    assert len(ticks) == 1
+    assert ticks[0]
+    assert ticks[0].status == TickStatus.FAILURE
+    assert ticks[0].timestamp == scenario.current_time.timestamp()
+    assert ticks[0].tick_data.end_timestamp == scenario.current_time.timestamp()
+
+    assert ticks[0].tick_data.auto_materialize_evaluation_id == 1
+
+    tick_data_written = crash_location not in ("EVALUATIONS_FINISHED", "ASSET_EVALUATIONS_ADDED")
+
+    cursor_written = crash_location not in (
+        "EVALUATIONS_FINISHED",
+        "ASSET_EVALUATIONS_ADDED",
+        "RUN_REQUESTS_CREATED",
+    )
+
+    if not tick_data_written:
+        assert not len(ticks[0].tick_data.reserved_run_ids)
+    else:
+        assert len(ticks[0].tick_data.reserved_run_ids) == 5
+
+    cursor = _get_raw_cursor(instance)
+    assert bool(cursor) == cursor_written
+
+    freeze_datetime = scenario.current_time.add(seconds=1)
+
+    # Run another tick with no failure, daemon continues on and succeeds
+    asset_daemon_process = spawn_ctx.Process(
+        target=_test_asset_daemon_in_subprocess,
+        args=[
+            "auto_materialize_policy_max_materializations_not_exceeded",
+            instance.get_ref(),
+            freeze_datetime,
+            None,  # No crash this time
+        ],
+    )
+    asset_daemon_process.start()
+    asset_daemon_process.join(timeout=60)
+
+    ticks = instance.get_ticks(
+        origin_id=FIXED_AUTO_MATERIALIZATION_ORIGIN_ID,
+        selector_id=FIXED_AUTO_MATERIALIZATION_SELECTOR_ID,
+    )
+
+    assert len(ticks) == 2
+
+    assert ticks[0]
+    assert ticks[0].status == TickStatus.SUCCESS
+    assert ticks[0].timestamp == freeze_datetime.timestamp()
+    assert ticks[0].tick_data.end_timestamp == freeze_datetime.timestamp()
+    assert len(ticks[0].tick_data.run_ids) == 5
+    assert ticks[0].tick_data.auto_materialize_evaluation_id == 1
+
+    _assert_run_requests_match(scenario.expected_run_requests, ticks[0].tick_data.run_requests)
+
+    runs = instance.get_runs()
+    assert len(runs) == 5
+
+    def sort_run_key_fn(run):
+        return (min(run.asset_selection), run.tags.get(PARTITION_NAME_TAG))
+
+    sorted_runs = sorted(runs[: len(scenario.expected_run_requests)], key=sort_run_key_fn)
+
+    evaluations = instance.schedule_storage.get_auto_materialize_asset_evaluations(
+        asset_key=AssetKey("hourly"), limit=100
+    )
+    assert len(evaluations) == 1
+    assert evaluations[0].evaluation.asset_key == AssetKey("hourly")
+    assert evaluations[0].evaluation.run_ids == {run.run_id for run in sorted_runs}
+
+    cursor = _get_raw_cursor(instance)
+    assert cursor


### PR DESCRIPTION
Summary:
This PR adds logic to the asset daemon to ensure that if it crashes or raises an exception in the middle of a tick, subsequent ticks resume where they left off without launching duplicate runs.

It allows us to submit runs one by one as they are computed, rather than computing the snapshots for every single run in the tick one by one before launching them (in case there is a failure partway through).

The way that we do this safely is by:
- first computing the evaluations, getting a bunch of run requests out
- Storing those run requests on the tick, along with a bunch of reserved run IDs
- Before each run is launched, double check that is wasn't already launched
- Write asset evaluations before the runs are launched (without the run IDs) and afterwards again (including the run IDs) - so that we don't lose evaluations either if there are crashes.

To account for crashing partway through, the daemon first looks at the state of the most recent tick. If it crashed (i.e. it is STARTED) or raised an exception (it is FAILED), it pulls the in-progress run requests and cursor off of that tick and picks up where it left off.

The error case only retries a certain number of times before writing the cursor anyway and moving on (this is a change from the current behavior, but allows a certain amount of transient errors before we move on)

Much like with the scheduler, a "UserCodeUnreachableError" (i.e a code server is down, or the Dagster Cloud agent is down) causes ticks to retry indefinitely until the code is available again.

Still a bit more testing to add here, but I figured it was ready for any initial feedabck.

## Summary & Motivation

## How I Tested These Changes
