### PR TITLE
[auto-materialize] Allow updated testing framework to run the AssetDaemon internally

### DIFF
--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
@@ -1,4 +1,5 @@
 import datetime
+import hashlib
 import logging
 import os
 import sys
@@ -14,7 +15,6 @@ from typing import (
 )
 
 import dagster._check as check
-from dagster._core.definitions.executor_definition import in_process_executor
 import pendulum
 from dagster import (
     AssetKey,
@@ -39,6 +39,7 @@ from dagster._core.definitions.auto_materialize_rule import (
     AutoMaterializeRuleEvaluationData,
 )
 from dagster._core.definitions.events import CoercibleToAssetKey
+from dagster._core.definitions.executor_definition import in_process_executor
 from dagster._core.host_representation.origin import InProcessCodeLocationOrigin
 from dagster._core.storage.dagster_run import RunsFilter
 from dagster._core.storage.tags import PARTITION_NAME_TAG
@@ -48,7 +49,6 @@ from dagster._core.test_utils import (
 )
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._daemon.asset_daemon import CURSOR_KEY, AssetDaemon
-import hashlib
 
 from .base_scenario import run_request
 
@@ -59,7 +59,6 @@ def get_code_location_origin(
     """Hacky method to allow us to point a code location at a module-scoped attribute, even though
     the attribute is not defined until the scenario is run.
     """
-
     attribute_name = (
         f"_asset_daemon_target_{hashlib.md5(str(scenario_state.asset_specs).encode()).hexdigest()}"
     )

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
@@ -59,7 +59,7 @@ from dagster._core.definitions.auto_materialize_rule import (
     AutoMaterializeRuleEvaluationData,
 )
 from dagster._core.definitions.data_version import DataVersionsByPartition
-from dagster._core.definitions.events import AssetKeyPartitionKey
+from dagster._core.definitions.events import AssetKeyPartitionKey, CoercibleToAssetKey
 from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
 from dagster._core.definitions.observe import observe
@@ -592,9 +592,11 @@ def run(
     )
 
 
-def run_request(asset_keys: List[str], partition_key: Optional[str] = None) -> RunRequest:
+def run_request(
+    asset_keys: Sequence[CoercibleToAssetKey], partition_key: Optional[str] = None
+) -> RunRequest:
     return RunRequest(
-        asset_selection=[AssetKey(key) for key in asset_keys],
+        asset_selection=[AssetKey.from_coercible(key) for key in asset_keys],
         partition_key=partition_key,
     )
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_scenarios.py
@@ -1,4 +1,7 @@
 import pytest
+from dagster._core.instance import DagsterInstance
+from dagster._core.instance_for_test import instance_for_test
+from dagster._daemon.asset_daemon import set_auto_materialize_paused
 
 from .asset_daemon_scenario import AssetDaemonScenario
 from .updated_scenarios.basic_scenarios import basic_scenarios
@@ -6,6 +9,25 @@ from .updated_scenarios.basic_scenarios import basic_scenarios
 all_scenarios = basic_scenarios
 
 
+@pytest.fixture
+def daemon_instance():
+    with instance_for_test(
+        overrides={
+            "run_launcher": {
+                "module": "dagster._core.launcher.sync_in_memory_run_launcher",
+                "class": "SyncInMemoryRunLauncher",
+            }
+        }
+    ) as the_instance:
+        set_auto_materialize_paused(the_instance, False)
+        yield the_instance
+
+
 @pytest.mark.parametrize("scenario", all_scenarios, ids=[scenario.id for scenario in all_scenarios])
-def test_scenario(scenario: AssetDaemonScenario) -> None:
-    scenario.evaluate()
+def test_scenario_fast(scenario: AssetDaemonScenario) -> None:
+    scenario.evaluate_fast()
+
+
+@pytest.mark.parametrize("scenario", all_scenarios, ids=[scenario.id for scenario in all_scenarios])
+def test_scenario_daemon(scenario: AssetDaemonScenario, daemon_instance: DagsterInstance) -> None:
+    scenario.evaluate_daemon(daemon_instance)


### PR DESCRIPTION
## Summary & Motivation

We typically have two modes of testing for the logic. The first is purely testing the logic (`test_asset_daemon_fast.py`), and the second is a more "authentic" test (`test_asset_daemon.py`).

Typically, in local development, you'd only run the fast tests, which don't require invoking heavier daemon machinery, as this will catch almost all errors. However, you'd still want to make sure that a full end to end test of the daemon machinery happens in CI/CD.

Note: the current suite of tests runs in ~3 seconds in the "fast" mode, but ~55 seconds in the "daemon" mode.

This also fixes an issue with the previous framework which made it impossible to test the daemon against scenarios where the asset graph changed between ticks, which is a key advantage of this new format (as it's now much easier to mutate the graph within the context of a scenario). It does this with a hacky function that elevates values into the module scope so that they can be picked up as code locations.

Previously, the testing framework would have a single asset graph per scenario (don't be fooled by definition_change_scenarios.py, this didn't actually function correctly), and this would remain static.

We do some massaging to make sure that `evaluate_tick()` ends up setting the same values regardless of if you're calling it from a daemon context or a "fast" context, meaning all the same assertions can happen regardless of how this was executed.

## How I Tested These Changes
