### PR TITLE
[auto-materialize] Faster time window partition validation

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/data_time.py
+++ b/python_modules/dagster/dagster/_core/definitions/data_time.py
@@ -84,7 +84,7 @@ class CachingDataTimeResolver:
         partition_subset = partitions_def.empty_subset().with_partition_keys(
             partition_key
             for partition_key in self._instance_queryer.get_materialized_partitions(asset_key)
-            if partitions_def.is_valid_partition_key(partition_key)
+            if partitions_def.has_partition_key(partition_key)
         )
 
         if not isinstance(partition_subset, TimeWindowPartitionsSubset):
@@ -122,7 +122,7 @@ class CachingDataTimeResolver:
         net_new_partitions = {
             partition_key
             for partition_key in (partitions - prev_partitions)
-            if partitions_def.is_valid_partition_key(partition_key)
+            if partitions_def.has_partition_key(partition_key)
         }
 
         # there are new materializations, but they don't fill any new partitions

--- a/python_modules/dagster/dagster/_core/definitions/data_time.py
+++ b/python_modules/dagster/dagster/_core/definitions/data_time.py
@@ -84,7 +84,9 @@ class CachingDataTimeResolver:
         partition_subset = partitions_def.empty_subset().with_partition_keys(
             partition_key
             for partition_key in self._instance_queryer.get_materialized_partitions(asset_key)
-            if partitions_def.has_partition_key(partition_key)
+            if partitions_def.has_partition_key(
+                partition_key, current_time=self._instance_queryer.evaluation_time
+            )
         )
 
         if not isinstance(partition_subset, TimeWindowPartitionsSubset):
@@ -122,7 +124,9 @@ class CachingDataTimeResolver:
         net_new_partitions = {
             partition_key
             for partition_key in (partitions - prev_partitions)
-            if partitions_def.has_partition_key(partition_key)
+            if partitions_def.has_partition_key(
+                partition_key, current_time=self._instance_queryer.evaluation_time
+            )
         }
 
         # there are new materializations, but they don't fill any new partitions

--- a/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
+++ b/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
@@ -30,6 +30,7 @@ from dagster._core.storage.tags import (
 from dagster._serdes import whitelist_for_serdes
 from dagster._serdes.errors import DeserializationError
 from dagster._serdes.serdes import deserialize_value
+import pendulum
 
 if TYPE_CHECKING:
     from dagster._core.storage.event_log.base import AssetRecord
@@ -214,7 +215,12 @@ def get_validated_partition_keys(
     else:
         if not isinstance(partitions_def, TimeWindowPartitionsDefinition):
             check.failed("Unexpected partitions definition type {partitions_def}")
-        validated_partitions = {pk for pk in partition_keys if partitions_def.has_partition_key(pk)}
+        current_time = pendulum.now("UTC")
+        validated_partitions = {
+            pk
+            for pk in partition_keys
+            if partitions_def.has_partition_key(pk, current_time=current_time)
+        }
     return validated_partitions
 
 

--- a/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
+++ b/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
@@ -214,9 +214,7 @@ def get_validated_partition_keys(
     else:
         if not isinstance(partitions_def, TimeWindowPartitionsDefinition):
             check.failed("Unexpected partitions definition type {partitions_def}")
-        validated_partitions = {
-            pk for pk in partition_keys if partitions_def.is_valid_partition_key(pk)
-        }
+        validated_partitions = {pk for pk in partition_keys if partitions_def.has_partition_key(pk)}
     return validated_partitions
 
 

--- a/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
+++ b/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
@@ -1,6 +1,8 @@
 from enum import Enum
 from typing import TYPE_CHECKING, Dict, List, NamedTuple, Optional, Sequence, Set, Tuple
 
+import pendulum
+
 from dagster import (
     AssetKey,
     DagsterEventType,
@@ -30,7 +32,6 @@ from dagster._core.storage.tags import (
 from dagster._serdes import whitelist_for_serdes
 from dagster._serdes.errors import DeserializationError
 from dagster._serdes.serdes import deserialize_value
-import pendulum
 
 if TYPE_CHECKING:
     from dagster._core.storage.event_log.base import AssetRecord

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
@@ -1178,9 +1178,7 @@ def test_external_time_window_valid_partition_key():
 
     external_partitions_def = external_time_window_partitions_definition_from_def(hourly_partition)
     assert (
-        external_partitions_def.get_partitions_definition().is_valid_partition_key(
-            "2023-03-11-15:00"
-        )
+        external_partitions_def.get_partitions_definition().has_partition_key("2023-03-11-15:00")
         is True
     )
     assert (


### PR DESCRIPTION
## Summary & Motivation

Two simple changes here, aimed at addressing: https://github.com/dagster-io/dagster/issues/17429

1. Remove the `_get_validated_time_window_for_partition_key `method, as this was only used in the context of the `has_partition_key` method, and neither the body of that function nor the caller actually accessed the end time for the validated time window. Instead, just compute the start time for the partition window (much faster in simple cases), and run it through the same validation steps.
2. When we call `.empty_subset().with_partition_keys()`, stick with the in-memory format of a list of partition key strings, rather than doing the expensive conversion process immediately.

I also removed the `is_valid_partition_key` method, as this is essentially just an outdated version of `has_partition_key` (and does not actually catch all the cases that `has_partition_key` does, e.g. it does not consider the end_date of a time partitions def)

## How I Tested These Changes
