### PR TITLE
[quick] Fix context methods in email on failure sensor

### DIFF
--- a/python_modules/dagster/dagster/_utils/alert.py
+++ b/python_modules/dagster/dagster/_utils/alert.py
@@ -22,7 +22,7 @@ def _default_failure_email_body(context: "RunFailureSensorContext") -> str:
 
     return "<br>".join(
         [
-            f"Pipeline {context.dagster_run.job_name} failed!",
+            f"Job {context.dagster_run.job_name} failed!",
             f"Run ID: {context.dagster_run.run_id}",
             f"Mode: {DEFAULT_MODE_NAME}",
             f"Error: {context.failure_event.message}",
@@ -31,7 +31,7 @@ def _default_failure_email_body(context: "RunFailureSensorContext") -> str:
 
 
 def _default_failure_email_subject(context) -> str:
-    return f"Dagster Run Failed: {context.pipeline_run.job_name}"
+    return f"Dagster Run Failed: {context.dagster_run.job_name}"
 
 
 EMAIL_MESSAGE = """From: {email_from}
@@ -165,7 +165,7 @@ def make_email_on_run_failure_sensor(
 
             def my_message_fn(context: RunFailureSensorContext) -> str:
                 return (
-                    f"Job {context.pipeline_run.job_name} failed!"
+                    f"Job {context.dagster_run.job_name} failed!"
                     f"Error: {context.failure_event.message}"
                 )
 


### PR DESCRIPTION
## Summary & Motivation
`make_email_on_run_failure_sensor` was using old context method `pipeline_run` that is no longer on the context. This replaces with `dagster_run`. 

## How I Tested These Changes
I couldn't find a unit test for these functions, but i successfully ran the sensor locally and received the expected email 