### PR TITLE
[ui] Move asset partition “stale” status to separate query

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitionDetail.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitionDetail.tsx
@@ -36,6 +36,8 @@ import {
   AssetPartitionLatestRunFragment,
   AssetPartitionDetailQuery,
   AssetPartitionDetailQueryVariables,
+  AssetPartitionStaleQuery,
+  AssetPartitionStaleQueryVariables,
 } from './types/AssetPartitionDetail.types';
 import {ASSET_MATERIALIZATION_FRAGMENT, ASSET_OBSERVATION_FRAGMENT} from './useRecentAssetEvents';
 
@@ -47,22 +49,22 @@ export const AssetPartitionDetailLoader: React.FC<{assetKey: AssetKey; partition
     {variables: {assetKey: props.assetKey, partitionKey: props.partitionKey}},
   );
 
-  const {materializations, observations, ...rest} = React.useMemo(() => {
+  const stale = useQuery<AssetPartitionStaleQuery, AssetPartitionStaleQueryVariables>(
+    ASSET_PARTITION_STALE_QUERY,
+    {variables: {assetKey: props.assetKey, partitionKey: props.partitionKey}},
+  );
+  const {materializations, observations, hasLineage, latestRunForPartition} = React.useMemo(() => {
     if (result.data?.assetNodeOrError?.__typename !== 'AssetNode') {
       return {
         materializations: [],
         observations: [],
         hasLineage: false,
-        staleCauses: [],
-        staleStatus: StaleStatus.FRESH,
         latestRunForPartition: null,
       };
     }
 
     return {
       stepKey: stepKeyForAsset(result.data.assetNodeOrError),
-      staleStatus: result.data.assetNodeOrError.staleStatus,
-      staleCauses: result.data.assetNodeOrError.staleCauses,
       latestRunForPartition: result.data.assetNodeOrError.latestRunForPartition,
       materializations: [...result.data.assetNodeOrError.assetMaterializations].sort(
         (a, b) => Number(b.timestamp) - Number(a.timestamp),
@@ -76,6 +78,19 @@ export const AssetPartitionDetailLoader: React.FC<{assetKey: AssetKey; partition
     };
   }, [result.data]);
 
+  const {staleStatus, staleCauses} = React.useMemo(() => {
+    if (stale.data?.assetNodeOrError?.__typename !== 'AssetNode') {
+      return {
+        staleCauses: [],
+        staleStatus: StaleStatus.FRESH,
+      };
+    }
+    return {
+      staleStatus: stale.data.assetNodeOrError.staleStatus,
+      staleCauses: stale.data.assetNodeOrError.staleCauses,
+    };
+  }, [stale.data]);
+
   const latest = materializations[0];
 
   if (result.loading || !result.data) {
@@ -84,7 +99,11 @@ export const AssetPartitionDetailLoader: React.FC<{assetKey: AssetKey; partition
 
   return (
     <AssetPartitionDetail
-      {...rest}
+      hasLineage={hasLineage}
+      hasStaleLoadingState={stale.loading}
+      latestRunForPartition={latestRunForPartition}
+      staleStatus={staleStatus}
+      staleCauses={staleCauses}
       assetKey={props.assetKey}
       group={{
         latest: latest || null,
@@ -104,17 +123,6 @@ export const ASSET_PARTITION_DETAIL_QUERY = gql`
       ... on AssetNode {
         id
         opNames
-        staleStatus(partition: $partitionKey)
-        staleCauses(partition: $partitionKey) {
-          key {
-            path
-          }
-          reason
-          category
-          dependency {
-            path
-          }
-        }
         latestRunForPartition(partition: $partitionKey) {
           id
           ...AssetPartitionLatestRunFragment
@@ -144,12 +152,34 @@ export const ASSET_PARTITION_DETAIL_QUERY = gql`
   ${ASSET_OBSERVATION_FRAGMENT}
 `;
 
+export const ASSET_PARTITION_STALE_QUERY = gql`
+  query AssetPartitionStaleQuery($assetKey: AssetKeyInput!, $partitionKey: String!) {
+    assetNodeOrError(assetKey: $assetKey) {
+      ... on AssetNode {
+        id
+        staleStatus(partition: $partitionKey)
+        staleCauses(partition: $partitionKey) {
+          key {
+            path
+          }
+          reason
+          category
+          dependency {
+            path
+          }
+        }
+      }
+    }
+  }
+`;
+
 export const AssetPartitionDetail: React.FC<{
   assetKey: AssetKey;
   group: AssetEventGroup;
   latestRunForPartition: AssetPartitionLatestRunFragment | null;
   hasLineage: boolean;
   hasLoadingState?: boolean;
+  hasStaleLoadingState?: boolean;
   stepKey?: string;
   staleCauses?: LiveDataForNode['staleCauses'];
   staleStatus?: LiveDataForNode['staleStatus'];
@@ -159,6 +189,7 @@ export const AssetPartitionDetail: React.FC<{
   group,
   hasLineage,
   hasLoadingState,
+  hasStaleLoadingState,
   latestRunForPartition,
   staleCauses,
   staleStatus,
@@ -203,7 +234,7 @@ export const AssetPartitionDetail: React.FC<{
           <div
             style={{
               display: 'grid',
-              gridTemplateColumns: 'minmax(0, 1fr) auto',
+              gridTemplateColumns: 'minmax(0, 1fr) auto auto',
               gap: 12,
               alignItems: 'center',
             }}
@@ -218,7 +249,9 @@ export const AssetPartitionDetail: React.FC<{
             ) : latest ? (
               <Tag intent="success">Materialized</Tag>
             ) : undefined}
-            {staleCauses && staleStatus ? (
+            {hasStaleLoadingState ? (
+              <Spinner purpose="body-text" />
+            ) : staleCauses && staleStatus ? (
               <StaleReasonsTags
                 liveData={{staleCauses, staleStatus}}
                 assetKey={assetKey}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__fixtures__/AssetEventDetail.fixtures.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__fixtures__/AssetEventDetail.fixtures.ts
@@ -2,9 +2,12 @@ import {MockedResponse} from '@apollo/client/testing';
 
 import {RunStatus, StaleStatus} from '../../graphql/types';
 import {ASSET_MATERIALIZATION_UPSTREAM_QUERY} from '../AssetMaterializationUpstreamData';
-import {ASSET_PARTITION_DETAIL_QUERY} from '../AssetPartitionDetail';
+import {ASSET_PARTITION_DETAIL_QUERY, ASSET_PARTITION_STALE_QUERY} from '../AssetPartitionDetail';
 import {AssetMaterializationUpstreamQuery} from '../types/AssetMaterializationUpstreamData.types';
-import {AssetPartitionDetailQuery} from '../types/AssetPartitionDetail.types';
+import {
+  AssetPartitionDetailQuery,
+  AssetPartitionStaleQuery,
+} from '../types/AssetPartitionDetail.types';
 import {
   AssetMaterializationFragment,
   AssetObservationFragment,
@@ -277,10 +280,6 @@ export const MaterializationUpstreamDataEmptyMock: MockedResponse<AssetMateriali
 
 export const buildAssetPartitionDetailMock = (
   currentRunStatus?: RunStatus,
-  staleCauses: Extract<
-    AssetPartitionDetailQuery['assetNodeOrError'],
-    {__typename: 'AssetNode'}
-  >['staleCauses'] = [],
 ): MockedResponse<AssetPartitionDetailQuery> => ({
   request: {
     operationName: 'AssetPartitionDetailQuery',
@@ -303,8 +302,6 @@ export const buildAssetPartitionDetailMock = (
             timestamp: `${Number(BasicObservationEvent.timestamp) + 2 * 60 * 1000}`,
           },
         ],
-        staleCauses,
-        staleStatus: staleCauses.length ? StaleStatus.STALE : StaleStatus.FRESH,
         latestRunForPartition: currentRunStatus
           ? {
               __typename: 'Run',
@@ -313,6 +310,30 @@ export const buildAssetPartitionDetailMock = (
               endTime: null,
             }
           : null,
+      },
+    },
+  },
+});
+
+export const buildAssetPartitionStaleMock = (
+  staleCauses: Extract<
+    AssetPartitionStaleQuery['assetNodeOrError'],
+    {__typename: 'AssetNode'}
+  >['staleCauses'] = [],
+): MockedResponse<AssetPartitionStaleQuery> => ({
+  request: {
+    operationName: 'AssetPartitionStaleQuery',
+    variables: {assetKey: {path: ['asset_1']}, partitionKey: Partition},
+    query: ASSET_PARTITION_STALE_QUERY,
+  },
+  result: {
+    data: {
+      __typename: 'Query',
+      assetNodeOrError: {
+        __typename: 'AssetNode',
+        id: 'test.py.repo.["asset_1"]',
+        staleCauses,
+        staleStatus: staleCauses.length ? StaleStatus.STALE : StaleStatus.FRESH,
       },
     },
   },

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__stories__/AssetPartitionDetail.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__stories__/AssetPartitionDetail.stories.tsx
@@ -12,6 +12,7 @@ import {
 } from '../AssetPartitionDetail';
 import {
   buildAssetPartitionDetailMock,
+  buildAssetPartitionStaleMock,
   MaterializationUpstreamDataFullMock,
 } from '../__fixtures__/AssetEventDetail.fixtures';
 
@@ -34,7 +35,11 @@ export const EmptyState = () => {
 export const MaterializationFollowedByObservations = () => {
   return (
     <MockedProvider
-      mocks={[buildAssetPartitionDetailMock(), MaterializationUpstreamDataFullMock]}
+      mocks={[
+        buildAssetPartitionDetailMock(),
+        buildAssetPartitionStaleMock(),
+        MaterializationUpstreamDataFullMock,
+      ]}
       cache={createAppCache()}
     >
       <WorkspaceProvider>
@@ -50,7 +55,8 @@ export const MaterializationWithRecentFailure = () => {
   return (
     <MockedProvider
       mocks={[
-        buildAssetPartitionDetailMock(RunStatus.FAILURE, [buildStaleCause()]),
+        buildAssetPartitionDetailMock(RunStatus.FAILURE),
+        buildAssetPartitionStaleMock([buildStaleCause()]),
         MaterializationUpstreamDataFullMock,
       ]}
       cache={createAppCache()}
@@ -69,6 +75,7 @@ export const MaterializationWithInProgressRun = () => {
     <MockedProvider
       mocks={[
         buildAssetPartitionDetailMock(RunStatus.STARTING),
+        buildAssetPartitionStaleMock(),
         MaterializationUpstreamDataFullMock,
       ]}
       cache={createAppCache()}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetPartitionDetail.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetPartitionDetail.types.ts
@@ -14,14 +14,6 @@ export type AssetPartitionDetailQuery = {
         __typename: 'AssetNode';
         id: string;
         opNames: Array<string>;
-        staleStatus: Types.StaleStatus | null;
-        staleCauses: Array<{
-          __typename: 'StaleCause';
-          reason: string;
-          category: Types.StaleCauseCategory;
-          key: {__typename: 'AssetKey'; path: Array<string>};
-          dependency: {__typename: 'AssetKey'; path: Array<string>} | null;
-        }>;
         latestRunForPartition: {
           __typename: 'Run';
           id: string;
@@ -342,4 +334,27 @@ export type AssetPartitionLatestRunFragment = {
   id: string;
   status: Types.RunStatus;
   endTime: number | null;
+};
+
+export type AssetPartitionStaleQueryVariables = Types.Exact<{
+  assetKey: Types.AssetKeyInput;
+  partitionKey: Types.Scalars['String'];
+}>;
+
+export type AssetPartitionStaleQuery = {
+  __typename: 'Query';
+  assetNodeOrError:
+    | {
+        __typename: 'AssetNode';
+        id: string;
+        staleStatus: Types.StaleStatus | null;
+        staleCauses: Array<{
+          __typename: 'StaleCause';
+          reason: string;
+          category: Types.StaleCauseCategory;
+          key: {__typename: 'AssetKey'; path: Array<string>};
+          dependency: {__typename: 'AssetKey'; path: Array<string>} | null;
+        }>;
+      }
+    | {__typename: 'AssetNotFoundError'};
 };


### PR DESCRIPTION
This allows the staleCauses to return very slowly (or potentially time out) without impacting the display of the rest of the detail panel.

I also fixed the stale cause wrapping to a new line, which was caused by a CSS grid with fewer columns than children

## Summary & Motivation

![image](https://github.com/dagster-io/dagster/assets/1037212/3b651e37-b1a7-4169-b22b-7491781899cd)

## How I Tested These Changes

Updated stories and used them to verify this change. I also put a `time.sleep(5)` in the python code for `resolve_staleCausesByPartition` and verified that a separate loading state appears when we're still waiting on the "Stale" tag to appear / not appear.


![image](https://github.com/dagster-io/dagster/assets/1037212/d50e5df4-e225-42b2-961b-3a16547b8d87)
