### PR TITLE
[wip] Add whitelist_for_serdes to partitions subsets

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -450,11 +450,7 @@ def build_partition_statuses(
         " in_progress_partitions_subset to be of the same type",
     )
 
-<<<<<<< HEAD
     if isinstance(materialized_partitions_subset, BaseTimeWindowPartitionsSubset):
-=======
-    if isinstance(partitions_def, TimeWindowPartitionsDefinition):
->>>>>>> 32cf1a8d2d (first stab)
         ranges = fetch_flattened_time_window_ranges(
             {
                 PartitionRangeStatus.MATERIALIZED: materialized_partitions_subset,
@@ -530,34 +526,34 @@ def get_2d_run_length_encoded_partitions(
         lambda: secondary_dim.partitions_def.empty_subset()
     )
     for partition_key in materialized_partitions_subset.get_partition_keys():
-        partition_key = partitions_def.get_partition_key_from_str(partition_key)
+        multipartition_key = partitions_def.get_partition_key_from_str(partition_key)
         dim2_materialized_partition_subset_by_dim1[
-            partition_key.keys_by_dimension[primary_dim.name]
+            multipartition_key.keys_by_dimension[primary_dim.name]
         ] = dim2_materialized_partition_subset_by_dim1[
-            partition_key.keys_by_dimension[primary_dim.name]
-        ].with_partition_keys([partition_key.keys_by_dimension[secondary_dim.name]])
+            multipartition_key.keys_by_dimension[primary_dim.name]
+        ].with_partition_keys([multipartition_key.keys_by_dimension[secondary_dim.name]])
 
     dim2_failed_partition_subset_by_dim1: Dict[str, PartitionsSubset] = defaultdict(
         lambda: secondary_dim.partitions_def.empty_subset()
     )
     for partition_key in failed_partitions_subset.get_partition_keys():
-        partition_key = partitions_def.get_partition_key_from_str(partition_key)
+        multipartition_key = partitions_def.get_partition_key_from_str(partition_key)
         dim2_failed_partition_subset_by_dim1[
-            partition_key.keys_by_dimension[primary_dim.name]
+            multipartition_key.keys_by_dimension[primary_dim.name]
         ] = dim2_failed_partition_subset_by_dim1[
-            partition_key.keys_by_dimension[primary_dim.name]
-        ].with_partition_keys([partition_key.keys_by_dimension[secondary_dim.name]])
+            multipartition_key.keys_by_dimension[primary_dim.name]
+        ].with_partition_keys([multipartition_key.keys_by_dimension[secondary_dim.name]])
 
     dim2_in_progress_partition_subset_by_dim1: Dict[str, PartitionsSubset] = defaultdict(
         lambda: secondary_dim.partitions_def.empty_subset()
     )
     for partition_key in in_progress_partitions_subset.get_partition_keys():
-        partition_key = partitions_def.get_partition_key_from_str(partition_key)
+        multipartition_key = partitions_def.get_partition_key_from_str(partition_key)
         dim2_in_progress_partition_subset_by_dim1[
-            partition_key.keys_by_dimension[primary_dim.name]
+            multipartition_key.keys_by_dimension[primary_dim.name]
         ] = dim2_in_progress_partition_subset_by_dim1[
-            partition_key.keys_by_dimension[primary_dim.name]
-        ].with_partition_keys([partition_key.keys_by_dimension[secondary_dim.name]])
+            multipartition_key.keys_by_dimension[primary_dim.name]
+        ].with_partition_keys([multipartition_key.keys_by_dimension[secondary_dim.name]])
 
     materialized_2d_ranges = []
 

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -20,18 +20,13 @@ from dagster import (
     DagsterEventType,
     DagsterInstance,
     EventRecordsFilter,
-    MultiPartitionKey,
     MultiPartitionsDefinition,
     _check as check,
 )
 from dagster._core.definitions.data_time import CachingDataTimeResolver
 from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
-from dagster._core.definitions.multi_dimensional_partitions import (
-    MultiPartitionsSubset,
-)
 from dagster._core.definitions.partition import (
     CachingDynamicPartitionsLoader,
-    DefaultPartitionsSubset,
     PartitionsDefinition,
     PartitionsSubset,
 )
