### PR TITLE
[gql] Fetch backfill policy from AssetNode

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -646,6 +646,7 @@ type AssetNode {
     beforeTimestampMillis: String
     limit: Int
   ): [ObservationEvent!]!
+  backfillPolicy: BackfillPolicy
   computeKind: String
   configField: ConfigTypeField
   dataVersion(partition: String): String
@@ -696,6 +697,17 @@ type MaterializationUpstreamDataVersion {
   assetKey: AssetKey!
   downstreamAssetKey: AssetKey!
   timestamp: String!
+}
+
+type BackfillPolicy {
+  maxPartitionsPerRun: Int
+  description: String!
+  policyType: BackfillPolicyType!
+}
+
+enum BackfillPolicyType {
+  SINGLE_RUN
+  MULTI_RUN
 }
 
 type AssetDependency {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -338,6 +338,7 @@ export type AssetNode = {
   assetObservations: Array<ObservationEvent>;
   assetPartitionStatuses: AssetPartitionStatuses;
   autoMaterializePolicy: Maybe<AutoMaterializePolicy>;
+  backfillPolicy: Maybe<BackfillPolicy>;
   computeKind: Maybe<Scalars['String']>;
   configField: Maybe<ConfigTypeField>;
   dataVersion: Maybe<Scalars['String']>;
@@ -551,6 +552,18 @@ export type BackfillNotFoundError = Error & {
   backfillId: Scalars['String'];
   message: Scalars['String'];
 };
+
+export type BackfillPolicy = {
+  __typename: 'BackfillPolicy';
+  description: Scalars['String'];
+  maxPartitionsPerRun: Maybe<Scalars['Int']>;
+  policyType: BackfillPolicyType;
+};
+
+export enum BackfillPolicyType {
+  MULTI_RUN = 'MULTI_RUN',
+  SINGLE_RUN = 'SINGLE_RUN',
+}
 
 export type BoolMetadataEntry = MetadataEntry & {
   __typename: 'BoolMetadataEntry';
@@ -5081,6 +5094,12 @@ export const buildAssetNode = (
         : relationshipsToOmit.has('AutoMaterializePolicy')
         ? ({} as AutoMaterializePolicy)
         : buildAutoMaterializePolicy({}, relationshipsToOmit),
+    backfillPolicy:
+      overrides && overrides.hasOwnProperty('backfillPolicy')
+        ? overrides.backfillPolicy!
+        : relationshipsToOmit.has('BackfillPolicy')
+        ? ({} as BackfillPolicy)
+        : buildBackfillPolicy({}, relationshipsToOmit),
     computeKind:
       overrides && overrides.hasOwnProperty('computeKind') ? overrides.computeKind! : 'quasi',
     configField:
@@ -5447,6 +5466,27 @@ export const buildBackfillNotFoundError = (
     backfillId:
       overrides && overrides.hasOwnProperty('backfillId') ? overrides.backfillId! : 'nobis',
     message: overrides && overrides.hasOwnProperty('message') ? overrides.message! : 'est',
+  };
+};
+
+export const buildBackfillPolicy = (
+  overrides?: Partial<BackfillPolicy>,
+  _relationshipsToOmit: Set<string> = new Set(),
+): {__typename: 'BackfillPolicy'} & BackfillPolicy => {
+  const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
+  relationshipsToOmit.add('BackfillPolicy');
+  return {
+    __typename: 'BackfillPolicy',
+    description:
+      overrides && overrides.hasOwnProperty('description') ? overrides.description! : 'molestiae',
+    maxPartitionsPerRun:
+      overrides && overrides.hasOwnProperty('maxPartitionsPerRun')
+        ? overrides.maxPartitionsPerRun!
+        : 9025,
+    policyType:
+      overrides && overrides.hasOwnProperty('policyType')
+        ? overrides.policyType!
+        : BackfillPolicyType.MULTI_RUN,
   };
 };
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -69,6 +69,7 @@ from ..schema.asset_checks import (
 from . import external
 from .asset_key import GrapheneAssetKey
 from .auto_materialize_policy import GrapheneAutoMaterializePolicy
+from .backfill import GrapheneBackfillPolicy
 from .dagster_types import (
     GrapheneDagsterType,
     GrapheneListDagsterType,
@@ -218,6 +219,7 @@ class GrapheneAssetNode(graphene.ObjectType):
         beforeTimestampMillis=graphene.String(),
         limit=graphene.Int(),
     )
+    backfillPolicy = graphene.Field(GrapheneBackfillPolicy)
     computeKind = graphene.String()
     configField = graphene.Field(GrapheneConfigTypeField)
     dataVersion = graphene.Field(graphene.String(), partition=graphene.String())
@@ -829,6 +831,13 @@ class GrapheneAssetNode(graphene.ObjectType):
     ) -> Optional[GrapheneAutoMaterializePolicy]:
         if self._external_asset_node.auto_materialize_policy:
             return GrapheneAutoMaterializePolicy(self._external_asset_node.auto_materialize_policy)
+        return None
+
+    def resolve_backfillPolicy(
+        self, _graphene_info: ResolveInfo
+    ) -> Optional[GrapheneBackfillPolicy]:
+        if self._external_asset_node.backfill_policy:
+            return GrapheneBackfillPolicy(self._external_asset_node.backfill_policy)
         return None
 
     def resolve_jobNames(self, _graphene_info: ResolveInfo) -> Sequence[str]:

--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -2,8 +2,8 @@ from typing import TYPE_CHECKING, Optional, Sequence
 
 import dagster._check as check
 import graphene
-from dagster._core.definitions.partition import PartitionsSubset
 from dagster._core.definitions.backfill_policy import BackfillPolicy, BackfillPolicyType
+from dagster._core.definitions.partition import PartitionsSubset
 from dagster._core.definitions.time_window_partitions import (
     TimeWindowPartitionsSubset,
 )

--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Optional, Sequence
 import dagster._check as check
 import graphene
 from dagster._core.definitions.partition import PartitionsSubset
+from dagster._core.definitions.backfill_policy import BackfillPolicy, BackfillPolicyType
 from dagster._core.definitions.time_window_partitions import (
     TimeWindowPartitionsSubset,
 )
@@ -485,3 +486,28 @@ class GraphenePartitionBackfillsOrError(graphene.Union):
     class Meta:
         types = (GraphenePartitionBackfills, GraphenePythonError)
         name = "PartitionBackfillsOrError"
+
+
+GrapheneBackfillPolicyType = graphene.Enum.from_enum(BackfillPolicyType)
+
+
+class GrapheneBackfillPolicy(graphene.ObjectType):
+    maxPartitionsPerRun = graphene.Field(graphene.Int())
+    description = graphene.NonNull(graphene.String)
+    policyType = graphene.NonNull(GrapheneBackfillPolicyType)
+
+    class Meta:
+        name = "BackfillPolicy"
+
+    def __init__(self, backfill_policy: BackfillPolicy):
+        self._backfill_policy = check.inst_param(backfill_policy, "backfill_policy", BackfillPolicy)
+        super().__init__(
+            maxPartitionsPerRun=backfill_policy.max_partitions_per_run,
+            policyType=backfill_policy.policy_type,
+        )
+
+    def resolve_description(self, _graphene_info: ResolveInfo) -> str:
+        if self._backfill_policy.max_partitions_per_run is None:
+            return "Backfills all partitions in a single run"
+        else:
+            return f"Backfills in multiple runs, with a maximum of {self._backfill_policy.max_partitions_per_run} partitions per run"

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_all_snapshot_ids.ambr
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_all_snapshot_ids.ambr
@@ -2058,6 +2058,996 @@
           "scalar_kind": null,
           "type_param_keys": null
         },
+        "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "[DEPRECATED]",
+              "is_required": false,
+              "name": "marker_to_close",
+              "type_key": "String"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"enabled\": {}}",
+              "description": "Whether retries are enabled or not. By default, retries are enabled.",
+              "is_required": false,
+              "name": "retries",
+              "type_key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.4942ebf48d32aa0f8268910e01ed6544ad5b0132": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "hanging_asset_resource",
+              "type_key": "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "io_manager",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.4942ebf48d32aa0f8268910e01ed6544ad5b0132",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "path",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.743e47901855cb245064dd633e217bfcb49a11a7": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "file",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.a9ef178ea955c852b26b45817b8aea6df99c9f02": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
+              "description": "Configure how steps are executed within a run.",
+              "is_required": false,
+              "name": "execution",
+              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Configure how loggers emit messages within a run.",
+              "is_required": false,
+              "name": "loggers",
+              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"multipartitions_1\": {}, \"multipartitions_2\": {}}",
+              "description": "Configure runtime parameters for ops or assets.",
+              "is_required": false,
+              "name": "ops",
+              "type_key": "Shape.e5ada7fdb5d104210dab388858ab047e8cee0f41"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"io_manager\": {}}",
+              "description": "Configure how shared resources are implemented within a run.",
+              "is_required": false,
+              "name": "resources",
+              "type_key": "Shape.4942ebf48d32aa0f8268910e01ed6544ad5b0132"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.a9ef178ea955c852b26b45817b8aea6df99c9f02",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "config",
+              "type_key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [],
+          "given_name": null,
+          "key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.e5ada7fdb5d104210dab388858ab047e8cee0f41": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "multipartitions_1",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "multipartitions_2",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.e5ada7fdb5d104210dab388858ab047e8cee0f41",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "console",
+              "type_key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "String": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "String",
+          "key": "String",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.STRING"
+          },
+          "type_param_keys": null
+        }
+      }
+    },
+    "dagster_type_namespace_snapshot": {
+      "__class__": "DagsterTypeNamespaceSnapshot",
+      "all_dagster_type_snaps_by_key": {
+        "Any": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Any",
+          "is_builtin": true,
+          "key": "Any",
+          "kind": {
+            "__enum__": "DagsterTypeKind.ANY"
+          },
+          "loader_schema_key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
+          "materializer_schema_key": null,
+          "name": "Any",
+          "type_param_keys": []
+        },
+        "Bool": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Bool",
+          "is_builtin": true,
+          "key": "Bool",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "materializer_schema_key": null,
+          "name": "Bool",
+          "type_param_keys": []
+        },
+        "Float": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Float",
+          "is_builtin": true,
+          "key": "Float",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "materializer_schema_key": null,
+          "name": "Float",
+          "type_param_keys": []
+        },
+        "Int": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Int",
+          "is_builtin": true,
+          "key": "Int",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "materializer_schema_key": null,
+          "name": "Int",
+          "type_param_keys": []
+        },
+        "Nothing": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Nothing",
+          "is_builtin": true,
+          "key": "Nothing",
+          "kind": {
+            "__enum__": "DagsterTypeKind.NOTHING"
+          },
+          "loader_schema_key": null,
+          "materializer_schema_key": null,
+          "name": "Nothing",
+          "type_param_keys": []
+        },
+        "String": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "String",
+          "is_builtin": true,
+          "key": "String",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "materializer_schema_key": null,
+          "name": "String",
+          "type_param_keys": []
+        }
+      }
+    },
+    "dep_structure_snapshot": {
+      "__class__": "DependencyStructureSnapshot",
+      "solid_invocation_snaps": [
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "multipartitions_1",
+          "solid_name": "multipartitions_1",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "multipartitions_1",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": [
+                {
+                  "__class__": "OutputHandleSnap",
+                  "output_name": "result",
+                  "solid_name": "multipartitions_1"
+                }
+              ]
+            }
+          ],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "multipartitions_2",
+          "solid_name": "multipartitions_2",
+          "tags": {}
+        }
+      ]
+    },
+    "description": null,
+    "graph_def_name": "multipartitions_job",
+    "lineage_snapshot": null,
+    "mode_def_snaps": [
+      {
+        "__class__": "ModeDefSnap",
+        "description": null,
+        "logger_def_snaps": [
+          {
+            "__class__": "LoggerDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
+              "description": "The default colored console logger.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
+            },
+            "description": "The default colored console logger.",
+            "name": "console"
+          }
+        ],
+        "name": "default",
+        "resource_def_snaps": [
+          {
+            "__class__": "ResourceDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "config",
+              "type_key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e"
+            },
+            "description": null,
+            "name": "hanging_asset_resource"
+          },
+          {
+            "__class__": "ResourceDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            },
+            "description": null,
+            "name": "io_manager"
+          }
+        ],
+        "root_config_key": "Shape.a9ef178ea955c852b26b45817b8aea6df99c9f02"
+      }
+    ],
+    "name": "multipartitions_job",
+    "solid_definitions_snapshot": {
+      "__class__": "SolidDefinitionsSnapshot",
+      "composite_solid_def_snaps": [],
+      "solid_def_snaps": [
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "multipartitions_1",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "name": "multipartitions_1"
+            }
+          ],
+          "name": "multipartitions_2",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        }
+      ]
+    },
+    "tags": {}
+  }
+  '''
+# ---
+# name: test_all_snapshot_ids[101]
+  'c656e8e7694e5110568efa51930949e52595fcc5'
+# ---
+# name: test_all_snapshot_ids[102]
+  '''
+  {
+    "__class__": "PipelineSnapshot",
+    "config_schema_snapshot": {
+      "__class__": "ConfigSchemaSnapshot",
+      "all_config_snaps_by_key": {
+        "Any": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Any",
+          "key": "Any",
+          "kind": {
+            "__enum__": "ConfigTypeKind.ANY"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Bool": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Bool",
+          "key": "Bool",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.BOOL"
+          },
+          "type_param_keys": null
+        },
+        "Float": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Float",
+          "key": "Float",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.FLOAT"
+          },
+          "type_param_keys": null
+        },
+        "Int": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Int",
+          "key": "Int",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.INT"
+          },
+          "type_param_keys": null
+        },
+        "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Bool",
+            "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59"
+          ]
+        },
+        "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Float",
+            "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3"
+          ]
+        },
+        "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Int",
+            "Selector.a9799b971d12ace70a2d8803c883c863417d0725"
+          ]
+        },
+        "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "String",
+            "Selector.e04723c9d9937e3ab21206435b22247cfbe58269"
+          ]
+        },
+        "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "disabled",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "enabled",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Int"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Bool"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Float"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Any"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.081354663b9d4b8fbfd1cb8e358763912953913f": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "\"INFO\"",
+              "description": "The logger's threshold.",
+              "is_required": false,
+              "name": "log_level",
+              "type_key": "String"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "\"dagster\"",
+              "description": "The name of your logger.",
+              "is_required": false,
+              "name": "name",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.09d73f0755bf4752d3f121837669c8660dcf451e": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"retries\": {\"enabled\": {}}}",
+              "description": "Execute all steps in a single process.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
+              "description": "The default colored console logger.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
         "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778": {
           "__class__": "ConfigTypeSnap",
           "description": null,
@@ -2644,10 +3634,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[101]
+# name: test_all_snapshot_ids[103]
   'c0668a7d87421329e47291f18575c0bfc0307acc'
 # ---
-# name: test_all_snapshot_ids[102]
+# name: test_all_snapshot_ids[104]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -3501,10 +4491,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[103]
+# name: test_all_snapshot_ids[105]
   '913c310b609478d52a81ee83bdd4b095d0f2932d'
 # ---
-# name: test_all_snapshot_ids[104]
+# name: test_all_snapshot_ids[106]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -4665,10 +5655,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[105]
+# name: test_all_snapshot_ids[107]
   '8e137c24b2245e55025e1cc7b71a42b99425dbec'
 # ---
-# name: test_all_snapshot_ids[106]
+# name: test_all_snapshot_ids[108]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -5586,10 +6576,1690 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[107]
+# name: test_all_snapshot_ids[109]
   'ab8f4b864ee53d2d9304b85f7a368aad7f678f29'
 # ---
-# name: test_all_snapshot_ids[108]
+# name: test_all_snapshot_ids[10]
+  '''
+  {
+    "__class__": "PipelineSnapshot",
+    "config_schema_snapshot": {
+      "__class__": "ConfigSchemaSnapshot",
+      "all_config_snaps_by_key": {
+        "Any": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Any",
+          "key": "Any",
+          "kind": {
+            "__enum__": "ConfigTypeKind.ANY"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Bool": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Bool",
+          "key": "Bool",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.BOOL"
+          },
+          "type_param_keys": null
+        },
+        "Float": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Float",
+          "key": "Float",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.FLOAT"
+          },
+          "type_param_keys": null
+        },
+        "Int": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Int",
+          "key": "Int",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.INT"
+          },
+          "type_param_keys": null
+        },
+        "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Bool",
+            "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59"
+          ]
+        },
+        "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Float",
+            "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3"
+          ]
+        },
+        "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Int",
+            "Selector.a9799b971d12ace70a2d8803c883c863417d0725"
+          ]
+        },
+        "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "String",
+            "Selector.e04723c9d9937e3ab21206435b22247cfbe58269"
+          ]
+        },
+        "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "disabled",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "enabled",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Int"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Bool"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Float"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Any"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.05c004f7ae4a4652822eb195559db5aaa9252a90": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "asset_1_my_check",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "check_in_op_asset",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "fresh_diamond_bottom",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "fresh_diamond_left",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "fresh_diamond_right",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "fresh_diamond_top",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "single_run_backfill_policy_asset",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"config\": {}}",
+              "description": null,
+              "is_required": false,
+              "name": "subsettable_checked_multi_asset",
+              "type_key": "Shape.62edccaf30696e25335ae92685bdc41e204e30e6"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "typed_asset",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"config\": {}}",
+              "description": null,
+              "is_required": false,
+              "name": "typed_multi_asset",
+              "type_key": "Shape.62edccaf30696e25335ae92685bdc41e204e30e6"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "unpartitioned_upstream_of_partitioned",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "untyped_asset",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "upstream_daily_partitioned_asset",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.05c004f7ae4a4652822eb195559db5aaa9252a90",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.081354663b9d4b8fbfd1cb8e358763912953913f": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "\"INFO\"",
+              "description": "The logger's threshold.",
+              "is_required": false,
+              "name": "log_level",
+              "type_key": "String"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "\"dagster\"",
+              "description": "The name of your logger.",
+              "is_required": false,
+              "name": "name",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.09d73f0755bf4752d3f121837669c8660dcf451e": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"retries\": {\"enabled\": {}}}",
+              "description": "Execute all steps in a single process.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
+              "description": "The default colored console logger.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "[DEPRECATED]",
+              "is_required": false,
+              "name": "marker_to_close",
+              "type_key": "String"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"enabled\": {}}",
+              "description": "Whether retries are enabled or not. By default, retries are enabled.",
+              "is_required": false,
+              "name": "retries",
+              "type_key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.4942ebf48d32aa0f8268910e01ed6544ad5b0132": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "hanging_asset_resource",
+              "type_key": "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "io_manager",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.4942ebf48d32aa0f8268910e01ed6544ad5b0132",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "path",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.62edccaf30696e25335ae92685bdc41e204e30e6": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.62edccaf30696e25335ae92685bdc41e204e30e6",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.743e47901855cb245064dd633e217bfcb49a11a7": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.88018c214f1ed9bdc606cb18e0cb1a0d3611fae7": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
+              "description": "Configure how steps are executed within a run.",
+              "is_required": false,
+              "name": "execution",
+              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Configure how loggers emit messages within a run.",
+              "is_required": false,
+              "name": "loggers",
+              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"asset_1_my_check\": {}, \"check_in_op_asset\": {}, \"fresh_diamond_bottom\": {}, \"fresh_diamond_left\": {}, \"fresh_diamond_right\": {}, \"fresh_diamond_top\": {}, \"single_run_backfill_policy_asset\": {}, \"subsettable_checked_multi_asset\": {\"config\": {}}, \"typed_asset\": {}, \"typed_multi_asset\": {\"config\": {}}, \"unpartitioned_upstream_of_partitioned\": {}, \"untyped_asset\": {}, \"upstream_daily_partitioned_asset\": {}}",
+              "description": "Configure runtime parameters for ops or assets.",
+              "is_required": false,
+              "name": "ops",
+              "type_key": "Shape.05c004f7ae4a4652822eb195559db5aaa9252a90"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"io_manager\": {}}",
+              "description": "Configure how shared resources are implemented within a run.",
+              "is_required": false,
+              "name": "resources",
+              "type_key": "Shape.4942ebf48d32aa0f8268910e01ed6544ad5b0132"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.88018c214f1ed9bdc606cb18e0cb1a0d3611fae7",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "file",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "config",
+              "type_key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [],
+          "given_name": null,
+          "key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "console",
+              "type_key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "String": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "String",
+          "key": "String",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.STRING"
+          },
+          "type_param_keys": null
+        }
+      }
+    },
+    "dagster_type_namespace_snapshot": {
+      "__class__": "DagsterTypeNamespaceSnapshot",
+      "all_dagster_type_snaps_by_key": {
+        "Any": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Any",
+          "is_builtin": true,
+          "key": "Any",
+          "kind": {
+            "__enum__": "DagsterTypeKind.ANY"
+          },
+          "loader_schema_key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
+          "materializer_schema_key": null,
+          "name": "Any",
+          "type_param_keys": []
+        },
+        "Bool": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Bool",
+          "is_builtin": true,
+          "key": "Bool",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "materializer_schema_key": null,
+          "name": "Bool",
+          "type_param_keys": []
+        },
+        "Float": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Float",
+          "is_builtin": true,
+          "key": "Float",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "materializer_schema_key": null,
+          "name": "Float",
+          "type_param_keys": []
+        },
+        "Int": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Int",
+          "is_builtin": true,
+          "key": "Int",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "materializer_schema_key": null,
+          "name": "Int",
+          "type_param_keys": []
+        },
+        "Nothing": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Nothing",
+          "is_builtin": true,
+          "key": "Nothing",
+          "kind": {
+            "__enum__": "DagsterTypeKind.NOTHING"
+          },
+          "loader_schema_key": null,
+          "materializer_schema_key": null,
+          "name": "Nothing",
+          "type_param_keys": []
+        },
+        "String": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "String",
+          "is_builtin": true,
+          "key": "String",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "materializer_schema_key": null,
+          "name": "String",
+          "type_param_keys": []
+        }
+      }
+    },
+    "dep_structure_snapshot": {
+      "__class__": "DependencyStructureSnapshot",
+      "solid_invocation_snaps": [
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "asset_1",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": []
+            }
+          ],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "asset_1_my_check",
+          "solid_name": "asset_1_my_check",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "check_in_op_asset",
+          "solid_name": "check_in_op_asset",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "fresh_diamond_left",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": [
+                {
+                  "__class__": "OutputHandleSnap",
+                  "output_name": "result",
+                  "solid_name": "fresh_diamond_left"
+                }
+              ]
+            },
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "fresh_diamond_right",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": [
+                {
+                  "__class__": "OutputHandleSnap",
+                  "output_name": "result",
+                  "solid_name": "fresh_diamond_right"
+                }
+              ]
+            }
+          ],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "fresh_diamond_bottom",
+          "solid_name": "fresh_diamond_bottom",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "fresh_diamond_top",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": [
+                {
+                  "__class__": "OutputHandleSnap",
+                  "output_name": "result",
+                  "solid_name": "fresh_diamond_top"
+                }
+              ]
+            }
+          ],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "fresh_diamond_left",
+          "solid_name": "fresh_diamond_left",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "fresh_diamond_top",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": [
+                {
+                  "__class__": "OutputHandleSnap",
+                  "output_name": "result",
+                  "solid_name": "fresh_diamond_top"
+                }
+              ]
+            }
+          ],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "fresh_diamond_right",
+          "solid_name": "fresh_diamond_right",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "diamond_source",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": []
+            }
+          ],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "fresh_diamond_top",
+          "solid_name": "fresh_diamond_top",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "single_run_backfill_policy_asset",
+          "solid_name": "single_run_backfill_policy_asset",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "subsettable_checked_multi_asset",
+          "solid_name": "subsettable_checked_multi_asset",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "int_asset",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": [
+                {
+                  "__class__": "OutputHandleSnap",
+                  "output_name": "int_asset",
+                  "solid_name": "typed_multi_asset"
+                }
+              ]
+            }
+          ],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "typed_asset",
+          "solid_name": "typed_asset",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "typed_multi_asset",
+          "solid_name": "typed_multi_asset",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "unpartitioned_upstream_of_partitioned",
+          "solid_name": "unpartitioned_upstream_of_partitioned",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "typed_asset",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": [
+                {
+                  "__class__": "OutputHandleSnap",
+                  "output_name": "result",
+                  "solid_name": "typed_asset"
+                }
+              ]
+            }
+          ],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "untyped_asset",
+          "solid_name": "untyped_asset",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "unpartitioned_upstream_of_partitioned",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": [
+                {
+                  "__class__": "OutputHandleSnap",
+                  "output_name": "result",
+                  "solid_name": "unpartitioned_upstream_of_partitioned"
+                }
+              ]
+            }
+          ],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "upstream_daily_partitioned_asset",
+          "solid_name": "upstream_daily_partitioned_asset",
+          "tags": {}
+        }
+      ]
+    },
+    "description": null,
+    "graph_def_name": "__ASSET_JOB_5",
+    "lineage_snapshot": null,
+    "mode_def_snaps": [
+      {
+        "__class__": "ModeDefSnap",
+        "description": null,
+        "logger_def_snaps": [
+          {
+            "__class__": "LoggerDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
+              "description": "The default colored console logger.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
+            },
+            "description": "The default colored console logger.",
+            "name": "console"
+          }
+        ],
+        "name": "default",
+        "resource_def_snaps": [
+          {
+            "__class__": "ResourceDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "config",
+              "type_key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e"
+            },
+            "description": null,
+            "name": "hanging_asset_resource"
+          },
+          {
+            "__class__": "ResourceDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            },
+            "description": null,
+            "name": "io_manager"
+          }
+        ],
+        "root_config_key": "Shape.88018c214f1ed9bdc606cb18e0cb1a0d3611fae7"
+      }
+    ],
+    "name": "__ASSET_JOB_5",
+    "solid_definitions_snapshot": {
+      "__class__": "SolidDefinitionsSnapshot",
+      "composite_solid_def_snaps": [],
+      "solid_def_snaps": [
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "name": "asset_1"
+            }
+          ],
+          "name": "asset_1_my_check",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "check_in_op_asset",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            },
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "check_in_op_asset_my_check"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "name": "fresh_diamond_left"
+            },
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "name": "fresh_diamond_right"
+            }
+          ],
+          "name": "fresh_diamond_bottom",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "name": "fresh_diamond_top"
+            }
+          ],
+          "name": "fresh_diamond_left",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "name": "fresh_diamond_top"
+            }
+          ],
+          "name": "fresh_diamond_right",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Nothing",
+              "description": null,
+              "name": "diamond_source"
+            }
+          ],
+          "name": "fresh_diamond_top",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "single_run_backfill_policy_asset",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{}",
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "subsettable_checked_multi_asset",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": false,
+              "name": "one"
+            },
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": false,
+              "name": "two"
+            },
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": false,
+              "name": "one_my_check"
+            },
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": false,
+              "name": "one_my_other_check"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "name": "int_asset"
+            }
+          ],
+          "name": "typed_asset",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Int",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{}",
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "typed_multi_asset",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Int",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "int_asset"
+            },
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "String",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "str_asset"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "unpartitioned_upstream_of_partitioned",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "name": "typed_asset"
+            }
+          ],
+          "name": "untyped_asset",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "name": "unpartitioned_upstream_of_partitioned"
+            }
+          ],
+          "name": "upstream_daily_partitioned_asset",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        }
+      ]
+    },
+    "tags": {}
+  }
+  '''
+# ---
+# name: test_all_snapshot_ids[110]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -6443,1646 +9113,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[109]
+# name: test_all_snapshot_ids[111]
   '98a8e544c66ff337c2aef1334603df0a3b1c7434'
 # ---
-# name: test_all_snapshot_ids[10]
-  '''
-  {
-    "__class__": "PipelineSnapshot",
-    "config_schema_snapshot": {
-      "__class__": "ConfigSchemaSnapshot",
-      "all_config_snaps_by_key": {
-        "Any": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Any",
-          "key": "Any",
-          "kind": {
-            "__enum__": "ConfigTypeKind.ANY"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Bool": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Bool",
-          "key": "Bool",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.BOOL"
-          },
-          "type_param_keys": null
-        },
-        "Float": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Float",
-          "key": "Float",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.FLOAT"
-          },
-          "type_param_keys": null
-        },
-        "Int": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Int",
-          "key": "Int",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.INT"
-          },
-          "type_param_keys": null
-        },
-        "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Bool",
-            "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59"
-          ]
-        },
-        "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Float",
-            "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3"
-          ]
-        },
-        "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Int",
-            "Selector.a9799b971d12ace70a2d8803c883c863417d0725"
-          ]
-        },
-        "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "String",
-            "Selector.e04723c9d9937e3ab21206435b22247cfbe58269"
-          ]
-        },
-        "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "disabled",
-              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "enabled",
-              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Int"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Bool"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Float"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Any"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.081354663b9d4b8fbfd1cb8e358763912953913f": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "\"INFO\"",
-              "description": "The logger's threshold.",
-              "is_required": false,
-              "name": "log_level",
-              "type_key": "String"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "\"dagster\"",
-              "description": "The name of your logger.",
-              "is_required": false,
-              "name": "name",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.09d73f0755bf4752d3f121837669c8660dcf451e": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"retries\": {\"enabled\": {}}}",
-              "description": "Execute all steps in a single process.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
-              "description": "The default colored console logger.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": "[DEPRECATED]",
-              "is_required": false,
-              "name": "marker_to_close",
-              "type_key": "String"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"enabled\": {}}",
-              "description": "Whether retries are enabled or not. By default, retries are enabled.",
-              "is_required": false,
-              "name": "retries",
-              "type_key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.4942ebf48d32aa0f8268910e01ed6544ad5b0132": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "hanging_asset_resource",
-              "type_key": "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "io_manager",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.4942ebf48d32aa0f8268910e01ed6544ad5b0132",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "path",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.62edccaf30696e25335ae92685bdc41e204e30e6": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.62edccaf30696e25335ae92685bdc41e204e30e6",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.6ef07a830b58ae029e6c03540ef29ac710cefa10": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
-              "description": "Configure how steps are executed within a run.",
-              "is_required": false,
-              "name": "execution",
-              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": "Configure how loggers emit messages within a run.",
-              "is_required": false,
-              "name": "loggers",
-              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"asset_1_my_check\": {}, \"check_in_op_asset\": {}, \"fresh_diamond_bottom\": {}, \"fresh_diamond_left\": {}, \"fresh_diamond_right\": {}, \"fresh_diamond_top\": {}, \"subsettable_checked_multi_asset\": {\"config\": {}}, \"typed_asset\": {}, \"typed_multi_asset\": {\"config\": {}}, \"unpartitioned_upstream_of_partitioned\": {}, \"untyped_asset\": {}, \"upstream_daily_partitioned_asset\": {}}",
-              "description": "Configure runtime parameters for ops or assets.",
-              "is_required": false,
-              "name": "ops",
-              "type_key": "Shape.abf22057133cf69038347f7c21c873f8e20034a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"io_manager\": {}}",
-              "description": "Configure how shared resources are implemented within a run.",
-              "is_required": false,
-              "name": "resources",
-              "type_key": "Shape.4942ebf48d32aa0f8268910e01ed6544ad5b0132"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.6ef07a830b58ae029e6c03540ef29ac710cefa10",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.743e47901855cb245064dd633e217bfcb49a11a7": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Any"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "file",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.abf22057133cf69038347f7c21c873f8e20034a7": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "asset_1_my_check",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "check_in_op_asset",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "fresh_diamond_bottom",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "fresh_diamond_left",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "fresh_diamond_right",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "fresh_diamond_top",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"config\": {}}",
-              "description": null,
-              "is_required": false,
-              "name": "subsettable_checked_multi_asset",
-              "type_key": "Shape.62edccaf30696e25335ae92685bdc41e204e30e6"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "typed_asset",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"config\": {}}",
-              "description": null,
-              "is_required": false,
-              "name": "typed_multi_asset",
-              "type_key": "Shape.62edccaf30696e25335ae92685bdc41e204e30e6"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "unpartitioned_upstream_of_partitioned",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "untyped_asset",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "upstream_daily_partitioned_asset",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.abf22057133cf69038347f7c21c873f8e20034a7",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "config",
-              "type_key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [],
-          "given_name": null,
-          "key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "console",
-              "type_key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "String": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "String",
-          "key": "String",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.STRING"
-          },
-          "type_param_keys": null
-        }
-      }
-    },
-    "dagster_type_namespace_snapshot": {
-      "__class__": "DagsterTypeNamespaceSnapshot",
-      "all_dagster_type_snaps_by_key": {
-        "Any": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Any",
-          "is_builtin": true,
-          "key": "Any",
-          "kind": {
-            "__enum__": "DagsterTypeKind.ANY"
-          },
-          "loader_schema_key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
-          "materializer_schema_key": null,
-          "name": "Any",
-          "type_param_keys": []
-        },
-        "Bool": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Bool",
-          "is_builtin": true,
-          "key": "Bool",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "materializer_schema_key": null,
-          "name": "Bool",
-          "type_param_keys": []
-        },
-        "Float": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Float",
-          "is_builtin": true,
-          "key": "Float",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "materializer_schema_key": null,
-          "name": "Float",
-          "type_param_keys": []
-        },
-        "Int": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Int",
-          "is_builtin": true,
-          "key": "Int",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "materializer_schema_key": null,
-          "name": "Int",
-          "type_param_keys": []
-        },
-        "Nothing": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Nothing",
-          "is_builtin": true,
-          "key": "Nothing",
-          "kind": {
-            "__enum__": "DagsterTypeKind.NOTHING"
-          },
-          "loader_schema_key": null,
-          "materializer_schema_key": null,
-          "name": "Nothing",
-          "type_param_keys": []
-        },
-        "String": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "String",
-          "is_builtin": true,
-          "key": "String",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "materializer_schema_key": null,
-          "name": "String",
-          "type_param_keys": []
-        }
-      }
-    },
-    "dep_structure_snapshot": {
-      "__class__": "DependencyStructureSnapshot",
-      "solid_invocation_snaps": [
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [
-            {
-              "__class__": "InputDependencySnap",
-              "input_name": "asset_1",
-              "is_dynamic_collect": false,
-              "upstream_output_snaps": []
-            }
-          ],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "asset_1_my_check",
-          "solid_name": "asset_1_my_check",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "check_in_op_asset",
-          "solid_name": "check_in_op_asset",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [
-            {
-              "__class__": "InputDependencySnap",
-              "input_name": "fresh_diamond_left",
-              "is_dynamic_collect": false,
-              "upstream_output_snaps": [
-                {
-                  "__class__": "OutputHandleSnap",
-                  "output_name": "result",
-                  "solid_name": "fresh_diamond_left"
-                }
-              ]
-            },
-            {
-              "__class__": "InputDependencySnap",
-              "input_name": "fresh_diamond_right",
-              "is_dynamic_collect": false,
-              "upstream_output_snaps": [
-                {
-                  "__class__": "OutputHandleSnap",
-                  "output_name": "result",
-                  "solid_name": "fresh_diamond_right"
-                }
-              ]
-            }
-          ],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "fresh_diamond_bottom",
-          "solid_name": "fresh_diamond_bottom",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [
-            {
-              "__class__": "InputDependencySnap",
-              "input_name": "fresh_diamond_top",
-              "is_dynamic_collect": false,
-              "upstream_output_snaps": [
-                {
-                  "__class__": "OutputHandleSnap",
-                  "output_name": "result",
-                  "solid_name": "fresh_diamond_top"
-                }
-              ]
-            }
-          ],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "fresh_diamond_left",
-          "solid_name": "fresh_diamond_left",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [
-            {
-              "__class__": "InputDependencySnap",
-              "input_name": "fresh_diamond_top",
-              "is_dynamic_collect": false,
-              "upstream_output_snaps": [
-                {
-                  "__class__": "OutputHandleSnap",
-                  "output_name": "result",
-                  "solid_name": "fresh_diamond_top"
-                }
-              ]
-            }
-          ],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "fresh_diamond_right",
-          "solid_name": "fresh_diamond_right",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [
-            {
-              "__class__": "InputDependencySnap",
-              "input_name": "diamond_source",
-              "is_dynamic_collect": false,
-              "upstream_output_snaps": []
-            }
-          ],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "fresh_diamond_top",
-          "solid_name": "fresh_diamond_top",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "subsettable_checked_multi_asset",
-          "solid_name": "subsettable_checked_multi_asset",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [
-            {
-              "__class__": "InputDependencySnap",
-              "input_name": "int_asset",
-              "is_dynamic_collect": false,
-              "upstream_output_snaps": [
-                {
-                  "__class__": "OutputHandleSnap",
-                  "output_name": "int_asset",
-                  "solid_name": "typed_multi_asset"
-                }
-              ]
-            }
-          ],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "typed_asset",
-          "solid_name": "typed_asset",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "typed_multi_asset",
-          "solid_name": "typed_multi_asset",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "unpartitioned_upstream_of_partitioned",
-          "solid_name": "unpartitioned_upstream_of_partitioned",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [
-            {
-              "__class__": "InputDependencySnap",
-              "input_name": "typed_asset",
-              "is_dynamic_collect": false,
-              "upstream_output_snaps": [
-                {
-                  "__class__": "OutputHandleSnap",
-                  "output_name": "result",
-                  "solid_name": "typed_asset"
-                }
-              ]
-            }
-          ],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "untyped_asset",
-          "solid_name": "untyped_asset",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [
-            {
-              "__class__": "InputDependencySnap",
-              "input_name": "unpartitioned_upstream_of_partitioned",
-              "is_dynamic_collect": false,
-              "upstream_output_snaps": [
-                {
-                  "__class__": "OutputHandleSnap",
-                  "output_name": "result",
-                  "solid_name": "unpartitioned_upstream_of_partitioned"
-                }
-              ]
-            }
-          ],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "upstream_daily_partitioned_asset",
-          "solid_name": "upstream_daily_partitioned_asset",
-          "tags": {}
-        }
-      ]
-    },
-    "description": null,
-    "graph_def_name": "__ASSET_JOB_5",
-    "lineage_snapshot": null,
-    "mode_def_snaps": [
-      {
-        "__class__": "ModeDefSnap",
-        "description": null,
-        "logger_def_snaps": [
-          {
-            "__class__": "LoggerDefSnap",
-            "config_field_snap": {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
-              "description": "The default colored console logger.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
-            },
-            "description": "The default colored console logger.",
-            "name": "console"
-          }
-        ],
-        "name": "default",
-        "resource_def_snaps": [
-          {
-            "__class__": "ResourceDefSnap",
-            "config_field_snap": {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "config",
-              "type_key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e"
-            },
-            "description": null,
-            "name": "hanging_asset_resource"
-          },
-          {
-            "__class__": "ResourceDefSnap",
-            "config_field_snap": {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Any"
-            },
-            "description": null,
-            "name": "io_manager"
-          }
-        ],
-        "root_config_key": "Shape.6ef07a830b58ae029e6c03540ef29ac710cefa10"
-      }
-    ],
-    "name": "__ASSET_JOB_5",
-    "solid_definitions_snapshot": {
-      "__class__": "SolidDefinitionsSnapshot",
-      "composite_solid_def_snaps": [],
-      "solid_def_snaps": [
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [
-            {
-              "__class__": "InputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "name": "asset_1"
-            }
-          ],
-          "name": "asset_1_my_check",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [],
-          "name": "check_in_op_asset",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            },
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "check_in_op_asset_my_check"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [
-            {
-              "__class__": "InputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "name": "fresh_diamond_left"
-            },
-            {
-              "__class__": "InputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "name": "fresh_diamond_right"
-            }
-          ],
-          "name": "fresh_diamond_bottom",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [
-            {
-              "__class__": "InputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "name": "fresh_diamond_top"
-            }
-          ],
-          "name": "fresh_diamond_left",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [
-            {
-              "__class__": "InputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "name": "fresh_diamond_top"
-            }
-          ],
-          "name": "fresh_diamond_right",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [
-            {
-              "__class__": "InputDefSnap",
-              "dagster_type_key": "Nothing",
-              "description": null,
-              "name": "diamond_source"
-            }
-          ],
-          "name": "fresh_diamond_top",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": true,
-            "default_value_as_json_str": "{}",
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
-          },
-          "description": null,
-          "input_def_snaps": [],
-          "name": "subsettable_checked_multi_asset",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": false,
-              "name": "one"
-            },
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": false,
-              "name": "two"
-            },
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": false,
-              "name": "one_my_check"
-            },
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": false,
-              "name": "one_my_other_check"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [
-            {
-              "__class__": "InputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "name": "int_asset"
-            }
-          ],
-          "name": "typed_asset",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Int",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": true,
-            "default_value_as_json_str": "{}",
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
-          },
-          "description": null,
-          "input_def_snaps": [],
-          "name": "typed_multi_asset",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Int",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "int_asset"
-            },
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "String",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "str_asset"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [],
-          "name": "unpartitioned_upstream_of_partitioned",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [
-            {
-              "__class__": "InputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "name": "typed_asset"
-            }
-          ],
-          "name": "untyped_asset",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [
-            {
-              "__class__": "InputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "name": "unpartitioned_upstream_of_partitioned"
-            }
-          ],
-          "name": "upstream_daily_partitioned_asset",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        }
-      ]
-    },
-    "tags": {}
-  }
-  '''
-# ---
-# name: test_all_snapshot_ids[110]
+# name: test_all_snapshot_ids[112]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -9005,10 +10039,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[111]
+# name: test_all_snapshot_ids[113]
   'b56e5292632a8b4ab9839c8c0a512c79a2fcfea5'
 # ---
-# name: test_all_snapshot_ids[112]
+# name: test_all_snapshot_ids[114]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -9862,10 +10896,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[113]
+# name: test_all_snapshot_ids[115]
   'd65a072229c6e8fc80db02c8d06067f3b0b48305'
 # ---
-# name: test_all_snapshot_ids[114]
+# name: test_all_snapshot_ids[116]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -10719,10 +11753,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[115]
+# name: test_all_snapshot_ids[117]
   '1b7d2d5d96a0b0728a8ac667c6217dea173e6c77'
 # ---
-# name: test_all_snapshot_ids[116]
+# name: test_all_snapshot_ids[118]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -11576,10 +12610,13 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[117]
+# name: test_all_snapshot_ids[119]
   '7efca79de5186cfdf88f49cf5f8c981c48fa2c93'
 # ---
-# name: test_all_snapshot_ids[118]
+# name: test_all_snapshot_ids[11]
+  'cc9b14de5591c5b8d3546e5d3591b3a9356c034a'
+# ---
+# name: test_all_snapshot_ids[120]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -12433,13 +13470,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[119]
+# name: test_all_snapshot_ids[121]
   '88c326b7e07c8c537ecd8086fd6429436a46c66f'
 # ---
-# name: test_all_snapshot_ids[11]
-  'f6fc2127abce24e8f45bc5eb1f32a77dbf03f1c2'
-# ---
-# name: test_all_snapshot_ids[120]
+# name: test_all_snapshot_ids[122]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -13339,10 +14373,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[121]
+# name: test_all_snapshot_ids[123]
   'a73f4941b2735f3a261d9617abaaed09a88aaebc'
 # ---
-# name: test_all_snapshot_ids[122]
+# name: test_all_snapshot_ids[124]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -14244,10 +15278,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[123]
+# name: test_all_snapshot_ids[125]
   '11f4785f61153adc6cca6935748af3807b59eee9'
 # ---
-# name: test_all_snapshot_ids[124]
+# name: test_all_snapshot_ids[126]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -15149,10 +16183,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[125]
+# name: test_all_snapshot_ids[127]
   '2b43566d7b3de2138b12c91b6953d6f1ddde0140'
 # ---
-# name: test_all_snapshot_ids[126]
+# name: test_all_snapshot_ids[128]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -15634,6 +16668,29 @@
           "scalar_kind": null,
           "type_param_keys": null
         },
