### PR TITLE
asset checks batched loader

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/asset_checks_loader.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/asset_checks_loader.py
@@ -1,11 +1,13 @@
-from typing import Iterable, List, Mapping, Optional
+from typing import Iterable, Iterator, List, Mapping, Optional, Tuple
 
 from dagster import (
     _check as check,
 )
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
-from dagster._core.host_representation.external_data import ExternalAssetCheck  # noqa: TCH002
+from dagster._core.host_representation.code_location import CodeLocation
+from dagster._core.host_representation.external import ExternalRepository
+from dagster._core.host_representation.external_data import ExternalAssetCheck
 from dagster._core.storage.asset_check_execution_record import AssetCheckInstanceSupport
 from dagster._core.workspace.context import WorkspaceRequestContext
 from packaging import version
@@ -19,6 +21,16 @@ from dagster_graphql.schema.asset_checks import (
     GrapheneAssetCheckNeedsUserCodeUpgrade,
     GrapheneAssetChecks,
 )
+
+from .fetch_assets import repository_iter
+
+
+def asset_checks_iter(
+    context: WorkspaceRequestContext
+) -> Iterator[Tuple[CodeLocation, ExternalRepository, ExternalAssetCheck]]:
+    for location, repository in repository_iter(context):
+        for external_check in repository.external_repository_data.external_asset_checks or []:
+            yield (location, repository, external_check)
 
 
 class AssetChecksLoader:
@@ -55,38 +67,30 @@ class AssetChecksLoader:
         external_checks: Mapping[AssetKey, List[ExternalAssetCheck]] = {}
         errors: Mapping[AssetKey, GrapheneAssetCheckNeedsUserCodeUpgrade] = {}
 
-        for location in self._context.code_locations:
-            for repository in location.get_repositories().values():
-                for external_check in (
-                    repository.external_repository_data.external_asset_checks or []
+        for location, _, external_check in asset_checks_iter(self._context):
+            if external_check.asset_key in self._asset_keys:
+                # check if the code location is too old to support executing asset checks individually
+                code_location_version = (location.get_dagster_library_versions() or {}).get(
+                    "dagster"
+                )
+                if code_location_version and version.parse(code_location_version) < version.parse(
+                    "1.5"
                 ):
-                    if external_check.asset_key in self._asset_keys:
-                        # check if the code location is too old to support executing asset checks individually
-                        code_location_version = (location.get_dagster_library_versions() or {}).get(
-                            "dagster"
+                    errors[external_check.asset_key] = GrapheneAssetCheckNeedsUserCodeUpgrade(
+                        message=(
+                            "Asset checks require dagster>=1.5. Upgrade your dagster"
+                            " version for this code location."
                         )
-                        if code_location_version and version.parse(
-                            code_location_version
-                        ) < version.parse("1.5"):
-                            errors[
-                                external_check.asset_key
-                            ] = GrapheneAssetCheckNeedsUserCodeUpgrade(
-                                message=(
-                                    "Asset checks require dagster>=1.5. Upgrade your dagster"
-                                    " version for this code location."
-                                )
-                            )
-                        else:
-                            if not external_checks.get(external_check.asset_key):
-                                external_checks[external_check.asset_key] = []
-                            external_checks[external_check.asset_key].append(external_check)
+                    )
+                else:
+                    external_checks.setdefault(external_check.asset_key, []).append(external_check)
 
         asset_graph = ExternalAssetGraph.from_workspace(self._context)
 
-        grapehene_checks: Mapping[AssetKey, AssetChecksOrErrorUnion] = {}
+        graphene_checks: Mapping[AssetKey, AssetChecksOrErrorUnion] = {}
         for asset_key in self._asset_keys:
             if asset_key in errors:
-                grapehene_checks[asset_key] = errors[asset_key]
+                graphene_checks[asset_key] = errors[asset_key]
             else:
                 checks = []
                 for external_check in external_checks.get(asset_key, []):
@@ -106,9 +110,9 @@ class AssetChecksLoader:
                             can_execute_individually=can_execute_individually,
                         )
                     )
-                grapehene_checks[asset_key] = GrapheneAssetChecks(checks=checks)
+                graphene_checks[asset_key] = GrapheneAssetChecks(checks=checks)
 
