### PR TITLE
Clarify dynamic partitions error on materialize when instance not provided

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -684,6 +684,18 @@ class JobDefinition(IHasInternalInit):
         if partition_key:
             if not (self.partitions_def and self.partitioned_config):
                 check.failed("Attempted to execute a partitioned run for a non-partitioned job")
+
+            if (
+                isinstance(self.partitions_def, DynamicPartitionsDefinition)
+                and self.partitions_def.name
+                and instance is None
+            ):
+                check.failed(
+                    "Must provide instance to validate partition key. This can be resolved by either:\n"
+                    "(1) Fetching your default instance via `DagsterInstance.get()` and passing it to `materialize`\n"
+                    "(2) Creating an ephemeral instance via `DagsterInstance.ephemeral()`, adding a dynamic partition, and passing it to `materialize`"
+                )
+
             self.partitions_def.validate_partition_key(
                 partition_key, dynamic_partitions_store=instance
             )


### PR DESCRIPTION
Resolves https://github.com/dagster-io/dagster/issues/17456

When an instance is not provided to `materialize` (and similar functions), an ephemeral instance is created which doesn't contain any dynamic partitions. This causes the validation check to fail.

This PR improves the error messaging to clarify the behavior and suggest ways to fix. 