### PR TITLE
[auto-materialize] Add MaterializeOnCronRule

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -577,6 +577,7 @@ class AssetDaemonContext:
                 ],
                 observe_request_timestamp=observe_request_timestamp,
                 evaluations=list(evaluations_by_asset_key.values()),
+                evaluation_time=self.instance_queryer.evaluation_time,
             ),
             # only record evaluations where something changed
             [

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
@@ -300,6 +300,7 @@ class AssetDaemonCursor(NamedTuple):
                     key.to_user_string(): serialize_value(evaluation)
                     for key, evaluation in self.latest_evaluation_by_asset_key.items()
                 },
+                "latest_evaluation_timestamp": self.latest_evaluation_timestamp,
             }
         )
         return serialized

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
@@ -59,6 +59,7 @@ class AssetDaemonCursor(NamedTuple):
     evaluation_id: int
     last_observe_request_timestamp_by_asset_key: Mapping[AssetKey, float]
     latest_evaluation_by_asset_key: Mapping[AssetKey, AutoMaterializeAssetEvaluation]
+    latest_evaluation_timestamp: float
 
     def was_previously_handled(self, asset_key: AssetKey) -> bool:
         return asset_key in self.handled_root_asset_keys
@@ -93,6 +94,7 @@ class AssetDaemonCursor(NamedTuple):
         newly_observe_requested_asset_keys: Sequence[AssetKey],
         observe_request_timestamp: float,
         evaluations: Sequence[AutoMaterializeAssetEvaluation],
+        evaluation_time: datetime.datetime,
     ) -> "AssetDaemonCursor":
         """Returns a cursor that represents this cursor plus the updates that have happened within the
         tick.
@@ -164,6 +166,7 @@ class AssetDaemonCursor(NamedTuple):
             evaluation_id=evaluation_id,
             last_observe_request_timestamp_by_asset_key=result_last_observe_request_timestamp_by_asset_key,
             latest_evaluation_by_asset_key=latest_evaluation_by_asset_key,
+            latest_evaluation_timestamp=evaluation_time.timestamp(),
         )
 
     @classmethod
@@ -175,6 +178,7 @@ class AssetDaemonCursor(NamedTuple):
             evaluation_id=0,
             last_observe_request_timestamp_by_asset_key={},
             latest_evaluation_by_asset_key={},
+            latest_evaluation_timestamp=0,
         )
 
     @classmethod
@@ -192,6 +196,7 @@ class AssetDaemonCursor(NamedTuple):
             evaluation_id = data[3] if len(data) == 4 else 0
             serialized_last_observe_request_timestamp_by_asset_key = {}
             serialized_latest_evaluation_by_asset_key = {}
+            latest_evaluation_timestamp = 0
         else:
             latest_storage_id = data["latest_storage_id"]
             serialized_handled_root_asset_keys = data["handled_root_asset_keys"]
@@ -205,6 +210,7 @@ class AssetDaemonCursor(NamedTuple):
             serialized_latest_evaluation_by_asset_key = data.get(
                 "latest_evaluation_by_asset_key", {}
             )
+            latest_evaluation_timestamp = data.get("latest_evaluation_timestamp", 0)
 
         handled_root_partitions_by_asset_key = {}
         for (
@@ -259,6 +265,7 @@ class AssetDaemonCursor(NamedTuple):
                 for key_str, timestamp in serialized_last_observe_request_timestamp_by_asset_key.items()
             },
             latest_evaluation_by_asset_key=latest_evaluation_by_asset_key,
+            latest_evaluation_timestamp=latest_evaluation_timestamp,
         )
 
     @classmethod

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
@@ -59,7 +59,7 @@ class AssetDaemonCursor(NamedTuple):
     evaluation_id: int
     last_observe_request_timestamp_by_asset_key: Mapping[AssetKey, float]
     latest_evaluation_by_asset_key: Mapping[AssetKey, AutoMaterializeAssetEvaluation]
-    latest_evaluation_timestamp: float
+    latest_evaluation_timestamp: Optional[float]
 
     def was_previously_handled(self, asset_key: AssetKey) -> bool:
         return asset_key in self.handled_root_asset_keys
@@ -178,7 +178,7 @@ class AssetDaemonCursor(NamedTuple):
             evaluation_id=0,
             last_observe_request_timestamp_by_asset_key={},
             latest_evaluation_by_asset_key={},
-            latest_evaluation_timestamp=0,
+            latest_evaluation_timestamp=None,
         )
 
     @classmethod

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -541,6 +541,7 @@ class MaterializeOnCronRule(
             )
         )
 
+        asset_partitions = set()
         if current_cron_schedule_tick != previous_cron_schedule_tick:
             partitions_def = context.asset_graph.get_partitions_def(context.asset_key)
             if partitions_def is not None:
@@ -552,22 +553,19 @@ class MaterializeOnCronRule(
                         )
                     }
                 else:
-                    asset_partitions = {
-                        AssetKeyPartitionKey(
-                            context.asset_key,
-                            partitions_def.get_last_partition_key(
-                                current_time=context.evaluation_time
-                            ),
-                        )
-                    }
+                    last_partition_key = partitions_def.get_last_partition_key(
+                        current_time=context.evaluation_time
+                    )
+                    if last_partition_key is not None:
+                        asset_partitions = {
+                            AssetKeyPartitionKey(context.asset_key, last_partition_key)
+                        }
             else:
                 asset_partitions = {AssetKeyPartitionKey(context.asset_key, None)}
-        else:
-            asset_partitions = set()
 
         return self.add_evaluation_data_from_previous_tick(
             context,
-            # TODO
+            # TODO: better evaluation data
             {TextRuleEvaluationData(text=self.cron_schedule): asset_partitions}
             if asset_partitions
             else {},

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -387,7 +387,7 @@ class AutoMaterializeRule(ABC):
     def materialize_on_cron(
         cron_schedule: str, timezone: str = "UTC", all_partitions: bool = False
     ) -> "MaterializeOnCronRule":
-        """Materialize an asset partition if it has not been materialized since the previous cron
+        """Materialize an asset partition if it has not been materialized since the latest cron
         schedule tick. For assets with a time component to their partitions_def, this rule will
         request all partitions that have been missed since the previous tick.
 
@@ -622,10 +622,7 @@ class MaterializeOnCronRule(
         asset_partitions_to_request = self.get_asset_partitions_to_request(context)
         asset_partitions_by_evaluation_data = defaultdict(set)
         if asset_partitions_to_request:
-            # TODO: better evaluation data
-            asset_partitions_by_evaluation_data[TextRuleEvaluationData(self.cron_schedule)].update(
-                asset_partitions_to_request
-            )
+            asset_partitions_by_evaluation_data[None].update(asset_partitions_to_request)
         return self.add_evaluation_data_from_previous_tick(
             context,
             asset_partitions_by_evaluation_data,

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -19,6 +19,8 @@ from typing import (
     cast,
 )
 
+import pytz
+
 import dagster._check as check
 from dagster._annotations import public
 from dagster._core.definitions.data_time import CachingDataTimeResolver
@@ -38,8 +40,11 @@ from dagster._serdes.serdes import (
     whitelist_for_serdes,
 )
 from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
-from dagster._utils.schedules import cron_string_iterator, is_valid_cron_string, reverse_cron_string_iterator
-import pytz
+from dagster._utils.schedules import (
+    cron_string_iterator,
+    is_valid_cron_string,
+    reverse_cron_string_iterator,
+)
 
 from .asset_graph import AssetGraph, sort_key_for_asset_partition
 from .partition import SerializedPartitionsSubset
@@ -396,8 +401,12 @@ class AutoMaterializeRule(ABC):
                 Defaults to False.
 
         """
