### PR TITLE
[docs] [cloud] - Make CI more prominent

### DIFF
--- a/docs/content/_navigation.json
+++ b/docs/content/_navigation.json
@@ -557,7 +557,7 @@
                 ]
               },
               {
-                "title": "Branch deployments",
+                "title": "Branch deployments (CI)",
                 "path": "/dagster-cloud/managing-deployments/branch-deployments",
                 "children": [
                   {

--- a/docs/content/dagster-cloud/getting-started.mdx
+++ b/docs/content/dagster-cloud/getting-started.mdx
@@ -152,7 +152,7 @@ The steps for accomplishing this vary depending on the **deployment type** you s
 <TabGroup>
 <TabItem name="Select deployment type">
 
-Click the tab for your deployment type - **Serverless** or **Hybrid** - to view what's next.
+Click the tab for your deployment type - [**Serverless**](#serverless) or [**Hybrid**](#hybrid) - to view what's next.
 
 </TabItem>
 <TabItem name="Serverless">
@@ -161,14 +161,16 @@ Click the tab for your deployment type - **Serverless** or **Hybrid** - to view 
 
 For **Serverless deployments**, there are two ways to deploy your code to Dagster Cloud:
 
-- **Start from a template** - Use one of our quickstart templates to get up and running. All templates come with CI/CD already configured and will be cloned to a new GitHub repository.
+- [**Start from a template**](#use-a-template) - Use one of our quickstart templates to get up and running. All templates come with CI/CD already configured and will be cloned to a new GitHub repository.
 
-- **Import an existing project** - Import an existing GitHub repository using our GitHub integration or the [dagster-cloud CLI](/dagster-cloud/managing-deployments/dagster-cloud-cli). **Note**: If using the GitHub integration, Dagster Cloud will automatically set up CI/CD for you.
+- [**Import an existing project**](#import-an-existing-project) - Import an existing GitHub repository using our GitHub integration or the [dagster-cloud CLI](/dagster-cloud/managing-deployments/dagster-cloud-cli). **Note**: If using the GitHub integration, Dagster Cloud will automatically set up CI/CD for you.
+
+#### Use a template
 
 <TabGroup>
-<TabItem name="Use a template">
+<TabItem name="GitHub">
 
-**With GitHub**
+##### GitHub
 
 1. Click **Select** to select a template.
 2. Sign in to your GitHub account, if prompted.
@@ -178,9 +180,14 @@ For **Serverless deployments**, there are two ways to deploy your code to Dagste
    - Check the **Make git repository private** box to make the repository private.
 4. When finished, click **Clone and deploy**.
 
-When finished, [continue to the next step](#step-4-set-up-environment-variables-and-secrets).
+When finished, [continue to Step 5](#step-5-set-up-environment-variables-and-secrets).
 
-**With Gitlab**
+---
+
+</TabItem>
+<TabItem name="GitLab">
+
+##### GitLab
 
 1. Click **Select** to select a template.
 2. Sign in to your Gitlab account, if prompted.
@@ -190,14 +197,21 @@ When finished, [continue to the next step](#step-4-set-up-environment-variables-
    - Check the **Make git project private** box to make the project private.
 4. When finished, click **Clone and deploy**.
 
-When finished, [continue to the next step](#step-4-set-up-environment-variables-and-secrets).
+When finished, [continue to Step 5](#step-5-set-up-environment-variables-and-secrets).
+
+---
 
 </TabItem>
-<TabItem name="Import an existing project">
+</TabGroup>
 
-To import existing Dagster code, you can use Dagster's GitHub / Gitlab app or the dagster-cloud CLI.
+#### Import an existing project
 
-**Using the GitHub integration**
+If you have existing Dagster code, you can use Dagster's GitHub / Gitlab app or the dagster-cloud CLI.
+
+<TabGroup>
+<TabItem name="GitHub">
+
+##### GitHub
 
 Using the GitHub integration to import an existing GitHub repository also sets up CI/CD for you.
 
@@ -223,9 +237,12 @@ After you've committed the file to the repository, come back to Dagster Cloud to
    - **Repository** - Select the repository.
 4. Click **Deploy**.
 
-When finished, [continue to the next step](#step-4-set-up-environment-variables-and-secrets).
+When finished, [continue to Step 5](#step-5-set-up-environment-variables-and-secrets).
 
-**Using the Gitlab integration**
+</TabItem>
+<TabItem name="GitLab">
+
+##### GitLab
 
 Using the Gitlab integration to import an existing Gitlab project also sets up CI/CD for you.
 
@@ -251,12 +268,16 @@ After you've committed the file to the project, come back to Dagster Cloud to co
    - **Project** - Select the project.
 4. Click **Deploy**.
 
-When finished, [continue to the next step](#step-4-set-up-environment-variables-and-secrets).
+When finished, [continue to Step 5](#step-5-set-up-environment-variables-and-secrets).
 
-**Using the dagster-cloud CLI**
+</TabItem>
+<TabItem name="dagster-cloud CLI">
+
+##### dagster-cloud CLI
 
 <Note>
-  Using the dagster-cloud CLI requires a recent version of Python 3 and Docker.
+  <strong>Heads up!</strong> Using the dagster-cloud CLI requires a recent
+  version of Python 3 and Docker.
 </Note>
 
 To complete this step using the CLI, you can use your own Dagster code or the [Dagster starter kit](https://github.com/dagster-io/quickstart-etl). The starter kit is a template with everything you need to get started using Serverless in Dagster Cloud, including CI/CD configuration and the required [`dagster_cloud.yaml` file](/dagster-cloud/managing-deployments/dagster-cloud-yaml).
@@ -287,7 +308,7 @@ After you've finished setting up your local project, move on to deploying using 
          --package-name "<PACKAGE_NAME>" \           # name of the Python package associated with the code location
    ```
 
-When finished, [continue to the next step](#step-4-set-up-environment-variables-and-secrets).
+When finished, [continue to Step 5](#step-5-set-up-environment-variables-and-secrets).
 
 </TabItem>
 </TabGroup>
@@ -299,13 +320,9 @@ When finished, [continue to the next step](#step-4-set-up-environment-variables-
 To set up Hybrid deployment and deploy your code, you'll need to:
 
 1. Set up an agent
-2. Configure CI/CD for your project
+2. Configure CI/CD for your project. We'll walk you through this in [Step 4](#step-4-configure-cicd-for-your-project).
 
 For most Hybrid deployments - with the exception of those using a local agent - you'll need to create a Docker image containing your Dagster code and then add a code location to Dagster Cloud that references the image.
-
----
-
-**Step 1: Create a Hybrid agent**
 
 1. The dialog that displays will contain a pre-generated [agent token](/dagster-cloud/account/managing-user-agent-tokens) and details about the agents currently supported by Dagster Cloud.
 
@@ -318,13 +335,23 @@ For most Hybrid deployments - with the exception of those using a local agent - 
    - [Kubernetes](/dagster-cloud/deployment/agents/kubernetes/configuring-running-kubernetes-agent)
    - [Local](/dagster-cloud/deployment/agents/local)
 
-The dialog will indicate when Dagster Cloud receives an agent heartbeat. Click **Continue**.
+3. The dialog will indicate when Dagster Cloud receives an agent heartbeat. Click **Continue**.
+
+When finished, [continue to the next step](#step-4-configure-cicd-for-your-project).
+
+</TabItem>
+</TabGroup>
 
 ---
 
-**Step 2: Configure CI/CD for your project**
+## Step 4: Configure CI/CD for your project
 
-Next, you'll configure CI/CD for your Dagster project. How this is accomplished depends on your CI/CD provider:
+<Note>
+  <strong>Skip to the next step if using Serverless.</strong> This step is only
+  required for Hybrid deployments.
+</Note>
+
+To finish setting up your Hybrid deployment, you'll configure CI/CD for your Dagster project. How this is accomplished depends on your CI/CD provider:
 
 - **GitHub** - If using GitHub, you can use our GitHub Action workflow to set up CI/CD for your project.
 - **Another CI/CD provider** - If you're not using GitHub, you can configure CI/CD using the dagster-cloud CLI.
@@ -332,21 +359,23 @@ Next, you'll configure CI/CD for your Dagster project. How this is accomplished 
 <TabGroup>
 <TabItem name="GitHub Actions">
 
+### GitHub Actions
+
 To set up continuous integration using GitHub Actions, you can use your own Dagster code or the [Dagster Cloud Hybrid Quickstart](https://github.com/dagster-io/dagster-cloud-hybrid-quickstart). The quickstart is a template with everything you need to get started using Hybrid deployment in Dagster Cloud.
 
 - **If using the template**, [clone the repository](https://github.com/dagster-io/dagster-cloud-hybrid-quickstart).
 
 - **If not using the template**, copy the GitHub workflow files (`.github/workflows`) from the [Hybrid quickstart repository](https://github.com/dagster-io/dagster-cloud-hybrid-quickstart/tree/main/.github/workflows) and add them to your repository. This is already done for you if using the quickstart.
 
-Configure the GitHub workflow YAML file as described below. The GitHub workflow deploys your code to Dagster Cloud using these steps:
+**Configure the GitHub workflow YAML file as described below**. The GitHub workflow deploys your code to Dagster Cloud using these steps:
 
-1. Initialize - check out your code and validate `dagster_cloud.yaml`.
+1. Initialize - Check out your code and validate `dagster_cloud.yaml`.
 
-2. Docker image push - build a Docker image from your code and upload it to your container registry.
+2. Docker image push - Build a Docker image from your code and upload it to your container registry.
 
-3. Deploy to Dagster Cloud - update code locations in Dagster Cloud to use the new Docker image.
+3. Deploy to Dagster Cloud - Update code locations in Dagster Cloud to use the new Docker image.
 
-To configure the workflow, follow these steps:
+**To configure the workflow**, follow these steps:
 
 1. In the repository, set the `DAGSTER_CLOUD_API_TOKEN` GitHub action secret. This is the Dagster Cloud agent token from the previous section. Refer to the [agent tokens documentation](/dagster-cloud/account/managing-user-agent-tokens#managing-agent-tokens) for more info.
 
@@ -358,10 +387,12 @@ To configure the workflow, follow these steps:
 
 After making the above changes and commiting the workflow file, the CI process should be triggered to deploy your GitHub repository to Dagster Cloud. During the deployment, the agent will attempt to load your code and update the metadata in Dagster Cloud. Once finished, you should see the GitHub Action complete successfully and also be able to see the code location under the **Deployment** tag in Dagster Cloud.
 
-When finished, [continue to the next step](#step-4-set-up-environment-variables-and-secrets).
+When finished, [continue to the next step](#step-5-set-up-environment-variables-and-secrets).
 
 </TabItem>
 <TabItem name="Other CI/CD provider">
+
+### Other CI/CD provider
 
 For continuous integration using a CI/CD provider other than GitHub, your system should use the `dagster-cloud ci` subcommand to deploy code locations to Dagster Cloud.
 
@@ -426,17 +457,14 @@ Ensure that you have created a `dagster_cloud.yaml` file as described in [the qu
 
 **Note**: Creating Branch Deployments using the CLI requires some additional steps. Refer to the [Branch Deployments with the dagster-cloud CLI guide](/dagster-cloud/managing-deployments/branch-deployments/using-branch-deployments) for more info.
 
-When finished, [continue to the next step](#step-4-set-up-environment-variables-and-secrets).
-
-</TabItem>
-</TabGroup>
+When finished, [continue to the next step](#step-5-set-up-environment-variables-and-secrets).
 
 </TabItem>
 </TabGroup>
 
 ---
 
-## Step 4: Set up environment variables and secrets
+## Step 5: Set up environment variables and secrets
 
 Congrats! At this point, your Dagster Cloud deployment should be up and running. To ensure the external services you use in your Dagster project work correctly, start setting up your [environment variables](/dagster-cloud/managing-deployments/environment-variables-and-secrets). Using environment variables, you can securely pass in sensitive info like passwords, API tokens, etc.
 

--- a/docs/content/dagster-cloud/getting-started.mdx
+++ b/docs/content/dagster-cloud/getting-started.mdx
@@ -477,4 +477,4 @@ From here, you can:
 - [Invite your team](/dagster-cloud/account/managing-users)
 - [Configure authentication for your account](/dagster-cloud/account/authentication)
 - [Set up monitoring and alerting](/dagster-cloud/managing-deployments/setting-up-alerts)
-- [Learn more about Branch Deployments](/dagster-cloud/managing-deployments/branch-deployments)
+- [Learn more setting up CI using Branch Deployments](/dagster-cloud/managing-deployments/branch-deployments)

--- a/docs/content/dagster-cloud/managing-deployments/branch-deployments.mdx
+++ b/docs/content/dagster-cloud/managing-deployments/branch-deployments.mdx
@@ -5,6 +5,8 @@ description: Develop and test in the cloud.
 
 # Branch Deployments in Dagster Cloud
 
+Dagster Cloud provides out-of-the-box support for Continuous Integration (CI) with **Branch Deployments**.
+
 Branch Deployments automatically create staging environments of your Dagster code, right in Dagster Cloud. For every push to a branch in your git repository, Dagster Cloud will create a unique deployment, allowing you to preview the changes in the branch in real-time.
 
 ---

--- a/docs/content/dagster-cloud/managing-deployments/branch-deployments/using-branch-deployments-with-github.mdx
+++ b/docs/content/dagster-cloud/managing-deployments/branch-deployments/using-branch-deployments-with-github.mdx
@@ -1,13 +1,13 @@
 ---
-title: Using Branch Deployments with GitHub Actions | Dagster Cloud
+title: Using Branch Deployments (CI) with GitHub Actions | Dagster Cloud
 description: Develop and test in the cloud.
 ---
 
-# Using Branch Deployments with GitHub Actions
+# Using Branch Deployments (CI) with GitHub Actions
 
 <Note>This guide is applicable to Dagster Cloud.</Note>
 
-In this guide, we'll walk you through setting up [Branch Deployments](/dagster-cloud/managing-deployments/branch-deployments) with GitHub Actions.
+In this guide, we'll walk you through setting up Continuous Integration (CI) using [Branch Deployments](/dagster-cloud/managing-deployments/branch-deployments) with GitHub Actions.
 
 Using this approach to branch deployments may be a good fit if:
 

--- a/docs/content/dagster-cloud/managing-deployments/branch-deployments/using-branch-deployments.mdx
+++ b/docs/content/dagster-cloud/managing-deployments/branch-deployments/using-branch-deployments.mdx
@@ -1,13 +1,13 @@
 ---
-title: Using Branch Deployments with the dagster-cloud CLI | Dagster Cloud
+title: Using Branch Deployments (CI) with the dagster-cloud CLI | Dagster Cloud
 description: Develop and test in the cloud.
 ---
 
-# Using Branch Deployments with the dagster-cloud CLI
+# Using Branch Deployments (CI) with the dagster-cloud CLI
 
 <Note>This guide is applicable to Dagster Cloud.</Note>
 
-In this guide, we'll walk you through setting up [Branch Deployments](/dagster-cloud/managing-deployments/branch-deployments) with a general continuous integration (CI) or git platform, using the [`dagster-cloud` CLI](/dagster-cloud/managing-deployments/dagster-cloud-cli).
+In this guide, we'll walk you through setting up Continuous Integration (CI) [Branch Deployments](/dagster-cloud/managing-deployments/branch-deployments) with a general continuous integration (CI) or git platform, using the [`dagster-cloud` CLI](/dagster-cloud/managing-deployments/dagster-cloud-cli).
 
 Using this approach to branch deployments may be a good fit if:
 

--- a/docs/next/components/mdx/MDXComponents.tsx
+++ b/docs/next/components/mdx/MDXComponents.tsx
@@ -625,7 +625,7 @@ const TabGroup: React.FC<{children: any; persistentKey?: string}> = ({children, 
                   'w-full py-3 text-sm font-bold leading-5',
                   'focus:outline-none border-gray-200',
                   selected
-                    ? 'border-b-2 border-primary-500 text-primary-500'
+                    ? 'border-b-2 border-primary-500 text-primary-500 bg-gray-150'
                     : 'border-b hover:border-gray-500 hover:text-gray-700',
                 )
               }

--- a/docs/next/components/mdx/includes/dagster-cloud/BDCreateConfigureAgent.mdx
+++ b/docs/next/components/mdx/includes/dagster-cloud/BDCreateConfigureAgent.mdx
@@ -1,7 +1,12 @@
 While you can use your existing production agent, we recommend creating a dedicated branch deployment agent. This ensures that your production instance isn't negatively impacted by the workload associated with branch deployments.
 
-<details>
-  <summary><strong>AMAZON ECS AGENTS</strong></summary>
+<TabGroup>
+<TabItem name="Select agent type">
+
+Using the tabs, select your agent type to view instructions.
+
+</TabItem>
+<TabItem name="Amazon ECS">
 
 1. **Deploy an ECS agent to serve your branch deployments**. Follow the [ECS agent](/dagster-cloud/deployment/agents#amazon-ecs) setup guide, making sure to set the **Enable Branch Deployments** parameter if using the CloudFormation template. If you are running an existing agent, follow the [upgrade guide](/dagster-cloud/deployment/agents/amazon-ecs/upgrading-cloudformation-template) to ensure your template is up-to-date. Then, turn on the **Enable Branch Deployments** parameter.
 
@@ -32,10 +37,8 @@ While you can use your existing production agent, we recommend creating a dedica
    height={420}
    />
 
-</details>
-
-<details>
-  <summary><strong>DOCKER AGENTS</strong></summary>
+</TabItem>
+<TabItem name="Docker">
 
 1. Set up a new Docker agent. Refer to the [Docker agent setup guide](/dagster-cloud/deployment/agents/docker) for instructions.
 2. After the agent is set up, modify the `dagster.yaml` file as follows:
@@ -67,10 +70,8 @@ While you can use your existing production agent, we recommend creating a dedica
          ttl_seconds: 7200 #2 hours
    ```
 
-</details>
-
-<details>
-  <summary><strong>KUBERNETES AGENTS</strong></summary>
+</TabItem>
+<TabItem name="Kubernetes">
 
 1. Set up a new Kubernetes agent. Refer to the [Kubernetes agent setup guide](/dagster-cloud/deployment/agents/kubernetes/configuring-running-kubernetes-agent) for instructions.
 
@@ -86,4 +87,5 @@ While you can use your existing production agent, we recommend creating a dedica
        ttlSeconds: 7200
    ```
 
-</details>
+</TabItem>
+</TabGroup>


### PR DESCRIPTION
## Summary & Motivation

This PR:

- Moves some sections in the Cloud GS guide around to make the CI steps for Hybrid more prominent
- Updates some copy throughout Cloud guides to sprinkle in mentions of CI
- Updates the sidenav
- Adds a light background highlight to tabs

It does not update the CLI for Branch Deployments guide or the CLI syntax - those will be part of a follow-up PR.

## How I Tested These Changes

:eyes:, clicking around