### PR TITLE
Reimplement [pythonic config][fix] Properly handle Pydantic validators w/ default values #17354

### DIFF
--- a/python_modules/dagster/dagster/_config/pythonic_config/config.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/config.py
@@ -271,10 +271,13 @@ class Config(MakeConfigCacheable, metaclass=BaseConfigMeta):
             field = model_fields(self).get(key)
 
             if field:
+                resolved_field_name = field.alias or key
+                print(
+                    resolved_field_name, field.annotation, is_literal(field.annotation)
+                )
                 if not is_literal(field.annotation) and value == field.default:
                     continue
 
-                resolved_field_name = field.alias or key
                 output[resolved_field_name] = value
             else:
                 output[key] = value
@@ -317,7 +320,9 @@ def _config_value_to_dict_representation(field: Optional[ModelFieldCompat], valu
     from dagster._config.field_utils import EnvVar, IntEnvVar
 
     if isinstance(value, dict):
-        return {k: _config_value_to_dict_representation(None, v) for k, v in value.items()}
+        return {
+            k: _config_value_to_dict_representation(None, v) for k, v in value.items()
+        }
     elif isinstance(value, list):
         return [_config_value_to_dict_representation(None, v) for v in value]
     elif isinstance(value, EnvVar):
@@ -334,7 +339,9 @@ def _config_value_to_dict_representation(field: Optional[ModelFieldCompat], valu
                 ).items()
             }
         else:
-            return {k: v for k, v in value._convert_to_config_dictionary().items()}  # noqa: SLF001
+            return {
+                k: v for k, v in value._convert_to_config_dictionary().items()
+            }  # noqa: SLF001
     elif isinstance(value, Enum):
         return value.name
 
@@ -403,7 +410,9 @@ def infer_schema_from_config_class(
         ):
             continue
 
