### PR TITLE
add asset checks to context.selected_output_names

### DIFF
--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_asset_decorator_with_check_specs.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_asset_decorator_with_check_specs.py
@@ -569,6 +569,12 @@ def test_can_subset_no_selection() -> None:
             AssetCheckKey(AssetKey("asset1"), "check1"),
             AssetCheckKey(AssetKey("asset2"), "check2"),
         }
+        assert context.selected_output_names == {
+            "asset1",
+            "asset2",
+            "asset1_check1",
+            "asset2_check2",
+        }
 
         yield Output(value=None, output_name="asset1")
         yield AssetCheckResult(asset_key="asset1", check_name="check1", passed=True)
@@ -595,6 +601,7 @@ def test_can_subset() -> None:
     def foo(context: AssetExecutionContext):
         assert context.selected_asset_keys == {AssetKey("asset1")}
         assert context.selected_asset_check_keys == {AssetCheckKey(AssetKey("asset1"), "check1")}
+        assert context.selected_output_names == {"asset1", "asset1_check1"}
 
         yield Output(value=None, output_name="asset1")
         yield AssetCheckResult(asset_key="asset1", check_name="check1", passed=True)
@@ -621,6 +628,7 @@ def test_can_subset_result_for_unselected_check() -> None:
     def foo(context: AssetExecutionContext):
         assert context.selected_asset_keys == {AssetKey("asset1")}
         assert context.selected_asset_check_keys == {AssetCheckKey(AssetKey("asset1"), "check1")}
+        assert context.selected_output_names == {"asset1", "asset1_check1"}
 
         yield Output(value=None, output_name="asset1")
         yield AssetCheckResult(asset_key="asset1", check_name="check1", passed=True)
@@ -642,6 +650,7 @@ def test_can_subset_select_only_asset() -> None:
     def foo(context: AssetExecutionContext):
         assert context.selected_asset_keys == {AssetKey("asset1")}
         assert context.selected_asset_check_keys == set()
+        assert context.selected_output_names == {"asset1"}
 
         yield Output(value=None, output_name="asset1")
 
@@ -669,6 +678,7 @@ def test_can_subset_select_only_check() -> None:
     def foo(context: AssetExecutionContext):
         assert context.selected_asset_keys == set()
         assert context.selected_asset_check_keys == {AssetCheckKey(AssetKey("asset1"), "check1")}
+        assert context.selected_output_names == {"asset1_check1"}
 
         yield AssetCheckResult(asset_key="asset1", check_name="check1", passed=True)
 


### PR DESCRIPTION
We weren't populating selected_output_names for checks, which caused a bug with the dbt integration which uses that field to detect subsets: https://dagsterlabs.slack.com/archives/C05KFG9TETB/p1697659050068569