### PR TITLE
[ui] Code locations list: Virtualize, make searchable

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/instance/CodeLocationsPage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/CodeLocationsPage.tsx
@@ -1,14 +1,17 @@
-import {Box, Heading, PageHeader, Subheading} from '@dagster-io/ui-components';
+import {Box, Heading, PageHeader, Subheading, TextInput} from '@dagster-io/ui-components';
 import * as React from 'react';
 
 import {useTrackPageView} from '../app/analytics';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {ReloadAllButton} from '../workspace/ReloadAllButton';
 import {RepositoryLocationsList} from '../workspace/RepositoryLocationsList';
+import {CodeLocationRowType} from '../workspace/VirtualizedCodeLocationRow';
 import {WorkspaceContext} from '../workspace/WorkspaceContext';
 
 import {InstancePageContext} from './InstancePageContext';
 import {InstanceTabs} from './InstanceTabs';
+
+const SEARCH_THRESHOLD = 10;
 
 export const CodeLocationsPage = () => {
   useTrackPageView();
@@ -17,39 +20,82 @@ export const CodeLocationsPage = () => {
   const {pageTitle} = React.useContext(InstancePageContext);
   const {locationEntries, loading} = React.useContext(WorkspaceContext);
 
+  const [searchValue, setSearchValue] = React.useState('');
+
+  const onChangeSearch = React.useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchValue(e.target.value);
+  }, []);
+
   // Consider each loaded repository to be a "code location".