+        "Shape.1629902fbbde68e17f4f310b85646b6a76efd18d": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "Base directory for storing files.",
+              "is_required": false,
+              "name": "base_dir",
+              "type_key": "Noneable.StringSourceType"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.1629902fbbde68e17f4f310b85646b6a76efd18d",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
         "Shape.24ee1fbfd9ec8adc8f4e5ab30e651b52389c861e": {
           "__class__": "ConfigTypeSnap",
           "description": null,
@@ -15701,38 +16758,6 @@
           ],
           "given_name": null,
           "key": "Shape.2e830fb24dc1eacc9bfa63a634b5715b46d81a2c",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.3f1ae09aca5685fa512e719e0e0f34132f10c8b3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "disable_gc",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"config\": {\"base_dir\": null}}",
-              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
-              "is_required": false,
-              "name": "io_manager",
-              "type_key": "Shape.9f45d547cea593c1893cee08a8d67b84989c16fc"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.3f1ae09aca5685fa512e719e0e0f34132f10c8b3",
           "kind": {
             "__enum__": "ConfigTypeKind.STRICT_SHAPE"
           },
@@ -15817,7 +16842,30 @@
           "scalar_kind": null,
           "type_param_keys": null
         },
-        "Shape.88643d5681d86336cf2207ad842fa2b2dfd27214": {
+        "Shape.aa06a6ac89e62cfd2f6a1f9bce137c6abfa63805": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.\n\n    The base directory that the pickle files live inside is determined by:\n\n    * The IO manager's \"base_dir\" configuration value, if specified. Otherwise...\n    * A \"storage/\" directory underneath the value for \"local_artifact_storage\" in your dagster.yaml\n      file, if specified. Otherwise...\n    * A \"storage/\" directory underneath the directory that the DAGSTER_HOME environment variable\n      points to, if that environment variable is specified. Otherwise...\n    * A temporary directory.\n\n    Assigns each op output to a unique filepath containing run ID, step key, and output name.\n    Assigns each asset to a single filesystem path, at \"<base_dir>/<asset_key>\". If the asset key\n    has multiple components, the final component is used as the name of the file, and the preceding\n    components as parent directories under the base_dir.\n\n    Subsequent materializations of an asset will overwrite previous materializations of that asset.\n    So, with a base directory of \"/my/base/path\", an asset with key\n    `AssetKey([\"one\", \"two\", \"three\"])` would be stored in a file called \"three\" in a directory\n    with path \"/my/base/path/one/two/\".\n\n    Example usage:\n\n\n    1. Attach an IO manager to a set of assets using the reserved resource key ``\"io_manager\"``.\n\n    .. code-block:: python\n\n        from dagster import Definitions, asset, FilesystemIOManager\n\n        @asset\n        def asset1():\n            # create df ...\n            return df\n\n        @asset\n        def asset2(asset1):\n            return asset1[:5]\n\n        defs = Definitions(\n            assets=[asset1, asset2],\n            resources={\n                \"io_manager\": FilesystemIOManager(base_dir=\"/my/base/path\")\n            },\n        )\n\n\n    2. Specify a job-level IO manager using the reserved resource key ``\"io_manager\"``,\n    which will set the given IO manager on all ops in a job.\n\n    .. code-block:: python\n\n        from dagster import FilesystemIOManager, job, op\n\n        @op\n        def op_a():\n            # create df ...\n            return df\n\n        @op\n        def op_b(df):\n            return df[:5]\n\n        @job(\n            resource_defs={\n                \"io_manager\": FilesystemIOManager(base_dir=\"/my/base/path\")\n            }\n        )\n        def job():\n            op_b(op_a())\n\n\n    3. Specify IO manager on :py:class:`Out`, which allows you to set different IO managers on\n    different step outputs.\n\n    .. code-block:: python\n\n        from dagster import FilesystemIOManager, job, op, Out\n\n        @op(out=Out(io_manager_key=\"my_io_manager\"))\n        def op_a():\n            # create df ...\n            return df\n\n        @op\n        def op_b(df):\n            return df[:5]\n\n        @job(resource_defs={\"my_io_manager\": FilesystemIOManager()})\n        def job():\n            op_b(op_a())",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.1629902fbbde68e17f4f310b85646b6a76efd18d"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.aa06a6ac89e62cfd2f6a1f9bce137c6abfa63805",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.b01e0f497d08ad2fa0e3b9d92d2409de1095b2c7": {
           "__class__": "ConfigTypeSnap",
           "description": null,
           "enum_values": null,
@@ -15852,61 +16900,15 @@
             {
               "__class__": "ConfigFieldSnap",
               "default_provided": true,
-              "default_value_as_json_str": "{\"disable_gc\": {}, \"io_manager\": {\"config\": {\"base_dir\": null}}}",
+              "default_value_as_json_str": "{\"disable_gc\": {}, \"io_manager\": {\"config\": {}}}",
               "description": "Configure how shared resources are implemented within a run.",
               "is_required": false,
               "name": "resources",
-              "type_key": "Shape.3f1ae09aca5685fa512e719e0e0f34132f10c8b3"
+              "type_key": "Shape.e6f1a85273b28fd3d7b57b81e9f94fad3bec2fe4"
             }
           ],
           "given_name": null,
-          "key": "Shape.88643d5681d86336cf2207ad842fa2b2dfd27214",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.9f45d547cea593c1893cee08a8d67b84989c16fc": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"base_dir\": null}",
-              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.\n\n    The base directory that the pickle files live inside is determined by:\n\n    * The IO manager's \"base_dir\" configuration value, if specified. Otherwise...\n    * A \"storage/\" directory underneath the value for \"local_artifact_storage\" in your dagster.yaml\n      file, if specified. Otherwise...\n    * A \"storage/\" directory underneath the directory that the DAGSTER_HOME environment variable\n      points to, if that environment variable is specified. Otherwise...\n    * A temporary directory.\n\n    Assigns each op output to a unique filepath containing run ID, step key, and output name.\n    Assigns each asset to a single filesystem path, at \"<base_dir>/<asset_key>\". If the asset key\n    has multiple components, the final component is used as the name of the file, and the preceding\n    components as parent directories under the base_dir.\n\n    Subsequent materializations of an asset will overwrite previous materializations of that asset.\n    So, with a base directory of \"/my/base/path\", an asset with key\n    `AssetKey([\"one\", \"two\", \"three\"])` would be stored in a file called \"three\" in a directory\n    with path \"/my/base/path/one/two/\".\n\n    Example usage:\n\n\n    1. Attach an IO manager to a set of assets using the reserved resource key ``\"io_manager\"``.\n\n    .. code-block:: python\n\n        from dagster import Definitions, asset, FilesystemIOManager\n\n        @asset\n        def asset1():\n            # create df ...\n            return df\n\n        @asset\n        def asset2(asset1):\n            return asset1[:5]\n\n        defs = Definitions(\n            assets=[asset1, asset2],\n            resources={\n                \"io_manager\": FilesystemIOManager(base_dir=\"/my/base/path\")\n            },\n        )\n\n\n    2. Specify a job-level IO manager using the reserved resource key ``\"io_manager\"``,\n    which will set the given IO manager on all ops in a job.\n\n    .. code-block:: python\n\n        from dagster import FilesystemIOManager, job, op\n\n        @op\n        def op_a():\n            # create df ...\n            return df\n\n        @op\n        def op_b(df):\n            return df[:5]\n\n        @job(\n            resource_defs={\n                \"io_manager\": FilesystemIOManager(base_dir=\"/my/base/path\")\n            }\n        )\n        def job():\n            op_b(op_a())\n\n\n    3. Specify IO manager on :py:class:`Out`, which allows you to set different IO managers on\n    different step outputs.\n\n    .. code-block:: python\n\n        from dagster import FilesystemIOManager, job, op, Out\n\n        @op(out=Out(io_manager_key=\"my_io_manager\"))\n        def op_a():\n            # create df ...\n            return df\n\n        @op\n        def op_b(df):\n            return df[:5]\n\n        @job(resource_defs={\"my_io_manager\": FilesystemIOManager()})\n        def job():\n            op_b(op_a())",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.b613ad485f01be6de3dda94dce6e7672b1d3c080"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.9f45d547cea593c1893cee08a8d67b84989c16fc",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.b613ad485f01be6de3dda94dce6e7672b1d3c080": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "null",
-              "description": "Base directory for storing files.",
-              "is_required": false,
-              "name": "base_dir",
-              "type_key": "Noneable.StringSourceType"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.b613ad485f01be6de3dda94dce6e7672b1d3c080",
+          "key": "Shape.b01e0f497d08ad2fa0e3b9d92d2409de1095b2c7",
           "kind": {
             "__enum__": "ConfigTypeKind.STRICT_SHAPE"
           },
@@ -15943,6 +16945,38 @@
           ],
           "given_name": null,
           "key": "Shape.dd25751df5066ca2b7e65e4907f386f04b08af64",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.e6f1a85273b28fd3d7b57b81e9f94fad3bec2fe4": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "disable_gc",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"config\": {}}",
+              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
+              "is_required": false,
+              "name": "io_manager",
+              "type_key": "Shape.aa06a6ac89e62cfd2f6a1f9bce137c6abfa63805"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.e6f1a85273b28fd3d7b57b81e9f94fad3bec2fe4",
           "kind": {
             "__enum__": "ConfigTypeKind.STRICT_SHAPE"
           },
@@ -16226,17 +17260,17 @@
             "config_field_snap": {
               "__class__": "ConfigFieldSnap",
               "default_provided": true,
-              "default_value_as_json_str": "{\"base_dir\": null}",
+              "default_value_as_json_str": "{}",
               "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.\n\n    The base directory that the pickle files live inside is determined by:\n\n    * The IO manager's \"base_dir\" configuration value, if specified. Otherwise...\n    * A \"storage/\" directory underneath the value for \"local_artifact_storage\" in your dagster.yaml\n      file, if specified. Otherwise...\n    * A \"storage/\" directory underneath the directory that the DAGSTER_HOME environment variable\n      points to, if that environment variable is specified. Otherwise...\n    * A temporary directory.\n\n    Assigns each op output to a unique filepath containing run ID, step key, and output name.\n    Assigns each asset to a single filesystem path, at \"<base_dir>/<asset_key>\". If the asset key\n    has multiple components, the final component is used as the name of the file, and the preceding\n    components as parent directories under the base_dir.\n\n    Subsequent materializations of an asset will overwrite previous materializations of that asset.\n    So, with a base directory of \"/my/base/path\", an asset with key\n    `AssetKey([\"one\", \"two\", \"three\"])` would be stored in a file called \"three\" in a directory\n    with path \"/my/base/path/one/two/\".\n\n    Example usage:\n\n\n    1. Attach an IO manager to a set of assets using the reserved resource key ``\"io_manager\"``.\n\n    .. code-block:: python\n\n        from dagster import Definitions, asset, FilesystemIOManager\n\n        @asset\n        def asset1():\n            # create df ...\n            return df\n\n        @asset\n        def asset2(asset1):\n            return asset1[:5]\n\n        defs = Definitions(\n            assets=[asset1, asset2],\n            resources={\n                \"io_manager\": FilesystemIOManager(base_dir=\"/my/base/path\")\n            },\n        )\n\n\n    2. Specify a job-level IO manager using the reserved resource key ``\"io_manager\"``,\n    which will set the given IO manager on all ops in a job.\n\n    .. code-block:: python\n\n        from dagster import FilesystemIOManager, job, op\n\n        @op\n        def op_a():\n            # create df ...\n            return df\n\n        @op\n        def op_b(df):\n            return df[:5]\n\n        @job(\n            resource_defs={\n                \"io_manager\": FilesystemIOManager(base_dir=\"/my/base/path\")\n            }\n        )\n        def job():\n            op_b(op_a())\n\n\n    3. Specify IO manager on :py:class:`Out`, which allows you to set different IO managers on\n    different step outputs.\n\n    .. code-block:: python\n\n        from dagster import FilesystemIOManager, job, op, Out\n\n        @op(out=Out(io_manager_key=\"my_io_manager\"))\n        def op_a():\n            # create df ...\n            return df\n\n        @op\n        def op_b(df):\n            return df[:5]\n\n        @job(resource_defs={\"my_io_manager\": FilesystemIOManager()})\n        def job():\n            op_b(op_a())",
               "is_required": false,
               "name": "config",
-              "type_key": "Shape.b613ad485f01be6de3dda94dce6e7672b1d3c080"
+              "type_key": "Shape.1629902fbbde68e17f4f310b85646b6a76efd18d"
             },
             "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
             "name": "io_manager"
           }
         ],
-        "root_config_key": "Shape.88643d5681d86336cf2207ad842fa2b2dfd27214"
+        "root_config_key": "Shape.b01e0f497d08ad2fa0e3b9d92d2409de1095b2c7"
       }
     ],
     "name": "retry_multi_input_early_terminate_job",
@@ -16389,1170 +17423,8 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[127]
-  '43f5a3b63b3dfe7ca769d3e75b79e1deed59e6ab'
-# ---
-# name: test_all_snapshot_ids[128]
-  '''
-  {
-    "__class__": "PipelineSnapshot",
-    "config_schema_snapshot": {
-      "__class__": "ConfigSchemaSnapshot",
-      "all_config_snaps_by_key": {
-        "Any": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Any",
-          "key": "Any",
-          "kind": {
-            "__enum__": "ConfigTypeKind.ANY"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Bool": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Bool",
-          "key": "Bool",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.BOOL"
-          },
-          "type_param_keys": null
-        },
-        "Float": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Float",
-          "key": "Float",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.FLOAT"
-          },
-          "type_param_keys": null
-        },
-        "Int": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Int",
-          "key": "Int",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.INT"
-          },
-          "type_param_keys": null
-        },
-        "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Bool",
-            "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59"
-          ]
-        },
-        "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Float",
-            "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3"
-          ]
-        },
-        "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Int",
-            "Selector.a9799b971d12ace70a2d8803c883c863417d0725"
-          ]
-        },
-        "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "String",
-            "Selector.e04723c9d9937e3ab21206435b22247cfbe58269"
-          ]
-        },
-        "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "disabled",
-              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "enabled",
-              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Int"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Bool"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Float"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Any"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.081354663b9d4b8fbfd1cb8e358763912953913f": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "\"INFO\"",
-              "description": "The logger's threshold.",
-              "is_required": false,
-              "name": "log_level",
-              "type_key": "String"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "\"dagster\"",
-              "description": "The name of your logger.",
-              "is_required": false,
-              "name": "name",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.09d73f0755bf4752d3f121837669c8660dcf451e": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"retries\": {\"enabled\": {}}}",
-              "description": "Execute all steps in a single process.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.0f759441a0a5dcbc16a099b6d7d106319ac492f9": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "fail",
-              "type_key": "Bool"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.0f759441a0a5dcbc16a099b6d7d106319ac492f9",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
-              "description": "The default colored console logger.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
-              "is_required": false,
-              "name": "io_manager",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.381bcdb53d3182896a9a86cdfc9f625f62080106": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
-              "description": "Configure how steps are executed within a run.",
-              "is_required": false,
-              "name": "execution",
-              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": "Configure how loggers emit messages within a run.",
-              "is_required": false,
-              "name": "loggers",
-              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": "Configure runtime parameters for ops or assets.",
-              "is_required": true,
-              "name": "ops",
-              "type_key": "Shape.857c24c238fce20e7bf57b59726c416b42738942"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"io_manager\": {}}",
-              "description": "Configure how shared resources are implemented within a run.",
-              "is_required": false,
-              "name": "resources",
-              "type_key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.381bcdb53d3182896a9a86cdfc9f625f62080106",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": "[DEPRECATED]",
-              "is_required": false,
-              "name": "marker_to_close",
-              "type_key": "String"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"enabled\": {}}",
-              "description": "Whether retries are enabled or not. By default, retries are enabled.",
-              "is_required": false,
-              "name": "retries",
-              "type_key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "path",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.743e47901855cb245064dd633e217bfcb49a11a7": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Any"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.857c24c238fce20e7bf57b59726c416b42738942": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "can_fail",
-              "type_key": "Shape.a62c224a9a675b7b35544be496fa9f28c429c6b6"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "child_fail",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "child_multi_skip",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "child_skip",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "grandchild_fail",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "multi",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.857c24c238fce20e7bf57b59726c416b42738942",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.a62c224a9a675b7b35544be496fa9f28c429c6b6": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "config",
-              "type_key": "Shape.0f759441a0a5dcbc16a099b6d7d106319ac492f9"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.a62c224a9a675b7b35544be496fa9f28c429c6b6",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [],
-          "given_name": null,
-          "key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "console",
-              "type_key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "String": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "String",
-          "key": "String",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.STRING"
-          },
-          "type_param_keys": null
-        }
-      }
-    },
-    "dagster_type_namespace_snapshot": {
-      "__class__": "DagsterTypeNamespaceSnapshot",
-      "all_dagster_type_snaps_by_key": {
-        "Any": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Any",
-          "is_builtin": true,
-          "key": "Any",
-          "kind": {
-            "__enum__": "DagsterTypeKind.ANY"
-          },
-          "loader_schema_key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
-          "materializer_schema_key": null,
-          "name": "Any",
-          "type_param_keys": []
-        },
-        "Bool": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Bool",
-          "is_builtin": true,
-          "key": "Bool",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "materializer_schema_key": null,
-          "name": "Bool",
-          "type_param_keys": []
-        },
-        "Float": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Float",
-          "is_builtin": true,
-          "key": "Float",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "materializer_schema_key": null,
-          "name": "Float",
-          "type_param_keys": []
-        },
-        "Int": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Int",
-          "is_builtin": true,
-          "key": "Int",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "materializer_schema_key": null,
-          "name": "Int",
-          "type_param_keys": []
-        },
-        "Nothing": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Nothing",
-          "is_builtin": true,
-          "key": "Nothing",
-          "kind": {
-            "__enum__": "DagsterTypeKind.NOTHING"
-          },
-          "loader_schema_key": null,
-          "materializer_schema_key": null,
-          "name": "Nothing",
-          "type_param_keys": []
-        },
-        "String": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "String",
-          "is_builtin": true,
-          "key": "String",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "materializer_schema_key": null,
-          "name": "String",
-          "type_param_keys": []
-        }
-      }
-    },
-    "dep_structure_snapshot": {
-      "__class__": "DependencyStructureSnapshot",
-      "solid_invocation_snaps": [
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [
-            {
-              "__class__": "InputDependencySnap",
-              "input_name": "inp",
-              "is_dynamic_collect": false,
-              "upstream_output_snaps": [
-                {
-                  "__class__": "OutputHandleSnap",
-                  "output_name": "success",
-                  "solid_name": "multi"
-                }
-              ]
-            }
-          ],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "can_fail",
-          "solid_name": "can_fail",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [
-            {
-              "__class__": "InputDependencySnap",
-              "input_name": "value",
-              "is_dynamic_collect": false,
-              "upstream_output_snaps": [
-                {
-                  "__class__": "OutputHandleSnap",
-                  "output_name": "start_fail",
-                  "solid_name": "can_fail"
-                }
-              ]
-            }
-          ],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "passthrough",
-          "solid_name": "child_fail",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [
-            {
-              "__class__": "InputDependencySnap",
-              "input_name": "start",
-              "is_dynamic_collect": false,
-              "upstream_output_snaps": [
-                {
-                  "__class__": "OutputHandleSnap",
-                  "output_name": "skip",
-                  "solid_name": "multi"
-                }
-              ]
-            }
-          ],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "no_output",
-          "solid_name": "child_multi_skip",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [
-            {
-              "__class__": "InputDependencySnap",
-              "input_name": "start",
-              "is_dynamic_collect": false,
-              "upstream_output_snaps": [
-                {
-                  "__class__": "OutputHandleSnap",
-                  "output_name": "start_skip",
-                  "solid_name": "can_fail"
-                }
-              ]
-            }
-          ],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "no_output",
-          "solid_name": "child_skip",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [
-            {
-              "__class__": "InputDependencySnap",
-              "input_name": "start",
-              "is_dynamic_collect": false,
-              "upstream_output_snaps": [
-                {
-                  "__class__": "OutputHandleSnap",
-                  "output_name": "result",
-                  "solid_name": "child_fail"
-                }
-              ]
-            }
-          ],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "no_output",
-          "solid_name": "grandchild_fail",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "multi",
-          "solid_name": "multi",
-          "tags": {}
-        }
-      ]
-    },
-    "description": null,
-    "graph_def_name": "retry_multi_output_job",
-    "lineage_snapshot": null,
-    "mode_def_snaps": [
-      {
-        "__class__": "ModeDefSnap",
-        "description": null,
-        "logger_def_snaps": [
-          {
-            "__class__": "LoggerDefSnap",
-            "config_field_snap": {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
-              "description": "The default colored console logger.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
-            },
-            "description": "The default colored console logger.",
-            "name": "console"
-          }
-        ],
-        "name": "default",
-        "resource_def_snaps": [
-          {
-            "__class__": "ResourceDefSnap",
-            "config_field_snap": {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Any"
-            },
-            "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
-            "name": "io_manager"
-          }
-        ],
-        "root_config_key": "Shape.381bcdb53d3182896a9a86cdfc9f625f62080106"
-      }
-    ],
-    "name": "retry_multi_output_job",
-    "solid_definitions_snapshot": {
-      "__class__": "SolidDefinitionsSnapshot",
-      "composite_solid_def_snaps": [],
-      "solid_def_snaps": [
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": true,
-            "name": "config",
-            "type_key": "Shape.0f759441a0a5dcbc16a099b6d7d106319ac492f9"
-          },
-          "description": null,
-          "input_def_snaps": [
-            {
-              "__class__": "InputDefSnap",
-              "dagster_type_key": "String",
-              "description": null,
-              "name": "inp"
-            }
-          ],
-          "name": "can_fail",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "String",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": false,
-              "name": "start_fail"
-            },
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "String",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": false,
-              "name": "start_skip"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [],
-          "name": "multi",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "String",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": false,
-              "name": "success"
-            },
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "String",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": false,
-              "name": "skip"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [
-            {
-              "__class__": "InputDefSnap",
-              "dagster_type_key": "Nothing",
-              "description": null,
-              "name": "start"
-            }
-          ],
-          "name": "no_output",
-          "output_def_snaps": [],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [
-            {
-              "__class__": "InputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "name": "value"
-            }
-          ],
-          "name": "passthrough",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        }
-      ]
-    },
-    "tags": {}
-  }
-  '''
-# ---
 # name: test_all_snapshot_ids[129]
