### PR TITLE
[AssetLiveDataProvider] Retry asset keys that fail to fetch after the poll interval.

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetLiveDataProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetLiveDataProvider.tsx
@@ -347,7 +347,17 @@ async function _batchedQueryAssets(
     doNextFetch(pollRate);
   } catch (e) {
     console.error(e);
-    // Retry fetching in 5 seconds if theres a network error
+
+    // Mark these assets as fetched so that we don't retry them until after the poll interval rather than retrying them immediately.
+    // This is preferable because if the assets failed to fetch it's likely due to a timeout due to the query being too expensive and retrying it
+    // will not make it more likely to succeed and it would add more load to the database.
+    const fetchedTime = Date.now();
+    assetKeys.forEach((key) => {
+      lastFetchedOrRequested[tokenForAssetKey(key)] = {
+        fetched: fetchedTime,
+      };
+    });
+
     setTimeout(doNextFetch, 5000);
   }
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetLiveDataProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetLiveDataProvider.tsx
@@ -358,7 +358,7 @@ async function _batchedQueryAssets(
       };
     });
 
-    setTimeout(doNextFetch, 5000);
+    setTimeout(doNextFetch, Math.min(pollRate, 5000));
   }
 }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/__tests__/AssetLiveDataProvider.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/__tests__/AssetLiveDataProvider.test.tsx
@@ -355,10 +355,10 @@ describe('AssetLiveDataProvider', () => {
   it('Skips over asset keys that fail to fetch', async () => {
     const assetKeys = [buildAssetKey({path: ['key1']})];
     const mockedQuery = buildMockedAssetGraphLiveQuery(assetKeys, undefined, [
-      new GraphQLError('timeout'),
+      new GraphQLError('500'),
     ]);
     const mockedQuery2 = buildMockedAssetGraphLiveQuery(assetKeys, undefined, [
-      new GraphQLError('timeout'),
+      new GraphQLError('500'),
     ]);
 
     const resultFn = getMockResultFn(mockedQuery);

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/__tests__/util.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/__tests__/util.ts
@@ -1,3 +1,5 @@
+import {GraphQLError} from 'graphql/error';
+
 import {
   AssetKeyInput,
   buildAssetNode,
@@ -11,20 +13,35 @@ import {
   AssetGraphLiveQueryVariables,
 } from '../types/AssetLiveDataProvider.types';
 
-export function buildMockedAssetGraphLiveQuery(assetKeys: AssetKeyInput[]) {
+export function buildMockedAssetGraphLiveQuery(
+  assetKeys: AssetKeyInput[],
+  data:
+    | Parameters<
+        typeof buildQueryMock<AssetGraphLiveQuery, AssetGraphLiveQueryVariables>
+      >[0]['data']
+    | undefined = undefined,
+  errors: readonly GraphQLError[] | undefined = undefined,
+) {
   return buildQueryMock<AssetGraphLiveQuery, AssetGraphLiveQueryVariables>({
     query: ASSETS_GRAPH_LIVE_QUERY,
     variables: {
       // strip __typename
       assetKeys: assetKeys.map((assetKey) => ({path: assetKey.path})),
     },
-    data: {
-      assetNodes: assetKeys.map((assetKey) =>
-        buildAssetNode({assetKey: buildAssetKey(assetKey), id: JSON.stringify(assetKey)}),
-      ),
-      assetsLatestInfo: assetKeys.map((assetKey) =>
-        buildAssetLatestInfo({assetKey: buildAssetKey(assetKey), id: JSON.stringify(assetKey)}),
-      ),
-    },
+    data:
+      data === undefined && errors === undefined
+        ? {
+            assetNodes: assetKeys.map((assetKey) =>
+              buildAssetNode({assetKey: buildAssetKey(assetKey), id: JSON.stringify(assetKey)}),
+            ),
+            assetsLatestInfo: assetKeys.map((assetKey) =>
+              buildAssetLatestInfo({
+                assetKey: buildAssetKey(assetKey),
+                id: JSON.stringify(assetKey),
+              }),
+            ),
+          }
+        : data,
+    errors,
   });
 }


### PR DESCRIPTION
## Summary & Motivation

Currently if an asset key fails to fetch we never retry fetching it again because it gets stuck in the requested state. This PR fixes that and marks them as "fetched" when this happens. This has the consequence of (1) letting us move on to the next set of asset keys which could succeed and (2) it means we'll retry the failed asset keys again after the polling interval threshold is crossed.

## How I Tested These Changes
jest. Locally threw an error and saw that we did end up retrying the failed asset keys after the polling interval was met.