### PR TITLE
better cursor handling switching from asset to multi-asset

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
@@ -125,7 +125,8 @@ class MultiAssetSensorContextCursor:
     # Must call MultiAssetSensorEvaluationContext._update_cursor_after_evaluation at end of tick
     # to serialize the cursor.
     def __init__(self, cursor: Optional[str], context: "MultiAssetSensorEvaluationContext"):
-        loaded_cursor = json.loads(cursor) if cursor and hasattr(cursor, "items") else {}
+        loaded_cursor = json.loads(cursor) if cursor else {}
+        loaded_cursor = loaded_cursor if isinstance(loaded_cursor, dict) else {}
         self._cursor_component_by_asset_key: Dict[str, MultiAssetSensorAssetCursorComponent] = {}
 
         # The initial latest consumed event ID at the beginning of the tick

--- a/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
@@ -125,7 +125,7 @@ class MultiAssetSensorContextCursor:
     # Must call MultiAssetSensorEvaluationContext._update_cursor_after_evaluation at end of tick
     # to serialize the cursor.
     def __init__(self, cursor: Optional[str], context: "MultiAssetSensorEvaluationContext"):
-        loaded_cursor = json.loads(cursor) if cursor else {}
+        loaded_cursor = json.loads(cursor) if cursor and hasattr(cursor, "items") else {}
         self._cursor_component_by_asset_key: Dict[str, MultiAssetSensorAssetCursorComponent] = {}
 
         # The initial latest consumed event ID at the beginning of the tick

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
@@ -24,6 +24,7 @@ from dagster import (
     SourceAsset,
     StaticPartitionsDefinition,
     asset,
+    asset_sensor,
     build_freshness_policy_sensor_context,
     build_multi_asset_sensor_context,
     build_run_status_sensor_context,
@@ -1039,21 +1040,35 @@ def test_multi_asset_sensor_can_start_from_asset_sensor_cursor():
     def my_asset():
         return Output(99)
 
+    @job
+    def my_job():
+        pass
+
+    @asset_sensor(asset_key=my_asset.key, job=my_job)
+    def my_asset_sensor(context):
+        return RunRequest(run_key=context.cursor, run_config={})
+
     @multi_asset_sensor(monitored_assets=[my_asset.key])
     def my_multi_asset_sensor(context):
         ctx.advance_all_cursors()
 
     with instance_for_test() as instance:
-        cursor_from_previously_an_asset_sensor = "1234"
+        ctx = build_sensor_context(
+            instance=instance,
+        )
+        materialize([my_asset], instance=instance)
+        my_asset_sensor.evaluate_tick(ctx)
 
+        assert ctx.cursor == '3'
+
+        # simulate changing a @asset_sensor to a @multi_asset_sensor with the same name and
+        # therefore inheriting the same cursor.
         ctx = build_multi_asset_sensor_context(
             monitored_assets=[my_asset.key],
             instance=instance,
             repository_def=my_repo,
-            cursor=cursor_from_previously_an_asset_sensor
+            cursor=ctx.cursor,
         )
-
-        materialize([my_asset], instance=instance)
         my_multi_asset_sensor(ctx)
 
         assert ctx.cursor == "{\"AssetKey(['my_asset'])\": [null, 3, {}]}"

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
@@ -1059,7 +1059,7 @@ def test_multi_asset_sensor_can_start_from_asset_sensor_cursor():
         materialize([my_asset], instance=instance)
         my_asset_sensor.evaluate_tick(ctx)
 
-        assert ctx.cursor == '3'
+        assert ctx.cursor == "3"
 
         # simulate changing a @asset_sensor to a @multi_asset_sensor with the same name and
         # therefore inheriting the same cursor.


### PR DESCRIPTION
## Summary & Motivation

When switching an existing `@asset_sensor` to the experimental `@multi_asset_sensor`, Dagster fails when trying to iterate over the last stored cursor.

```python
dagster._core.errors.SensorExecutionError: Error occurred during the execution of evaluation_fn for sensor test_sensor_for_pull_request
  File "/usr/local/lib/python3.9/site-packages/dagster/_grpc/impl.py", line 371, in get_external_sensor_execution
    return sensor_def.evaluate_tick(sensor_context)
  File "/usr/local/lib/python3.9/contextlib.py", line 137, in __exit__
    self.gen.throw(typ, value, traceback)
  File "/usr/local/lib/python3.9/site-packages/dagster/_core/errors.py", line 293, in user_code_error_boundary
    raise error_cls(
The above exception was caused by the following exception:
AttributeError: 'int' object has no attribute 'items'
  File "/usr/local/lib/python3.9/site-packages/dagster/_core/errors.py", line 286, in user_code_error_boundary
    yield
  File "/usr/local/lib/python3.9/site-packages/dagster/_grpc/impl.py", line 371, in get_external_sensor_execution
    return sensor_def.evaluate_tick(sensor_context)
  File "/usr/local/lib/python3.9/site-packages/dagster/_core/definitions/sensor_definition.py", line 722, in evaluate_tick
    result = self._evaluation_fn(context)
  File "/usr/local/lib/python3.9/site-packages/dagster/_core/definitions/sensor_definition.py", line 1034, in _wrapped_fn
    result.append(next(raw_evaluation_result))
  File "/usr/local/lib/python3.9/site-packages/dagster/_core/definitions/multi_asset_sensor_definition.py", line 1124, in _fn
    with MultiAssetSensorEvaluationContext(
  File "/usr/local/lib/python3.9/site-packages/dagster/_core/decorator_utils.py", line 195, in wrapped_with_pre_call_fn
    return fn(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/dagster/_core/definitions/multi_asset_sensor_definition.py", line 264, in __init__
    self._unpacked_cursor = MultiAssetSensorContextCursor(cursor, self)
  File "/usr/local/lib/python3.9/site-packages/dagster/_core/definitions/multi_asset_sensor_definition.py", line 134, in __init__
    for str_asset_key, cursor_list in loaded_cursor.items():
```

I tried to truncate some tables in the database, hopping I would help Dagster forget about the existence of the `@asset_sensor`, but I didn't manage. I then decided to make loading the cursor a bit more robust in the `MultiAssetSensorContextCursor`. I'm proposing this pretty simple change here, even it might not be a situation people encounter often.

## How I Tested These Changes

First create a normal sensor:
```python
@asset
def test_asset_for_pullrequest() -> str:
    return 'myasset'

@job
def do_nothing():
    return None

@asset_sensor(
    asset_key=AssetKey("test_asset_for_pullrequest"),
    job=do_nothing,
)
def test_sensor_for_pull_request(context):
    yield RunRequest(
        run_key=context.cursor,
        run_config=RunConfig(),
    )
```

Materialized the asset, let the sensor see it. Then, switch to a `@multi_asset_sensor`:
```python
@asset
def test_asset_for_pullrequest() -> str:
    return 'myasset'

@job
def do_nothing():
    return None

@multi_asset_sensor(
    monitored_assets=AssetSelection.groups("doesnt_matter"),
    job=do_nothing,
)
def test_sensor_for_pull_request(context):
    context.advance_all_cursors()
    yield RunRequest(
        run_key=context.cursor,
        run_config=RunConfig(),
    )
```

After this change, the sensor goes in state _Failed` and the _Last tick_ reason in the UI shows the error from the description above. Push a new version of user-code with this patch.

The sensor doesn't try to load the cursor, consider there was a change, and starts working again.