-  '9a9a09da6b3a1dbab13bfde5e155c0f097dd22a5'
+  '728ab5201b611eddf16a949174470c76a353c3be'
 # ---
 # name: test_all_snapshot_ids[12]
   '''
@@ -19249,6 +19121,1168 @@
           },
           "type_param_keys": null
         },
+        "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Bool",
+            "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59"
+          ]
+        },
+        "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Float",
+            "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3"
+          ]
+        },
+        "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Int",
+            "Selector.a9799b971d12ace70a2d8803c883c863417d0725"
+          ]
+        },
+        "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "String",
+            "Selector.e04723c9d9937e3ab21206435b22247cfbe58269"
+          ]
+        },
+        "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "disabled",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "enabled",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Int"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Bool"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Float"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Any"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.081354663b9d4b8fbfd1cb8e358763912953913f": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "\"INFO\"",
+              "description": "The logger's threshold.",
+              "is_required": false,
+              "name": "log_level",
+              "type_key": "String"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "\"dagster\"",
+              "description": "The name of your logger.",
+              "is_required": false,
+              "name": "name",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.09d73f0755bf4752d3f121837669c8660dcf451e": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"retries\": {\"enabled\": {}}}",
+              "description": "Execute all steps in a single process.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.0f759441a0a5dcbc16a099b6d7d106319ac492f9": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "fail",
+              "type_key": "Bool"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.0f759441a0a5dcbc16a099b6d7d106319ac492f9",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
+              "description": "The default colored console logger.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
+              "is_required": false,
+              "name": "io_manager",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.381bcdb53d3182896a9a86cdfc9f625f62080106": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
+              "description": "Configure how steps are executed within a run.",
+              "is_required": false,
+              "name": "execution",
+              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Configure how loggers emit messages within a run.",
+              "is_required": false,
+              "name": "loggers",
+              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "Configure runtime parameters for ops or assets.",
+              "is_required": true,
+              "name": "ops",
+              "type_key": "Shape.857c24c238fce20e7bf57b59726c416b42738942"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"io_manager\": {}}",
+              "description": "Configure how shared resources are implemented within a run.",
+              "is_required": false,
+              "name": "resources",
+              "type_key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.381bcdb53d3182896a9a86cdfc9f625f62080106",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "[DEPRECATED]",
+              "is_required": false,
+              "name": "marker_to_close",
+              "type_key": "String"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"enabled\": {}}",
+              "description": "Whether retries are enabled or not. By default, retries are enabled.",
+              "is_required": false,
+              "name": "retries",
+              "type_key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "path",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.743e47901855cb245064dd633e217bfcb49a11a7": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.857c24c238fce20e7bf57b59726c416b42738942": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "can_fail",
+              "type_key": "Shape.a62c224a9a675b7b35544be496fa9f28c429c6b6"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "child_fail",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "child_multi_skip",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "child_skip",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "grandchild_fail",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "multi",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.857c24c238fce20e7bf57b59726c416b42738942",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.a62c224a9a675b7b35544be496fa9f28c429c6b6": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "config",
+              "type_key": "Shape.0f759441a0a5dcbc16a099b6d7d106319ac492f9"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.a62c224a9a675b7b35544be496fa9f28c429c6b6",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [],
+          "given_name": null,
+          "key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "console",
+              "type_key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "String": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "String",
+          "key": "String",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.STRING"
+          },
+          "type_param_keys": null
+        }
+      }
+    },
+    "dagster_type_namespace_snapshot": {
+      "__class__": "DagsterTypeNamespaceSnapshot",
+      "all_dagster_type_snaps_by_key": {
+        "Any": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Any",
+          "is_builtin": true,
+          "key": "Any",
+          "kind": {
+            "__enum__": "DagsterTypeKind.ANY"
+          },
+          "loader_schema_key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
+          "materializer_schema_key": null,
+          "name": "Any",
+          "type_param_keys": []
+        },
+        "Bool": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Bool",
+          "is_builtin": true,
+          "key": "Bool",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "materializer_schema_key": null,
+          "name": "Bool",
+          "type_param_keys": []
+        },
+        "Float": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Float",
+          "is_builtin": true,
+          "key": "Float",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "materializer_schema_key": null,
+          "name": "Float",
+          "type_param_keys": []
+        },
+        "Int": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Int",
+          "is_builtin": true,
+          "key": "Int",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "materializer_schema_key": null,
+          "name": "Int",
+          "type_param_keys": []
+        },
+        "Nothing": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Nothing",
+          "is_builtin": true,
+          "key": "Nothing",
+          "kind": {
+            "__enum__": "DagsterTypeKind.NOTHING"
+          },
+          "loader_schema_key": null,
+          "materializer_schema_key": null,
+          "name": "Nothing",
+          "type_param_keys": []
+        },
+        "String": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "String",
+          "is_builtin": true,
+          "key": "String",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "materializer_schema_key": null,
+          "name": "String",
+          "type_param_keys": []
+        }
+      }
+    },
+    "dep_structure_snapshot": {
+      "__class__": "DependencyStructureSnapshot",
+      "solid_invocation_snaps": [
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "inp",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": [
+                {
+                  "__class__": "OutputHandleSnap",
+                  "output_name": "success",
+                  "solid_name": "multi"
+                }
+              ]
+            }
+          ],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "can_fail",
+          "solid_name": "can_fail",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "value",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": [
+                {
+                  "__class__": "OutputHandleSnap",
+                  "output_name": "start_fail",
+                  "solid_name": "can_fail"
+                }
+              ]
+            }
+          ],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "passthrough",
+          "solid_name": "child_fail",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "start",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": [
+                {
+                  "__class__": "OutputHandleSnap",
+                  "output_name": "skip",
+                  "solid_name": "multi"
+                }
+              ]
+            }
+          ],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "no_output",
+          "solid_name": "child_multi_skip",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "start",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": [
+                {
+                  "__class__": "OutputHandleSnap",
+                  "output_name": "start_skip",
+                  "solid_name": "can_fail"
+                }
+              ]
+            }
+          ],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "no_output",
+          "solid_name": "child_skip",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "start",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": [
+                {
+                  "__class__": "OutputHandleSnap",
+                  "output_name": "result",
+                  "solid_name": "child_fail"
+                }
+              ]
+            }
+          ],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "no_output",
+          "solid_name": "grandchild_fail",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "multi",
+          "solid_name": "multi",
+          "tags": {}
+        }
+      ]
+    },
+    "description": null,
+    "graph_def_name": "retry_multi_output_job",
+    "lineage_snapshot": null,
+    "mode_def_snaps": [
+      {
+        "__class__": "ModeDefSnap",
+        "description": null,
+        "logger_def_snaps": [
+          {
+            "__class__": "LoggerDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
+              "description": "The default colored console logger.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
+            },
+            "description": "The default colored console logger.",
+            "name": "console"
+          }
+        ],
+        "name": "default",
+        "resource_def_snaps": [
+          {
+            "__class__": "ResourceDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            },
+            "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
+            "name": "io_manager"
+          }
+        ],
+        "root_config_key": "Shape.381bcdb53d3182896a9a86cdfc9f625f62080106"
+      }
+    ],
+    "name": "retry_multi_output_job",
+    "solid_definitions_snapshot": {
+      "__class__": "SolidDefinitionsSnapshot",
+      "composite_solid_def_snaps": [],
+      "solid_def_snaps": [
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": true,
+            "name": "config",
+            "type_key": "Shape.0f759441a0a5dcbc16a099b6d7d106319ac492f9"
+          },
+          "description": null,
+          "input_def_snaps": [
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "String",
+              "description": null,
+              "name": "inp"
+            }
+          ],
+          "name": "can_fail",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "String",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": false,
+              "name": "start_fail"
+            },
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "String",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": false,
+              "name": "start_skip"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "multi",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "String",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": false,
+              "name": "success"
+            },
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "String",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": false,
+              "name": "skip"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Nothing",
+              "description": null,
+              "name": "start"
+            }
+          ],
+          "name": "no_output",
+          "output_def_snaps": [],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "name": "value"
+            }
+          ],
+          "name": "passthrough",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        }
+      ]
+    },
+    "tags": {}
+  }
+  '''
+# ---
+# name: test_all_snapshot_ids[131]
+  '9a9a09da6b3a1dbab13bfde5e155c0f097dd22a5'
+# ---
+# name: test_all_snapshot_ids[132]
+  '''
+  {
+    "__class__": "PipelineSnapshot",
+    "config_schema_snapshot": {
+      "__class__": "ConfigSchemaSnapshot",
+      "all_config_snaps_by_key": {
+        "Any": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Any",
+          "key": "Any",
+          "kind": {
+            "__enum__": "ConfigTypeKind.ANY"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Bool": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Bool",
+          "key": "Bool",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.BOOL"
+          },
+          "type_param_keys": null
+        },
+        "Float": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Float",
+          "key": "Float",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.FLOAT"
+          },
+          "type_param_keys": null
+        },
+        "Int": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Int",
+          "key": "Int",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.INT"
+          },
+          "type_param_keys": null
+        },
         "Noneable.StringSourceType": {
           "__class__": "ConfigTypeSnap",
           "description": null,
@@ -19666,6 +20700,29 @@
           "scalar_kind": null,
           "type_param_keys": null
         },
+        "Shape.1629902fbbde68e17f4f310b85646b6a76efd18d": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "Base directory for storing files.",
+              "is_required": false,
+              "name": "base_dir",
+              "type_key": "Noneable.StringSourceType"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.1629902fbbde68e17f4f310b85646b6a76efd18d",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
         "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c": {
           "__class__": "ConfigTypeSnap",
           "description": null,
@@ -19776,53 +20833,7 @@
           "scalar_kind": null,
           "type_param_keys": null
         },
-        "Shape.9f45d547cea593c1893cee08a8d67b84989c16fc": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"base_dir\": null}",
-              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.\n\n    The base directory that the pickle files live inside is determined by:\n\n    * The IO manager's \"base_dir\" configuration value, if specified. Otherwise...\n    * A \"storage/\" directory underneath the value for \"local_artifact_storage\" in your dagster.yaml\n      file, if specified. Otherwise...\n    * A \"storage/\" directory underneath the directory that the DAGSTER_HOME environment variable\n      points to, if that environment variable is specified. Otherwise...\n    * A temporary directory.\n\n    Assigns each op output to a unique filepath containing run ID, step key, and output name.\n    Assigns each asset to a single filesystem path, at \"<base_dir>/<asset_key>\". If the asset key\n    has multiple components, the final component is used as the name of the file, and the preceding\n    components as parent directories under the base_dir.\n\n    Subsequent materializations of an asset will overwrite previous materializations of that asset.\n    So, with a base directory of \"/my/base/path\", an asset with key\n    `AssetKey([\"one\", \"two\", \"three\"])` would be stored in a file called \"three\" in a directory\n    with path \"/my/base/path/one/two/\".\n\n    Example usage:\n\n\n    1. Attach an IO manager to a set of assets using the reserved resource key ``\"io_manager\"``.\n\n    .. code-block:: python\n\n        from dagster import Definitions, asset, FilesystemIOManager\n\n        @asset\n        def asset1():\n            # create df ...\n            return df\n\n        @asset\n        def asset2(asset1):\n            return asset1[:5]\n\n        defs = Definitions(\n            assets=[asset1, asset2],\n            resources={\n                \"io_manager\": FilesystemIOManager(base_dir=\"/my/base/path\")\n            },\n        )\n\n\n    2. Specify a job-level IO manager using the reserved resource key ``\"io_manager\"``,\n    which will set the given IO manager on all ops in a job.\n\n    .. code-block:: python\n\n        from dagster import FilesystemIOManager, job, op\n\n        @op\n        def op_a():\n            # create df ...\n            return df\n\n        @op\n        def op_b(df):\n            return df[:5]\n\n        @job(\n            resource_defs={\n                \"io_manager\": FilesystemIOManager(base_dir=\"/my/base/path\")\n            }\n        )\n        def job():\n            op_b(op_a())\n\n\n    3. Specify IO manager on :py:class:`Out`, which allows you to set different IO managers on\n    different step outputs.\n\n    .. code-block:: python\n\n        from dagster import FilesystemIOManager, job, op, Out\n\n        @op(out=Out(io_manager_key=\"my_io_manager\"))\n        def op_a():\n            # create df ...\n            return df\n\n        @op\n        def op_b(df):\n            return df[:5]\n\n        @job(resource_defs={\"my_io_manager\": FilesystemIOManager()})\n        def job():\n            op_b(op_a())",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.b613ad485f01be6de3dda94dce6e7672b1d3c080"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.9f45d547cea593c1893cee08a8d67b84989c16fc",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.b613ad485f01be6de3dda94dce6e7672b1d3c080": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "null",
-              "description": "Base directory for storing files.",
-              "is_required": false,
-              "name": "base_dir",
-              "type_key": "Noneable.StringSourceType"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.b613ad485f01be6de3dda94dce6e7672b1d3c080",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.ca6a996bf4027dd8e7559fa71467c44396a78dff": {
+        "Shape.829973262158134d91916a48835fb0c656ac2f5f": {
           "__class__": "ConfigTypeSnap",
           "description": null,
           "enum_values": null,
@@ -19848,22 +20859,45 @@
             {
               "__class__": "ConfigFieldSnap",
               "default_provided": true,
-              "default_value_as_json_str": "{\"config\": {\"base_dir\": null}}",
+              "default_value_as_json_str": "{\"config\": {}}",
               "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
               "is_required": false,
               "name": "io_manager",
-              "type_key": "Shape.9f45d547cea593c1893cee08a8d67b84989c16fc"
+              "type_key": "Shape.aa06a6ac89e62cfd2f6a1f9bce137c6abfa63805"
             }
           ],
           "given_name": null,
-          "key": "Shape.ca6a996bf4027dd8e7559fa71467c44396a78dff",
+          "key": "Shape.829973262158134d91916a48835fb0c656ac2f5f",
           "kind": {
             "__enum__": "ConfigTypeKind.STRICT_SHAPE"
           },
           "scalar_kind": null,
           "type_param_keys": null
         },
-        "Shape.d841aa810e865d68b7ffec15a2afbe56ee454fb8": {
+        "Shape.aa06a6ac89e62cfd2f6a1f9bce137c6abfa63805": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.\n\n    The base directory that the pickle files live inside is determined by:\n\n    * The IO manager's \"base_dir\" configuration value, if specified. Otherwise...\n    * A \"storage/\" directory underneath the value for \"local_artifact_storage\" in your dagster.yaml\n      file, if specified. Otherwise...\n    * A \"storage/\" directory underneath the directory that the DAGSTER_HOME environment variable\n      points to, if that environment variable is specified. Otherwise...\n    * A temporary directory.\n\n    Assigns each op output to a unique filepath containing run ID, step key, and output name.\n    Assigns each asset to a single filesystem path, at \"<base_dir>/<asset_key>\". If the asset key\n    has multiple components, the final component is used as the name of the file, and the preceding\n    components as parent directories under the base_dir.\n\n    Subsequent materializations of an asset will overwrite previous materializations of that asset.\n    So, with a base directory of \"/my/base/path\", an asset with key\n    `AssetKey([\"one\", \"two\", \"three\"])` would be stored in a file called \"three\" in a directory\n    with path \"/my/base/path/one/two/\".\n\n    Example usage:\n\n\n    1. Attach an IO manager to a set of assets using the reserved resource key ``\"io_manager\"``.\n\n    .. code-block:: python\n\n        from dagster import Definitions, asset, FilesystemIOManager\n\n        @asset\n        def asset1():\n            # create df ...\n            return df\n\n        @asset\n        def asset2(asset1):\n            return asset1[:5]\n\n        defs = Definitions(\n            assets=[asset1, asset2],\n            resources={\n                \"io_manager\": FilesystemIOManager(base_dir=\"/my/base/path\")\n            },\n        )\n\n\n    2. Specify a job-level IO manager using the reserved resource key ``\"io_manager\"``,\n    which will set the given IO manager on all ops in a job.\n\n    .. code-block:: python\n\n        from dagster import FilesystemIOManager, job, op\n\n        @op\n        def op_a():\n            # create df ...\n            return df\n\n        @op\n        def op_b(df):\n            return df[:5]\n\n        @job(\n            resource_defs={\n                \"io_manager\": FilesystemIOManager(base_dir=\"/my/base/path\")\n            }\n        )\n        def job():\n            op_b(op_a())\n\n\n    3. Specify IO manager on :py:class:`Out`, which allows you to set different IO managers on\n    different step outputs.\n\n    .. code-block:: python\n\n        from dagster import FilesystemIOManager, job, op, Out\n\n        @op(out=Out(io_manager_key=\"my_io_manager\"))\n        def op_a():\n            # create df ...\n            return df\n\n        @op\n        def op_b(df):\n            return df[:5]\n\n        @job(resource_defs={\"my_io_manager\": FilesystemIOManager()})\n        def job():\n            op_b(op_a())",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.1629902fbbde68e17f4f310b85646b6a76efd18d"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.aa06a6ac89e62cfd2f6a1f9bce137c6abfa63805",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.c798ed8f6a16231e878ec2f37ffaf63d0aa0b669": {
           "__class__": "ConfigTypeSnap",
           "description": null,
           "enum_values": null,
@@ -19898,15 +20932,15 @@
             {
               "__class__": "ConfigFieldSnap",
               "default_provided": true,
-              "default_value_as_json_str": "{\"a\": {}, \"b\": {}, \"io_manager\": {\"config\": {\"base_dir\": null}}}",
+              "default_value_as_json_str": "{\"a\": {}, \"b\": {}, \"io_manager\": {\"config\": {}}}",
               "description": "Configure how shared resources are implemented within a run.",
               "is_required": false,
               "name": "resources",
-              "type_key": "Shape.ca6a996bf4027dd8e7559fa71467c44396a78dff"
+              "type_key": "Shape.829973262158134d91916a48835fb0c656ac2f5f"
             }
           ],
           "given_name": null,
-          "key": "Shape.d841aa810e865d68b7ffec15a2afbe56ee454fb8",
+          "key": "Shape.c798ed8f6a16231e878ec2f37ffaf63d0aa0b669",
           "kind": {
             "__enum__": "ConfigTypeKind.STRICT_SHAPE"
           },
@@ -20163,17 +21197,17 @@
             "config_field_snap": {
               "__class__": "ConfigFieldSnap",
               "default_provided": true,
-              "default_value_as_json_str": "{\"base_dir\": null}",
+              "default_value_as_json_str": "{}",
               "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.\n\n    The base directory that the pickle files live inside is determined by:\n\n    * The IO manager's \"base_dir\" configuration value, if specified. Otherwise...\n    * A \"storage/\" directory underneath the value for \"local_artifact_storage\" in your dagster.yaml\n      file, if specified. Otherwise...\n    * A \"storage/\" directory underneath the directory that the DAGSTER_HOME environment variable\n      points to, if that environment variable is specified. Otherwise...\n    * A temporary directory.\n\n    Assigns each op output to a unique filepath containing run ID, step key, and output name.\n    Assigns each asset to a single filesystem path, at \"<base_dir>/<asset_key>\". If the asset key\n    has multiple components, the final component is used as the name of the file, and the preceding\n    components as parent directories under the base_dir.\n\n    Subsequent materializations of an asset will overwrite previous materializations of that asset.\n    So, with a base directory of \"/my/base/path\", an asset with key\n    `AssetKey([\"one\", \"two\", \"three\"])` would be stored in a file called \"three\" in a directory\n    with path \"/my/base/path/one/two/\".\n\n    Example usage:\n\n\n    1. Attach an IO manager to a set of assets using the reserved resource key ``\"io_manager\"``.\n\n    .. code-block:: python\n\n        from dagster import Definitions, asset, FilesystemIOManager\n\n        @asset\n        def asset1():\n            # create df ...\n            return df\n\n        @asset\n        def asset2(asset1):\n            return asset1[:5]\n\n        defs = Definitions(\n            assets=[asset1, asset2],\n            resources={\n                \"io_manager\": FilesystemIOManager(base_dir=\"/my/base/path\")\n            },\n        )\n\n\n    2. Specify a job-level IO manager using the reserved resource key ``\"io_manager\"``,\n    which will set the given IO manager on all ops in a job.\n\n    .. code-block:: python\n\n        from dagster import FilesystemIOManager, job, op\n\n        @op\n        def op_a():\n            # create df ...\n            return df\n\n        @op\n        def op_b(df):\n            return df[:5]\n\n        @job(\n            resource_defs={\n                \"io_manager\": FilesystemIOManager(base_dir=\"/my/base/path\")\n            }\n        )\n        def job():\n            op_b(op_a())\n\n\n    3. Specify IO manager on :py:class:`Out`, which allows you to set different IO managers on\n    different step outputs.\n\n    .. code-block:: python\n\n        from dagster import FilesystemIOManager, job, op, Out\n\n        @op(out=Out(io_manager_key=\"my_io_manager\"))\n        def op_a():\n            # create df ...\n            return df\n\n        @op\n        def op_b(df):\n            return df[:5]\n\n        @job(resource_defs={\"my_io_manager\": FilesystemIOManager()})\n        def job():\n            op_b(op_a())",
               "is_required": false,
               "name": "config",
-              "type_key": "Shape.b613ad485f01be6de3dda94dce6e7672b1d3c080"
+              "type_key": "Shape.1629902fbbde68e17f4f310b85646b6a76efd18d"
             },
             "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
             "name": "io_manager"
           }
         ],
-        "root_config_key": "Shape.d841aa810e865d68b7ffec15a2afbe56ee454fb8"
+        "root_config_key": "Shape.c798ed8f6a16231e878ec2f37ffaf63d0aa0b669"
       }
     ],
     "name": "retry_resource_job",
@@ -20252,10 +21286,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[131]
-  'c4bb3ae01a9a02bb508d899fbcb41cf04f342b51'
+# name: test_all_snapshot_ids[133]
+  'f347f3d93efff88c83539160011b75771fb73b95'
 # ---
-# name: test_all_snapshot_ids[132]
+# name: test_all_snapshot_ids[134]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -21241,10 +22275,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[133]
+# name: test_all_snapshot_ids[135]
   'ca68b52613bfcadc230b3dc1ec7e1045f9bc5836'
 # ---
-# name: test_all_snapshot_ids[134]
+# name: test_all_snapshot_ids[136]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -22098,10 +23132,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[135]
+# name: test_all_snapshot_ids[137]
   '4fbe2b21985de715173a8d630c5d1506a0c7f040'
 # ---
-# name: test_all_snapshot_ids[136]
+# name: test_all_snapshot_ids[138]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -22955,10 +23989,13 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[137]
+# name: test_all_snapshot_ids[139]
   'c58bbee5967b5e43b907f2ee09bfa26b5b017899'
 # ---
-# name: test_all_snapshot_ids[138]
+# name: test_all_snapshot_ids[13]
+  '4e666ba1a90b137d5ae2cc5440f2f362fbfde874'
+# ---
+# name: test_all_snapshot_ids[140]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -23812,13 +24849,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[139]
+# name: test_all_snapshot_ids[141]
   '9109ebc6447db70cdcd17a7bf8b90ec61ffd02fe'
 # ---
-# name: test_all_snapshot_ids[13]
-  '4e666ba1a90b137d5ae2cc5440f2f362fbfde874'
-# ---
-# name: test_all_snapshot_ids[140]
+# name: test_all_snapshot_ids[142]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -24672,10 +25706,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[141]
+# name: test_all_snapshot_ids[143]
   '673ec5c1c0fce5ffec0506edd32bcdbd018e79bb'
 # ---
-# name: test_all_snapshot_ids[142]
+# name: test_all_snapshot_ids[144]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -25808,10 +26842,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[143]
+# name: test_all_snapshot_ids[145]
   '1087cd246d853fe095a4eaaf1d64f38a6648835b'
 # ---
-# name: test_all_snapshot_ids[144]
+# name: test_all_snapshot_ids[146]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -26665,10 +27699,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[145]
+# name: test_all_snapshot_ids[147]
   '927cbfcff5af3bd40ebed1cae3eed1baf4c3547f'
 # ---
-# name: test_all_snapshot_ids[146]
+# name: test_all_snapshot_ids[148]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -27524,10 +28558,1626 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[147]
+# name: test_all_snapshot_ids[149]
   '8e516c94a1e0d32aabc7ea8d8fc27d68afdb45cf'
 # ---
-# name: test_all_snapshot_ids[148]
+# name: test_all_snapshot_ids[14]
+  '''
+  {
+    "__class__": "PipelineSnapshot",
+    "config_schema_snapshot": {
+      "__class__": "ConfigSchemaSnapshot",
+      "all_config_snaps_by_key": {
+        "Any": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Any",
+          "key": "Any",
+          "kind": {
+            "__enum__": "ConfigTypeKind.ANY"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Bool": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Bool",
+          "key": "Bool",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.BOOL"
+          },
+          "type_param_keys": null
+        },
+        "Float": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Float",
+          "key": "Float",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.FLOAT"
+          },
+          "type_param_keys": null
+        },
+        "Int": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Int",
+          "key": "Int",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.INT"
+          },
+          "type_param_keys": null
+        },
+        "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Bool",
+            "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59"
+          ]
+        },
+        "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Float",
+            "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3"
+          ]
+        },
+        "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Int",
+            "Selector.a9799b971d12ace70a2d8803c883c863417d0725"
+          ]
+        },
+        "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "String",
+            "Selector.e04723c9d9937e3ab21206435b22247cfbe58269"
+          ]
+        },
+        "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "disabled",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "enabled",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Int"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Bool"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Float"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Any"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.081354663b9d4b8fbfd1cb8e358763912953913f": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "\"INFO\"",
+              "description": "The logger's threshold.",
+              "is_required": false,
+              "name": "log_level",
+              "type_key": "String"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "\"dagster\"",
+              "description": "The name of your logger.",
+              "is_required": false,
+              "name": "name",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.09d73f0755bf4752d3f121837669c8660dcf451e": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"retries\": {\"enabled\": {}}}",
+              "description": "Execute all steps in a single process.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
+              "description": "The default colored console logger.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "[DEPRECATED]",
+              "is_required": false,
+              "name": "marker_to_close",
+              "type_key": "String"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"enabled\": {}}",
+              "description": "Whether retries are enabled or not. By default, retries are enabled.",
+              "is_required": false,
+              "name": "retries",
+              "type_key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.4942ebf48d32aa0f8268910e01ed6544ad5b0132": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "hanging_asset_resource",
+              "type_key": "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "io_manager",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.4942ebf48d32aa0f8268910e01ed6544ad5b0132",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "path",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.62edccaf30696e25335ae92685bdc41e204e30e6": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.62edccaf30696e25335ae92685bdc41e204e30e6",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.743e47901855cb245064dd633e217bfcb49a11a7": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.8844e4a5ed02ce67d7999b84cf0a0647e3753bc2": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "asset_1_my_check",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "check_in_op_asset",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "fresh_diamond_bottom",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "fresh_diamond_left",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "fresh_diamond_right",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "fresh_diamond_top",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "multi_run_backfill_policy_asset",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"config\": {}}",
+              "description": null,
+              "is_required": false,
+              "name": "subsettable_checked_multi_asset",
+              "type_key": "Shape.62edccaf30696e25335ae92685bdc41e204e30e6"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "typed_asset",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"config\": {}}",
+              "description": null,
+              "is_required": false,
+              "name": "typed_multi_asset",
+              "type_key": "Shape.62edccaf30696e25335ae92685bdc41e204e30e6"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "unpartitioned_upstream_of_partitioned",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "untyped_asset",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.8844e4a5ed02ce67d7999b84cf0a0647e3753bc2",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "file",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "config",
+              "type_key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [],
+          "given_name": null,
+          "key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "console",
+              "type_key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.ec2de1b21d49804c0bf1672c1ed6e7e65cf2edce": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
+              "description": "Configure how steps are executed within a run.",
+              "is_required": false,
+              "name": "execution",
+              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Configure how loggers emit messages within a run.",
+              "is_required": false,
+              "name": "loggers",
+              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"asset_1_my_check\": {}, \"check_in_op_asset\": {}, \"fresh_diamond_bottom\": {}, \"fresh_diamond_left\": {}, \"fresh_diamond_right\": {}, \"fresh_diamond_top\": {}, \"multi_run_backfill_policy_asset\": {}, \"subsettable_checked_multi_asset\": {\"config\": {}}, \"typed_asset\": {}, \"typed_multi_asset\": {\"config\": {}}, \"unpartitioned_upstream_of_partitioned\": {}, \"untyped_asset\": {}}",
+              "description": "Configure runtime parameters for ops or assets.",
+              "is_required": false,
+              "name": "ops",
+              "type_key": "Shape.8844e4a5ed02ce67d7999b84cf0a0647e3753bc2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"io_manager\": {}}",
+              "description": "Configure how shared resources are implemented within a run.",
+              "is_required": false,
+              "name": "resources",
+              "type_key": "Shape.4942ebf48d32aa0f8268910e01ed6544ad5b0132"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.ec2de1b21d49804c0bf1672c1ed6e7e65cf2edce",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "String": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "String",
+          "key": "String",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.STRING"
+          },
+          "type_param_keys": null
+        }
+      }
+    },
+    "dagster_type_namespace_snapshot": {
+      "__class__": "DagsterTypeNamespaceSnapshot",
+      "all_dagster_type_snaps_by_key": {
+        "Any": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Any",
+          "is_builtin": true,
+          "key": "Any",
+          "kind": {
+            "__enum__": "DagsterTypeKind.ANY"
+          },
+          "loader_schema_key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
+          "materializer_schema_key": null,
+          "name": "Any",
+          "type_param_keys": []
+        },
+        "Bool": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Bool",
+          "is_builtin": true,
+          "key": "Bool",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "materializer_schema_key": null,
+          "name": "Bool",
+          "type_param_keys": []
+        },
+        "Float": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Float",
+          "is_builtin": true,
+          "key": "Float",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "materializer_schema_key": null,
+          "name": "Float",
+          "type_param_keys": []
+        },
+        "Int": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Int",
+          "is_builtin": true,
+          "key": "Int",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "materializer_schema_key": null,
+          "name": "Int",
+          "type_param_keys": []
+        },
+        "Nothing": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Nothing",
+          "is_builtin": true,
+          "key": "Nothing",
+          "kind": {
+            "__enum__": "DagsterTypeKind.NOTHING"
+          },
+          "loader_schema_key": null,
+          "materializer_schema_key": null,
+          "name": "Nothing",
+          "type_param_keys": []
+        },
+        "String": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "String",
+          "is_builtin": true,
+          "key": "String",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "materializer_schema_key": null,
+          "name": "String",
+          "type_param_keys": []
+        }
+      }
+    },
+    "dep_structure_snapshot": {
+      "__class__": "DependencyStructureSnapshot",
+      "solid_invocation_snaps": [
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "asset_1",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": []
+            }
+          ],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "asset_1_my_check",
+          "solid_name": "asset_1_my_check",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "check_in_op_asset",
+          "solid_name": "check_in_op_asset",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "fresh_diamond_left",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": [
+                {
+                  "__class__": "OutputHandleSnap",
+                  "output_name": "result",
+                  "solid_name": "fresh_diamond_left"
+                }
+              ]
+            },
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "fresh_diamond_right",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": [
+                {
+                  "__class__": "OutputHandleSnap",
+                  "output_name": "result",
+                  "solid_name": "fresh_diamond_right"
+                }
+              ]
+            }
+          ],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "fresh_diamond_bottom",
+          "solid_name": "fresh_diamond_bottom",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "fresh_diamond_top",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": [
+                {
+                  "__class__": "OutputHandleSnap",
+                  "output_name": "result",
+                  "solid_name": "fresh_diamond_top"
+                }
+              ]
+            }
+          ],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "fresh_diamond_left",
+          "solid_name": "fresh_diamond_left",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "fresh_diamond_top",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": [
+                {
+                  "__class__": "OutputHandleSnap",
+                  "output_name": "result",
+                  "solid_name": "fresh_diamond_top"
+                }
+              ]
+            }
+          ],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "fresh_diamond_right",
+          "solid_name": "fresh_diamond_right",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "diamond_source",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": []
+            }
+          ],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "fresh_diamond_top",
+          "solid_name": "fresh_diamond_top",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "multi_run_backfill_policy_asset",
+          "solid_name": "multi_run_backfill_policy_asset",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "subsettable_checked_multi_asset",
+          "solid_name": "subsettable_checked_multi_asset",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "int_asset",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": [
+                {
+                  "__class__": "OutputHandleSnap",
+                  "output_name": "int_asset",
+                  "solid_name": "typed_multi_asset"
+                }
+              ]
+            }
+          ],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "typed_asset",
+          "solid_name": "typed_asset",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "typed_multi_asset",
+          "solid_name": "typed_multi_asset",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "unpartitioned_upstream_of_partitioned",
+          "solid_name": "unpartitioned_upstream_of_partitioned",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "typed_asset",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": [
+                {
+                  "__class__": "OutputHandleSnap",
+                  "output_name": "result",
+                  "solid_name": "typed_asset"
+                }
+              ]
+            }
+          ],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "untyped_asset",
+          "solid_name": "untyped_asset",
+          "tags": {}
+        }
+      ]
+    },
+    "description": null,
+    "graph_def_name": "__ASSET_JOB_7",
+    "lineage_snapshot": null,
+    "mode_def_snaps": [
+      {
+        "__class__": "ModeDefSnap",
+        "description": null,
+        "logger_def_snaps": [
+          {
+            "__class__": "LoggerDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
+              "description": "The default colored console logger.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
+            },
+            "description": "The default colored console logger.",
+            "name": "console"
+          }
+        ],
+        "name": "default",
+        "resource_def_snaps": [
+          {
+            "__class__": "ResourceDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "config",
+              "type_key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e"
+            },
+            "description": null,
+            "name": "hanging_asset_resource"
+          },
+          {
+            "__class__": "ResourceDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            },
+            "description": null,
+            "name": "io_manager"
+          }
+        ],
+        "root_config_key": "Shape.ec2de1b21d49804c0bf1672c1ed6e7e65cf2edce"
+      }
+    ],
+    "name": "__ASSET_JOB_7",
+    "solid_definitions_snapshot": {
+      "__class__": "SolidDefinitionsSnapshot",
+      "composite_solid_def_snaps": [],
+      "solid_def_snaps": [
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "name": "asset_1"
+            }
+          ],
+          "name": "asset_1_my_check",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "check_in_op_asset",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            },
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "check_in_op_asset_my_check"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "name": "fresh_diamond_left"
+            },
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "name": "fresh_diamond_right"
+            }
+          ],
+          "name": "fresh_diamond_bottom",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "name": "fresh_diamond_top"
+            }
+          ],
+          "name": "fresh_diamond_left",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "name": "fresh_diamond_top"
+            }
+          ],
+          "name": "fresh_diamond_right",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Nothing",
+              "description": null,
+              "name": "diamond_source"
+            }
+          ],
+          "name": "fresh_diamond_top",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "multi_run_backfill_policy_asset",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{}",
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "subsettable_checked_multi_asset",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": false,
+              "name": "one"
+            },
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": false,
+              "name": "two"
+            },
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": false,
+              "name": "one_my_check"
+            },
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": false,
+              "name": "one_my_other_check"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "name": "int_asset"
+            }
+          ],
+          "name": "typed_asset",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Int",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{}",
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "typed_multi_asset",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Int",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "int_asset"
+            },
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "String",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "str_asset"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "unpartitioned_upstream_of_partitioned",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "name": "typed_asset"
+            }
+          ],
+          "name": "untyped_asset",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        }
+      ]
+    },
+    "tags": {}
+  }
+  '''
+# ---
+# name: test_all_snapshot_ids[150]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -28445,980 +31095,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[149]
+# name: test_all_snapshot_ids[151]
   'ad883aacd52aa8f195f3f099041955fbc5acf349'
 # ---
-# name: test_all_snapshot_ids[14]
-  '''
-  {
-    "__class__": "PipelineSnapshot",
-    "config_schema_snapshot": {
-      "__class__": "ConfigSchemaSnapshot",
-      "all_config_snaps_by_key": {
-        "Any": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Any",
-          "key": "Any",
-          "kind": {
-            "__enum__": "ConfigTypeKind.ANY"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Bool": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Bool",
-          "key": "Bool",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.BOOL"
-          },
-          "type_param_keys": null
-        },
-        "Float": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Float",
-          "key": "Float",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.FLOAT"
-          },
-          "type_param_keys": null
-        },
-        "Int": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Int",
-          "key": "Int",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.INT"
-          },
-          "type_param_keys": null
-        },
-        "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Bool",
-            "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59"
-          ]
-        },
-        "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Float",
-            "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3"
-          ]
-        },
-        "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Int",
-            "Selector.a9799b971d12ace70a2d8803c883c863417d0725"
-          ]
-        },
-        "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "String",
-            "Selector.e04723c9d9937e3ab21206435b22247cfbe58269"
-          ]
-        },
-        "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "disabled",
-              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "enabled",
-              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Int"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Bool"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Float"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Any"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.081354663b9d4b8fbfd1cb8e358763912953913f": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "\"INFO\"",
-              "description": "The logger's threshold.",
-              "is_required": false,
-              "name": "log_level",
-              "type_key": "String"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "\"dagster\"",
-              "description": "The name of your logger.",
-              "is_required": false,
-              "name": "name",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.09d73f0755bf4752d3f121837669c8660dcf451e": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"retries\": {\"enabled\": {}}}",
-              "description": "Execute all steps in a single process.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
-              "description": "The default colored console logger.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
-              "is_required": false,
-              "name": "io_manager",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.2d34be653f74a6198202299211241f24acd5b099": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "asset_1",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "asset_1_my_check",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "check_in_op_asset",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.2d34be653f74a6198202299211241f24acd5b099",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": "[DEPRECATED]",
-              "is_required": false,
-              "name": "marker_to_close",
-              "type_key": "String"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"enabled\": {}}",
-              "description": "Whether retries are enabled or not. By default, retries are enabled.",
-              "is_required": false,
-              "name": "retries",
-              "type_key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "path",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.743e47901855cb245064dd633e217bfcb49a11a7": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Any"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [],
-          "given_name": null,
-          "key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "console",
-              "type_key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.f1d73cdbdefe5e3a5ae06abe742ee4242a13ec5d": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
-              "description": "Configure how steps are executed within a run.",
-              "is_required": false,
-              "name": "execution",
-              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": "Configure how loggers emit messages within a run.",
-              "is_required": false,
-              "name": "loggers",
-              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"asset_1\": {}, \"asset_1_my_check\": {}, \"check_in_op_asset\": {}}",
-              "description": "Configure runtime parameters for ops or assets.",
-              "is_required": false,
-              "name": "ops",
-              "type_key": "Shape.2d34be653f74a6198202299211241f24acd5b099"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"io_manager\": {}}",
-              "description": "Configure how shared resources are implemented within a run.",
-              "is_required": false,
-              "name": "resources",
-              "type_key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.f1d73cdbdefe5e3a5ae06abe742ee4242a13ec5d",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "String": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "String",
-          "key": "String",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.STRING"
-          },
-          "type_param_keys": null
-        }
-      }
-    },
-    "dagster_type_namespace_snapshot": {
-      "__class__": "DagsterTypeNamespaceSnapshot",
-      "all_dagster_type_snaps_by_key": {
-        "Any": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Any",
-          "is_builtin": true,
-          "key": "Any",
-          "kind": {
-            "__enum__": "DagsterTypeKind.ANY"
-          },
-          "loader_schema_key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
-          "materializer_schema_key": null,
-          "name": "Any",
-          "type_param_keys": []
-        },
-        "Bool": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Bool",
-          "is_builtin": true,
-          "key": "Bool",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "materializer_schema_key": null,
-          "name": "Bool",
-          "type_param_keys": []
-        },
-        "Float": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Float",
-          "is_builtin": true,
-          "key": "Float",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "materializer_schema_key": null,
-          "name": "Float",
-          "type_param_keys": []
-        },
-        "Int": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Int",
-          "is_builtin": true,
-          "key": "Int",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "materializer_schema_key": null,
-          "name": "Int",
-          "type_param_keys": []
-        },
-        "Nothing": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Nothing",
-          "is_builtin": true,
-          "key": "Nothing",
-          "kind": {
-            "__enum__": "DagsterTypeKind.NOTHING"
-          },
-          "loader_schema_key": null,
-          "materializer_schema_key": null,
-          "name": "Nothing",
-          "type_param_keys": []
-        },
-        "String": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "String",
-          "is_builtin": true,
-          "key": "String",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "materializer_schema_key": null,
-          "name": "String",
-          "type_param_keys": []
-        }
-      }
-    },
-    "dep_structure_snapshot": {
-      "__class__": "DependencyStructureSnapshot",
-      "solid_invocation_snaps": [
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "asset_1",
-          "solid_name": "asset_1",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [
-            {
-              "__class__": "InputDependencySnap",
-              "input_name": "asset_1",
-              "is_dynamic_collect": false,
-              "upstream_output_snaps": [
-                {
-                  "__class__": "OutputHandleSnap",
-                  "output_name": "result",
-                  "solid_name": "asset_1"
-                }
-              ]
-            }
-          ],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "asset_1_my_check",
-          "solid_name": "asset_1_my_check",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "check_in_op_asset",
-          "solid_name": "check_in_op_asset",
-          "tags": {}
-        }
-      ]
-    },
-    "description": null,
-    "graph_def_name": "asset_check_job",
-    "lineage_snapshot": null,
-    "mode_def_snaps": [
-      {
-        "__class__": "ModeDefSnap",
-        "description": null,
-        "logger_def_snaps": [
-          {
-            "__class__": "LoggerDefSnap",
-            "config_field_snap": {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
-              "description": "The default colored console logger.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
-            },
-            "description": "The default colored console logger.",
-            "name": "console"
-          }
-        ],
-        "name": "default",
-        "resource_def_snaps": [
-          {
-            "__class__": "ResourceDefSnap",
-            "config_field_snap": {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Any"
-            },
-            "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
-            "name": "io_manager"
-          }
-        ],
-        "root_config_key": "Shape.f1d73cdbdefe5e3a5ae06abe742ee4242a13ec5d"
-      }
-    ],
-    "name": "asset_check_job",
-    "solid_definitions_snapshot": {
-      "__class__": "SolidDefinitionsSnapshot",
-      "composite_solid_def_snaps": [],
-      "solid_def_snaps": [
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [],
-          "name": "asset_1",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [
-            {
-              "__class__": "InputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "name": "asset_1"
-            }
-          ],
-          "name": "asset_1_my_check",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [],
-          "name": "check_in_op_asset",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            },
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "check_in_op_asset_my_check"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        }
-      ]
-    },
-    "tags": {}
-  }
-  '''
-# ---
-# name: test_all_snapshot_ids[150]
+# name: test_all_snapshot_ids[152]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -30336,10 +32016,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[151]
+# name: test_all_snapshot_ids[153]
   'b4c6cefd99a913393f6f7ce00ccd26a12803867f'
 # ---
-# name: test_all_snapshot_ids[152]
+# name: test_all_snapshot_ids[154]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -31319,10 +32999,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[153]
+# name: test_all_snapshot_ids[155]
   '4b4b18dca82ef0567492f476ff2bcbbf7392206d'
 # ---
-# name: test_all_snapshot_ids[154]
+# name: test_all_snapshot_ids[156]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -32404,13 +34084,986 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[155]
+# name: test_all_snapshot_ids[157]
   '56eb8d6bacee6e5580100ffc965e875c761acee5'
 # ---
 # name: test_all_snapshot_ids[15]
-  '1e0671d807a7bc5552e819bf33087c0a7bfb5a61'
+  'aea8aec1464224dd2c0a50be37b8c33d54d3d0cd'
 # ---
 # name: test_all_snapshot_ids[16]
+  '''
+  {
+    "__class__": "PipelineSnapshot",
+    "config_schema_snapshot": {
+      "__class__": "ConfigSchemaSnapshot",
+      "all_config_snaps_by_key": {
+        "Any": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Any",
+          "key": "Any",
+          "kind": {
+            "__enum__": "ConfigTypeKind.ANY"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Bool": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Bool",
+          "key": "Bool",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.BOOL"
+          },
+          "type_param_keys": null
+        },
+        "Float": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Float",
+          "key": "Float",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.FLOAT"
+          },
+          "type_param_keys": null
+        },
+        "Int": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Int",
+          "key": "Int",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.INT"
+          },
+          "type_param_keys": null
+        },
+        "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Bool",
+            "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59"
+          ]
+        },
+        "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Float",
+            "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3"
+          ]
+        },
+        "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Int",
+            "Selector.a9799b971d12ace70a2d8803c883c863417d0725"
+          ]
+        },
+        "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "String",
+            "Selector.e04723c9d9937e3ab21206435b22247cfbe58269"
+          ]
+        },
+        "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "disabled",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "enabled",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Int"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Bool"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Float"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Any"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.081354663b9d4b8fbfd1cb8e358763912953913f": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "\"INFO\"",
+              "description": "The logger's threshold.",
+              "is_required": false,
+              "name": "log_level",
+              "type_key": "String"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "\"dagster\"",
+              "description": "The name of your logger.",
+              "is_required": false,
+              "name": "name",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.09d73f0755bf4752d3f121837669c8660dcf451e": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"retries\": {\"enabled\": {}}}",
+              "description": "Execute all steps in a single process.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
+              "description": "The default colored console logger.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
+              "is_required": false,
+              "name": "io_manager",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.2d34be653f74a6198202299211241f24acd5b099": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "asset_1",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "asset_1_my_check",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "check_in_op_asset",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.2d34be653f74a6198202299211241f24acd5b099",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "[DEPRECATED]",
+              "is_required": false,
+              "name": "marker_to_close",
+              "type_key": "String"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"enabled\": {}}",
+              "description": "Whether retries are enabled or not. By default, retries are enabled.",
+              "is_required": false,
+              "name": "retries",
+              "type_key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "path",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.743e47901855cb245064dd633e217bfcb49a11a7": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [],
+          "given_name": null,
+          "key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "console",
+              "type_key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.f1d73cdbdefe5e3a5ae06abe742ee4242a13ec5d": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
+              "description": "Configure how steps are executed within a run.",
+              "is_required": false,
+              "name": "execution",
+              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Configure how loggers emit messages within a run.",
+              "is_required": false,
+              "name": "loggers",
+              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"asset_1\": {}, \"asset_1_my_check\": {}, \"check_in_op_asset\": {}}",
+              "description": "Configure runtime parameters for ops or assets.",
+              "is_required": false,
+              "name": "ops",
+              "type_key": "Shape.2d34be653f74a6198202299211241f24acd5b099"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"io_manager\": {}}",
+              "description": "Configure how shared resources are implemented within a run.",
+              "is_required": false,
+              "name": "resources",
+              "type_key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.f1d73cdbdefe5e3a5ae06abe742ee4242a13ec5d",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "String": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "String",
+          "key": "String",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.STRING"
+          },
+          "type_param_keys": null
+        }
+      }
+    },
+    "dagster_type_namespace_snapshot": {
+      "__class__": "DagsterTypeNamespaceSnapshot",
+      "all_dagster_type_snaps_by_key": {
+        "Any": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Any",
+          "is_builtin": true,
+          "key": "Any",
+          "kind": {
+            "__enum__": "DagsterTypeKind.ANY"
+          },
+          "loader_schema_key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
+          "materializer_schema_key": null,
+          "name": "Any",
+          "type_param_keys": []
+        },
+        "Bool": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Bool",
+          "is_builtin": true,
+          "key": "Bool",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "materializer_schema_key": null,
+          "name": "Bool",
+          "type_param_keys": []
+        },
+        "Float": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Float",
+          "is_builtin": true,
+          "key": "Float",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "materializer_schema_key": null,
+          "name": "Float",
+          "type_param_keys": []
+        },
+        "Int": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Int",
+          "is_builtin": true,
+          "key": "Int",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "materializer_schema_key": null,
+          "name": "Int",
+          "type_param_keys": []
+        },
+        "Nothing": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Nothing",
+          "is_builtin": true,
+          "key": "Nothing",
+          "kind": {
+            "__enum__": "DagsterTypeKind.NOTHING"
+          },
+          "loader_schema_key": null,
+          "materializer_schema_key": null,
+          "name": "Nothing",
+          "type_param_keys": []
+        },
+        "String": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "String",
+          "is_builtin": true,
+          "key": "String",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "materializer_schema_key": null,
+          "name": "String",
+          "type_param_keys": []
+        }
+      }
+    },
+    "dep_structure_snapshot": {
+      "__class__": "DependencyStructureSnapshot",
+      "solid_invocation_snaps": [
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "asset_1",
+          "solid_name": "asset_1",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "asset_1",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": [
+                {
+                  "__class__": "OutputHandleSnap",
+                  "output_name": "result",
+                  "solid_name": "asset_1"
+                }
+              ]
+            }
+          ],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "asset_1_my_check",
+          "solid_name": "asset_1_my_check",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "check_in_op_asset",
+          "solid_name": "check_in_op_asset",
+          "tags": {}
+        }
+      ]
+    },
+    "description": null,
+    "graph_def_name": "asset_check_job",
+    "lineage_snapshot": null,
+    "mode_def_snaps": [
+      {
+        "__class__": "ModeDefSnap",
+        "description": null,
+        "logger_def_snaps": [
+          {
+            "__class__": "LoggerDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
+              "description": "The default colored console logger.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
+            },
+            "description": "The default colored console logger.",
+            "name": "console"
+          }
+        ],
+        "name": "default",
+        "resource_def_snaps": [
+          {
+            "__class__": "ResourceDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            },
+            "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
+            "name": "io_manager"
+          }
+        ],
+        "root_config_key": "Shape.f1d73cdbdefe5e3a5ae06abe742ee4242a13ec5d"
+      }
+    ],
+    "name": "asset_check_job",
+    "solid_definitions_snapshot": {
+      "__class__": "SolidDefinitionsSnapshot",
+      "composite_solid_def_snaps": [],
+      "solid_def_snaps": [
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "asset_1",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "name": "asset_1"
+            }
+          ],
+          "name": "asset_1_my_check",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "check_in_op_asset",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            },
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "check_in_op_asset_my_check"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        }
+      ]
+    },
+    "tags": {}
+  }
+  '''
+# ---
+# name: test_all_snapshot_ids[17]
+  '1e0671d807a7bc5552e819bf33087c0a7bfb5a61'
+# ---
+# name: test_all_snapshot_ids[18]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -33264,10 +35917,13 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[17]
+# name: test_all_snapshot_ids[19]
   '9699a524d810d89264bf60d01dab3c751fe47461'
 # ---
-# name: test_all_snapshot_ids[18]
+# name: test_all_snapshot_ids[1]
+  '362d866f2c055f03fc904446157b77956cbe84f5'
+# ---
+# name: test_all_snapshot_ids[20]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -34061,13 +36717,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[19]
+# name: test_all_snapshot_ids[21]
   'cd81ec29a7fde8a337dc04fb109dd707a2962d18'
 # ---
-# name: test_all_snapshot_ids[1]
-  '362d866f2c055f03fc904446157b77956cbe84f5'
-# ---
-# name: test_all_snapshot_ids[20]
+# name: test_all_snapshot_ids[22]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -35049,10 +37702,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[21]
+# name: test_all_snapshot_ids[23]
   '1f3478e419b57370edfc5959b967300b91ad776c'
 # ---
-# name: test_all_snapshot_ids[22]
+# name: test_all_snapshot_ids[24]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -36022,10 +38675,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[23]
+# name: test_all_snapshot_ids[25]
   'e55a6b5eb4a5c68a8daa48cd789e47ac3690182e'
 # ---
-# name: test_all_snapshot_ids[24]
+# name: test_all_snapshot_ids[26]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -36950,10 +39603,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[25]
+# name: test_all_snapshot_ids[27]
   'ac30d35b2d3b8c25490824aaa8dac2281ad4f860'
 # ---
-# name: test_all_snapshot_ids[26]
+# name: test_all_snapshot_ids[28]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -38329,1074 +40982,8 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[27]
-  'd9f6d85793df3d9df94d4aedb21bb659c1202bda'
-# ---
-# name: test_all_snapshot_ids[28]
-  '''
-  {
-    "__class__": "PipelineSnapshot",
-    "config_schema_snapshot": {
-      "__class__": "ConfigSchemaSnapshot",
-      "all_config_snaps_by_key": {
-        "Any": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Any",
-          "key": "Any",
-          "kind": {
-            "__enum__": "ConfigTypeKind.ANY"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Array.Noneable.Int": {
-          "__class__": "ConfigTypeSnap",
-          "description": "List of Array.Noneable.Int",
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "Array.Noneable.Int",
-          "kind": {
-            "__enum__": "ConfigTypeKind.ARRAY"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Noneable.Int"
-          ]
-        },
-        "Bool": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Bool",
-          "key": "Bool",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.BOOL"
-          },
-          "type_param_keys": null
-        },
-        "Float": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Float",
-          "key": "Float",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.FLOAT"
-          },
-          "type_param_keys": null
-        },
-        "Int": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Int",
-          "key": "Int",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.INT"
-          },
-          "type_param_keys": null
-        },
-        "Map.Bool.Int": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "Map.Bool.Int",
-          "kind": {
-            "__enum__": "ConfigTypeKind.MAP"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Bool",
-            "Int"
-          ]
-        },
-        "Map.String.Int:name: username": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": "username",
-          "key": "Map.String.Int:name: username",
-          "kind": {
-            "__enum__": "ConfigTypeKind.MAP"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "String",
-            "Int"
-          ]
-        },
-        "Map.String.Shape.c509723c946dae900588fedb3aad4c7e4a3bd168": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "Map.String.Shape.c509723c946dae900588fedb3aad4c7e4a3bd168",
-          "kind": {
-            "__enum__": "ConfigTypeKind.MAP"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "String",
-            "Shape.c509723c946dae900588fedb3aad4c7e4a3bd168"
-          ]
-        },
-        "Noneable.Int": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "Noneable.Int",
-          "kind": {
-            "__enum__": "ConfigTypeKind.NONEABLE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Int"
-          ]
-        },
-        "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Bool",
-            "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59"
-          ]
-        },
-        "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Float",
-            "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3"
-          ]
-        },
-        "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Int",
-            "Selector.a9799b971d12ace70a2d8803c883c863417d0725"
-          ]
-        },
-        "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "String",
-            "Selector.e04723c9d9937e3ab21206435b22247cfbe58269"
-          ]
-        },
-        "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "disabled",
-              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "enabled",
-              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Int"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Bool"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Float"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Any"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.081354663b9d4b8fbfd1cb8e358763912953913f": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "\"INFO\"",
-              "description": "The logger's threshold.",
-              "is_required": false,
-              "name": "log_level",
-              "type_key": "String"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "\"dagster\"",
-              "description": "The name of your logger.",
-              "is_required": false,
-              "name": "name",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.095fa51bda86a8b26c653bdaea124c15ea83783d": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
-              "description": "Configure how steps are executed within a run.",
-              "is_required": false,
-              "name": "execution",
-              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": "Configure how loggers emit messages within a run.",
-              "is_required": false,
-              "name": "loggers",
-              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": "Configure runtime parameters for ops or assets.",
-              "is_required": true,
-              "name": "ops",
-              "type_key": "Shape.940fa1e55b24388b9f0b7a0a05bec3712295e88d"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"io_manager\": {}}",
-              "description": "Configure how shared resources are implemented within a run.",
-              "is_required": false,
-              "name": "resources",
-              "type_key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.095fa51bda86a8b26c653bdaea124c15ea83783d",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.09d73f0755bf4752d3f121837669c8660dcf451e": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"retries\": {\"enabled\": {}}}",
-              "description": "Execute all steps in a single process.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
-              "description": "The default colored console logger.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
-              "is_required": false,
-              "name": "io_manager",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.303f566e70c2a9bbe3b9c0b251dd13a17bd93ca7": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "field_one",
-              "type_key": "Map.String.Int:name: username"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"test\": {\"nested\": [null, 1, 2]}}",
-              "description": null,
-              "is_required": false,
-              "name": "field_three",
-              "type_key": "Map.String.Shape.c509723c946dae900588fedb3aad4c7e4a3bd168"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "field_two",
-              "type_key": "Map.Bool.Int"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.303f566e70c2a9bbe3b9c0b251dd13a17bd93ca7",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": "[DEPRECATED]",
-              "is_required": false,
-              "name": "marker_to_close",
-              "type_key": "String"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"enabled\": {}}",
-              "description": "Whether retries are enabled or not. By default, retries are enabled.",
-              "is_required": false,
-              "name": "retries",
-              "type_key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "path",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.743e47901855cb245064dd633e217bfcb49a11a7": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Any"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.940fa1e55b24388b9f0b7a0a05bec3712295e88d": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "noop_op",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "op_with_map_config",
-              "type_key": "Shape.eacf3d84eb87d743cabe5ea4b078eb7fe6566547"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.940fa1e55b24388b9f0b7a0a05bec3712295e88d",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.c509723c946dae900588fedb3aad4c7e4a3bd168": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "nested",
-              "type_key": "Array.Noneable.Int"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.c509723c946dae900588fedb3aad4c7e4a3bd168",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [],
-          "given_name": null,
-          "key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "console",
-              "type_key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.eacf3d84eb87d743cabe5ea4b078eb7fe6566547": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "config",
-              "type_key": "Shape.303f566e70c2a9bbe3b9c0b251dd13a17bd93ca7"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.eacf3d84eb87d743cabe5ea4b078eb7fe6566547",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "String": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "String",
-          "key": "String",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.STRING"
-          },
-          "type_param_keys": null
-        }
-      }
-    },
-    "dagster_type_namespace_snapshot": {
-      "__class__": "DagsterTypeNamespaceSnapshot",
-      "all_dagster_type_snaps_by_key": {
-        "Any": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Any",
-          "is_builtin": true,
-          "key": "Any",
-          "kind": {
-            "__enum__": "DagsterTypeKind.ANY"
-          },
-          "loader_schema_key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
-          "materializer_schema_key": null,
-          "name": "Any",
-          "type_param_keys": []
-        },
-        "Bool": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Bool",
-          "is_builtin": true,
-          "key": "Bool",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "materializer_schema_key": null,
-          "name": "Bool",
-          "type_param_keys": []
-        },
-        "Float": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Float",
-          "is_builtin": true,
-          "key": "Float",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "materializer_schema_key": null,
-          "name": "Float",
-          "type_param_keys": []
-        },
-        "Int": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Int",
-          "is_builtin": true,
-          "key": "Int",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "materializer_schema_key": null,
-          "name": "Int",
-          "type_param_keys": []
-        },
-        "Nothing": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Nothing",
-          "is_builtin": true,
-          "key": "Nothing",
-          "kind": {
-            "__enum__": "DagsterTypeKind.NOTHING"
-          },
-          "loader_schema_key": null,
-          "materializer_schema_key": null,
-          "name": "Nothing",
-          "type_param_keys": []
-        },
-        "String": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "String",
-          "is_builtin": true,
-          "key": "String",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "materializer_schema_key": null,
-          "name": "String",
-          "type_param_keys": []
-        }
-      }
-    },
-    "dep_structure_snapshot": {
-      "__class__": "DependencyStructureSnapshot",
-      "solid_invocation_snaps": [
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "noop_op",
-          "solid_name": "noop_op",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "op_with_map_config",
-          "solid_name": "op_with_map_config",
-          "tags": {}
-        }
-      ]
-    },
-    "description": null,
-    "graph_def_name": "config_with_map",
-    "lineage_snapshot": null,
-    "mode_def_snaps": [
-      {
-        "__class__": "ModeDefSnap",
-        "description": null,
-        "logger_def_snaps": [
-          {
-            "__class__": "LoggerDefSnap",
-            "config_field_snap": {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
-              "description": "The default colored console logger.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
-            },
-            "description": "The default colored console logger.",
-            "name": "console"
-          }
-        ],
-        "name": "default",
-        "resource_def_snaps": [
-          {
-            "__class__": "ResourceDefSnap",
-            "config_field_snap": {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Any"
-            },
-            "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
-            "name": "io_manager"
-          }
-        ],
-        "root_config_key": "Shape.095fa51bda86a8b26c653bdaea124c15ea83783d"
-      }
-    ],
-    "name": "config_with_map",
-    "solid_definitions_snapshot": {
-      "__class__": "SolidDefinitionsSnapshot",
-      "composite_solid_def_snaps": [],
-      "solid_def_snaps": [
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [],
-          "name": "noop_op",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": true,
-            "name": "config",
-            "type_key": "Shape.303f566e70c2a9bbe3b9c0b251dd13a17bd93ca7"
-          },
-          "description": null,
-          "input_def_snaps": [],
-          "name": "op_with_map_config",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        }
-      ]
-    },
-    "tags": {}
-  }
-  '''
-# ---
 # name: test_all_snapshot_ids[29]
-  '9041a32e00b2c27d78e168f10272a992f819e88d'
+  'd9f6d85793df3d9df94d4aedb21bb659c1202bda'
 # ---
 # name: test_all_snapshot_ids[2]
   '''