-        return grapehene_checks
+        return graphene_checks
 
     def get_checks_for_asset(self, asset_key: AssetKey) -> AssetChecksOrErrorUnion:
         if self._checks is None:

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/asset_checks_loader.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/asset_checks_loader.py
@@ -1,0 +1,121 @@
+from typing import Iterable, List, Mapping, Optional
+
+from dagster import (
+    _check as check,
+)
+from dagster._core.definitions.events import AssetKey
+from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
+from dagster._core.host_representation.external_data import ExternalAssetCheck  # noqa: TCH002
+from dagster._core.storage.asset_check_execution_record import AssetCheckInstanceSupport
+from dagster._core.workspace.context import WorkspaceRequestContext
+from packaging import version
+
+from dagster_graphql.schema.asset_checks import (
+    AssetChecksOrErrorUnion,
+    GrapheneAssetCheck,
+    GrapheneAssetCheckCanExecuteIndividually,
+    GrapheneAssetCheckNeedsAgentUpgradeError,
+    GrapheneAssetCheckNeedsMigrationError,
+    GrapheneAssetCheckNeedsUserCodeUpgrade,
+    GrapheneAssetChecks,
+)
+
+
+class AssetChecksLoader:
+    """A batch loader that fetches asset check definitions for a set of asset keys."""
+
+    def __init__(self, context: WorkspaceRequestContext, asset_keys: Iterable[AssetKey]):
+        self._context = context
+        self._asset_keys = list(asset_keys)
+        self._checks: Optional[Mapping[AssetKey, AssetChecksOrErrorUnion]] = None
+
+    def _fetch_checks(self) -> Mapping[AssetKey, AssetChecksOrErrorUnion]:
+        instance = self._context.instance
+        asset_check_support = instance.get_asset_check_support()
+        if asset_check_support == AssetCheckInstanceSupport.NEEDS_MIGRATION:
+            return {
+                asset_key: GrapheneAssetCheckNeedsMigrationError(
+                    message="Asset checks require an instance migration. Run `dagster instance migrate`."
+                )
+                for asset_key in self._asset_keys
+            }
+        elif asset_check_support == AssetCheckInstanceSupport.NEEDS_AGENT_UPGRADE:
+            return {
+                asset_key: GrapheneAssetCheckNeedsAgentUpgradeError(
+                    "Asset checks require an agent upgrade to 1.5.0 or greater."
+                )
+                for asset_key in self._asset_keys
+            }
+        else:
+            check.invariant(
+                asset_check_support == AssetCheckInstanceSupport.SUPPORTED,
+                f"Unexpected asset check support status {asset_check_support}",
+            )
+
+        external_checks: Mapping[AssetKey, List[ExternalAssetCheck]] = {}
+        errors: Mapping[AssetKey, GrapheneAssetCheckNeedsUserCodeUpgrade] = {}
+
+        for location in self._context.code_locations:
+            for repository in location.get_repositories().values():
+                for external_check in (
+                    repository.external_repository_data.external_asset_checks or []
+                ):
+                    if external_check.asset_key in self._asset_keys:
+                        # check if the code location is too old to support executing asset checks individually
+                        code_location_version = (location.get_dagster_library_versions() or {}).get(
+                            "dagster"
+                        )
+                        if code_location_version and version.parse(
+                            code_location_version
+                        ) < version.parse("1.5"):
+                            errors[
+                                external_check.asset_key
+                            ] = GrapheneAssetCheckNeedsUserCodeUpgrade(
+                                message=(
+                                    "Asset checks require dagster>=1.5. Upgrade your dagster"
+                                    " version for this code location."
+                                )
+                            )
+                        else:
+                            if not external_checks.get(external_check.asset_key):
+                                external_checks[external_check.asset_key] = []
+                            external_checks[external_check.asset_key].append(external_check)
+
+        asset_graph = ExternalAssetGraph.from_workspace(self._context)
+
+        grapehene_checks: Mapping[AssetKey, AssetChecksOrErrorUnion] = {}
+        for asset_key in self._asset_keys:
+            if asset_key in errors:
+                grapehene_checks[asset_key] = errors[asset_key]
+            else:
+                checks = []
+                for external_check in external_checks.get(asset_key, []):
+                    can_execute_individually = (
+                        GrapheneAssetCheckCanExecuteIndividually.CAN_EXECUTE
+                        if len(
+                            asset_graph.get_required_asset_and_check_keys(external_check.key) or []
+                        )
+                        <= 1
+                        # NOTE: once we support multi checks, we'll need to add a case for
+                        # non subsettable multi checks
+                        else GrapheneAssetCheckCanExecuteIndividually.REQUIRES_MATERIALIZATION
+                    )
+                    checks.append(
+                        GrapheneAssetCheck(
+                            asset_check=external_check,
+                            can_execute_individually=can_execute_individually,
+                        )
+                    )
+                grapehene_checks[asset_key] = GrapheneAssetChecks(checks=checks)
+
+        return grapehene_checks
+
+    def get_checks_for_asset(self, asset_key: AssetKey) -> AssetChecksOrErrorUnion:
+        if self._checks is None:
+            self._checks = self._fetch_checks()
+
+        check.invariant(
+            asset_key in self._checks, f"Asset key {asset_key} not included in this loader."
+        )
+
+        return self._checks[asset_key]

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_checks.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_checks.py
@@ -17,7 +17,7 @@ from ..schema.asset_checks import (
     GrapheneAssetCheckExecution,
     GrapheneAssetChecks,
 )
