### PR TITLE
surface ruff exit code in make check_ruff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ ruff:
 	ruff format .
 
 check_ruff:
-	-ruff .
+	ruff .
 	ruff format --check .
 
 yamllint:

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -29,7 +29,6 @@ from dagster._core.definitions.data_version import (
 )
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
 from dagster._core.definitions.partition import DynamicPartitionsDefinition, PartitionsSubset
-from dagster._core.definitions.partition_mapping import AllPartitionMapping
 from dagster._core.definitions.time_window_partitions import (
     TimeWindowPartitionsDefinition,
     get_time_partition_key,

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_from_modules.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_from_modules.py
@@ -249,11 +249,6 @@ def _load_assets_from_module_with_assets(**kwargs):
     ],
 )
 def test_source_key_prefix(load_fn):
-    from . import asset_package
-    from .asset_package import module_with_assets
-
-    print(asset_package.__name__, module_with_assets.__name__)
-
     prefix = ["foo", "my_cool_prefix"]
     assets_without_prefix_sources = load_fn(key_prefix=prefix)
     assert get_source_asset_with_key(assets_without_prefix_sources, AssetKey(["elvis_presley"]))


### PR DESCRIPTION
Because

```
# - Multi-command rules (like `ruff` below) by default terminate as soon as a command has a non-0
#   exit status. Prefix the command with "-" to instruct make to continue to the next command
#   regardless of the preceding command's exit status.
```

, ruff has been failing silently https://buildkite.com/dagster/dagster/builds/69577#018b6410-23bd-4629-82f8-0833112f6ac0/207-276