@@ -41142,6 +42729,1072 @@
           "scalar_kind": null,
           "type_param_keys": null
         },
+        "Array.Noneable.Int": {
+          "__class__": "ConfigTypeSnap",
+          "description": "List of Array.Noneable.Int",
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "Array.Noneable.Int",
+          "kind": {
+            "__enum__": "ConfigTypeKind.ARRAY"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Noneable.Int"
+          ]
+        },
+        "Bool": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Bool",
+          "key": "Bool",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.BOOL"
+          },
+          "type_param_keys": null
+        },
+        "Float": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Float",
+          "key": "Float",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.FLOAT"
+          },
+          "type_param_keys": null
+        },
+        "Int": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Int",
+          "key": "Int",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.INT"
+          },
+          "type_param_keys": null
+        },
+        "Map.Bool.Int": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "Map.Bool.Int",
+          "kind": {
+            "__enum__": "ConfigTypeKind.MAP"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Bool",
+            "Int"
+          ]
+        },
+        "Map.String.Int:name: username": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": "username",
+          "key": "Map.String.Int:name: username",
+          "kind": {
+            "__enum__": "ConfigTypeKind.MAP"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "String",
+            "Int"
+          ]
+        },
+        "Map.String.Shape.c509723c946dae900588fedb3aad4c7e4a3bd168": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "Map.String.Shape.c509723c946dae900588fedb3aad4c7e4a3bd168",
+          "kind": {
+            "__enum__": "ConfigTypeKind.MAP"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "String",
+            "Shape.c509723c946dae900588fedb3aad4c7e4a3bd168"
+          ]
+        },
+        "Noneable.Int": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "Noneable.Int",
+          "kind": {
+            "__enum__": "ConfigTypeKind.NONEABLE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Int"
+          ]
+        },
+        "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Bool",
+            "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59"
+          ]
+        },
+        "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Float",
+            "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3"
+          ]
+        },
+        "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Int",
+            "Selector.a9799b971d12ace70a2d8803c883c863417d0725"
+          ]
+        },
+        "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "String",
+            "Selector.e04723c9d9937e3ab21206435b22247cfbe58269"
+          ]
+        },
+        "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "disabled",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "enabled",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Int"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Bool"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Float"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Any"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.081354663b9d4b8fbfd1cb8e358763912953913f": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "\"INFO\"",
+              "description": "The logger's threshold.",
+              "is_required": false,
+              "name": "log_level",
+              "type_key": "String"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "\"dagster\"",
+              "description": "The name of your logger.",
+              "is_required": false,
+              "name": "name",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.095fa51bda86a8b26c653bdaea124c15ea83783d": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
+              "description": "Configure how steps are executed within a run.",
+              "is_required": false,
+              "name": "execution",
+              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Configure how loggers emit messages within a run.",
+              "is_required": false,
+              "name": "loggers",
+              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "Configure runtime parameters for ops or assets.",
+              "is_required": true,
+              "name": "ops",
+              "type_key": "Shape.940fa1e55b24388b9f0b7a0a05bec3712295e88d"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"io_manager\": {}}",
+              "description": "Configure how shared resources are implemented within a run.",
+              "is_required": false,
+              "name": "resources",
+              "type_key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.095fa51bda86a8b26c653bdaea124c15ea83783d",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.09d73f0755bf4752d3f121837669c8660dcf451e": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"retries\": {\"enabled\": {}}}",
+              "description": "Execute all steps in a single process.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
+              "description": "The default colored console logger.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
+              "is_required": false,
+              "name": "io_manager",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.303f566e70c2a9bbe3b9c0b251dd13a17bd93ca7": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "field_one",
+              "type_key": "Map.String.Int:name: username"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"test\": {\"nested\": [null, 1, 2]}}",
+              "description": null,
+              "is_required": false,
+              "name": "field_three",
+              "type_key": "Map.String.Shape.c509723c946dae900588fedb3aad4c7e4a3bd168"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "field_two",
+              "type_key": "Map.Bool.Int"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.303f566e70c2a9bbe3b9c0b251dd13a17bd93ca7",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "[DEPRECATED]",
+              "is_required": false,
+              "name": "marker_to_close",
+              "type_key": "String"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"enabled\": {}}",
+              "description": "Whether retries are enabled or not. By default, retries are enabled.",
+              "is_required": false,
+              "name": "retries",
+              "type_key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "path",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.743e47901855cb245064dd633e217bfcb49a11a7": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.940fa1e55b24388b9f0b7a0a05bec3712295e88d": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "noop_op",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "op_with_map_config",
+              "type_key": "Shape.eacf3d84eb87d743cabe5ea4b078eb7fe6566547"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.940fa1e55b24388b9f0b7a0a05bec3712295e88d",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.c509723c946dae900588fedb3aad4c7e4a3bd168": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "nested",
+              "type_key": "Array.Noneable.Int"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.c509723c946dae900588fedb3aad4c7e4a3bd168",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [],
+          "given_name": null,
+          "key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "console",
+              "type_key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.eacf3d84eb87d743cabe5ea4b078eb7fe6566547": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "config",
+              "type_key": "Shape.303f566e70c2a9bbe3b9c0b251dd13a17bd93ca7"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.eacf3d84eb87d743cabe5ea4b078eb7fe6566547",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "String": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "String",
+          "key": "String",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.STRING"
+          },
+          "type_param_keys": null
+        }
+      }
+    },
+    "dagster_type_namespace_snapshot": {
+      "__class__": "DagsterTypeNamespaceSnapshot",
+      "all_dagster_type_snaps_by_key": {
+        "Any": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Any",
+          "is_builtin": true,
+          "key": "Any",
+          "kind": {
+            "__enum__": "DagsterTypeKind.ANY"
+          },
+          "loader_schema_key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
+          "materializer_schema_key": null,
+          "name": "Any",
+          "type_param_keys": []
+        },
+        "Bool": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Bool",
+          "is_builtin": true,
+          "key": "Bool",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "materializer_schema_key": null,
+          "name": "Bool",
+          "type_param_keys": []
+        },
+        "Float": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Float",
+          "is_builtin": true,
+          "key": "Float",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "materializer_schema_key": null,
+          "name": "Float",
+          "type_param_keys": []
+        },
+        "Int": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Int",
+          "is_builtin": true,
+          "key": "Int",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "materializer_schema_key": null,
+          "name": "Int",
+          "type_param_keys": []
+        },
+        "Nothing": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Nothing",
+          "is_builtin": true,
+          "key": "Nothing",
+          "kind": {
+            "__enum__": "DagsterTypeKind.NOTHING"
+          },
+          "loader_schema_key": null,
+          "materializer_schema_key": null,
+          "name": "Nothing",
+          "type_param_keys": []
+        },
+        "String": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "String",
+          "is_builtin": true,
+          "key": "String",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "materializer_schema_key": null,
+          "name": "String",
+          "type_param_keys": []
+        }
+      }
+    },
+    "dep_structure_snapshot": {
+      "__class__": "DependencyStructureSnapshot",
+      "solid_invocation_snaps": [
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "noop_op",
+          "solid_name": "noop_op",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "op_with_map_config",
+          "solid_name": "op_with_map_config",
+          "tags": {}
+        }
+      ]
+    },
+    "description": null,
+    "graph_def_name": "config_with_map",
+    "lineage_snapshot": null,
+    "mode_def_snaps": [
+      {
+        "__class__": "ModeDefSnap",
+        "description": null,
+        "logger_def_snaps": [
+          {
+            "__class__": "LoggerDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
+              "description": "The default colored console logger.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
+            },
+            "description": "The default colored console logger.",
+            "name": "console"
+          }
+        ],
+        "name": "default",
+        "resource_def_snaps": [
+          {
+            "__class__": "ResourceDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            },
+            "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
+            "name": "io_manager"
+          }
+        ],
+        "root_config_key": "Shape.095fa51bda86a8b26c653bdaea124c15ea83783d"
+      }
+    ],
+    "name": "config_with_map",
+    "solid_definitions_snapshot": {
+      "__class__": "SolidDefinitionsSnapshot",
+      "composite_solid_def_snaps": [],
+      "solid_def_snaps": [
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "noop_op",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": true,
+            "name": "config",
+            "type_key": "Shape.303f566e70c2a9bbe3b9c0b251dd13a17bd93ca7"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "op_with_map_config",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        }
+      ]
+    },
+    "tags": {}
+  }
+  '''
+# ---
+# name: test_all_snapshot_ids[31]
+  '9041a32e00b2c27d78e168f10272a992f819e88d'
+# ---
+# name: test_all_snapshot_ids[32]
+  '''
+  {
+    "__class__": "PipelineSnapshot",
+    "config_schema_snapshot": {
+      "__class__": "ConfigSchemaSnapshot",
+      "all_config_snaps_by_key": {
+        "Any": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Any",
+          "key": "Any",
+          "kind": {
+            "__enum__": "ConfigTypeKind.ANY"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
         "Bool": {
           "__class__": "ConfigTypeSnap",
           "description": "",
@@ -42123,10 +44776,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[31]
+# name: test_all_snapshot_ids[33]
   '9d2930f7c072c5a01688d84b725c49d4ae718c65'
 # ---
-# name: test_all_snapshot_ids[32]
+# name: test_all_snapshot_ids[34]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -43127,10 +45780,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[33]
+# name: test_all_snapshot_ids[35]
   'a28dd9e490e08f05fab6ab1309de27da5cd3eb0f'
 # ---
-# name: test_all_snapshot_ids[34]
+# name: test_all_snapshot_ids[36]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -44067,10 +46720,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[35]
+# name: test_all_snapshot_ids[37]
   'a62baecf830886bfa322863f86bbd7344ef9c359'
 # ---
-# name: test_all_snapshot_ids[36]
+# name: test_all_snapshot_ids[38]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -45135,10 +47788,13 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[37]
+# name: test_all_snapshot_ids[39]
   '2bc0dc6a7c8ccb4ec4352fde1925f82521d71675'
 # ---
-# name: test_all_snapshot_ids[38]
+# name: test_all_snapshot_ids[3]
+  '97b11e5ca77c719ca88c82a1311e678916d1c363'
+# ---
+# name: test_all_snapshot_ids[40]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -45992,13 +48648,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[39]
+# name: test_all_snapshot_ids[41]
   '458a303a0e8d51f99eb8417d4be851f0b982b5a5'
 # ---
-# name: test_all_snapshot_ids[3]
-  '97b11e5ca77c719ca88c82a1311e678916d1c363'
-# ---
-# name: test_all_snapshot_ids[40]
+# name: test_all_snapshot_ids[42]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -46985,10 +49638,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[41]
+# name: test_all_snapshot_ids[43]
   '9224ed1364dbf02ced98648c1f9637686e8a1a29'
 # ---
-# name: test_all_snapshot_ids[42]
+# name: test_all_snapshot_ids[44]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -48193,10 +50846,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[43]
+# name: test_all_snapshot_ids[45]
   'db3c9e009bad031bbf9b5f278cc09b691a00eaec'
 # ---
-# name: test_all_snapshot_ids[44]
+# name: test_all_snapshot_ids[46]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -49114,10 +51767,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[45]
+# name: test_all_snapshot_ids[47]
   '6650ed807e4b516f8100a8933b134c401b4dd4ff'
 # ---
-# name: test_all_snapshot_ids[46]
+# name: test_all_snapshot_ids[48]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -49614,7 +52267,30 @@
           "scalar_kind": null,
           "type_param_keys": null
         },
-        "Shape.2b3f3e9d949df8c357faf83cac0c090a6454a1a7": {
+        "Shape.1629902fbbde68e17f4f310b85646b6a76efd18d": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "Base directory for storing files.",
+              "is_required": false,
+              "name": "base_dir",
+              "type_key": "Noneable.StringSourceType"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.1629902fbbde68e17f4f310b85646b6a76efd18d",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.41f0a64274b46628551366b5411b86685f577251": {
           "__class__": "ConfigTypeSnap",
           "description": null,
           "enum_values": null,
@@ -49622,42 +52298,24 @@
             {
               "__class__": "ConfigFieldSnap",
               "default_provided": true,
-              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
-              "description": "Configure how steps are executed within a run.",
+              "default_value_as_json_str": "{\"config\": {}}",
+              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
               "is_required": false,
-              "name": "execution",
-              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
+              "name": "io_manager",
+              "type_key": "Shape.aa06a6ac89e62cfd2f6a1f9bce137c6abfa63805"
             },
             {
               "__class__": "ConfigFieldSnap",
               "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": "Configure how loggers emit messages within a run.",
+              "default_value_as_json_str": "{\"config\": {\"count\": 0}}",
+              "description": null,
               "is_required": false,
-              "name": "loggers",
-              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"collect\": {}, \"fail\": {}, \"fail_2\": {}, \"fail_3\": {}, \"reset\": {}, \"spawn\": {}}",
-              "description": "Configure runtime parameters for ops or assets.",
-              "is_required": false,
-              "name": "ops",
-              "type_key": "Shape.e8eb58275cb40d02b8439c5e0c90d6b938bdb0b9"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"io_manager\": {\"config\": {\"base_dir\": null}}, \"retry_count\": {\"config\": {\"count\": 0}}}",
-              "description": "Configure how shared resources are implemented within a run.",
-              "is_required": false,
-              "name": "resources",
-              "type_key": "Shape.e573162f1753fdf6bea0a36267493c819fae004c"
+              "name": "retry_count",
+              "type_key": "Shape.7df68601e94646b87c0edb05b7142282503f0f64"
             }
           ],
           "given_name": null,
-          "key": "Shape.2b3f3e9d949df8c357faf83cac0c090a6454a1a7",
+          "key": "Shape.41f0a64274b46628551366b5411b86685f577251",
           "kind": {
             "__enum__": "ConfigTypeKind.STRICT_SHAPE"
           },
@@ -49765,7 +52423,7 @@
           "scalar_kind": null,
           "type_param_keys": null
         },
-        "Shape.9f45d547cea593c1893cee08a8d67b84989c16fc": {
+        "Shape.aa06a6ac89e62cfd2f6a1f9bce137c6abfa63805": {
           "__class__": "ConfigTypeSnap",
           "description": null,
           "enum_values": null,
@@ -49773,38 +52431,15 @@
             {
               "__class__": "ConfigFieldSnap",
               "default_provided": true,
-              "default_value_as_json_str": "{\"base_dir\": null}",
+              "default_value_as_json_str": "{}",
               "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.\n\n    The base directory that the pickle files live inside is determined by:\n\n    * The IO manager's \"base_dir\" configuration value, if specified. Otherwise...\n    * A \"storage/\" directory underneath the value for \"local_artifact_storage\" in your dagster.yaml\n      file, if specified. Otherwise...\n    * A \"storage/\" directory underneath the directory that the DAGSTER_HOME environment variable\n      points to, if that environment variable is specified. Otherwise...\n    * A temporary directory.\n\n    Assigns each op output to a unique filepath containing run ID, step key, and output name.\n    Assigns each asset to a single filesystem path, at \"<base_dir>/<asset_key>\". If the asset key\n    has multiple components, the final component is used as the name of the file, and the preceding\n    components as parent directories under the base_dir.\n\n    Subsequent materializations of an asset will overwrite previous materializations of that asset.\n    So, with a base directory of \"/my/base/path\", an asset with key\n    `AssetKey([\"one\", \"two\", \"three\"])` would be stored in a file called \"three\" in a directory\n    with path \"/my/base/path/one/two/\".\n\n    Example usage:\n\n\n    1. Attach an IO manager to a set of assets using the reserved resource key ``\"io_manager\"``.\n\n    .. code-block:: python\n\n        from dagster import Definitions, asset, FilesystemIOManager\n\n        @asset\n        def asset1():\n            # create df ...\n            return df\n\n        @asset\n        def asset2(asset1):\n            return asset1[:5]\n\n        defs = Definitions(\n            assets=[asset1, asset2],\n            resources={\n                \"io_manager\": FilesystemIOManager(base_dir=\"/my/base/path\")\n            },\n        )\n\n\n    2. Specify a job-level IO manager using the reserved resource key ``\"io_manager\"``,\n    which will set the given IO manager on all ops in a job.\n\n    .. code-block:: python\n\n        from dagster import FilesystemIOManager, job, op\n\n        @op\n        def op_a():\n            # create df ...\n            return df\n\n        @op\n        def op_b(df):\n            return df[:5]\n\n        @job(\n            resource_defs={\n                \"io_manager\": FilesystemIOManager(base_dir=\"/my/base/path\")\n            }\n        )\n        def job():\n            op_b(op_a())\n\n\n    3. Specify IO manager on :py:class:`Out`, which allows you to set different IO managers on\n    different step outputs.\n\n    .. code-block:: python\n\n        from dagster import FilesystemIOManager, job, op, Out\n\n        @op(out=Out(io_manager_key=\"my_io_manager\"))\n        def op_a():\n            # create df ...\n            return df\n\n        @op\n        def op_b(df):\n            return df[:5]\n\n        @job(resource_defs={\"my_io_manager\": FilesystemIOManager()})\n        def job():\n            op_b(op_a())",
               "is_required": false,
               "name": "config",
-              "type_key": "Shape.b613ad485f01be6de3dda94dce6e7672b1d3c080"
+              "type_key": "Shape.1629902fbbde68e17f4f310b85646b6a76efd18d"
             }
           ],
           "given_name": null,
-          "key": "Shape.9f45d547cea593c1893cee08a8d67b84989c16fc",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.b613ad485f01be6de3dda94dce6e7672b1d3c080": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "null",
-              "description": "Base directory for storing files.",
-              "is_required": false,
-              "name": "base_dir",
-              "type_key": "Noneable.StringSourceType"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.b613ad485f01be6de3dda94dce6e7672b1d3c080",
+          "key": "Shape.aa06a6ac89e62cfd2f6a1f9bce137c6abfa63805",
           "kind": {
             "__enum__": "ConfigTypeKind.STRICT_SHAPE"
           },
@@ -49841,38 +52476,6 @@
           ],
           "given_name": null,
           "key": "Shape.dc1eacbaac67d3ef292c2c343ce6fd5c3560d40a",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.e573162f1753fdf6bea0a36267493c819fae004c": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"config\": {\"base_dir\": null}}",
-              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
-              "is_required": false,
-              "name": "io_manager",
-              "type_key": "Shape.9f45d547cea593c1893cee08a8d67b84989c16fc"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"config\": {\"count\": 0}}",
-              "description": null,
-              "is_required": false,
-              "name": "retry_count",
-              "type_key": "Shape.7df68601e94646b87c0edb05b7142282503f0f64"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.e573162f1753fdf6bea0a36267493c819fae004c",
           "kind": {
             "__enum__": "ConfigTypeKind.STRICT_SHAPE"
           },
@@ -49964,6 +52567,56 @@
           ],
           "given_name": null,
           "key": "Shape.e8eb58275cb40d02b8439c5e0c90d6b938bdb0b9",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.f3bb94e318312d74b55184f515aca7635aa7fd91": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
+              "description": "Configure how steps are executed within a run.",
+              "is_required": false,
+              "name": "execution",
+              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Configure how loggers emit messages within a run.",
+              "is_required": false,
+              "name": "loggers",
+              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"collect\": {}, \"fail\": {}, \"fail_2\": {}, \"fail_3\": {}, \"reset\": {}, \"spawn\": {}}",
+              "description": "Configure runtime parameters for ops or assets.",
+              "is_required": false,
+              "name": "ops",
+              "type_key": "Shape.e8eb58275cb40d02b8439c5e0c90d6b938bdb0b9"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"io_manager\": {\"config\": {}}, \"retry_count\": {\"config\": {\"count\": 0}}}",
+              "description": "Configure how shared resources are implemented within a run.",
+              "is_required": false,
+              "name": "resources",
+              "type_key": "Shape.41f0a64274b46628551366b5411b86685f577251"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.f3bb94e318312d74b55184f515aca7635aa7fd91",
           "kind": {
             "__enum__": "ConfigTypeKind.STRICT_SHAPE"
           },
@@ -50266,11 +52919,11 @@
             "config_field_snap": {
               "__class__": "ConfigFieldSnap",
               "default_provided": true,
-              "default_value_as_json_str": "{\"base_dir\": null}",
+              "default_value_as_json_str": "{}",
               "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.\n\n    The base directory that the pickle files live inside is determined by:\n\n    * The IO manager's \"base_dir\" configuration value, if specified. Otherwise...\n    * A \"storage/\" directory underneath the value for \"local_artifact_storage\" in your dagster.yaml\n      file, if specified. Otherwise...\n    * A \"storage/\" directory underneath the directory that the DAGSTER_HOME environment variable\n      points to, if that environment variable is specified. Otherwise...\n    * A temporary directory.\n\n    Assigns each op output to a unique filepath containing run ID, step key, and output name.\n    Assigns each asset to a single filesystem path, at \"<base_dir>/<asset_key>\". If the asset key\n    has multiple components, the final component is used as the name of the file, and the preceding\n    components as parent directories under the base_dir.\n\n    Subsequent materializations of an asset will overwrite previous materializations of that asset.\n    So, with a base directory of \"/my/base/path\", an asset with key\n    `AssetKey([\"one\", \"two\", \"three\"])` would be stored in a file called \"three\" in a directory\n    with path \"/my/base/path/one/two/\".\n\n    Example usage:\n\n\n    1. Attach an IO manager to a set of assets using the reserved resource key ``\"io_manager\"``.\n\n    .. code-block:: python\n\n        from dagster import Definitions, asset, FilesystemIOManager\n\n        @asset\n        def asset1():\n            # create df ...\n            return df\n\n        @asset\n        def asset2(asset1):\n            return asset1[:5]\n\n        defs = Definitions(\n            assets=[asset1, asset2],\n            resources={\n                \"io_manager\": FilesystemIOManager(base_dir=\"/my/base/path\")\n            },\n        )\n\n\n    2. Specify a job-level IO manager using the reserved resource key ``\"io_manager\"``,\n    which will set the given IO manager on all ops in a job.\n\n    .. code-block:: python\n\n        from dagster import FilesystemIOManager, job, op\n\n        @op\n        def op_a():\n            # create df ...\n            return df\n\n        @op\n        def op_b(df):\n            return df[:5]\n\n        @job(\n            resource_defs={\n                \"io_manager\": FilesystemIOManager(base_dir=\"/my/base/path\")\n            }\n        )\n        def job():\n            op_b(op_a())\n\n\n    3. Specify IO manager on :py:class:`Out`, which allows you to set different IO managers on\n    different step outputs.\n\n    .. code-block:: python\n\n        from dagster import FilesystemIOManager, job, op, Out\n\n        @op(out=Out(io_manager_key=\"my_io_manager\"))\n        def op_a():\n            # create df ...\n            return df\n\n        @op\n        def op_b(df):\n            return df[:5]\n\n        @job(resource_defs={\"my_io_manager\": FilesystemIOManager()})\n        def job():\n            op_b(op_a())",
               "is_required": false,
               "name": "config",
-              "type_key": "Shape.b613ad485f01be6de3dda94dce6e7672b1d3c080"
+              "type_key": "Shape.1629902fbbde68e17f4f310b85646b6a76efd18d"
             },
             "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
             "name": "io_manager"
@@ -50290,7 +52943,7 @@
             "name": "retry_count"
           }
         ],
-        "root_config_key": "Shape.2b3f3e9d949df8c357faf83cac0c090a6454a1a7"
+        "root_config_key": "Shape.f3bb94e318312d74b55184f515aca7635aa7fd91"
       }
     ],
     "name": "eventually_successful",
