### PR TITLE
[ui] Fix crash when displaying a graph op with 4+ outputs or inputs

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graph/OpNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/OpNode.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 import {withMiddleTruncation} from '../app/Util';
 import {displayNameForAssetKey} from '../asset-graph/Utils';
 import {AssetKey} from '../assets/types';
+import {testId} from '../testing/testId';
 
 import {OpIOBox, metadataForIO} from './OpIOBox';
 import {OpTags, IOpTag} from './OpTags';
@@ -119,6 +120,7 @@ export class OpNode extends React.Component<IOpNodeProps> {
         $dim={dim}
         onClick={this.handleClick}
         onDoubleClick={this.handleDoubleClick}
+        data-testid={testId(definition.name)}
       >
         <div className="highlight-box" style={{...position(layout.bounds)}} />
         {composite && <div className="composite-marker" style={{...position(layout.op)}} />}

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/ParentOpNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/ParentOpNode.tsx
@@ -57,10 +57,28 @@ export const ParentOpNode: React.FC<ParentOpNodeProps> = (props) => {
         minified={minified}
       />
       {def.inputMappings.map(({definition, mappedInput}, idx) => {
-        const destination = layout.nodes[mappedInput.solid.name];
-        const sourcePort = parentLayout.inputs[definition.name]?.port;
-        const trgtPort = destination?.inputs[mappedInput.definition.name]?.port;
-        if (!destination || !sourcePort || !trgtPort) {
+        // The mappings link the IOs of the parent graph op to the
+        // input / outputs of ops within the subgraph.
+
+        const parentIO = parentLayout.inputs[definition.name];
+        const destinationNode = layout.nodes[mappedInput.solid.name];
+        if (!destinationNode || !parentIO) {
+          console.warn(
+            `Assertion failure - Unable to find ${mappedInput.solid.name} in the layout ` +
+              `or ${definition.name} in the parent layout`,
+          );
+          return <g key={mappedInput.solid.name} />;
+        }
+
+        const destinationIOFull = destinationNode.inputs[mappedInput.definition.name];
+        const destinationIOCollapsed = Object.values(destinationNode.inputs).find((o) =>
+          o.collapsed.includes(mappedInput.definition.name),
+        );
+        const destinationIO = destinationIOFull || destinationIOCollapsed;
+        if (!destinationIO) {
+          console.warn(
+            `Assertion failure - Unable to find port for ${mappedInput.definition.name}`,
+          );
           return <g key={mappedInput.solid.name} />;
         }
 
@@ -68,8 +86,8 @@ export const ParentOpNode: React.FC<ParentOpNodeProps> = (props) => {
           <MappingLine
             {...highlightingProps}
             key={`in-${idx}`}
-            target={trgtPort}
-            source={sourcePort}
+            target={destinationIO.port}
+            source={parentIO.port}
             minified={minified}
             leftEdgeX={mappingLeftEdge - idx * mappingLeftSpacing}
             edge={{a: titleOfIO(mappedInput), b: PARENT_IN}}
@@ -77,19 +95,32 @@ export const ParentOpNode: React.FC<ParentOpNodeProps> = (props) => {
         );
       })}
       {def.outputMappings.map(({definition, mappedOutput}, idx) => {
+        const parentIO = parentLayout.outputs[definition.name];
         const destination = layout.nodes[mappedOutput.solid.name];
-        if (!destination) {
+        if (!destination || !parentIO) {
+          console.warn(
+            `Unable to find ${mappedOutput.solid.name} in the layout ` +
+              `or ${definition.name} in the parent layout`,
+          );
           return <g key={mappedOutput.solid.name} />;
         }
-        const sourcePort = parentLayout.outputs[definition.name]!.port;
-        const trgtPort = destination.outputs[mappedOutput.definition.name]!.port;
+
+        const destinationIOFull = destination.outputs[mappedOutput.definition.name];
+        const destinationIOCollapsed = Object.values(destination.outputs).find((o) =>
+          o.collapsed.includes(mappedOutput.definition.name),
+        );
+        const destinationIO = destinationIOFull || destinationIOCollapsed;
+        if (!destinationIO) {
+          console.warn(`Unable to find port for ${mappedOutput.definition.name}`);
+          return <g key={mappedOutput.solid.name} />;
+        }
 
         return (
           <MappingLine
             {...highlightingProps}
             key={`out-${idx}`}
-            target={trgtPort}
-            source={sourcePort}
+            target={destinationIO.port}
+            source={parentIO.port}
             minified={minified}
             leftEdgeX={mappingLeftEdge - idx * mappingLeftSpacing}
             edge={{a: titleOfIO(mappedOutput), b: PARENT_OUT}}

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/__fixtures__/OpGraph.fixtures.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/__fixtures__/OpGraph.fixtures.ts
@@ -1,0 +1,196 @@
+import {OpGraphOpFragment} from '../types/OpGraph.types';
+
+const IO_TYPE = {
+  __typename: 'RegularDagsterType',
+  displayName: 'Int',
+} as const;
+
+interface Edge {
+  fromOp: string;
+  fromIO: string;
+  toOp: string;
+  toIO: string;
+}
+
+function buildEdge(descriptor: string): Edge {
+  const match = /([\w\d.]*):([\w\d.]*) ?=> ?([\w\d.]*):([\w\d.]*)/g.exec(descriptor);
+  if (!match) {
+    throw new Error(`Cannot parse ${descriptor}`);
+  }
+  const [_, fromOp, fromIO, toOp, toIO] = match;
+  return {fromOp: fromOp!, fromIO: fromIO!, toOp: toOp!, toIO: toIO!};
+}
+
+function buildGraphSolidFragment(sname: string, ins: string[], outs: string[], edges: Edge[]) {
+  const result: OpGraphOpFragment = {
+    __typename: 'Solid',
+    name: sname,
+    definition: {
+      __typename: 'SolidDefinition',
+      name: sname,
+      description: '',
+      metadata: [],
+      inputDefinitions: ins.map((iname) => ({
+        __typename: 'InputDefinition',
+        name: iname,
+        type: IO_TYPE,
+      })),
+      outputDefinitions: outs.map((oname) => ({
+        __typename: 'OutputDefinition',
+        name: oname,
+        type: IO_TYPE,
+        isDynamic: false,
+      })),
+      configField: null,
+      assetNodes: [],
+    },
+    inputs: ins.map((iname) => ({
+      __typename: 'Input',
+      definition: {__typename: 'InputDefinition', name: iname},
+      isDynamicCollect: false,
+      dependsOn: edges
+        .filter((e) => e.toOp === sname && e.toIO === iname)
+        .map((o) => ({
+          __typename: 'Output',
+          solid: {name: o.fromOp, __typename: 'Solid'},
+          definition: {__typename: 'OutputDefinition', name: o.fromIO, type: IO_TYPE},
+        })),
+    })),
+    outputs: outs.map((oname) => ({
+      __typename: 'Output',
+      dependedBy: edges
+        .filter((e) => e.fromOp === sname && e.fromIO === oname)
+        .map((o) => ({
+          __typename: 'Input',
+          solid: {name: o.toOp, __typename: 'Solid'},
+          definition: {__typename: 'InputDefinition', name: o.toIO, type: IO_TYPE},
+        })),
+      definition: {__typename: 'OutputDefinition', name: oname},
+    })),
+    isDynamicMapped: false,
+  };
+  return result;
+}
+
+export function buildBasicDAG() {
+  const edges = ['A:out=>B:in', 'B:out1=>C:in', 'B:out2=>D:in1', 'C:out=>D:in2'].map(buildEdge);
+
+  const ops: OpGraphOpFragment[] = [
+    buildGraphSolidFragment('A', [], ['out'], edges),
+    buildGraphSolidFragment('B', ['in'], ['out1', 'out2'], edges),
+    buildGraphSolidFragment('C', ['in'], ['out'], edges),
+    buildGraphSolidFragment('D', ['in1', 'in2'], [], edges),
+  ];
+  return ops;
+}
+
+export function buildFanOutDAG() {
+  const edges = [];
+  for (let ii = 0; ii < 60; ii++) {
+    edges.push(buildEdge(`A:out=>B${ii}:in`));
+    edges.push(buildEdge(`B${ii}:out=>C:in`));
+  }
+  const ops: OpGraphOpFragment[] = [];
+  ops.push(buildGraphSolidFragment('A', ['in'], ['out'], edges));
+  ops.push(buildGraphSolidFragment('C', ['in'], ['out'], edges));
+  for (let ii = 0; ii < 60; ii++) {
+    ops.push(buildGraphSolidFragment(`B${ii}`, ['in'], ['out'], edges));
+  }
+  return ops;
+}
+
+export function buildTaggedDAG() {
+  const ops = buildBasicDAG();
+
+  ['ipynb', 'sql', 'verylongtypename', 'story'].forEach((kind, idx) =>
+    ops[idx]!.definition.metadata.push({
+      key: 'kind',
+      value: kind,
+      __typename: 'MetadataItemDefinition',
+    }),
+  );
+
+  return ops;
+}
+
+export function buildCompositeDAG() {
+  const ops = buildBasicDAG();
+  const composite = ops.find((s) => s.name === 'C')!;
+
+  const edges = [buildEdge(`CA:out=>CB:in`)];
+  const childOps = [
+    buildGraphSolidFragment(`CA`, ['in'], ['out'], edges),
+    buildGraphSolidFragment(`CB`, ['in'], ['out'], edges),
+  ];
+
+  composite.definition = {
+    ...composite.definition,
+    __typename: 'CompositeSolidDefinition',
+    id: 'composite-solid-id',
+    inputMappings: [
+      {
+        __typename: 'InputMapping',
+        definition: composite.definition.inputDefinitions[0]!,
+        mappedInput: {
+          __typename: 'Input',
+          solid: childOps[0]!,
+          definition: childOps[0]!.definition.inputDefinitions[0]!,
+        },
+      },
+    ],
+    outputMappings: [
+      {
+        __typename: 'OutputMapping',
+        definition: composite.definition.outputDefinitions[0]!,
+        mappedOutput: {
+          __typename: 'Output',
+          solid: childOps[1]!,
+          definition: childOps[1]!.definition.outputDefinitions[0]!,
+        },
+      },
+    ],
+  };
+  return {ops, composite, childOps};
+}
+
+export function buildCompositeCollapsedIODAG() {
+  const composite = buildGraphSolidFragment(
+    'C',
+    ['in1', 'in2', 'in3', 'in4', 'in5'],
+    ['out1', 'out2', 'out3', 'out4', 'out5'],
+    [],
+  );
+  const ops: OpGraphOpFragment[] = [composite];
+
+  const childEdges = [buildEdge(`CA:out=>CB:in`)];
+  const childOps = [
+    buildGraphSolidFragment(`CA`, ['in1', 'in2', 'in3', 'in4', 'in5'], ['out'], childEdges),
+    buildGraphSolidFragment(`CB`, ['in'], ['out1', 'out2', 'out3', 'out4', 'out5'], childEdges),
+  ];
+
+  composite.definition = {
+    ...composite.definition,
+    __typename: 'CompositeSolidDefinition',
+    id: 'composite-solid-id',
+    inputMappings: childOps[0]!.definition.inputDefinitions.map((inputDef, idx) => ({
+      __typename: 'InputMapping',
+      definition: composite.definition.inputDefinitions[idx]!,
+      mappedInput: {
+        __typename: 'Input',
+        solid: childOps[0]!,
+        definition: inputDef!,
+      },
+    })),
+    outputMappings: childOps[1]!.definition.outputDefinitions.map((outputDef, idx) => ({
+      __typename: 'OutputMapping',
+      definition: composite.definition.outputDefinitions[idx]!,
+      mappedOutput: {
+        __typename: 'Output',
+        solid: childOps[1]!,
+        definition: outputDef!,
+      },
+    })),
+  };
+
+  return {ops, composite, childOps};
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/__stories__/OpGraph.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/__stories__/OpGraph.stories.tsx
@@ -4,98 +4,20 @@ import * as React from 'react';
 import {OpNameOrPath} from '../../ops/OpNameOrPath';
 import {OpGraph} from '../OpGraph';
 import {SVGViewport} from '../SVGViewport';
+import {
+  buildBasicDAG,
+  buildCompositeCollapsedIODAG,
+  buildCompositeDAG,
+  buildFanOutDAG,
+  buildTaggedDAG,
+} from '../__fixtures__/OpGraph.fixtures';
 import {getFullOpLayout} from '../asyncGraphLayout';
-import {OpGraphOpFragment} from '../types/OpGraph.types';
 
 // eslint-disable-next-line import/no-default-export
 export default {
   title: 'OpGraph',
   component: OpGraph,
 } as Meta;
-
-const IO_TYPE = {
-  __typename: 'RegularDagsterType',
-  displayName: 'Int',
-} as const;
-
-interface Edge {
-  fromOp: string;
-  fromIO: string;
-  toOp: string;
-  toIO: string;
-}
-
-function buildEdge(descriptor: string): Edge {
-  const match = /([\w\d.]*):([\w\d.]*) ?=> ?([\w\d.]*):([\w\d.]*)/g.exec(descriptor);
-  if (!match) {
-    throw new Error(`Cannot parse ${descriptor}`);
-  }
-  const [_, fromOp, fromIO, toOp, toIO] = match;
-  return {fromOp: fromOp!, fromIO: fromIO!, toOp: toOp!, toIO: toIO!};
-}
-
-function buildGraphSolidFragment(sname: string, ins: string[], outs: string[], edges: Edge[]) {
-  const result: OpGraphOpFragment = {
-    __typename: 'Solid',
-    name: sname,
-    definition: {
-      __typename: 'SolidDefinition',
-      name: sname,
-      description: '',
-      metadata: [],
-      inputDefinitions: ins.map((iname) => ({
-        __typename: 'InputDefinition',
-        name: iname,
-        type: IO_TYPE,
-      })),
-      outputDefinitions: outs.map((oname) => ({
-        __typename: 'OutputDefinition',
-        name: oname,
-        type: IO_TYPE,
-        isDynamic: false,
-      })),
-      configField: null,
-      assetNodes: [],
-    },
-    inputs: ins.map((iname) => ({
-      __typename: 'Input',
-      definition: {__typename: 'InputDefinition', name: iname},
-      isDynamicCollect: false,
-      dependsOn: edges
-        .filter((e) => e.toOp === sname && e.toIO === iname)
-        .map((o) => ({
-          __typename: 'Output',
-          solid: {name: o.fromOp, __typename: 'Solid'},
-          definition: {__typename: 'OutputDefinition', name: o.fromIO, type: IO_TYPE},
-        })),
-    })),
-    outputs: outs.map((oname) => ({
-      __typename: 'Output',
-      dependedBy: edges
-        .filter((e) => e.fromOp === sname && e.fromIO === oname)
-        .map((o) => ({
-          __typename: 'Input',
-          solid: {name: o.toOp, __typename: 'Solid'},
-          definition: {__typename: 'InputDefinition', name: o.toIO, type: IO_TYPE},
-        })),
-      definition: {__typename: 'OutputDefinition', name: oname},
-    })),
-    isDynamicMapped: false,
-  };
-  return result;
-}
-
-function buildBasicDAG() {
-  const edges = ['A:out=>B:in', 'B:out1=>C:in', 'B:out2=>D:in1', 'C:out=>D:in2'].map(buildEdge);
-
-  const ops: OpGraphOpFragment[] = [
-    buildGraphSolidFragment('A', [], ['out'], edges),
-    buildGraphSolidFragment('B', ['in'], ['out1', 'out2'], edges),
-    buildGraphSolidFragment('C', ['in'], ['out'], edges),
-    buildGraphSolidFragment('D', ['in1', 'in2'], [], edges),
-  ];
-  return ops;
-}
 
 export const Basic = () => {
   const [focusOps, setsetFocusOps] = React.useState<string[]>([]);
@@ -117,18 +39,7 @@ export const Basic = () => {
 export const FanOut = () => {
   const [focusOps, setsetFocusOps] = React.useState<string[]>([]);
 
-  const edges = [];
-  for (let ii = 0; ii < 60; ii++) {
-    edges.push(buildEdge(`A:out=>B${ii}:in`));
-    edges.push(buildEdge(`B${ii}:out=>C:in`));
-  }
-  const ops: OpGraphOpFragment[] = [];
-  ops.push(buildGraphSolidFragment('A', ['in'], ['out'], edges));
-  ops.push(buildGraphSolidFragment('C', ['in'], ['out'], edges));
-  for (let ii = 0; ii < 60; ii++) {
-    ops.push(buildGraphSolidFragment(`B${ii}`, ['in'], ['out'], edges));
-  }
-
+  const ops = buildFanOutDAG();
   return (
     <OpGraph
       jobName="Test Pipeline"
@@ -144,16 +55,7 @@ export const FanOut = () => {
 
 export const Tagged = () => {
   const [focusOps, setsetFocusOps] = React.useState<string[]>([]);
-  const ops = buildBasicDAG();
-
-  ['ipynb', 'sql', 'verylongtypename', 'story'].forEach((kind, idx) =>
-    ops[idx]!.definition.metadata.push({
-      key: 'kind',
-      value: kind,
-      __typename: 'MetadataItemDefinition',
-    }),
-  );
-
+  const ops = buildTaggedDAG();
   return (
     <OpGraph
       jobName="Test Pipeline"
@@ -170,44 +72,9 @@ export const Tagged = () => {
 export const Composite = () => {
   const [focusOps, setFocusOps] = React.useState<string[]>([]);
   const [parentOpName, setParentOpName] = React.useState<string | undefined>();
-  const ops = buildBasicDAG();
-  const composite = ops.find((s) => s.name === 'C')!;
-
-  const edges = [buildEdge(`CA:out=>CB:in`)];
-  const childOps = [
-    buildGraphSolidFragment(`CA`, ['in'], ['out'], edges),
-    buildGraphSolidFragment(`CB`, ['in'], ['out'], edges),
-  ];
-
-  composite.definition = {
-    ...composite.definition,
-    __typename: 'CompositeSolidDefinition',
-    id: 'composite-solid-id',
-    inputMappings: [
-      {
-        __typename: 'InputMapping',
-        definition: composite.definition.inputDefinitions[0]!,
-        mappedInput: {
-          __typename: 'Input',
-          solid: childOps[0]!,
-          definition: childOps[0]!.definition.inputDefinitions[0]!,
-        },
-      },
-    ],
-    outputMappings: [
-      {
-        __typename: 'OutputMapping',
-        definition: composite.definition.outputDefinitions[0]!,
-        mappedOutput: {
-          __typename: 'Output',
-          solid: childOps[1]!,
-          definition: childOps[1]!.definition.outputDefinitions[0]!,
-        },
-      },
-    ],
-  };
 
   const toName = (s: OpNameOrPath) => ('name' in s ? s.name : s.path.join('.'));
+  const {ops, childOps} = buildCompositeDAG();
   const parentOp = ops.find((s) => s.name === parentOpName);
 
   return (
@@ -237,45 +104,9 @@ export const CompositeCollapsedIO = () => {
   const [focusOps, setFocusOps] = React.useState<string[]>([]);
   const [parentOpName, setParentOpName] = React.useState<string | undefined>();
 
-  const composite = buildGraphSolidFragment(
-    'C',
-    ['in1', 'in2', 'in3', 'in4', 'in5'],
-    ['out1', 'out2', 'out3', 'out4', 'out5'],
-    [],
-  );
-  const ops: OpGraphOpFragment[] = [composite];
-
-  const childEdges = [buildEdge(`CA:out=>CB:in`)];
-  const childOps = [
-    buildGraphSolidFragment(`CA`, ['in1', 'in2', 'in3', 'in4', 'in5'], ['out'], childEdges),
-    buildGraphSolidFragment(`CB`, ['in'], ['out1', 'out2', 'out3', 'out4', 'out5'], childEdges),
-  ];
-
-  composite.definition = {
-    ...composite.definition,
-    __typename: 'CompositeSolidDefinition',
-    id: 'composite-solid-id',
-    inputMappings: childOps[0]!.definition.inputDefinitions.map((inputDef, idx) => ({
-      __typename: 'InputMapping',
-      definition: composite.definition.inputDefinitions[idx]!,
-      mappedInput: {
-        __typename: 'Input',
-        solid: childOps[0]!,
-        definition: inputDef!,
-      },
-    })),
-    outputMappings: childOps[1]!.definition.outputDefinitions.map((outputDef, idx) => ({
-      __typename: 'OutputMapping',
-      definition: composite.definition.outputDefinitions[idx]!,
-      mappedOutput: {
-        __typename: 'Output',
-        solid: childOps[1]!,
-        definition: outputDef!,
-      },
-    })),
-  };
-
   const toName = (s: OpNameOrPath) => ('name' in s ? s.name : s.path.join('.'));
+
+  const {ops, childOps} = buildCompositeCollapsedIODAG();
   const parentOp = ops.find((s) => s.name === parentOpName);
 
   return (

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/__tests__/OpGraph.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/__tests__/OpGraph.test.tsx
@@ -1,0 +1,133 @@
+import {render, screen} from '@testing-library/react';
+import React from 'react';
+
+import {OpGraph} from '../OpGraph';
+import {SVGViewport} from '../SVGViewport';
+import {
+  buildBasicDAG,
+  buildCompositeCollapsedIODAG,
+  buildCompositeDAG,
+  buildFanOutDAG,
+  buildTaggedDAG,
+} from '../__fixtures__/OpGraph.fixtures';
+import {getFullOpLayout} from '../asyncGraphLayout';
+import * as Common from '../common';
+
+describe('OpGraph', () => {
+  beforeEach(() => {
+    jest.spyOn(Common, 'isNodeOffscreen').mockReturnValue(false);
+  });
+
+  it('renders a basic op graph without crashing', async () => {
+    const ops = buildBasicDAG();
+    render(
+      <OpGraph
+        jobName="Test Pipeline"
+        ops={ops}
+        layout={getFullOpLayout(ops, {})}
+        interactor={SVGViewport.Interactors.PanAndZoom}
+        focusOps={[]}
+        highlightedOps={[]}
+        onClickOp={() => {}}
+      />,
+    );
+    expect(await screen.getByTestId('A')).toBeVisible();
+  });
+
+  it('renders a fan-out op graph', async () => {
+    const ops = buildFanOutDAG();
+    render(
+      <OpGraph
+        jobName="Test Pipeline"
+        ops={ops}
+        layout={getFullOpLayout(ops, {})}
+        interactor={SVGViewport.Interactors.PanAndZoom}
+        focusOps={[]}
+        highlightedOps={[]}
+        onClickOp={() => {}}
+      />,
+    );
+    expect(await screen.getByTestId('A')).toBeVisible();
+  });
+
+  it('renders an op graph containing tagged ops', async () => {
+    const ops = buildTaggedDAG();
+    render(
+      <OpGraph
+        jobName="Test Pipeline"
+        ops={ops}
+        layout={getFullOpLayout(ops, {})}
+        interactor={SVGViewport.Interactors.PanAndZoom}
+        focusOps={[]}
+        highlightedOps={[]}
+        onClickOp={() => {}}
+      />,
+    );
+    expect(await screen.getByTestId('A')).toBeVisible();
+  });
+
+  it('renders a basic composite graph - root level', async () => {
+    const {ops} = buildCompositeDAG();
+
+    render(
+      <OpGraph
+        jobName="Test Pipeline"
+        ops={ops}
+        layout={getFullOpLayout(ops, {})}
+        interactor={SVGViewport.Interactors.PanAndZoom}
+        focusOps={[]}
+        highlightedOps={[]}
+        onClickOp={() => {}}
+        onEnterSubgraph={() => {}}
+        onLeaveSubgraph={() => {}}
+        onDoubleClickOp={() => {}}
+      />,
+    );
+    expect(await screen.getByTestId('A')).toBeVisible();
+  });
+
+  it('renders a basic composite graph with many IOs - root level', async () => {
+    const {ops} = buildCompositeCollapsedIODAG();
+
+    render(
+      <OpGraph
+        jobName="Test Pipeline"
+        ops={ops}
+        parentOp={undefined}
+        parentHandleID={undefined}
+        layout={getFullOpLayout(ops, {})}
+        interactor={SVGViewport.Interactors.PanAndZoom}
+        focusOps={[]}
+        highlightedOps={[]}
+        onClickOp={() => {}}
+        onEnterSubgraph={() => {}}
+        onLeaveSubgraph={() => {}}
+        onDoubleClickOp={() => {}}
+      />,
+    );
+    expect(await screen.getByTestId('C')).toBeVisible();
+  });
+
+  it('renders a basic composite graph with many IOs - expanded', async () => {
+    const {composite: parentOp, childOps} = buildCompositeCollapsedIODAG();
+
+    render(
+      <OpGraph
+        jobName="Test Pipeline"
+        ops={childOps}
+        parentOp={parentOp}
+        parentHandleID={parentOp.definition.name}
+        layout={getFullOpLayout(childOps, {parentOp})}
+        interactor={SVGViewport.Interactors.PanAndZoom}
+        focusOps={[]}
+        highlightedOps={[]}
+        onClickOp={() => {}}
+        onEnterSubgraph={() => {}}
+        onLeaveSubgraph={() => {}}
+        onDoubleClickOp={() => {}}
+      />,
+    );
+    expect(await screen.getByTestId('CA')).toBeVisible();
+    expect(await screen.getByTestId('CB')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary & Motivation

This fixes a crash observed here https://dagsterlabs.slack.com/archives/C058CBEL230/p1698075923055629

In our layout code, we "collapse" op inputs / outputs if there are >4. (see `IO_THRESHOLD_FOR_MINI`). When this happens, we're not able to "find" the dot that these input mappings are supposed to connect to in the subgraph, which caused the graph to crash.

This fixes the IO layout lookup so that we can find the dot that the inputs/outputs were "collapsed into". I also renamed several variables in here to be more clear because it took me a while to remember what was going on here.

![image](https://github.com/dagster-io/dagster/assets/1037212/edc4b824-d84a-4bf6-876f-a2dbbc79a659)


## How I Tested These Changes

I tested this by creating a new story for `OpGraph` that exhibits >4 outputs and >4 inputs. Hooray for stories 🙏 