### PR TITLE
Pin mysql:8.0.34 in tests

### DIFF
--- a/python_modules/libraries/dagster-mysql/dagster_mysql_tests/docker-compose.yml
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql_tests/docker-compose.yml
@@ -7,7 +7,7 @@ services:
   # This is the standard MySQL test instance, running the latest version of MySQL. We use this for
   # all of our storage tests.
   test-mysql-db:
-    image: mysql:8
+    image: mysql:8.0.34
     command: mysqld --default-authentication-plugin=mysql_native_password
     container_name: test-mysql-db
     ports:


### PR DESCRIPTION
This aims to reproduce a failure that popped up over the weekend in our msyql test suite. Based on the timing, I have a suspicion that this might be related to Friday's release of mysql:8.0.35.

I'm temporarily pinning to see if I can narrow in further.