@@ -50435,932 +53088,8 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[47]
-  '9ab88cad2b40a1213bf6ca216b32750917ff88c1'
-# ---
-# name: test_all_snapshot_ids[48]
-  '''
-  {
-    "__class__": "PipelineSnapshot",
-    "config_schema_snapshot": {
-      "__class__": "ConfigSchemaSnapshot",
-      "all_config_snaps_by_key": {
-        "Any": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Any",
-          "key": "Any",
-          "kind": {
-            "__enum__": "ConfigTypeKind.ANY"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Bool": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Bool",
-          "key": "Bool",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.BOOL"
-          },
-          "type_param_keys": null
-        },
-        "Float": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Float",
-          "key": "Float",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.FLOAT"
-          },
-          "type_param_keys": null
-        },
-        "Int": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Int",
-          "key": "Int",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.INT"
-          },
-          "type_param_keys": null
-        },
-        "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Bool",
-            "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59"
-          ]
-        },
-        "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Float",
-            "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3"
-          ]
-        },
-        "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Int",
-            "Selector.a9799b971d12ace70a2d8803c883c863417d0725"
-          ]
-        },
-        "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "String",
-            "Selector.e04723c9d9937e3ab21206435b22247cfbe58269"
-          ]
-        },
-        "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "disabled",
-              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "enabled",
-              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Int"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Bool"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Float"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Any"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.081354663b9d4b8fbfd1cb8e358763912953913f": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "\"INFO\"",
-              "description": "The logger's threshold.",
-              "is_required": false,
-              "name": "log_level",
-              "type_key": "String"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "\"dagster\"",
-              "description": "The name of your logger.",
-              "is_required": false,
-              "name": "name",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.09d73f0755bf4752d3f121837669c8660dcf451e": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"retries\": {\"enabled\": {}}}",
-              "description": "Execute all steps in a single process.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
-              "description": "The default colored console logger.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
-              "is_required": false,
-              "name": "io_manager",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": "[DEPRECATED]",
-              "is_required": false,
-              "name": "marker_to_close",
-              "type_key": "String"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"enabled\": {}}",
-              "description": "Whether retries are enabled or not. By default, retries are enabled.",
-              "is_required": false,
-              "name": "retries",
-              "type_key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.4b31d5ef60e37188801c3f6e571925c17751e5d6": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "executable_asset",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"config\": {}}",
-              "description": null,
-              "is_required": false,
-              "name": "unexecutable_asset",
-              "type_key": "Shape.62edccaf30696e25335ae92685bdc41e204e30e6"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.4b31d5ef60e37188801c3f6e571925c17751e5d6",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "path",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.4dfd32a4f7289a1d2b17c4582b2b68dc904bc200": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
-              "description": "Configure how steps are executed within a run.",
-              "is_required": false,
-              "name": "execution",
-              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": "Configure how loggers emit messages within a run.",
-              "is_required": false,
-              "name": "loggers",
-              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"executable_asset\": {}, \"unexecutable_asset\": {\"config\": {}}}",
-              "description": "Configure runtime parameters for ops or assets.",
-              "is_required": false,
-              "name": "ops",
-              "type_key": "Shape.4b31d5ef60e37188801c3f6e571925c17751e5d6"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"io_manager\": {}}",
-              "description": "Configure how shared resources are implemented within a run.",
-              "is_required": false,
-              "name": "resources",
-              "type_key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.4dfd32a4f7289a1d2b17c4582b2b68dc904bc200",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.62edccaf30696e25335ae92685bdc41e204e30e6": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.62edccaf30696e25335ae92685bdc41e204e30e6",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.743e47901855cb245064dd633e217bfcb49a11a7": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Any"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [],
-          "given_name": null,
-          "key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "console",
-              "type_key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "String": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "String",
-          "key": "String",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.STRING"
-          },
-          "type_param_keys": null
-        }
-      }
-    },
-    "dagster_type_namespace_snapshot": {
-      "__class__": "DagsterTypeNamespaceSnapshot",
-      "all_dagster_type_snaps_by_key": {
-        "Any": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Any",
-          "is_builtin": true,
-          "key": "Any",
-          "kind": {
-            "__enum__": "DagsterTypeKind.ANY"
-          },
-          "loader_schema_key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
-          "materializer_schema_key": null,
-          "name": "Any",
-          "type_param_keys": []
-        },
-        "Bool": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Bool",
-          "is_builtin": true,
-          "key": "Bool",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "materializer_schema_key": null,
-          "name": "Bool",
-          "type_param_keys": []
-        },
-        "Float": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Float",
-          "is_builtin": true,
-          "key": "Float",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "materializer_schema_key": null,
-          "name": "Float",
-          "type_param_keys": []
-        },
-        "Int": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Int",
-          "is_builtin": true,
-          "key": "Int",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "materializer_schema_key": null,
-          "name": "Int",
-          "type_param_keys": []
-        },
-        "Nothing": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Nothing",
-          "is_builtin": true,
-          "key": "Nothing",
-          "kind": {
-            "__enum__": "DagsterTypeKind.NOTHING"
-          },
-          "loader_schema_key": null,
-          "materializer_schema_key": null,
-          "name": "Nothing",
-          "type_param_keys": []
-        },
-        "String": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "String",
-          "is_builtin": true,
-          "key": "String",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "materializer_schema_key": null,
-          "name": "String",
-          "type_param_keys": []
-        }
-      }
-    },
-    "dep_structure_snapshot": {
-      "__class__": "DependencyStructureSnapshot",
-      "solid_invocation_snaps": [
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "executable_asset",
-          "solid_name": "executable_asset",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "unexecutable_asset",
-          "solid_name": "unexecutable_asset",
-          "tags": {}
-        }
-      ]
-    },
-    "description": null,
-    "graph_def_name": "executable_test_job",
-    "lineage_snapshot": null,
-    "mode_def_snaps": [
-      {
-        "__class__": "ModeDefSnap",
-        "description": null,
-        "logger_def_snaps": [
-          {
-            "__class__": "LoggerDefSnap",
-            "config_field_snap": {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
-              "description": "The default colored console logger.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
-            },
-            "description": "The default colored console logger.",
-            "name": "console"
-          }
-        ],
-        "name": "default",
-        "resource_def_snaps": [
-          {
-            "__class__": "ResourceDefSnap",
-            "config_field_snap": {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Any"
-            },
-            "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
-            "name": "io_manager"
-          }
-        ],
-        "root_config_key": "Shape.4dfd32a4f7289a1d2b17c4582b2b68dc904bc200"
-      }
-    ],
-    "name": "executable_test_job",
-    "solid_definitions_snapshot": {
-      "__class__": "SolidDefinitionsSnapshot",
-      "composite_solid_def_snaps": [],
-      "solid_def_snaps": [
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [],
-          "name": "executable_asset",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Nothing",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": true,
-            "default_value_as_json_str": "{}",
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
-          },
-          "description": null,
-          "input_def_snaps": [],
-          "name": "unexecutable_asset",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Nothing",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "unexecutable_asset"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        }
-      ]
-    },
-    "tags": {}
-  }
-  '''
-# ---
 # name: test_all_snapshot_ids[49]
