### PR TITLE
assetCheckExecutions resolver

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -3112,6 +3112,12 @@ type Query {
     afterTimestamp: Float
   ): [InstigationTick!]!
   assetChecksOrError(assetKey: AssetKeyInput!, checkName: String): AssetChecksOrError!
+  assetCheckExecutions(
+    assetKey: AssetKeyInput!
+    checkName: String!
+    limit: Int!
+    cursor: String
+  ): [AssetCheckExecution!]!
 }
 
 union WorkspaceOrError = Workspace | PythonError

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -2856,6 +2856,7 @@ export type PythonError = Error & {
 export type Query = {
   __typename: 'Query';
   allTopLevelResourceDetailsOrError: ResourcesOrError;
+  assetCheckExecutions: Array<AssetCheckExecution>;
   assetChecksOrError: AssetChecksOrError;
   assetNodeDefinitionCollisions: Array<AssetNodeDefinitionCollision>;
   assetNodeOrError: AssetNodeOrError;
@@ -2910,6 +2911,13 @@ export type Query = {
 
 export type QueryAllTopLevelResourceDetailsOrErrorArgs = {
   repositorySelector: RepositorySelector;
+};
+
+export type QueryAssetCheckExecutionsArgs = {
+  assetKey: AssetKeyInput;
+  checkName: Scalars['String'];
+  cursor?: InputMaybe<Scalars['String']>;
+  limit: Scalars['Int'];
 };
 
 export type QueryAssetChecksOrErrorArgs = {
@@ -9858,6 +9866,10 @@ export const buildQuery = (
         : relationshipsToOmit.has('PythonError')
         ? ({} as PythonError)
         : buildPythonError({}, relationshipsToOmit),
+    assetCheckExecutions:
+      overrides && overrides.hasOwnProperty('assetCheckExecutions')
+        ? overrides.assetCheckExecutions!
+        : [],
     assetChecksOrError:
       overrides && overrides.hasOwnProperty('assetChecksOrError')
         ? overrides.assetChecksOrError!

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_checks.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_checks.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, List, Optional, cast
 import dagster._check as check
 from dagster import AssetKey
 from dagster._core.definitions.asset_check_evaluation import AssetCheckEvaluation
+from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.host_representation.external_data import ExternalAssetCheck
 from dagster._core.instance import DagsterInstance
 from dagster._core.storage.asset_check_execution_record import (
@@ -77,11 +78,11 @@ def _get_asset_check_execution_status(
         check.failed(f"Unexpected status {record_status}")
 
 
-def fetch_executions(
-    instance: DagsterInstance, asset_check: ExternalAssetCheck, limit: int, cursor: Optional[str]
+def fetch_asset_check_executions(
+    instance: DagsterInstance, asset_check_key: AssetCheckKey, limit: int, cursor: Optional[str]
 ) -> List[GrapheneAssetCheckExecution]:
     executions = instance.event_log_storage.get_asset_check_execution_history(
-        check_key=asset_check.key,
+        check_key=asset_check_key,
         limit=limit,
         cursor=int(cursor) if cursor else None,
     )

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_checks.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_checks.py
@@ -127,6 +127,7 @@ class GrapheneAssetCheck(graphene.ObjectType):
     name = graphene.NonNull(graphene.String)
     assetKey = graphene.NonNull(GrapheneAssetKey)
     description = graphene.String()
+    # deprecated. Use the top level assetCheckExecutions resolver instead
     executions = graphene.Field(
         non_null_list(GrapheneAssetCheckExecution),
         limit=graphene.NonNull(graphene.Int),
@@ -159,11 +160,14 @@ class GrapheneAssetCheck(graphene.ObjectType):
         self, graphene_info: ResolveInfo, **kwargs
     ) -> List[GrapheneAssetCheckExecution]:
         from dagster_graphql.implementation.fetch_asset_checks import (
-            fetch_executions,
+            fetch_asset_check_executions,
         )
 
-        return fetch_executions(
-            graphene_info.context.instance, self._asset_check, kwargs["limit"], kwargs.get("cursor")
+        return fetch_asset_check_executions(
+            graphene_info.context.instance,
+            self._asset_check.key,
+            kwargs["limit"],
+            kwargs.get("cursor"),
         )
 
     def resolve_executionForLatestMaterialization(


### PR DESCRIPTION
Add a top level assetCheckExecutions resolver to power the check history modal. It didn't make sense to have this as a field on AssetCheck, because it's always queried separately.

Once the front end uses this as the new field on assetNode, we can remove the top level assetChecks resolver plus the executions resolver on AssetCheck