### PR TITLE
[docs] change HTTPS to HTTP in GraphQL API example

### DIFF
--- a/docs/content/concepts/webserver/graphql.mdx
+++ b/docs/content/concepts/webserver/graphql.mdx
@@ -28,7 +28,7 @@ The GraphQL API is served from the webserver. To start the server, run the follo
 dagster dev
 ```
 
-The webserver serves the GraphQL endpoint at the `/graphql` endpoint. If you are running the webserver locally on port 3000, you can access the API at <https://localhost:3000/graphql>.
+The webserver serves the GraphQL endpoint at the `/graphql` endpoint. If you are running the webserver locally on port 3000, you can access the API at <http://localhost:3000/graphql>.
 
 ### Using the GraphQL playground
 


### PR DESCRIPTION
## Summary & Motivation
If I start up the example project locally with `dagster dev` and then try to connect to the GraphQL endpoint with`gql` using the link in the example, I get an `SSL_WRONG_VERSION` error. I also get this error if I use `dagster_graphql.DagsterGraphQLClient` with `use_https=True`.

```
requests.exceptions.SSLError: HTTPSConnectionPool(host='127.0.0.1', port=3000): Max retries exceeded with url: /graphql (Caused by SSLError(SSLError(1, '[SSL: WRONG_VERSION_NUMBER] wrong version number (_ssl.c:992)')))
```

I figured out that the error means I'm trying to connect to something that doesn't use HTTPS. Here's an example of someone explaining the error: https://github.com/psf/requests/issues/5943#issuecomment-925930558

## How I Tested These Changes

If I change the link to instead use HTTP, `gql` successfully connects and queries the endpoint. `dagster_graphql.DagsterGraphQLClient` works as expected if I set `use_https=False`.