-  '6a914ad611e5cd4a7108f332bce41cf9ebfacfbc'
+  'f871b53e30b83794c20d128b5cf209f63eb603d3'
 # ---
 # name: test_all_snapshot_ids[4]
   '''
@@ -53408,6 +55137,930 @@
           "scalar_kind": null,
           "type_param_keys": null
         },
+        "Shape.081354663b9d4b8fbfd1cb8e358763912953913f": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "\"INFO\"",
+              "description": "The logger's threshold.",
+              "is_required": false,
+              "name": "log_level",
+              "type_key": "String"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "\"dagster\"",
+              "description": "The name of your logger.",
+              "is_required": false,
+              "name": "name",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.09d73f0755bf4752d3f121837669c8660dcf451e": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"retries\": {\"enabled\": {}}}",
+              "description": "Execute all steps in a single process.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
+              "description": "The default colored console logger.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
+              "is_required": false,
+              "name": "io_manager",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "[DEPRECATED]",
+              "is_required": false,
+              "name": "marker_to_close",
+              "type_key": "String"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"enabled\": {}}",
+              "description": "Whether retries are enabled or not. By default, retries are enabled.",
+              "is_required": false,
+              "name": "retries",
+              "type_key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.4b31d5ef60e37188801c3f6e571925c17751e5d6": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "executable_asset",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"config\": {}}",
+              "description": null,
+              "is_required": false,
+              "name": "unexecutable_asset",
+              "type_key": "Shape.62edccaf30696e25335ae92685bdc41e204e30e6"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.4b31d5ef60e37188801c3f6e571925c17751e5d6",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "path",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.4dfd32a4f7289a1d2b17c4582b2b68dc904bc200": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
+              "description": "Configure how steps are executed within a run.",
+              "is_required": false,
+              "name": "execution",
+              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Configure how loggers emit messages within a run.",
+              "is_required": false,
+              "name": "loggers",
+              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"executable_asset\": {}, \"unexecutable_asset\": {\"config\": {}}}",
+              "description": "Configure runtime parameters for ops or assets.",
+              "is_required": false,
+              "name": "ops",
+              "type_key": "Shape.4b31d5ef60e37188801c3f6e571925c17751e5d6"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"io_manager\": {}}",
+              "description": "Configure how shared resources are implemented within a run.",
+              "is_required": false,
+              "name": "resources",
+              "type_key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.4dfd32a4f7289a1d2b17c4582b2b68dc904bc200",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.62edccaf30696e25335ae92685bdc41e204e30e6": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.62edccaf30696e25335ae92685bdc41e204e30e6",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.743e47901855cb245064dd633e217bfcb49a11a7": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [],
+          "given_name": null,
+          "key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "console",
+              "type_key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "String": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "String",
+          "key": "String",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.STRING"
+          },
+          "type_param_keys": null
+        }
+      }
+    },
+    "dagster_type_namespace_snapshot": {
+      "__class__": "DagsterTypeNamespaceSnapshot",
+      "all_dagster_type_snaps_by_key": {
+        "Any": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Any",
+          "is_builtin": true,
+          "key": "Any",
+          "kind": {
+            "__enum__": "DagsterTypeKind.ANY"
+          },
+          "loader_schema_key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
+          "materializer_schema_key": null,
+          "name": "Any",
+          "type_param_keys": []
+        },
+        "Bool": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Bool",
+          "is_builtin": true,
+          "key": "Bool",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "materializer_schema_key": null,
+          "name": "Bool",
+          "type_param_keys": []
+        },
+        "Float": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Float",
+          "is_builtin": true,
+          "key": "Float",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "materializer_schema_key": null,
+          "name": "Float",
+          "type_param_keys": []
+        },
+        "Int": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Int",
+          "is_builtin": true,
+          "key": "Int",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "materializer_schema_key": null,
+          "name": "Int",
+          "type_param_keys": []
+        },
+        "Nothing": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Nothing",
+          "is_builtin": true,
+          "key": "Nothing",
+          "kind": {
+            "__enum__": "DagsterTypeKind.NOTHING"
+          },
+          "loader_schema_key": null,
+          "materializer_schema_key": null,
+          "name": "Nothing",
+          "type_param_keys": []
+        },
+        "String": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "String",
+          "is_builtin": true,
+          "key": "String",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "materializer_schema_key": null,
+          "name": "String",
+          "type_param_keys": []
+        }
+      }
+    },
+    "dep_structure_snapshot": {
+      "__class__": "DependencyStructureSnapshot",
+      "solid_invocation_snaps": [
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "executable_asset",
+          "solid_name": "executable_asset",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "unexecutable_asset",
+          "solid_name": "unexecutable_asset",
+          "tags": {}
+        }
+      ]
+    },
+    "description": null,
+    "graph_def_name": "executable_test_job",
+    "lineage_snapshot": null,
+    "mode_def_snaps": [
+      {
+        "__class__": "ModeDefSnap",
+        "description": null,
+        "logger_def_snaps": [
+          {
+            "__class__": "LoggerDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
+              "description": "The default colored console logger.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
+            },
+            "description": "The default colored console logger.",
+            "name": "console"
+          }
+        ],
+        "name": "default",
+        "resource_def_snaps": [
+          {
+            "__class__": "ResourceDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            },
+            "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
+            "name": "io_manager"
+          }
+        ],
+        "root_config_key": "Shape.4dfd32a4f7289a1d2b17c4582b2b68dc904bc200"
+      }
+    ],
+    "name": "executable_test_job",
+    "solid_definitions_snapshot": {
+      "__class__": "SolidDefinitionsSnapshot",
+      "composite_solid_def_snaps": [],
+      "solid_def_snaps": [
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "executable_asset",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Nothing",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{}",
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "unexecutable_asset",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Nothing",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "unexecutable_asset"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        }
+      ]
+    },
+    "tags": {}
+  }
+  '''
+# ---
+# name: test_all_snapshot_ids[51]
+  '6a914ad611e5cd4a7108f332bce41cf9ebfacfbc'
+# ---
+# name: test_all_snapshot_ids[52]
+  '''
+  {
+    "__class__": "PipelineSnapshot",
+    "config_schema_snapshot": {
+      "__class__": "ConfigSchemaSnapshot",
+      "all_config_snaps_by_key": {
+        "Any": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Any",
+          "key": "Any",
+          "kind": {
+            "__enum__": "ConfigTypeKind.ANY"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Bool": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Bool",
+          "key": "Bool",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.BOOL"
+          },
+          "type_param_keys": null
+        },
+        "Float": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Float",
+          "key": "Float",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.FLOAT"
+          },
+          "type_param_keys": null
+        },
+        "Int": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Int",
+          "key": "Int",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.INT"
+          },
+          "type_param_keys": null
+        },
+        "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Bool",
+            "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59"
+          ]
+        },
+        "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Float",
+            "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3"
+          ]
+        },
+        "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Int",
+            "Selector.a9799b971d12ace70a2d8803c883c863417d0725"
+          ]
+        },
+        "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "String",
+            "Selector.e04723c9d9937e3ab21206435b22247cfbe58269"
+          ]
+        },
+        "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "disabled",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "enabled",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Int"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Bool"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Float"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Any"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
         "Shape.06069286ad8e9e662d8619edf66d64aceed069e5": {
           "__class__": "ConfigTypeSnap",
           "description": null,
@@ -53896,10 +56549,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[51]
+# name: test_all_snapshot_ids[53]
   'a8c59968b6bfc4a69dfeddadb403ef103814d7bd'
 # ---
-# name: test_all_snapshot_ids[52]
+# name: test_all_snapshot_ids[54]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -54881,10 +57534,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[53]
+# name: test_all_snapshot_ids[55]
   '8063efa9c804f1ca24f243d02c895bb881a3f552'
 # ---
-# name: test_all_snapshot_ids[54]
+# name: test_all_snapshot_ids[56]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -55972,10 +58625,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[55]
+# name: test_all_snapshot_ids[57]
   '8686ac202978e5594035fcfe0f90b6d83ef1a5eb'
 # ---
-# name: test_all_snapshot_ids[56]
+# name: test_all_snapshot_ids[58]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -57122,10 +59775,13 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[57]
+# name: test_all_snapshot_ids[59]
   '252960d8f0b17cdcd1efaa2b6803c10e7e851bfa'
 # ---
-# name: test_all_snapshot_ids[58]
+# name: test_all_snapshot_ids[5]
+  'a4217f356ff02a52de8f66d393f69b80850cdf74'
+# ---
+# name: test_all_snapshot_ids[60]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -58329,13 +60985,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[59]
+# name: test_all_snapshot_ids[61]
   '053169bccb033d2fc2fd11d13696b36a32c0e610'
 # ---
-# name: test_all_snapshot_ids[5]
-  'a4217f356ff02a52de8f66d393f69b80850cdf74'
-# ---
-# name: test_all_snapshot_ids[60]
+# name: test_all_snapshot_ids[62]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -59402,10 +62055,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[61]
+# name: test_all_snapshot_ids[63]
   'd603c1e9d8630c3aa099d79e0515968e7514384f'
 # ---
-# name: test_all_snapshot_ids[62]
+# name: test_all_snapshot_ids[64]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -60330,10 +62983,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[63]
+# name: test_all_snapshot_ids[65]
   'fd77a8459b2e767ea52b6a77574a79491326073d'
 # ---
-# name: test_all_snapshot_ids[64]
+# name: test_all_snapshot_ids[66]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -61297,10 +63950,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[65]
+# name: test_all_snapshot_ids[67]
   'c6b504611b1ee7582092807ac90bdd4ac64bac3b'
 # ---
-# name: test_all_snapshot_ids[66]
+# name: test_all_snapshot_ids[68]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -62156,911 +64809,8 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[67]
-  'dc190868e8887ba5ac3669da13473252cd0ab098'
-# ---
-# name: test_all_snapshot_ids[68]
-  '''
-  {
-    "__class__": "PipelineSnapshot",
-    "config_schema_snapshot": {
-      "__class__": "ConfigSchemaSnapshot",
-      "all_config_snaps_by_key": {
-        "Any": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Any",
-          "key": "Any",
-          "kind": {
-            "__enum__": "ConfigTypeKind.ANY"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Bool": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Bool",
-          "key": "Bool",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.BOOL"
-          },
-          "type_param_keys": null
-        },
-        "Float": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Float",
-          "key": "Float",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.FLOAT"
-          },
-          "type_param_keys": null
-        },
-        "Int": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Int",
-          "key": "Int",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.INT"
-          },
-          "type_param_keys": null
-        },
-        "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Bool",
-            "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59"
-          ]
-        },
-        "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Float",
-            "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3"
-          ]
-        },
-        "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Int",
-            "Selector.a9799b971d12ace70a2d8803c883c863417d0725"
-          ]
-        },
-        "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "String",
-            "Selector.e04723c9d9937e3ab21206435b22247cfbe58269"
-          ]
-        },
-        "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "disabled",
-              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "enabled",
-              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Int"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Bool"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Float"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Any"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.081354663b9d4b8fbfd1cb8e358763912953913f": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "\"INFO\"",
-              "description": "The logger's threshold.",
-              "is_required": false,
-              "name": "log_level",
-              "type_key": "String"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "\"dagster\"",
-              "description": "The name of your logger.",
-              "is_required": false,
-              "name": "name",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.09d73f0755bf4752d3f121837669c8660dcf451e": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"retries\": {\"enabled\": {}}}",
-              "description": "Execute all steps in a single process.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
-              "description": "The default colored console logger.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
-              "is_required": false,
-              "name": "io_manager",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": "[DEPRECATED]",
-              "is_required": false,
-              "name": "marker_to_close",
-              "type_key": "String"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"enabled\": {}}",
-              "description": "Whether retries are enabled or not. By default, retries are enabled.",
-              "is_required": false,
-              "name": "retries",
-              "type_key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "path",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.743e47901855cb245064dd633e217bfcb49a11a7": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Any"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.7a2485929d7236949338d36f0435c94a9e354a77": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
-              "description": "Configure how steps are executed within a run.",
-              "is_required": false,
-              "name": "execution",
-              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": "Configure how loggers emit messages within a run.",
-              "is_required": false,
-              "name": "loggers",
-              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": "Configure runtime parameters for ops or assets.",
-              "is_required": true,
-              "name": "ops",
-              "type_key": "Shape.f1d05596db6e35312901196d530dfee6946a33fe"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"io_manager\": {}}",
-              "description": "Configure how shared resources are implemented within a run.",
-              "is_required": false,
-              "name": "resources",
-              "type_key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.7a2485929d7236949338d36f0435c94a9e354a77",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "file",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "config",
-              "type_key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [],
-          "given_name": null,
-          "key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "console",
-              "type_key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.f1d05596db6e35312901196d530dfee6946a33fe": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "loop",
-              "type_key": "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.f1d05596db6e35312901196d530dfee6946a33fe",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "String": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "String",
-          "key": "String",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.STRING"
-          },
-          "type_param_keys": null
-        }
-      }
-    },
-    "dagster_type_namespace_snapshot": {
-      "__class__": "DagsterTypeNamespaceSnapshot",
-      "all_dagster_type_snaps_by_key": {
-        "Any": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Any",
-          "is_builtin": true,
-          "key": "Any",
-          "kind": {
-            "__enum__": "DagsterTypeKind.ANY"
-          },
-          "loader_schema_key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
-          "materializer_schema_key": null,
-          "name": "Any",
-          "type_param_keys": []
-        },
-        "Bool": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Bool",
-          "is_builtin": true,
-          "key": "Bool",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "materializer_schema_key": null,
-          "name": "Bool",
-          "type_param_keys": []
-        },
-        "Float": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Float",
-          "is_builtin": true,
-          "key": "Float",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "materializer_schema_key": null,
-          "name": "Float",
-          "type_param_keys": []
-        },
-        "Int": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Int",
-          "is_builtin": true,
-          "key": "Int",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "materializer_schema_key": null,
-          "name": "Int",
-          "type_param_keys": []
-        },
-        "Nothing": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Nothing",
-          "is_builtin": true,
-          "key": "Nothing",
-          "kind": {
-            "__enum__": "DagsterTypeKind.NOTHING"
-          },
-          "loader_schema_key": null,
-          "materializer_schema_key": null,
-          "name": "Nothing",
-          "type_param_keys": []
-        },
-        "String": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "String",
-          "is_builtin": true,
-          "key": "String",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "materializer_schema_key": null,
-          "name": "String",
-          "type_param_keys": []
-        }
-      }
-    },
-    "dep_structure_snapshot": {
-      "__class__": "DependencyStructureSnapshot",
-      "solid_invocation_snaps": [
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "loop",
-          "solid_name": "loop",
-          "tags": {}
-        }
-      ]
-    },
-    "description": null,
-    "graph_def_name": "infinite_loop_job",
-    "lineage_snapshot": null,
-    "mode_def_snaps": [
-      {
-        "__class__": "ModeDefSnap",
-        "description": null,
-        "logger_def_snaps": [
-          {
-            "__class__": "LoggerDefSnap",
-            "config_field_snap": {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
-              "description": "The default colored console logger.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
-            },
-            "description": "The default colored console logger.",
-            "name": "console"
-          }
-        ],
-        "name": "default",
-        "resource_def_snaps": [
-          {
-            "__class__": "ResourceDefSnap",
-            "config_field_snap": {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Any"
-            },
-            "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
-            "name": "io_manager"
-          }
-        ],
-        "root_config_key": "Shape.7a2485929d7236949338d36f0435c94a9e354a77"
-      }
-    ],
-    "name": "infinite_loop_job",
-    "solid_definitions_snapshot": {
-      "__class__": "SolidDefinitionsSnapshot",
-      "composite_solid_def_snaps": [],
-      "solid_def_snaps": [
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": true,
-            "name": "config",
-            "type_key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e"
-          },
-          "description": null,
-          "input_def_snaps": [],
-          "name": "loop",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        }
-      ]
-    },
-    "tags": {}
-  }
-  '''
-# ---
 # name: test_all_snapshot_ids[69]
-  '83469e8c700778e0c1e268f158672fca54d5896b'
+  'dc190868e8887ba5ac3669da13473252cd0ab098'
 # ---
 # name: test_all_snapshot_ids[6]
   '''
@@ -65410,6 +67160,909 @@
           "scalar_kind": null,
           "type_param_keys": null
         },
