### PR TITLE
apply the asset checks loader on GrapheneAssetNode

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -61,8 +61,6 @@ from dagster_graphql.implementation.loader import (
     StaleStatusLoader,
 )
 
-from .asset_checks_loader import AssetChecksLoader
-
 if TYPE_CHECKING:
     from ..schema.asset_graph import GrapheneAssetNode, GrapheneAssetNodeDefinitionCollision
     from ..schema.errors import GrapheneAssetNotFoundError
@@ -188,6 +186,7 @@ def get_asset_nodes_by_asset_key(
     has an op.
     """
     from ..schema.asset_graph import GrapheneAssetNode
+    from .asset_checks_loader import AssetChecksLoader
 
     depended_by_loader = CrossRepoAssetDependedByLoader(context=graphene_info.context)
 
@@ -202,8 +201,10 @@ def get_asset_nodes_by_asset_key(
         AssetKey, Tuple[CodeLocation, ExternalRepository, ExternalAssetNode]
     ] = {}
     for repo_loc, repo, external_asset_node in asset_node_iter(graphene_info):
-        preexisting_node_tuple = asset_nodes_by_asset_key.get(external_asset_node.asset_key)
-        if preexisting_node_tuple is None or preexisting_node_tuple[2].is_source:
+        _, _, preexisting_asset_node = asset_nodes_by_asset_key.get(
+            external_asset_node.asset_key, (None, None, None)
+        )
+        if preexisting_asset_node is None or preexisting_asset_node.is_source:
             asset_nodes_by_asset_key[external_asset_node.asset_key] = (
                 repo_loc,
                 repo,

--- a/python_modules/dagster-graphql/dagster_graphql/schema/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/external.py
@@ -1,5 +1,6 @@
 import asyncio
 from typing import TYPE_CHECKING, Dict, List
+from dagster_graphql.implementation.asset_checks_loader import AssetChecksLoader
 
 import graphene
 from dagster import (
@@ -340,12 +341,18 @@ class GrapheneRepository(graphene.ObjectType):
             if value is not None
         ]
 
-    def resolve_assetNodes(self, _graphene_info: ResolveInfo):
+    def resolve_assetNodes(self, graphene_info: ResolveInfo):
+        external_asset_nodes = self._repository.get_external_asset_nodes()
+        asset_checks_loader = AssetChecksLoader(
+            context=graphene_info.context,
+            asset_keys=[node.asset_key for node in external_asset_nodes],
+        )
         return [
             GrapheneAssetNode(
                 self._repository_location,
                 self._repository,
                 external_asset_node,
+                asset_checks_loader=asset_checks_loader,
                 stale_status_loader=self._stale_status_loader,
                 dynamic_partitions_loader=self._dynamic_partitions_loader,
             )

--- a/python_modules/dagster-graphql/dagster_graphql/schema/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/external.py
@@ -1,6 +1,5 @@
 import asyncio
 from typing import TYPE_CHECKING, Dict, List
-from dagster_graphql.implementation.asset_checks_loader import AssetChecksLoader
 
 import graphene
 from dagster import (
@@ -29,6 +28,7 @@ from dagster._core.workspace.workspace import (
     CodeLocationLoadStatus,
 )
 
+from dagster_graphql.implementation.asset_checks_loader import AssetChecksLoader
 from dagster_graphql.implementation.fetch_solids import get_solid, get_solids
 from dagster_graphql.implementation.loader import (
     RepositoryScopedBatchLoader,

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -1,7 +1,6 @@
 from typing import Any, Dict, List, Mapping, Optional, Sequence, cast
 
 import dagster._check as check
-from dagster_graphql.implementation.asset_checks_loader import AssetChecksLoader
 import graphene
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
@@ -21,6 +20,7 @@ from dagster._core.scheduler.instigation import (
 )
 from dagster._core.workspace.permissions import Permissions
 
+from dagster_graphql.implementation.asset_checks_loader import AssetChecksLoader
 from dagster_graphql.implementation.fetch_auto_materialize_asset_evaluations import (
     fetch_auto_materialize_asset_evaluations,
     fetch_auto_materialize_asset_evaluations_for_evaluation_id,

--- a/python_modules/dagster-graphql/dagster_graphql/schema/solids.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/solids.py
@@ -2,7 +2,6 @@ from functools import lru_cache
 from typing import TYPE_CHECKING, List, Mapping, Optional, Sequence, Union
 
 import dagster._check as check
-from dagster_graphql.implementation.asset_checks_loader import AssetChecksLoader
 import graphene
 from dagster._core.definitions import NodeHandle
 from dagster._core.host_representation import RepresentedJob
@@ -12,6 +11,7 @@ from dagster._core.snap import DependencyStructureIndex, GraphDefSnap, OpDefSnap
 from dagster._core.snap.node import InputMappingSnap, OutputMappingSnap
 from dagster._core.storage.dagster_run import RunsFilter
 
+from dagster_graphql.implementation.asset_checks_loader import AssetChecksLoader
 from dagster_graphql.implementation.events import iterate_metadata_entries
 from dagster_graphql.schema.logs.events import GrapheneRunStepStats
 from dagster_graphql.schema.metadata import GrapheneMetadataEntry

--- a/python_modules/dagster-graphql/dagster_graphql/schema/solids.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/solids.py
@@ -2,6 +2,7 @@ from functools import lru_cache
 from typing import TYPE_CHECKING, List, Mapping, Optional, Sequence, Union
 
 import dagster._check as check
+from dagster_graphql.implementation.asset_checks_loader import AssetChecksLoader
 import graphene
 from dagster._core.definitions import NodeHandle
 from dagster._core.host_representation import RepresentedJob
@@ -431,7 +432,13 @@ class ISolidDefinitionMixin:
                 for node in ext_repo.get_external_asset_nodes()
                 if node.op_name == self.solid_def_name
             ]
-            return [GrapheneAssetNode(location, ext_repo, node) for node in nodes]
+            asset_checks_loader = AssetChecksLoader(
+                context=graphene_info.context, asset_keys=[node.asset_key for node in nodes]
+            )
+            return [
+                GrapheneAssetNode(location, ext_repo, node, asset_checks_loader=asset_checks_loader)
+                for node in nodes
+            ]
 
 
 class GrapheneSolidDefinition(graphene.ObjectType, ISolidDefinitionMixin):


### PR DESCRIPTION
Pass in the loader object to GrapheneAssetNode so that we batch fetching asset check definitions.

I think the optional loader pattern we've used with the other loaders is a little sketchy. I'm open to pushback, but I think it's cleaner to always pass in the loader. It means that we initialize it in some unneeded places (which should be cheap, just adds code), but it means we only have one code path when we read from the loader and we guarantee that we'll use batching when we query for checks.

**Test plan**
added coverage for the resolver on AssetNode.

In terms of perf, the query

```gql
query {
  assetNodes {
  	assetChecks {
        name
    }
  }
}
```

used to take 3 minutes running on the big toys repo because it loaded the asset graph for each of the ~2k assets. Now it takes 1 second.