### PR TITLE
[auto-materialize] Don't store empty evaluation data on the cursor

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
@@ -151,7 +151,10 @@ class AssetDaemonCursor(NamedTuple):
             )
 
         latest_evaluation_by_asset_key = {
-            evaluation.asset_key: evaluation for evaluation in evaluations
+            evaluation.asset_key: evaluation
+            for evaluation in evaluations
+            # don't bother storing empty evaluations on the cursor
+            if not evaluation.is_empty
         }
 
         return AssetDaemonCursor(

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/auto_materialize_policy_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/auto_materialize_policy_scenarios.py
@@ -245,7 +245,6 @@ auto_materialize_policy_scenarios = {
                 )
             ],
             expected_evaluations=[
-                AssetEvaluationSpec.empty("daily"),
                 AssetEvaluationSpec(
                     asset_key="hourly",
                     rule_evaluations=[
@@ -332,7 +331,6 @@ auto_materialize_policy_scenarios = {
             run_request(["hourly"], partition_key="2013-01-05-04:00"),
         ],
         expected_evaluations=[
-            AssetEvaluationSpec.empty("daily"),
             AssetEvaluationSpec(
                 asset_key="hourly",
                 rule_evaluations=[
@@ -377,7 +375,6 @@ auto_materialize_policy_scenarios = {
             run_request(["hourly"], partition_key="2013-01-05-00:00"),
         ],
         expected_evaluations=[
-            AssetEvaluationSpec.empty("daily"),
             AssetEvaluationSpec(
                 asset_key="hourly",
                 rule_evaluations=[
@@ -412,8 +409,6 @@ auto_materialize_policy_scenarios = {
         unevaluated_runs=[run(["asset1", "asset2", "asset3", "asset4"]), run(["asset1", "asset2"])],
         expected_run_requests=[run_request(asset_keys=["asset3", "asset4"])],
         expected_evaluations=[
-            AssetEvaluationSpec.empty("asset1"),
-            AssetEvaluationSpec.empty("asset2"),
             AssetEvaluationSpec(
                 asset_key="asset3",
                 rule_evaluations=[
@@ -570,7 +565,6 @@ auto_materialize_policy_scenarios = {
                 ],
                 expected_run_requests=[],
                 expected_evaluations=[
-                    AssetEvaluationSpec.empty("C"),
                     AssetEvaluationSpec(
                         asset_key="D",
                         rule_evaluations=[
@@ -857,8 +851,6 @@ auto_materialize_policy_scenarios = {
         current_time=create_pendulum_time(year=2023, month=1, day=1, hour=4),
         expected_run_requests=[run_request(["asset3"], "2023-01-01-03:00")],
         expected_evaluations=[
-            AssetEvaluationSpec.empty("asset1"),
-            AssetEvaluationSpec.empty("asset2"),
             AssetEvaluationSpec(
                 asset_key="asset3",
                 rule_evaluations=[
@@ -932,8 +924,6 @@ auto_materialize_policy_scenarios = {
             run_request(["asset3"], "2023-01-01-03:00"),
         ],
         expected_evaluations=[
-            AssetEvaluationSpec.empty("asset1"),
-            AssetEvaluationSpec.empty("asset2"),
             AssetEvaluationSpec(
                 asset_key="asset3",
                 rule_evaluations=[

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/basic_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/basic_scenarios.py
@@ -113,7 +113,6 @@ basic_scenarios = {
         unevaluated_runs=[single_asset_run(asset_key="asset1")],
         expected_run_requests=[run_request(asset_keys=["asset2"])],
         expected_evaluations=[
-            AssetEvaluationSpec.empty("asset1"),
             AssetEvaluationSpec(
                 "asset2",
                 [
@@ -143,7 +142,6 @@ basic_scenarios = {
         unevaluated_runs=[single_asset_run(asset_key="asset1")],
         expected_run_requests=[run_request(asset_keys=["asset2", "asset3"])],
         expected_evaluations=[
-            AssetEvaluationSpec.empty("asset1"),
             AssetEvaluationSpec(
                 "asset2",
                 [
@@ -221,12 +219,26 @@ basic_scenarios = {
         ],
         expected_run_requests=[run_request(asset_keys=["asset2"])],
     ),
+    "parent_rematerialized_next_tick_empty": AssetReconciliationScenario(
+        assets=two_assets_in_sequence,
+        unevaluated_runs=[],
+        cursor_from=AssetReconciliationScenario(
+            assets=two_assets_in_sequence,
+            unevaluated_runs=[
+                run(["asset1", "asset2"]),
+                single_asset_run(asset_key="asset1"),
+            ],
+            expected_run_requests=[run_request(asset_keys=["asset2"])],
+        ),
+        expected_run_requests=[],
+        # should have no evaluation data for asset2 anymore
+        expected_evaluations=[AssetEvaluationSpec.empty("asset2")],
+    ),
     "one_parent_materialized_other_never_materialized": AssetReconciliationScenario(
         assets=one_asset_depends_on_two,
         unevaluated_runs=[single_asset_run(asset_key="parent1")],
         expected_run_requests=[run_request(asset_keys=["parent2", "child"])],
         expected_evaluations=[
-            AssetEvaluationSpec.empty("parent1"),
             AssetEvaluationSpec.from_single_rule(
                 "parent2", AutoMaterializeRule.materialize_on_missing()
             ),

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/freshness_policy_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/freshness_policy_scenarios.py
@@ -396,14 +396,11 @@ freshness_policy_scenarios = {
         evaluation_delta=datetime.timedelta(minutes=35),
         expected_run_requests=[run_request(asset_keys=["asset2", "asset5"])],
         expected_evaluations=[
-            AssetEvaluationSpec.empty("asset1"),
             AssetEvaluationSpec.from_single_rule(
                 "asset2",
                 AutoMaterializeRule.materialize_on_required_for_freshness(),
                 TextRuleEvaluationData("Required by downstream asset's policy"),
             ),
-            AssetEvaluationSpec.empty("asset3"),
-            AssetEvaluationSpec.empty("asset4"),
             AssetEvaluationSpec.from_single_rule(
                 "asset5",
                 AutoMaterializeRule.materialize_on_required_for_freshness(),

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/observable_source_asset_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/observable_source_asset_scenarios.py
@@ -242,7 +242,7 @@ observable_source_asset_scenarios = {
         assets=partitioned_downstream_of_changing_observable_source,
         unevaluated_runs=[],
         expected_run_requests=[],
-        expected_evaluations=[AssetEvaluationSpec.empty("asset1")],
+        expected_evaluations=[],
     ),
     "partitioned_downstream_of_unchanging_observable_source": AssetReconciliationScenario(
         assets=partitioned_downstream_of_unchanging_observable_source,

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/partition_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/partition_scenarios.py
@@ -467,7 +467,6 @@ partition_scenarios = {
                 num_requested=4,
                 num_skipped=1,
             ),
-            AssetEvaluationSpec.empty("daily"),
         ],
     ),
     "test_skip_entire_asset_on_backfill_in_progress": AssetReconciliationScenario(
@@ -529,7 +528,6 @@ partition_scenarios = {
                 num_requested=0,
                 num_skipped=5,
             ),
-            AssetEvaluationSpec.empty("daily"),
         ],
     ),
 }

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon.py
@@ -585,14 +585,9 @@ def test_run_ids():
             assert set(run.asset_selection) == set(expected_run_request.asset_selection)
             assert run.tags.get(PARTITION_NAME_TAG) == expected_run_request.partition_key
 
-        evaluations = sorted(
-            instance.schedule_storage.get_auto_materialize_asset_evaluations(
-                asset_key=AssetKey("asset4"), limit=100
-            ),
-            key=lambda evaluation: evaluation.evaluation_id,
+        evaluations = instance.schedule_storage.get_auto_materialize_asset_evaluations(
+            asset_key=AssetKey("asset4"), limit=100
         )
-        assert len(evaluations) == 2
+        assert len(evaluations) == 1
         assert evaluations[0].evaluation.asset_key == AssetKey("asset4")
-        assert evaluations[0].evaluation.run_ids == set()
-        assert evaluations[1].evaluation.asset_key == AssetKey("asset4")
-        assert evaluations[1].evaluation.run_ids == {run.run_id for run in sorted_runs}
+        assert evaluations[0].evaluation.run_ids == {run.run_id for run in sorted_runs}


### PR DESCRIPTION
## Summary & Motivation

Two changes here:

1. Stop storing the latest AutoMaterializeAssetEvaluation for an asset if it is empty, as this wastes a lot of space
2. Update the equivalent_to_stored_evaluation method to return True if the target evaluation is empty. This will avoid us writing out an evaluation to the table every tick if an asset continually evaluates as empty (as we wouldn't have any data in the cursor, but nothing would be changing tick to tick)

Re: "wastes a lot of space", this doesn't help the worst case scenario for cursor size, where all assets have at least one partition that is currently being skipped, but it does help a lot in the more common case (where most assets do not have any skipped partitions). This took a 1.2Mb cursor down to 4Kb in one test.

## How I Tested These Changes