-from .asset_checks_loader import AssetChecksLoader
+from .asset_checks_loader import AssetChecksLoader, asset_checks_iter
 
 if TYPE_CHECKING:
     from ..schema.util import ResolveInfo
@@ -27,12 +27,10 @@ def has_asset_checks(
     graphene_info: "ResolveInfo",
     asset_key: AssetKey,
 ) -> bool:
-    for location in graphene_info.context.code_locations:
-        for repository in location.get_repositories().values():
-            for external_check in repository.external_repository_data.external_asset_checks or []:
-                if external_check.asset_key == asset_key:
-                    return True
-    return False
+    return any(
+        external_check.asset_key == asset_key
+        for _, _, external_check in asset_checks_iter(graphene_info.context)
+    )
 
 
 def fetch_asset_checks(

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_checks.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_checks.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, cast
+from typing import List, Optional, Union, cast
 
 import dagster._check as check
 import graphene
@@ -210,6 +210,14 @@ class GrapheneAssetCheckNeedsUserCodeUpgrade(graphene.ObjectType):
     class Meta:
         interfaces = (GrapheneError,)
         name = "AssetCheckNeedsUserCodeUpgrade"
+
+
+AssetChecksOrErrorUnion = Union[
+    GrapheneAssetCheckNeedsMigrationError,
+    GrapheneAssetCheckNeedsUserCodeUpgrade,
+    GrapheneAssetCheckNeedsAgentUpgradeError,
+    GrapheneAssetChecks,
+]
 
 
 class GrapheneAssetChecksOrError(graphene.Union):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -1103,9 +1103,7 @@ class GrapheneAssetNode(graphene.ObjectType):
     def resolve_assetChecks(self, graphene_info: ResolveInfo) -> List[GrapheneAssetCheck]:
         # use the batched loader with a single asset
         asset_key = self._external_asset_node.asset_key
-        loader = AssetChecksLoader(
-            context=graphene_info.context, asset_keys=[self._external_asset_node.asset_key]
-        )
+        loader = AssetChecksLoader(context=graphene_info.context, asset_keys=[asset_key])
         res = loader.get_checks_for_asset(asset_key)
         if not isinstance(res, GrapheneAssetChecks):
             return []


### PR DESCRIPTION
Loader for asset check definitions. Once this is hooked up we only have to load the asset graph once, instead of per asset. For now, this just moves the logic that was in fetch_asset_checks. 

I'll follow this up with batching for fetching execution status.

**Test plan**
existing tests

perf benefit is demonstrated in https://github.com/dagster-io/dagster/pull/17400

**Alternatives**

I think this loader pattern isn't straightforwards to read, but we've settled on it elsewhere for perf.

An easier solution would be to use the top level `assetChecks` resolver and make it take a list of asset keys. Then remove the `assetChecks` resolver on AssetNode. Batching would be very straightforwards because we'd have all the asset keys in one resolver.

However it puts more burden on the front end, which would have to do an extra round trip to get checks once it knows the asset keys, then join those checks with the assets. The resolver on assetNode is best for the front end, and we need something like this loader to support batching with it.