### PR TITLE
[sensor daemon] Remove extra yields

### DIFF
--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -244,7 +244,8 @@ def execute_sensor_iteration_loop(
     threadpool_executor = None
     with ExitStack() as stack:
         settings = workspace_process_context.instance.get_settings("sensors")
-        if settings.get("use_threads"):
+        use_threads = settings.get("use_threads")
+        if use_threads:
             threadpool_executor = stack.enter_context(
                 InheritContextThreadPoolExecutor(
                     max_workers=settings.get("num_workers"),
@@ -282,7 +283,8 @@ def execute_sensor_iteration_loop(
             )
             # Yield to check for heartbeats in case there were no yields within
             # execute_sensor_iteration
-            yield None
+            if not use_threads:
+                yield None
 
             end_time = pendulum.now("UTC").timestamp()
 
@@ -293,7 +295,8 @@ def execute_sensor_iteration_loop(
             sleep_time = max(0, MIN_INTERVAL_LOOP_TIME - loop_duration)
             shutdown_event.wait(sleep_time)
 
-            yield None
+            if not use_threads:
+                yield None
 
 
 def execute_sensor_iteration(

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -272,7 +272,6 @@ def execute_sensor_iteration_loop(
                 last_verbose_time is None or start_time - last_verbose_time > VERBOSE_LOGS_INTERVAL
             )
 
-            yielded = False
             for result in execute_sensor_iteration(
                 workspace_process_context,
                 logger,
@@ -283,13 +282,11 @@ def execute_sensor_iteration_loop(
                 log_verbose_checks=verbose_logs_iteration,
             ):
                 if result:
-                    yielded = True
                     yield result
 
             # Yield to check for heartbeats in case there were no yields within
             # execute_sensor_iteration
-            if not yielded:
-                yield None
+            yield None
 
             end_time = pendulum.now("UTC").timestamp()
 

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -67,7 +67,11 @@ from dagster._core.test_utils import (
 )
 from dagster._core.workspace.context import WorkspaceProcessContext
 from dagster._daemon import get_default_daemon_logger
-from dagster._daemon.sensor import execute_sensor_iteration, execute_sensor_iteration_loop, MIN_INTERVAL_LOOP_TIME
+from dagster._daemon.sensor import (
+    MIN_INTERVAL_LOOP_TIME,
+    execute_sensor_iteration,
+    execute_sensor_iteration_loop,
+)
 from dagster._seven.compat.pendulum import create_pendulum_time, to_timezone
 
 from .conftest import create_workspace_load_target
@@ -1537,9 +1541,7 @@ def test_custom_interval_sensor_with_offset(
         assert sum(sleeps) == expected_seconds
 
 
-def test_execute_sensor_iteration_loop_yield_count(
-    monkeypatch, workspace_context
-):
+def test_execute_sensor_iteration_loop_yield_count(monkeypatch, executor, workspace_context):
     freeze_datetime = to_timezone(
         create_pendulum_time(year=2019, month=2, day=28, tz="UTC"), "US/Central"
     )

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -1576,8 +1576,6 @@ def test_execute_sensor_iteration_loop_yield_count(monkeypatch, executor, worksp
         assert sum(sleeps) == expected_seconds
 
 
-
-
 def test_sensor_start_stop(executor, instance, workspace_context, external_repo):
     freeze_datetime = to_timezone(
         create_pendulum_time(year=2019, month=2, day=27, tz="UTC"),


### PR DESCRIPTION
## Summary & Motivation
With threaded sensors, there is a reduced need for extra yields here.  Threaded sensors currently also only yield None.  With this change, the daemon will now only yield None once for each iteration.  This allows better understanding by the controlling loop about the unit of work boundary, and reduces context switching.

## How I Tested These Changes
Added a new test and modified an existing test to be resilient to min interval changes