### PR TITLE
[ui] Fix autolinker error in Safari

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/ui/__tests__/autolinking.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/__tests__/autolinking.test.tsx
@@ -3,14 +3,15 @@ import React from 'react';
 
 import {autolinkTextContent} from '../autolinking';
 
-const Test = ({message}: {message: string}) => {
+const Test = ({message, useIdleCallback}: {message: string; useIdleCallback: boolean}) => {
   const messageEl = React.createRef<HTMLDivElement>();
   React.useEffect(() => {
     if (messageEl.current) {
-      // Note: window.requestIdleCallback is not available in the test runner
-      autolinkTextContent(messageEl.current, {useIdleCallback: false});
+      // Note: window.requestIdleCallback is not available in the test runner,
+      // requesting it tests the fallback async code path
+      autolinkTextContent(messageEl.current, {useIdleCallback});
     }
-  }, [message, messageEl]);
+  }, [message, messageEl, useIdleCallback]);
 
   return <div ref={messageEl}>{message}</div>;
 };
@@ -41,7 +42,7 @@ describe('autolinking', () => {
         https://www.google.com/maps/place/Nashville,+TN/@36.1865271,-86.9503948,11z/data=!3m1!4b1!4m6!3m5!1s0x8864ec3213eb903d:0x7d3fb9d0a1e9daa0!8m2!3d36.1626638!4d-86.7816016!16zL20vMDVqYm4?entry=ttu
         `;
 
-    const rendered = render(<Test message={message} />);
+    const rendered = render(<Test message={message} useIdleCallback={false} />);
 
     waitFor(() => expect(screen.getByRole('link')).toBeDefined());
 
@@ -61,69 +62,7 @@ describe('autolinking', () => {
   });
 
   it('linkifies URLs in the text without altering the node text content', async () => {
-    const message = `
-    This is my log message with some https://cloud.google.com/dataproc/ docs: {
-        "kind": "discovery#restDescription",
-        "description": "Manages Hadoop-based clusters and jobs on Google Cloud Platform.",
-        "servicePath": "",
-        "basePath": "",
-        "revision": "20190627",
-        "documentationLink": "https://cloud.google.com/dataproc/",
-        "id": "dataproc:v1",
-        "discoveryVersion": "v1",
-        "schemas": {
-            "Cluster": {
-                "description": "Describes the identifying information, config, and status of a cluster of Compute Engine instances.",
-                "type": "object",
-                "properties": {
-                    "labels": {
-                        "description": "Optional. The labels to associate with this cluster. Label keys must contain 1 to 63 characters, and must conform to RFC 1035 (https://www.ietf.org/rfc/rfc1035.txt). Label values may be empty, but, if present, must contain 1 to 63 characters, and must conform to RFC 1035 (https://www.ietf.org/rfc/rfc1035.txt). No more than 32 labels can be associated with a cluster.",
-                        "type": "object",
-                        "additionalProperties": {
-                            "type": "string"
-                        }
-                    },
-                    "status": {
-                        "$ref": "ClusterStatus",
-                        "description": "Output only. Cluster status."
-                    },
-                    "metrics": {
-                        "$ref": "ClusterMetrics",
-                        "description": "Contains cluster daemon metrics such as HDFS and YARN stats.Beta Feature: This report is available for testing purposes only. It may be changed before final release."
-                    },
-                    "config": {
-                        "$ref": "ClusterConfig",
-                        "description": "Required. The cluster config. Note that Cloud Dataproc may set default values, and values may change when clusters are updated."
-                    },
-                    "statusHistory": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "ClusterStatus"
-                        },
-                        "description": "Output only. The previous cluster status."
-                    },
-                    "clusterUuid": {
-                        "description": "Output only. A cluster UUID (Unique Universal Identifier). Cloud Dataproc generates this value when it creates the cluster.",
-                        "type": "string"
-                    },
-                    "clusterName": {
-                        "type": "string",
-                        "description": "Required. The cluster name. Cluster names within a project must be unique. Names of deleted clusters can be reused."
-                    },
-                    "projectId": {
-                        "description": "Required. The Google Cloud Platform project ID that the cluster belongs to.",
-                        "type": "string"
-                    }
-                },
-                "id": "Cluster"
-            },
-        },
-        "version": "v1",
-        "baseUrl": "https://dataproc.googleapis.com/"
-    }
-    `;
-
-    const rendered = render(<Test message={message} />);
+    const rendered = render(<Test message={LongMessage} useIdleCallback={false} />);
 
     waitFor(() => expect(screen.getByRole('link')).toBeDefined());
 
@@ -137,6 +76,87 @@ describe('autolinking', () => {
       'https://dataproc.googleapis.com/',
     ]);
 
-    expect(rendered.container.textContent!.trim()).toEqual(message.trim());
+    expect(rendered.container.textContent!.trim()).toEqual(LongMessage.trim());
+  });
+
+  it('linkifies URLs in the text in async chunks if useIdleCallback is requested but not available', async () => {
+    expect('useIdleCallback' in window).toEqual(false);
+
+    const rendered = render(<Test message={LongMessage} useIdleCallback={true} />);
+
+    await waitFor(() => {
+      const links = screen.getAllByRole('link');
+      const hrefs = Array.from(links).map((el) => el.getAttribute('href'));
+      expect(hrefs).toEqual([
+        'https://cloud.google.com/dataproc/',
+        'https://cloud.google.com/dataproc/',
+        'https://www.ietf.org/rfc/rfc1035.txt',
+        'https://www.ietf.org/rfc/rfc1035.txt',
+        'https://dataproc.googleapis.com/',
+      ]);
+    });
+    expect(rendered.container.textContent!.trim()).toEqual(LongMessage.trim());
   });
 });
+
+const LongMessage = `
+This is my log message with some https://cloud.google.com/dataproc/ docs: {
+    "kind": "discovery#restDescription",
+    "description": "Manages Hadoop-based clusters and jobs on Google Cloud Platform.",
+    "servicePath": "",
+    "basePath": "",
+    "revision": "20190627",
+    "documentationLink": "https://cloud.google.com/dataproc/",
+    "id": "dataproc:v1",
+    "discoveryVersion": "v1",
+    "schemas": {
+        "Cluster": {
+            "description": "Describes the identifying information, config, and status of a cluster of Compute Engine instances.",
+            "type": "object",
+            "properties": {
+                "labels": {
+                    "description": "Optional. The labels to associate with this cluster. Label keys must contain 1 to 63 characters, and must conform to RFC 1035 (https://www.ietf.org/rfc/rfc1035.txt). Label values may be empty, but, if present, must contain 1 to 63 characters, and must conform to RFC 1035 (https://www.ietf.org/rfc/rfc1035.txt). No more than 32 labels can be associated with a cluster.",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "status": {
+                    "$ref": "ClusterStatus",
+                    "description": "Output only. Cluster status."
+                },
+                "metrics": {
+                    "$ref": "ClusterMetrics",
+                    "description": "Contains cluster daemon metrics such as HDFS and YARN stats.Beta Feature: This report is available for testing purposes only. It may be changed before final release."
+                },
+                "config": {
+                    "$ref": "ClusterConfig",
+                    "description": "Required. The cluster config. Note that Cloud Dataproc may set default values, and values may change when clusters are updated."
+                },
+                "statusHistory": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "ClusterStatus"
+                    },
+                    "description": "Output only. The previous cluster status."
+                },
+                "clusterUuid": {
+                    "description": "Output only. A cluster UUID (Unique Universal Identifier). Cloud Dataproc generates this value when it creates the cluster.",
+                    "type": "string"
+                },
+                "clusterName": {
+                    "type": "string",
+                    "description": "Required. The cluster name. Cluster names within a project must be unique. Names of deleted clusters can be reused."
+                },
+                "projectId": {
+                    "description": "Required. The Google Cloud Platform project ID that the cluster belongs to.",
+                    "type": "string"
+                }
+            },
+            "id": "Cluster"
+        },
+    },
+    "version": "v1",
+    "baseUrl": "https://dataproc.googleapis.com/"
+}
+`;


### PR DESCRIPTION
## Summary & Motivation

It turns out that Safari does not support `window.requestIdleCallback`, so extremely large logs in the log viewer cause the bottom portion of the run log page to show an inline error box.

This PR makes the autolinker fall back to a "run for 500ms, with short gaps to avoid blocking the event loop" strategy that just uses a setTimeout.  The goal at the end of the day is just to make sure autolinking doesn't ever block the JS event loop and "lock" the page.

<img width="1420" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/ca45cadc-c959-4b8d-9d0b-92ba400268c1">


## How I Tested These Changes

I wrote a new test case to verify that this fallback works, because conveniently the jest env also does not have `window.requestIdleCallback`. I also set the "work ms" to something very low (15ms), and then did a perf trace on a 120,000 character string with many links. The trace shows that it suspends and resumes and eventually stops (good!) and scrolling to the bottom of the message indicates it linkified the very last link (good!)


I also cruised around most of Dagster UI with Safari to make sure things are generally looking good because it's been a while. Looking good!