### PR TITLE
[prototype] AssetExecutionContext with sub-objects

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -1325,7 +1325,7 @@ class AssetInfo(
         provenance: Optional[DataProvenance] = None,
         assets_def: Optional[AssetsDefinition] = None,
     ):
-        super(AssetInfo, cls).__new__(
+        return super(AssetInfo, cls).__new__(
             cls, key=key, code_version=code_version, provenance=provenance, assets_def=assets_def
         )
 
@@ -1348,7 +1348,7 @@ class RunInfo(
         run_config: Mapping[str, object],
         retry_number: int,
     ):
-        super(RunInfo, cls).__new__(
+        return super(RunInfo, cls).__new__(
             cls,
             run_id=run_id,
             dagster_run=dagster_run,
@@ -1400,6 +1400,7 @@ class AssetExecutionContext(OpExecutionContext):
                 key=asset_key,
                 code_version=self.assets_def.code_versions_by_key[asset_key],
                 provenance=self.get_asset_provenance(asset_key),
+                assets_def=self.assets_def,
             )
 
         return self._asset_info_by_key

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_context.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_context.py
@@ -435,7 +435,7 @@ def test_asset_context_with_subobjects():
 
     @multi_asset(specs=[spec1, spec2])
     def my_multi_asset_with_specs(context: AssetExecutionContext):
-        spec1_info = context.asset_info_by_key[spec1.key]
-        spec2_info = context.asset_info_by_key[spec2.key]
+        context.asset_info_by_key[spec1.key]
+        context.asset_info_by_key[spec2.key]
 
     materialize([my_multi_asset, my_multi_asset_with_specs])

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_context.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_context.py
@@ -7,6 +7,7 @@ from dagster import (
     AssetExecutionContext,
     AssetKey,
     AssetOut,
+    AssetSpec,
     DagsterInstance,
     Definitions,
     GraphDefinition,
@@ -423,3 +424,18 @@ def test_asset_context_with_subobjects():
         # context.deps_info_by_key[my_asset.key]
 
     materialize([my_asset, downstream])
+
+    @multi_asset(outs={"out1": AssetOut(), "out2": AssetOut()})
+    def my_multi_asset(context: AssetExecutionContext):
+        context.asset_info_by_key[AssetKey("out1")]
+        context.asset_info_by_key[AssetKey("out2")]
+
+    spec1 = AssetSpec(key="spec1")
+    spec2 = AssetSpec(key="spec2")
+
+    @multi_asset(specs=[spec1, spec2])
+    def my_multi_asset_with_specs(context: AssetExecutionContext):
+        spec1_info = context.asset_info_by_key[spec1.key]
+        spec2_info = context.asset_info_by_key[spec2.key]
+
+    materialize([my_multi_asset, my_multi_asset_with_specs])


### PR DESCRIPTION
## Summary & Motivation
Prototype of AssetExecutionContext with sub-ohjects contains asset, run, partition info etc. as discussed [here](https://github.com/dagster-io/internal/discussions/7283#discussioncomment-7318834). I wrote up a simple test that showcases accessing some properties, but will add some more. 

The main thing that stuck out to me when writing up the sample test was that there isn't a way to get info about the upstream dependencies. This may not be a big issue with the current prototype since it only addresses AssetInfo and RunInfo, but I can see this getting stickier when we address partition methods. 

I also found it a bit annoying to need to access the `_by_key` method by constructing an `AssetKey`. This is better in the multi asset with `AssetSpecs` case, but the non-specs case isn't as ergonomic. 

Note that this does not attempt to do any deprecation shenanigans with OpExecutionContext. I think it gets in the way of assessing if this sub-object approach is one we like.
## How I Tested These Changes
