### PR TITLE
release concurrency slots between op retries

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/plan/active.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/active.py
@@ -538,6 +538,8 @@ class ActiveExecution:
                     else None
                 ),
             )
+            if self._instance_concurrency_context:
+                self._instance_concurrency_context.free_step(step_key)
         elif dagster_event.is_successful_output:
             event_specific_data = cast(StepOutputData, dagster_event.event_specific_data)
             self.mark_step_produced_output(event_specific_data.step_output_handle)

--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_op_concurrency.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_op_concurrency.py
@@ -2,8 +2,11 @@ import time
 
 import pytest
 from dagster import (
+    Failure,
+    RetryPolicy,
     graph,
     in_process_executor,
+    job,
     op,
     repository,
 )
@@ -72,6 +75,17 @@ def two_tier_graph():
     second_op(simple_op())
 
 
+@op(tags={GLOBAL_CONCURRENCY_TAG: "foo"}, retry_policy=RetryPolicy(max_retries=1))
+def retry_op():
+    raise Failure("I fail")
+
+
+@job(executor_def=in_process_executor)
+def retry_job():
+    retry_op()
+    simple_op()
+
+
 error_job_multiprocess = error_graph.to_job(name="error_job")
 error_job_inprocess = error_graph.to_job(
     name="error_job_in_process", executor_def=in_process_executor
@@ -104,6 +118,7 @@ def concurrency_repo():
         parallel_job_multiprocess,
         parallel_job_inprocess,
         parallel_job_stepdelegating,
+        retry_job,
         two_tier_job_multiprocess,
         two_tier_job_inprocess,
         two_tier_job_step_delegating,
@@ -134,12 +149,17 @@ def define_error_stepdelegating_job():
     return error_job_stepdelegating
 
 
+def define_retry_job():
+    return retry_job
+
+
 recon_error_inprocess = reconstructable(define_error_inprocess_job)
 recon_error_multiprocess = reconstructable(define_error_multiprocess_job)
 recon_error_stepdelegating = reconstructable(define_error_stepdelegating_job)
 recon_parallel_inprocess = reconstructable(define_parallel_inprocess_job)
 recon_parallel_multiprocess = reconstructable(define_parallel_multiprocess_job)
 recon_parallel_stepdelegating = reconstructable(define_parallel_stepdelegating_job)
+recon_retry_job = reconstructable(define_retry_job)
 
 
 @pytest.fixture(
@@ -323,3 +343,41 @@ def test_multi_run_concurrency(instance, workspace, two_tier_job_def):
     assert foo_info.active_slot_count == 0
     assert foo_info.pending_step_count == 0
     assert foo_info.assigned_step_count == 0
+
+
+def test_retry_concurrency_release(instance):
+    instance.event_log_storage.set_concurrency_slots("foo", 1)
+    foo_info = instance.event_log_storage.get_concurrency_info("foo")
+    assert foo_info.slot_count == 1
+    assert foo_info.active_slot_count == 0
+    assert foo_info.pending_step_count == 0
+    assert foo_info.assigned_step_count == 0
+
+    events = []
+    with execute_job(recon_retry_job, instance=instance) as result:
+        for event in result.all_events:
+            if event.step_key and event.event_type_value in (
+                DagsterEventType.STEP_START.value,
+                DagsterEventType.STEP_SUCCESS.value,
+                DagsterEventType.STEP_FAILURE.value,
+                DagsterEventType.STEP_RESTARTED.value,
+                DagsterEventType.STEP_UP_FOR_RETRY.value,
+            ):
+                events.append((event.step_key, event.event_type_value))
+
+    # job has released any claimed slots
+    assert foo_info.slot_count == 1
+    assert foo_info.active_slot_count == 0
+    assert foo_info.pending_step_count == 0
+    assert foo_info.assigned_step_count == 0
+
+    # retry_op starts before simple_op starts
+    # simple_op succeeds before second execution of retry_op fails
+    assert events == [
+        ("retry_op", "STEP_START"),
+        ("retry_op", "STEP_UP_FOR_RETRY"),
+        ("simple_op", "STEP_START"),
+        ("simple_op", "STEP_SUCCESS"),
+        ("retry_op", "STEP_RESTARTED"),
+        ("retry_op", "STEP_FAILURE"),
+    ]


### PR DESCRIPTION
## Summary & Motivation
Concurrency slots are currently retained in between op retries.  This changes the execution plan to release slots while there is not an in-flight step executing that takes up that slot.

Each retry attempts to reclaim the slot.

## How I Tested These Changes
BK