### PR TITLE
add missing libraries to make sanity_check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ sanity_check:
 #NOTE:  fails on nonPOSIX-compliant shells (e.g. CMD, powershell)
 #NOTE:  dagster-hex is an external package
 	@echo Checking for prod installs - if any are listed below reinstall with 'pip -e'
-	@! (pip list --exclude-editable | grep -e dagster | grep -v dagster-hex)
+	@! (pip list --exclude-editable | grep -e dagster | grep -v dagster-hex | grep -v dagster-hightouch)
 
 rebuild_ui: sanity_check
 	cd js_modules/dagster-ui/; yarn install && yarn build


### PR DESCRIPTION
Summary:
Without these the command fails and installs these dependencies from pypi.

Test Plan: make dev_install

## Summary & Motivation

## How I Tested These Changes