+        "Shape.743e47901855cb245064dd633e217bfcb49a11a7": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.7a2485929d7236949338d36f0435c94a9e354a77": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
+              "description": "Configure how steps are executed within a run.",
+              "is_required": false,
+              "name": "execution",
+              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Configure how loggers emit messages within a run.",
+              "is_required": false,
+              "name": "loggers",
+              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "Configure runtime parameters for ops or assets.",
+              "is_required": true,
+              "name": "ops",
+              "type_key": "Shape.f1d05596db6e35312901196d530dfee6946a33fe"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"io_manager\": {}}",
+              "description": "Configure how shared resources are implemented within a run.",
+              "is_required": false,
+              "name": "resources",
+              "type_key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.7a2485929d7236949338d36f0435c94a9e354a77",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "file",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "config",
+              "type_key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [],
+          "given_name": null,
+          "key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "console",
+              "type_key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.f1d05596db6e35312901196d530dfee6946a33fe": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "loop",
+              "type_key": "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.f1d05596db6e35312901196d530dfee6946a33fe",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "String": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "String",
+          "key": "String",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.STRING"
+          },
+          "type_param_keys": null
+        }
+      }
+    },
+    "dagster_type_namespace_snapshot": {
+      "__class__": "DagsterTypeNamespaceSnapshot",
+      "all_dagster_type_snaps_by_key": {
+        "Any": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Any",
+          "is_builtin": true,
+          "key": "Any",
+          "kind": {
+            "__enum__": "DagsterTypeKind.ANY"
+          },
+          "loader_schema_key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
+          "materializer_schema_key": null,
+          "name": "Any",
+          "type_param_keys": []
+        },
+        "Bool": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Bool",
+          "is_builtin": true,
+          "key": "Bool",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "materializer_schema_key": null,
+          "name": "Bool",
+          "type_param_keys": []
+        },
+        "Float": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Float",
+          "is_builtin": true,
+          "key": "Float",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "materializer_schema_key": null,
+          "name": "Float",
+          "type_param_keys": []
+        },
+        "Int": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Int",
+          "is_builtin": true,
+          "key": "Int",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "materializer_schema_key": null,
+          "name": "Int",
+          "type_param_keys": []
+        },
+        "Nothing": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Nothing",
+          "is_builtin": true,
+          "key": "Nothing",
+          "kind": {
+            "__enum__": "DagsterTypeKind.NOTHING"
+          },
+          "loader_schema_key": null,
+          "materializer_schema_key": null,
+          "name": "Nothing",
+          "type_param_keys": []
+        },
+        "String": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "String",
+          "is_builtin": true,
+          "key": "String",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "materializer_schema_key": null,
+          "name": "String",
+          "type_param_keys": []
+        }
+      }
+    },
+    "dep_structure_snapshot": {
+      "__class__": "DependencyStructureSnapshot",
+      "solid_invocation_snaps": [
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "loop",
+          "solid_name": "loop",
+          "tags": {}
+        }
+      ]
+    },
+    "description": null,
+    "graph_def_name": "infinite_loop_job",
+    "lineage_snapshot": null,
+    "mode_def_snaps": [
+      {
+        "__class__": "ModeDefSnap",
+        "description": null,
+        "logger_def_snaps": [
+          {
+            "__class__": "LoggerDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
+              "description": "The default colored console logger.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
+            },
+            "description": "The default colored console logger.",
+            "name": "console"
+          }
+        ],
+        "name": "default",
+        "resource_def_snaps": [
+          {
+            "__class__": "ResourceDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            },
+            "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
+            "name": "io_manager"
+          }
+        ],
+        "root_config_key": "Shape.7a2485929d7236949338d36f0435c94a9e354a77"
+      }
+    ],
+    "name": "infinite_loop_job",
+    "solid_definitions_snapshot": {
+      "__class__": "SolidDefinitionsSnapshot",
+      "composite_solid_def_snaps": [],
+      "solid_def_snaps": [
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": true,
+            "name": "config",
+            "type_key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "loop",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        }
+      ]
+    },
+    "tags": {}
+  }
+  '''
+# ---
+# name: test_all_snapshot_ids[71]
+  '83469e8c700778e0c1e268f158672fca54d5896b'
+# ---
+# name: test_all_snapshot_ids[72]
+  '''
+  {
+    "__class__": "PipelineSnapshot",
+    "config_schema_snapshot": {
+      "__class__": "ConfigSchemaSnapshot",
+      "all_config_snaps_by_key": {
+        "Any": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Any",
+          "key": "Any",
+          "kind": {
+            "__enum__": "ConfigTypeKind.ANY"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Bool": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Bool",
+          "key": "Bool",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.BOOL"
+          },
+          "type_param_keys": null
+        },
+        "Float": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Float",
+          "key": "Float",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.FLOAT"
+          },
+          "type_param_keys": null
+        },
+        "Int": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Int",
+          "key": "Int",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.INT"
+          },
+          "type_param_keys": null
+        },
+        "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Bool",
+            "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59"
+          ]
+        },
+        "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Float",
+            "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3"
+          ]
+        },
+        "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Int",
+            "Selector.a9799b971d12ace70a2d8803c883c863417d0725"
+          ]
+        },
+        "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "String",
+            "Selector.e04723c9d9937e3ab21206435b22247cfbe58269"
+          ]
+        },
+        "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "disabled",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "enabled",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Int"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Bool"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Float"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Any"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.081354663b9d4b8fbfd1cb8e358763912953913f": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "\"INFO\"",
+              "description": "The logger's threshold.",
+              "is_required": false,
+              "name": "log_level",
+              "type_key": "String"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "\"dagster\"",
+              "description": "The name of your logger.",
+              "is_required": false,
+              "name": "name",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.09d73f0755bf4752d3f121837669c8660dcf451e": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"retries\": {\"enabled\": {}}}",
+              "description": "Execute all steps in a single process.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
+              "description": "The default colored console logger.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
+              "is_required": false,
+              "name": "io_manager",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "[DEPRECATED]",
+              "is_required": false,
+              "name": "marker_to_close",
+              "type_key": "String"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"enabled\": {}}",
+              "description": "Whether retries are enabled or not. By default, retries are enabled.",
+              "is_required": false,
+              "name": "retries",
+              "type_key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "path",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
         "Shape.61678299d213abc6dacb4a403face86263e676d7": {
           "__class__": "ConfigTypeSnap",
           "description": null,
@@ -65742,10 +68395,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[71]
+# name: test_all_snapshot_ids[73]
   'c4fee3a0c56b1ef6fcea9b64ceaacd06c4d5e216'
 # ---
-# name: test_all_snapshot_ids[72]
+# name: test_all_snapshot_ids[74]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -66645,10 +69298,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[73]
+# name: test_all_snapshot_ids[75]
   '643e2b02ca69b0087d15b448a9108d39d5b35036'
 # ---
-# name: test_all_snapshot_ids[74]
+# name: test_all_snapshot_ids[76]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -67554,10 +70207,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[75]
+# name: test_all_snapshot_ids[77]
   '158a79ab642707e63923c59c6abaf7960b36211e'
 # ---
-# name: test_all_snapshot_ids[76]
+# name: test_all_snapshot_ids[78]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -68472,10 +71125,13 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[77]
+# name: test_all_snapshot_ids[79]
   '25eed9832eef95ee97a63357e836659193775b3d'
 # ---
-# name: test_all_snapshot_ids[78]
+# name: test_all_snapshot_ids[7]
+  'f192c173b0d05359cd6594a0387c93bf9f6bd2e3'
+# ---
+# name: test_all_snapshot_ids[80]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -69420,13 +72076,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[79]
+# name: test_all_snapshot_ids[81]
   '6069db2378a5bcd370c5f8ce8e8ee51d997e3447'
 # ---
-# name: test_all_snapshot_ids[7]
-  'f192c173b0d05359cd6594a0387c93bf9f6bd2e3'
-# ---
-# name: test_all_snapshot_ids[80]
+# name: test_all_snapshot_ids[82]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -70358,10 +73011,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[81]
+# name: test_all_snapshot_ids[83]
   'de3cee0b30bf45c5c28b57035caff8a592cb8a99'
 # ---
-# name: test_all_snapshot_ids[82]
+# name: test_all_snapshot_ids[84]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -71244,10 +73897,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[83]
+# name: test_all_snapshot_ids[85]
   '68f90c6bc3483e01ab1317573d90e23d0efe14a9'
 # ---
-# name: test_all_snapshot_ids[84]
+# name: test_all_snapshot_ids[86]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -72147,10 +74800,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[85]
+# name: test_all_snapshot_ids[87]
   '1c4b82d393f7eacd9a358e3d82925d2afb9afbc0'
 # ---
-# name: test_all_snapshot_ids[86]
+# name: test_all_snapshot_ids[88]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -73004,865 +75657,8 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[87]
-  'ab213b2b0286d659e9d7044d7dcec9b13d5b8bc7'
-# ---
-# name: test_all_snapshot_ids[88]
-  '''
-  {
-    "__class__": "PipelineSnapshot",
-    "config_schema_snapshot": {
-      "__class__": "ConfigSchemaSnapshot",
-      "all_config_snaps_by_key": {
-        "Any": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Any",
-          "key": "Any",
-          "kind": {
-            "__enum__": "ConfigTypeKind.ANY"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Bool": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Bool",
-          "key": "Bool",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.BOOL"
-          },
-          "type_param_keys": null
-        },
-        "Float": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Float",
-          "key": "Float",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.FLOAT"
-          },
-          "type_param_keys": null
-        },
-        "Int": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Int",
-          "key": "Int",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.INT"
-          },
-          "type_param_keys": null
-        },
-        "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Bool",
-            "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59"
-          ]
-        },
-        "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Float",
-            "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3"
-          ]
-        },
-        "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Int",
-            "Selector.a9799b971d12ace70a2d8803c883c863417d0725"
-          ]
-        },
-        "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "String",
-            "Selector.e04723c9d9937e3ab21206435b22247cfbe58269"
-          ]
-        },
-        "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "disabled",
-              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "enabled",
-              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Int"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Bool"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Float"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Any"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.081354663b9d4b8fbfd1cb8e358763912953913f": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "\"INFO\"",
-              "description": "The logger's threshold.",
-              "is_required": false,
-              "name": "log_level",
-              "type_key": "String"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "\"dagster\"",
-              "description": "The name of your logger.",
-              "is_required": false,
-              "name": "name",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.09d73f0755bf4752d3f121837669c8660dcf451e": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"retries\": {\"enabled\": {}}}",
-              "description": "Execute all steps in a single process.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
-              "description": "The default colored console logger.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
-              "is_required": false,
-              "name": "io_manager",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.2846d3347cb819c3383fc37633746e4c2510b3e1": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "my_op",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.2846d3347cb819c3383fc37633746e4c2510b3e1",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": "[DEPRECATED]",
-              "is_required": false,
-              "name": "marker_to_close",
-              "type_key": "String"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"enabled\": {}}",
-              "description": "Whether retries are enabled or not. By default, retries are enabled.",
-              "is_required": false,
-              "name": "retries",
-              "type_key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "path",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.743e47901855cb245064dd633e217bfcb49a11a7": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Any"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.883f869771a421fc4c8a587a772eef9138f3f7c0": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
-              "description": "Configure how steps are executed within a run.",
-              "is_required": false,
-              "name": "execution",
-              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": "Configure how loggers emit messages within a run.",
-              "is_required": false,
-              "name": "loggers",
-              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"my_op\": {}}",
-              "description": "Configure runtime parameters for ops or assets.",
-              "is_required": false,
-              "name": "ops",
-              "type_key": "Shape.2846d3347cb819c3383fc37633746e4c2510b3e1"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"io_manager\": {}}",
-              "description": "Configure how shared resources are implemented within a run.",
-              "is_required": false,
-              "name": "resources",
-              "type_key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.883f869771a421fc4c8a587a772eef9138f3f7c0",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [],
-          "given_name": null,
-          "key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "console",
-              "type_key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "String": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "String",
-          "key": "String",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.STRING"
-          },
-          "type_param_keys": null
-        }
-      }
-    },
-    "dagster_type_namespace_snapshot": {
-      "__class__": "DagsterTypeNamespaceSnapshot",
-      "all_dagster_type_snaps_by_key": {
-        "Any": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Any",
-          "is_builtin": true,
-          "key": "Any",
-          "kind": {
-            "__enum__": "DagsterTypeKind.ANY"
-          },
-          "loader_schema_key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
-          "materializer_schema_key": null,
-          "name": "Any",
-          "type_param_keys": []
-        },
-        "Bool": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Bool",
-          "is_builtin": true,
-          "key": "Bool",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "materializer_schema_key": null,
-          "name": "Bool",
-          "type_param_keys": []
-        },
-        "Float": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Float",
-          "is_builtin": true,
-          "key": "Float",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "materializer_schema_key": null,
-          "name": "Float",
-          "type_param_keys": []
-        },
-        "Int": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Int",
-          "is_builtin": true,
-          "key": "Int",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "materializer_schema_key": null,
-          "name": "Int",
-          "type_param_keys": []
-        },
-        "Nothing": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Nothing",
-          "is_builtin": true,
-          "key": "Nothing",
-          "kind": {
-            "__enum__": "DagsterTypeKind.NOTHING"
-          },
-          "loader_schema_key": null,
-          "materializer_schema_key": null,
-          "name": "Nothing",
-          "type_param_keys": []
-        },
-        "String": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "String",
-          "is_builtin": true,
-          "key": "String",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "materializer_schema_key": null,
-          "name": "String",
-          "type_param_keys": []
-        }
-      }
-    },
-    "dep_structure_snapshot": {
-      "__class__": "DependencyStructureSnapshot",
-      "solid_invocation_snaps": [
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "my_op",
-          "solid_name": "my_op",
-          "tags": {}
-        }
-      ]
-    },
-    "description": null,
-    "graph_def_name": "memoization_job",
-    "lineage_snapshot": null,
-    "mode_def_snaps": [
-      {
-        "__class__": "ModeDefSnap",
-        "description": null,
-        "logger_def_snaps": [
-          {
-            "__class__": "LoggerDefSnap",
-            "config_field_snap": {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
-              "description": "The default colored console logger.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
-            },
-            "description": "The default colored console logger.",
-            "name": "console"
-          }
-        ],
-        "name": "default",
-        "resource_def_snaps": [
-          {
-            "__class__": "ResourceDefSnap",
-            "config_field_snap": {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Any"
-            },
-            "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
-            "name": "io_manager"
-          }
-        ],
-        "root_config_key": "Shape.883f869771a421fc4c8a587a772eef9138f3f7c0"
-      }
-    ],
-    "name": "memoization_job",
-    "solid_definitions_snapshot": {
-      "__class__": "SolidDefinitionsSnapshot",
-      "composite_solid_def_snaps": [],
-      "solid_def_snaps": [
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [],
-          "name": "my_op",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        }
-      ]
-    },
-    "tags": {}
-  }
-  '''
-# ---
 # name: test_all_snapshot_ids[89]
-  '87d32ef521015d8d415511a54b821524bc7a789f'
+  'ab213b2b0286d659e9d7044d7dcec9b13d5b8bc7'
 # ---
 # name: test_all_snapshot_ids[8]
   '''
@@ -75949,6 +77745,863 @@
           "scalar_kind": null,
           "type_param_keys": null
         },
+        "Shape.2846d3347cb819c3383fc37633746e4c2510b3e1": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "my_op",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.2846d3347cb819c3383fc37633746e4c2510b3e1",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "[DEPRECATED]",
+              "is_required": false,
+              "name": "marker_to_close",
+              "type_key": "String"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"enabled\": {}}",
+              "description": "Whether retries are enabled or not. By default, retries are enabled.",
+              "is_required": false,
+              "name": "retries",
+              "type_key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "path",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.743e47901855cb245064dd633e217bfcb49a11a7": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.883f869771a421fc4c8a587a772eef9138f3f7c0": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
+              "description": "Configure how steps are executed within a run.",
+              "is_required": false,
+              "name": "execution",
+              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Configure how loggers emit messages within a run.",
+              "is_required": false,
+              "name": "loggers",
+              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"my_op\": {}}",
+              "description": "Configure runtime parameters for ops or assets.",
+              "is_required": false,
+              "name": "ops",
+              "type_key": "Shape.2846d3347cb819c3383fc37633746e4c2510b3e1"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"io_manager\": {}}",
+              "description": "Configure how shared resources are implemented within a run.",
+              "is_required": false,
+              "name": "resources",
+              "type_key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.883f869771a421fc4c8a587a772eef9138f3f7c0",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [],
+          "given_name": null,
+          "key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "console",
+              "type_key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "String": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "String",
+          "key": "String",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.STRING"
+          },
+          "type_param_keys": null
+        }
+      }
+    },
+    "dagster_type_namespace_snapshot": {
+      "__class__": "DagsterTypeNamespaceSnapshot",
+      "all_dagster_type_snaps_by_key": {
+        "Any": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Any",
+          "is_builtin": true,
+          "key": "Any",
+          "kind": {
+            "__enum__": "DagsterTypeKind.ANY"
+          },
+          "loader_schema_key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
+          "materializer_schema_key": null,
+          "name": "Any",
+          "type_param_keys": []
+        },
+        "Bool": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Bool",
+          "is_builtin": true,
+          "key": "Bool",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "materializer_schema_key": null,
+          "name": "Bool",
+          "type_param_keys": []
+        },
+        "Float": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Float",
+          "is_builtin": true,
+          "key": "Float",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "materializer_schema_key": null,
+          "name": "Float",
+          "type_param_keys": []
+        },
+        "Int": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Int",
+          "is_builtin": true,
+          "key": "Int",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "materializer_schema_key": null,
+          "name": "Int",
+          "type_param_keys": []
+        },
+        "Nothing": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Nothing",
+          "is_builtin": true,
+          "key": "Nothing",
+          "kind": {
+            "__enum__": "DagsterTypeKind.NOTHING"
+          },
+          "loader_schema_key": null,
+          "materializer_schema_key": null,
+          "name": "Nothing",
+          "type_param_keys": []
+        },
+        "String": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "String",
+          "is_builtin": true,
+          "key": "String",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "materializer_schema_key": null,
+          "name": "String",
+          "type_param_keys": []
+        }
+      }
+    },
+    "dep_structure_snapshot": {
+      "__class__": "DependencyStructureSnapshot",
+      "solid_invocation_snaps": [
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "my_op",
+          "solid_name": "my_op",
+          "tags": {}
+        }
+      ]
+    },
+    "description": null,
+    "graph_def_name": "memoization_job",
+    "lineage_snapshot": null,
+    "mode_def_snaps": [
+      {
+        "__class__": "ModeDefSnap",
+        "description": null,
+        "logger_def_snaps": [
+          {
+            "__class__": "LoggerDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
+              "description": "The default colored console logger.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
+            },
+            "description": "The default colored console logger.",
+            "name": "console"
+          }
+        ],
+        "name": "default",
+        "resource_def_snaps": [
+          {
+            "__class__": "ResourceDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            },
+            "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
+            "name": "io_manager"
+          }
+        ],
+        "root_config_key": "Shape.883f869771a421fc4c8a587a772eef9138f3f7c0"
+      }
+    ],
+    "name": "memoization_job",
+    "solid_definitions_snapshot": {
+      "__class__": "SolidDefinitionsSnapshot",
+      "composite_solid_def_snaps": [],
+      "solid_def_snaps": [
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "my_op",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        }
+      ]
+    },
+    "tags": {}
+  }
+  '''
+# ---
+# name: test_all_snapshot_ids[91]
+  '87d32ef521015d8d415511a54b821524bc7a789f'
+# ---
+# name: test_all_snapshot_ids[92]
+  '''
+  {
+    "__class__": "PipelineSnapshot",
+    "config_schema_snapshot": {
+      "__class__": "ConfigSchemaSnapshot",
+      "all_config_snaps_by_key": {
+        "Any": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Any",
+          "key": "Any",
+          "kind": {
+            "__enum__": "ConfigTypeKind.ANY"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Bool": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Bool",
+          "key": "Bool",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.BOOL"
+          },
+          "type_param_keys": null
+        },
+        "Float": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Float",
+          "key": "Float",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.FLOAT"
+          },
+          "type_param_keys": null
+        },
+        "Int": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Int",
+          "key": "Int",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.INT"
+          },
+          "type_param_keys": null
+        },
+        "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Bool",
+            "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59"
+          ]
+        },
+        "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Float",
+            "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3"
+          ]
+        },
+        "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Int",
+            "Selector.a9799b971d12ace70a2d8803c883c863417d0725"
+          ]
+        },
+        "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "String",
+            "Selector.e04723c9d9937e3ab21206435b22247cfbe58269"
+          ]
+        },
+        "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "disabled",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "enabled",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Int"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Bool"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Float"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Any"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.081354663b9d4b8fbfd1cb8e358763912953913f": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "\"INFO\"",
+              "description": "The logger's threshold.",
+              "is_required": false,
+              "name": "log_level",
+              "type_key": "String"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "\"dagster\"",
+              "description": "The name of your logger.",
+              "is_required": false,
+              "name": "name",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.09d73f0755bf4752d3f121837669c8660dcf451e": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"retries\": {\"enabled\": {}}}",
+              "description": "Execute all steps in a single process.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
+              "description": "The default colored console logger.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
+              "is_required": false,
+              "name": "io_manager",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
         "Shape.229b6731a336bf9c6372da5f99a6c27bc6d086ef": {
           "__class__": "ConfigTypeSnap",
           "description": null,
@@ -76444,10 +79097,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[91]
+# name: test_all_snapshot_ids[93]
   '06068d3cd0c89f54330c52e56f4e72a338f19a9f'
 # ---
-# name: test_all_snapshot_ids[92]
+# name: test_all_snapshot_ids[94]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -77445,10 +80098,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[93]
+# name: test_all_snapshot_ids[95]
   '10cfd966244a4e4064ff00517d3e012ad6ce4c7d'
 # ---
-# name: test_all_snapshot_ids[94]
+# name: test_all_snapshot_ids[96]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -78366,10 +81019,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[95]
+# name: test_all_snapshot_ids[97]
   'b7499dc1851fe912eb84bbbcead7d7db511e64d8'
 # ---
-# name: test_all_snapshot_ids[96]
+# name: test_all_snapshot_ids[98]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -79292,998 +81945,8 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[97]
-  '52e9a3ca99126add43b9626288695fe94c05f8c5'
-# ---
-# name: test_all_snapshot_ids[98]
-  '''
-  {
-    "__class__": "PipelineSnapshot",
-    "config_schema_snapshot": {
-      "__class__": "ConfigSchemaSnapshot",
-      "all_config_snaps_by_key": {
-        "Any": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Any",
-          "key": "Any",
-          "kind": {
-            "__enum__": "ConfigTypeKind.ANY"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Bool": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Bool",
-          "key": "Bool",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.BOOL"
-          },
-          "type_param_keys": null
-        },
-        "Float": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Float",
-          "key": "Float",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.FLOAT"
-          },
-          "type_param_keys": null
-        },
-        "Int": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Int",
-          "key": "Int",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.INT"
-          },
-          "type_param_keys": null
-        },
-        "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Bool",
-            "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59"
-          ]
-        },
-        "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Float",
-            "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3"
-          ]
-        },
-        "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Int",
-            "Selector.a9799b971d12ace70a2d8803c883c863417d0725"
-          ]
-        },
-        "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "String",
-            "Selector.e04723c9d9937e3ab21206435b22247cfbe58269"
-          ]
-        },
-        "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "disabled",
-              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "enabled",
-              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Int"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Bool"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Float"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Any"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.081354663b9d4b8fbfd1cb8e358763912953913f": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "\"INFO\"",
-              "description": "The logger's threshold.",
-              "is_required": false,
-              "name": "log_level",
-              "type_key": "String"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "\"dagster\"",
-              "description": "The name of your logger.",
-              "is_required": false,
-              "name": "name",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.09d73f0755bf4752d3f121837669c8660dcf451e": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"retries\": {\"enabled\": {}}}",
-              "description": "Execute all steps in a single process.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
-              "description": "The default colored console logger.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": "[DEPRECATED]",
-              "is_required": false,
-              "name": "marker_to_close",
-              "type_key": "String"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"enabled\": {}}",
-              "description": "Whether retries are enabled or not. By default, retries are enabled.",
-              "is_required": false,
-              "name": "retries",
-              "type_key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.4942ebf48d32aa0f8268910e01ed6544ad5b0132": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "hanging_asset_resource",
-              "type_key": "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "io_manager",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.4942ebf48d32aa0f8268910e01ed6544ad5b0132",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "path",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.743e47901855cb245064dd633e217bfcb49a11a7": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Any"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "file",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.a9ef178ea955c852b26b45817b8aea6df99c9f02": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
-              "description": "Configure how steps are executed within a run.",
-              "is_required": false,
-              "name": "execution",
-              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": "Configure how loggers emit messages within a run.",
-              "is_required": false,
-              "name": "loggers",
-              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"multipartitions_1\": {}, \"multipartitions_2\": {}}",
-              "description": "Configure runtime parameters for ops or assets.",
-              "is_required": false,
-              "name": "ops",
-              "type_key": "Shape.e5ada7fdb5d104210dab388858ab047e8cee0f41"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"io_manager\": {}}",
-              "description": "Configure how shared resources are implemented within a run.",
-              "is_required": false,
-              "name": "resources",
-              "type_key": "Shape.4942ebf48d32aa0f8268910e01ed6544ad5b0132"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.a9ef178ea955c852b26b45817b8aea6df99c9f02",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "config",
-              "type_key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [],
-          "given_name": null,
-          "key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.e5ada7fdb5d104210dab388858ab047e8cee0f41": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "multipartitions_1",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "multipartitions_2",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.e5ada7fdb5d104210dab388858ab047e8cee0f41",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "console",
-              "type_key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "String": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "String",
-          "key": "String",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.STRING"
-          },
-          "type_param_keys": null
-        }
-      }
-    },
-    "dagster_type_namespace_snapshot": {
-      "__class__": "DagsterTypeNamespaceSnapshot",
-      "all_dagster_type_snaps_by_key": {
-        "Any": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Any",
-          "is_builtin": true,
-          "key": "Any",
-          "kind": {
-            "__enum__": "DagsterTypeKind.ANY"
-          },
-          "loader_schema_key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
-          "materializer_schema_key": null,
-          "name": "Any",
-          "type_param_keys": []
-        },
-        "Bool": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Bool",
-          "is_builtin": true,
-          "key": "Bool",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "materializer_schema_key": null,
-          "name": "Bool",
-          "type_param_keys": []
-        },
-        "Float": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Float",
-          "is_builtin": true,
-          "key": "Float",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "materializer_schema_key": null,
-          "name": "Float",
-          "type_param_keys": []
-        },
-        "Int": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Int",
-          "is_builtin": true,
-          "key": "Int",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "materializer_schema_key": null,
-          "name": "Int",
-          "type_param_keys": []
-        },
-        "Nothing": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Nothing",
-          "is_builtin": true,
-          "key": "Nothing",
-          "kind": {
-            "__enum__": "DagsterTypeKind.NOTHING"
-          },
-          "loader_schema_key": null,
-          "materializer_schema_key": null,
-          "name": "Nothing",
-          "type_param_keys": []
-        },
-        "String": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "String",
-          "is_builtin": true,
-          "key": "String",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "materializer_schema_key": null,
-          "name": "String",
-          "type_param_keys": []
-        }
-      }
-    },
-    "dep_structure_snapshot": {
-      "__class__": "DependencyStructureSnapshot",
-      "solid_invocation_snaps": [
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "multipartitions_1",
-          "solid_name": "multipartitions_1",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [
-            {
-              "__class__": "InputDependencySnap",
-              "input_name": "multipartitions_1",
-              "is_dynamic_collect": false,
-              "upstream_output_snaps": [
-                {
-                  "__class__": "OutputHandleSnap",
-                  "output_name": "result",
-                  "solid_name": "multipartitions_1"
-                }
-              ]
-            }
-          ],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "multipartitions_2",
-          "solid_name": "multipartitions_2",
-          "tags": {}
-        }
-      ]
-    },
-    "description": null,
-    "graph_def_name": "multipartitions_job",
-    "lineage_snapshot": null,
-    "mode_def_snaps": [
-      {
-        "__class__": "ModeDefSnap",
-        "description": null,
-        "logger_def_snaps": [
-          {
-            "__class__": "LoggerDefSnap",
-            "config_field_snap": {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
-              "description": "The default colored console logger.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
-            },
-            "description": "The default colored console logger.",
-            "name": "console"
-          }
-        ],
-        "name": "default",
-        "resource_def_snaps": [
-          {
-            "__class__": "ResourceDefSnap",
-            "config_field_snap": {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "config",
-              "type_key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e"
-            },
-            "description": null,
-            "name": "hanging_asset_resource"
-          },
-          {
-            "__class__": "ResourceDefSnap",
-            "config_field_snap": {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Any"
-            },
-            "description": null,
-            "name": "io_manager"
-          }
-        ],
-        "root_config_key": "Shape.a9ef178ea955c852b26b45817b8aea6df99c9f02"
-      }
-    ],
-    "name": "multipartitions_job",
-    "solid_definitions_snapshot": {
-      "__class__": "SolidDefinitionsSnapshot",
-      "composite_solid_def_snaps": [],
-      "solid_def_snaps": [
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [],
-          "name": "multipartitions_1",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [
-            {
-              "__class__": "InputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "name": "multipartitions_1"
-            }
-          ],
-          "name": "multipartitions_2",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        }
-      ]
-    },
-    "tags": {}
-  }
-  '''
-# ---
 # name: test_all_snapshot_ids[99]
-  'c656e8e7694e5110568efa51930949e52595fcc5'
+  '52e9a3ca99126add43b9626288695fe94c05f8c5'
 # ---
 # name: test_all_snapshot_ids[9]
   '823f7a630c065c04ec779707092bb7769c51ef6e'

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_all_snapshot_ids.ambr
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_all_snapshot_ids.ambr
@@ -16668,29 +16668,6 @@
           "scalar_kind": null,
           "type_param_keys": null
         },
-        "Shape.1629902fbbde68e17f4f310b85646b6a76efd18d": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": "Base directory for storing files.",
-              "is_required": false,
-              "name": "base_dir",
-              "type_key": "Noneable.StringSourceType"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.1629902fbbde68e17f4f310b85646b6a76efd18d",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
         "Shape.24ee1fbfd9ec8adc8f4e5ab30e651b52389c861e": {
           "__class__": "ConfigTypeSnap",
           "description": null,
@@ -16758,6 +16735,38 @@
           ],
           "given_name": null,
           "key": "Shape.2e830fb24dc1eacc9bfa63a634b5715b46d81a2c",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.3f1ae09aca5685fa512e719e0e0f34132f10c8b3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "disable_gc",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"config\": {\"base_dir\": null}}",
+              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
+              "is_required": false,
+              "name": "io_manager",
+              "type_key": "Shape.9f45d547cea593c1893cee08a8d67b84989c16fc"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.3f1ae09aca5685fa512e719e0e0f34132f10c8b3",
           "kind": {
             "__enum__": "ConfigTypeKind.STRICT_SHAPE"
           },
@@ -16842,30 +16851,7 @@
           "scalar_kind": null,
           "type_param_keys": null
         },
-        "Shape.aa06a6ac89e62cfd2f6a1f9bce137c6abfa63805": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.\n\n    The base directory that the pickle files live inside is determined by:\n\n    * The IO manager's \"base_dir\" configuration value, if specified. Otherwise...\n    * A \"storage/\" directory underneath the value for \"local_artifact_storage\" in your dagster.yaml\n      file, if specified. Otherwise...\n    * A \"storage/\" directory underneath the directory that the DAGSTER_HOME environment variable\n      points to, if that environment variable is specified. Otherwise...\n    * A temporary directory.\n\n    Assigns each op output to a unique filepath containing run ID, step key, and output name.\n    Assigns each asset to a single filesystem path, at \"<base_dir>/<asset_key>\". If the asset key\n    has multiple components, the final component is used as the name of the file, and the preceding\n    components as parent directories under the base_dir.\n\n    Subsequent materializations of an asset will overwrite previous materializations of that asset.\n    So, with a base directory of \"/my/base/path\", an asset with key\n    `AssetKey([\"one\", \"two\", \"three\"])` would be stored in a file called \"three\" in a directory\n    with path \"/my/base/path/one/two/\".\n\n    Example usage:\n\n\n    1. Attach an IO manager to a set of assets using the reserved resource key ``\"io_manager\"``.\n\n    .. code-block:: python\n\n        from dagster import Definitions, asset, FilesystemIOManager\n\n        @asset\n        def asset1():\n            # create df ...\n            return df\n\n        @asset\n        def asset2(asset1):\n            return asset1[:5]\n\n        defs = Definitions(\n            assets=[asset1, asset2],\n            resources={\n                \"io_manager\": FilesystemIOManager(base_dir=\"/my/base/path\")\n            },\n        )\n\n\n    2. Specify a job-level IO manager using the reserved resource key ``\"io_manager\"``,\n    which will set the given IO manager on all ops in a job.\n\n    .. code-block:: python\n\n        from dagster import FilesystemIOManager, job, op\n\n        @op\n        def op_a():\n            # create df ...\n            return df\n\n        @op\n        def op_b(df):\n            return df[:5]\n\n        @job(\n            resource_defs={\n                \"io_manager\": FilesystemIOManager(base_dir=\"/my/base/path\")\n            }\n        )\n        def job():\n            op_b(op_a())\n\n\n    3. Specify IO manager on :py:class:`Out`, which allows you to set different IO managers on\n    different step outputs.\n\n    .. code-block:: python\n\n        from dagster import FilesystemIOManager, job, op, Out\n\n        @op(out=Out(io_manager_key=\"my_io_manager\"))\n        def op_a():\n            # create df ...\n            return df\n\n        @op\n        def op_b(df):\n            return df[:5]\n\n        @job(resource_defs={\"my_io_manager\": FilesystemIOManager()})\n        def job():\n            op_b(op_a())",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.1629902fbbde68e17f4f310b85646b6a76efd18d"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.aa06a6ac89e62cfd2f6a1f9bce137c6abfa63805",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.b01e0f497d08ad2fa0e3b9d92d2409de1095b2c7": {
+        "Shape.88643d5681d86336cf2207ad842fa2b2dfd27214": {
           "__class__": "ConfigTypeSnap",
           "description": null,
           "enum_values": null,
@@ -16900,15 +16886,61 @@
             {
               "__class__": "ConfigFieldSnap",
               "default_provided": true,
-              "default_value_as_json_str": "{\"disable_gc\": {}, \"io_manager\": {\"config\": {}}}",
+              "default_value_as_json_str": "{\"disable_gc\": {}, \"io_manager\": {\"config\": {\"base_dir\": null}}}",
               "description": "Configure how shared resources are implemented within a run.",
               "is_required": false,
               "name": "resources",
-              "type_key": "Shape.e6f1a85273b28fd3d7b57b81e9f94fad3bec2fe4"
+              "type_key": "Shape.3f1ae09aca5685fa512e719e0e0f34132f10c8b3"
             }
           ],
           "given_name": null,
-          "key": "Shape.b01e0f497d08ad2fa0e3b9d92d2409de1095b2c7",
+          "key": "Shape.88643d5681d86336cf2207ad842fa2b2dfd27214",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.9f45d547cea593c1893cee08a8d67b84989c16fc": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"base_dir\": null}",
+              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.\n\n    The base directory that the pickle files live inside is determined by:\n\n    * The IO manager's \"base_dir\" configuration value, if specified. Otherwise...\n    * A \"storage/\" directory underneath the value for \"local_artifact_storage\" in your dagster.yaml\n      file, if specified. Otherwise...\n    * A \"storage/\" directory underneath the directory that the DAGSTER_HOME environment variable\n      points to, if that environment variable is specified. Otherwise...\n    * A temporary directory.\n\n    Assigns each op output to a unique filepath containing run ID, step key, and output name.\n    Assigns each asset to a single filesystem path, at \"<base_dir>/<asset_key>\". If the asset key\n    has multiple components, the final component is used as the name of the file, and the preceding\n    components as parent directories under the base_dir.\n\n    Subsequent materializations of an asset will overwrite previous materializations of that asset.\n    So, with a base directory of \"/my/base/path\", an asset with key\n    `AssetKey([\"one\", \"two\", \"three\"])` would be stored in a file called \"three\" in a directory\n    with path \"/my/base/path/one/two/\".\n\n    Example usage:\n\n\n    1. Attach an IO manager to a set of assets using the reserved resource key ``\"io_manager\"``.\n\n    .. code-block:: python\n\n        from dagster import Definitions, asset, FilesystemIOManager\n\n        @asset\n        def asset1():\n            # create df ...\n            return df\n\n        @asset\n        def asset2(asset1):\n            return asset1[:5]\n\n        defs = Definitions(\n            assets=[asset1, asset2],\n            resources={\n                \"io_manager\": FilesystemIOManager(base_dir=\"/my/base/path\")\n            },\n        )\n\n\n    2. Specify a job-level IO manager using the reserved resource key ``\"io_manager\"``,\n    which will set the given IO manager on all ops in a job.\n\n    .. code-block:: python\n\n        from dagster import FilesystemIOManager, job, op\n\n        @op\n        def op_a():\n            # create df ...\n            return df\n\n        @op\n        def op_b(df):\n            return df[:5]\n\n        @job(\n            resource_defs={\n                \"io_manager\": FilesystemIOManager(base_dir=\"/my/base/path\")\n            }\n        )\n        def job():\n            op_b(op_a())\n\n\n    3. Specify IO manager on :py:class:`Out`, which allows you to set different IO managers on\n    different step outputs.\n\n    .. code-block:: python\n\n        from dagster import FilesystemIOManager, job, op, Out\n\n        @op(out=Out(io_manager_key=\"my_io_manager\"))\n        def op_a():\n            # create df ...\n            return df\n\n        @op\n        def op_b(df):\n            return df[:5]\n\n        @job(resource_defs={\"my_io_manager\": FilesystemIOManager()})\n        def job():\n            op_b(op_a())",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.b613ad485f01be6de3dda94dce6e7672b1d3c080"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.9f45d547cea593c1893cee08a8d67b84989c16fc",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.b613ad485f01be6de3dda94dce6e7672b1d3c080": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "null",
+              "description": "Base directory for storing files.",
+              "is_required": false,
+              "name": "base_dir",
+              "type_key": "Noneable.StringSourceType"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.b613ad485f01be6de3dda94dce6e7672b1d3c080",
           "kind": {
             "__enum__": "ConfigTypeKind.STRICT_SHAPE"
           },
@@ -16945,38 +16977,6 @@
           ],
           "given_name": null,
           "key": "Shape.dd25751df5066ca2b7e65e4907f386f04b08af64",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.e6f1a85273b28fd3d7b57b81e9f94fad3bec2fe4": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "disable_gc",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"config\": {}}",
-              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
-              "is_required": false,
-              "name": "io_manager",
-              "type_key": "Shape.aa06a6ac89e62cfd2f6a1f9bce137c6abfa63805"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.e6f1a85273b28fd3d7b57b81e9f94fad3bec2fe4",
           "kind": {
             "__enum__": "ConfigTypeKind.STRICT_SHAPE"
           },
@@ -17260,17 +17260,17 @@
             "config_field_snap": {
               "__class__": "ConfigFieldSnap",
               "default_provided": true,
-              "default_value_as_json_str": "{}",
+              "default_value_as_json_str": "{\"base_dir\": null}",
               "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.\n\n    The base directory that the pickle files live inside is determined by:\n\n    * The IO manager's \"base_dir\" configuration value, if specified. Otherwise...\n    * A \"storage/\" directory underneath the value for \"local_artifact_storage\" in your dagster.yaml\n      file, if specified. Otherwise...\n    * A \"storage/\" directory underneath the directory that the DAGSTER_HOME environment variable\n      points to, if that environment variable is specified. Otherwise...\n    * A temporary directory.\n\n    Assigns each op output to a unique filepath containing run ID, step key, and output name.\n    Assigns each asset to a single filesystem path, at \"<base_dir>/<asset_key>\". If the asset key\n    has multiple components, the final component is used as the name of the file, and the preceding\n    components as parent directories under the base_dir.\n\n    Subsequent materializations of an asset will overwrite previous materializations of that asset.\n    So, with a base directory of \"/my/base/path\", an asset with key\n    `AssetKey([\"one\", \"two\", \"three\"])` would be stored in a file called \"three\" in a directory\n    with path \"/my/base/path/one/two/\".\n\n    Example usage:\n\n\n    1. Attach an IO manager to a set of assets using the reserved resource key ``\"io_manager\"``.\n\n    .. code-block:: python\n\n        from dagster import Definitions, asset, FilesystemIOManager\n\n        @asset\n        def asset1():\n            # create df ...\n            return df\n\n        @asset\n        def asset2(asset1):\n            return asset1[:5]\n\n        defs = Definitions(\n            assets=[asset1, asset2],\n            resources={\n                \"io_manager\": FilesystemIOManager(base_dir=\"/my/base/path\")\n            },\n        )\n\n\n    2. Specify a job-level IO manager using the reserved resource key ``\"io_manager\"``,\n    which will set the given IO manager on all ops in a job.\n\n    .. code-block:: python\n\n        from dagster import FilesystemIOManager, job, op\n\n        @op\n        def op_a():\n            # create df ...\n            return df\n\n        @op\n        def op_b(df):\n            return df[:5]\n\n        @job(\n            resource_defs={\n                \"io_manager\": FilesystemIOManager(base_dir=\"/my/base/path\")\n            }\n        )\n        def job():\n            op_b(op_a())\n\n\n    3. Specify IO manager on :py:class:`Out`, which allows you to set different IO managers on\n    different step outputs.\n\n    .. code-block:: python\n\n        from dagster import FilesystemIOManager, job, op, Out\n\n        @op(out=Out(io_manager_key=\"my_io_manager\"))\n        def op_a():\n            # create df ...\n            return df\n\n        @op\n        def op_b(df):\n            return df[:5]\n\n        @job(resource_defs={\"my_io_manager\": FilesystemIOManager()})\n        def job():\n            op_b(op_a())",
               "is_required": false,
               "name": "config",
-              "type_key": "Shape.1629902fbbde68e17f4f310b85646b6a76efd18d"
+              "type_key": "Shape.b613ad485f01be6de3dda94dce6e7672b1d3c080"
             },
             "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
             "name": "io_manager"
           }
         ],
-        "root_config_key": "Shape.b01e0f497d08ad2fa0e3b9d92d2409de1095b2c7"
+        "root_config_key": "Shape.88643d5681d86336cf2207ad842fa2b2dfd27214"
       }
     ],
     "name": "retry_multi_input_early_terminate_job",
@@ -17424,7 +17424,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[129]
-  '728ab5201b611eddf16a949174470c76a353c3be'
+  '43f5a3b63b3dfe7ca769d3e75b79e1deed59e6ab'
 # ---
 # name: test_all_snapshot_ids[12]
   '''
@@ -20700,29 +20700,6 @@
           "scalar_kind": null,
           "type_param_keys": null
         },
-        "Shape.1629902fbbde68e17f4f310b85646b6a76efd18d": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": "Base directory for storing files.",
-              "is_required": false,
-              "name": "base_dir",
-              "type_key": "Noneable.StringSourceType"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.1629902fbbde68e17f4f310b85646b6a76efd18d",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
         "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c": {
           "__class__": "ConfigTypeSnap",
           "description": null,
@@ -20833,7 +20810,53 @@
           "scalar_kind": null,
           "type_param_keys": null
         },
