### PR TITLE
[asset backfill] Add resolver to preview targeted asset partitions

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -3246,8 +3246,7 @@ type BackfillNotFoundError implements Error {
 
 type AssetPartitions {
   assetKey: AssetKey!
-  partitionKeys: [String!]
-  partitionRanges: [PartitionKeyRange!]
+  partitions: AssetBackfillTargetPartitions
 }
 
 input AssetBackfillPreviewParams {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -3098,6 +3098,7 @@ type Query {
   assetNodeOrError(assetKey: AssetKeyInput!): AssetNodeOrError!
   assetNodeDefinitionCollisions(assetKeys: [AssetKeyInput!]): [AssetNodeDefinitionCollision!]!
   partitionBackfillOrError(backfillId: String!): PartitionBackfillOrError!
+  assetBackfillPreview(params: AssetBackfillPreviewParams!): [AssetPartitions!]!
   partitionBackfillsOrError(
     status: BulkActionStatus
     cursor: String
@@ -3241,6 +3242,17 @@ union PartitionBackfillOrError = PartitionBackfill | BackfillNotFoundError | Pyt
 type BackfillNotFoundError implements Error {
   message: String!
   backfillId: String!
+}
+
+type AssetPartitions {
+  assetKey: AssetKey!
+  partitionKeys: [String!]
+  partitionRanges: [PartitionKeyRange!]
+}
+
+input AssetBackfillPreviewParams {
+  partitionNames: [String!]!
+  assetSelection: [AssetKeyInput!]!
 }
 
 union PartitionBackfillsOrError = PartitionBackfills | PythonError

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -462,8 +462,7 @@ export type AssetPartitionStatuses =
 export type AssetPartitions = {
   __typename: 'AssetPartitions';
   assetKey: AssetKey;
-  partitionKeys: Maybe<Array<Scalars['String']>>;
-  partitionRanges: Maybe<Array<PartitionKeyRange>>;
+  partitions: Maybe<AssetBackfillTargetPartitions>;
 };
 
 export type AssetPartitionsStatusCounts = {
@@ -5305,10 +5304,12 @@ export const buildAssetPartitions = (
         : relationshipsToOmit.has('AssetKey')
         ? ({} as AssetKey)
         : buildAssetKey({}, relationshipsToOmit),
-    partitionKeys:
-      overrides && overrides.hasOwnProperty('partitionKeys') ? overrides.partitionKeys! : [],
-    partitionRanges:
-      overrides && overrides.hasOwnProperty('partitionRanges') ? overrides.partitionRanges! : [],
+    partitions:
+      overrides && overrides.hasOwnProperty('partitions')
+        ? overrides.partitions!
+        : relationshipsToOmit.has('AssetBackfillTargetPartitions')
+        ? ({} as AssetBackfillTargetPartitions)
+        : buildAssetBackfillTargetPartitions({}, relationshipsToOmit),
   };
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -111,6 +111,11 @@ export type AssetBackfillData = {
   rootTargetedPartitions: AssetBackfillTargetPartitions;
 };
 
+export type AssetBackfillPreviewParams = {
+  assetSelection: Array<AssetKeyInput>;
+  partitionNames: Array<Scalars['String']>;
+};
+
 export type AssetBackfillStatus = AssetPartitionsStatusCounts | UnpartitionedAssetStatus;
 
 export type AssetBackfillTargetPartitions = {
@@ -453,6 +458,13 @@ export type AssetPartitionStatuses =
   | DefaultPartitionStatuses
   | MultiPartitionStatuses
   | TimePartitionStatuses;
+
+export type AssetPartitions = {
+  __typename: 'AssetPartitions';
+  assetKey: AssetKey;
+  partitionKeys: Maybe<Array<Scalars['String']>>;
+  partitionRanges: Maybe<Array<PartitionKeyRange>>;
+};
 
 export type AssetPartitionsStatusCounts = {
   __typename: 'AssetPartitionsStatusCounts';
@@ -2879,6 +2891,7 @@ export type PythonError = Error & {
 export type Query = {
   __typename: 'Query';
   allTopLevelResourceDetailsOrError: ResourcesOrError;
+  assetBackfillPreview: Array<AssetPartitions>;
   assetCheckExecutions: Array<AssetCheckExecution>;
   assetChecksOrError: AssetChecksOrError;
   assetNodeDefinitionCollisions: Array<AssetNodeDefinitionCollision>;
@@ -2934,6 +2947,10 @@ export type Query = {
 
 export type QueryAllTopLevelResourceDetailsOrErrorArgs = {
   repositorySelector: RepositorySelector;
+};
+
+export type QueryAssetBackfillPreviewArgs = {
+  params: AssetBackfillPreviewParams;
 };
 
 export type QueryAssetCheckExecutionsArgs = {
@@ -4570,6 +4587,20 @@ export const buildAssetBackfillData = (
   };
 };
 
+export const buildAssetBackfillPreviewParams = (
+  overrides?: Partial<AssetBackfillPreviewParams>,
+  _relationshipsToOmit: Set<string> = new Set(),
+): AssetBackfillPreviewParams => {
+  const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
+  relationshipsToOmit.add('AssetBackfillPreviewParams');
+  return {
+    assetSelection:
+      overrides && overrides.hasOwnProperty('assetSelection') ? overrides.assetSelection! : [],
+    partitionNames:
+      overrides && overrides.hasOwnProperty('partitionNames') ? overrides.partitionNames! : [],
+  };
+};
+
 export const buildAssetBackfillTargetPartitions = (
   overrides?: Partial<AssetBackfillTargetPartitions>,
   _relationshipsToOmit: Set<string> = new Set(),
@@ -5257,6 +5288,27 @@ export const buildAssetNotFoundError = (
   return {
     __typename: 'AssetNotFoundError',
     message: overrides && overrides.hasOwnProperty('message') ? overrides.message! : 'beatae',
+  };
+};
+
+export const buildAssetPartitions = (
+  overrides?: Partial<AssetPartitions>,
+  _relationshipsToOmit: Set<string> = new Set(),
+): {__typename: 'AssetPartitions'} & AssetPartitions => {
+  const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
+  relationshipsToOmit.add('AssetPartitions');
+  return {
+    __typename: 'AssetPartitions',
+    assetKey:
+      overrides && overrides.hasOwnProperty('assetKey')
+        ? overrides.assetKey!
+        : relationshipsToOmit.has('AssetKey')
+        ? ({} as AssetKey)
+        : buildAssetKey({}, relationshipsToOmit),
+    partitionKeys:
+      overrides && overrides.hasOwnProperty('partitionKeys') ? overrides.partitionKeys! : [],
+    partitionRanges:
+      overrides && overrides.hasOwnProperty('partitionRanges') ? overrides.partitionRanges! : [],
   };
 };
 
@@ -9934,6 +9986,10 @@ export const buildQuery = (
         : relationshipsToOmit.has('PythonError')
         ? ({} as PythonError)
         : buildPythonError({}, relationshipsToOmit),
+    assetBackfillPreview:
+      overrides && overrides.hasOwnProperty('assetBackfillPreview')
+        ? overrides.assetBackfillPreview!
+        : [],
     assetCheckExecutions:
       overrides && overrides.hasOwnProperty('assetCheckExecutions')
         ? overrides.assetCheckExecutions!

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
@@ -29,12 +29,12 @@ if TYPE_CHECKING:
     from dagster_graphql.schema.util import ResolveInfo
 
     from ...schema.backfill import (
+        GrapheneAssetPartitions,
         GrapheneCancelBackfillSuccess,
         GrapheneLaunchBackfillSuccess,
         GrapheneResumeBackfillSuccess,
     )
     from ...schema.errors import GraphenePartitionSetNotFoundError
-    from ...schema.partition_sets import GrapheneAssetPartitions
 
 
 def _assert_permission_for_asset_graph(
@@ -76,7 +76,7 @@ def _assert_permission_for_asset_graph(
 def get_asset_backfill_preview(
     graphene_info: "ResolveInfo", backfill_preview_params: AssetBackfillPreviewParams
 ) -> Sequence["GrapheneAssetPartitions"]:
-    from ...schema.partition_sets import GrapheneAssetPartitions
+    from ...schema.backfill import GrapheneAssetPartitions
 
     asset_graph = ExternalAssetGraph.from_workspace(graphene_info.context)
 

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
@@ -6,6 +6,7 @@ from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
 from dagster._core.definitions.selector import PartitionsByAssetSelector, RepositorySelector
 from dagster._core.errors import DagsterError, DagsterUserCodeProcessError
 from dagster._core.events import AssetKey
+from dagster._core.execution.asset_backfill import create_asset_backfill_data_from_asset_partitions
 from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
 from dagster._core.execution.job_backfill import submit_backfill_runs
 from dagster._core.host_representation.external_data import ExternalPartitionExecutionErrorData
@@ -14,7 +15,12 @@ from dagster._core.workspace.permissions import Permissions
 from dagster._utils import utc_datetime_from_timestamp
 from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
 
-from ..utils import BackfillParams, assert_permission, assert_permission_for_location
+from ..utils import (
+    AssetBackfillPreviewParams,
+    BackfillParams,
+    assert_permission,
+    assert_permission_for_location,
+)
 
 BACKFILL_CHUNK_SIZE = 25
 
@@ -28,6 +34,7 @@ if TYPE_CHECKING:
         GrapheneResumeBackfillSuccess,
     )
     from ...schema.errors import GraphenePartitionSetNotFoundError
+    from ...schema.partition_sets import GrapheneAssetPartitions
 
 
 def _assert_permission_for_asset_graph(
@@ -64,6 +71,44 @@ def _assert_permission_for_asset_graph(
     else:
         for location_name in location_names:
             assert_permission_for_location(graphene_info, permission, location_name)
+
+
+def get_asset_backfill_preview(
+    graphene_info: "ResolveInfo", backfill_preview_params: AssetBackfillPreviewParams
+) -> Sequence["GrapheneAssetPartitions"]:
+    from ...schema.partition_sets import GrapheneAssetPartitions
+
+    asset_graph = ExternalAssetGraph.from_workspace(graphene_info.context)
+
+    check.invariant(backfill_preview_params.get("assetSelection") is not None)
+    check.invariant(backfill_preview_params.get("partitionNames") is not None)
+
+    asset_selection = [
+        cast(AssetKey, AssetKey.from_graphql_input(asset_key))
+        for asset_key in backfill_preview_params["assetSelection"]
+    ]
+    partition_names: List[str] = backfill_preview_params["partitionNames"]
+
+    asset_backfill_data = create_asset_backfill_data_from_asset_partitions(
+        asset_graph, asset_selection, partition_names, graphene_info.context.instance
+    )
+
+    asset_partitions = []
+
+    for asset_key in asset_backfill_data.get_targeted_asset_keys_topological_order():
+        if asset_graph.get_partitions_def(asset_key):
+            partitions_subset = asset_backfill_data.target_subset.partitions_subsets_by_asset_key[
+                asset_key
+            ]
+            asset_partitions.append(
+                GrapheneAssetPartitions(asset_key=asset_key, partitions_subset=partitions_subset)
+            )
+        else:
+            asset_partitions.append(
+                GrapheneAssetPartitions(asset_key=asset_key, partitions_subset=None)
+            )
+
+    return asset_partitions
 
 
 def create_and_launch_partition_backfill(

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
@@ -254,3 +254,4 @@ class ExecutionMetadata(
 
 
 BackfillParams: TypeAlias = Mapping[str, Any]
+AssetBackfillPreviewParams: TypeAlias = Mapping[str, Any]

--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Optional, Sequence
 
 import dagster._check as check
 import graphene
+from dagster import AssetKey
 from dagster._core.definitions.backfill_policy import BackfillPolicy, BackfillPolicyType
 from dagster._core.definitions.partition import PartitionsSubset
 from dagster._core.definitions.time_window_partitions import (
@@ -143,6 +144,22 @@ class GrapheneAssetBackfillTargetPartitions(graphene.ObjectType):
             ranges=ranges,
             partitionKeys=partition_keys,
         )
+
+
+class GrapheneAssetPartitions(graphene.ObjectType):
+    assetKey = graphene.NonNull(GrapheneAssetKey)
+    partitions = graphene.Field(GrapheneAssetBackfillTargetPartitions)
+
+    class Meta:
+        name = "AssetPartitions"
+
+    def __init__(self, asset_key: AssetKey, partitions_subset: Optional[PartitionsSubset]):
+        if partitions_subset is None:
+            partitions = None
+        else:
+            partitions = GrapheneAssetBackfillTargetPartitions(partitions_subset)
+
+        super().__init__(assetKey=GrapheneAssetKey(path=asset_key.path), partitions=partitions)
 
 
 class GrapheneAssetBackfillData(graphene.ObjectType):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
@@ -175,6 +175,14 @@ class GraphenePartitionsByAssetSelector(graphene.InputObjectType):
         name = "PartitionsByAssetSelector"
 
 
+class GrapheneAssetBackfillPreviewParams(graphene.InputObjectType):
+    partitionNames = graphene.InputField(non_null_list(graphene.String))
+    assetSelection = graphene.InputField(non_null_list(GrapheneAssetKeyInput))
+
+    class Meta:
+        name = "AssetBackfillPreviewParams"
+
+
 class GrapheneLaunchBackfillParams(graphene.InputObjectType):
     selector = graphene.InputField(GraphenePartitionSetSelector)
     partitionNames = graphene.List(graphene.NonNull(graphene.String))

--- a/python_modules/dagster-graphql/dagster_graphql/schema/partition_sets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/partition_sets.py
@@ -2,9 +2,7 @@ from typing import Optional, cast
 
 import dagster._check as check
 import graphene
-from dagster import AssetKey, MultiPartitionsDefinition
-from dagster._core.definitions.partition import PartitionsSubset
-from dagster._core.definitions.time_window_partitions import TimeWindowPartitionsSubset
+from dagster import MultiPartitionsDefinition
 from dagster._core.host_representation import ExternalPartitionSet, RepositoryHandle
 from dagster._core.host_representation.external_data import (
     ExternalDynamicPartitionsDefinitionData,
@@ -492,41 +490,6 @@ class GrapheneDimensionPartitionKeys(graphene.ObjectType):
 
     class Meta:
         name = "DimensionPartitionKeys"
-
-
-# TODO replace this with GrapheneAssetBackfillTargetPartitions
-# once https://github.com/dagster-io/dagster/pull/17244 merges
-class GrapheneAssetPartitions(graphene.ObjectType):
-    assetKey = graphene.NonNull(GrapheneAssetKey)
-    partitionKeys = graphene.List(graphene.NonNull(graphene.String))
-    partitionRanges = graphene.List(
-        graphene.NonNull("dagster_graphql.schema.partition_sets.GraphenePartitionKeyRange")
-    )
-
-    class Meta:
-        name = "AssetPartitions"
-
-    def __init__(self, asset_key: AssetKey, partitions_subset: Optional[PartitionsSubset]):
-        from dagster_graphql.schema.partition_sets import GraphenePartitionKeyRange
-
-        if partitions_subset is None:
-            ranges = None
-            partition_keys = None
-        elif isinstance(partitions_subset, TimeWindowPartitionsSubset):
-            ranges = [
-                GraphenePartitionKeyRange(start, end)
-                for start, end in partitions_subset.get_partition_key_ranges()
-            ]
-            partition_keys = None
-        else:  # Default partitions subset
-            ranges = None
-            partition_keys = partitions_subset.get_partition_keys()
-
-        super().__init__(
-            assetKey=GrapheneAssetKey(path=asset_key.path),
-            partitionRanges=ranges,
-            partitionKeys=partition_keys,
-        )
 
 
 types = [

--- a/python_modules/dagster-graphql/dagster_graphql/schema/partition_sets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/partition_sets.py
@@ -2,7 +2,9 @@ from typing import Optional, cast
 
 import dagster._check as check
 import graphene
-from dagster import MultiPartitionsDefinition
+from dagster import AssetKey, MultiPartitionsDefinition
+from dagster._core.definitions.partition import PartitionsSubset
+from dagster._core.definitions.time_window_partitions import TimeWindowPartitionsSubset
 from dagster._core.host_representation import ExternalPartitionSet, RepositoryHandle
 from dagster._core.host_representation.external_data import (
     ExternalDynamicPartitionsDefinitionData,
@@ -490,6 +492,41 @@ class GrapheneDimensionPartitionKeys(graphene.ObjectType):
 
     class Meta:
         name = "DimensionPartitionKeys"
+
+
+# TODO replace this with GrapheneAssetBackfillTargetPartitions
+# once https://github.com/dagster-io/dagster/pull/17244 merges
+class GrapheneAssetPartitions(graphene.ObjectType):
+    assetKey = graphene.NonNull(GrapheneAssetKey)
+    partitionKeys = graphene.List(graphene.NonNull(graphene.String))
+    partitionRanges = graphene.List(
+        graphene.NonNull("dagster_graphql.schema.partition_sets.GraphenePartitionKeyRange")
+    )
+
+    class Meta:
+        name = "AssetPartitions"
+
+    def __init__(self, asset_key: AssetKey, partitions_subset: Optional[PartitionsSubset]):
+        from dagster_graphql.schema.partition_sets import GraphenePartitionKeyRange
+
+        if partitions_subset is None:
+            ranges = None
+            partition_keys = None
+        elif isinstance(partitions_subset, TimeWindowPartitionsSubset):
+            ranges = [
+                GraphenePartitionKeyRange(start, end)
+                for start, end in partitions_subset.get_partition_key_ranges()
+            ]
+            partition_keys = None
+        else:  # Default partitions subset
+            ranges = None
+            partition_keys = partitions_subset.get_partition_keys()
+
+        super().__init__(
+            assetKey=GrapheneAssetKey(path=asset_key.path),
+            partitionRanges=ranges,
+            partitionKeys=partition_keys,
+        )
 
 
 types = [

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -100,6 +100,7 @@ from ..asset_graph import (
     GrapheneAssetNodeOrError,
 )
 from ..backfill import (
+    GrapheneAssetPartitions,
     GrapheneBulkActionStatus,
     GraphenePartitionBackfillOrError,
     GraphenePartitionBackfillsOrError,
@@ -139,7 +140,6 @@ from ..logs.compute_logs import (
     from_captured_log_data,
 )
 from ..partition_sets import (
-    GrapheneAssetPartitions,
     GraphenePartitionSetOrError,
     GraphenePartitionSetsOrError,
 )

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -22,6 +22,7 @@ from dagster._core.scheduler.instigation import (
 from dagster._core.workspace.permissions import Permissions
 
 from dagster_graphql.implementation.asset_checks_loader import AssetChecksLoader
+from dagster_graphql.implementation.execution.backfill import get_asset_backfill_preview
 from dagster_graphql.implementation.fetch_auto_materialize_asset_evaluations import (
     fetch_auto_materialize_asset_evaluations,
     fetch_auto_materialize_asset_evaluations_for_evaluation_id,
@@ -111,6 +112,7 @@ from ..external import (
     GrapheneWorkspaceOrError,
 )
 from ..inputs import (
+    GrapheneAssetBackfillPreviewParams,
     GrapheneAssetGroupSelector,
     GrapheneAssetKeyInput,
     GrapheneGraphSelector,
@@ -136,7 +138,11 @@ from ..logs.compute_logs import (
     GrapheneCapturedLogsMetadata,
     from_captured_log_data,
 )
-from ..partition_sets import GraphenePartitionSetOrError, GraphenePartitionSetsOrError
+from ..partition_sets import (
+    GrapheneAssetPartitions,
+    GraphenePartitionSetOrError,
+    GraphenePartitionSetsOrError,
+)
 from ..permissions import GraphenePermission
 from ..pipelines.config_result import GraphenePipelineConfigValidationResult
 from ..pipelines.pipeline import GrapheneEventConnectionOrError, GrapheneRunOrError
@@ -428,6 +434,12 @@ class GrapheneQuery(graphene.ObjectType):
         graphene.NonNull(GraphenePartitionBackfillOrError),
         backfillId=graphene.Argument(graphene.NonNull(graphene.String)),
         description="Retrieve a backfill by backfill id.",
+    )
+
+    assetBackfillPreview = graphene.Field(
+        non_null_list(GrapheneAssetPartitions),
+        params=graphene.Argument(graphene.NonNull(GrapheneAssetBackfillPreviewParams)),
+        description="Fetch the partitions that would be targeted by a backfill, given the root partitions targeted.",
     )
 
     partitionBackfillsOrError = graphene.Field(
@@ -1002,6 +1014,11 @@ class GrapheneQuery(graphene.ObjectType):
             cursor=cursor,
             limit=limit,
         )
+
+    def resolve_assetBackfillPreview(
+        self, graphene_info: ResolveInfo, params: GrapheneAssetBackfillPreviewParams
+    ) -> Sequence[GrapheneAssetPartitions]:
+        return get_asset_backfill_preview(graphene_info, params)
 
     def resolve_permissions(self, graphene_info: ResolveInfo):
         permissions = graphene_info.context.permissions

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py
@@ -93,10 +93,12 @@ query assetBackfillPreview($params: AssetBackfillPreviewParams!) {
     assetKey {
       path
     }
-    partitionKeys
-    partitionRanges {
-      start
-      end
+    partitions {
+      partitionKeys
+      ranges {
+        start
+        end
+      }
     }
   }
 }
@@ -722,20 +724,19 @@ def test_asset_backfill_preview_time_partitioned():
 
             # Assert toposorted
             assert target_asset_partitions[0]["assetKey"] == {"path": ["hourly"]}
-            assert target_asset_partitions[0]["partitionRanges"] == [
+            assert target_asset_partitions[0]["partitions"]["ranges"] == [
                 {"start": "2020-01-02-22:00", "end": "2020-01-03-00:00"}
             ]
-            assert target_asset_partitions[0]["partitionKeys"] == None
+            assert target_asset_partitions[0]["partitions"]["partitionKeys"] is None
 
             assert target_asset_partitions[1]["assetKey"] == {"path": ["daily"]}
-            assert target_asset_partitions[1]["partitionRanges"] == [
+            assert target_asset_partitions[1]["partitions"]["ranges"] == [
                 {"start": "2020-01-02", "end": "2020-01-03"}
             ]
-            assert target_asset_partitions[1]["partitionKeys"] == None
+            assert target_asset_partitions[1]["partitions"]["partitionKeys"] is None
 
             assert target_asset_partitions[2]["assetKey"] == {"path": ["non_partitioned"]}
-            assert target_asset_partitions[2]["partitionRanges"] == None
-            assert target_asset_partitions[2]["partitionKeys"] == None
+            assert target_asset_partitions[2]["partitions"] is None
 
 
 def test_asset_backfill_preview_static_partitioned():
@@ -761,16 +762,19 @@ def test_asset_backfill_preview_static_partitioned():
 
             # Assert toposorted
             assert target_asset_partitions[0]["assetKey"] == {"path": ["asset1"]}
-            assert target_asset_partitions[0]["partitionRanges"] == None
-            assert set(target_asset_partitions[0]["partitionKeys"]) == set(partition_keys)
+            assert target_asset_partitions[0]["partitions"]["ranges"] is None
+            assert set(target_asset_partitions[0]["partitions"]["partitionKeys"]) == set(
+                partition_keys
+            )
 
             assert target_asset_partitions[1]["assetKey"] == {"path": ["asset2"]}
-            assert target_asset_partitions[1]["partitionRanges"] == None
-            assert set(target_asset_partitions[1]["partitionKeys"]) == set(partition_keys)
+            assert target_asset_partitions[1]["partitions"]["ranges"] is None
+            assert set(target_asset_partitions[1]["partitions"]["partitionKeys"]) == set(
+                partition_keys
+            )
 
             assert target_asset_partitions[2]["assetKey"] == {"path": ["asset3"]}
-            assert target_asset_partitions[2]["partitionRanges"] == None
-            assert target_asset_partitions[2]["partitionKeys"] == None
+            assert target_asset_partitions[2]["partitions"] is None
 
 
 def _get_backfill_data(

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py
@@ -87,6 +87,21 @@ ASSET_BACKFILL_DATA_QUERY = """
   }
 """
 
+ASSET_BACKFILL_PREVIEW_QUERY = """
+query assetBackfillPreview($params: AssetBackfillPreviewParams!) {
+  assetBackfillPreview(params: $params) {
+    assetKey {
+      path
+    }
+    partitionKeys
+    partitionRanges {
+      start
+      end
+    }
+  }
+}
+"""
+
 
 def get_repo() -> RepositoryDefinition:
     partitions_def = StaticPartitionsDefinition(["a", "b", "c"])
@@ -679,6 +694,83 @@ def test_launch_asset_backfill_with_upstream_anchor_asset_and_non_partitioned_as
             assert len(targeted_ranges) == 1
             assert targeted_ranges[0]["start"] == "2020-01-02-22:00"
             assert targeted_ranges[0]["end"] == "2020-01-03-00:00"
+
+
+def test_asset_backfill_preview_time_partitioned():
+    repo = get_daily_hourly_non_partitioned_repo()
+    all_asset_keys = repo.asset_graph.materializable_asset_keys
+
+    hourly_partitions = ["2020-01-02-23:00", "2020-01-02-22:00", "2020-01-03-00:00"]
+
+    with instance_for_test() as instance:
+        with define_out_of_process_context(
+            __file__, "get_daily_hourly_non_partitioned_repo", instance
+        ) as context:
+            backfill_preview_result = execute_dagster_graphql(
+                context,
+                ASSET_BACKFILL_PREVIEW_QUERY,
+                variables={
+                    "params": {
+                        "assetSelection": [key.to_graphql_input() for key in all_asset_keys],
+                        "partitionNames": hourly_partitions,
+                    }
+                },
+            )
+
+            target_asset_partitions = backfill_preview_result.data["assetBackfillPreview"]
+            assert len(target_asset_partitions) == 3
+
+            # Assert toposorted
+            assert target_asset_partitions[0]["assetKey"] == {"path": ["hourly"]}
+            assert target_asset_partitions[0]["partitionRanges"] == [
+                {"start": "2020-01-02-22:00", "end": "2020-01-03-00:00"}
+            ]
+            assert target_asset_partitions[0]["partitionKeys"] == None
+
+            assert target_asset_partitions[1]["assetKey"] == {"path": ["daily"]}
+            assert target_asset_partitions[1]["partitionRanges"] == [
+                {"start": "2020-01-02", "end": "2020-01-03"}
+            ]
+            assert target_asset_partitions[1]["partitionKeys"] == None
+
+            assert target_asset_partitions[2]["assetKey"] == {"path": ["non_partitioned"]}
+            assert target_asset_partitions[2]["partitionRanges"] == None
+            assert target_asset_partitions[2]["partitionKeys"] == None
+
+
+def test_asset_backfill_preview_static_partitioned():
+    repo = get_repo()
+    all_asset_keys = repo.asset_graph.materializable_asset_keys
+    partition_keys = ["a", "b"]
+
+    with instance_for_test() as instance:
+        with define_out_of_process_context(__file__, "get_repo", instance) as context:
+            backfill_preview_result = execute_dagster_graphql(
+                context,
+                ASSET_BACKFILL_PREVIEW_QUERY,
+                variables={
+                    "params": {
+                        "partitionNames": partition_keys,
+                        "assetSelection": [key.to_graphql_input() for key in all_asset_keys],
+                    }
+                },
+            )
+
+            target_asset_partitions = backfill_preview_result.data["assetBackfillPreview"]
+            assert len(target_asset_partitions) == 3
+
+            # Assert toposorted
+            assert target_asset_partitions[0]["assetKey"] == {"path": ["asset1"]}
+            assert target_asset_partitions[0]["partitionRanges"] == None
+            assert set(target_asset_partitions[0]["partitionKeys"]) == set(partition_keys)
+
+            assert target_asset_partitions[1]["assetKey"] == {"path": ["asset2"]}
+            assert target_asset_partitions[1]["partitionRanges"] == None
+            assert set(target_asset_partitions[1]["partitionKeys"]) == set(partition_keys)
+
+            assert target_asset_partitions[2]["assetKey"] == {"path": ["asset3"]}
+            assert target_asset_partitions[2]["partitionRanges"] == None
+            assert target_asset_partitions[2]["partitionKeys"] == None
 
 
 def _get_backfill_data(

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -19,6 +19,8 @@ from typing import (
     cast,
 )
 
+import pendulum
+
 from dagster import (
     PartitionKeyRange,
     _check as check,
@@ -559,6 +561,23 @@ class AssetBackfillData(NamedTuple):
             ),
         }
         return json.dumps(storage_dict)
+
+
+def create_asset_backfill_data_from_asset_partitions(
+    asset_graph: ExternalAssetGraph,
+    asset_selection: Sequence[AssetKey],
+    partition_names: Sequence[str],
+    dynamic_partitions_store: DynamicPartitionsStore,
+) -> AssetBackfillData:
+    backfill_timestamp = pendulum.now("UTC").timestamp()
+    return AssetBackfillData.from_asset_partitions(
+        asset_graph=asset_graph,
+        partition_names=partition_names,
+        asset_selection=asset_selection,
+        dynamic_partitions_store=dynamic_partitions_store,
+        all_partitions=False,
+        backfill_start_time=utc_datetime_from_timestamp(backfill_timestamp),
+    )
 
 
 def _get_unloadable_location_names(context: IWorkspace, logger: logging.Logger) -> Sequence[str]:


### PR DESCRIPTION
This PR adds a `assetBackfillPreview` resolver that supports fetching the asset partitions that would be targeted by a given asset backfill.

Params accepted:
- Asset selection
- Partition names of the root partitioned assets

Returns a list of `GrapheneAssetPartitions`, each of which contains:
- Asset key
- Either a set of partition keys in the default partition case, or a list of partition ranges in the time partitioned case

I tested this function's performance on the [large time partitioned graph](https://github.com/dagster-io/dagster/blob/master/python_modules/dagster-test/dagster_test/toys/auto_materializing/large_graph.py) with 300+ assets and hundreds of thousands of partitions. It took around 15s, which I think is reasonable, but it would be good to ensure that this query can be called independently so other page content won't be blocked.