### PR TITLE
remove intersect from event storage

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -237,10 +237,6 @@ class SqlRunStorage(RunStorage):
 
         return query
 
-    @property
-    def supports_intersect(self) -> bool:
-        return True
-
     def _add_filters_to_query(self, query: SqlAlchemyQuery, filters: RunsFilter) -> SqlAlchemyQuery:
         check.inst_param(filters, "filters", RunsFilter)
 

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/event_log/event_log.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/event_log/event_log.py
@@ -32,12 +32,9 @@ from ..utils import (
     mysql_alembic_config,
     mysql_isolation_level,
     mysql_url_from_config,
-    parse_mysql_version,
     retry_mysql_connection_fn,
     retry_mysql_creation_fn,
 )
-
-MINIMUM_MYSQL_INTERSECT_VERSION = "8.0.31"
 
 
 class MySQLEventLogStorage(SqlEventLogStorage, ConfigurableClass):
@@ -207,12 +204,6 @@ class MySQLEventLogStorage(SqlEventLogStorage, ConfigurableClass):
 
     def end_watch(self, run_id: str, handler: EventHandlerFn) -> None:
         self._event_watcher.unwatch_run(run_id, handler)
-
-    @property
-    def supports_intersect(self) -> bool:
-        return parse_mysql_version(self._mysql_version) >= parse_mysql_version(  # type: ignore  # (possible none)
-            MINIMUM_MYSQL_INTERSECT_VERSION
-        )
 
     @property
     def event_watcher(self) -> SqlPollingEventWatcher:

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/run_storage/run_storage.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/run_storage/run_storage.py
@@ -30,13 +30,11 @@ from ..utils import (
     mysql_alembic_config,
     mysql_isolation_level,
     mysql_url_from_config,
-    parse_mysql_version,
     retry_mysql_connection_fn,
     retry_mysql_creation_fn,
 )
 
 MINIMUM_MYSQL_BUCKET_VERSION = "8.0.0"
-MINIMUM_MYSQL_INTERSECT_VERSION = "8.0.31"
 
 
 class MySQLRunStorage(SqlRunStorage, ConfigurableClass):
@@ -157,12 +155,6 @@ class MySQLRunStorage(SqlRunStorage, ConfigurableClass):
         super(MySQLRunStorage, self).mark_index_built(migration_name)
         if migration_name in self._index_migration_cache:
             del self._index_migration_cache[migration_name]
-
-    @property
-    def supports_intersect(self) -> bool:
-        return parse_mysql_version(self._mysql_version) >= parse_mysql_version(  # type: ignore
-            MINIMUM_MYSQL_INTERSECT_VERSION
-        )
 
     def add_daemon_heartbeat(self, daemon_heartbeat: DaemonHeartbeat) -> None:
         with self.connect() as conn:

--- a/python_modules/libraries/dagster-mysql/dagster_mysql_tests/test_event_log.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql_tests/test_event_log.py
@@ -116,6 +116,3 @@ class TestMySQLEventLogStorage(TestEventLogStorage):
                 from_explicit = explicit_instance._event_storage  # noqa: SLF001
 
                 assert from_url.mysql_url == from_explicit.mysql_url
-
-    def test_materialization_tag_on_wipe(self, storage, instance):
-        pytest.skip("Running in to error we haven't tracked down yet. Skipping for now.")


### PR DESCRIPTION
Mysql 8.0.35 has a change that breaks our usage of `intersect`. We primarily added this for run tags, but no longer use it there. Let's remove it from event logs too.

I don't have the full context here. @prha et al. could you give this some extra scrutiny