-        resolved_field_name = pydantic_field_info.alias if pydantic_field_info.alias else key
+        resolved_field_name = (
+            pydantic_field_info.alias if pydantic_field_info.alias else key
+        )
         if key not in fields_to_omit:
             if isinstance(pydantic_field_info.default, DagsterField):
                 raise DagsterInvalidDefinitionError(
@@ -413,7 +422,9 @@ def infer_schema_from_config_class(
                 )
 
             try:
-                fields[resolved_field_name] = _convert_pydantic_field(pydantic_field_info)
+                fields[resolved_field_name] = _convert_pydantic_field(
+                    pydantic_field_info
+                )
             except DagsterInvalidConfigDefinitionError as e:
                 raise DagsterInvalidPythonicConfigDefinitionError(
                     config_class=model_cls,

--- a/python_modules/dagster/dagster/_config/pythonic_config/config.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/config.py
@@ -271,13 +271,10 @@ class Config(MakeConfigCacheable, metaclass=BaseConfigMeta):
             field = model_fields(self).get(key)
 
             if field:
-                resolved_field_name = field.alias or key
-                print(
-                    resolved_field_name, field.annotation, is_literal(field.annotation)
-                )
                 if not is_literal(field.annotation) and value == field.default:
                     continue
 
+                resolved_field_name = field.alias or key
                 output[resolved_field_name] = value
             else:
                 output[key] = value
@@ -320,9 +317,7 @@ def _config_value_to_dict_representation(field: Optional[ModelFieldCompat], valu
     from dagster._config.field_utils import EnvVar, IntEnvVar
 
     if isinstance(value, dict):
-        return {
-            k: _config_value_to_dict_representation(None, v) for k, v in value.items()
-        }
+        return {k: _config_value_to_dict_representation(None, v) for k, v in value.items()}
     elif isinstance(value, list):
         return [_config_value_to_dict_representation(None, v) for v in value]
     elif isinstance(value, EnvVar):
@@ -339,9 +334,7 @@ def _config_value_to_dict_representation(field: Optional[ModelFieldCompat], valu
                 ).items()
             }
         else:
-            return {
-                k: v for k, v in value._convert_to_config_dictionary().items()
-            }  # noqa: SLF001
+            return {k: v for k, v in value._convert_to_config_dictionary().items()}  # noqa: SLF001
     elif isinstance(value, Enum):
         return value.name
 
@@ -410,9 +403,7 @@ def infer_schema_from_config_class(
         ):
             continue
 
-        resolved_field_name = (
-            pydantic_field_info.alias if pydantic_field_info.alias else key
-        )
+        resolved_field_name = pydantic_field_info.alias if pydantic_field_info.alias else key
         if key not in fields_to_omit:
             if isinstance(pydantic_field_info.default, DagsterField):
                 raise DagsterInvalidDefinitionError(
@@ -422,9 +413,7 @@ def infer_schema_from_config_class(
                 )
 
             try:
-                fields[resolved_field_name] = _convert_pydantic_field(
-                    pydantic_field_info
-                )
+                fields[resolved_field_name] = _convert_pydantic_field(pydantic_field_info)
             except DagsterInvalidConfigDefinitionError as e:
                 raise DagsterInvalidPythonicConfigDefinitionError(
                     config_class=model_cls,

--- a/python_modules/dagster/dagster/_config/pythonic_config/resource.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/resource.py
@@ -450,7 +450,7 @@ class ConfigurableResourceFactory(
         # Since Resource extends BaseModel and is a dataclass, we know that the
         # signature of any __init__ method will always consist of the fields
         # of this class. We can therefore safely pass in the values as kwargs.
-        out = self.__class__(**{**self._get_non_none_public_field_values(), **values})
+        out = self.__class__(**{**self._get_non_default_public_field_values(), **values})
         out._state__internal__ = out._state__internal__._replace(  # noqa: SLF001
             resource_context=self._state__internal__.resource_context
         )

--- a/python_modules/dagster/dagster/_config/pythonic_config/type_check_utils.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/type_check_utils.py
@@ -1,4 +1,4 @@
-from typing import Any, Type, Union
+from typing import Any, Literal, Type, Union
 
 try:
     # this type only exists in python 3.10+
@@ -48,3 +48,7 @@ def is_optional(annotation: Type) -> bool:
         return len(get_args(annotation)) == 2 and type(None) in get_args(annotation)
 
     return False
+
+
+def is_literal(annotation: Type) -> bool:
+    return get_origin(annotation) == Literal

--- a/python_modules/dagster/dagster/_config/pythonic_config/type_check_utils.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/type_check_utils.py
@@ -1,4 +1,5 @@
 from typing import Any, Literal, Type, Union
+from typing_extensions import Literal as ExtLiteral
 
 try:
     # this type only exists in python 3.10+
@@ -51,4 +52,4 @@ def is_optional(annotation: Type) -> bool:
 
 
 def is_literal(annotation: Type) -> bool:
-    return get_origin(annotation) == Literal
+    return get_origin(annotation) in (Literal, ExtLiteral)

--- a/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_validation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_validation.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import pytest
 from dagster import job, op
 from dagster._config.pythonic_config import Config
@@ -63,3 +65,63 @@ def test_validators_basic() -> None:
             {"ops": {"greet_user": {"config": {"name": "Arthur", "username": "arthur"}}}}
         )
     assert not executed
+
+
+def test_validator_default_contract() -> None:
+    # ensures Pydantic's validator decorator works as expected
+    # in particular that it does not validate default values
+    # but does validate any explicit inputs matching the default
+    class UserConfig(Config):
+        name: Optional[str] = None
+
+        @validator("name")
+        def name_must_not_be_provided(cls, name):
+            raise ValueError("I always error with a non-default value!")
+
+    UserConfig()
+    with pytest.raises(ValidationError, match="I always error with a non-default value!"):
+        UserConfig(name="Arthur Miller")
+    with pytest.raises(ValidationError, match="I always error with a non-default value!"):
+        UserConfig(name=None)
+
+
+def test_validator_default_contract_nested() -> None:
+    # as above, more complex case
+    class InnerConfig(Config):
+        name: Optional[str] = None
+
+        @validator("name")
+        def name_must_not_be_provided(cls, name):
+            raise ValueError("Inner always errors with a non-default value!")
+
+    class OuterConfig(Config):
+        inner: InnerConfig
+        name: Optional[str] = None
+
+        @validator("name")
+        def name_must_not_be_provided(cls, name):
+            raise ValueError("Outer always errors with a non-default value!")
+
+    OuterConfig(inner=InnerConfig())
+    with pytest.raises(ValidationError, match="Outer always errors with a non-default value!"):
+        OuterConfig(inner=InnerConfig(), name=None)
+    with pytest.raises(ValidationError, match="Inner always errors with a non-default value!"):
+        OuterConfig(inner=InnerConfig(name=None))
+
+    executed = {}
+
+    @op
+    def my_op(config: OuterConfig) -> None:
+        executed["my_op"] = True
+
+    @job
+    def my_job() -> None:
+        my_op()
+
+    assert my_job.execute_in_process().success
+    assert executed["my_op"]
+
+    executed.clear()
+
+    with pytest.raises(ValidationError, match="Outer always errors with a non-default value!"):
+        my_job.execute_in_process({"ops": {"my_op": {"config": {"name": None}}}})

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_validation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_validation.py
@@ -1,0 +1,87 @@
+from typing import Optional
+
+import pytest
+from dagster import Definitions, asset, job, op
+from dagster._config.pythonic_config import Config, ConfigurableResource
+from dagster._core.errors import DagsterResourceFunctionError
+from pydantic import ValidationError, validator
+
+
+def test_validator_default_contract_nested() -> None:
+    # ensures Pydantic's validator decorator works as expected
+    # in particular that it does not validate default values
+    # but does validate any explicit inputs matching the default
+    class InnerConfig(Config):
+        name: Optional[str] = None
+
+        @validator("name")
+        def name_must_not_be_provided(cls, name):
+            raise ValueError("Inner always errors with a non-default value!")
+
+    class MyResource(ConfigurableResource):
+        inner: InnerConfig
+        name: Optional[str] = None
+
+        @validator("name")
+        def name_must_not_be_provided(cls, name):
+            raise ValueError("Resource always errors with a non-default value!")
+
+    MyResource(inner=InnerConfig())
+    with pytest.raises(ValidationError, match="Resource always errors with a non-default value!"):
+        MyResource(inner=InnerConfig(), name=None)
+    with pytest.raises(ValidationError, match="Inner always errors with a non-default value!"):
+        MyResource(inner=InnerConfig(name=None))
+
+    executed = {}
+
+    @op
+    def my_op(resource: MyResource) -> None:
+        executed["my_op"] = True
+
+    @job
+    def my_job() -> None:
+        my_op()
+
+    assert my_job.execute_in_process(
+        resources={"resource": MyResource(inner=InnerConfig())}
+    ).success
+    assert executed["my_op"]
+
+    executed.clear()
+
+
+def test_validator_default_contract_runtime_config() -> None:
+    # as above, runtime resource configuration
+    class InnerConfig(Config):
+        name: Optional[str] = None
+
+        @validator("name")
+        def name_must_not_be_provided(cls, name):
+            raise ValueError("Inner always errors with a non-default value!")
+
+    class MyResource(ConfigurableResource):
+        inner: InnerConfig
+        name: Optional[str] = None
+
+        @validator("name")
+        def name_must_not_be_provided(cls, name):
+            raise ValueError("Resource always errors with a non-default value!")
+
+    executed = {}
+
+    @asset
+    def hello_world_asset(my_resource: MyResource):
+        executed["hello_world_asset"] = True
+
+    defs = Definitions(
+        assets=[hello_world_asset],
+        resources={"my_resource": MyResource.configure_at_launch()},
+    )
+
+    defs.get_implicit_global_asset_job_def().execute_in_process()
+    assert executed["hello_world_asset"]
+
+    with pytest.raises(DagsterResourceFunctionError):
+        defs.get_implicit_global_asset_job_def().execute_in_process(
+            {"resources": {"my_resource": {"config": {"name": None}}}}
+        )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources.py
@@ -481,7 +481,7 @@ class DbtCliClientResource(ConfigurableResourceWithCliFlags, IAttachDifferentObj
         context = self.get_resource_context()
         default_flags = {
             k: v
-            for k, v in self._get_non_none_public_field_values().items()
+            for k, v in self._get_non_default_public_field_values().items()
             if k not in COMMON_OPTION_KEYS
         }
 


### PR DESCRIPTION
## Summary

Revert of the revert of #17354. This test was failing on Windows because `typing_extensions.Literal` is not necessarily equivalent to `typing.Literal`.

## Test Plan

[Run windows tests](https://dev.azure.com/elementl/dagster/_build/results?buildId=21474&view=results)