### PR TITLE
[docs] [cloud] - add commit-hash and git-url to cli example

### DIFF
--- a/docs/content/dagster-cloud/managing-deployments/branch-deployments/using-branch-deployments.mdx
+++ b/docs/content/dagster-cloud/managing-deployments/branch-deployments/using-branch-deployments.mdx
@@ -112,7 +112,9 @@ After the above has occurred:
        --api-token $DAGSTER_CLOUD_API_TOKEN \
        --location-file $LOCATION_FILE \
        --location-name $LOCATION_NAME \
-       --image "${LOCATION_REGISTRY_URL}:${IMAGE_TAG}"
+       --image "${LOCATION_REGISTRY_URL}:${IMAGE_TAG}" \
+       --commit-hash "${COMMIT_SHA}" \
+       --git-url "${GIT_URL}"
    ```
 
    Refer to the [Code location guide](/dagster-cloud/managing-deployments/code-locations) for more info on how a location's details are specified.


### PR DESCRIPTION
## Summary & Motivation
Adds in example of passing in the `--commit-hash` and `--git-url` arguments to the `dagster-cloud workspace add-location` command. This should help CLI users quickly populate all fields of the branch deployment when viewing the docs [here](https://docs.dagster.io/dagster-cloud/managing-deployments/branch-deployments/using-branch-deployments#:~:text=Deploy%20the%20code%20to%20the%20branch%20deployment%3A).

## How I Tested These Changes
Tested in private Hybrid deployment on Dagster Cloud