-        "Shape.829973262158134d91916a48835fb0c656ac2f5f": {
+        "Shape.9f45d547cea593c1893cee08a8d67b84989c16fc": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"base_dir\": null}",
+              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.\n\n    The base directory that the pickle files live inside is determined by:\n\n    * The IO manager's \"base_dir\" configuration value, if specified. Otherwise...\n    * A \"storage/\" directory underneath the value for \"local_artifact_storage\" in your dagster.yaml\n      file, if specified. Otherwise...\n    * A \"storage/\" directory underneath the directory that the DAGSTER_HOME environment variable\n      points to, if that environment variable is specified. Otherwise...\n    * A temporary directory.\n\n    Assigns each op output to a unique filepath containing run ID, step key, and output name.\n    Assigns each asset to a single filesystem path, at \"<base_dir>/<asset_key>\". If the asset key\n    has multiple components, the final component is used as the name of the file, and the preceding\n    components as parent directories under the base_dir.\n\n    Subsequent materializations of an asset will overwrite previous materializations of that asset.\n    So, with a base directory of \"/my/base/path\", an asset with key\n    `AssetKey([\"one\", \"two\", \"three\"])` would be stored in a file called \"three\" in a directory\n    with path \"/my/base/path/one/two/\".\n\n    Example usage:\n\n\n    1. Attach an IO manager to a set of assets using the reserved resource key ``\"io_manager\"``.\n\n    .. code-block:: python\n\n        from dagster import Definitions, asset, FilesystemIOManager\n\n        @asset\n        def asset1():\n            # create df ...\n            return df\n\n        @asset\n        def asset2(asset1):\n            return asset1[:5]\n\n        defs = Definitions(\n            assets=[asset1, asset2],\n            resources={\n                \"io_manager\": FilesystemIOManager(base_dir=\"/my/base/path\")\n            },\n        )\n\n\n    2. Specify a job-level IO manager using the reserved resource key ``\"io_manager\"``,\n    which will set the given IO manager on all ops in a job.\n\n    .. code-block:: python\n\n        from dagster import FilesystemIOManager, job, op\n\n        @op\n        def op_a():\n            # create df ...\n            return df\n\n        @op\n        def op_b(df):\n            return df[:5]\n\n        @job(\n            resource_defs={\n                \"io_manager\": FilesystemIOManager(base_dir=\"/my/base/path\")\n            }\n        )\n        def job():\n            op_b(op_a())\n\n\n    3. Specify IO manager on :py:class:`Out`, which allows you to set different IO managers on\n    different step outputs.\n\n    .. code-block:: python\n\n        from dagster import FilesystemIOManager, job, op, Out\n\n        @op(out=Out(io_manager_key=\"my_io_manager\"))\n        def op_a():\n            # create df ...\n            return df\n\n        @op\n        def op_b(df):\n            return df[:5]\n\n        @job(resource_defs={\"my_io_manager\": FilesystemIOManager()})\n        def job():\n            op_b(op_a())",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.b613ad485f01be6de3dda94dce6e7672b1d3c080"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.9f45d547cea593c1893cee08a8d67b84989c16fc",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.b613ad485f01be6de3dda94dce6e7672b1d3c080": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "null",
+              "description": "Base directory for storing files.",
+              "is_required": false,
+              "name": "base_dir",
+              "type_key": "Noneable.StringSourceType"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.b613ad485f01be6de3dda94dce6e7672b1d3c080",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.ca6a996bf4027dd8e7559fa71467c44396a78dff": {
           "__class__": "ConfigTypeSnap",
           "description": null,
           "enum_values": null,
@@ -20859,45 +20882,22 @@
             {
               "__class__": "ConfigFieldSnap",
               "default_provided": true,
-              "default_value_as_json_str": "{\"config\": {}}",
+              "default_value_as_json_str": "{\"config\": {\"base_dir\": null}}",
               "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
               "is_required": false,
               "name": "io_manager",
-              "type_key": "Shape.aa06a6ac89e62cfd2f6a1f9bce137c6abfa63805"
+              "type_key": "Shape.9f45d547cea593c1893cee08a8d67b84989c16fc"
             }
           ],
           "given_name": null,
-          "key": "Shape.829973262158134d91916a48835fb0c656ac2f5f",
+          "key": "Shape.ca6a996bf4027dd8e7559fa71467c44396a78dff",
           "kind": {
             "__enum__": "ConfigTypeKind.STRICT_SHAPE"
           },
           "scalar_kind": null,
           "type_param_keys": null
         },
-        "Shape.aa06a6ac89e62cfd2f6a1f9bce137c6abfa63805": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.\n\n    The base directory that the pickle files live inside is determined by:\n\n    * The IO manager's \"base_dir\" configuration value, if specified. Otherwise...\n    * A \"storage/\" directory underneath the value for \"local_artifact_storage\" in your dagster.yaml\n      file, if specified. Otherwise...\n    * A \"storage/\" directory underneath the directory that the DAGSTER_HOME environment variable\n      points to, if that environment variable is specified. Otherwise...\n    * A temporary directory.\n\n    Assigns each op output to a unique filepath containing run ID, step key, and output name.\n    Assigns each asset to a single filesystem path, at \"<base_dir>/<asset_key>\". If the asset key\n    has multiple components, the final component is used as the name of the file, and the preceding\n    components as parent directories under the base_dir.\n\n    Subsequent materializations of an asset will overwrite previous materializations of that asset.\n    So, with a base directory of \"/my/base/path\", an asset with key\n    `AssetKey([\"one\", \"two\", \"three\"])` would be stored in a file called \"three\" in a directory\n    with path \"/my/base/path/one/two/\".\n\n    Example usage:\n\n\n    1. Attach an IO manager to a set of assets using the reserved resource key ``\"io_manager\"``.\n\n    .. code-block:: python\n\n        from dagster import Definitions, asset, FilesystemIOManager\n\n        @asset\n        def asset1():\n            # create df ...\n            return df\n\n        @asset\n        def asset2(asset1):\n            return asset1[:5]\n\n        defs = Definitions(\n            assets=[asset1, asset2],\n            resources={\n                \"io_manager\": FilesystemIOManager(base_dir=\"/my/base/path\")\n            },\n        )\n\n\n    2. Specify a job-level IO manager using the reserved resource key ``\"io_manager\"``,\n    which will set the given IO manager on all ops in a job.\n\n    .. code-block:: python\n\n        from dagster import FilesystemIOManager, job, op\n\n        @op\n        def op_a():\n            # create df ...\n            return df\n\n        @op\n        def op_b(df):\n            return df[:5]\n\n        @job(\n            resource_defs={\n                \"io_manager\": FilesystemIOManager(base_dir=\"/my/base/path\")\n            }\n        )\n        def job():\n            op_b(op_a())\n\n\n    3. Specify IO manager on :py:class:`Out`, which allows you to set different IO managers on\n    different step outputs.\n\n    .. code-block:: python\n\n        from dagster import FilesystemIOManager, job, op, Out\n\n        @op(out=Out(io_manager_key=\"my_io_manager\"))\n        def op_a():\n            # create df ...\n            return df\n\n        @op\n        def op_b(df):\n            return df[:5]\n\n        @job(resource_defs={\"my_io_manager\": FilesystemIOManager()})\n        def job():\n            op_b(op_a())",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.1629902fbbde68e17f4f310b85646b6a76efd18d"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.aa06a6ac89e62cfd2f6a1f9bce137c6abfa63805",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.c798ed8f6a16231e878ec2f37ffaf63d0aa0b669": {
+        "Shape.d841aa810e865d68b7ffec15a2afbe56ee454fb8": {
           "__class__": "ConfigTypeSnap",
           "description": null,
           "enum_values": null,
@@ -20932,15 +20932,15 @@
             {
               "__class__": "ConfigFieldSnap",
               "default_provided": true,
-              "default_value_as_json_str": "{\"a\": {}, \"b\": {}, \"io_manager\": {\"config\": {}}}",
+              "default_value_as_json_str": "{\"a\": {}, \"b\": {}, \"io_manager\": {\"config\": {\"base_dir\": null}}}",
               "description": "Configure how shared resources are implemented within a run.",
               "is_required": false,
               "name": "resources",
-              "type_key": "Shape.829973262158134d91916a48835fb0c656ac2f5f"
+              "type_key": "Shape.ca6a996bf4027dd8e7559fa71467c44396a78dff"
             }
           ],
           "given_name": null,
-          "key": "Shape.c798ed8f6a16231e878ec2f37ffaf63d0aa0b669",
+          "key": "Shape.d841aa810e865d68b7ffec15a2afbe56ee454fb8",
           "kind": {
             "__enum__": "ConfigTypeKind.STRICT_SHAPE"
           },
@@ -21197,17 +21197,17 @@
             "config_field_snap": {
               "__class__": "ConfigFieldSnap",
               "default_provided": true,
-              "default_value_as_json_str": "{}",
+              "default_value_as_json_str": "{\"base_dir\": null}",
               "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.\n\n    The base directory that the pickle files live inside is determined by:\n\n    * The IO manager's \"base_dir\" configuration value, if specified. Otherwise...\n    * A \"storage/\" directory underneath the value for \"local_artifact_storage\" in your dagster.yaml\n      file, if specified. Otherwise...\n    * A \"storage/\" directory underneath the directory that the DAGSTER_HOME environment variable\n      points to, if that environment variable is specified. Otherwise...\n    * A temporary directory.\n\n    Assigns each op output to a unique filepath containing run ID, step key, and output name.\n    Assigns each asset to a single filesystem path, at \"<base_dir>/<asset_key>\". If the asset key\n    has multiple components, the final component is used as the name of the file, and the preceding\n    components as parent directories under the base_dir.\n\n    Subsequent materializations of an asset will overwrite previous materializations of that asset.\n    So, with a base directory of \"/my/base/path\", an asset with key\n    `AssetKey([\"one\", \"two\", \"three\"])` would be stored in a file called \"three\" in a directory\n    with path \"/my/base/path/one/two/\".\n\n    Example usage:\n\n\n    1. Attach an IO manager to a set of assets using the reserved resource key ``\"io_manager\"``.\n\n    .. code-block:: python\n\n        from dagster import Definitions, asset, FilesystemIOManager\n\n        @asset\n        def asset1():\n            # create df ...\n            return df\n\n        @asset\n        def asset2(asset1):\n            return asset1[:5]\n\n        defs = Definitions(\n            assets=[asset1, asset2],\n            resources={\n                \"io_manager\": FilesystemIOManager(base_dir=\"/my/base/path\")\n            },\n        )\n\n\n    2. Specify a job-level IO manager using the reserved resource key ``\"io_manager\"``,\n    which will set the given IO manager on all ops in a job.\n\n    .. code-block:: python\n\n        from dagster import FilesystemIOManager, job, op\n\n        @op\n        def op_a():\n            # create df ...\n            return df\n\n        @op\n        def op_b(df):\n            return df[:5]\n\n        @job(\n            resource_defs={\n                \"io_manager\": FilesystemIOManager(base_dir=\"/my/base/path\")\n            }\n        )\n        def job():\n            op_b(op_a())\n\n\n    3. Specify IO manager on :py:class:`Out`, which allows you to set different IO managers on\n    different step outputs.\n\n    .. code-block:: python\n\n        from dagster import FilesystemIOManager, job, op, Out\n\n        @op(out=Out(io_manager_key=\"my_io_manager\"))\n        def op_a():\n            # create df ...\n            return df\n\n        @op\n        def op_b(df):\n            return df[:5]\n\n        @job(resource_defs={\"my_io_manager\": FilesystemIOManager()})\n        def job():\n            op_b(op_a())",
               "is_required": false,
               "name": "config",
-              "type_key": "Shape.1629902fbbde68e17f4f310b85646b6a76efd18d"
+              "type_key": "Shape.b613ad485f01be6de3dda94dce6e7672b1d3c080"
             },
             "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
             "name": "io_manager"
           }
         ],
-        "root_config_key": "Shape.c798ed8f6a16231e878ec2f37ffaf63d0aa0b669"
+        "root_config_key": "Shape.d841aa810e865d68b7ffec15a2afbe56ee454fb8"
       }
     ],
     "name": "retry_resource_job",
@@ -21287,7 +21287,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[133]
-  'f347f3d93efff88c83539160011b75771fb73b95'
+  'c4bb3ae01a9a02bb508d899fbcb41cf04f342b51'
 # ---
 # name: test_all_snapshot_ids[134]
   '''
@@ -52267,30 +52267,7 @@
           "scalar_kind": null,
           "type_param_keys": null
         },
-        "Shape.1629902fbbde68e17f4f310b85646b6a76efd18d": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": "Base directory for storing files.",
-              "is_required": false,
-              "name": "base_dir",
-              "type_key": "Noneable.StringSourceType"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.1629902fbbde68e17f4f310b85646b6a76efd18d",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.41f0a64274b46628551366b5411b86685f577251": {
+        "Shape.2b3f3e9d949df8c357faf83cac0c090a6454a1a7": {
           "__class__": "ConfigTypeSnap",
           "description": null,
           "enum_values": null,
@@ -52298,24 +52275,42 @@
             {
               "__class__": "ConfigFieldSnap",
               "default_provided": true,
-              "default_value_as_json_str": "{\"config\": {}}",
-              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
+              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
+              "description": "Configure how steps are executed within a run.",
               "is_required": false,
-              "name": "io_manager",
-              "type_key": "Shape.aa06a6ac89e62cfd2f6a1f9bce137c6abfa63805"
+              "name": "execution",
+              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
             },
             {
               "__class__": "ConfigFieldSnap",
               "default_provided": true,
-              "default_value_as_json_str": "{\"config\": {\"count\": 0}}",
-              "description": null,
+              "default_value_as_json_str": "{}",
+              "description": "Configure how loggers emit messages within a run.",
               "is_required": false,
-              "name": "retry_count",
-              "type_key": "Shape.7df68601e94646b87c0edb05b7142282503f0f64"
+              "name": "loggers",
+              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"collect\": {}, \"fail\": {}, \"fail_2\": {}, \"fail_3\": {}, \"reset\": {}, \"spawn\": {}}",
+              "description": "Configure runtime parameters for ops or assets.",
+              "is_required": false,
+              "name": "ops",
+              "type_key": "Shape.e8eb58275cb40d02b8439c5e0c90d6b938bdb0b9"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"io_manager\": {\"config\": {\"base_dir\": null}}, \"retry_count\": {\"config\": {\"count\": 0}}}",
+              "description": "Configure how shared resources are implemented within a run.",
+              "is_required": false,
+              "name": "resources",
+              "type_key": "Shape.e573162f1753fdf6bea0a36267493c819fae004c"
             }
           ],
           "given_name": null,
-          "key": "Shape.41f0a64274b46628551366b5411b86685f577251",
+          "key": "Shape.2b3f3e9d949df8c357faf83cac0c090a6454a1a7",
           "kind": {
             "__enum__": "ConfigTypeKind.STRICT_SHAPE"
           },
@@ -52423,7 +52418,7 @@
           "scalar_kind": null,
           "type_param_keys": null
         },
-        "Shape.aa06a6ac89e62cfd2f6a1f9bce137c6abfa63805": {
+        "Shape.9f45d547cea593c1893cee08a8d67b84989c16fc": {
           "__class__": "ConfigTypeSnap",
           "description": null,
           "enum_values": null,
@@ -52431,15 +52426,38 @@
             {
               "__class__": "ConfigFieldSnap",
               "default_provided": true,
-              "default_value_as_json_str": "{}",
+              "default_value_as_json_str": "{\"base_dir\": null}",
               "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.\n\n    The base directory that the pickle files live inside is determined by:\n\n    * The IO manager's \"base_dir\" configuration value, if specified. Otherwise...\n    * A \"storage/\" directory underneath the value for \"local_artifact_storage\" in your dagster.yaml\n      file, if specified. Otherwise...\n    * A \"storage/\" directory underneath the directory that the DAGSTER_HOME environment variable\n      points to, if that environment variable is specified. Otherwise...\n    * A temporary directory.\n\n    Assigns each op output to a unique filepath containing run ID, step key, and output name.\n    Assigns each asset to a single filesystem path, at \"<base_dir>/<asset_key>\". If the asset key\n    has multiple components, the final component is used as the name of the file, and the preceding\n    components as parent directories under the base_dir.\n\n    Subsequent materializations of an asset will overwrite previous materializations of that asset.\n    So, with a base directory of \"/my/base/path\", an asset with key\n    `AssetKey([\"one\", \"two\", \"three\"])` would be stored in a file called \"three\" in a directory\n    with path \"/my/base/path/one/two/\".\n\n    Example usage:\n\n\n    1. Attach an IO manager to a set of assets using the reserved resource key ``\"io_manager\"``.\n\n    .. code-block:: python\n\n        from dagster import Definitions, asset, FilesystemIOManager\n\n        @asset\n        def asset1():\n            # create df ...\n            return df\n\n        @asset\n        def asset2(asset1):\n            return asset1[:5]\n\n        defs = Definitions(\n            assets=[asset1, asset2],\n            resources={\n                \"io_manager\": FilesystemIOManager(base_dir=\"/my/base/path\")\n            },\n        )\n\n\n    2. Specify a job-level IO manager using the reserved resource key ``\"io_manager\"``,\n    which will set the given IO manager on all ops in a job.\n\n    .. code-block:: python\n\n        from dagster import FilesystemIOManager, job, op\n\n        @op\n        def op_a():\n            # create df ...\n            return df\n\n        @op\n        def op_b(df):\n            return df[:5]\n\n        @job(\n            resource_defs={\n                \"io_manager\": FilesystemIOManager(base_dir=\"/my/base/path\")\n            }\n        )\n        def job():\n            op_b(op_a())\n\n\n    3. Specify IO manager on :py:class:`Out`, which allows you to set different IO managers on\n    different step outputs.\n\n    .. code-block:: python\n\n        from dagster import FilesystemIOManager, job, op, Out\n\n        @op(out=Out(io_manager_key=\"my_io_manager\"))\n        def op_a():\n            # create df ...\n            return df\n\n        @op\n        def op_b(df):\n            return df[:5]\n\n        @job(resource_defs={\"my_io_manager\": FilesystemIOManager()})\n        def job():\n            op_b(op_a())",
               "is_required": false,
               "name": "config",
-              "type_key": "Shape.1629902fbbde68e17f4f310b85646b6a76efd18d"
+              "type_key": "Shape.b613ad485f01be6de3dda94dce6e7672b1d3c080"
             }
           ],
           "given_name": null,
-          "key": "Shape.aa06a6ac89e62cfd2f6a1f9bce137c6abfa63805",
+          "key": "Shape.9f45d547cea593c1893cee08a8d67b84989c16fc",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.b613ad485f01be6de3dda94dce6e7672b1d3c080": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "null",
+              "description": "Base directory for storing files.",
+              "is_required": false,
+              "name": "base_dir",
+              "type_key": "Noneable.StringSourceType"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.b613ad485f01be6de3dda94dce6e7672b1d3c080",
           "kind": {
             "__enum__": "ConfigTypeKind.STRICT_SHAPE"
           },
@@ -52476,6 +52494,38 @@
           ],
           "given_name": null,
           "key": "Shape.dc1eacbaac67d3ef292c2c343ce6fd5c3560d40a",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.e573162f1753fdf6bea0a36267493c819fae004c": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"config\": {\"base_dir\": null}}",
+              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
+              "is_required": false,
+              "name": "io_manager",
+              "type_key": "Shape.9f45d547cea593c1893cee08a8d67b84989c16fc"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"config\": {\"count\": 0}}",
+              "description": null,
+              "is_required": false,
+              "name": "retry_count",
+              "type_key": "Shape.7df68601e94646b87c0edb05b7142282503f0f64"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.e573162f1753fdf6bea0a36267493c819fae004c",
           "kind": {
             "__enum__": "ConfigTypeKind.STRICT_SHAPE"
           },
@@ -52567,56 +52617,6 @@
           ],
           "given_name": null,
           "key": "Shape.e8eb58275cb40d02b8439c5e0c90d6b938bdb0b9",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.f3bb94e318312d74b55184f515aca7635aa7fd91": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
-              "description": "Configure how steps are executed within a run.",
-              "is_required": false,
-              "name": "execution",
-              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": "Configure how loggers emit messages within a run.",
-              "is_required": false,
-              "name": "loggers",
-              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"collect\": {}, \"fail\": {}, \"fail_2\": {}, \"fail_3\": {}, \"reset\": {}, \"spawn\": {}}",
-              "description": "Configure runtime parameters for ops or assets.",
-              "is_required": false,
-              "name": "ops",
-              "type_key": "Shape.e8eb58275cb40d02b8439c5e0c90d6b938bdb0b9"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"io_manager\": {\"config\": {}}, \"retry_count\": {\"config\": {\"count\": 0}}}",
-              "description": "Configure how shared resources are implemented within a run.",
-              "is_required": false,
-              "name": "resources",
-              "type_key": "Shape.41f0a64274b46628551366b5411b86685f577251"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.f3bb94e318312d74b55184f515aca7635aa7fd91",
           "kind": {
             "__enum__": "ConfigTypeKind.STRICT_SHAPE"
           },
@@ -52919,11 +52919,11 @@
             "config_field_snap": {
               "__class__": "ConfigFieldSnap",
               "default_provided": true,
-              "default_value_as_json_str": "{}",
+              "default_value_as_json_str": "{\"base_dir\": null}",
               "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.\n\n    The base directory that the pickle files live inside is determined by:\n\n    * The IO manager's \"base_dir\" configuration value, if specified. Otherwise...\n    * A \"storage/\" directory underneath the value for \"local_artifact_storage\" in your dagster.yaml\n      file, if specified. Otherwise...\n    * A \"storage/\" directory underneath the directory that the DAGSTER_HOME environment variable\n      points to, if that environment variable is specified. Otherwise...\n    * A temporary directory.\n\n    Assigns each op output to a unique filepath containing run ID, step key, and output name.\n    Assigns each asset to a single filesystem path, at \"<base_dir>/<asset_key>\". If the asset key\n    has multiple components, the final component is used as the name of the file, and the preceding\n    components as parent directories under the base_dir.\n\n    Subsequent materializations of an asset will overwrite previous materializations of that asset.\n    So, with a base directory of \"/my/base/path\", an asset with key\n    `AssetKey([\"one\", \"two\", \"three\"])` would be stored in a file called \"three\" in a directory\n    with path \"/my/base/path/one/two/\".\n\n    Example usage:\n\n\n    1. Attach an IO manager to a set of assets using the reserved resource key ``\"io_manager\"``.\n\n    .. code-block:: python\n\n        from dagster import Definitions, asset, FilesystemIOManager\n\n        @asset\n        def asset1():\n            # create df ...\n            return df\n\n        @asset\n        def asset2(asset1):\n            return asset1[:5]\n\n        defs = Definitions(\n            assets=[asset1, asset2],\n            resources={\n                \"io_manager\": FilesystemIOManager(base_dir=\"/my/base/path\")\n            },\n        )\n\n\n    2. Specify a job-level IO manager using the reserved resource key ``\"io_manager\"``,\n    which will set the given IO manager on all ops in a job.\n\n    .. code-block:: python\n\n        from dagster import FilesystemIOManager, job, op\n\n        @op\n        def op_a():\n            # create df ...\n            return df\n\n        @op\n        def op_b(df):\n            return df[:5]\n\n        @job(\n            resource_defs={\n                \"io_manager\": FilesystemIOManager(base_dir=\"/my/base/path\")\n            }\n        )\n        def job():\n            op_b(op_a())\n\n\n    3. Specify IO manager on :py:class:`Out`, which allows you to set different IO managers on\n    different step outputs.\n\n    .. code-block:: python\n\n        from dagster import FilesystemIOManager, job, op, Out\n\n        @op(out=Out(io_manager_key=\"my_io_manager\"))\n        def op_a():\n            # create df ...\n            return df\n\n        @op\n        def op_b(df):\n            return df[:5]\n\n        @job(resource_defs={\"my_io_manager\": FilesystemIOManager()})\n        def job():\n            op_b(op_a())",
               "is_required": false,
               "name": "config",
-              "type_key": "Shape.1629902fbbde68e17f4f310b85646b6a76efd18d"
+              "type_key": "Shape.b613ad485f01be6de3dda94dce6e7672b1d3c080"
             },
             "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
             "name": "io_manager"
@@ -52943,7 +52943,7 @@
             "name": "retry_count"
           }
         ],
-        "root_config_key": "Shape.f3bb94e318312d74b55184f515aca7635aa7fd91"
+        "root_config_key": "Shape.2b3f3e9d949df8c357faf83cac0c090a6454a1a7"
       }
     ],
     "name": "eventually_successful",
@@ -53089,7 +53089,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[49]
-  'f871b53e30b83794c20d128b5cf209f63eb603d3'
+  '9ab88cad2b40a1213bf6ca216b32750917ff88c1'
 # ---
 # name: test_all_snapshot_ids[4]
   '''

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_assets.ambr
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_assets.ambr
@@ -279,6 +279,13 @@
         dict({
           'key': dict({
             'path': list([
+              'multi_run_backfill_policy_asset',
+            ]),
+          }),
+        }),
+        dict({
+          'key': dict({
+            'path': list([
               'multipartitions_1',
             ]),
           }),
@@ -315,6 +322,13 @@
           'key': dict({
             'path': list([
               'one',
+            ]),
+          }),
+        }),
+        dict({
+          'key': dict({
+            'path': list([
+              'single_run_backfill_policy_asset',
             ]),
           }),
         }),
@@ -634,6 +648,11 @@
       dict({
         'freshnessInfo': None,
         'freshnessPolicy': None,
+        'id': 'test.test_repo.["multi_run_backfill_policy_asset"]',
+      }),
+      dict({
+        'freshnessInfo': None,
+        'freshnessPolicy': None,
         'id': 'test.test_repo.["multipartitions_1"]',
       }),
       dict({
@@ -660,6 +679,11 @@
         'freshnessInfo': None,
         'freshnessPolicy': None,
         'id': 'test.test_repo.["one"]',
+      }),
+      dict({
+        'freshnessInfo': None,
+        'freshnessPolicy': None,
+        'id': 'test.test_repo.["single_run_backfill_policy_asset"]',
       }),
       dict({
         'freshnessInfo': None,

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_solids.ambr
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_solids.ambr
@@ -218,6 +218,14 @@
             }),
             dict({
               'pipeline': dict({
+                'name': '__ASSET_JOB_7',
+              }),
+              'solidHandle': dict({
+                'handleID': 'asset_1_my_check',
+              }),
+            }),
+            dict({
+              'pipeline': dict({
                 'name': 'asset_check_job',
               }),
               'solidHandle': dict({
@@ -411,6 +419,14 @@
             dict({
               'pipeline': dict({
                 'name': '__ASSET_JOB_6',
+              }),
+              'solidHandle': dict({
+                'handleID': 'check_in_op_asset',
+              }),
+            }),
+            dict({
+              'pipeline': dict({
+                'name': '__ASSET_JOB_7',
               }),
               'solidHandle': dict({
                 'handleID': 'check_in_op_asset',
@@ -922,6 +938,14 @@
             }),
             dict({
               'pipeline': dict({
+                'name': '__ASSET_JOB_7',
+              }),
+              'solidHandle': dict({
+                'handleID': 'fresh_diamond_bottom',
+              }),
+            }),
+            dict({
+              'pipeline': dict({
                 'name': 'fresh_diamond_assets',
               }),
               'solidHandle': dict({
@@ -987,6 +1011,14 @@
             dict({
               'pipeline': dict({
                 'name': '__ASSET_JOB_6',
+              }),
+              'solidHandle': dict({
+                'handleID': 'fresh_diamond_left',
+              }),
+            }),
+            dict({
+              'pipeline': dict({
+                'name': '__ASSET_JOB_7',
               }),
               'solidHandle': dict({
                 'handleID': 'fresh_diamond_left',
@@ -1066,6 +1098,14 @@
             }),
             dict({
               'pipeline': dict({
+                'name': '__ASSET_JOB_7',
+              }),
+              'solidHandle': dict({
+                'handleID': 'fresh_diamond_right',
+              }),
+            }),
+            dict({
+              'pipeline': dict({
                 'name': 'fresh_diamond_assets',
               }),
               'solidHandle': dict({
@@ -1131,6 +1171,14 @@
             dict({
               'pipeline': dict({
                 'name': '__ASSET_JOB_6',
+              }),
+              'solidHandle': dict({
+                'handleID': 'fresh_diamond_top',
+              }),
+            }),
+            dict({
+              'pipeline': dict({
+                'name': '__ASSET_JOB_7',
               }),
               'solidHandle': dict({
                 'handleID': 'fresh_diamond_top',
@@ -1422,6 +1470,22 @@
               }),
               'solidHandle': dict({
                 'handleID': 'multi',
+              }),
+            }),
+          ]),
+        }),
+        dict({
+          '__typename': 'UsedSolid',
+          'definition': dict({
+            'name': 'multi_run_backfill_policy_asset',
+          }),
+          'invocations': list([
+            dict({
+              'pipeline': dict({
+                'name': '__ASSET_JOB_7',
+              }),
+              'solidHandle': dict({
+                'handleID': 'multi_run_backfill_policy_asset',
               }),
             }),
           ]),
@@ -2245,6 +2309,22 @@
         dict({
           '__typename': 'UsedSolid',
           'definition': dict({
+            'name': 'single_run_backfill_policy_asset',
+          }),
+          'invocations': list([
+            dict({
+              'pipeline': dict({
+                'name': '__ASSET_JOB_5',
+              }),
+              'solidHandle': dict({
+                'handleID': 'single_run_backfill_policy_asset',
+              }),
+            }),
+          ]),
+        }),
+        dict({
+          '__typename': 'UsedSolid',
+          'definition': dict({
             'name': 'spawn',
           }),
           'invocations': list([
@@ -2363,6 +2443,14 @@
             dict({
               'pipeline': dict({
                 'name': '__ASSET_JOB_6',
+              }),
+              'solidHandle': dict({
+                'handleID': 'subsettable_checked_multi_asset',
+              }),
+            }),
+            dict({
+              'pipeline': dict({
+                'name': '__ASSET_JOB_7',
               }),
               'solidHandle': dict({
                 'handleID': 'subsettable_checked_multi_asset',
@@ -2610,6 +2698,14 @@
             }),
             dict({
               'pipeline': dict({
+                'name': '__ASSET_JOB_7',
+              }),
+              'solidHandle': dict({
+                'handleID': 'typed_asset',
+              }),
+            }),
+            dict({
+              'pipeline': dict({
                 'name': 'typed_assets',
               }),
               'solidHandle': dict({
@@ -2675,6 +2771,14 @@
             dict({
               'pipeline': dict({
                 'name': '__ASSET_JOB_6',
+              }),
+              'solidHandle': dict({
+                'handleID': 'typed_multi_asset',
+              }),
+            }),
+            dict({
+              'pipeline': dict({
+                'name': '__ASSET_JOB_7',
               }),
               'solidHandle': dict({
                 'handleID': 'typed_multi_asset',
@@ -2816,6 +2920,14 @@
                 'handleID': 'unpartitioned_upstream_of_partitioned',
               }),
             }),
+            dict({
+              'pipeline': dict({
+                'name': '__ASSET_JOB_7',
+              }),
+              'solidHandle': dict({
+                'handleID': 'unpartitioned_upstream_of_partitioned',
+              }),
+            }),
           ]),
         }),
         dict({
@@ -2875,6 +2987,14 @@
             dict({
               'pipeline': dict({
                 'name': '__ASSET_JOB_6',
+              }),
+              'solidHandle': dict({
+                'handleID': 'untyped_asset',
+              }),
+            }),
+            dict({
+              'pipeline': dict({
+                'name': '__ASSET_JOB_7',
               }),
               'solidHandle': dict({
                 'handleID': 'untyped_asset',

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
@@ -23,6 +23,7 @@ from dagster import (
     AssetsDefinition,
     AssetSelection,
     AutoMaterializePolicy,
+    BackfillPolicy,
     Bool,
     DagsterInstance,
     DailyPartitionsDefinition,
@@ -1772,6 +1773,22 @@ def dynamic_in_multipartitions_fail(context, dynamic_in_multipartitions_success)
     raise Exception("oops")
 
 
+@asset(
+    partitions_def=DailyPartitionsDefinition("2023-01-01"),
+    backfill_policy=BackfillPolicy.single_run(),
+)
+def single_run_backfill_policy_asset(context):
+    pass
+
+
+@asset(
+    partitions_def=DailyPartitionsDefinition("2023-01-03"),
+    backfill_policy=BackfillPolicy.multi_run(10),
+)
+def multi_run_backfill_policy_asset(context):
+    pass
+
+
 named_groups_job = build_assets_job(
     "named_groups_job",
     [
@@ -1924,6 +1941,8 @@ def define_asset_jobs():
         checked_multi_asset_job,
         check_in_op_asset,
         asset_check_job,
+        single_run_backfill_policy_asset,
+        multi_run_backfill_policy_asset,
     ]
 
 


### PR DESCRIPTION
Adds a `backfillPolicy` resolver on `GrapheneAssetNode` so we can display the backfill policy in the UI