### PR TITLE
Enable downstream method for last partition mapping

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
@@ -202,7 +202,7 @@ class LastPartitionMapping(PartitionMapping, NamedTuple("_LastPartitionMapping",
         dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
     ) -> UpstreamPartitionsResult:
         last = upstream_partitions_def.get_last_partition_key(
-            current_time=None, dynamic_partitions_store=dynamic_partitions_store
+            current_time=current_time, dynamic_partitions_store=dynamic_partitions_store
         )
 
         upstream_subset = upstream_partitions_def.empty_subset()
@@ -218,7 +218,15 @@ class LastPartitionMapping(PartitionMapping, NamedTuple("_LastPartitionMapping",
         current_time: Optional[datetime] = None,
         dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
     ) -> PartitionsSubset:
-        raise NotImplementedError()
+        last_upstream_partition = upstream_partitions_subset.partitions_def.get_last_partition_key(
+            current_time=current_time, dynamic_partitions_store=dynamic_partitions_store
+        )
+        if last_upstream_partition and last_upstream_partition in upstream_partitions_subset:
+            return downstream_partitions_def.subset_with_all_partitions(
+                current_time=current_time, dynamic_partitions_store=dynamic_partitions_store
+            )
+        else:
+            return downstream_partitions_def.empty_subset()
 
 
 @whitelist_for_serdes

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_asset_partition_mappings.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_asset_partition_mappings.py
@@ -844,3 +844,35 @@ def test_dynamic_partition_mapping_with_asset_deps():
         materialize(
             [asset_1_multi_asset, asset_2_multi_asset], partition_key="orange", instance=instance
         )
+
+
+def test_last_partition_mapping_get_downstream_partitions():
+    upstream_partitions_def = DailyPartitionsDefinition("2023-10-01")
+    downstream_partitions_def = DailyPartitionsDefinition("2023-10-01")
+
+    current_time = datetime(2023, 10, 5, 1)
+
+    assert LastPartitionMapping().get_downstream_partitions_for_partitions(
+        upstream_partitions_def.empty_subset().with_partition_keys(["2023-10-04"]),
+        downstream_partitions_def,
+        current_time,
+    ) == downstream_partitions_def.empty_subset().with_partition_keys(
+        downstream_partitions_def.get_partition_keys(current_time)
+    )
+
+    assert LastPartitionMapping().get_downstream_partitions_for_partitions(
+        upstream_partitions_def.empty_subset().with_partition_keys(["2023-10-03", "2023-10-04"]),
+        downstream_partitions_def,
+        current_time,
+    ) == downstream_partitions_def.empty_subset().with_partition_keys(
+        downstream_partitions_def.get_partition_keys(current_time)
+    )
+
+    assert (
+        LastPartitionMapping().get_downstream_partitions_for_partitions(
+            upstream_partitions_def.empty_subset().with_partition_keys(["2023-10-03"]),
+            downstream_partitions_def,
+            current_time,
+        )
+        == downstream_partitions_def.empty_subset()
+    )


### PR DESCRIPTION
Users are hitting a `NotImplementedError` when attempting to launch an asset backfill targeting partitioned assets with a `LastPartitionMapping` between them.

In this case, when calling `get_downstream_partitions_for_partitions`, if the upstream subset contains the upstream partitions def's last partition key, then all downstream partitions are dependencies. This PR implements this.

One situation this is useful is if you have an upstream time partitioned asset and a downstream static partitioned asset that incorporates the last day's data.