-        check.param_invariant(is_valid_cron_string(cron_schedule), "cron_schedule", "must be a valid cron string")
-        check.param_invariant(timezone in pytz.all_timezones_set, "timezone", "must be a valid timezone")
+        check.param_invariant(
+            is_valid_cron_string(cron_schedule), "cron_schedule", "must be a valid cron string"
+        )
+        check.param_invariant(
+            timezone in pytz.all_timezones_set, "timezone", "must be a valid timezone"
+        )
         return MaterializeOnCronRule(
             cron_schedule=cron_schedule, timezone=timezone, all_partitions=all_partitions
         )
@@ -559,7 +568,6 @@ class MaterializeOnCronRule(
         self, context: RuleEvaluationContext
     ) -> AbstractSet[AssetKeyPartitionKey]:
         missed_ticks = self.missed_cron_ticks(context)
-        print("MISSED", missed_ticks)
 
         if not missed_ticks:
             return set()

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -1,4 +1,3 @@
-from audioop import reverse
 import datetime
 import functools
 from abc import ABC, abstractmethod, abstractproperty
@@ -11,7 +10,6 @@ from typing import (
     Callable,
     Dict,
     FrozenSet,
-    Iterator,
     Mapping,
     NamedTuple,
     Optional,
@@ -20,7 +18,6 @@ from typing import (
     Tuple,
     cast,
 )
-from dagster._core.definitions.time_window_partitions import get_time_partitions_def
 
 import dagster._check as check
 from dagster._annotations import public
@@ -29,9 +26,10 @@ from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
 from dagster._core.definitions.freshness_based_auto_materialize import (
     freshness_evaluation_results_for_asset_key,
 )
-from dagster._core.definitions.partition_mapping import IdentityPartitionMapping
 from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionsDefinition
+from dagster._core.definitions.partition_mapping import IdentityPartitionMapping
 from dagster._core.definitions.time_window_partition_mapping import TimeWindowPartitionMapping
+from dagster._core.definitions.time_window_partitions import get_time_partitions_def
 from dagster._serdes.serdes import (
     NamedTupleSerializer,
     UnpackContext,
@@ -534,7 +532,7 @@ class MaterializeOnCronRule(
         return str(self)
 
     def missed_cron_ticks(self, context: RuleEvaluationContext) -> Sequence[datetime.datetime]:
-        """Returns the cron ticks which have been missed since the previous tick"""
+        """Returns the cron ticks which have been missed since the previous cursor was generated."""
         if not context.cursor.latest_evaluation_timestamp:
             previous_dt = next(
                 reverse_cron_string_iterator(

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -399,8 +399,11 @@ class AutoMaterializeRule(ABC):
     @public
     @staticmethod
     def materialize_on_parent_updated() -> "MaterializeOnParentUpdatedRule":
-        """Materialize an asset partition if it has not been materialized since the previous
-        cron schedule tick.
+        """Materialize an asset partition if one of its parents has been updated more recently
+        than it has.
+
+        Note: For time-partitioned or dynamic-partitioned assets downstream of an unpartitioned
+        asset, this rule will only fire for the most recent partition of the downstream.
         """
         return MaterializeOnParentUpdatedRule()
 

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -399,7 +399,6 @@ class AutoMaterializeRule(ABC):
             all_partitions (bool): If True, this rule fires for all partitions of this asset on each
                 cron tick. If False, this rule fires only for the last partition of this asset.
                 Defaults to False.
-
         """
         check.param_invariant(
             is_valid_cron_string(cron_schedule), "cron_schedule", "must be a valid cron string"

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -392,7 +392,7 @@ class AutoMaterializeRule(ABC):
         request all partitions that have been missed since the previous tick.
 
         Args:
-            cron_schedule (str): A cron schedule string (e.g. "0 * * * *") indicating the ticks for
+            cron_schedule (str): A cron schedule string (e.g. "`0 * * * *`") indicating the ticks for
                 which this rule should fire.
             timezone (str): The timezone in which this cron schedule should be evaluated. Defaults
                 to "UTC".

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -4,7 +4,6 @@ from abc import ABC, abstractmethod, abstractproperty
 from collections import defaultdict
 from dataclasses import dataclass
 from enum import Enum
-from dagster._utils.schedules import cron_string_iterator
 from typing import (
     TYPE_CHECKING,
     AbstractSet,
@@ -37,6 +36,7 @@ from dagster._serdes.serdes import (
     whitelist_for_serdes,
 )
 from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
+from dagster._utils.schedules import cron_string_iterator
 
 from .asset_graph import AssetGraph, sort_key_for_asset_partition
 from .partition import SerializedPartitionsSubset

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -381,6 +381,14 @@ class AutoMaterializeRule(ABC):
 
     @public
     @staticmethod
+    def materialize_on_parent_updated() -> "MaterializeOnParentUpdatedRule":
+        """Materialize an asset partition if it has not been materialized since the previous
+        cron schedule tick.
+        """
+        return MaterializeOnParentUpdatedRule()
+
+    @public
+    @staticmethod
     def materialize_on_missing() -> "MaterializeOnMissingRule":
         """Materialize an asset partition if it has never been materialized before. This rule will
         not fire for non-root assets unless that asset's parents have been updated.

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
@@ -17,6 +17,8 @@ from typing import (
 )
 
 import dagster._check as check
+from dagster._core.definitions.executor_definition import in_process_executor
+from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
 import pendulum
 from dagster import (
     AssetKey,
@@ -50,6 +52,7 @@ from dagster._core.test_utils import (
     create_test_daemon_workspace_context,
 )
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
+import hashlib
 from dagster._daemon.asset_daemon import CURSOR_KEY, AssetDaemon
 
 from .base_scenario import run_request

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
@@ -17,8 +17,6 @@ from typing import (
 )
 
 import dagster._check as check
-from dagster._core.definitions.executor_definition import in_process_executor
-from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
 import pendulum
 from dagster import (
     AssetKey,
@@ -52,7 +50,6 @@ from dagster._core.test_utils import (
     create_test_daemon_workspace_context,
 )
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
-import hashlib
 from dagster._daemon.asset_daemon import CURSOR_KEY, AssetDaemon
 
 from .base_scenario import run_request

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_cursor.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_cursor.py
@@ -3,6 +3,7 @@ import json
 from dagster import AssetKey, StaticPartitionsDefinition, asset
 from dagster._core.definitions.asset_daemon_cursor import AssetDaemonCursor
 from dagster._core.definitions.asset_graph import AssetGraph
+import datetime
 
 partitions = StaticPartitionsDefinition(partition_keys=["a", "b", "c"])
 
@@ -12,7 +13,7 @@ def my_asset(_):
     pass
 
 
-def test_asset_reconciliation_cursor_evaluation_id_backcompat():
+def test_asset_reconciliation_cursor_evaluation_id_backcompat() -> None:
     backcompat_serialized = (
         """[20, ["a"], {"my_asset": "{\\"version\\": 1, \\"subset\\": [\\"a\\"]}"}]"""
     )
@@ -29,6 +30,7 @@ def test_asset_reconciliation_cursor_evaluation_id_backcompat():
         0,
         {},
         {},
+        0,
     )
 
     c2 = c.with_updates(
@@ -42,6 +44,7 @@ def test_asset_reconciliation_cursor_evaluation_id_backcompat():
         [],
         0,
         [],
+        datetime.datetime.now(),
     )
 
     serdes_c2 = AssetDaemonCursor.from_serialized(c2.serialize(), asset_graph)

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_cursor.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_cursor.py
@@ -1,9 +1,9 @@
+import datetime
 import json
 
 from dagster import AssetKey, StaticPartitionsDefinition, asset
 from dagster._core.definitions.asset_daemon_cursor import AssetDaemonCursor
 from dagster._core.definitions.asset_graph import AssetGraph
-import datetime
 
 partitions = StaticPartitionsDefinition(partition_keys=["a", "b", "c"])
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_scenarios.py
@@ -1,4 +1,5 @@
 import pytest
+from dagster import DagsterInstance
 from dagster._core.instance_for_test import instance_for_test
 from dagster._daemon.asset_daemon import set_auto_materialize_paused
 
@@ -29,8 +30,6 @@ def test_scenario_fast(scenario: AssetDaemonScenario) -> None:
     scenario.evaluate_fast()
 
 
-"""
 @pytest.mark.parametrize("scenario", all_scenarios, ids=[scenario.id for scenario in all_scenarios])
 def test_scenario_daemon(scenario: AssetDaemonScenario, daemon_instance: DagsterInstance) -> None:
     scenario.evaluate_daemon(daemon_instance)
-"""

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_scenarios.py
@@ -1,12 +1,11 @@
 import pytest
-from dagster._core.instance import DagsterInstance
 from dagster._core.instance_for_test import instance_for_test
 from dagster._daemon.asset_daemon import set_auto_materialize_paused
 
 from .asset_daemon_scenario import AssetDaemonScenario
 from .updated_scenarios.basic_scenarios import basic_scenarios
-from .updated_scenarios.partition_scenarios import partition_scenarios
 from .updated_scenarios.cron_scenarios import cron_scenarios
+from .updated_scenarios.partition_scenarios import partition_scenarios
 
 all_scenarios = basic_scenarios + partition_scenarios + cron_scenarios
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_scenarios.py
@@ -6,8 +6,9 @@ from dagster._daemon.asset_daemon import set_auto_materialize_paused
 from .asset_daemon_scenario import AssetDaemonScenario
 from .updated_scenarios.basic_scenarios import basic_scenarios
 from .updated_scenarios.partition_scenarios import partition_scenarios
+from .updated_scenarios.cron_scenarios import cron_scenarios
 
-all_scenarios = basic_scenarios + partition_scenarios
+all_scenarios = basic_scenarios + partition_scenarios + cron_scenarios
 
 
 @pytest.fixture
@@ -29,6 +30,8 @@ def test_scenario_fast(scenario: AssetDaemonScenario) -> None:
     scenario.evaluate_fast()
 
 
+"""
 @pytest.mark.parametrize("scenario", all_scenarios, ids=[scenario.id for scenario in all_scenarios])
 def test_scenario_daemon(scenario: AssetDaemonScenario, daemon_instance: DagsterInstance) -> None:
     scenario.evaluate_daemon(daemon_instance)
+"""

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/cron_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/cron_scenarios.py
@@ -35,16 +35,22 @@ cron_scenarios = [
         .assert_requested_runs(run_request(["A"]))
         .assert_evaluation("A", [AssetRuleEvaluationSpec(basic_hourly_cron_rule)])
         # next tick should not request any more runs
-        .with_current_time_advanced(seconds=30).evaluate_tick().assert_requested_runs()
+        .with_current_time_advanced(seconds=30)
+        .evaluate_tick()
+        .assert_requested_runs()
         # still no runs should be requested
-        .with_current_time_advanced(minutes=50).evaluate_tick().assert_requested_runs()
+        .with_current_time_advanced(minutes=50)
+        .evaluate_tick()
+        .assert_requested_runs()
         # moved to a new cron schedule tick, request another run
         .with_current_time_advanced(minutes=10)
         .evaluate_tick()
         .assert_requested_runs(run_request(["A"]))
         .assert_evaluation("A", [AssetRuleEvaluationSpec(basic_hourly_cron_rule)])
         # next tick should not request any more runs
-        .with_current_time_advanced(seconds=30).evaluate_tick().assert_requested_runs(),
+        .with_current_time_advanced(seconds=30)
+        .evaluate_tick()
+        .assert_requested_runs(),
     ),
     AssetDaemonScenario(
         id="basic_hourly_cron_partitioned",
@@ -65,9 +71,13 @@ cron_scenarios = [
             ],
         )
         # next tick should not request any more runs
-        .with_current_time_advanced(seconds=30).evaluate_tick().assert_requested_runs()
+        .with_current_time_advanced(seconds=30)
+        .evaluate_tick()
+        .assert_requested_runs()
         # still no runs should be requested
-        .with_current_time_advanced(minutes=50).evaluate_tick().assert_requested_runs()
+        .with_current_time_advanced(minutes=50)
+        .evaluate_tick()
+        .assert_requested_runs()
         # moved to a new cron schedule tick, request another run for the new partition
         .with_current_time_advanced(minutes=10)
         .evaluate_tick()
@@ -134,7 +144,9 @@ cron_scenarios = [
         .assert_requested_runs(run_request("C"))
         .assert_evaluation("C", [AssetRuleEvaluationSpec(basic_hourly_cron_rule)])
         # next tick should not request any more runs
-        .with_current_time_advanced(seconds=30).evaluate_tick().assert_requested_runs(),
+        .with_current_time_advanced(seconds=30)
+        .evaluate_tick()
+        .assert_requested_runs(),
     ),
     AssetDaemonScenario(
         id="hourly_cron_partitioned_wait_for_parents",
@@ -150,7 +162,8 @@ cron_scenarios = [
         .with_current_time(time_partitions_start),
         scenario=lambda state: state.evaluate_tick()
         # no partitions exist yet
-        .assert_requested_runs().assert_evaluation("C", [])
+        .assert_requested_runs()
+        .assert_evaluation("C", [])
         # don't materialize C because we're waiting for A and B
         .with_current_time_advanced(hours=1, minutes=5)
         .evaluate_tick()
@@ -221,7 +234,9 @@ cron_scenarios = [
             run_request("C", hour_partition_key(state.current_time, delta=3)),
         )
         # next tick should not request any more runs
-        .with_current_time_advanced(seconds=30).evaluate_tick().assert_requested_runs()
+        .with_current_time_advanced(seconds=30)
+        .evaluate_tick()
+        .assert_requested_runs()
         # now we get two new cron schedule ticks, but parents are not available for either, so we
         # keep track of both new partitions
         .with_current_time_advanced(hours=1)

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/cron_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/cron_scenarios.py
@@ -31,26 +31,20 @@ cron_scenarios = [
         initial_state=one_asset.with_asset_properties(
             auto_materialize_policy=get_cron_policy(basic_hourly_cron_rule)
         ).with_current_time("2020-01-01T00:05"),
-        scenario=lambda state: state.evaluate_tick()
+        execution_fn=lambda state: state.evaluate_tick()
         .assert_requested_runs(run_request(["A"]))
         .assert_evaluation("A", [AssetRuleEvaluationSpec(basic_hourly_cron_rule)])
         # next tick should not request any more runs
-        .with_current_time_advanced(seconds=30)
-        .evaluate_tick()
-        .assert_requested_runs()
+        .with_current_time_advanced(seconds=30).evaluate_tick().assert_requested_runs()
         # still no runs should be requested
-        .with_current_time_advanced(minutes=50)
-        .evaluate_tick()
-        .assert_requested_runs()
+        .with_current_time_advanced(minutes=50).evaluate_tick().assert_requested_runs()
         # moved to a new cron schedule tick, request another run
         .with_current_time_advanced(minutes=10)
         .evaluate_tick()
         .assert_requested_runs(run_request(["A"]))
         .assert_evaluation("A", [AssetRuleEvaluationSpec(basic_hourly_cron_rule)])
         # next tick should not request any more runs
-        .with_current_time_advanced(seconds=30)
-        .evaluate_tick()
-        .assert_requested_runs(),
+        .with_current_time_advanced(seconds=30).evaluate_tick().assert_requested_runs(),
     ),
     AssetDaemonScenario(
         id="basic_hourly_cron_partitioned",
@@ -60,7 +54,7 @@ cron_scenarios = [
         )
         .with_current_time(time_partitions_start)
         .with_current_time_advanced(days=1, minutes=5),
-        scenario=lambda state: state.evaluate_tick()
+        execution_fn=lambda state: state.evaluate_tick()
         .assert_requested_runs(run_request(["A"], hour_partition_key(state.current_time)))
         .assert_evaluation(
             "A",
@@ -71,13 +65,9 @@ cron_scenarios = [
             ],
         )
         # next tick should not request any more runs
-        .with_current_time_advanced(seconds=30)
-        .evaluate_tick()
-        .assert_requested_runs()
+        .with_current_time_advanced(seconds=30).evaluate_tick().assert_requested_runs()
         # still no runs should be requested
-        .with_current_time_advanced(minutes=50)
-        .evaluate_tick()
-        .assert_requested_runs()
+        .with_current_time_advanced(minutes=50).evaluate_tick().assert_requested_runs()
         # moved to a new cron schedule tick, request another run for the new partition
         .with_current_time_advanced(minutes=10)
         .evaluate_tick()
@@ -88,7 +78,7 @@ cron_scenarios = [
         initial_state=one_asset_depends_on_two.with_asset_properties(
             keys="C", auto_materialize_policy=get_cron_policy(basic_hourly_cron_rule)
         ).with_current_time("2020-01-01T00:05"),
-        scenario=lambda state: state.evaluate_tick()
+        execution_fn=lambda state: state.evaluate_tick()
         # don't materialize C because we're waiting for A and B
         .assert_requested_runs()
         .assert_evaluation(
@@ -144,9 +134,7 @@ cron_scenarios = [
         .assert_requested_runs(run_request("C"))
         .assert_evaluation("C", [AssetRuleEvaluationSpec(basic_hourly_cron_rule)])
         # next tick should not request any more runs
-        .with_current_time_advanced(seconds=30)
-        .evaluate_tick()
-        .assert_requested_runs(),
+        .with_current_time_advanced(seconds=30).evaluate_tick().assert_requested_runs(),
     ),
     AssetDaemonScenario(
         id="hourly_cron_partitioned_wait_for_parents",
@@ -160,10 +148,9 @@ cron_scenarios = [
             ),
         )
         .with_current_time(time_partitions_start),
-        scenario=lambda state: state.evaluate_tick()
+        execution_fn=lambda state: state.evaluate_tick()
         # no partitions exist yet
-        .assert_requested_runs()
-        .assert_evaluation("C", [])
+        .assert_requested_runs().assert_evaluation("C", [])
         # don't materialize C because we're waiting for A and B
         .with_current_time_advanced(hours=1, minutes=5)
         .evaluate_tick()
@@ -234,9 +221,7 @@ cron_scenarios = [
             run_request("C", hour_partition_key(state.current_time, delta=3)),
         )
         # next tick should not request any more runs
-        .with_current_time_advanced(seconds=30)
-        .evaluate_tick()
-        .assert_requested_runs()
+        .with_current_time_advanced(seconds=30).evaluate_tick().assert_requested_runs()
         # now we get two new cron schedule ticks, but parents are not available for either, so we
         # keep track of both new partitions
         .with_current_time_advanced(hours=1)

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/cron_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/cron_scenarios.py
@@ -1,0 +1,307 @@
+from dagster import AutoMaterializePolicy, AutoMaterializeRule
+from dagster._core.definitions.auto_materialize_rule import WaitingOnAssetsRuleEvaluationData
+
+from ..asset_daemon_scenario import AssetDaemonScenario, AssetRuleEvaluationSpec, hour_partition_key
+from ..base_scenario import run_request
+from .asset_daemon_scenario_states import (
+    hourly_partitions_def,
+    one_asset,
+    one_asset_depends_on_two,
+    time_partitions_start,
+)
+
+
+def get_cron_policy(
+    cron_rule: AutoMaterializeRule,
+    max_materializations_per_minute: int = 1,
+):
+    return AutoMaterializePolicy(
+        rules={cron_rule, AutoMaterializeRule.skip_on_not_all_parents_updated()},
+        max_materializations_per_minute=max_materializations_per_minute,
+    )
+
+
+basic_hourly_cron_rule = AutoMaterializeRule.materialize_on_cron(
+    cron_schedule="0 * * * *", timezone="UTC"
+)
+
+cron_scenarios = [
+    AssetDaemonScenario(
+        id="basic_hourly_cron_unpartitioned",
+        initial_state=one_asset.with_asset_properties(
+            auto_materialize_policy=get_cron_policy(basic_hourly_cron_rule)
+        ).with_current_time("2020-01-01T00:05"),
+        scenario=lambda state: state.evaluate_tick()
+        .assert_requested_runs(run_request(["A"]))
+        .assert_evaluation("A", [AssetRuleEvaluationSpec(basic_hourly_cron_rule)])
+        # next tick should not request any more runs
+        .with_current_time_advanced(seconds=30)
+        .evaluate_tick()
+        .assert_requested_runs()
+        # still no runs should be requested
+        .with_current_time_advanced(minutes=50)
+        .evaluate_tick()
+        .assert_requested_runs()
+        # moved to a new cron schedule tick, request another run
+        .with_current_time_advanced(minutes=10)
+        .evaluate_tick()
+        .assert_requested_runs(run_request(["A"]))
+        .assert_evaluation("A", [AssetRuleEvaluationSpec(basic_hourly_cron_rule)])
+        # next tick should not request any more runs
+        .with_current_time_advanced(seconds=30)
+        .evaluate_tick()
+        .assert_requested_runs(),
+    ),
+    AssetDaemonScenario(
+        id="basic_hourly_cron_partitioned",
+        initial_state=one_asset.with_asset_properties(
+            partitions_def=hourly_partitions_def,
+            auto_materialize_policy=get_cron_policy(basic_hourly_cron_rule),
+        )
+        .with_current_time(time_partitions_start)
+        .with_current_time_advanced(days=1, minutes=5),
+        scenario=lambda state: state.evaluate_tick()
+        .assert_requested_runs(run_request(["A"], hour_partition_key(state.current_time)))
+        .assert_evaluation(
+            "A",
+            [
+                AssetRuleEvaluationSpec(
+                    basic_hourly_cron_rule, [hour_partition_key(state.current_time)]
+                )
+            ],
+        )
+        # next tick should not request any more runs
+        .with_current_time_advanced(seconds=30)
+        .evaluate_tick()
+        .assert_requested_runs()
+        # still no runs should be requested
+        .with_current_time_advanced(minutes=50)
+        .evaluate_tick()
+        .assert_requested_runs()
+        # moved to a new cron schedule tick, request another run for the new partition
+        .with_current_time_advanced(minutes=10)
+        .evaluate_tick()
+        .assert_requested_runs(run_request(["A"], hour_partition_key(state.current_time, 1))),
+    ),
+    AssetDaemonScenario(
+        id="hourly_cron_unpartitioned_wait_for_parents",
+        initial_state=one_asset_depends_on_two.with_asset_properties(
+            keys="C", auto_materialize_policy=get_cron_policy(basic_hourly_cron_rule)
+        ).with_current_time("2020-01-01T00:05"),
+        scenario=lambda state: state.evaluate_tick()
+        # don't materialize C because we're waiting for A and B
+        .assert_requested_runs()
+        .assert_evaluation(
+            "C",
+            [
+                AssetRuleEvaluationSpec(basic_hourly_cron_rule),
+                AssetRuleEvaluationSpec(
+                    AutoMaterializeRule.skip_on_not_all_parents_updated()
+                ).with_rule_evaluation_data(
+                    WaitingOnAssetsRuleEvaluationData, waiting_on_asset_keys={"A", "B"}
+                ),
+            ],
+            num_requested=0,
+            num_skipped=1,
+        )
+        .with_runs(run_request("A"))
+        .with_current_time_advanced(seconds=30)
+        .evaluate_tick()
+        .assert_requested_runs()
+        # now just waiting on B
+        .assert_evaluation(
+            "C",
+            [
+                AssetRuleEvaluationSpec(basic_hourly_cron_rule),
+                AssetRuleEvaluationSpec(
+                    AutoMaterializeRule.skip_on_not_all_parents_updated()
+                ).with_rule_evaluation_data(
+                    WaitingOnAssetsRuleEvaluationData, waiting_on_asset_keys={"B"}
+                ),
+            ],
+            num_requested=0,
+            num_skipped=1,
+        )
+        .with_runs(run_request("B"))
+        .with_current_time_advanced(seconds=30)
+        .evaluate_tick()
+        .assert_requested_runs(run_request(["C"]))
+        .assert_evaluation("C", [AssetRuleEvaluationSpec(basic_hourly_cron_rule)])
+        # next tick should not request any more runs
+        .with_current_time_advanced(seconds=30)
+        .evaluate_tick()
+        .assert_requested_runs()
+        .assert_evaluation("C", [])
+        # even if both parents update, still on the same cron schedule tick
+        .with_runs(run_request(["A", "B"]))
+        .with_current_time_advanced(seconds=30)
+        .evaluate_tick()
+        .assert_requested_runs()
+        .assert_evaluation("C", [])
+        # moved to a new cron schedule tick, immediately request run
+        .with_current_time_advanced(minutes=60)
+        .evaluate_tick()
+        .assert_requested_runs(run_request("C"))
+        .assert_evaluation("C", [AssetRuleEvaluationSpec(basic_hourly_cron_rule)])
+        # next tick should not request any more runs
+        .with_current_time_advanced(seconds=30)
+        .evaluate_tick()
+        .assert_requested_runs(),
+    ),
+    AssetDaemonScenario(
+        id="hourly_cron_partitioned_wait_for_parents",
+        initial_state=one_asset_depends_on_two.with_asset_properties(
+            partitions_def=hourly_partitions_def,
+        )
+        .with_asset_properties(
+            keys="C", auto_materialize_policy=get_cron_policy(basic_hourly_cron_rule)
+        )
+        .with_current_time(time_partitions_start),
+        scenario=lambda state: state.evaluate_tick()
+        # no partitions exist yet
+        .assert_requested_runs()
+        .assert_evaluation("C", [])
+        # don't materialize C because we're waiting for A and B
+        .with_current_time_advanced(hours=1, minutes=5)
+        .evaluate_tick()
+        .assert_requested_runs()
+        .assert_evaluation(
+            "C",
+            [
+                AssetRuleEvaluationSpec(
+                    basic_hourly_cron_rule, [hour_partition_key(state.current_time, delta=1)]
+                ),
+                AssetRuleEvaluationSpec(
+                    AutoMaterializeRule.skip_on_not_all_parents_updated(),
+                    [hour_partition_key(state.current_time, delta=1)],
+                ).with_rule_evaluation_data(
+                    WaitingOnAssetsRuleEvaluationData, waiting_on_asset_keys={"A", "B"}
+                ),
+            ],
+            num_requested=0,
+            num_skipped=1,
+        )
+        .with_runs(run_request("A", hour_partition_key(state.current_time, delta=1)))
+        .with_current_time_advanced(seconds=30)
+        .evaluate_tick()
+        .assert_requested_runs()
+        # now just waiting on B
+        .assert_evaluation(
+            "C",
+            [
+                AssetRuleEvaluationSpec(
+                    basic_hourly_cron_rule, [hour_partition_key(state.current_time, delta=1)]
+                ),
+                AssetRuleEvaluationSpec(
+                    AutoMaterializeRule.skip_on_not_all_parents_updated(),
+                    [hour_partition_key(state.current_time, delta=1)],
+                ).with_rule_evaluation_data(
+                    WaitingOnAssetsRuleEvaluationData, waiting_on_asset_keys={"B"}
+                ),
+            ],
+            num_requested=0,
+            num_skipped=1,
+        )
+        .with_runs(run_request("B", hour_partition_key(state.current_time, delta=1)))
+        .with_current_time_advanced(seconds=30)
+        .evaluate_tick()
+        .assert_requested_runs(run_request("C", hour_partition_key(state.current_time, delta=1)))
+        .assert_evaluation(
+            "C",
+            [
+                AssetRuleEvaluationSpec(
+                    basic_hourly_cron_rule, [hour_partition_key(state.current_time, delta=1)]
+                )
+            ],
+        )
+        # next tick should not request any more runs
+        .with_current_time_advanced(seconds=30)
+        .evaluate_tick()
+        .assert_requested_runs()
+        .assert_evaluation("C", [])
+        # now 2 hours later, only materialize the latest partition even though multiple partitions
+        # have updated
+        .with_current_time_advanced(hours=2)
+        .with_runs(
+            run_request(["A", "B"], hour_partition_key(state.current_time, delta=2)),
+            run_request(["A", "B"], hour_partition_key(state.current_time, delta=3)),
+        )
+        .evaluate_tick()
+        .assert_requested_runs(run_request("C", hour_partition_key(state.current_time, delta=3)))
+        # next tick should not request any more runs
+        .with_current_time_advanced(seconds=30)
+        .evaluate_tick()
+        .assert_requested_runs()
+        # now we get two new cron schedule ticks, but parents are not available for either, so we
+        # keep track of both new partitions
+        .with_current_time_advanced(hours=1)
+        .evaluate_tick()
+        .assert_requested_runs()
+        .with_current_time_advanced(hours=1)
+        .evaluate_tick()
+        .assert_requested_runs()
+        .assert_evaluation(
+            "C",
+            [
+                AssetRuleEvaluationSpec(
+                    basic_hourly_cron_rule,
+                    [
+                        # still need to materialize both of these partitions
+                        hour_partition_key(state.current_time, delta=4),
+                        hour_partition_key(state.current_time, delta=5),
+                    ],
+                ),
+                AssetRuleEvaluationSpec(
+                    AutoMaterializeRule.skip_on_not_all_parents_updated(),
+                    [
+                        hour_partition_key(state.current_time, delta=4),
+                        hour_partition_key(state.current_time, delta=5),
+                    ],
+                ),
+            ],
+        )
+        # now an older set of parents become available, so we materialize the child of those parents
+        .with_current_time_advanced(seconds=30)
+        .with_runs(
+            run_request(["A", "B"], hour_partition_key(state.current_time, delta=4)),
+        )
+        .evaluate_tick()
+        .assert_requested_runs(run_request("C", hour_partition_key(state.current_time, delta=4)))
+        .assert_evaluation(
+            "C",
+            [
+                AssetRuleEvaluationSpec(
+                    basic_hourly_cron_rule,
+                    [
+                        hour_partition_key(state.current_time, delta=4),
+                        hour_partition_key(state.current_time, delta=5),
+                    ],
+                ),
+                AssetRuleEvaluationSpec(
+                    AutoMaterializeRule.skip_on_not_all_parents_updated(),
+                    [hour_partition_key(state.current_time, delta=5)],
+                ),
+            ],
+        )
+        # now the newer set of parents become available, so we materialize the child of those parents
+        .with_current_time_advanced(seconds=30)
+        .with_runs(
+            run_request(["A", "B"], hour_partition_key(state.current_time, delta=5)),
+        )
+        .evaluate_tick()
+        .assert_requested_runs(run_request("C", hour_partition_key(state.current_time, delta=5)))
+        .assert_evaluation(
+            "C",
+            [
+                AssetRuleEvaluationSpec(
+                    basic_hourly_cron_rule, [hour_partition_key(state.current_time, delta=5)]
+                ),
+            ],
+        )
+        # finally, no more runs should be requested
+        .with_current_time_advanced(seconds=30)
+        .evaluate_tick()
+        .assert_requested_runs()
+        .assert_evaluation("C", []),
+    ),
+]


### PR DESCRIPTION
## Summary & Motivation

Adds a rule which will attempt to materialize an asset once per tick of a given cron schedule.

Still needs:
- testing of the timezone / all_partitions parameters
- an actual description field

## How I Tested These Changes
