### PR TITLE
add partition_keys property to context

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -317,8 +317,6 @@ class OpExecutionContext(AbstractComputeExecutionContext, metaclass=OpExecutionC
         you can use ``partition_keys`` to get all of the partitions being materialized
         by the backfill.
 
-        Raises an error if the asset is a multi-asset. In a multi-asset, use ``asset_partition_keys_for_output``
-
         Examples:
             .. code-block:: python
 
@@ -331,25 +329,12 @@ class OpExecutionContext(AbstractComputeExecutionContext, metaclass=OpExecutionC
 
                 # running a backfill of the 2023-08-21 through 2023-08-25 partitions of this asset will log:
                 #   ["2023-08-21", "2023-08-22", "2023-08-23", "2023-08-24", "2023-08-25"]
-
-
-                @asset(
-                    partitions_def=partitions_def,
-                    ins={
-                        "self_dependent_asset": AssetIn(partition_mapping=TimeWindowPartitionMapping(start_offset=-1, end_offset=-1))
-                    }
-                )
-                def self_dependent_asset(context: AssetExecutionContext, self_dependent_asset):
-                    context.log.info(context.partition_keys)
-
-                # running a backfill of the 2023-08-21 through 2023-08-25 partitions of this asset will log:
-                #   ["2023-08-21", "2023-08-22", "2023-08-23", "2023-08-24", "2023-08-25"]
         """
         key_range = self.partition_key_range
         partitions_def = self.assets_def.partitions_def
         if partitions_def is None:
             raise DagsterInvariantViolationError(
-                "Cannot access partition_key for a non-partitioned run"
+                "Cannot access partition_keys for a non-partitioned run"
             )
 
         return partitions_def.get_partition_keys_in_range(

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
@@ -604,6 +604,7 @@ def test_partition_range_single_run():
             partitions_def.time_window_for_partition_key(key_range.start).start,
             partitions_def.time_window_for_partition_key(key_range.end).end,
         )
+        assert context.partition_keys == partitions_def.get_partition_keys_in_range(key_range)
 
     @asset(partitions_def=partitions_def, deps=["upstream_asset"])
     def downstream_asset(context) -> None:


### PR DESCRIPTION
## Summary & Motivation
`context.partition_keys` is mentioned in the backfill docs, but doesn't exist on `OpExecutionContext`. This adds the method

## How I Tested These Changes

is there a specific file where the partition methods on the context are tested? otherwise I'll put something in `test_partitioned_assets.py`