### PR TITLE
[pipes] Pipes opened payload processing

### DIFF
--- a/python_modules/dagster-pipes/dagster_pipes/__init__.py
+++ b/python_modules/dagster-pipes/dagster_pipes/__init__.py
@@ -32,6 +32,7 @@ from typing import (
     TypeVar,
     Union,
     cast,
+    final,
     get_args,
 )
 
@@ -63,6 +64,14 @@ def _make_message(method: str, params: Optional[Mapping[str, Any]]) -> "PipesMes
 
 # Can't use a constant for TypedDict key so this value is repeated in `ExtMessage` defn.
 PIPES_PROTOCOL_VERSION_FIELD = "__dagster_pipes_version"
+
+
+class PipesOpenedData(TypedDict):
+    """Payload generated on startup of the external-side `PipesMessageWriter` containing arbitrary
+    information about the external process.
+    """
+
+    extras: Mapping[str, Any]
 
 
 class PipesMessage(TypedDict):
@@ -443,6 +452,26 @@ class PipesMessageWriter(ABC, Generic[T_MessageChannel]):
             PipesMessageWriterChannel: Channel for writing messagse back to Dagster.
         """
 
+    @final
+    def get_opened_payload(self) -> PipesOpenedData:
+        """Return a payload containing information about the external process to be passed back to
+        the the orchestration process. This should contain information that cannot be known before
+        the external process is launched.
+
+        This method should not be overridden by users. Instead, users should
+        override `get_opened_extras` to inject custom data.
+        """
+        return {"extras": self.get_opened_extras()}
+
+    def get_opened_extras(self) -> PipesExtras:
+        """Return arbitary reader-specific information to be passed back to the orchestration
+        process under the `extras` key of the initialization payload.
+
+        Returns:
+            PipesExtras: A dict of arbitrary data to be passed back to the orchestration process.
+        """
+        return {}
+
 
 class PipesMessageWriterChannel(ABC, Generic[T_MessageChannel]):
     """Object that writes messages back to the Dagster orchestration process."""
@@ -533,23 +562,25 @@ class PipesBlobStoreMessageWriterChannel(PipesMessageWriterChannel):
     @contextmanager
     def buffered_upload_loop(self) -> Iterator[None]:
         thread = None
-        is_task_complete = Event()
+        is_session_closed = Event()
         try:
-            thread = Thread(target=self._upload_loop, args=(is_task_complete,), daemon=True)
+            thread = Thread(target=self._upload_loop, args=(is_session_closed,), daemon=True)
             thread.start()
             yield
         finally:
-            is_task_complete.set()
+            is_session_closed.set()
             if thread:
                 thread.join(timeout=60)
 
-    def _upload_loop(self, is_task_complete: Event) -> None:
+    def _upload_loop(self, is_session_closed: Event) -> None:
         start_or_last_upload = datetime.datetime.now()
         while True:
             now = datetime.datetime.now()
-            if self._buffer.empty() and is_task_complete.is_set():
+            if self._buffer.empty() and is_session_closed.is_set():
                 break
-            elif is_task_complete.is_set() or (now - start_or_last_upload).seconds > self._interval:
+            elif (
+                is_session_closed.is_set() or (now - start_or_last_upload).seconds > self._interval
+            ):
                 payload = "\n".join([json.dumps(message) for message in self.flush_messages()])
                 if len(payload) > 0:
                     self.upload_messages_chunk(StringIO(payload), self._counter)
@@ -794,6 +825,48 @@ class PipesDbfsMessageWriter(PipesBlobStoreMessageWriter):
             interval=self.interval,
         )
 
+    def get_opened_extras(self) -> PipesExtras:
+        # Extract the cluster log location from the SparkSession. This requires
+        # digging into the databricks `clusterUsageTags` config. This is set
+        # automatically by Databricks in the spark session that is created
+        # prior to job execution. Here are some sparse docs on cluster log
+        # delivery:
+        #   https://docs.databricks.com/en/clusters/configure.html#cluster-log-delivery
+        #
+        # It is not clear whether official docs exist for the config set in
+        # `spark.databricks.clusterUsageTags`, but you can see the full spark config for a job by
+        # selecting the "Spark UI" tab and then "Environment" on the job details page in the
+        # Databricks UI.
+        try:
+            from py4j.protocol import Py4JJavaError
+            from pyspark.sql import SparkSession
+        except ImportError as e:
+            raise DagsterPipesError(
+                "`PipesDbfsMessageWriter` requires pyspark and py4j to be available for import."
+            ) from e
+
+        spark = SparkSession.getActiveSession()
+        if spark is None:
+            raise DagsterPipesError(
+                "`PipesDbfsMessageWriter` expects an active `SparkSession` pre-configured by Databricks. Did not detect an active spark session."
+            )
+        try:
+            if spark.conf.get("spark.databricks.clusterUsageTags.clusterLogDeliveryEnabled"):
+                cluster_log_destination = spark.conf.get(
+                    "spark.databricks.clusterUsageTags.clusterLogDestination"
+                )
+                cluster_id = spark.conf.get("spark.databricks.clusterUsageTags.clusterId")
+                return {"cluster_driver_log_root": f"{cluster_log_destination}/{cluster_id}/driver"}
+            else:
+                return {}
+        except Py4JJavaError as e:
+            warnings.warn(
+                "A Py4JJavaError was thrown while reading the spark config to extract cluster logging information."
+                f" Log forwarding disabled. Error:\n  {e}",
+                category=DagsterPipesWarning,
+            )
+            return {}
+
 
 # ########################
 # ##### CONTEXT
@@ -888,7 +961,8 @@ class PipesContext:
         self._io_stack = ExitStack()
         self._data = self._io_stack.enter_context(context_loader.load_context(context_params))
         self._message_channel = self._io_stack.enter_context(message_writer.open(messages_params))
-        self._message_channel.write_message(_make_message("opened", {}))
+        opened_payload = message_writer.get_opened_payload()
+        self._message_channel.write_message(_make_message("opened", opened_payload))
         self._logger = _PipesLogger(self)
         self._materialized_assets: Set[str] = set()
         self._closed: bool = False

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -495,10 +495,10 @@ from dagster._core.pipes.context import (
 from dagster._core.pipes.subprocess import PipesSubprocessClient as PipesSubprocessClient
 from dagster._core.pipes.utils import (
     PipesBlobStoreMessageReader as PipesBlobStoreMessageReader,
-    PipesBlobStoreStdioReader as PipesBlobStoreStdioReader,
     PipesEnvContextInjector as PipesEnvContextInjector,
     PipesFileContextInjector as PipesFileContextInjector,
     PipesFileMessageReader as PipesFileMessageReader,
+    PipesLogReader as PipesLogReader,
     PipesTempFileContextInjector as PipesTempFileContextInjector,
     PipesTempFileMessageReader as PipesTempFileMessageReader,
     open_pipes_session as open_pipes_session,

--- a/python_modules/dagster/dagster/_core/pipes/client.py
+++ b/python_modules/dagster/dagster/_core/pipes/client.py
@@ -6,6 +6,7 @@ from dagster_pipes import (
     DagsterPipesError,
     PipesContextData,
     PipesExtras,
+    PipesOpenedData,
     PipesParams,
 )
 
@@ -134,6 +135,14 @@ class PipesMessageReader(ABC):
         Yields:
             PipesParams: A dict of parameters that can be used by the external process to determine
             where to write messages.
+        """
+
+    def on_opened(self, opened_payload: PipesOpenedData) -> None:
+        """Hook called when the external process has successfully launched and returned an opened
+        payload.
+
+        By default this is a no-op. Specific message readers can override this to action information
+        that can only be obtained from the external process.
         """
 
     @abstractmethod

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/__init__.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/__init__.py
@@ -27,8 +27,8 @@ from .ops import (
 from .pipes import (
     PipesDatabricksClient as PipesDatabricksClient,
     PipesDbfsContextInjector as PipesDbfsContextInjector,
+    PipesDbfsLogReader as PipesDbfsLogReader,
     PipesDbfsMessageReader as PipesDbfsMessageReader,
-    PipesDbfsStdioReader as PipesDbfsStdioReader,
 )
 from .resources import (
     DatabricksClientResource as DatabricksClientResource,

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_pipes.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_pipes.py
@@ -10,7 +10,10 @@ from typing import Any, Callable, Iterator
 import pytest
 from dagster import AssetExecutionContext, asset, materialize
 from dagster._core.errors import DagsterPipesExecutionError
-from dagster_databricks.pipes import PipesDatabricksClient, dbfs_tempdir
+from dagster_databricks.pipes import (
+    PipesDatabricksClient,
+    dbfs_tempdir,
+)
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.service import files, jobs
 
@@ -97,10 +100,15 @@ def upload_dagster_pipes_whl(client: WorkspaceClient) -> Iterator[None]:
     yield
 
 
-def _make_submit_task(path: str) -> jobs.SubmitTask:
+def _make_submit_task(path: str, forward_logs: bool) -> jobs.SubmitTask:
+    cluster_settings = CLUSTER_DEFAULTS.copy()
+    if forward_logs:
+        cluster_settings["cluster_log_conf"] = {
+            "dbfs": {"destination": "dbfs:/cluster-logs"},
+        }
     return jobs.SubmitTask.from_dict(
         {
-            "new_cluster": CLUSTER_DEFAULTS,
+            "new_cluster": cluster_settings,
             "libraries": [
                 {"whl": DAGSTER_PIPES_WHL_PATH},
             ],
@@ -113,13 +121,18 @@ def _make_submit_task(path: str) -> jobs.SubmitTask:
     )
 
 
+# Test both with and without log forwarding. This is important because the PipesClient spins up log
+# readers before it knows the task specification
+
+
 @pytest.mark.skipif(IS_BUILDKITE, reason="Not configured to run on BK yet.")
-def test_pipes_client(capsys, client: WorkspaceClient):
+@pytest.mark.parametrize("forward_logs", [True, False])
+def test_pipes_client(capsys, client: WorkspaceClient, forward_logs: bool):
     @asset
     def number_x(context: AssetExecutionContext, pipes_client: PipesDatabricksClient):
         with upload_dagster_pipes_whl(client):
             with temp_script(script_fn, client) as script_path:
-                task = _make_submit_task(script_path)
+                task = _make_submit_task(script_path, forward_logs)
                 return pipes_client.run(
                     task=task,
                     context=context,
@@ -138,16 +151,17 @@ def test_pipes_client(capsys, client: WorkspaceClient):
     assert result.success
     mats = result.asset_materializations_for_node(number_x.op.name)
     assert mats[0].metadata["value"].value == 4
-    captured = capsys.readouterr()
-    assert re.search(r"hello from databricks stdout\n", captured.out, re.MULTILINE)
-    assert re.search(r"hello from databricks stderr\n", captured.err, re.MULTILINE)
+    if forward_logs:
+        captured = capsys.readouterr()
+        assert re.search(r"hello from databricks stdout\n", captured.out, re.MULTILINE)
+        assert re.search(r"hello from databricks stderr\n", captured.err, re.MULTILINE)
 
 
 @pytest.mark.skipif(IS_BUILDKITE, reason="Not configured to run on BK yet.")
 def test_nonexistent_entry_point(client: WorkspaceClient):
     @asset
     def fake(context: AssetExecutionContext, pipes_client: PipesDatabricksClient):
-        task = _make_submit_task("/fake/fake")
+        task = _make_submit_task("/fake/fake", forward_logs=False)
         return pipes_client.run(task=task, context=context).get_results()
 
     with pytest.raises(DagsterPipesExecutionError, match=r"Cannot read the python file"):


### PR DESCRIPTION
## Summary & Motivation

This PR builds on the `opened` message processing in Pipes with the goal of allowing message readers to perform processing dependent on information sourced from the external process. The immediate impetus is to allow the message reader to read DBFS logs whose location is only known once a Databricks process has been started.

- `PipesMessageWriter` now has a `get_opened_payload` method. This is called during the initialization routine in the external process, with the returned "opened payload" passed back as parameters with the `opened` message. Currently the opened payload has only one key, "extras" , where an environment-specific message writer can put arbitrary information. For the `PipesDbfsMessageWriter`, we use this for the cluster log root path.
    - I think we will want to add other keys to the opened payload in the future, and we may want to have the `PipesDbfsContextLoader` contribute to it as well.
- `received_any_message` on the `PipesMessageHandler` was changed to `received_opened_message`. This is equivalent since the `opened` message will _always_ be the first message received.
- `PipesMessageHandler` now takes `PipesMessageReader` in its constructor instead of passing it to `handle_messages`. It calls an `on_opened` callback on the `PipesMessageReader` when the opened payload is received.
- `PipesStdioReader` has been renamed to `PipesLogReader`. This makes it clear that the mechanism can read any log file, which may or may not correspond to a stdio stream.
- `PipesMessageReader` now takes an `Optional[Sequence[PipesLogReader]]` instead of dedicated slots for stdout/stderr readers.
- Because we now take a default empty list of `PipesLogReader`, the `PipesNoOpStdioReader` is removed.
- The `start`/`stop`/`is_ready` interface of `PipesLogReader` was retained, but is now called slightly differently in the `PipesBlobStoreMessageReader`:
    - `read_messages` now launches a separate "logs thread" from the main message reading thread. This thread waits for the reception of the opened payload and then launches the log readers. It then waits until the external task is finished, at which point it spends up to a minute waiting for logs to be written.
- The Databricks pipes integration and tests have been updated to use this new system.

### Caveats

- I'm uncertain on the "opened payload" terminology`, but at least it's pretty clear what it corresponds to.
- I have some reservations about the interaction of `PipesMessageHandler` and `PipesMessageReader`. Currently the implementation of `PipesMessageReader.on_opened` is left totally open (no-op) by default, and this leads to a somewhat awkward situation in `PipesBlobStoreMessageReader` where `on_opened` sets an attribute that the `log_starter_thread` is polling for. I think this can probably be improved.

## How I Tested These Changes

- Update databricks Pipes client tests