### PR TITLE
Don't hit croniter at all when calculating daily schedules

### DIFF
--- a/python_modules/dagster/dagster/_seven/compat/pendulum.py
+++ b/python_modules/dagster/dagster/_seven/compat/pendulum.py
@@ -1,3 +1,4 @@
+import datetime
 from contextlib import contextmanager
 
 import packaging.version
@@ -21,6 +22,23 @@ def mock_pendulum_timezone(override_timezone):
 
 
 def create_pendulum_time(year, month, day, *args, **kwargs):
+    if "tz" in kwargs and "dst_rule" in kwargs and not _IS_PENDULUM_2:
+        tz = pendulum.timezone(kwargs.pop("tz"))
+        dst_rule = kwargs.pop("dst_rule")
+
+        return pendulum.instance(
+            tz.convert(
+                datetime.datetime(
+                    year,
+                    month,
+                    day,
+                    *args,
+                    **kwargs,
+                ),
+                dst_rule=dst_rule,
+            )
+        )
+
     return (
         pendulum.datetime(year, month, day, *args, **kwargs)
         if _IS_PENDULUM_2

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -86,7 +86,7 @@ setup(
         f"grpcio>={GRPC_VERSION_FLOOR}",
         f"grpcio-health-checking>={GRPC_VERSION_FLOOR}",
         "packaging>=20.9",
-        "pendulum",
+        "pendulum<3",
         "protobuf>=3.20.0",  # min protobuf version to be compatible with both protobuf 3 and 4
         "python-dateutil",
         "python-dotenv",

--- a/python_modules/libraries/dagster-airflow/setup.py
+++ b/python_modules/libraries/dagster-airflow/setup.py
@@ -34,7 +34,7 @@ setup(
         f"dagster{pin}",
         "docker>=5.0.3,<6.0.0",
         "lazy_object_proxy",
-        "pendulum",
+        "pendulum<3",
     ],
     project_urls={
         # airflow will embed a link this in the providers page UI


### PR DESCRIPTION
Summary:
Work around upstream croniter dst transition bugs by special-casing daily schedules and doing our own implementation of the last remaining callsite to croniter in that path, the method that takes in a datetime and figures out the most recent datetime before that timestamp that matches the cronstring.

## Summary & Motivation

## How I Tested These Changes
