### PR TITLE
[ui] Use measureElement on code locations list rows

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/RepositoryLocationsList.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/RepositoryLocationsList.tsx
@@ -74,15 +74,14 @@ export const RepositoryLocationsList = ({loading, codeLocations, searchValue}: P
         <Container ref={parentRef}>
           <Inner $totalHeight={totalHeight}>
             <DynamicRowContainer $start={items[0]?.start ?? 0}>
-              {items.map(({index, key}) => {
+              {items.map(({index, key, measureElement}) => {
                 const row: CodeLocationRowType = codeLocations[index]!;
                 if (row.type === 'error') {
                   return (
                     <VirtualizedCodeLocationErrorRow
                       key={key}
-                      data-index={index}
                       locationNode={row.node}
-                      measure={rowVirtualizer.measure}
+                      measure={measureElement}
                     />
                   );
                 }
@@ -90,10 +89,9 @@ export const RepositoryLocationsList = ({loading, codeLocations, searchValue}: P
                 return (
                   <VirtualizedCodeLocationRow
                     key={key}
-                    data-index={index}
                     codeLocation={row.codeLocation}
                     repository={row.repository}
-                    measure={rowVirtualizer.measure}
+                    measure={measureElement}
                   />
                 );
               })}


### PR DESCRIPTION
## Summary & Motivation

Looks like the code locations list row needs a `data-index` to ensure correct measurement of the dynamically sized row. Add it.

## How I Tested These Changes

Render an extra line (or not) of text on the row based on `index % 2`. Shrink viewport, scroll. Verify that all rows are correctly measured and sized.