-  const entryCount = React.useMemo(() => {
-    let count = 0;
-    locationEntries.forEach((entry) => {
-      if (!entry.locationOrLoadError || entry.locationOrLoadError?.__typename === 'PythonError') {
-        count += 1;
+  const flattened = React.useMemo(() => {
+    const all: CodeLocationRowType[] = [];
+    for (const locationNode of locationEntries) {
+      const {locationOrLoadError} = locationNode;
+      if (!locationOrLoadError || locationOrLoadError?.__typename === 'PythonError') {
+        all.push({type: 'error' as const, node: locationNode});
       } else {
-        count += entry.locationOrLoadError.repositories.length;
+        locationOrLoadError.repositories.forEach((repo) => {
+          all.push({type: 'repository' as const, codeLocation: locationNode, repository: repo});
+        });
       }
-    });
-    return count;
+    }
+    return all;
   }, [locationEntries]);
+
+  const queryString = searchValue.toLocaleLowerCase();
+  const filtered = React.useMemo(() => {
+    return flattened.filter((row) => {
+      if (row.type === 'error') {
+        return row.node.name.toLocaleLowerCase().includes(queryString);
+      }
+      return (
+        row.codeLocation.name.toLocaleLowerCase().includes(queryString) ||
+        row.repository.name.toLocaleLowerCase().includes(queryString)
+      );
+    });
+  }, [flattened, queryString]);
+
+  const entryCount = flattened.length;
+  const showSearch = entryCount > SEARCH_THRESHOLD;
 
   const subheadingText = () => {
     if (loading || !entryCount) {
       return 'Code locations';
     }
+
     return entryCount === 1 ? '1 code location' : `${entryCount} code locations`;
   };
 
   return (
-    <>
+    <Box flex={{direction: 'column'}} style={{height: '100%', overflow: 'hidden'}}>
       <PageHeader title={<Heading>{pageTitle}</Heading>} tabs={<InstanceTabs tab="locations" />} />
       <Box
         padding={{vertical: 16, horizontal: 24}}
         flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'center'}}
         style={{height: '64px'}}
       >
-        <Subheading id="repository-locations">{subheadingText()}</Subheading>
-        <ReloadAllButton />
+        {showSearch ? (
+          <TextInput
+            icon="search"
+            value={searchValue}
+            onChange={onChangeSearch}
+            placeholder="Filter code locations by name…"
+            style={{width: '400px'}}
+          />
+        ) : (
+          <Subheading id="repository-locations">{subheadingText()}</Subheading>
+        )}
+        <Box flex={{direction: 'row', gap: 12, alignItems: 'center'}}>
+          {showSearch ? <div>{`${entryCount} code locations`}</div> : null}
+          <ReloadAllButton />
+        </Box>
       </Box>
-      <RepositoryLocationsList />
-    </>
+      <RepositoryLocationsList
+        loading={loading}
+        codeLocations={filtered}
+        searchValue={searchValue}
+      />
+    </Box>
   );
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/VirtualizedTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/VirtualizedTable.tsx
@@ -2,11 +2,17 @@ import {Box, Colors} from '@dagster-io/ui-components';
 import * as React from 'react';
 import styled from 'styled-components';
 
-export const HeaderCell = ({children}: {children?: React.ReactNode}) => (
+export const HeaderCell = ({
+  children,
+  style,
+}: {
+  children?: React.ReactNode;
+  style?: React.CSSProperties;
+}) => (
   <CellBox
     padding={{vertical: 8, horizontal: 12}}
     border="right"
-    style={{whiteSpace: 'nowrap', textOverflow: 'ellipsis', overflow: 'hidden'}}
+    style={{whiteSpace: 'nowrap', textOverflow: 'ellipsis', overflow: 'hidden', ...(style || {})}}
   >
     {children}
   </CellBox>
@@ -70,4 +76,17 @@ export const Row = styled.div.attrs<RowProps>(({$height, $start}) => ({
   right: 0;
   top: 0;
   overflow: hidden;
+`;
+
+type DynamicRowContainerProps = {$start: number};
+
+export const DynamicRowContainer = styled.div.attrs<DynamicRowContainerProps>(({$start}) => ({
+  style: {
+    transform: `translateY(${$start}px)`,
+  },
+}))<DynamicRowContainerProps>`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
 `;

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/CodeLocationRowSet.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/CodeLocationRowSet.tsx
@@ -183,7 +183,7 @@ export const ModuleOrPackageOrFile: React.FC<{metadata: WorkspaceDisplayMetadata
   return null;
 };
 
-const LocationStatus: React.FC<{
+export const LocationStatus: React.FC<{
   location: string;
   locationOrError: WorkspaceRepositoryLocationNode;
 }> = (props) => {
@@ -242,7 +242,7 @@ const LocationStatus: React.FC<{
   );
 };
 
-const ReloadButton: React.FC<{location: string}> = ({location}) => {
+export const ReloadButton: React.FC<{location: string}> = ({location}) => {
   return (
     <ReloadRepositoryLocationButton
       location={location}

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/RepositoryLocationsList.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/RepositoryLocationsList.tsx
@@ -1,13 +1,36 @@
-import {Box, NonIdealState, Spinner, Table} from '@dagster-io/ui-components';
+import {Box, NonIdealState, Spinner} from '@dagster-io/ui-components';
+import {useVirtualizer} from '@tanstack/react-virtual';
 import * as React from 'react';
 
-import {CodeLocationRowSet} from './CodeLocationRowSet';
-import {WorkspaceContext} from './WorkspaceContext';
+import {Container, DynamicRowContainer, Inner} from '../ui/VirtualizedTable';
 
-export const RepositoryLocationsList = () => {
-  const {locationEntries, loading} = React.useContext(WorkspaceContext);
+import {
+  CodeLocationRowType,
+  VirtualizedCodeLocationErrorRow,
+  VirtualizedCodeLocationHeader,
+  VirtualizedCodeLocationRow,
+} from './VirtualizedCodeLocationRow';
 
-  if (loading && !locationEntries.length) {
+interface Props {
+  loading: boolean;
+  codeLocations: CodeLocationRowType[];
+  searchValue: string;
+}
+
+export const RepositoryLocationsList = ({loading, codeLocations, searchValue}: Props) => {
+  const parentRef = React.useRef<HTMLDivElement | null>(null);
+
+  const rowVirtualizer = useVirtualizer({
+    count: codeLocations.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => 64,
+    overscan: 10,
+  });
+
+  const totalHeight = rowVirtualizer.getTotalSize();
+  const items = rowVirtualizer.getVirtualItems();
+
+  if (loading && !items.length) {
     return (
       <Box flex={{gap: 8, alignItems: 'center'}} padding={{horizontal: 24}}>
         <Spinner purpose="body-text" />
@@ -16,7 +39,23 @@ export const RepositoryLocationsList = () => {
     );
   }
 
-  if (!locationEntries.length) {
+  if (!items.length) {
+    if (searchValue) {
+      return (
+        <Box padding={{vertical: 32}}>
+          <NonIdealState
+            icon="folder"
+            title="No matching code locations"
+            description={
+              <div>
+                No code locations were found for search query <strong>{searchValue}</strong>.
+              </div>
+            }
+          />
+        </Box>
+      );
+    }
+
     return (
       <Box padding={{vertical: 32}}>
         <NonIdealState
@@ -29,21 +68,39 @@ export const RepositoryLocationsList = () => {
   }
 
   return (
-    <Table>
-      <thead>
-        <tr>
-          <th>Name</th>
-          <th>Status</th>
-          <th>Updated</th>
-          <th>Definitions</th>
-          <th>Actions</th>
-        </tr>
-      </thead>
-      <tbody>
-        {locationEntries.map((location) => (
-          <CodeLocationRowSet key={location.name} locationNode={location} />
-        ))}
-      </tbody>
-    </Table>
+    <>
+      <VirtualizedCodeLocationHeader />
+      <div style={{overflow: 'hidden'}}>
+        <Container ref={parentRef}>
+          <Inner $totalHeight={totalHeight}>
+            <DynamicRowContainer $start={items[0]?.start ?? 0}>
+              {items.map(({index, key}) => {
+                const row: CodeLocationRowType = codeLocations[index]!;
+                if (row.type === 'error') {
+                  return (
+                    <VirtualizedCodeLocationErrorRow
+                      key={key}
+                      data-index={index}
+                      locationNode={row.node}
+                      measure={rowVirtualizer.measure}
+                    />
+                  );
+                }
+
+                return (
+                  <VirtualizedCodeLocationRow
+                    key={key}
+                    data-index={index}
+                    codeLocation={row.codeLocation}
+                    repository={row.repository}
+                    measure={rowVirtualizer.measure}
+                  />
+                );
+              })}
+            </DynamicRowContainer>
+          </Inner>
+        </Container>
+      </div>
+    </>
   );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedCodeLocationRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedCodeLocationRow.tsx
@@ -1,0 +1,141 @@
+import {Box, Colors, JoinedButtons, MiddleTruncate} from '@dagster-io/ui-components';
+import * as React from 'react';
+import {Link} from 'react-router-dom';
+import styled from 'styled-components';
+
+import {TimeFromNow} from '../ui/TimeFromNow';
+import {HeaderCell, RowCell} from '../ui/VirtualizedTable';
+
+import {CodeLocationMenu} from './CodeLocationMenu';
+import {ImageName, LocationStatus, ModuleOrPackageOrFile, ReloadButton} from './CodeLocationRowSet';
+import {RepositoryCountTags} from './RepositoryCountTags';
+import {WorkspaceRepositoryLocationNode} from './WorkspaceContext';
+import {buildRepoAddress} from './buildRepoAddress';
+import {repoAddressAsHumanString} from './repoAddressAsString';
+import {
+  WorkspaceLocationNodeFragment,
+  WorkspaceRepositoryFragment,
+} from './types/WorkspaceContext.types';
+import {workspacePathFromAddress} from './workspacePath';
+
+export type CodeLocationRowType =
+  | {
+      type: 'repository';
+      codeLocation: WorkspaceLocationNodeFragment;
+      repository: WorkspaceRepositoryFragment;
+    }
+  | {type: 'error'; node: WorkspaceLocationNodeFragment};
+
+const TEMPLATE_COLUMNS = '3fr 1fr 1fr 240px 160px';
+
+interface ErrorRowProps {
+  locationNode: WorkspaceRepositoryLocationNode;
+  measure: (node: Element | null) => void;
+}
+
+export const VirtualizedCodeLocationErrorRow = (props: ErrorRowProps) => {
+  const {locationNode, measure} = props;
+  const {name} = locationNode;
+  return (
+    <div ref={measure}>
+      <RowGrid border="bottom">
+        <RowCell>
+          <MiddleTruncate text={name} />
+        </RowCell>
+        <RowCell>
+          <div>
+            <LocationStatus location={name} locationOrError={locationNode} />
+          </div>
+        </RowCell>
+        <RowCell>
+          <div style={{whiteSpace: 'nowrap'}}>
+            <TimeFromNow unixTimestamp={locationNode.updatedTimestamp} />
+          </div>
+        </RowCell>
+        <RowCell>{'\u2013'}</RowCell>
+        <RowCell>
+          <JoinedButtons>
+            <ReloadButton location={name} />
+            <CodeLocationMenu locationNode={locationNode} />
+          </JoinedButtons>
+        </RowCell>
+      </RowGrid>
+    </div>
+  );
+};
+
+interface Props {
+  codeLocation: WorkspaceRepositoryLocationNode;
+  repository: WorkspaceRepositoryFragment;
+  measure: (node: Element | null) => void;
+}
+
+export const VirtualizedCodeLocationRow = (props: Props) => {
+  const {codeLocation, repository, measure} = props;
+  const repoAddress = buildRepoAddress(repository.name, repository.location.name);
+
+  const allMetadata = [...codeLocation.displayMetadata, ...repository.displayMetadata];
+
+  return (
+    <div ref={measure}>
+      <RowGrid border="bottom">
+        <RowCell>
+          <Box flex={{direction: 'column', gap: 4}}>
+            <div style={{fontWeight: 500}}>
+              <Link to={workspacePathFromAddress(repoAddress)}>
+                <MiddleTruncate text={repoAddressAsHumanString(repoAddress)} />
+              </Link>
+            </div>
+            <ImageName metadata={allMetadata} />
+            <ModuleOrPackageOrFile metadata={allMetadata} />
+          </Box>
+        </RowCell>
+        <RowCell>
+          <div>
+            <LocationStatus location={repository.name} locationOrError={codeLocation} />
+          </div>
+        </RowCell>
+        <RowCell>
+          <div style={{whiteSpace: 'nowrap'}}>
+            <TimeFromNow unixTimestamp={codeLocation.updatedTimestamp} />
+          </div>
+        </RowCell>
+        <RowCell>
+          <RepositoryCountTags repo={repository} repoAddress={repoAddress} />
+        </RowCell>
+        <RowCell style={{alignItems: 'flex-end'}}>
+          <JoinedButtons>
+            <ReloadButton location={codeLocation.name} />
+            <CodeLocationMenu locationNode={codeLocation} />
+          </JoinedButtons>
+        </RowCell>
+      </RowGrid>
+    </div>
+  );
+};
+
+export const VirtualizedCodeLocationHeader = () => {
+  return (
+    <Box
+      border="top-and-bottom"
+      style={{
+        display: 'grid',
+        gridTemplateColumns: TEMPLATE_COLUMNS,
+        height: '32px',
+        fontSize: '12px',
+        color: Colors.Gray600,
+      }}
+    >
+      <HeaderCell>Name</HeaderCell>
+      <HeaderCell>Status</HeaderCell>
+      <HeaderCell>Updated</HeaderCell>
+      <HeaderCell>Definitions</HeaderCell>
+      <HeaderCell style={{textAlign: 'right'}}>Actions</HeaderCell>
+    </Box>
+  );
+};
+
+const RowGrid = styled(Box)`
+  display: grid;
+  grid-template-columns: ${TEMPLATE_COLUMNS};
+`;


### PR DESCRIPTION
## Summary & Motivation

Resolves https://github.com/dagster-io/internal/issues/7274.

Make the code locations list virtualized and searchable. This should help the page scale better for users with very large numbers of code locations.

I moved the location/repo flattening up to the top level as part of this, and the virtualized table uses dynamic row heights since all of the relevant data is available for each row in the workspace, with no further querying.

https://github.com/dagster-io/dagster/assets/2823852/c37175ec-f256-4e48-bd5b-610744600d2c

<img width="1342" alt="Screenshot 2023-10-25 at 10 36 13 AM" src="https://github.com/dagster-io/dagster/assets/2823852/9d8a3cfd-a7b7-4f23-a8d4-7115b96cf793">

## How I Tested These Changes

View Code locations list, verify correct rendering and virtualization behavior.

Type a search query, verify correct filtering and empty state.

Add an error to toys repo, reload the location. Verify that the error row renders and behaves correctly. Fix the error, reload locations, verify that things go back to normal.
