### PR TITLE
fix(dbt): allow empty exclude

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
@@ -311,9 +311,8 @@ def select_unique_ids_from_manifest(
     parsed_spec: SelectionSpec = graph_cli.parse_union([select], True)
 
     if exclude:
-        parsed_spec = graph_cli.SelectionDifference(
-            components=[parsed_spec, graph_cli.parse_union([exclude], True)]
-        )
+        parsed_exclude_spec = graph_cli.parse_union([exclude], False)
+        parsed_spec = graph_cli.SelectionDifference(components=[parsed_spec, parsed_exclude_spec])
 
     # execute this selection against the graph
     selector = graph_selector.NodeSelector(graph, manifest, previous_state=previous_state)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_decorator.py
@@ -138,6 +138,18 @@ def test_manifest_argument(manifest: DbtManifestParam):
                 "cereals",
             },
         ),
+        (
+            "*",
+            "tag:does-not-exist",
+            {
+                "sort_by_calories",
+                "cold_schema/sort_cold_cereals_by_calories",
+                "subdir_schema/least_caloric",
+                "sort_hot_cereals_by_calories",
+                "orders_snapshot",
+                "cereals",
+            },
+        ),
     ],
 )
 def test_selections(


### PR DESCRIPTION
## Summary & Motivation
If an exclude statement comes up empty handed, still allow it. We should only expect the select statement to have a non-empty result.

In the case that an exclude is empty, a set difference against it is treated as if exclude was not populated to begin with. 

## How I Tested These Changes
local, add a test
