### PR TITLE
fix issue when partition outside of def materialized during backfill

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
@@ -313,6 +313,9 @@ class TimeWindowPartitionMapping(
         This method covers a set of easy cases where these operations aren't required. It returns
         None if the mapping doesn't fit into any of these cases.
         """
+        if from_partitions_subset.is_empty:
+            return UpstreamPartitionsResult(to_partitions_def.empty_subset(), [])
+
         if start_offset != 0 or end_offset != 0:
             return None
 

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -1442,7 +1442,18 @@ class TimeWindowPartitionsSubset(PartitionsSubset):
                 next(iter(self._included_partition_keys))
             )
         else:
+            if len(self.included_time_windows) == 0:
+                check.failed(
+                    f"Empty subset. self._included_partition_keys: {self._included_partition_keys}"
+                )
             return self.included_time_windows[0].start
+
+    @property
+    def is_empty(self) -> bool:
+        if self._included_partition_keys is not None:
+            return len(self._included_partition_keys) == 0
+        else:
+            return len(self.included_time_windows) == 0
 
     def cheap_ends_before(self, dt: datetime, dt_cron_schedule: str) -> bool:
         """Performs a cheap calculation that checks whether the latest window in this subset ends

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -599,6 +599,7 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
                         )
                     ]
                 )
+
                 for child in self.asset_graph.get_children(asset_key):
                     child_partitions_def = self.asset_graph.get_partitions_def(child)
                     if child not in target_asset_keys:


### PR DESCRIPTION
## Summary & Motivation

A user hit the error included below.

Diagnosis:
- The PartitionMapping perf changes made it so that we raise an error when trying to map from an empty set of partitions.
- It turns out that the backfill code sometimes tries to map from an empty set of partitions.
- This occurs when new partitions pop into existence since the start of the backfill, and those partitions are materialized  in an upstream asset during the backfill

Fix: don't raise an raise an error when trying to map from an empty set of partitions

```
IndexError: list index out of range
  File "/dagster/dagster/_daemon/backfill.py", line 34, in execute_backfill_iteration
    yield from execute_asset_backfill_iteration(
  File "/dagster/dagster/_core/execution/asset_backfill.py", line 764, in execute_asset_backfill_iteration
    for result in execute_asset_backfill_iteration_inner(
  File "/dagster/dagster/_core/execution/asset_backfill.py", line 1102, in execute_asset_backfill_iteration_inner
    ) = instance_queryer.asset_partitions_with_newly_updated_parents_and_new_latest_storage_id(
  File "/dagster/dagster/_utils/caching_instance_queryer.py", line 614, in asset_partitions_with_newly_updated_parents_and_new_latest_storage_id
    partition_mapping.get_downstream_partitions_for_partitions(
  File "/dagster/dagster/_core/definitions/time_window_partition_mapping.py", line 138, in get_downstream_partitions_for_partitions
    return self._map_partitions(
  File "/dagster/dagster/_core/definitions/time_window_partition_mapping.py", line 187, in _map_partitions
    result = self._do_cheap_partition_mapping_if_possible(
  File "/dagster/dagster/_core/definitions/time_window_partition_mapping.py", line 328, in _do_cheap_partition_mapping_if_possible
    or from_partitions_subset.first_start >= to_partitions_def.start
  File "/dagster/dagster/_core/definitions/time_window_partitions.py", line 1445, in first_start
    return self.included_time_windows[0].start
```

## How I Tested These Changes
- Added a test
- Did a dry-run of the backfill tick on the user backfill in Cloud and verified that it fixed the issue