### PR TITLE
[auto-materialize] Go back to using recursion in get_outdated_parents

### DIFF
--- a/python_modules/dagster/dagster/_config/pythonic_config/type_check_utils.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/type_check_utils.py
@@ -1,5 +1,4 @@
 from typing import Any, Literal, Type, Union
-
 from typing_extensions import Literal as ExtLiteral
 
 try:

--- a/python_modules/dagster/dagster/_config/pythonic_config/type_check_utils.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/type_check_utils.py
@@ -1,4 +1,5 @@
 from typing import Any, Literal, Type, Union
+
 from typing_extensions import Literal as ExtLiteral
 
 try:

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -41,7 +41,11 @@ from .events import AssetKey, AssetKeyPartitionKey
 from .freshness_policy import FreshnessPolicy
 from .partition import PartitionsDefinition, PartitionsSubset
 from .partition_key_range import PartitionKeyRange
-from .partition_mapping import PartitionMapping, UpstreamPartitionsResult, infer_partition_mapping
+from .partition_mapping import (
+    PartitionMapping,
+    UpstreamPartitionsResult,
+    infer_partition_mapping,
+)
 from .source_asset import SourceAsset
 from .time_window_partitions import (
     get_time_partition_key,

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -476,7 +476,7 @@ class SkipOnParentOutdatedRule(AutoMaterializeRule, NamedTuple("_SkipOnParentOut
             for parent in context.get_parents_that_will_not_be_materialized_on_current_tick(
                 asset_partition=candidate
             ):
-                if context.instance_queryer.have_ignorable_partition_mapping_for_outdated_check(
+                if context.instance_queryer.have_ignorable_partition_mapping_for_outdated(
                     candidate.asset_key, parent.asset_key
                 ):
                     continue

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -476,6 +476,13 @@ class SkipOnParentOutdatedRule(AutoMaterializeRule, NamedTuple("_SkipOnParentOut
             for parent in context.get_parents_that_will_not_be_materialized_on_current_tick(
                 asset_partition=candidate
             ):
+                if context.asset_graph.is_partitioned(parent.asset_key) and not isinstance(
+                    context.asset_graph.get_partition_mapping(
+                        candidate.asset_key, parent.asset_key
+                    ),
+                    IdentityPartitionMapping,
+                ):
+                    continue
                 outdated_ancestors.update(
                     context.instance_queryer.get_outdated_ancestors(asset_partition=parent)
                 )

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -476,11 +476,8 @@ class SkipOnParentOutdatedRule(AutoMaterializeRule, NamedTuple("_SkipOnParentOut
             for parent in context.get_parents_that_will_not_be_materialized_on_current_tick(
                 asset_partition=candidate
             ):
-                if context.asset_graph.is_partitioned(parent.asset_key) and not isinstance(
-                    context.asset_graph.get_partition_mapping(
-                        candidate.asset_key, parent.asset_key
-                    ),
-                    IdentityPartitionMapping,
+                if context.instance_queryer.have_ignorable_partition_mapping_for_outdated_check(
+                    candidate.asset_key, parent.asset_key
                 ):
                     continue
                 outdated_ancestors.update(

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -855,7 +855,7 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
         return updated_parents
 
     def have_ignorable_partition_mapping_for_outdated(
-        self, asset_key: AssetKey, in_asset_key: AssetKey
+        self, asset_key: AssetKey, upstream_asset_key: AssetKey
     ) -> bool:
         """Returns whether the given assets have a partition mapping between them which can be
         ignored in the context of calculating if an asset is outdated or not.
@@ -865,14 +865,16 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
         to be considered up to date.
         """
         # Self partition mappings impose constraints on all historical partitions
-        if asset_key == in_asset_key:
+        if asset_key == upstream_asset_key:
             return True
         # Unpartitioned children of partitioned parents impose constraints on all upstream
         # partitions if they have the default AllPartitionMapping
         if not self.asset_graph.is_partitioned(asset_key) and self.asset_graph.is_partitioned(
-            in_asset_key
+            upstream_asset_key
         ):
-            partition_mapping = self.asset_graph.get_partition_mapping(asset_key, in_asset_key)
+            partition_mapping = self.asset_graph.get_partition_mapping(
+                asset_key, upstream_asset_key
+            )
             return isinstance(partition_mapping, AllPartitionMapping)
         return False
 

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -854,15 +854,15 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
             )
         return updated_parents
 
-    def have_ignorable_partition_mapping_for_outdated_check(
+    def have_ignorable_partition_mapping_for_outdated(
         self, asset_key: AssetKey, in_asset_key: AssetKey
     ) -> bool:
         """Returns whether the given assets have a partition mapping between them which can be
-        ignored in the context of the skip_on_parent_outdated rule.
+        ignored in the context of calculating if an asset is outdated or not.
 
         These mappings are ignored in cases where respecting them would require an unrealistic
-        number of upstream partitions to be in a good state before allowing the downstream asset to
-        be materialized.
+        number of upstream partitions to be in a 'good' state before allowing a downstream asset
+        to be considered up to date.
         """
         # Self partition mappings impose constraints on all historical partitions
         if asset_key == in_asset_key:
@@ -894,9 +894,7 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
         ignored_parent_keys = {
             parent
             for parent in self.asset_graph.get_parents(asset_partition.asset_key)
-            if self.have_ignorable_partition_mapping_for_outdated_check(
-                asset_partition.asset_key, parent
-            )
+            if self.have_ignorable_partition_mapping_for_outdated(asset_partition.asset_key, parent)
         }
 
         updated_parents = self.get_parent_asset_partitions_updated_after_child(

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -865,18 +865,8 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
         to be considered up to date.
         """
         # Self partition mappings impose constraints on all historical partitions
-        if asset_key == upstream_asset_key:
-            return True
-        # Unpartitioned children of partitioned parents impose constraints on all upstream
-        # partitions if they have the default AllPartitionMapping
-        if not self.asset_graph.is_partitioned(asset_key) and self.asset_graph.is_partitioned(
-            upstream_asset_key
-        ):
-            partition_mapping = self.asset_graph.get_partition_mapping(
-                asset_key, upstream_asset_key
-            )
-            return isinstance(partition_mapping, AllPartitionMapping)
-        return False
+        # TODO: add more filters
+        return asset_key == upstream_asset_key
 
     @cached_method
     def get_outdated_ancestors(

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -865,7 +865,6 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
         to be considered up to date.
         """
         # Self partition mappings impose constraints on all historical partitions
-        # TODO: add more filters
         return asset_key == upstream_asset_key
 
     @cached_method

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/auto_materialize_policy_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/auto_materialize_policy_scenarios.py
@@ -691,25 +691,6 @@ auto_materialize_policy_scenarios = {
         ],
         expected_run_requests=[run_request(["unpartitioned2"])],
     ),
-    "test_allow_outdated_partitioned_parent": AssetReconciliationScenario(
-        assets=two_partitioned_to_three_unpartitioned,
-        asset_selection=AssetSelection.keys("unpartitioned1", "unpartitioned2", "unpartitioned3"),
-        unevaluated_runs=[
-            # fully backfill
-            run(["partitioned1", "partitioned2"], partition_key="a"),
-            run(["partitioned1", "partitioned2"], partition_key="b"),
-            run(["unpartitioned1", "unpartitioned2", "unpartitioned3"]),
-            # now partitioned2 is outdated...
-            run(["partitioned1"], partition_key="b"),
-            # ...and unpartitioned1 has been updated
-            run(["unpartitioned1"]),
-        ],
-        expected_run_requests=[
-            # unpartitioned2/unpartitioned3 should be able to materialize even though partitioned2
-            # is outdated
-            run_request(["unpartitioned2", "unpartitioned3"]),
-        ],
-    ),
     "test_dont_allow_outdated_unpartitioned_parent": AssetReconciliationScenario(
         assets=two_partitioned_to_three_unpartitioned,
         asset_selection=AssetSelection.keys("unpartitioned3"),


### PR DESCRIPTION
## Summary & Motivation

This ends up being significantly more performant than the iterative solution, and we've resolved the underlying recursion depth limit issue by filtering out self dependencies

## How I Tested These Changes
