### PR TITLE
add prefix to build_asset_with_blocking_check ops to avoid conflicts

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_checks.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_checks.py
@@ -194,7 +194,10 @@ def build_asset_with_blocking_check(
     check.invariant(len(asset_def.op.output_defs) == 1)
     asset_out_type = asset_def.op.output_defs[0].dagster_type
 
-    @op(ins={"asset_return_value": In(asset_out_type), "check_evaluations": In(Nothing)})
+    @op(
+        name=f"{asset_def.op.name}_asset_and_checks",
+        ins={"asset_return_value": In(asset_out_type), "check_evaluations": In(Nothing)},
+    )
     def fan_in_checks_and_asset_return_value(context: OpExecutionContext, asset_return_value: Any):
         # we pass the asset_return_value through and store it again so that downstream assets can load it.
         # This is a little silly- we only do this because this op has the asset key in its StepOutputProperties
@@ -219,7 +222,9 @@ def build_asset_with_blocking_check(
 
     # kwargs are the inputs to the asset_def.op that we are wrapping
     def blocking_asset(**kwargs):
-        asset_return_value = asset_def.op.with_replaced_properties(name="asset_op")(**kwargs)
+        asset_return_value = asset_def.op.with_replaced_properties(
+            name=f"{asset_def.op.name}_graph_asset_op"
+        )(**kwargs)
         check_evaluations = [check.node_def(asset_return_value) for check in checks]
 
         return {

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_blocking_asset_checks.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_blocking_asset_checks.py
@@ -170,3 +170,35 @@ def test_check_fail_and_block_with_inputs():
     assert len(materialization_events) == 2
     assert materialization_events[0].asset_key == AssetKey(["upstream_asset"])
     assert materialization_events[1].asset_key == AssetKey(["my_asset_with_managed_input"])
+
+
+@asset
+def asset1():
+    return "asset1"
+
+
+@asset
+def asset2():
+    return "asset2"
+
+
+@asset_check(asset="asset1")
+def check1():
+    return AssetCheckResult(passed=True)
+
+
+@asset_check(asset="asset2")
+def check2():
+    return AssetCheckResult(passed=True)
+
+
+blocking_asset_1 = build_asset_with_blocking_check(asset_def=asset1, checks=[check1])
+blocking_asset_2 = build_asset_with_blocking_check(asset_def=asset2, checks=[check2])
+
+
+def test_multiple_blocking_assets():
+    result = execute_assets_and_checks(
+        assets=[blocking_asset_1, blocking_asset_2],
+        raise_on_error=False,
+    )
+    assert result.success


### PR DESCRIPTION
Closes https://github.com/dagster-io/dagster/issues/17469. Inspired by https://github.com/dagster-io/dagster/pull/17503

This graph asset factory function returned ops with the same names, which caused `dagster._core.errors.DagsterInvalidDefinitionError: Detected conflicting node definitions with the same name "fan_in_checks_and_asset_return_value"` if you created more than one. Update it to prefix with the name of the asset op that's passed in. This means you can only create one per asset, but I think that's reasonable.