@@ -420,6 +415,7 @@ def build_partition_statuses(
     materialized_partitions_subset: Optional[PartitionsSubset],
     failed_partitions_subset: Optional[PartitionsSubset],
     in_progress_partitions_subset: Optional[PartitionsSubset],
+    partitions_def: Optional[PartitionsDefinition],
 ) -> Union[
     "GrapheneTimePartitionStatuses",
     "GrapheneDefaultPartitionStatuses",
@@ -454,7 +450,11 @@ def build_partition_statuses(
         " in_progress_partitions_subset to be of the same type",
     )
 
+<<<<<<< HEAD
     if isinstance(materialized_partitions_subset, BaseTimeWindowPartitionsSubset):
+=======
+    if isinstance(partitions_def, TimeWindowPartitionsDefinition):
+>>>>>>> 32cf1a8d2d (first stab)
         ranges = fetch_flattened_time_window_ranges(
             {
                 PartitionRangeStatus.MATERIALIZED: materialized_partitions_subset,
@@ -469,7 +469,7 @@ def build_partition_statuses(
         graphene_ranges = []
         for r in ranges:
             partition_key_range = cast(
-                TimeWindowPartitionsDefinition, materialized_partitions_subset.partitions_def
+                TimeWindowPartitionsDefinition, partitions_def
             ).get_partition_key_range_for_time_window(r.time_window)
             graphene_ranges.append(
                 GrapheneTimePartitionRangeStatus(
@@ -481,14 +481,15 @@ def build_partition_statuses(
                 )
             )
         return GrapheneTimePartitionStatuses(ranges=graphene_ranges)
-    elif isinstance(materialized_partitions_subset, MultiPartitionsSubset):
+    elif isinstance(partitions_def, MultiPartitionsDefinition):
         return get_2d_run_length_encoded_partitions(
             dynamic_partitions_store,
             materialized_partitions_subset,
             failed_partitions_subset,
             in_progress_partitions_subset,
+            partitions_def,
         )
-    elif isinstance(materialized_partitions_subset, DefaultPartitionsSubset):
+    elif partitions_def:
         materialized_keys = materialized_partitions_subset.get_partition_keys()
         failed_keys = failed_partitions_subset.get_partition_keys()
         in_progress_keys = in_progress_partitions_subset.get_partition_keys()
@@ -499,7 +500,7 @@ def build_partition_statuses(
             - set(in_progress_keys),
             failedPartitions=failed_keys,
             unmaterializedPartitions=materialized_partitions_subset.get_partition_keys_not_in_subset(
-                dynamic_partitions_store=dynamic_partitions_store
+                partitions_def=partitions_def, dynamic_partitions_store=dynamic_partitions_store
             ),
             materializingPartitions=in_progress_keys,
         )
@@ -512,28 +513,24 @@ def get_2d_run_length_encoded_partitions(
     materialized_partitions_subset: PartitionsSubset,
     failed_partitions_subset: PartitionsSubset,
     in_progress_partitions_subset: PartitionsSubset,
+    partitions_def: MultiPartitionsDefinition,
 ) -> "GrapheneMultiPartitionStatuses":
     from ..schema.pipelines.pipeline import (
         GrapheneMultiPartitionRangeStatuses,
         GrapheneMultiPartitionStatuses,
     )
 
-    if (
-        not isinstance(materialized_partitions_subset.partitions_def, MultiPartitionsDefinition)
-        or not isinstance(failed_partitions_subset.partitions_def, MultiPartitionsDefinition)
-        or not isinstance(in_progress_partitions_subset.partitions_def, MultiPartitionsDefinition)
-    ):
+    if not isinstance(partitions_def, MultiPartitionsDefinition):
         check.failed("Can only fetch 2D run length encoded partitions for multipartitioned assets")
 
-    primary_dim = materialized_partitions_subset.partitions_def.primary_dimension
-    secondary_dim = materialized_partitions_subset.partitions_def.secondary_dimension
+    primary_dim = partitions_def.primary_dimension
+    secondary_dim = partitions_def.secondary_dimension
 
     dim2_materialized_partition_subset_by_dim1: Dict[str, PartitionsSubset] = defaultdict(
         lambda: secondary_dim.partitions_def.empty_subset()
     )
-    for partition_key in cast(
-        Sequence[MultiPartitionKey], materialized_partitions_subset.get_partition_keys()
-    ):
+    for partition_key in materialized_partitions_subset.get_partition_keys():
+        partition_key = partitions_def.get_partition_key_from_str(partition_key)
         dim2_materialized_partition_subset_by_dim1[
             partition_key.keys_by_dimension[primary_dim.name]
         ] = dim2_materialized_partition_subset_by_dim1[
@@ -543,9 +540,8 @@ def get_2d_run_length_encoded_partitions(
     dim2_failed_partition_subset_by_dim1: Dict[str, PartitionsSubset] = defaultdict(
         lambda: secondary_dim.partitions_def.empty_subset()
     )
-    for partition_key in cast(
-        Sequence[MultiPartitionKey], failed_partitions_subset.get_partition_keys()
-    ):
+    for partition_key in failed_partitions_subset.get_partition_keys():
+        partition_key = partitions_def.get_partition_key_from_str(partition_key)
         dim2_failed_partition_subset_by_dim1[
             partition_key.keys_by_dimension[primary_dim.name]
         ] = dim2_failed_partition_subset_by_dim1[
@@ -555,9 +551,8 @@ def get_2d_run_length_encoded_partitions(
     dim2_in_progress_partition_subset_by_dim1: Dict[str, PartitionsSubset] = defaultdict(
         lambda: secondary_dim.partitions_def.empty_subset()
     )
-    for partition_key in cast(
-        Sequence[MultiPartitionKey], in_progress_partitions_subset.get_partition_keys()
-    ):
+    for partition_key in in_progress_partitions_subset.get_partition_keys():
+        partition_key = partitions_def.get_partition_key_from_str(partition_key)
         dim2_in_progress_partition_subset_by_dim1[
             partition_key.keys_by_dimension[primary_dim.name]
         ] = dim2_in_progress_partition_subset_by_dim1[
@@ -626,6 +621,7 @@ def get_2d_run_length_encoded_partitions(
                             dim2_materialized_partition_subset_by_dim1[start_key],
                             dim2_failed_partition_subset_by_dim1[start_key],
                             dim2_in_progress_partition_subset_by_dim1[start_key],
+                            secondary_dim.partitions_def,
                         ),
                     )
                 )

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -36,6 +36,7 @@ from dagster._core.definitions.partition import (
     PartitionsSubset,
 )
 from dagster._core.definitions.time_window_partitions import (
+    BaseTimeWindowPartitionsSubset,
     PartitionRangeStatus,
     TimeWindowPartitionsDefinition,
     TimeWindowPartitionsSubset,
@@ -127,7 +128,7 @@ def get_assets(
 
 
 def repository_iter(
-    context: WorkspaceRequestContext
+    context: WorkspaceRequestContext,
 ) -> Iterator[Tuple[CodeLocation, ExternalRepository]]:
     for location in context.code_locations:
         for repository in location.get_repositories().values():
@@ -453,7 +454,7 @@ def build_partition_statuses(
         " in_progress_partitions_subset to be of the same type",
     )
 
-    if isinstance(materialized_partitions_subset, TimeWindowPartitionsSubset):
+    if isinstance(materialized_partitions_subset, BaseTimeWindowPartitionsSubset):
         ranges = fetch_flattened_time_window_ranges(
             {
                 PartitionRangeStatus.MATERIALIZED: materialized_partitions_subset,

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -934,6 +934,12 @@ class GrapheneAssetNode(graphene.ObjectType):
         if not self._dynamic_partitions_loader:
             check.failed("dynamic_partitions_loader must be provided to get partition keys")
 
+        partitions_def = (
+            self._external_asset_node.partitions_def_data.get_partitions_definition()
+            if self._external_asset_node.partitions_def_data
+            else None
+        )
+
         (
             materialized_partition_subset,
             failed_partition_subset,
@@ -942,11 +948,7 @@ class GrapheneAssetNode(graphene.ObjectType):
             graphene_info.context.instance,
             asset_key,
             self._dynamic_partitions_loader,
-            (
-                self._external_asset_node.partitions_def_data.get_partitions_definition()
-                if self._external_asset_node.partitions_def_data
-                else None
-            ),
+            partitions_def,
         )
 
         return build_partition_statuses(
@@ -954,6 +956,7 @@ class GrapheneAssetNode(graphene.ObjectType):
             materialized_partition_subset,
             failed_partition_subset,
             in_progress_subset,
+            partitions_def,
         )
 
     def resolve_partitionStats(

--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -6,7 +6,7 @@ from dagster import AssetKey
 from dagster._core.definitions.backfill_policy import BackfillPolicy, BackfillPolicyType
 from dagster._core.definitions.partition import PartitionsSubset
 from dagster._core.definitions.time_window_partitions import (
-    TimeWindowPartitionsSubset,
+    BaseTimeWindowPartitionsSubset,
 )
 from dagster._core.execution.asset_backfill import (
     AssetBackfillStatus,
@@ -130,7 +130,7 @@ class GrapheneAssetBackfillTargetPartitions(graphene.ObjectType):
     def __init__(self, partition_subset: PartitionsSubset):
         from dagster_graphql.schema.partition_sets import GraphenePartitionKeyRange
 
-        if isinstance(partition_subset, TimeWindowPartitionsSubset):
+        if isinstance(partition_subset, BaseTimeWindowPartitionsSubset):
             ranges = [
                 GraphenePartitionKeyRange(start, end)
                 for start, end in partition_subset.get_partition_key_ranges()

--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -133,7 +133,9 @@ class GrapheneAssetBackfillTargetPartitions(graphene.ObjectType):
         if isinstance(partition_subset, BaseTimeWindowPartitionsSubset):
             ranges = [
                 GraphenePartitionKeyRange(start, end)
-                for start, end in partition_subset.get_partition_key_ranges()
+                for start, end in partition_subset.get_partition_key_ranges(
+                    partition_subset.partitions_def
+                )
             ]
             partition_keys = None
         else:  # Default partitions subset

--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -134,7 +134,7 @@ class GrapheneAssetBackfillTargetPartitions(graphene.ObjectType):
             ranges = [
                 GraphenePartitionKeyRange(start, end)
                 for start, end in partition_subset.get_partition_key_ranges(
-                    partition_subset.partitions_def
+                    partition_subset.get_partitions_def()
                 )
             ]
             partition_keys = None

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -714,7 +714,7 @@ def _build_run_requests_with_backfill_policy(
 ) -> Sequence[RunRequest]:
     run_requests = []
     partition_subset = partitions_def.subset_with_partition_keys(partition_keys)
-    partition_key_ranges = partition_subset.get_partition_key_ranges()
+    partition_key_ranges = partition_subset.get_partition_key_ranges(partitions_def)
     for partition_key_range in partition_key_ranges:
         # We might resolve more than one partition key range for the given partition keys.
         # We can only apply chunking on individual partition key ranges.

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
@@ -77,6 +77,7 @@ class AssetDaemonCursor(NamedTuple):
         )
 
         return handled_subset.get_partition_keys_not_in_subset(
+            partitions_def=partitions_def,
             current_time=current_time,
             dynamic_partitions_store=dynamic_partitions_store,
         )
@@ -231,7 +232,7 @@ class AssetDaemonCursor(NamedTuple):
                     and isinstance(partitions_def, TimeWindowPartitionsDefinition)
                     and any(
                         time_window.start < partitions_def.start
-                        for time_window in subset.included_time_windows
+                        for time_window in subset.get_included_time_windows()
                     )
                 ):
                     subset = partitions_def.empty_subset()

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -364,6 +364,7 @@ class AssetGraph:
         partition_mapping = self.get_partition_mapping(child_asset_key, parent_asset_key)
         child_partitions_subset = partition_mapping.get_downstream_partitions_for_partitions(
             parent_partitions_def.empty_subset().with_partition_keys([parent_partition_key]),
+            parent_partitions_def,
             downstream_partitions_def=child_partitions_def,
             dynamic_partitions_store=dynamic_partitions_store,
             current_time=current_time,
@@ -437,7 +438,7 @@ class AssetGraph:
         """
         partition_key = check.opt_str_param(partition_key, "partition_key")
 
-        child_partitions_def = self.get_partitions_def(child_asset_key)
+        child_partitions_def = cast(PartitionsDefinition, self.get_partitions_def(child_asset_key))
         parent_partitions_def = self.get_partitions_def(parent_asset_key)
 
         if parent_partitions_def is None:
@@ -449,12 +450,11 @@ class AssetGraph:
 
         return partition_mapping.get_upstream_mapped_partitions_result_for_partitions(
             (
-                cast(PartitionsDefinition, child_partitions_def).subset_with_partition_keys(
-                    [partition_key]
-                )
+                child_partitions_def.subset_with_partition_keys([partition_key])
                 if partition_key
                 else None
             ),
+            downstream_partitions_def=child_partitions_def,
             upstream_partitions_def=parent_partitions_def,
             dynamic_partitions_store=dynamic_partitions_store,
             current_time=current_time,
@@ -611,6 +611,7 @@ class AssetGraph:
                             child_partitions_subset = (
                                 partition_mapping.get_downstream_partitions_for_partitions(
                                     partitions_subset,
+                                    check.not_none(self.get_partitions_def(asset_key)),
                                     downstream_partitions_def=child_partitions_def,
                                     dynamic_partitions_store=dynamic_partitions_store,
                                     current_time=current_time,

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
@@ -94,14 +94,18 @@ class AssetGraphSubset:
                 for key, value in self.partitions_subsets_by_asset_key.items()
             },
             "serializable_partitions_def_ids_by_asset_key": {
-                key.to_user_string(): value.partitions_def.get_serializable_unique_identifier(
+                key.to_user_string(): check.not_none(
+                    self._asset_graph.get_partitions_def(key)
+                ).get_serializable_unique_identifier(
                     dynamic_partitions_store=dynamic_partitions_store
                 )
-                for key, value in self.partitions_subsets_by_asset_key.items()
+                for key, _ in self.partitions_subsets_by_asset_key.items()
             },
             "partitions_def_class_names_by_asset_key": {
-                key.to_user_string(): value.partitions_def.__class__.__name__
-                for key, value in self.partitions_subsets_by_asset_key.items()
+                key.to_user_string(): check.not_none(
+                    self._asset_graph.get_partitions_def(key)
+                ).__class__.__name__
+                for key, _ in self.partitions_subsets_by_asset_key.items()
             },
             "non_partitioned_asset_keys": [
                 key.to_user_string() for key in self._non_partitioned_asset_keys

--- a/python_modules/dagster/dagster/_core/definitions/data_time.py
+++ b/python_modules/dagster/dagster/_core/definitions/data_time.py
@@ -92,7 +92,7 @@ class CachingDataTimeResolver:
         if not isinstance(partition_subset, BaseTimeWindowPartitionsSubset):
             check.failed(f"Invalid partition subset {type(partition_subset)}")
 
-        sorted_time_windows = sorted(partition_subset.included_time_windows)
+        sorted_time_windows = sorted(partition_subset.get_included_time_windows())
         # no time windows, no data
         if len(sorted_time_windows) == 0:
             return None

--- a/python_modules/dagster/dagster/_core/definitions/data_time.py
+++ b/python_modules/dagster/dagster/_core/definitions/data_time.py
@@ -28,8 +28,8 @@ from dagster._core.definitions.data_version import (
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
 from dagster._core.definitions.freshness_policy import FreshnessMinutes
 from dagster._core.definitions.time_window_partitions import (
+    BaseTimeWindowPartitionsSubset,
     TimeWindowPartitionsDefinition,
-    TimeWindowPartitionsSubset,
 )
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.event_api import EventLogRecord
@@ -89,7 +89,7 @@ class CachingDataTimeResolver:
             )
         )
 
-        if not isinstance(partition_subset, TimeWindowPartitionsSubset):
+        if not isinstance(partition_subset, BaseTimeWindowPartitionsSubset):
             check.failed(f"Invalid partition subset {type(partition_subset)}")
 
         sorted_time_windows = sorted(partition_subset.included_time_windows)

--- a/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
@@ -718,6 +718,7 @@ class MultiAssetSensorEvaluationContext(SensorEvaluationContext):
         downstream_partition_key_subset = (
             partition_mapping.get_downstream_partitions_for_partitions(
                 from_asset.partitions_def.empty_subset().with_partition_keys([partition_key]),
+                from_asset.partitions_def,
                 downstream_partitions_def=to_partitions_def,
                 dynamic_partitions_store=self.instance,
             )

--- a/python_modules/dagster/dagster/_core/definitions/multi_dimensional_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_dimensional_partitions.py
@@ -4,7 +4,6 @@ from datetime import datetime
 from functools import lru_cache, reduce
 from typing import (
     Dict,
-    Iterable,
     List,
     Mapping,
     NamedTuple,
@@ -216,7 +215,7 @@ class MultiPartitionsDefinition(PartitionsDefinition[MultiPartitionKey]):
 
     @property
     def partitions_subset_class(self) -> Type["PartitionsSubset"]:
-        return MultiPartitionsSubset
+        return DefaultPartitionsSubset
 
     def get_serializable_unique_identifier(
         self, dynamic_partitions_store: Optional[DynamicPartitionsStore] = None
@@ -507,33 +506,6 @@ class MultiPartitionsDefinition(PartitionsDefinition[MultiPartitionKey]):
             for dim in self.partitions_defs
         ]
         return reduce(lambda x, y: x * y, dimension_counts, 1)
-
-
-class MultiPartitionsSubset(DefaultPartitionsSubset):
-    def __init__(
-        self,
-        partitions_def: MultiPartitionsDefinition,
-        subset: Optional[Set[str]] = None,
-    ):
-        check.inst_param(partitions_def, "partitions_def", MultiPartitionsDefinition)
-        subset = (
-            set(
-                [
-                    partitions_def.get_partition_key_from_str(key)
-                    for key in subset
-                    if MULTIPARTITION_KEY_DELIMITER in key
-                ]
-            )
-            if subset
-            else set()
-        )
-        super(MultiPartitionsSubset, self).__init__(partitions_def, subset)
-
-    def with_partition_keys(self, partition_keys: Iterable[str]) -> "MultiPartitionsSubset":
-        return MultiPartitionsSubset(
-            cast(MultiPartitionsDefinition, self._partitions_def),
-            self._subset | set(partition_keys),
-        )
 
 
 def get_tags_from_multi_partition_key(multi_partition_key: MultiPartitionKey) -> Mapping[str, str]:

--- a/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
@@ -226,7 +226,9 @@ class LastPartitionMapping(PartitionMapping, NamedTuple("_LastPartitionMapping",
         current_time: Optional[datetime] = None,
         dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
     ) -> PartitionsSubset:
-        last_upstream_partition = upstream_partitions_subset.partitions_def.get_last_partition_key(
+        last_upstream_partition = check.not_none(
+            upstream_partitions_subset.get_partitions_def()
+        ).get_last_partition_key(
             current_time=current_time, dynamic_partitions_store=dynamic_partitions_store
         )
         if last_upstream_partition and last_upstream_partition in upstream_partitions_subset:

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
@@ -117,7 +117,7 @@ class TimeWindowPartitionMapping(
             check.failed("downstream_partitions_subset must be a BaseTimeWindowPartitionsSubset")
 
         return self._map_partitions(
-            downstream_partitions_subset.partitions_def,
+            downstream_partitions_subset.get_partitions_def(),
             upstream_partitions_def,
             downstream_partitions_subset,
             start_offset=self.start_offset,

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
@@ -6,6 +6,7 @@ from dagster._annotations import PublicAttr, experimental_param
 from dagster._core.definitions.partition import PartitionsDefinition, PartitionsSubset
 from dagster._core.definitions.partition_mapping import PartitionMapping, UpstreamPartitionsResult
 from dagster._core.definitions.time_window_partitions import (
+    BaseTimeWindowPartitionsSubset,
     TimeWindow,
     TimeWindowPartitionsDefinition,
     TimeWindowPartitionsSubset,
@@ -111,8 +112,8 @@ class TimeWindowPartitionMapping(
         current_time: Optional[datetime] = None,
         dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
     ) -> UpstreamPartitionsResult:
-        if not isinstance(downstream_partitions_subset, TimeWindowPartitionsSubset):
-            check.failed("downstream_partitions_subset must be a TimeWindowPartitionsSubset")
+        if not isinstance(downstream_partitions_subset, BaseTimeWindowPartitionsSubset):
+            check.failed("downstream_partitions_subset must be a BaseTimeWindowPartitionsSubset")
 
         return self._map_partitions(
             downstream_partitions_subset.partitions_def,
@@ -161,8 +162,8 @@ class TimeWindowPartitionMapping(
         the filtered subset, also returning a bool indicating whether there were mapped time windows
         that did not exist in to_partitions_def.
         """
-        if not isinstance(from_partitions_subset, TimeWindowPartitionsSubset):
-            check.failed("from_partitions_subset must be a TimeWindowPartitionsSubset")
+        if not isinstance(from_partitions_subset, BaseTimeWindowPartitionsSubset):
+            check.failed("from_partitions_subset must be a BaseTimeWindowPartitionsSubset")
 
         if not isinstance(from_partitions_def, TimeWindowPartitionsDefinition):
             check.failed("from_partitions_def must be a TimeWindowPartitionsDefinition")
@@ -303,7 +304,7 @@ class TimeWindowPartitionMapping(
         self,
         from_partitions_def: TimeWindowPartitionsDefinition,
         to_partitions_def: TimeWindowPartitionsDefinition,
-        from_partitions_subset: TimeWindowPartitionsSubset,
+        from_partitions_subset: BaseTimeWindowPartitionsSubset,
         start_offset: int,
         end_offset: int,
         current_time: Optional[datetime],

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
@@ -108,6 +108,7 @@ class TimeWindowPartitionMapping(
     def get_upstream_mapped_partitions_result_for_partitions(
         self,
         downstream_partitions_subset: Optional[PartitionsSubset],
+        downstream_partitions_def: Optional[PartitionsDefinition],
         upstream_partitions_def: PartitionsDefinition,
         current_time: Optional[datetime] = None,
         dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
@@ -127,6 +128,7 @@ class TimeWindowPartitionMapping(
     def get_downstream_partitions_for_partitions(
         self,
         upstream_partitions_subset: PartitionsSubset,
+        upstream_partitions_def: PartitionsDefinition,
         downstream_partitions_def: Optional[PartitionsDefinition],
         current_time: Optional[datetime] = None,
         dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
@@ -137,7 +139,7 @@ class TimeWindowPartitionMapping(
         if not provided.
         """
         return self._map_partitions(
-            upstream_partitions_subset.partitions_def,
+            upstream_partitions_def,
             downstream_partitions_def,
             upstream_partitions_subset,
             end_offset=-self.start_offset,
@@ -200,7 +202,7 @@ class TimeWindowPartitionMapping(
         last_window = to_partitions_def.get_last_partition_window(current_time=current_time)
 
         time_windows = []
-        for from_partition_time_window in from_partitions_subset.included_time_windows:
+        for from_partition_time_window in from_partitions_subset.get_included_time_windows():
             from_start_dt, from_end_dt = from_partition_time_window
 
             offsetted_start_dt = _offsetted_datetime(
@@ -363,7 +365,7 @@ class TimeWindowPartitionMapping(
                 TimeWindowPartitionsSubset(
                     partitions_def=to_partitions_def,
                     num_partitions=None,
-                    included_time_windows=from_partitions_subset.included_time_windows,
+                    included_time_windows=from_partitions_subset.get_included_time_windows(),
                 ),
                 [],
             )
@@ -377,7 +379,7 @@ class TimeWindowPartitionMapping(
             else:
                 required_but_nonexistent_partition_keys = [
                     pk
-                    for time_window in from_partitions_subset.included_time_windows
+                    for time_window in from_partitions_subset.get_included_time_windows()
                     for pk in to_partitions_def.get_partition_keys_in_time_window(
                         time_window=time_window
                     )

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -29,8 +29,10 @@ from dagster._annotations import PublicAttr, public
 from dagster._core.instance import DynamicPartitionsStore
 from dagster._utils.cached_method import cached_method
 from dagster._serdes import whitelist_for_serdes
+from dagster._serdes import NamedTupleSerializer, whitelist_for_serdes
 from dagster._serdes.serdes import FieldSerializer
 from dagster._utils import utc_datetime_from_timestamp
+from dagster._utils.cached_method import cached_method
 from dagster._utils.partitions import DEFAULT_HOURLY_FORMAT_WITHOUT_TIMEZONE
 from dagster._utils.schedules import (
     cron_string_iterator,
@@ -1413,13 +1415,16 @@ class BaseTimeWindowPartitionsSubset(PartitionsSubset):
     # This will ensure that we can gracefully degrade when deserializing old data.
     SERIALIZATION_VERSION = 1
 
-    @property
     @abstractmethod
-    def included_time_windows(self) -> Sequence[TimeWindow]:
+    def get_included_time_windows(self) -> Sequence[TimeWindow]:
         ...
 
-    @abstractproperty
-    def num_partitions(self) -> int:
+    @abstractmethod
+    def get_num_partitions(self) -> int:
+        ...
+
+    @abstractmethod
+    def get_partitions_def(self) -> TimeWindowPartitionsDefinition:
         ...
 
     def _get_partition_time_windows_not_in_subset(
@@ -1430,48 +1435,51 @@ class BaseTimeWindowPartitionsSubset(PartitionsSubset):
         Each time window is a single partition.
         """
         first_tw = cast(
-            TimeWindowPartitionsDefinition, self.partitions_def
+            TimeWindowPartitionsDefinition, self.get_partitions_def()
         ).get_first_partition_window(current_time=current_time)
         last_tw = cast(
-            TimeWindowPartitionsDefinition, self.partitions_def
+            TimeWindowPartitionsDefinition, self.get_partitions_def()
         ).get_last_partition_window(current_time=current_time)
 
         if not first_tw or not last_tw:
             check.failed("No partitions found")
 
-        if len(self.included_time_windows) == 0:
+        if len(self.get_included_time_windows()) == 0:
             return [TimeWindow(first_tw.start, last_tw.end)]
 
         time_windows = []
-        if first_tw.start < self.included_time_windows[0].start:
-            time_windows.append(TimeWindow(first_tw.start, self.included_time_windows[0].start))
+        if first_tw.start < self.get_included_time_windows()[0].start:
+            time_windows.append(
+                TimeWindow(first_tw.start, self.get_included_time_windows()[0].start)
+            )
 
-        for i in range(len(self.included_time_windows) - 1):
-            if self.included_time_windows[i].start >= last_tw.end:
+        for i in range(len(self.get_included_time_windows()) - 1):
+            if self.get_included_time_windows()[i].start >= last_tw.end:
                 break
-            if self.included_time_windows[i].end < last_tw.end:
-                if self.included_time_windows[i + 1].start <= last_tw.end:
+            if self.get_included_time_windows()[i].end < last_tw.end:
+                if self.get_included_time_windows()[i + 1].start <= last_tw.end:
                     time_windows.append(
                         TimeWindow(
-                            self.included_time_windows[i].end,
-                            self.included_time_windows[i + 1].start,
+                            self.get_included_time_windows()[i].end,
+                            self.get_included_time_windows()[i + 1].start,
                         )
                     )
                 else:
                     time_windows.append(
                         TimeWindow(
-                            self.included_time_windows[i].end,
+                            self.get_included_time_windows()[i].end,
                             last_tw.end,
                         )
                     )
 
-        if last_tw.end > self.included_time_windows[-1].end:
-            time_windows.append(TimeWindow(self.included_time_windows[-1].end, last_tw.end))
+        if last_tw.end > self.get_included_time_windows()[-1].end:
+            time_windows.append(TimeWindow(self.get_included_time_windows()[-1].end, last_tw.end))
 
         return time_windows
 
     def get_partition_keys_not_in_subset(
         self,
+        partitions_def: PartitionsDefinition,
         current_time: Optional[datetime] = None,
         dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
     ) -> Iterable[str]:
@@ -1479,7 +1487,7 @@ class BaseTimeWindowPartitionsSubset(PartitionsSubset):
         for tw in self._get_partition_time_windows_not_in_subset(current_time):
             partition_keys.extend(
                 cast(
-                    TimeWindowPartitionsDefinition, self.partitions_def
+                    TimeWindowPartitionsDefinition, self.get_partitions_def()
                 ).get_partition_keys_in_time_window(tw)
             )
         return partition_keys
@@ -1504,14 +1512,15 @@ class BaseTimeWindowPartitionsSubset(PartitionsSubset):
 
     def get_partition_key_ranges(
         self,
+        partitions_def: PartitionsDefinition,
         current_time: Optional[datetime] = None,
         dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
     ) -> Sequence[PartitionKeyRange]:
         return [
             cast(
-                TimeWindowPartitionsDefinition, self.partitions_def
+                TimeWindowPartitionsDefinition, self.get_partitions_def()
             ).get_partition_key_range_for_time_window(window)
-            for window in self.included_time_windows
+            for window in self.get_included_time_windows()
         ]
 
     def _add_partitions_to_time_windows(
@@ -1525,7 +1534,7 @@ class BaseTimeWindowPartitionsSubset(PartitionsSubset):
         """
         result_windows = [*initial_windows]
         time_windows = cast(
-            TimeWindowPartitionsDefinition, self.partitions_def
+            TimeWindowPartitionsDefinition, self.get_partitions_def()
         ).time_windows_for_partition_keys(frozenset(partition_keys), validate=validate)
         num_added_partitions = 0
         for window in sorted(time_windows):
@@ -1577,9 +1586,9 @@ class BaseTimeWindowPartitionsSubset(PartitionsSubset):
                 # stable serialization between identical subsets
                 "time_windows": [
                     (window.start.timestamp(), window.end.timestamp())
-                    for window in self.included_time_windows
+                    for window in self.get_included_time_windows()
                 ],
-                "num_partitions": self.num_partitions,
+                "num_partitions": self.get_num_partitions(),
             }
         )
 
@@ -1655,17 +1664,17 @@ class BaseTimeWindowPartitionsSubset(PartitionsSubset):
         )
 
     def __len__(self) -> int:
-        return self.num_partitions
+        return self.get_num_partitions()
 
     def __contains__(self, partition_key: str) -> bool:
         time_window = cast(
-            TimeWindowPartitionsDefinition, self.partitions_def
+            TimeWindowPartitionsDefinition, self.get_partitions_def()
         ).time_window_for_partition_key(partition_key)
 
         return any(
             time_window.start >= included_time_window.start
             and time_window.start < included_time_window.end
-            for included_time_window in self.included_time_windows
+            for included_time_window in self.get_included_time_windows()
         )
 
     def __eq__(self, other):
@@ -1689,6 +1698,9 @@ class TimePartitionKeyPartitionsSubset(BaseTimeWindowPartitionsSubset):
             included_partition_keys, "included_partition_keys", of_type=str
         )
 
+    def get_partitions_def(self) -> TimeWindowPartitionsDefinition:
+        return self._partitions_def
+
     def with_partition_keys(
         self, partition_keys: Iterable[str]
     ) -> "BaseTimeWindowPartitionsSubset":
@@ -1698,9 +1710,8 @@ class TimePartitionKeyPartitionsSubset(BaseTimeWindowPartitionsSubset):
             included_partition_keys=new_partitions,
         )
 
-    @property
     @cached_method
-    def included_time_windows(self) -> Sequence[TimeWindow]:
+    def get_included_time_windows(self) -> Sequence[TimeWindow]:
         result_time_windows, _ = self._add_partitions_to_time_windows(
             initial_windows=[],
             partition_keys=list(check.not_none(self._included_partition_keys)),
@@ -1712,9 +1723,8 @@ class TimePartitionKeyPartitionsSubset(BaseTimeWindowPartitionsSubset):
     def partitions_def(self) -> TimeWindowPartitionsDefinition:
         return self._partitions_def
 
-    @property
     @cached_method
-    def num_partitions(self) -> int:
+    def get_num_partitions(self) -> int:
         return len(self._included_partition_keys)
 
     @public
@@ -1730,11 +1740,11 @@ class TimePartitionKeyPartitionsSubset(BaseTimeWindowPartitionsSubset):
                 next(iter(self._included_partition_keys))
             )
         else:
-            if len(self.included_time_windows) == 0:
+            if len(self.get_included_time_windows()) == 0:
                 check.failed(
                     f"Empty subset. self._included_partition_keys: {self._included_partition_keys}"
                 )
-            return self.included_time_windows[0].start
+            return self.get_included_time_windows()[0].start
 
     @property
     def is_empty(self) -> bool:
@@ -1779,7 +1789,9 @@ class TimePartitionKeyPartitionsSubset(BaseTimeWindowPartitionsSubset):
         ) or super(TimePartitionKeyPartitionsSubset, self).__eq__(other)
 
     @classmethod
-    def empty_subset(cls, partitions_def: PartitionsDefinition) -> "PartitionsSubset":
+    def empty_subset(
+        cls, partitions_def: Optional[PartitionsDefinition] = None
+    ) -> "PartitionsSubset":
         if not isinstance(partitions_def, TimeWindowPartitionsDefinition):
             check.failed("Partitions definition must be a TimeWindowPartitionsDefinition")
         partitions_def = cast(TimeWindowPartitionsDefinition, partitions_def)
@@ -1801,48 +1813,59 @@ class TimePartitionKeyPartitionsSubset(BaseTimeWindowPartitionsSubset):
     def resolve(self) -> "TimeWindowPartitionsSubset":
         return TimeWindowPartitionsSubset(
             partitions_def=self._partitions_def,
-            num_partitions=self.num_partitions,
-            included_time_windows=self.included_time_windows,
+            num_partitions=self.get_num_partitions(),
+            included_time_windows=self.get_included_time_windows(),
         )
 
 
-class TimeWindowPartitionsSubset(BaseTimeWindowPartitionsSubset):
-    def __init__(
-        self,
+@whitelist_for_serdes
+class TimeWindowPartitionsSubset(
+    BaseTimeWindowPartitionsSubset,
+    NamedTuple(
+        "_TimeWindowPartitionsSubset",
+        [
+            ("partitions_def", TimeWindowPartitionsDefinition),
+            ("num_partitions", int),
+            ("included_time_windows", Sequence[TimeWindow]),
+        ],
+    ),
+):
+    def __new__(
+        cls,
         partitions_def: TimeWindowPartitionsDefinition,
         num_partitions: Optional[int] = None,
         included_time_windows: Sequence[TimeWindow] = [],
     ):
         check.opt_int_param(num_partitions, "num_partitions")
-        self._partitions_def = check.inst_param(
-            partitions_def, "partitions_def", TimeWindowPartitionsDefinition
-        )
-        self._num_partitions = (
-            num_partitions
-            if num_partitions
-            else self._num_partitions_from_time_windows(partitions_def, included_time_windows)
-        )
-        self._included_time_windows = check.sequence_param(
-            included_time_windows, "included_time_windows", of_type=TimeWindow
+        return super(TimeWindowPartitionsSubset, cls).__new__(
+            cls,
+            partitions_def=partitions_def,
+            num_partitions=(
+                num_partitions
+                if num_partitions
+                else cls._num_partitions_from_time_windows(partitions_def, included_time_windows)
+            ),
+            included_time_windows=check.sequence_param(
+                included_time_windows, "included_time_windows", of_type=TimeWindow
+            ),
         )
 
     def get_included_time_windows(self) -> Sequence[TimeWindow]:
-        return self._included_time_windows
+        return self.included_time_windows
 
-    @property
-    def partitions_def(self) -> TimeWindowPartitionsDefinition:
-        return self._partitions_def
+    def get_partitions_def(self) -> TimeWindowPartitionsDefinition:
+        return self.partitions_def
 
     @property
     def first_start(self) -> datetime:
         """The start datetime of the earliest partition in the subset."""
-        if len(self._included_time_windows) == 0:
+        if len(self.included_time_windows) == 0:
             check.failed("Empty subset")
-        return self._included_time_windows[0].start
+        return self.included_time_windows[0].start
 
     @property
     def is_empty(self) -> bool:
-        return len(self._included_time_windows) == 0
+        return len(self.included_time_windows) == 0
 
     def cheap_ends_before(self, dt: datetime, dt_cron_schedule: str) -> bool:
         """Performs a cheap calculation that checks whether the latest window in this subset ends
@@ -1853,18 +1876,13 @@ class TimeWindowPartitionsSubset(BaseTimeWindowPartitionsSubset):
         Args:
             dt_cron_schedule (str): A cron schedule that dt is on one of the ticks of.
         """
-        if self._included_time_windows is not None:
-            return self._included_time_windows[-1].end <= dt
+        if self.included_time_windows is not None:
+            return self.included_time_windows[-1].end <= dt
 
         return False
 
-    @property
-    def num_partitions(self) -> int:
-        return self._num_partitions
-
-    @property
-    def included_time_windows(self) -> Sequence[TimeWindow]:
-        return self._included_time_windows
+    def get_num_partitions(self) -> int:
+        return self.num_partitions
 
     @classmethod
     def _num_partitions_from_time_windows(
@@ -1879,18 +1897,18 @@ class TimeWindowPartitionsSubset(BaseTimeWindowPartitionsSubset):
     def get_partition_keys(self, current_time: Optional[datetime] = None) -> Iterable[str]:
         return [
             pk
-            for time_window in self._included_time_windows
+            for time_window in self.included_time_windows
             for pk in self.partitions_def.get_partition_keys_in_time_window(time_window)
         ]
 
     def with_partition_keys(self, partition_keys: Iterable[str]) -> "TimeWindowPartitionsSubset":
         result_windows, added_partitions = self._add_partitions_to_time_windows(
-            self._included_time_windows, list(partition_keys)
+            self.included_time_windows, list(partition_keys)
         )
 
         return TimeWindowPartitionsSubset(
-            self._partitions_def,
-            num_partitions=self._num_partitions + added_partitions,
+            self.partitions_def,
+            num_partitions=self.num_partitions + added_partitions,
             included_time_windows=result_windows,
         )
 
@@ -1907,18 +1925,18 @@ class TimeWindowPartitionsSubset(BaseTimeWindowPartitionsSubset):
         self, partitions_def: TimeWindowPartitionsDefinition
     ) -> "BaseTimeWindowPartitionsSubset":
         check.invariant(
-            partitions_def.cron_schedule == self._partitions_def.cron_schedule,
+            partitions_def.cron_schedule == self.partitions_def.cron_schedule,
             "num_partitions would become inaccurate if the partitions_defs had different cron"
             " schedules",
         )
         return TimeWindowPartitionsSubset(
             partitions_def=partitions_def,
-            num_partitions=self._num_partitions,
-            included_time_windows=self._included_time_windows,
+            num_partitions=self.num_partitions,
+            included_time_windows=self.included_time_windows,
         )
 
     def __repr__(self) -> str:
-        return f"TimeWindowPartitionsSubset({self.get_partition_key_ranges()})"
+        return f"TimeWindowPartitionsSubset({self.get_partition_key_ranges(self.partitions_def)})"
 
 
 class PartitionRangeStatus(Enum):
@@ -2044,7 +2062,7 @@ def fetch_flattened_time_window_ranges(
     flattened_time_window_statuses = []
     for status, subset in prioritized_subsets:
         subset_time_window_statuses = [
-            PartitionTimeWindowStatus(tw, status) for tw in subset.included_time_windows
+            PartitionTimeWindowStatus(tw, status) for tw in subset.get_included_time_windows()
         ]
         flattened_time_window_statuses = _flatten(
             flattened_time_window_statuses, subset_time_window_statuses

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -734,7 +734,7 @@ class TimeWindowPartitionsDefinition(
 
     @property
     def partitions_subset_class(self) -> Type["PartitionsSubset"]:
-        return UnresolvedTimeWindowPartitionsSubset
+        return TimePartitionKeyPartitionsSubset
 
     def empty_subset(self) -> "PartitionsSubset":
         return self.partitions_subset_class.empty_subset(self)
@@ -1647,7 +1647,7 @@ class BaseTimeWindowPartitionsSubset(PartitionsSubset):
         )
 
 
-class UnresolvedTimeWindowPartitionsSubset(BaseTimeWindowPartitionsSubset):
+class TimePartitionKeyPartitionsSubset(BaseTimeWindowPartitionsSubset):
     def __init__(
         self,
         partitions_def: TimeWindowPartitionsDefinition,
@@ -1664,7 +1664,7 @@ class UnresolvedTimeWindowPartitionsSubset(BaseTimeWindowPartitionsSubset):
         self, partition_keys: Iterable[str]
     ) -> "BaseTimeWindowPartitionsSubset":
         new_partitions = {*(self._included_partition_keys or []), *partition_keys}
-        return UnresolvedTimeWindowPartitionsSubset(
+        return TimePartitionKeyPartitionsSubset(
             self._partitions_def,
             included_partition_keys=new_partitions,
         )
@@ -1744,10 +1744,10 @@ class UnresolvedTimeWindowPartitionsSubset(BaseTimeWindowPartitionsSubset):
 
     def __eq__(self, other):
         return (
-            isinstance(other, UnresolvedTimeWindowPartitionsSubset)
+            isinstance(other, TimePartitionKeyPartitionsSubset)
             and self.partitions_def == other.partitions_def
             and self._included_partition_keys == other._included_partition_keys
-        ) or super(UnresolvedTimeWindowPartitionsSubset, self).__eq__(other)
+        ) or super(TimePartitionKeyPartitionsSubset, self).__eq__(other)
 
     @classmethod
     def empty_subset(cls, partitions_def: PartitionsDefinition) -> "PartitionsSubset":
@@ -1764,7 +1764,7 @@ class UnresolvedTimeWindowPartitionsSubset(BaseTimeWindowPartitionsSubset):
             "num_partitions would become inaccurate if the partitions_defs had different cron"
             " schedules",
         )
-        return UnresolvedTimeWindowPartitionsSubset(
+        return TimePartitionKeyPartitionsSubset(
             partitions_def=partitions_def,
             included_partition_keys=self._included_partition_keys,
         )

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -27,9 +27,9 @@ import pendulum
 import dagster._check as check
 from dagster._annotations import PublicAttr, public
 from dagster._core.instance import DynamicPartitionsStore
-from dagster._utils.cached_method import cached_method
-from dagster._serdes import whitelist_for_serdes
-from dagster._serdes import NamedTupleSerializer, whitelist_for_serdes
+from dagster._serdes import (
+    whitelist_for_serdes,
+)
 from dagster._serdes.serdes import FieldSerializer
 from dagster._utils import utc_datetime_from_timestamp
 from dagster._utils.cached_method import cached_method
@@ -73,6 +73,9 @@ class DatetimeFieldSerializer(FieldSerializer):
         return utc_datetime_from_timestamp(datetime_float) if datetime_float else None
 
 
+@whitelist_for_serdes(
+    field_serializers={"start": DatetimeFieldSerializer, "end": DatetimeFieldSerializer}
+)
 class TimeWindow(NamedTuple):
     """An interval that is closed at the start and open at the end.
 
@@ -1681,7 +1684,7 @@ class BaseTimeWindowPartitionsSubset(PartitionsSubset):
         return (
             isinstance(other, BaseTimeWindowPartitionsSubset)
             and self.partitions_def == other.partitions_def
-            and self.included_time_windows == other.included_time_windows
+            and self.get_included_time_windows() == other.get_included_time_windows()
         )
 
 

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -28,6 +28,9 @@ import dagster._check as check
 from dagster._annotations import PublicAttr, public
 from dagster._core.instance import DynamicPartitionsStore
 from dagster._utils.cached_method import cached_method
+from dagster._serdes import whitelist_for_serdes
+from dagster._serdes.serdes import FieldSerializer
+from dagster._utils import utc_datetime_from_timestamp
 from dagster._utils.partitions import DEFAULT_HOURLY_FORMAT_WITHOUT_TIMEZONE
 from dagster._utils.schedules import (
     cron_string_iterator,
@@ -50,6 +53,24 @@ from .partition import (
 from .partition_key_range import PartitionKeyRange
 
 
+class DatetimeFieldSerializer(FieldSerializer):
+    """Serializes datetime objects to and from floats."""
+
+    def pack(self, datetime: Optional[datetime], **_kwargs) -> Optional[float]:
+        if datetime:
+            check.invariant(datetime.tzinfo is not None)
+
+        # Get the timestamp in UTC
+        return datetime.timestamp() if datetime else None
+
+    def unpack(
+        self,
+        datetime_float: Optional[float],
+        **_kwargs,
+    ) -> Optional[datetime]:
+        return utc_datetime_from_timestamp(datetime_float) if datetime_float else None
+
+
 class TimeWindow(NamedTuple):
     """An interval that is closed at the start and open at the end.
 
@@ -62,15 +83,18 @@ class TimeWindow(NamedTuple):
     end: PublicAttr[datetime]
 
 
+@whitelist_for_serdes(
+    field_serializers={"start": DatetimeFieldSerializer, "end": DatetimeFieldSerializer}
+)
 class TimeWindowPartitionsDefinition(
     PartitionsDefinition,
     NamedTuple(
         "_TimeWindowPartitionsDefinition",
         [
             ("start", PublicAttr[datetime]),
+            ("fmt", PublicAttr[str]),
             ("timezone", PublicAttr[str]),
             ("end", PublicAttr[Optional[datetime]]),
-            ("fmt", PublicAttr[str]),
             ("end_offset", PublicAttr[int]),
             ("cron_schedule", PublicAttr[str]),
         ],
@@ -108,20 +132,25 @@ class TimeWindowPartitionsDefinition(
         cls,
         start: Union[datetime, str],
         fmt: str,
-        end: Union[datetime, str, None] = None,
-        schedule_type: Optional[ScheduleType] = None,
         timezone: Optional[str] = None,
+        end: Union[datetime, str, None] = None,
         end_offset: int = 0,
+        cron_schedule: Optional[str] = None,
+        schedule_type: Optional[ScheduleType] = None,
         minute_offset: Optional[int] = None,
         hour_offset: Optional[int] = None,
         day_offset: Optional[int] = None,
-        cron_schedule: Optional[str] = None,
     ):
         check.opt_str_param(timezone, "timezone")
         timezone = timezone or "UTC"
 
         if isinstance(start, datetime):
             start_dt = pendulum.instance(start, tz=timezone)
+
+            if start.tzinfo:
+                # Pendulum.instance does not override the timezone of the datetime object,
+                # so we convert it to the provided timezone
+                start_dt = start_dt.in_tz(tz=timezone)
         else:
             start_dt = pendulum.instance(datetime.strptime(start, fmt), tz=timezone)
 
@@ -156,7 +185,7 @@ class TimeWindowPartitionsDefinition(
             )
 
         return super(TimeWindowPartitionsDefinition, cls).__new__(
-            cls, start_dt, timezone, end_dt, fmt, end_offset, cron_schedule
+            cls, start_dt, fmt, timezone, end_dt, end_offset, cron_schedule
         )
 
     def get_current_timestamp(self, current_time: Optional[datetime] = None) -> float:

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -270,9 +270,10 @@ class AssetBackfillData(NamedTuple):
             .sources()
             .resolve(self.target_subset.asset_graph)
         )
+        asset_key = next(iter(root_partitioned_asset_keys))
 
         # Return the targeted partitions for the root partitioned asset keys
-        return self.target_subset.get_partitions_subset(next(iter(root_partitioned_asset_keys)))
+        return self.target_subset.get_partitions_subset(asset_key)
 
     def get_num_partitions(self) -> Optional[int]:
         """Only valid when the same number of partitions are targeted in every asset.

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -182,26 +182,6 @@ class PartitionBackfill(
         else:
             return None
 
-    def get_target_root_partitions_subset(
-        self, workspace: IWorkspace
-    ) -> Optional[PartitionsSubset]:
-        if not self.is_valid_serialization(workspace):
-            return None
-
-        if self.serialized_asset_backfill_data is not None:
-            try:
-                asset_backfill_data = AssetBackfillData.from_serialized(
-                    self.serialized_asset_backfill_data,
-                    ExternalAssetGraph.from_workspace(workspace),
-                    self.backfill_timestamp,
-                )
-            except DagsterDefinitionChangedDeserializationError:
-                return None
-
-            return asset_backfill_data.get_target_root_partitions_subset()
-        else:
-            return None
-
     def get_num_partitions(self, workspace: IWorkspace) -> Optional[int]:
         if not self.is_valid_serialization(workspace):
             return 0

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -182,6 +182,26 @@ class PartitionBackfill(
         else:
             return None
 
+    def get_target_root_partitions_subset(
+        self, workspace: IWorkspace
+    ) -> Optional[PartitionsSubset]:
+        if not self.is_valid_serialization(workspace):
+            return None
+
+        if self.serialized_asset_backfill_data is not None:
+            try:
+                asset_backfill_data = AssetBackfillData.from_serialized(
+                    self.serialized_asset_backfill_data,
+                    ExternalAssetGraph.from_workspace(workspace),
+                    self.backfill_timestamp,
+                )
+            except DagsterDefinitionChangedDeserializationError:
+                return None
+
+            return asset_backfill_data.get_target_root_partitions_subset()
+        else:
+            return None
+
     def get_num_partitions(self, workspace: IWorkspace) -> Optional[int]:
         if not self.is_valid_serialization(workspace):
             return 0

--- a/python_modules/dagster/dagster/_core/execution/context/input.py
+++ b/python_modules/dagster/dagster/_core/execution/context/input.py
@@ -365,7 +365,7 @@ class InputContext:
             )
 
         partition_key_ranges = subset.get_partition_key_ranges(
-            dynamic_partitions_store=self.instance
+            self.asset_partitions_def, dynamic_partitions_store=self.instance
         )
         if len(partition_key_ranges) != 1:
             check.failed(
@@ -411,7 +411,7 @@ class InputContext:
                 " with time windows.",
             )
 
-        time_windows = subset.included_time_windows
+        time_windows = subset.get_included_time_windows()
         if len(time_windows) != 1:
             check.failed(
                 "Tried to access asset_partitions_time_window, but there are "
@@ -608,7 +608,7 @@ def build_input_context(
     )
     if asset_partitions_def and asset_partition_key_range:
         asset_partitions_subset = asset_partitions_def.empty_subset().with_partition_key_range(
-            asset_partition_key_range, dynamic_partitions_store=instance
+            asset_partitions_def, asset_partition_key_range, dynamic_partitions_store=instance
         )
     elif asset_partition_key_range:
         asset_partitions_subset = KeyRangeNoPartitionsDefPartitionsSubset(asset_partition_key_range)
@@ -643,6 +643,7 @@ class KeyRangeNoPartitionsDefPartitionsSubset(PartitionsSubset):
 
     def get_partition_keys_not_in_subset(
         self,
+        partitions_def: "PartitionsDefinition",
         current_time: Optional[datetime] = None,
         dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
     ) -> Iterable[str]:
@@ -656,6 +657,7 @@ class KeyRangeNoPartitionsDefPartitionsSubset(PartitionsSubset):
 
     def get_partition_key_ranges(
         self,
+        partitions_def: "PartitionsDefinition",
         current_time: Optional[datetime] = None,
         dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
     ) -> Sequence[PartitionKeyRange]:
@@ -701,5 +703,7 @@ class KeyRangeNoPartitionsDefPartitionsSubset(PartitionsSubset):
         raise NotImplementedError()
 
     @classmethod
-    def empty_subset(cls, partitions_def: "PartitionsDefinition") -> "PartitionsSubset":
+    def empty_subset(
+        cls, partitions_def: Optional["PartitionsDefinition"] = None
+    ) -> "PartitionsSubset":
         raise NotImplementedError()

--- a/python_modules/dagster/dagster/_core/execution/context/input.py
+++ b/python_modules/dagster/dagster/_core/execution/context/input.py
@@ -20,7 +20,10 @@ from dagster._core.definitions.metadata import (
 )
 from dagster._core.definitions.partition import PartitionsSubset
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
-from dagster._core.definitions.time_window_partitions import TimeWindow, TimeWindowPartitionsSubset
+from dagster._core.definitions.time_window_partitions import (
+    BaseTimeWindowPartitionsSubset,
+    TimeWindow,
+)
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.instance import DagsterInstance, DynamicPartitionsStore
 
@@ -402,7 +405,7 @@ class InputContext:
                 "Tried to access asset_partitions_time_window, but the asset is not partitioned.",
             )
 
-        if not isinstance(subset, TimeWindowPartitionsSubset):
+        if not isinstance(subset, BaseTimeWindowPartitionsSubset):
             check.failed(
                 "Tried to access asset_partitions_time_window, but the asset is not partitioned"
                 " with time windows.",

--- a/python_modules/dagster/dagster/_core/execution/context/system.py
+++ b/python_modules/dagster/dagster/_core/execution/context/system.py
@@ -1101,8 +1101,19 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
 
     def asset_partition_key_range_for_input(self, input_name: str) -> PartitionKeyRange:
         subset = self.asset_partitions_subset_for_input(input_name)
+
+        # TODO refactor upstream_asset_partitions_def as method
+        asset_layer = self.job_def.asset_layer
+        upstream_asset_key = asset_layer.asset_key_for_input(self.node_handle, input_name)
+        check.not_none(upstream_asset_key)
+        upstream_asset_partitions_def = asset_layer.partitions_def_for_asset(
+            cast(AssetKey, upstream_asset_key)
+        )
+        check.not_none(upstream_asset_partitions_def)
+
         partition_key_ranges = subset.get_partition_key_ranges(
-            dynamic_partitions_store=self.instance
+            partitions_def=cast(PartitionsDefinition, upstream_asset_partitions_def),
+            dynamic_partitions_store=self.instance,
         )
 
         if len(partition_key_ranges) != 1:
@@ -1127,7 +1138,9 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
                 partitions_def = assets_def.partitions_def if assets_def else None
                 partitions_subset = (
                     partitions_def.empty_subset().with_partition_key_range(
-                        self.asset_partition_key_range, dynamic_partitions_store=self.instance
+                        partitions_def,
+                        self.asset_partition_key_range,
+                        dynamic_partitions_store=self.instance,
                     )
                     if partitions_def
                     else None
@@ -1142,6 +1155,7 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
                 mapped_partitions_result = (
                     partition_mapping.get_upstream_mapped_partitions_result_for_partitions(
                         partitions_subset,
+                        partitions_def,
                         upstream_asset_partitions_def,
                         dynamic_partitions_store=self.instance,
                     )

--- a/python_modules/dagster/dagster/_serdes/serdes.py
+++ b/python_modules/dagster/dagster/_serdes/serdes.py
@@ -509,6 +509,9 @@ class NamedTupleSerializer(Serializer, Generic[T_NamedTuple]):
     ) -> Dict[str, JsonSerializableValue]:
         packed: Dict[str, JsonSerializableValue] = {}
         packed["__class__"] = self.get_storage_name()
+
+        value = self.before_pack(value)
+
         for key, inner_value in value._asdict().items():
             if key in self.skip_when_empty_fields and inner_value in EMPTY_VALUES_TO_SKIP:
                 continue
@@ -535,6 +538,9 @@ class NamedTupleSerializer(Serializer, Generic[T_NamedTuple]):
     # string.
     def after_pack(self, **packed_dict: JsonSerializableValue) -> Dict[str, JsonSerializableValue]:
         return packed_dict
+
+    def before_pack(self, value: T_NamedTuple) -> T_NamedTuple:
+        return value
 
     @property
     @cached_method

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -613,6 +613,7 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
                         child_partitions_subset = (
                             partition_mapping.get_downstream_partitions_for_partitions(
                                 partitions_subset,
+                                partitions_def,
                                 downstream_partitions_def=child_partitions_def,
                                 dynamic_partitions_store=self,
                                 current_time=self.evaluation_time,

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_asset_partition_mappings.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_asset_partition_mappings.py
@@ -64,6 +64,7 @@ def test_access_partition_keys_from_context_non_identity_partition_mapping():
         def get_upstream_mapped_partitions_result_for_partitions(
             self,
             downstream_partitions_subset: Optional[PartitionsSubset],
+            downstream_partitions_def: Optional[PartitionsDefinition],
             upstream_partitions_def: PartitionsDefinition,
             current_time: Optional[datetime] = None,
             dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
@@ -74,7 +75,8 @@ def test_access_partition_keys_from_context_non_identity_partition_mapping():
             partition_keys = list(downstream_partitions_subset.get_partition_keys())
             return UpstreamPartitionsResult(
                 upstream_partitions_def.empty_subset().with_partition_key_range(
-                    PartitionKeyRange(str(max(1, int(partition_keys[0]) - 1)), partition_keys[-1])
+                    upstream_partitions_def,
+                    PartitionKeyRange(str(max(1, int(partition_keys[0]) - 1)), partition_keys[-1]),
                 ),
                 [],
             )
@@ -82,6 +84,7 @@ def test_access_partition_keys_from_context_non_identity_partition_mapping():
         def get_downstream_partitions_for_partitions(
             self,
             upstream_partitions_subset: PartitionsSubset,
+            upstream_partitions_def: PartitionsDefinition,
             downstream_partitions_def: PartitionsDefinition,
             current_time: Optional[datetime] = None,
             dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
@@ -260,24 +263,24 @@ def test_specific_partitions_partition_mapping_downstream_partitions():
 
     # cases where at least one of the specific partitions is in the upstream partitions subset
     for partition_subset in [
-        DefaultPartitionsSubset(upstream_partitions_def, {"a"}),
-        DefaultPartitionsSubset(upstream_partitions_def, {"a", "b"}),
-        DefaultPartitionsSubset(upstream_partitions_def, {"a", "b", "c", "d"}),
+        DefaultPartitionsSubset({"a"}),
+        DefaultPartitionsSubset({"a", "b"}),
+        DefaultPartitionsSubset({"a", "b", "c", "d"}),
     ]:
         assert (
             partition_mapping.get_downstream_partitions_for_partitions(
-                partition_subset, downstream_partitions_def
+                partition_subset, upstream_partitions_def, downstream_partitions_def
             )
             == downstream_partitions_def.subset_with_all_partitions()
         )
 
     for partition_subset in [
-        DefaultPartitionsSubset(upstream_partitions_def, {"c"}),
-        DefaultPartitionsSubset(upstream_partitions_def, {"c", "d"}),
+        DefaultPartitionsSubset({"c"}),
+        DefaultPartitionsSubset({"c", "d"}),
     ]:
         assert (
             partition_mapping.get_downstream_partitions_for_partitions(
-                partition_subset, downstream_partitions_def
+                partition_subset, upstream_partitions_def, downstream_partitions_def
             )
             == downstream_partitions_def.empty_subset()
         )
@@ -564,13 +567,13 @@ def test_identity_partition_mapping():
     zx = StaticPartitionsDefinition(["z", "x"])
 
     result = IdentityPartitionMapping().get_upstream_mapped_partitions_result_for_partitions(
-        zx.empty_subset().with_partition_keys(["z", "x"]), xy
+        zx.empty_subset().with_partition_keys(["z", "x"]), zx, xy
     )
     assert result.partitions_subset.get_partition_keys() == set(["x"])
     assert result.required_but_nonexistent_partition_keys == ["z"]
 
     result = IdentityPartitionMapping().get_downstream_partitions_for_partitions(
-        zx.empty_subset().with_partition_keys(["z", "x"]), xy
+        zx.empty_subset().with_partition_keys(["z", "x"]), zx, xy
     )
     assert result.get_partition_keys() == set(["x"])
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_multipartition_partition_mapping.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_multipartition_partition_mapping.py
@@ -40,10 +40,11 @@ def test_get_downstream_partitions_single_key_in_range():
     )
 
     single_dimension_subset = single_dimension_def.empty_subset().with_partition_key_range(
-        PartitionKeyRange("a", "a")
+        single_dimension_def, PartitionKeyRange("a", "a")
     )
     result = MultiToSingleDimensionPartitionMapping().get_downstream_partitions_for_partitions(
         upstream_partitions_subset=single_dimension_subset,
+        upstream_partitions_def=single_dimension_def,
         downstream_partitions_def=multipartitions_def,
     )
     multipartitions_subset = multipartitions_def.empty_subset().with_partition_keys(
@@ -57,6 +58,7 @@ def test_get_downstream_partitions_single_key_in_range():
 
     result = MultiToSingleDimensionPartitionMapping().get_downstream_partitions_for_partitions(
         upstream_partitions_subset=multipartitions_subset,
+        upstream_partitions_def=multipartitions_def,
         downstream_partitions_def=single_dimension_def,
     )
     assert result == single_dimension_subset
@@ -67,12 +69,12 @@ def test_get_downstream_partitions_single_key_in_range():
 
     result = MultiToSingleDimensionPartitionMapping().get_downstream_partitions_for_partitions(
         upstream_partitions_subset=single_dimension_def.empty_subset().with_partition_key_range(
-            PartitionKeyRange("b", "b")
+            partitions_def=single_dimension_def, partition_key_range=PartitionKeyRange("b", "b")
         ),
+        upstream_partitions_def=single_dimension_def,
         downstream_partitions_def=multipartitions_def,
     )
     assert result == DefaultPartitionsSubset(
-        multipartitions_def,
         {
             MultiPartitionKey({"abc": "b", "xyz": "x"}),
             MultiPartitionKey({"abc": "b", "xyz": "y"}),
@@ -87,7 +89,7 @@ def test_get_downstream_partitions_multiple_keys_in_range():
         {"abc": single_dimension_def, "123": StaticPartitionsDefinition(["1", "2", "3"])}
     )
     single_dimension_subset = single_dimension_def.empty_subset().with_partition_key_range(
-        PartitionKeyRange("a", "b")
+        single_dimension_def, PartitionKeyRange("a", "b")
     )
     multipartitions_subset = multipartitions_def.empty_subset().with_partition_keys(
         {
@@ -102,12 +104,14 @@ def test_get_downstream_partitions_multiple_keys_in_range():
 
     result = MultiToSingleDimensionPartitionMapping().get_downstream_partitions_for_partitions(
         upstream_partitions_subset=single_dimension_subset,
+        upstream_partitions_def=single_dimension_def,
         downstream_partitions_def=multipartitions_def,
     )
     assert result == multipartitions_subset
 
     result = MultiToSingleDimensionPartitionMapping().get_downstream_partitions_for_partitions(
         upstream_partitions_subset=multipartitions_subset,
+        upstream_partitions_def=multipartitions_def,
         downstream_partitions_def=single_dimension_def,
     )
     assert result == single_dimension_subset
@@ -127,17 +131,19 @@ weekly_multipartitions_def = MultiPartitionsDefinition(
 
 
 @pytest.mark.parametrize(
-    "upstream_partitions_def,upstream_partitions_subset,downstream_partitions_subset",
+    "upstream_partitions_def,upstream_partitions_subset,downstream_partitions_subset,downstream_partitions_def",
     [
         (
             static_partitions_def,
             static_partitions_def.empty_subset().with_partition_keys({"a"}),
             static_multipartitions_def.empty_subset().with_partition_key_range(
+                static_multipartitions_def,
                 PartitionKeyRange(
                     MultiPartitionKey({"abc": "a", "123": "1"}),
                     MultiPartitionKey({"abc": "a", "123": "1"}),
-                )
+                ),
             ),
+            static_multipartitions_def,
         ),
         (
             static_partitions_def,
@@ -148,6 +154,7 @@ weekly_multipartitions_def = MultiPartitionsDefinition(
                     MultiPartitionKey({"abc": "a", "123": "2"}),
                 }
             ),
+            static_multipartitions_def,
         ),
         (
             static_multipartitions_def,
@@ -159,6 +166,7 @@ weekly_multipartitions_def = MultiPartitionsDefinition(
                 }
             ),
             static_partitions_def.empty_subset().with_partition_keys({"a"}),
+            static_partitions_def,
         ),
         (
             static_multipartitions_def,
@@ -173,12 +181,17 @@ weekly_multipartitions_def = MultiPartitionsDefinition(
                 }
             ),
             static_partitions_def.empty_subset().with_partition_keys({"a", "b"}),
+            static_partitions_def,
         ),
         (
             daily_partitions_def,
             daily_partitions_def.empty_subset()
-            .with_partition_key_range(PartitionKeyRange(start="2023-01-08", end="2023-01-14"))
-            .with_partition_key_range(PartitionKeyRange(start="2023-01-29", end="2023-02-04")),
+            .with_partition_key_range(
+                daily_partitions_def, PartitionKeyRange(start="2023-01-08", end="2023-01-14")
+            )
+            .with_partition_key_range(
+                daily_partitions_def, PartitionKeyRange(start="2023-01-29", end="2023-02-04")
+            ),
             weekly_multipartitions_def.empty_subset().with_partition_keys(
                 {
                     MultiPartitionKey({"ab": "a", "week": "2023-01-08"}),
@@ -187,6 +200,7 @@ weekly_multipartitions_def = MultiPartitionsDefinition(
                     MultiPartitionKey({"ab": "b", "week": "2023-01-29"}),
                 }
             ),
+            weekly_multipartitions_def,
         ),
     ],
 )
@@ -194,11 +208,13 @@ def test_get_upstream_single_dimension_to_multi_partition_mapping(
     upstream_partitions_def,
     upstream_partitions_subset,
     downstream_partitions_subset,
+    downstream_partitions_def,
 ):
     assert (
         MultiToSingleDimensionPartitionMapping()
         .get_upstream_mapped_partitions_result_for_partitions(
             downstream_partitions_subset,
+            downstream_partitions_def,
             upstream_partitions_def,
         )
         .partitions_subset
@@ -219,38 +235,44 @@ def test_error_thrown_when_no_partition_dimension_name_provided():
     with pytest.raises(CheckError, match="dimension name must be specified"):
         MultiToSingleDimensionPartitionMapping().get_upstream_mapped_partitions_result_for_partitions(
             multipartitions_def.empty_subset().with_partition_key_range(
+                multipartitions_def,
                 PartitionKeyRange(
                     MultiPartitionKey({"a": "1", "b": "1"}),
                     MultiPartitionKey({"a": "1", "b": "1"}),
-                )
+                ),
             ),
+            multipartitions_def,
             single_dimension_def,
         )
 
     with pytest.raises(CheckError, match="dimension name must be specified"):
         MultiToSingleDimensionPartitionMapping().get_downstream_partitions_for_partitions(
             multipartitions_def.empty_subset().with_partition_key_range(
+                multipartitions_def,
                 PartitionKeyRange(
                     MultiPartitionKey({"a": "1", "b": "1"}),
                     MultiPartitionKey({"a": "1", "b": "1"}),
-                )
+                ),
             ),
+            multipartitions_def,
             single_dimension_def,
         )
 
     with pytest.raises(CheckError, match="dimension name must be specified"):
         MultiToSingleDimensionPartitionMapping().get_upstream_mapped_partitions_result_for_partitions(
             single_dimension_def.empty_subset().with_partition_key_range(
-                PartitionKeyRange("1", "1")
+                single_dimension_def, PartitionKeyRange("1", "1")
             ),
+            single_dimension_def,
             multipartitions_def,
         )
 
     with pytest.raises(CheckError, match="dimension name must be specified"):
         MultiToSingleDimensionPartitionMapping().get_downstream_partitions_for_partitions(
             single_dimension_def.empty_subset().with_partition_key_range(
-                PartitionKeyRange("1", "1")
+                single_dimension_def, PartitionKeyRange("1", "1")
             ),
+            single_dimension_def,
             multipartitions_def,
         )
 
@@ -629,6 +651,7 @@ def test_multipartitions_mapping_get_upstream_partitions(
 ):
     result = partitions_mapping.get_upstream_mapped_partitions_result_for_partitions(
         downstream_partitions_def.empty_subset().with_partition_keys(downstream_partition_keys),
+        downstream_partitions_def,
         upstream_partitions_def,
     )
     assert result.partitions_subset.get_partition_keys() == set(upstream_partition_keys)
@@ -665,6 +688,7 @@ def test_multipartitions_required_but_invalid_upstream_partitions():
                 MultiPartitionKey({"time": "2023-06-01", "123": "1"}),
             ]
         ),
+        may_multipartitions_def,
         june_multipartitions_def,
     )
     assert result.partitions_subset.get_partition_keys() == set(
@@ -689,6 +713,7 @@ def test_multipartitions_mapping_get_downstream_partitions(
 ):
     assert partitions_mapping.get_downstream_partitions_for_partitions(
         upstream_partitions_def.empty_subset().with_partition_keys(upstream_partition_keys),
+        upstream_partitions_def,
         downstream_partitions_def,
     ).get_partition_keys() == set(downstream_partition_keys)
 
@@ -715,6 +740,7 @@ def test_multipartitions_mapping_dynamic():
             downstream_partitions_def.empty_subset().with_partition_keys(
                 [MultiPartitionKey({"dynamic": "a", "123": "1"})]
             ),
+            downstream_partitions_def,
             upstream_partitions_def,
             dynamic_partitions_store=instance,
         )
@@ -749,7 +775,9 @@ def test_error_multipartitions_mapping():
                     "other nonexistent dimension", SpecificPartitionsPartitionMapping(["c"])
                 )
             }
-        ).get_upstream_mapped_partitions_result_for_partitions(weekly_abc.empty_subset(), daily_123)
+        ).get_upstream_mapped_partitions_result_for_partitions(
+            weekly_abc.empty_subset(), weekly_abc, daily_123
+        )
 
 
 def test_multi_partition_mapping_with_asset_deps():

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_static_partition_mapping.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_static_partition_mapping.py
@@ -16,19 +16,21 @@ def test_single_valued_static_mapping():
         upstream_partitions_subset=upstream_parts.empty_subset().with_partition_keys(
             ["p1", "p3", "q2", "r1"]
         ),
+        upstream_partitions_def=upstream_parts,
         downstream_partitions_def=downstream_parts,
     )
 
-    assert result == DefaultPartitionsSubset(downstream_parts, {"p", "r"})
+    assert result == DefaultPartitionsSubset({"p", "r"})
 
     result = mapping.get_upstream_mapped_partitions_result_for_partitions(
         downstream_partitions_subset=downstream_parts.empty_subset().with_partition_keys(
             ["p", "q"]
         ),
+        downstream_partitions_def=downstream_parts,
         upstream_partitions_def=upstream_parts,
     )
 
-    assert result.partitions_subset == DefaultPartitionsSubset(upstream_parts, {"p1", "p2", "p3"})
+    assert result.partitions_subset == DefaultPartitionsSubset({"p1", "p2", "p3"})
 
 
 def test_multi_valued_static_mapping():
@@ -39,19 +41,21 @@ def test_multi_valued_static_mapping():
 
     result = mapping.get_downstream_partitions_for_partitions(
         upstream_partitions_subset=upstream_parts.empty_subset().with_partition_keys(["p", "r"]),
+        upstream_partitions_def=upstream_parts,
         downstream_partitions_def=downstream_parts,
     )
 
-    assert result == DefaultPartitionsSubset(downstream_parts, {"p1", "p2", "p3"})
+    assert result == DefaultPartitionsSubset({"p1", "p2", "p3"})
 
     result = mapping.get_upstream_mapped_partitions_result_for_partitions(
         downstream_partitions_subset=downstream_parts.empty_subset().with_partition_keys(
             ["p2", "p3", "q"]
         ),
+        downstream_partitions_def=downstream_parts,
         upstream_partitions_def=upstream_parts,
     )
 
-    assert result.partitions_subset == DefaultPartitionsSubset(upstream_parts, {"p", "q1", "q2"})
+    assert result.partitions_subset == DefaultPartitionsSubset({"p", "q1", "q2"})
 
 
 def test_error_on_extra_keys_in_mapping():
@@ -63,6 +67,7 @@ def test_error_on_extra_keys_in_mapping():
             {"p": "p", "q": {"q", "OTHER"}}
         ).get_downstream_partitions_for_partitions(
             upstream_partitions_subset=upstream_parts.empty_subset(),
+            upstream_partitions_def=upstream_parts,
             downstream_partitions_def=downstream_parts,
         )
 
@@ -71,6 +76,7 @@ def test_error_on_extra_keys_in_mapping():
             {"p": "p", "q": "q", "OTHER": "q"}
         ).get_upstream_mapped_partitions_result_for_partitions(
             downstream_partitions_subset=downstream_parts.empty_subset(),
+            downstream_partitions_def=downstream_parts,
             upstream_partitions_def=upstream_parts,
         )
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_time_window_partition_mapping.py
@@ -30,6 +30,7 @@ def test_get_upstream_partitions_for_partition_range_same_partitioning():
     # single partition key
     result = TimeWindowPartitionMapping().get_upstream_mapped_partitions_result_for_partitions(
         subset_with_keys(downstream_partitions_def, ["2021-05-07"]),
+        downstream_partitions_def,
         upstream_partitions_def,
     )
     assert result.partitions_subset == upstream_partitions_def.empty_subset().with_partition_keys(
@@ -39,6 +40,7 @@ def test_get_upstream_partitions_for_partition_range_same_partitioning():
     # range of partition keys
     result = TimeWindowPartitionMapping().get_upstream_mapped_partitions_result_for_partitions(
         subset_with_key_range(downstream_partitions_def, "2021-05-07", "2021-05-09"),
+        downstream_partitions_def,
         upstream_partitions_def,
     )
     assert result.partitions_subset == subset_with_key_range(
@@ -52,6 +54,7 @@ def test_get_upstream_partitions_for_partition_range_same_partitioning_different
 
     result = TimeWindowPartitionMapping().get_upstream_mapped_partitions_result_for_partitions(
         subset_with_key_range(downstream_partitions_def, "2021-05-07", "2021-05-09"),
+        downstream_partitions_def,
         upstream_partitions_def,
     )
     assert result.partitions_subset == subset_with_key_range(
@@ -70,6 +73,7 @@ def test_get_upstream_partitions_for_partition_range_hourly_downstream_daily_ups
     upstream_partitions_def = DailyPartitionsDefinition(start_date="2021-05-05")
     result = TimeWindowPartitionMapping().get_upstream_mapped_partitions_result_for_partitions(
         subset_with_keys(downstream_partitions_def, ["2021-05-07-05:00"]),
+        downstream_partitions_def,
         upstream_partitions_def,
     )
     assert result.partitions_subset == upstream_partitions_def.empty_subset().with_partition_keys(
@@ -78,6 +82,7 @@ def test_get_upstream_partitions_for_partition_range_hourly_downstream_daily_ups
 
     result = TimeWindowPartitionMapping().get_upstream_mapped_partitions_result_for_partitions(
         subset_with_key_range(downstream_partitions_def, "2021-05-07-05:00", "2021-05-09-09:00"),
+        downstream_partitions_def,
         upstream_partitions_def,
     )
     assert (
@@ -93,6 +98,7 @@ def test_get_upstream_partitions_for_partition_range_daily_downstream_hourly_ups
     upstream_partitions_def = HourlyPartitionsDefinition(start_date="2021-05-05-00:00")
     result = TimeWindowPartitionMapping().get_upstream_mapped_partitions_result_for_partitions(
         subset_with_keys(downstream_partitions_def, ["2021-05-07"]),
+        downstream_partitions_def,
         upstream_partitions_def,
     )
     assert (
@@ -104,6 +110,7 @@ def test_get_upstream_partitions_for_partition_range_daily_downstream_hourly_ups
 
     result = TimeWindowPartitionMapping().get_upstream_mapped_partitions_result_for_partitions(
         subset_with_key_range(downstream_partitions_def, "2021-05-07", "2021-05-09"),
+        downstream_partitions_def,
         upstream_partitions_def,
     )
     assert (
@@ -119,6 +126,7 @@ def test_get_upstream_partitions_for_partition_range_monthly_downstream_daily_up
     upstream_partitions_def = DailyPartitionsDefinition(start_date="2021-05-01")
     result = TimeWindowPartitionMapping().get_upstream_mapped_partitions_result_for_partitions(
         subset_with_key_range(downstream_partitions_def, "2021-05-01", "2021-07-01"),
+        downstream_partitions_def,
         upstream_partitions_def,
     )
     assert (
@@ -139,6 +147,7 @@ def test_get_upstream_partitions_for_partition_range_twice_daily_downstream_dail
     )
     result = TimeWindowPartitionMapping().get_upstream_mapped_partitions_result_for_partitions(
         subset_with_key_range(downstream_partitions_def, "2021-05-01", "2021-05-03"),
+        downstream_partitions_def,
         upstream_partitions_def,
     )
     assert (
@@ -159,6 +168,7 @@ def test_get_upstream_partitions_for_partition_range_daily_downstream_twice_dail
     )
     result = TimeWindowPartitionMapping().get_upstream_mapped_partitions_result_for_partitions(
         subset_with_key_range(downstream_partitions_def, "2021-05-01 00:00", "2021-05-03 00:00"),
+        downstream_partitions_def,
         upstream_partitions_def,
     )
     assert (
@@ -179,6 +189,7 @@ def test_get_upstream_partitions_for_partition_range_daily_non_aligned():
     )
     result = TimeWindowPartitionMapping().get_upstream_mapped_partitions_result_for_partitions(
         subset_with_key_range(downstream_partitions_def, "2021-05-02", "2021-05-04"),
+        downstream_partitions_def,
         upstream_partitions_def,
     )
     assert (
@@ -197,6 +208,7 @@ def test_get_upstream_partitions_for_partition_range_weekly_with_offset():
     result = TimeWindowPartitionMapping().get_upstream_mapped_partitions_result_for_partitions(
         subset_with_key_range(partitions_def, "2022-09-11", "2022-09-11"),
         partitions_def,
+        partitions_def,
     )
     assert result.partitions_subset.get_partition_keys() == (
         partitions_def.get_partition_keys_in_range(PartitionKeyRange("2022-09-11", "2022-09-11"))
@@ -211,17 +223,23 @@ def test_daily_to_daily_lag():
 
     # single partition key
     assert mapping.get_upstream_mapped_partitions_result_for_partitions(
-        subset_with_keys(downstream_partitions_def, ["2021-05-07"]), upstream_partitions_def
+        subset_with_keys(downstream_partitions_def, ["2021-05-07"]),
+        downstream_partitions_def,
+        upstream_partitions_def,
     ).partitions_subset.get_partition_keys() == ["2021-05-06"]
 
     assert mapping.get_downstream_partitions_for_partitions(
-        subset_with_keys(upstream_partitions_def, ["2021-05-06"]), downstream_partitions_def
+        subset_with_keys(upstream_partitions_def, ["2021-05-06"]),
+        upstream_partitions_def,
+        downstream_partitions_def,
     ).get_partition_keys() == ["2021-05-07"]
 
     # first partition key
     assert (
         mapping.get_upstream_mapped_partitions_result_for_partitions(
-            subset_with_keys(downstream_partitions_def, ["2021-05-05"]), upstream_partitions_def
+            subset_with_keys(downstream_partitions_def, ["2021-05-05"]),
+            downstream_partitions_def,
+            upstream_partitions_def,
         ).partitions_subset.get_partition_keys()
         == []
     )
@@ -229,17 +247,20 @@ def test_daily_to_daily_lag():
     # range of partition keys
     assert mapping.get_upstream_mapped_partitions_result_for_partitions(
         subset_with_key_range(downstream_partitions_def, "2021-05-07", "2021-05-09"),
+        downstream_partitions_def,
         upstream_partitions_def,
     ).partitions_subset.get_partition_keys() == ["2021-05-06", "2021-05-07", "2021-05-08"]
 
     assert mapping.get_downstream_partitions_for_partitions(
-        subset_with_key_range(downstream_partitions_def, "2021-05-06", "2021-05-08"),
+        subset_with_key_range(upstream_partitions_def, "2021-05-06", "2021-05-08"),
+        upstream_partitions_def,
         downstream_partitions_def,
     ).get_partition_keys() == ["2021-05-07", "2021-05-08", "2021-05-09"]
 
     # range overlaps start
     assert mapping.get_upstream_mapped_partitions_result_for_partitions(
         subset_with_key_range(downstream_partitions_def, "2021-05-05", "2021-05-07"),
+        downstream_partitions_def,
         upstream_partitions_def,
     ).partitions_subset.get_partition_keys() == ["2021-05-05", "2021-05-06"]
 
@@ -252,17 +273,23 @@ def test_exotic_cron_schedule_lag():
     mapping = TimeWindowPartitionMapping(start_offset=-1, end_offset=-1)
     # single partition key
     assert mapping.get_upstream_mapped_partitions_result_for_partitions(
-        subset_with_keys(downstream_partitions_def, ["2021-05-06_04"]), upstream_partitions_def
+        subset_with_keys(downstream_partitions_def, ["2021-05-06_04"]),
+        downstream_partitions_def,
+        upstream_partitions_def,
     ).partitions_subset.get_partition_keys() == ["2021-05-06_00"]
 
     assert mapping.get_downstream_partitions_for_partitions(
-        subset_with_keys(upstream_partitions_def, ["2021-05-06_00"]), downstream_partitions_def
+        subset_with_keys(upstream_partitions_def, ["2021-05-06_00"]),
+        upstream_partitions_def,
+        downstream_partitions_def,
     ).get_partition_keys() == ["2021-05-06_04"]
 
     # first partition key
     assert (
         mapping.get_upstream_mapped_partitions_result_for_partitions(
-            subset_with_keys(downstream_partitions_def, ["2021-05-05_00"]), upstream_partitions_def
+            subset_with_keys(downstream_partitions_def, ["2021-05-05_00"]),
+            downstream_partitions_def,
+            upstream_partitions_def,
         ).partitions_subset.get_partition_keys()
         == []
     )
@@ -270,17 +297,20 @@ def test_exotic_cron_schedule_lag():
     # range of partition keys
     assert mapping.get_upstream_mapped_partitions_result_for_partitions(
         subset_with_key_range(downstream_partitions_def, "2021-05-07_04", "2021-05-07_12"),
+        downstream_partitions_def,
         upstream_partitions_def,
     ).partitions_subset.get_partition_keys() == ["2021-05-07_00", "2021-05-07_04", "2021-05-07_08"]
 
     assert mapping.get_downstream_partitions_for_partitions(
-        subset_with_key_range(downstream_partitions_def, "2021-05-07_04", "2021-05-07_12"),
+        subset_with_key_range(upstream_partitions_def, "2021-05-07_04", "2021-05-07_12"),
+        upstream_partitions_def,
         downstream_partitions_def,
     ).get_partition_keys() == ["2021-05-07_08", "2021-05-07_12", "2021-05-07_16"]
 
     # range overlaps start
     assert mapping.get_upstream_mapped_partitions_result_for_partitions(
         subset_with_key_range(downstream_partitions_def, "2021-05-05_00", "2021-05-05_08"),
+        downstream_partitions_def,
         upstream_partitions_def,
     ).partitions_subset.get_partition_keys() == ["2021-05-05_00", "2021-05-05_04"]
 
@@ -291,11 +321,15 @@ def test_daily_to_daily_lag_different_start_date():
     mapping = TimeWindowPartitionMapping(start_offset=-1, end_offset=-1)
 
     assert mapping.get_upstream_mapped_partitions_result_for_partitions(
-        subset_with_keys(downstream_partitions_def, ["2021-05-06"]), upstream_partitions_def
+        subset_with_keys(downstream_partitions_def, ["2021-05-06"]),
+        downstream_partitions_def,
+        upstream_partitions_def,
     ).partitions_subset.get_partition_keys() == ["2021-05-05"]
 
     assert mapping.get_downstream_partitions_for_partitions(
-        subset_with_keys(upstream_partitions_def, ["2021-05-05"]), downstream_partitions_def
+        subset_with_keys(upstream_partitions_def, ["2021-05-05"]),
+        upstream_partitions_def,
+        downstream_partitions_def,
     ).get_partition_keys() == ["2021-05-06"]
 
 
@@ -305,25 +339,33 @@ def test_daily_to_daily_many_to_one():
     mapping = TimeWindowPartitionMapping(start_offset=-1)
 
     assert mapping.get_upstream_mapped_partitions_result_for_partitions(
-        subset_with_keys(downstream_partitions_def, ["2022-07-04"]), upstream_partitions_def
+        subset_with_keys(downstream_partitions_def, ["2022-07-04"]),
+        downstream_partitions_def,
+        upstream_partitions_def,
     ).partitions_subset.get_partition_keys() == ["2022-07-03", "2022-07-04"]
 
     assert mapping.get_upstream_mapped_partitions_result_for_partitions(
         subset_with_keys(downstream_partitions_def, ["2022-07-04", "2022-07-05"]),
+        downstream_partitions_def,
         upstream_partitions_def,
     ).partitions_subset.get_partition_keys() == ["2022-07-03", "2022-07-04", "2022-07-05"]
 
     assert mapping.get_downstream_partitions_for_partitions(
         subset_with_keys(upstream_partitions_def, ["2022-07-03", "2022-07-04"]),
+        upstream_partitions_def,
         downstream_partitions_def,
     ).get_partition_keys() == ["2022-07-03", "2022-07-04", "2022-07-05"]
 
     assert mapping.get_downstream_partitions_for_partitions(
-        subset_with_keys(upstream_partitions_def, ["2022-07-03"]), downstream_partitions_def
+        subset_with_keys(upstream_partitions_def, ["2022-07-03"]),
+        upstream_partitions_def,
+        downstream_partitions_def,
     ).get_partition_keys() == ["2022-07-03", "2022-07-04"]
 
     assert mapping.get_downstream_partitions_for_partitions(
-        subset_with_keys(upstream_partitions_def, ["2022-07-04"]), downstream_partitions_def
+        subset_with_keys(upstream_partitions_def, ["2022-07-04"]),
+        upstream_partitions_def,
+        downstream_partitions_def,
     ).get_partition_keys() == ["2022-07-04", "2022-07-05"]
 
 
@@ -385,6 +427,7 @@ def test_get_downstream_with_current_time(
     assert (
         mapping.get_downstream_partitions_for_partitions(
             subset_with_keys(upstream_partitions_def, upstream_keys),
+            upstream_partitions_def,
             downstream_partitions_def,
             current_time=current_time,
         ).get_partition_keys()
@@ -489,6 +532,7 @@ def test_get_upstream_with_current_time(
 
     upstream_partitions_result = mapping.get_upstream_mapped_partitions_result_for_partitions(
         subset_with_keys(downstream_partitions_def, downstream_keys),
+        downstream_partitions_def,
         upstream_partitions_def,
         current_time=current_time,
     )
@@ -508,6 +552,7 @@ def test_different_start_time_partitions_defs():
         TimeWindowPartitionMapping()
         .get_downstream_partitions_for_partitions(
             upstream_partitions_subset=subset_with_keys(jan_start, ["2023-01-15"]),
+            upstream_partitions_def=jan_start,
             downstream_partitions_def=feb_start,
         )
         .get_partition_keys()
@@ -517,6 +562,7 @@ def test_different_start_time_partitions_defs():
     upstream_partitions_result = (
         TimeWindowPartitionMapping().get_upstream_mapped_partitions_result_for_partitions(
             downstream_partitions_subset=subset_with_keys(jan_start, ["2023-01-15"]),
+            downstream_partitions_def=jan_start,
             upstream_partitions_def=feb_start,
         )
     )
@@ -530,6 +576,7 @@ def test_different_end_time_partitions_defs():
 
     assert TimeWindowPartitionMapping().get_downstream_partitions_for_partitions(
         upstream_partitions_subset=subset_with_keys(jan_partitions_def, ["2023-01-15"]),
+        upstream_partitions_def=jan_partitions_def,
         downstream_partitions_def=jan_feb_partitions_def,
     ).get_partition_keys() == ["2023-01-15"]
 
@@ -537,6 +584,7 @@ def test_different_end_time_partitions_defs():
         TimeWindowPartitionMapping()
         .get_downstream_partitions_for_partitions(
             upstream_partitions_subset=subset_with_keys(jan_feb_partitions_def, ["2023-02-15"]),
+            upstream_partitions_def=jan_feb_partitions_def,
             downstream_partitions_def=jan_partitions_def,
         )
         .get_partition_keys()
@@ -546,6 +594,7 @@ def test_different_end_time_partitions_defs():
     upstream_partitions_result = (
         TimeWindowPartitionMapping().get_upstream_mapped_partitions_result_for_partitions(
             downstream_partitions_subset=subset_with_keys(jan_feb_partitions_def, ["2023-02-15"]),
+            downstream_partitions_def=jan_feb_partitions_def,
             upstream_partitions_def=jan_partitions_def,
         )
     )
@@ -566,6 +615,7 @@ def test_daily_upstream_of_yearly():
         allow_nonexistent_upstream_partitions=True
     ).get_upstream_mapped_partitions_result_for_partitions(
         downstream_partitions_subset=subset_with_keys(yearly, ["2023-01-01"]),
+        downstream_partitions_def=yearly,
         upstream_partitions_def=daily,
         current_time=datetime(2023, 1, 5, 0),
     ).partitions_subset.get_partition_keys() == [
@@ -633,6 +683,7 @@ def test_downstream_partition_has_valid_upstream_partitions(
         allow_nonexistent_upstream_partitions=allow_nonexistent_upstream_partitions
     ).get_upstream_mapped_partitions_result_for_partitions(
         downstream_partitions_subset=downstream_partitions_subset,
+        downstream_partitions_def=downstream_partitions_subset.partitions_def,
         upstream_partitions_def=upstream_partitions_def,
         current_time=current_time,
     )

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_time_window_partition_mapping.py
@@ -11,7 +11,7 @@ from dagster import (
     WeeklyPartitionsDefinition,
 )
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
-from dagster._core.definitions.time_window_partitions import TimeWindowPartitionsSubset
+from dagster._core.definitions.time_window_partitions import BaseTimeWindowPartitionsSubset
 
 
 def subset_with_keys(partitions_def: TimeWindowPartitionsDefinition, keys: Sequence[str]):
@@ -622,7 +622,7 @@ def test_daily_upstream_of_yearly():
     ],
 )
 def test_downstream_partition_has_valid_upstream_partitions(
-    downstream_partitions_subset: TimeWindowPartitionsSubset,
+    downstream_partitions_subset: BaseTimeWindowPartitionsSubset,
     upstream_partitions_def: TimeWindowPartitionsDefinition,
     allow_nonexistent_upstream_partitions: bool,
     current_time: datetime,

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_time_window_partition_mapping.py
@@ -683,7 +683,7 @@ def test_downstream_partition_has_valid_upstream_partitions(
         allow_nonexistent_upstream_partitions=allow_nonexistent_upstream_partitions
     ).get_upstream_mapped_partitions_result_for_partitions(
         downstream_partitions_subset=downstream_partitions_subset,
-        downstream_partitions_def=downstream_partitions_subset.partitions_def,
+        downstream_partitions_def=downstream_partitions_subset.get_partitions_def(),
         upstream_partitions_def=upstream_partitions_def,
         current_time=current_time,
     )

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
@@ -213,6 +213,7 @@ def test_custom_unsupported_partition_mapping():
         def get_upstream_mapped_partitions_result_for_partitions(
             self,
             downstream_partitions_subset: Optional[PartitionsSubset],
+            downstream_partitions_def: Optional[PartitionsDefinition],
             upstream_partitions_def: PartitionsDefinition,
             current_time: Optional[datetime] = None,
             dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
@@ -223,7 +224,8 @@ def test_custom_unsupported_partition_mapping():
             partition_keys = list(downstream_partitions_subset.get_partition_keys())
             return UpstreamPartitionsResult(
                 upstream_partitions_def.empty_subset().with_partition_key_range(
-                    PartitionKeyRange(str(max(1, int(partition_keys[0]) - 1)), partition_keys[-1])
+                    upstream_partitions_def,
+                    PartitionKeyRange(str(max(1, int(partition_keys[0]) - 1)), partition_keys[-1]),
                 ),
                 [],
             )
@@ -231,6 +233,7 @@ def test_custom_unsupported_partition_mapping():
         def get_downstream_partitions_for_partitions(
             self,
             upstream_partitions_subset: PartitionsSubset,
+            upstream_partitions_def: PartitionsDefinition,
             downstream_partitions_def: PartitionsDefinition,
             current_time: Optional[datetime] = None,
             dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
@@ -405,7 +408,8 @@ def test_bfs_filter_asset_subsets(asset_graph_from_assets):
         asset_graph,
         partitions_subsets_by_asset_key={
             asset3.key: asset3.partitions_def.empty_subset().with_partition_key_range(
-                PartitionKeyRange("2022-01-02-00:00", "2022-01-03-23:00")
+                asset3.partitions_def,
+                PartitionKeyRange("2022-01-02-00:00", "2022-01-03-23:00"),
             ),
         },
     )

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
@@ -71,10 +71,13 @@ def get_upstream_partitions_for_partition_range(
     upstream_partitions_subset = (
         downstream_partition_mapping.get_upstream_mapped_partitions_result_for_partitions(
             downstream_partitions_subset,
+            downstream_partitions_def,
             upstream_partitions_def,
         ).partitions_subset
     )
-    upstream_key_ranges = upstream_partitions_subset.get_partition_key_ranges()
+    upstream_key_ranges = upstream_partitions_subset.get_partition_key_ranges(
+        upstream_partitions_def
+    )
     check.invariant(len(upstream_key_ranges) == 1)
     return upstream_key_ranges[0]
 
@@ -101,10 +104,13 @@ def get_downstream_partitions_for_partition_range(
     downstream_partitions_subset = (
         downstream_partition_mapping.get_downstream_partitions_for_partitions(
             upstream_partitions_subset,
+            upstream_partitions_def,
             downstream_assets_def.partitions_def,
         )
     )
-    downstream_key_ranges = downstream_partitions_subset.get_partition_key_ranges()
+    downstream_key_ranges = downstream_partitions_subset.get_partition_key_ranges(
+        downstream_assets_def.partitions_def
+    )
     check.invariant(len(downstream_key_ranges) == 1)
     return downstream_key_ranges[0]
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitions_subset.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitions_subset.py
@@ -3,6 +3,7 @@ from dagster import DailyPartitionsDefinition, MultiPartitionsDefinition, Static
 from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionsSubset
 from dagster._core.definitions.partition import DefaultPartitionsSubset
 from dagster._core.definitions.time_window_partitions import (
+    BaseTimeWindowPartitionsSubset,
     TimeWindowPartitionsSubset,
 )
 from dagster._core.errors import DagsterInvalidDeserializationVersionError
@@ -77,4 +78,4 @@ def test_get_subset_type():
 def test_empty_subsets():
     assert type(composite.empty_subset()) is MultiPartitionsSubset
     assert type(static_partitions.empty_subset()) is DefaultPartitionsSubset
-    assert type(time_window_partitions.empty_subset()) is TimeWindowPartitionsSubset
+    assert type(time_window_partitions.empty_subset()) is BaseTimeWindowPartitionsSubset

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitions_subset.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitions_subset.py
@@ -3,8 +3,8 @@ from dagster import DailyPartitionsDefinition, MultiPartitionsDefinition, Static
 from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionsSubset
 from dagster._core.definitions.partition import DefaultPartitionsSubset
 from dagster._core.definitions.time_window_partitions import (
-    BaseTimeWindowPartitionsSubset,
     TimeWindowPartitionsSubset,
+    UnresolvedTimeWindowPartitionsSubset,
 )
 from dagster._core.errors import DagsterInvalidDeserializationVersionError
 
@@ -78,4 +78,4 @@ def test_get_subset_type():
 def test_empty_subsets():
     assert type(composite.empty_subset()) is MultiPartitionsSubset
     assert type(static_partitions.empty_subset()) is DefaultPartitionsSubset
-    assert type(time_window_partitions.empty_subset()) is BaseTimeWindowPartitionsSubset
+    assert type(time_window_partitions.empty_subset()) is UnresolvedTimeWindowPartitionsSubset

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitions_subset.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitions_subset.py
@@ -3,8 +3,8 @@ from dagster import DailyPartitionsDefinition, MultiPartitionsDefinition, Static
 from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionsSubset
 from dagster._core.definitions.partition import DefaultPartitionsSubset
 from dagster._core.definitions.time_window_partitions import (
+    TimePartitionKeyPartitionsSubset,
     TimeWindowPartitionsSubset,
-    UnresolvedTimeWindowPartitionsSubset,
 )
 from dagster._core.errors import DagsterInvalidDeserializationVersionError
 
@@ -78,4 +78,4 @@ def test_get_subset_type():
 def test_empty_subsets():
     assert type(composite.empty_subset()) is MultiPartitionsSubset
     assert type(static_partitions.empty_subset()) is DefaultPartitionsSubset
-    assert type(time_window_partitions.empty_subset()) is UnresolvedTimeWindowPartitionsSubset
+    assert type(time_window_partitions.empty_subset()) is TimePartitionKeyPartitionsSubset

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitions_subset.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitions_subset.py
@@ -1,6 +1,5 @@
 import pytest
 from dagster import DailyPartitionsDefinition, MultiPartitionsDefinition, StaticPartitionsDefinition
-from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionsSubset
 from dagster._core.definitions.partition import DefaultPartitionsSubset
 from dagster._core.definitions.time_window_partitions import (
     TimePartitionKeyPartitionsSubset,
@@ -76,6 +75,5 @@ def test_get_subset_type():
 
 
 def test_empty_subsets():
-    assert type(composite.empty_subset()) is MultiPartitionsSubset
     assert type(static_partitions.empty_subset()) is DefaultPartitionsSubset
     assert type(time_window_partitions.empty_subset()) is TimePartitionKeyPartitionsSubset

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
@@ -1389,7 +1389,9 @@ def test_asset_backfill_unpartitioned_downstream_of_partitioned():
     )
 
     assert asset_backfill_data.target_subset.partitions_subsets_by_asset_key == {
-        foo.key: foo_partitions_def.empty_subset().with_partition_key_range(partition_key_range),
+        foo.key: foo_partitions_def.empty_subset().with_partition_key_range(
+            foo_partitions_def, partition_key_range
+        ),
         foo_child.key: foo_partitions_def.empty_subset().with_partition_key_range(
             partition_key_range
         ),

--- a/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_partition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_partition.py
@@ -142,10 +142,10 @@ def test_static_partitions_subset():
     assert len(subset) == 0
     assert "bar" not in subset
     with_some_partitions = subset.with_partition_keys(["foo", "bar"])
-    assert with_some_partitions.get_partition_keys_not_in_subset() == {"baz", "qux"}
+    assert with_some_partitions.get_partition_keys_not_in_subset(partitions) == {"baz", "qux"}
     serialized = with_some_partitions.serialize()
     deserialized = partitions.deserialize_subset(serialized)
-    assert deserialized.get_partition_keys_not_in_subset() == {"baz", "qux"}
+    assert deserialized.get_partition_keys_not_in_subset(partitions) == {"baz", "qux"}
     assert len(with_some_partitions) == 2
     assert len(deserialized) == 2
     assert "bar" in with_some_partitions

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
@@ -165,7 +165,10 @@ class AssetReconciliationScenario(
             ("cursor_from", Optional["AssetReconciliationScenario"]),
             ("current_time", Optional[datetime.datetime]),
             ("asset_selection", Optional[AssetSelection]),
-            ("active_backfill_targets", Optional[Sequence[Mapping[AssetKey, PartitionsSubset]]]),
+            (
+                "active_backfill_targets",
+                Optional[Sequence[Union[Mapping[AssetKey, PartitionsSubset], Sequence[AssetKey]]]],
+            ),
             ("dagster_runs", Optional[Sequence[DagsterRun]]),
             ("event_log_entries", Optional[Sequence[EventLogEntry]]),
             ("expected_run_requests", Optional[Sequence[RunRequest]]),
@@ -189,7 +192,9 @@ class AssetReconciliationScenario(
         cursor_from: Optional["AssetReconciliationScenario"] = None,
         current_time: Optional[datetime.datetime] = None,
         asset_selection: Optional[AssetSelection] = None,
-        active_backfill_targets: Optional[Sequence[Mapping[AssetKey, PartitionsSubset]]] = None,
+        active_backfill_targets: Optional[
+            Sequence[Union[Mapping[AssetKey, PartitionsSubset], Sequence[AssetKey]]]
+        ] = None,
         dagster_runs: Optional[Sequence[DagsterRun]] = None,
         event_log_entries: Optional[Sequence[EventLogEntry]] = None,
         expected_run_requests: Optional[Sequence[RunRequest]] = None,
@@ -299,11 +304,18 @@ class AssetReconciliationScenario(
 
             # add any backfills to the instance
             for i, target in enumerate(self.active_backfill_targets or []):
-                target_subset = AssetGraphSubset(
-                    asset_graph=repo.asset_graph,
-                    partitions_subsets_by_asset_key=target,
-                    non_partitioned_asset_keys=set(),
-                )
+                if isinstance(target, Mapping):
+                    target_subset = AssetGraphSubset(
+                        asset_graph=repo.asset_graph,
+                        partitions_subsets_by_asset_key=target,
+                        non_partitioned_asset_keys=set(),
+                    )
+                else:
+                    target_subset = AssetGraphSubset(
+                        asset_graph=repo.asset_graph,
+                        partitions_subsets_by_asset_key={},
+                        non_partitioned_asset_keys=target,
+                    )
                 empty_subset = AssetGraphSubset(
                     asset_graph=repo.asset_graph,
                     partitions_subsets_by_asset_key={},

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/partition_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/partition_scenarios.py
@@ -131,19 +131,19 @@ partition_scenarios = {
         active_backfill_targets=[
             {
                 AssetKey("daily"): TimeWindowPartitionsSubset(
-                    daily_partitions_def, num_partitions=1, included_partition_keys={"2013-01-06"}
-                )
+                    daily_partitions_def
+                ).with_partition_keys(["2013-01-06"])
             },
             {
                 AssetKey("hourly"): TimeWindowPartitionsSubset(
-                    hourly_partitions_def,
-                    num_partitions=3,
-                    included_partition_keys={
+                    hourly_partitions_def
+                ).with_partition_keys(
+                    [
                         "2013-01-06-01:00",
                         "2013-01-06-02:00",
                         "2013-01-06-03:00",
-                    },
-                )
+                    ]
+                ),
             },
         ],
         current_time=create_pendulum_time(year=2013, month=1, day=7, hour=4),
@@ -160,24 +160,22 @@ partition_scenarios = {
         active_backfill_targets=[
             {
                 AssetKey("hourly"): TimeWindowPartitionsSubset(
-                    hourly_partitions_def,
-                    num_partitions=3,
-                    included_partition_keys={
+                    hourly_partitions_def
+                ).with_partition_keys(
+                    [
                         "2013-01-05-00:00",
                         "2013-01-05-01:00",
                         "2013-01-05-02:00",
-                    },
+                    ],
                 ),
             },
             {
                 AssetKey(
                     "non_existant_asset"  # ignored since can't be loaded
-                ): TimeWindowPartitionsSubset(
-                    hourly_partitions_def,
-                    num_partitions=1,
-                    included_partition_keys={
+                ): TimeWindowPartitionsSubset(hourly_partitions_def).with_partition_keys(
+                    [
                         "2013-01-05-00:00",
-                    },
+                    ],
                 ),
             },
         ],
@@ -195,23 +193,13 @@ partition_scenarios = {
         active_backfill_targets=[
             {
                 AssetKey("hourly"): TimeWindowPartitionsSubset(
-                    hourly_partitions_def,
-                    num_partitions=len(
-                        {
-                            partition_key
-                            for partition_key in hourly_partitions_def.get_partition_keys_in_range(
-                                PartitionKeyRange(start="2013-01-05-00:00", end="2013-01-07-03:00")
-                            )
-                        },
-                    ),
-                    included_partition_keys={
-                        partition_key
-                        for partition_key in hourly_partitions_def.get_partition_keys_in_range(
-                            PartitionKeyRange(start="2013-01-05-00:00", end="2013-01-07-03:00")
-                        )
-                    },
+                    hourly_partitions_def
+                ).with_partition_keys(
+                    hourly_partitions_def.get_partition_keys_in_range(
+                        PartitionKeyRange(start="2013-01-05-00:00", end="2013-01-07-03:00")
+                    )
                 )
-            },
+            }
         ],
         current_time=create_pendulum_time(year=2013, month=1, day=7, hour=4),
         expected_run_requests=[],
@@ -241,10 +229,8 @@ partition_scenarios = {
         active_backfill_targets=[
             {
                 AssetKey("hourly"): TimeWindowPartitionsSubset(
-                    hourly_partitions_def,
-                    num_partitions=1,
-                    included_partition_keys={"2013-01-05-04:00"},
-                )
+                    hourly_partitions_def
+                ).with_partition_keys(["2013-01-05-04:00"])
             }
         ],
         unevaluated_runs=[],
@@ -302,9 +288,7 @@ partition_scenarios = {
             {
                 AssetKey("hourly"): TimeWindowPartitionsSubset(
                     hourly_partitions_def,
-                    num_partitions=1,
-                    included_partition_keys={"2013-01-05-04:00"},
-                )
+                ).with_partition_keys(["2013-01-05-04:00"])
             }
         ],
         unevaluated_runs=[],

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/partition_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/partition_scenarios.py
@@ -169,6 +169,7 @@ partition_scenarios = {
                     ],
                 ),
             },
+<<<<<<< HEAD
             {
                 AssetKey(
                     "non_existant_asset"  # ignored since can't be loaded
@@ -178,6 +179,9 @@ partition_scenarios = {
                     ],
                 ),
             },
+=======
+            [AssetKey("non_existant_asset")],  # ignored since can't be loaded
+>>>>>>> 32cf1a8d2d (first stab)
         ],
         current_time=create_pendulum_time(year=2013, month=1, day=5, hour=17),
         expected_run_requests=[

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/partition_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/partition_scenarios.py
@@ -169,19 +169,7 @@ partition_scenarios = {
                     ],
                 ),
             },
-<<<<<<< HEAD
-            {
-                AssetKey(
-                    "non_existant_asset"  # ignored since can't be loaded
-                ): TimeWindowPartitionsSubset(hourly_partitions_def).with_partition_keys(
-                    [
-                        "2013-01-05-00:00",
-                    ],
-                ),
-            },
-=======
             [AssetKey("non_existant_asset")],  # ignored since can't be loaded
->>>>>>> 32cf1a8d2d (first stab)
         ],
         current_time=create_pendulum_time(year=2013, month=1, day=5, hour=17),
         expected_run_requests=[

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_flatten_time_window_ranges.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_flatten_time_window_ranges.py
@@ -38,10 +38,10 @@ def test_no_overlap() -> None:
     _check_flatten_time_window_ranges(
         {
             PartitionRangeStatus.MATERIALIZED: empty_subset.with_partition_key_range(
-                PartitionKeyRange("2022-01-02", "2022-01-05")
+                partitions_def, PartitionKeyRange("2022-01-02", "2022-01-05")
             ),
             PartitionRangeStatus.FAILED: empty_subset.with_partition_key_range(
-                PartitionKeyRange("2022-01-06", "2022-01-06")
+                partitions_def, PartitionKeyRange("2022-01-06", "2022-01-06")
             ),
         },
         [
@@ -57,13 +57,13 @@ def test_no_overlap() -> None:
     _check_flatten_time_window_ranges(
         {
             PartitionRangeStatus.MATERIALIZED: empty_subset.with_partition_key_range(
-                PartitionKeyRange("2022-01-02", "2022-01-05")
+                partitions_def, PartitionKeyRange("2022-01-02", "2022-01-05")
             ),
             PartitionRangeStatus.FAILED: empty_subset.with_partition_key_range(
-                PartitionKeyRange("2022-01-06", "2022-01-06")
+                partitions_def, PartitionKeyRange("2022-01-06", "2022-01-06")
             ),
             PartitionRangeStatus.MATERIALIZING: empty_subset.with_partition_key_range(
-                PartitionKeyRange("2022-01-8", "2022-01-09")
+                partitions_def, PartitionKeyRange("2022-01-8", "2022-01-09")
             ),
         },
         [
@@ -86,10 +86,10 @@ def test_overlapped() -> None:
     _check_flatten_time_window_ranges(
         {
             PartitionRangeStatus.MATERIALIZED: empty_subset.with_partition_key_range(
-                PartitionKeyRange("2022-01-02", "2022-01-05")
+                partitions_def, PartitionKeyRange("2022-01-02", "2022-01-05")
             ),
             PartitionRangeStatus.FAILED: empty_subset.with_partition_key_range(
-                PartitionKeyRange("2022-01-05", "2022-01-06")
+                partitions_def, PartitionKeyRange("2022-01-05", "2022-01-06")
             ),
             PartitionRangeStatus.MATERIALIZING: empty_subset,
         },
@@ -106,10 +106,10 @@ def test_overlapped() -> None:
     _check_flatten_time_window_ranges(
         {
             PartitionRangeStatus.MATERIALIZED: empty_subset.with_partition_key_range(
-                PartitionKeyRange("2022-01-05", "2022-01-06")
+                partitions_def, PartitionKeyRange("2022-01-05", "2022-01-06")
             ),
             PartitionRangeStatus.FAILED: empty_subset.with_partition_key_range(
-                PartitionKeyRange("2022-01-02", "2022-01-05")
+                partitions_def, PartitionKeyRange("2022-01-02", "2022-01-05")
             ),
             PartitionRangeStatus.MATERIALIZING: empty_subset,
         },
@@ -132,10 +132,10 @@ def test_materialized_spans_failed() -> None:
     _check_flatten_time_window_ranges(
         {
             PartitionRangeStatus.MATERIALIZED: empty_subset.with_partition_key_range(
-                PartitionKeyRange("2022-01-02", "2022-01-10")
+                partitions_def, PartitionKeyRange("2022-01-02", "2022-01-10")
             ),
             PartitionRangeStatus.FAILED: empty_subset.with_partition_key_range(
-                PartitionKeyRange("2022-01-05", "2022-01-06")
+                partitions_def, PartitionKeyRange("2022-01-05", "2022-01-06")
             ),
             PartitionRangeStatus.MATERIALIZING: empty_subset,
         },
@@ -159,12 +159,18 @@ def test_materialized_spans_many_failed() -> None:
     _check_flatten_time_window_ranges(
         {
             PartitionRangeStatus.MATERIALIZED: empty_subset.with_partition_key_range(
-                PartitionKeyRange("2022-01-01", "2022-12-10")
+                partitions_def, PartitionKeyRange("2022-01-01", "2022-12-10")
             ),
             PartitionRangeStatus.FAILED: (
-                empty_subset.with_partition_key_range(PartitionKeyRange("2022-01-05", "2022-01-06"))
-                .with_partition_key_range(PartitionKeyRange("2022-03-01", "2022-03-10"))
-                .with_partition_key_range(PartitionKeyRange("2022-09-01", "2022-10-01"))
+                empty_subset.with_partition_key_range(
+                    partitions_def, PartitionKeyRange("2022-01-05", "2022-01-06")
+                )
+                .with_partition_key_range(
+                    partitions_def, PartitionKeyRange("2022-03-01", "2022-03-10")
+                )
+                .with_partition_key_range(
+                    partitions_def, PartitionKeyRange("2022-09-01", "2022-10-01")
+                )
             ),
             PartitionRangeStatus.MATERIALIZING: empty_subset,
         },
@@ -221,8 +227,10 @@ def test_empty() -> None:
     _check_flatten_time_window_ranges(
         {
             PartitionRangeStatus.MATERIALIZED: empty_subset.with_partition_key_range(
-                PartitionKeyRange("2022-01-02", "2022-01-10")
-            ).with_partition_key_range(PartitionKeyRange("2022-01-20", "2022-02-10")),
+                partitions_def, PartitionKeyRange("2022-01-02", "2022-01-10")
+            ).with_partition_key_range(
+                partitions_def, PartitionKeyRange("2022-01-20", "2022-02-10")
+            ),
             PartitionRangeStatus.FAILED: empty_subset,
             PartitionRangeStatus.MATERIALIZING: empty_subset,
         },
@@ -244,8 +252,10 @@ def test_empty() -> None:
         {
             PartitionRangeStatus.MATERIALIZED: empty_subset,
             PartitionRangeStatus.FAILED: empty_subset.with_partition_key_range(
-                PartitionKeyRange("2022-01-02", "2022-01-10")
-            ).with_partition_key_range(PartitionKeyRange("2022-01-20", "2022-02-10")),
+                partitions_def, PartitionKeyRange("2022-01-02", "2022-01-10")
+            ).with_partition_key_range(
+                partitions_def, PartitionKeyRange("2022-01-20", "2022-02-10")
+            ),
             PartitionRangeStatus.MATERIALIZING: empty_subset,
         },
         [
@@ -267,8 +277,10 @@ def test_empty() -> None:
             PartitionRangeStatus.MATERIALIZED: empty_subset,
             PartitionRangeStatus.FAILED: empty_subset,
             PartitionRangeStatus.MATERIALIZING: empty_subset.with_partition_key_range(
-                PartitionKeyRange("2022-01-02", "2022-01-10")
-            ).with_partition_key_range(PartitionKeyRange("2022-01-20", "2022-02-10")),
+                partitions_def, PartitionKeyRange("2022-01-02", "2022-01-10")
+            ).with_partition_key_range(
+                partitions_def, PartitionKeyRange("2022-01-20", "2022-02-10")
+            ),
         },
         [
             {
@@ -289,10 +301,12 @@ def test_cancels_out() -> None:
     _check_flatten_time_window_ranges(
         {
             PartitionRangeStatus.MATERIALIZED: empty_subset.with_partition_key_range(
-                PartitionKeyRange("2022-01-02", "2022-01-05")
-            ).with_partition_key_range(PartitionKeyRange("2022-01-12", "2022-01-13")),
+                partitions_def, PartitionKeyRange("2022-01-02", "2022-01-05")
+            ).with_partition_key_range(
+                partitions_def, PartitionKeyRange("2022-01-12", "2022-01-13")
+            ),
             PartitionRangeStatus.FAILED: empty_subset.with_partition_key_range(
-                PartitionKeyRange("2022-01-02", "2022-01-05")
+                partitions_def, PartitionKeyRange("2022-01-02", "2022-01-05")
             ),
             PartitionRangeStatus.MATERIALIZING: empty_subset,
         },
@@ -315,27 +329,37 @@ def test_lots() -> None:
     _check_flatten_time_window_ranges(
         {
             PartitionRangeStatus.MATERIALIZED: (
-                empty_subset.with_partition_key_range(PartitionKeyRange("2022-01-02", "2022-01-05"))
-                .with_partition_key_range(PartitionKeyRange("2022-01-12", "2022-01-13"))
-                .with_partition_key_range(PartitionKeyRange("2022-01-15", "2022-01-17"))
-                .with_partition_key_range(PartitionKeyRange("2022-01-19", "2022-01-20"))
-                .with_partition_key_range(PartitionKeyRange("2022-01-22", "2022-01-24"))
+                empty_subset.with_partition_key_range(
+                    partitions_def, PartitionKeyRange("2022-01-02", "2022-01-05")
+                )
+                .with_partition_key_range(
+                    partitions_def, PartitionKeyRange("2022-01-12", "2022-01-13")
+                )
+                .with_partition_key_range(
+                    partitions_def, PartitionKeyRange("2022-01-15", "2022-01-17")
+                )
+                .with_partition_key_range(
+                    partitions_def, PartitionKeyRange("2022-01-19", "2022-01-20")
+                )
+                .with_partition_key_range(
+                    partitions_def, PartitionKeyRange("2022-01-22", "2022-01-24")
+                )
             ),
             PartitionRangeStatus.FAILED: (
                 empty_subset.with_partition_key_range(
-                    PartitionKeyRange("2021-12-30", "2021-12-31")
+                    partitions_def, PartitionKeyRange("2021-12-30", "2021-12-31")
                 )  # before materialized subset
                 .with_partition_key_range(
-                    PartitionKeyRange("2022-01-02", "2022-01-03")
+                    partitions_def, PartitionKeyRange("2022-01-02", "2022-01-03")
                 )  # within materialized subset
                 .with_partition_key_range(
-                    PartitionKeyRange("2022-01-05", "2022-01-06")
+                    partitions_def, PartitionKeyRange("2022-01-05", "2022-01-06")
                 )  # directly after materialized subset
                 .with_partition_key_range(
-                    PartitionKeyRange("2022-01-08", "2022-01-09")
+                    partitions_def, PartitionKeyRange("2022-01-08", "2022-01-09")
                 )  # between materialized subsets
                 .with_partition_key_range(
-                    PartitionKeyRange("2022-01-11", "2022-01-14")
+                    partitions_def, PartitionKeyRange("2022-01-11", "2022-01-14")
                 )  # encompasses materialized subset
                 .with_partition_keys(["2022-01-20"])  # at end materialized subset
                 .with_partition_keys(
@@ -381,13 +405,13 @@ def test_multiple_overlap_types():
     _check_flatten_time_window_ranges(
         {
             PartitionRangeStatus.MATERIALIZED: empty_subset.with_partition_key_range(
-                PartitionKeyRange("2022-01-01", "2022-01-06")
+                partitions_def, PartitionKeyRange("2022-01-01", "2022-01-06")
             ),
             PartitionRangeStatus.FAILED: empty_subset.with_partition_key_range(
-                PartitionKeyRange("2022-01-02", "2022-01-05")
+                partitions_def, PartitionKeyRange("2022-01-02", "2022-01-05")
             ),
             PartitionRangeStatus.MATERIALIZING: empty_subset.with_partition_key_range(
-                PartitionKeyRange("2022-01-03", "2022-01-04")
+                partitions_def, PartitionKeyRange("2022-01-03", "2022-01-04")
             ),
         },
         [

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_multi_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_multi_partitions.py
@@ -320,9 +320,9 @@ def test_multipartitions_subset_addition(initial, added):
     assert added_subset.get_partition_keys(current_time=current_day) == set(
         added_subset_keys + initial_subset_keys
     )
-    assert added_subset.get_partition_keys_not_in_subset(current_time=current_day) == set(
-        expected_keys_not_in_updated_subset
-    )
+    assert added_subset.get_partition_keys_not_in_subset(
+        multipartitions_def, current_time=current_day
+    ) == set(expected_keys_not_in_updated_subset)
 
 
 def test_asset_partition_key_is_multipartition_key():

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
@@ -25,6 +25,7 @@ from dagster._core.definitions.time_window_partitions import (
     TimeWindow,
     TimeWindowPartitionsSubset,
 )
+from dagster._serdes import deserialize_value, serialize_value
 from dagster._seven.compat.pendulum import create_pendulum_time
 from dagster._utils.partitions import DEFAULT_HOURLY_FORMAT_WITHOUT_TIMEZONE
 
@@ -1287,3 +1288,25 @@ def test_partition_with_end_date(
     assert partitions_def.has_partition_key(first_partition_window[0])
     assert partitions_def.has_partition_key(last_partition_window[0])
     assert not partitions_def.has_partition_key(last_partition_window[1])
+
+
+@pytest.mark.parametrize(
+    "partitions_def",
+    [
+        (DailyPartitionsDefinition("2023-01-01", timezone="America/New_York")),
+        (DailyPartitionsDefinition("2023-01-01", timezone="America/New_York")),
+    ],
+)
+def test_time_window_partitions_def_serialization(partitions_def):
+    time_window_partitions_def = TimeWindowPartitionsDefinition(
+        start=partitions_def.start,
+        end=partitions_def.end,
+        cron_schedule="0 0 * * *",
+        fmt="%Y-%m-%d",
+        timezone=partitions_def.timezone,
+        end_offset=partitions_def.end_offset,
+    )
+    deserialized = deserialize_value(
+        serialize_value(time_window_partitions_def), TimeWindowPartitionsDefinition
+    )
+    assert deserialized == time_window_partitions_def

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
@@ -787,19 +787,20 @@ def test_partition_subset_get_partition_keys_not_in_subset(
         assert partition_key in subset
     assert (
         subset.get_partition_keys_not_in_subset(
-            current_time=partitions_def.end_time_for_partition_key(full_set_keys[-1])
+            partitions_def=partitions_def,
+            current_time=partitions_def.end_time_for_partition_key(full_set_keys[-1]),
         )
         == expected_keys_not_in_subset
     )
     assert (
         cast(
             TimeWindowPartitionsSubset, partitions_def.deserialize_subset(subset.serialize())
-        ).included_time_windows
-        == subset.included_time_windows
+        ).get_included_time_windows()
+        == subset.get_included_time_windows()
     )
 
     expected_range_count = case_str.count("-+") + (1 if case_str[0] == "+" else 0)
-    assert len(subset.included_time_windows) == expected_range_count, case_str
+    assert len(subset.get_included_time_windows()) == expected_range_count, case_str
     assert len(subset) == case_str.count("+")
 
 
@@ -925,7 +926,8 @@ def test_partition_subset_with_partition_keys(
     assert all(partition_key in updated_subset for partition_key in added_subset_keys)
     assert (
         updated_subset.get_partition_keys_not_in_subset(
-            current_time=partitions_def.end_time_for_partition_key(full_set_keys[-1])
+            partitions_def=partitions_def,
+            current_time=partitions_def.end_time_for_partition_key(full_set_keys[-1]),
         )
         == expected_keys_not_in_updated_subset
     )
@@ -936,7 +938,9 @@ def test_partition_subset_with_partition_keys(
     expected_range_count = updated_subset_str.count("-+") + (
         1 if updated_subset_str[0] == "+" else 0
     )
-    assert len(updated_subset.included_time_windows) == expected_range_count, updated_subset_str
+    assert (
+        len(updated_subset.get_included_time_windows()) == expected_range_count
+    ), updated_subset_str
     assert len(updated_subset) == updated_subset_str.count("+")
 
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
@@ -21,9 +21,9 @@ from dagster._check import CheckError
 from dagster._core.definitions.time_window_partitions import (
     BaseTimeWindowPartitionsSubset,
     ScheduleType,
+    TimePartitionKeyPartitionsSubset,
     TimeWindow,
     TimeWindowPartitionsSubset,
-    UnresolvedTimeWindowPartitionsSubset,
 )
 from dagster._seven.compat.pendulum import create_pendulum_time
 from dagster._utils.partitions import DEFAULT_HOURLY_FORMAT_WITHOUT_TIMEZONE
@@ -745,7 +745,7 @@ def test_start_not_aligned():
 
 @pytest.mark.parametrize(
     "partitions_subset_class",
-    [UnresolvedTimeWindowPartitionsSubset, TimeWindowPartitionsSubset],
+    [TimePartitionKeyPartitionsSubset, TimeWindowPartitionsSubset],
 )
 @pytest.mark.parametrize(
     "case_str",
@@ -822,7 +822,7 @@ def test_time_partitions_subset_identical_serialization():
 
 @pytest.mark.parametrize(
     "partitions_subset_class",
-    [UnresolvedTimeWindowPartitionsSubset, TimeWindowPartitionsSubset],
+    [TimePartitionKeyPartitionsSubset, TimeWindowPartitionsSubset],
 )
 @pytest.mark.parametrize(
     "initial, added",

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
@@ -19,6 +19,7 @@ from dagster import (
 )
 from dagster._check import CheckError
 from dagster._core.definitions.time_window_partitions import (
+    BaseTimeWindowPartitionsSubset,
     ScheduleType,
     TimeWindow,
     TimeWindowPartitionsSubset,
@@ -771,7 +772,8 @@ def test_partition_subset_get_partition_keys_not_in_subset(case_str: str):
             expected_keys_not_in_subset.append(full_set_keys[i])
 
     subset = cast(
-        TimeWindowPartitionsSubset, partitions_def.empty_subset().with_partition_keys(subset_keys)
+        BaseTimeWindowPartitionsSubset,
+        partitions_def.empty_subset().with_partition_keys(subset_keys),
     )
     for partition_key in subset_keys:
         assert partition_key in subset
@@ -901,7 +903,9 @@ def test_partition_subset_with_partition_keys(initial: str, added: str):
 
     subset = partitions_def.empty_subset().with_partition_keys(initial_subset_keys)
     assert all(partition_key in subset for partition_key in initial_subset_keys)
-    updated_subset = cast(TimeWindowPartitionsSubset, subset.with_partition_keys(added_subset_keys))
+    updated_subset = cast(
+        BaseTimeWindowPartitionsSubset, subset.with_partition_keys(added_subset_keys)
+    )
     assert all(partition_key in updated_subset for partition_key in added_subset_keys)
     assert (
         updated_subset.get_partition_keys_not_in_subset(

--- a/python_modules/dagster/dagster_tests/storage_tests/test_fs_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_fs_io_manager.py
@@ -295,6 +295,7 @@ def test_fs_io_manager_partitioned_no_partitions():
             def get_upstream_mapped_partitions_result_for_partitions(
                 self,
                 downstream_partitions_subset: Optional[PartitionsSubset],
+                downstream_partitions_def: Optional[PartitionsDefinition],
                 upstream_partitions_def: PartitionsDefinition,
                 current_time: Optional[datetime] = None,
                 dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
@@ -304,6 +305,7 @@ def test_fs_io_manager_partitioned_no_partitions():
             def get_downstream_partitions_for_partitions(
                 self,
                 upstream_partitions_subset,
+                upstream_partitions_def,
                 downstream_partitions_def,
                 current_time: Optional[datetime] = None,
                 dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,


### PR DESCRIPTION
This PR contains a set of changes to refactor `PartitionsSubset` objects to be serialized via `whitelist_for_serdes`. This is still a work in progress, so detailing a set of changes to more easily gather early thoughts from reviewers:

1. This PR stacks on top of https://github.com/dagster-io/dagster/pull/17660, which makes `TimeWindowPartitionsDefinition`s serializable/deserializable

2. Supports making `TimeWindowPartitionsSubset` serializable. This includes:
    - Making it a named tuple
    - Adding a new `before_pack` method to the `NamedTupleSerializer`. `TimeWindowPartitionsSubsets` currently have a lot of performance improvement logic that keeps contents in partition key format when possible, and during serialization we want to transform these contents into time windows
    - Renaming the `included_time_windows` and `num_partitions` methods that return resolved values to not conflict with name tuple field names
        - The new named tuple field names `included_time_windows` and `num_partitions` conflict with existing methods with the same names. Unfortunately the logic in each is different -- in some cases the `num_partitions` and `included_time_window` named tuple fields are unpopulated for performance, while the methods fully resolve the value by loading `included_partition_keys` as time windows. 
        - This PR (admittedly confusingly) renames the "resolution" methods" to be `get_included_time_windows()` and `get_num_partitions()` to be called when the resolved value is needed.

3. Removes `partitions_def` as a field from `DefaultPartitionsSubset` in order to make it serializable
    - Unfortunately, this means that partitions subsets methods that require the partitions def (`get_partition_key_ranges`, `get_partition_keys_not_in_subset`, etc.) now must accept a partitions def
    - `PartitionMapping`s that previously just accepted a subset now must accept a partitions def too (corresponding to the subset) which requires threading the partitions def through the `get_upstream...` and `get_downstream...` methods

4. Removes the `MultiPartitionsSubset` class
    - This class previously subclassed `DefaultPartitionsSubset` and was responsible for casting partition key strings into `MultiPartitionKey` objects
    - Named tuple inheritance sucks (so can't accept extra constructor params, and overriding methods didn't work when I tried it). This PR changes callsites that expect `MultiPartitionKey`s to instead perform this conversion per-callsite.


Unknowns:
- This changes the concept of partition subset equivalence (since previously the partitions def needed to be the same in order to be equivalent). Not sure if there are any breakages here