### PR TITLE
feat(dbt): add `get_partition_mapping` to `DagsterDbtTranslator`

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
@@ -5,6 +5,7 @@ from dagster import (
     AssetKey,
     AutoMaterializePolicy,
     FreshnessPolicy,
+    PartitionMapping,
     _check as check,
 )
 from dagster._annotations import public
@@ -114,6 +115,37 @@ class DagsterDbtTranslator:
                         return asset_key
         """
         return default_asset_key_fn(dbt_resource_props)
+
+    @classmethod
+    @public
+    def get_partition_mapping(
+        cls,
+        dbt_resource_props: Mapping[str, Any],
+        dbt_parent_resource_props: Mapping[str, Any],
+    ) -> Optional[PartitionMapping]:
+        """A function that takes two dictionaries: the first, representing properties of a dbt
+        resource; and the second, representing the properties of a parent dependency to the first
+        dbt resource. The function returns the Dagster partition mapping for the dbt dependency.
+
+        Note that a dbt resource is unrelated to Dagster's resource concept, and simply represents
+        a model, seed, snapshot or source in a given dbt project. You can learn more about dbt
+        resources and the properties available in this dictionary here:
+        https://docs.getdbt.com/reference/artifacts/manifest-json#resource-details
+
+        This method can be overridden to provide a custom partition mapping for a dbt dependency.
+
+        Args:
+            dbt_resource_props (Mapping[str, Any]):
+                A dictionary representing the dbt child resource.
+            dbt_parent_resource_props (Mapping[str, Any]):
+                A dictionary representing the dbt parent resource, in relationship to the child.
+
+        Returns:
+            Optional[PartitionMapping]:
+                The Dagster partition mapping for the dbt resource. If None is returned, the
+                default partition mapping will be used.
+        """
+        return None
 
     @classmethod
     @public


### PR DESCRIPTION

## Summary & Motivation
Resolves https://github.com/dagster-io/dagster/issues/13053.

Allow `PartitionMapping` to be defined for dbt root dependencies (e.g. dbt sources, dbt models with no dependencies). In a follow-up PR, we will add a way to define self-dependencies on dbt models, so that `PartitionMapping`'s can be defined on a model's previous partitions rather than the model's inputs.

## How I Tested These Changes
add a test
